### PR TITLE
Handle SchedulingEquivalenceHashing skipped workloads in UnadmittedWorkloadsObservability

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -117,9 +117,10 @@ type ClusterQueue struct {
 	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
 	inadmissibleWorkloads inadmissibleWorkloads
 
-	// noFitSchedulingHashReasons tracks scheduling equivalence classes and their reasons.
+	// hashToBulkMoveReason tracks scheduling equivalence classes and the reason
+	// why workloads with that hash were bulk-moved to inadmissibleWorkloads.
 	// Cleared when queueInadmissibleWorkloads runs.
-	noFitSchedulingHashReasons map[string]string
+	hashToBulkMoveReason map[string]string
 
 	finishedWorkloads sets.Set[workload.Reference]
 
@@ -246,19 +247,19 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
 	return &ClusterQueue{
-		heap:                       *heap.New(workloadKey, lessFunc),
-		inadmissibleWorkloads:      make(inadmissibleWorkloads),
-		noFitSchedulingHashReasons: make(map[string]string),
-		finishedWorkloads:          sets.New[workload.Reference](),
-		queueInadmissibleCycle:     -1,
-		compareFunc:                compareFunc,
-		snapshotSort:               snapshotSort,
-		rwm:                        sync.RWMutex{},
-		clock:                      clock,
-		afsEntryPenalties:          options.afsEntryPenalties,
-		localQueuesInClusterQueue:  make(map[utilqueue.LocalQueueReference]bool),
-		sw:                         &sw,
-		pendingResourcesTotal:      make(map[corev1.ResourceName]int64),
+		heap:                      *heap.New(workloadKey, lessFunc),
+		inadmissibleWorkloads:     make(inadmissibleWorkloads),
+		hashToBulkMoveReason:      make(map[string]string),
+		finishedWorkloads:         sets.New[workload.Reference](),
+		queueInadmissibleCycle:    -1,
+		compareFunc:               compareFunc,
+		snapshotSort:              snapshotSort,
+		rwm:                       sync.RWMutex{},
+		clock:                     clock,
+		afsEntryPenalties:         options.afsEntryPenalties,
+		localQueuesInClusterQueue: make(map[utilqueue.LocalQueueReference]bool),
+		sw:                        &sw,
+		pendingResourcesTotal:     make(map[corev1.ResourceName]int64),
 	}
 }
 
@@ -377,10 +378,10 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 		c.insertInadmissible(key, wInfo)
 		return
 	}
-	// Skip to inadmissible if the workload's equivalence class is already known to be NoFit
+	// Skip to inadmissible if the workload's equivalence class was already bulk-moved to inadmissible
 	// (only for BestEffortFIFO; StrictFIFO preserves strict ordering).
 	if c.queueingStrategy == kueue.BestEffortFIFO && c.heap.GetByKey(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
-		if _, has := c.noFitSchedulingHashReasons[wInfo.SchedulingHash]; has {
+		if _, has := c.hashToBulkMoveReason[wInfo.SchedulingHash]; has {
 			c.insertInadmissible(key, wInfo)
 			return
 		}
@@ -410,13 +411,14 @@ func draRequestsChanged(oldInfo, newInfo *workload.Info) bool {
 	return !equality.Semantic.DeepEqual(oldInfo.TotalRequests, newInfo.TotalRequests)
 }
 
-func (c *ClusterQueue) GetNoFitReason(wlKey workload.Reference, hash string) (string, bool) {
+func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	if !c.inadmissibleWorkloads.hasKey(wlKey) {
+	wlInfo := c.inadmissibleWorkloads.get(wl)
+	if wlInfo == nil {
 		return "", false
 	}
-	reason, ok := c.noFitSchedulingHashReasons[hash]
+	reason, ok := c.hashToBulkMoveReason[wlInfo.SchedulingHash]
 	return reason, ok
 }
 
@@ -512,6 +514,13 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue, role
 	reportCQFinishedWorkloads(c, roleTracker, cl)
 }
 
+func resolveQuotaReservedReason(statusReason string) string {
+	if statusReason == "" {
+		return kueue.WorkloadQuotaReservedReasonPendingEvaluation
+	}
+	return statusReason
+}
+
 // requeueIfNotPresent inserts a workload that cannot be admitted into
 // ClusterQueue, unless it is already in the queue. If immediate is true
 // or if there was a call to QueueInadmissibleWorkloads after a call to Pop,
@@ -565,11 +574,7 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 
 	if features.Enabled(features.SchedulingEquivalenceHashing) && wInfo.SchedulingHash != workload.SchedulingHashUnknown &&
 		(reason == RequeueReasonNoFit || reason == RequeueReasonPreemptionNoCandidates) {
-		quotaReservedReason := statusReason
-		if quotaReservedReason == "" {
-			quotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
-		}
-		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, quotaReservedReason); moved > 0 {
+		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, resolveQuotaReservedReason(statusReason)); moved > 0 {
 			log.V(2).Info("Bulk-moved equivalent workloads to inadmissible", "hash", wInfo.SchedulingHash, "movedCount", moved)
 		}
 	}
@@ -591,7 +596,7 @@ func (c *ClusterQueue) handleInadmissibleHash(hash string, reason string) int {
 	if c.queueingStrategy != kueue.BestEffortFIFO {
 		return 0
 	}
-	c.noFitSchedulingHashReasons[hash] = reason
+	c.hashToBulkMoveReason[hash] = reason
 	moved := 0
 	for _, wInfo := range c.heap.List() {
 		if wInfo.SchedulingHash == hash {

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -514,6 +514,12 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue, role
 	reportCQFinishedWorkloads(c, roleTracker, cl)
 }
 
+// resolveQuotaReservedReason returns statusReason if set, or defaults to
+// WorkloadQuotaReservedReasonPendingEvaluation when empty.
+// We do not feature-gate the fallback here because this function only computes
+// the reason string stored in the ClusterQueue's in-memory hashToBulkMoveReason map.
+// Whether status conditions are actually written to the Workload API object is
+// governed by the workload controller (shouldCheckEquivalenceHash).
 func resolveQuotaReservedReason(statusReason string) string {
 	if statusReason == "" {
 		return kueue.WorkloadQuotaReservedReasonPendingEvaluation
@@ -529,7 +535,7 @@ func resolveQuotaReservedReason(statusReason string) string {
 // When SchedulingEquivalenceHashing is enabled and the reason is NoFit or
 // PreemptionNoCandidates, equivalent workloads in the heap are bulk-moved
 // to inadmissible.
-func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, statusReason string) bool {
+func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason string) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
@@ -574,7 +580,7 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 
 	if features.Enabled(features.SchedulingEquivalenceHashing) && wInfo.SchedulingHash != workload.SchedulingHashUnknown &&
 		(reason == RequeueReasonNoFit || reason == RequeueReasonPreemptionNoCandidates) {
-		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, resolveQuotaReservedReason(statusReason)); moved > 0 {
+		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, resolveQuotaReservedReason(quotaReservedReason)); moved > 0 {
 			log.V(2).Info("Bulk-moved equivalent workloads to inadmissible", "hash", wInfo.SchedulingHash, "movedCount", moved)
 		}
 	}
@@ -880,8 +886,9 @@ func (c *ClusterQueue) Active() bool {
 // in the latter case the implementation may choose to keep the workload in "inadmissible workloads"
 // where it doesn't compete with other workloads, until cluster events free up quota.
 // The workload should not be reinserted if it's already in the ClusterQueue.
+// quotaReservedReason represents the WorkloadQuotaReserved condition reason computed by the scheduler.
 // Returns true if the workload was inserted.
-func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, statusReason string) bool {
+func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, quotaReservedReason string) bool {
 	// when preemptions are in-progress, we keep attempting to
 	// schedule the same workload for BestEffortFIFO queues. See
 	// documentation of stickyWorkload for more details
@@ -902,7 +909,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 			reason == RequeueReasonPendingMigration ||
 			reason == RequeueReasonPreemptionFailed
 	}
-	return c.requeueIfNotPresent(log, wInfo, immediate, reason, statusReason)
+	return c.requeueIfNotPresent(log, wInfo, immediate, reason, quotaReservedReason)
 }
 
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -117,9 +117,9 @@ type ClusterQueue struct {
 	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
 	inadmissibleWorkloads inadmissibleWorkloads
 
-	// noFitSchedulingHashes tracks scheduling equivalence classes that received
-	// NoFit or PreemptionNoCandidates. Cleared when queueInadmissibleWorkloads runs.
-	noFitSchedulingHashes sets.Set[string]
+	// noFitSchedulingHashReasons tracks scheduling equivalence classes and their reasons.
+	// Cleared when queueInadmissibleWorkloads runs.
+	noFitSchedulingHashReasons map[string]string
 
 	finishedWorkloads sets.Set[workload.Reference]
 
@@ -246,19 +246,19 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
 	return &ClusterQueue{
-		heap:                      *heap.New(workloadKey, lessFunc),
-		inadmissibleWorkloads:     make(inadmissibleWorkloads),
-		noFitSchedulingHashes:     sets.New[string](),
-		finishedWorkloads:         sets.New[workload.Reference](),
-		queueInadmissibleCycle:    -1,
-		compareFunc:               compareFunc,
-		snapshotSort:              snapshotSort,
-		rwm:                       sync.RWMutex{},
-		clock:                     clock,
-		afsEntryPenalties:         options.afsEntryPenalties,
-		localQueuesInClusterQueue: make(map[utilqueue.LocalQueueReference]bool),
-		sw:                        &sw,
-		pendingResourcesTotal:     make(map[corev1.ResourceName]int64),
+		heap:                       *heap.New(workloadKey, lessFunc),
+		inadmissibleWorkloads:      make(inadmissibleWorkloads),
+		noFitSchedulingHashReasons: make(map[string]string),
+		finishedWorkloads:          sets.New[workload.Reference](),
+		queueInadmissibleCycle:     -1,
+		compareFunc:                compareFunc,
+		snapshotSort:               snapshotSort,
+		rwm:                        sync.RWMutex{},
+		clock:                      clock,
+		afsEntryPenalties:          options.afsEntryPenalties,
+		localQueuesInClusterQueue:  make(map[utilqueue.LocalQueueReference]bool),
+		sw:                         &sw,
+		pendingResourcesTotal:      make(map[corev1.ResourceName]int64),
 	}
 }
 
@@ -379,9 +379,11 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	}
 	// Skip to inadmissible if the workload's equivalence class is already known to be NoFit
 	// (only for BestEffortFIFO; StrictFIFO preserves strict ordering).
-	if c.queueingStrategy == kueue.BestEffortFIFO && c.heap.GetByKey(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown && c.noFitSchedulingHashes.Has(wInfo.SchedulingHash) {
-		c.insertInadmissible(key, wInfo)
-		return
+	if c.queueingStrategy == kueue.BestEffortFIFO && c.heap.GetByKey(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
+		if _, has := c.noFitSchedulingHashReasons[wInfo.SchedulingHash]; has {
+			c.insertInadmissible(key, wInfo)
+			return
+		}
 	}
 	// Subtract the old entry's resources before overwriting; requests may have changed.
 	if oldHeapInfo := c.heap.GetByKey(key); oldHeapInfo != nil {
@@ -406,6 +408,16 @@ func draRequestsChanged(oldInfo, newInfo *workload.Info) bool {
 		return false
 	}
 	return !equality.Semantic.DeepEqual(oldInfo.TotalRequests, newInfo.TotalRequests)
+}
+
+func (c *ClusterQueue) GetNoFitReason(wlKey workload.Reference, hash string) (string, bool) {
+	c.rwm.RLock()
+	defer c.rwm.RUnlock()
+	if !c.inadmissibleWorkloads.hasKey(wlKey) {
+		return "", false
+	}
+	reason, ok := c.noFitSchedulingHashReasons[hash]
+	return reason, ok
 }
 
 func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
@@ -508,7 +520,7 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue, role
 // When SchedulingEquivalenceHashing is enabled and the reason is NoFit or
 // PreemptionNoCandidates, equivalent workloads in the heap are bulk-moved
 // to inadmissible.
-func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason) bool {
+func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, statusReason string) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
@@ -553,7 +565,11 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 
 	if features.Enabled(features.SchedulingEquivalenceHashing) && wInfo.SchedulingHash != workload.SchedulingHashUnknown &&
 		(reason == RequeueReasonNoFit || reason == RequeueReasonPreemptionNoCandidates) {
-		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash); moved > 0 {
+		quotaReservedReason := statusReason
+		if quotaReservedReason == "" {
+			quotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+		}
+		if moved := c.handleInadmissibleHash(wInfo.SchedulingHash, quotaReservedReason); moved > 0 {
 			log.V(2).Info("Bulk-moved equivalent workloads to inadmissible", "hash", wInfo.SchedulingHash, "movedCount", moved)
 		}
 	}
@@ -571,11 +587,11 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 // scheduling hash to inadmissibleWorkloads. Returns the number moved.
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
 // stays in the heap and must not cause equivalent workloads to be skipped.
-func (c *ClusterQueue) handleInadmissibleHash(hash string) int {
+func (c *ClusterQueue) handleInadmissibleHash(hash string, reason string) int {
 	if c.queueingStrategy != kueue.BestEffortFIFO {
 		return 0
 	}
-	c.noFitSchedulingHashes.Insert(hash)
+	c.noFitSchedulingHashReasons[hash] = reason
 	moved := 0
 	for _, wInfo := range c.heap.List() {
 		if wInfo.SchedulingHash == hash {
@@ -860,7 +876,7 @@ func (c *ClusterQueue) Active() bool {
 // where it doesn't compete with other workloads, until cluster events free up quota.
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
-func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason) bool {
+func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, statusReason string) bool {
 	// when preemptions are in-progress, we keep attempting to
 	// schedule the same workload for BestEffortFIFO queues. See
 	// documentation of stickyWorkload for more details
@@ -881,7 +897,7 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 			reason == RequeueReasonPendingMigration ||
 			reason == RequeueReasonPreemptionFailed
 	}
-	return c.requeueIfNotPresent(log, wInfo, immediate, reason)
+	return c.requeueIfNotPresent(log, wInfo, immediate, reason, statusReason)
 }
 
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -67,6 +67,20 @@ const (
 	RequeueReasonPreemptionNoCandidates RequeueReason = "PreemptionNoCandidates"
 )
 
+// QuotaReservedReason represents the reason for the WorkloadQuotaReserved condition
+// computed by the scheduler or queue manager during evaluation.
+type QuotaReservedReason string
+
+const (
+	QuotaReservedReasonGeneric                      QuotaReservedReason = ""
+	QuotaReservedReasonPendingEvaluation            QuotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+	QuotaReservedReasonWaitingForQuota              QuotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
+	QuotaReservedReasonWaitingForPreemptedWorkloads QuotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
+	QuotaReservedReasonSuspended                    QuotaReservedReason = kueue.WorkloadQuotaReservedReasonSuspended
+	QuotaReservedReasonMisconfigured                QuotaReservedReason = kueue.WorkloadQuotaReservedReasonMisconfigured
+	QuotaReservedReasonAdmissionGated               QuotaReservedReason = kueue.WorkloadAdmissionGated
+)
+
 var (
 	realClock = clock.RealClock{}
 )
@@ -120,7 +134,7 @@ type ClusterQueue struct {
 	// hashToBulkMoveReason tracks scheduling equivalence classes and the reason
 	// why workloads with that hash were bulk-moved to inadmissibleWorkloads.
 	// Cleared when queueInadmissibleWorkloads runs.
-	hashToBulkMoveReason map[string]string
+	hashToBulkMoveReason map[string]QuotaReservedReason
 
 	finishedWorkloads sets.Set[workload.Reference]
 
@@ -249,7 +263,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(inadmissibleWorkloads),
-		hashToBulkMoveReason:      make(map[string]string),
+		hashToBulkMoveReason:      make(map[string]QuotaReservedReason),
 		finishedWorkloads:         sets.New[workload.Reference](),
 		queueInadmissibleCycle:    -1,
 		compareFunc:               compareFunc,
@@ -419,7 +433,7 @@ func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 		return "", false
 	}
 	reason, ok := c.hashToBulkMoveReason[wlInfo.SchedulingHash]
-	return reason, ok
+	return string(reason), ok
 }
 
 func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
@@ -520,11 +534,11 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue, role
 // the reason string stored in the ClusterQueue's in-memory hashToBulkMoveReason map.
 // Whether status conditions are actually written to the Workload API object is
 // governed by the workload controller (shouldCheckEquivalenceHash).
-func resolveQuotaReservedReason(statusReason string) string {
-	if statusReason == "" {
-		return kueue.WorkloadQuotaReservedReasonPendingEvaluation
+func resolveQuotaReservedReason(reason QuotaReservedReason) QuotaReservedReason {
+	if reason == "" {
+		return QuotaReservedReasonPendingEvaluation
 	}
-	return statusReason
+	return reason
 }
 
 // requeueIfNotPresent inserts a workload that cannot be admitted into
@@ -535,7 +549,7 @@ func resolveQuotaReservedReason(statusReason string) string {
 // When SchedulingEquivalenceHashing is enabled and the reason is NoFit or
 // PreemptionNoCandidates, equivalent workloads in the heap are bulk-moved
 // to inadmissible.
-func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason string) bool {
+func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
@@ -598,7 +612,7 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 // scheduling hash to inadmissibleWorkloads. Returns the number moved.
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
 // stays in the heap and must not cause equivalent workloads to be skipped.
-func (c *ClusterQueue) handleInadmissibleHash(hash string, reason string) int {
+func (c *ClusterQueue) handleInadmissibleHash(hash string, reason QuotaReservedReason) int {
 	if c.queueingStrategy != kueue.BestEffortFIFO {
 		return 0
 	}
@@ -888,7 +902,7 @@ func (c *ClusterQueue) Active() bool {
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // quotaReservedReason represents the WorkloadQuotaReserved condition reason computed by the scheduler.
 // Returns true if the workload was inserted.
-func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, quotaReservedReason string) bool {
+func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	// when preemptions are in-progress, we keep attempting to
 	// schedule the same workload for BestEffortFIFO queues. See
 	// documentation of stickyWorkload for more details

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1534,22 +1534,22 @@ func TestRecordInadmissibleHash(t *testing.T) {
 
 func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 	cases := map[string]struct {
-		noFitSchedulingHashes []string
-		pushHash              string
-		wantActive            int
-		wantInadmissible      int
+		inadmissibleHashes []string
+		pushHash           string
+		wantActive         int
+		wantInadmissible   int
 	}{
 		"workload with blocked hash goes to inadmissible": {
-			noFitSchedulingHashes: []string{"blocked"},
-			pushHash:              "blocked",
-			wantActive:            0,
-			wantInadmissible:      1,
+			inadmissibleHashes: []string{"blocked"},
+			pushHash:           "blocked",
+			wantActive:         0,
+			wantInadmissible:   1,
 		},
 		"workload with non-blocked hash goes to heap": {
-			noFitSchedulingHashes: []string{"blocked"},
-			pushHash:              "allowed",
-			wantActive:            1,
-			wantInadmissible:      0,
+			inadmissibleHashes: []string{"blocked"},
+			pushHash:           "allowed",
+			wantActive:         1,
+			wantInadmissible:   0,
 		},
 	}
 	for name, tc := range cases {
@@ -1558,8 +1558,8 @@ func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
 			cq.queueingStrategy = kueue.BestEffortFIFO
 
-			for _, h := range tc.noFitSchedulingHashes {
-				cq.noFitSchedulingHashReasons[h] = "dummy-reason"
+			for _, h := range tc.inadmissibleHashes {
+				cq.hashToBulkMoveReason[h] = "dummy-reason"
 			}
 
 			wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
@@ -1592,7 +1592,7 @@ func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
 	cq.PushOrUpdate(info)
 	cq.handleInadmissibleHash("test-hash", "dummy-reason")
 
-	if _, has := cq.noFitSchedulingHashReasons["test-hash"]; !has {
+	if _, has := cq.hashToBulkMoveReason["test-hash"]; !has {
 		t.Fatal("hash should be recorded before clearing")
 	}
 
@@ -1600,8 +1600,8 @@ func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
 		wl, utiltesting.MakeNamespace(defaultNamespace),
 	))
 
-	if _, has := cq.noFitSchedulingHashReasons["test-hash"]; has {
-		t.Error("noFitSchedulingHashReasons should be cleared after queueInadmissibleWorkloads")
+	if _, has := cq.hashToBulkMoveReason["test-hash"]; has {
+		t.Error("hashToBulkMoveReason should be cleared after queueInadmissibleWorkloads")
 	}
 
 	active, inadmissible := cq.Pending()
@@ -1656,9 +1656,9 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 			info.SchedulingHash = "test-hash-abc"
 			cq.RequeueIfNotPresent(ctx, info, tc.reason, "WaitingForQuota")
 
-			_, gotHash := cq.noFitSchedulingHashReasons["test-hash-abc"]
+			_, gotHash := cq.hashToBulkMoveReason["test-hash-abc"]
 			if gotHash != tc.wantHash {
-				t.Errorf("noFitSchedulingHashReasons.Has(hash) = %v, want %v", gotHash, tc.wantHash)
+				t.Errorf("hashToBulkMoveReason.Has(hash) = %v, want %v", gotHash, tc.wantHash)
 			}
 		})
 	}
@@ -1731,7 +1731,7 @@ func TestGetNoFitReason(t *testing.T) {
 				cq.rwm.Unlock()
 			}
 
-			reason, ok := cq.GetNoFitReason(wlKey, info.SchedulingHash)
+			reason, ok := cq.GetNoFitReason(wlKey)
 			if ok != tc.wantOk {
 				t.Errorf("GetNoFitReason() ok = %v, want %v", ok, tc.wantOk)
 			}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1722,7 +1722,7 @@ func TestGetNoFitReason(t *testing.T) {
 			info := workload.NewInfo(wl)
 			info.SchedulingHash = "test-hash"
 
-			cq.RequeueIfNotPresent(ctx, info, tc.requeueReason, tc.conditionReason)
+			cq.RequeueIfNotPresent(ctx, info, tc.requeueReason, QuotaReservedReason(tc.conditionReason))
 
 			wlKey := workload.Key(wl)
 			if tc.deleteFromInadmissible {

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -288,7 +288,7 @@ func TestPushOrUpdateGenerationChanged(t *testing.T) {
 			// Simulate RequeueWorkload with info.Update: inadmissible entry gets new generation.
 			updatedInfo := workload.NewInfo(tc.updatedWorkload)
 			updatedInfo.LastEvaluatedGeneration = head.LastEvaluatedGeneration
-			cq.requeueIfNotPresent(log, updatedInfo, false, RequeueReasonGeneric)
+			cq.requeueIfNotPresent(log, updatedInfo, false, RequeueReasonGeneric, "")
 
 			// PushOrUpdate from informer event with the updated workload.
 			cq.PushOrUpdate(workload.NewInfo(tc.updatedWorkload))
@@ -400,7 +400,7 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 				cq.PushOrUpdate(workload.NewInfo(w))
 			}
 			for _, w := range tc.inadmissibleWorkloads {
-				cq.requeueIfNotPresent(log, workload.NewInfo(w), false, RequeueReasonGeneric)
+				cq.requeueIfNotPresent(log, workload.NewInfo(w), false, RequeueReasonGeneric, "")
 			}
 
 			firstSnap := cq.Snapshot()
@@ -517,7 +517,7 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 				return
 			default:
 				for _, wl := range wls {
-					cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonPendingPreemption)
+					cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonPendingPreemption, "")
 				}
 			}
 		}
@@ -555,7 +555,7 @@ func TestPendingResources(t *testing.T) {
 
 	cq.PushOrUpdate(wl1)
 	cq.PushOrUpdate(wl3)
-	cq.requeueIfNotPresent(log, wl2, false, RequeueReasonGeneric)
+	cq.requeueIfNotPresent(log, wl2, false, RequeueReasonGeneric, "")
 
 	// Pop wl1 or wl3 to make it inflight (heap pops in creation order).
 	inflight := cq.Pop()
@@ -643,7 +643,7 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 
 	for _, w := range inadmissibleWorkloads {
 		wInfo := workload.NewInfo(w)
-		cq.requeueIfNotPresent(log, wInfo, false, RequeueReasonGeneric)
+		cq.requeueIfNotPresent(log, wInfo, false, RequeueReasonGeneric, "")
 		qImpl.AddOrUpdate(wInfo)
 	}
 
@@ -830,10 +830,10 @@ func TestClusterQueueImpl(t *testing.T) {
 			}
 
 			for _, w := range test.inadmissibleWorkloadsToRequeue {
-				cq.requeueIfNotPresent(log, w, false, RequeueReasonGeneric)
+				cq.requeueIfNotPresent(log, w, false, RequeueReasonGeneric, "")
 			}
 			for _, w := range test.admissibleWorkloadsToRequeue {
-				cq.requeueIfNotPresent(log, w, true, RequeueReasonGeneric)
+				cq.requeueIfNotPresent(log, w, true, RequeueReasonGeneric, "")
 			}
 
 			for _, w := range test.workloadsToUpdate {
@@ -880,7 +880,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	// Simulate requeuing during scheduling attempt.
 	head := cq.Pop()
 	queueInadmissibleWorkloads(ctx, cq, cl)
-	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric)
+	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric, "")
 
 	activeWorkloads, _ = cq.Dump()
 	wantActiveWorkloads = []workload.Reference{workload.Key(wl)}
@@ -890,7 +890,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 
 	// Simulating scheduling again without requeuing.
 	head = cq.Pop()
-	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric)
+	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric, "")
 	activeWorkloads, _ = cq.Dump()
 	wantActiveWorkloads = nil
 	if diff := cmp.Diff(wantActiveWorkloads, activeWorkloads, cmpDump...); diff != "" {
@@ -1035,7 +1035,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(wl)
 			info.LastAssignment = tc.lastAssignment
-			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason); !ok {
+			if ok := cq.RequeueIfNotPresent(ctx, info, tc.reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -1049,7 +1049,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Unexpected sticky status (-want,+got):\n%s", diff)
 			}
 
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), tc.reason); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), tc.reason, ""); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -1269,7 +1269,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
 				nil, nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason); !ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
@@ -1278,7 +1278,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				t.Errorf("Got inadmissible after requeue %t, want %t", gotInadmissible, test.wantInadmissible)
 			}
 
-			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason); ok {
+			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason, ""); ok {
 				t.Error("Re-queued a workload that was already present")
 			}
 		})
@@ -1516,7 +1516,7 @@ func TestRecordInadmissibleHash(t *testing.T) {
 				i++
 			}
 
-			moved := cq.handleInadmissibleHash(tc.hashToRecord)
+			moved := cq.handleInadmissibleHash(tc.hashToRecord, "dummy-reason")
 			if moved != tc.wantMoved {
 				t.Errorf("handleInadmissibleHash moved %d, want %d", moved, tc.wantMoved)
 			}
@@ -1559,7 +1559,7 @@ func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 			cq.queueingStrategy = kueue.BestEffortFIFO
 
 			for _, h := range tc.noFitSchedulingHashes {
-				cq.noFitSchedulingHashes.Insert(h)
+				cq.noFitSchedulingHashReasons[h] = "dummy-reason"
 			}
 
 			wl := utiltestingapi.MakeWorkload("wl", defaultNamespace).
@@ -1590,9 +1590,9 @@ func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
 	info := workload.NewInfo(wl)
 	info.SchedulingHash = "test-hash"
 	cq.PushOrUpdate(info)
-	cq.handleInadmissibleHash("test-hash")
+	cq.handleInadmissibleHash("test-hash", "dummy-reason")
 
-	if !cq.noFitSchedulingHashes.Has("test-hash") {
+	if _, has := cq.noFitSchedulingHashReasons["test-hash"]; !has {
 		t.Fatal("hash should be recorded before clearing")
 	}
 
@@ -1600,8 +1600,8 @@ func TestQueueInadmissibleWorkloadsClearsHashes(t *testing.T) {
 		wl, utiltesting.MakeNamespace(defaultNamespace),
 	))
 
-	if cq.noFitSchedulingHashes.Has("test-hash") {
-		t.Error("noFitSchedulingHashes should be cleared after queueInadmissibleWorkloads")
+	if _, has := cq.noFitSchedulingHashReasons["test-hash"]; has {
+		t.Error("noFitSchedulingHashReasons should be cleared after queueInadmissibleWorkloads")
 	}
 
 	active, inadmissible := cq.Pending()
@@ -1654,11 +1654,89 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 				Request(corev1.ResourceCPU, "1").Obj()
 			info := workload.NewInfo(wl)
 			info.SchedulingHash = "test-hash-abc"
-			cq.RequeueIfNotPresent(ctx, info, tc.reason)
+			cq.RequeueIfNotPresent(ctx, info, tc.reason, "WaitingForQuota")
 
-			gotHash := cq.noFitSchedulingHashes.Has("test-hash-abc")
+			_, gotHash := cq.noFitSchedulingHashReasons["test-hash-abc"]
 			if gotHash != tc.wantHash {
-				t.Errorf("noFitSchedulingHashes.Has(hash) = %v, want %v", gotHash, tc.wantHash)
+				t.Errorf("noFitSchedulingHashReasons.Has(hash) = %v, want %v", gotHash, tc.wantHash)
+			}
+		})
+	}
+}
+
+func TestGetNoFitReason(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.SchedulingEquivalenceHashing, true)
+	cases := map[string]struct {
+		conditionReason        string
+		requeueReason          RequeueReason
+		deleteFromInadmissible bool
+		wantReason             string
+		wantOk                 bool
+	}{
+		"records status reason when requeued as NoFit": {
+			conditionReason: kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+			requeueReason:   RequeueReasonNoFit,
+			wantReason:      kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+			wantOk:          true,
+		},
+		"records status reason when requeued as PreemptionNoCandidates": {
+			conditionReason: kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+			requeueReason:   RequeueReasonPreemptionNoCandidates,
+			wantReason:      kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+			wantOk:          true,
+		},
+		"falls back to PendingEvaluation if no status condition is present": {
+			conditionReason: "",
+			requeueReason:   RequeueReasonNoFit,
+			wantReason:      kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+			wantOk:          true,
+		},
+		"returns false if workload is not in inadmissibleWorkloads": {
+			conditionReason:        kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+			requeueReason:          RequeueReasonNoFit,
+			deleteFromInadmissible: true,
+			wantOk:                 false,
+		},
+		"returns false if requeued with non-capacity reason": {
+			conditionReason: kueue.WorkloadQuotaReservedReasonExceedsMaxQuota,
+			requeueReason:   RequeueReasonNamespaceMismatch,
+			wantOk:          false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
+			cq.queueingStrategy = kueue.BestEffortFIFO
+
+			wlBuilder := utiltestingapi.MakeWorkload("wl", defaultNamespace)
+			if tc.conditionReason != "" {
+				wlBuilder.Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  tc.conditionReason,
+					Message: "failed",
+				})
+			}
+			wl := wlBuilder.Obj()
+			info := workload.NewInfo(wl)
+			info.SchedulingHash = "test-hash"
+
+			cq.RequeueIfNotPresent(ctx, info, tc.requeueReason, tc.conditionReason)
+
+			wlKey := workload.Key(wl)
+			if tc.deleteFromInadmissible {
+				cq.rwm.Lock()
+				cq.inadmissibleWorkloads.delete(wlKey)
+				cq.rwm.Unlock()
+			}
+
+			reason, ok := cq.GetNoFitReason(wlKey, info.SchedulingHash)
+			if ok != tc.wantOk {
+				t.Errorf("GetNoFitReason() ok = %v, want %v", ok, tc.wantOk)
+			}
+			if ok && reason != tc.wantReason {
+				t.Errorf("GetNoFitReason() reason = %q, want %q", reason, tc.wantReason)
 			}
 		})
 	}

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -170,8 +170,8 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	defer c.rwm.Unlock()
 	log := ctrl.LoggerFrom(ctx)
 	c.queueInadmissibleCycle = c.popCycle
-	// Clear NoFit scheduling hashes so re-queued workloads are re-evaluated fresh.
-	c.noFitSchedulingHashReasons = make(map[string]string)
+	// Clear bulk-move scheduling hashes so re-queued workloads are re-evaluated fresh.
+	c.hashToBulkMoveReason = make(map[string]string)
 	if c.inadmissibleWorkloads.empty() {
 		return 0
 	}

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -171,7 +171,7 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	log := ctrl.LoggerFrom(ctx)
 	c.queueInadmissibleCycle = c.popCycle
 	// Clear NoFit scheduling hashes so re-queued workloads are re-evaluated fresh.
-	c.noFitSchedulingHashes = sets.New[string]()
+	c.noFitSchedulingHashReasons = make(map[string]string)
 	if c.inadmissibleWorkloads.empty() {
 		return 0
 	}

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -171,7 +171,7 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	log := ctrl.LoggerFrom(ctx)
 	c.queueInadmissibleCycle = c.popCycle
 	// Clear bulk-move scheduling hashes so re-queued workloads are re-evaluated fresh.
-	c.hashToBulkMoveReason = make(map[string]string)
+	c.hashToBulkMoveReason = make(map[string]QuotaReservedReason)
 	if c.inadmissibleWorkloads.empty() {
 		return 0
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -385,7 +385,7 @@ func (m *Manager) IsConcurrentAdmissionParentWithoutLock(wl *kueue.Workload) boo
 	if !features.Enabled(features.ConcurrentAdmission) {
 		return false
 	}
-	cqName, _ := m.ClusterQueueForWorkloadWithoutLock(wl)
+	cqName, _ := m.ClusterQueueNameForWorkloadWithoutLock(wl)
 	return m.ConcurrentAdmissionEnabledWithoutLock(cqName) && !concurrentadmission.IsVariant(wl)
 }
 
@@ -612,10 +612,10 @@ func (m *Manager) QueueForWorkloadExists(wl *kueue.Workload) bool {
 func (m *Manager) ClusterQueueForWorkload(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	return m.ClusterQueueForWorkloadWithoutLock(wl)
+	return m.ClusterQueueNameForWorkloadWithoutLock(wl)
 }
 
-func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
+func (m *Manager) ClusterQueueNameForWorkloadWithoutLock(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
 	q, ok := m.localQueues[queue.KeyFromWorkload(wl)]
 	if !ok {
 		return "", false
@@ -624,20 +624,25 @@ func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) (kueue.
 	return q.ClusterQueue, ok
 }
 
+// ClusterQueueForWorkloadWithoutLock returns the ClusterQueue where the
+// workload should be queued, or nil if it doesn't exist.
+func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) *ClusterQueue {
+	q, ok := m.localQueues[queue.KeyFromWorkload(wl)]
+	if !ok {
+		return nil
+	}
+	return m.hm.ClusterQueue(q.ClusterQueue)
+}
+
 func (m *Manager) GetNoFitReason(wl *kueue.Workload) (string, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	cqName, ok := m.ClusterQueueForWorkloadWithoutLock(wl)
-	if !ok {
-		return "", false
-	}
-	cq := m.hm.ClusterQueue(cqName)
+	cq := m.ClusterQueueForWorkloadWithoutLock(wl)
 	if cq == nil {
 		return "", false
 	}
 	wlKey := workload.Key(wl)
-	reason, ok := cq.GetNoFitReason(wlKey)
-	return reason, ok
+	return cq.GetNoFitReason(wlKey)
 }
 
 // AddOrUpdateWorkload adds or updates workload to the corresponding queue.
@@ -692,7 +697,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 // The quotaReservedReason parameter represents the WorkloadQuotaReserved condition reason
 // computed by the scheduler during this cycle. It must be passed explicitly because info.Obj
 // has not yet been patched with the updated condition when RequeueWorkload is called.
-func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, quotaReservedReason string) bool {
+func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, quotaReservedReason QuotaReservedReason) bool {
 	m.Lock()
 	defer m.Unlock()
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -624,6 +624,27 @@ func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) (kueue.
 	return q.ClusterQueue, ok
 }
 
+func (m *Manager) GetNoFitReason(wl *kueue.Workload) (string, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	wlKey := workload.Key(wl)
+	qKey, ok := m.workloadAssignedQueues[wlKey]
+	if !ok {
+		return "", false
+	}
+	q := m.localQueues[qKey]
+	if q == nil {
+		return "", false
+	}
+	cq := m.hm.ClusterQueue(q.ClusterQueue)
+	if cq == nil {
+		return "", false
+	}
+	wInfo := workload.NewInfo(wl, m.workloadInfoOptions...)
+	reason, ok := cq.GetNoFitReason(wlKey, wInfo.SchedulingHash)
+	return reason, ok
+}
+
 // AddOrUpdateWorkload adds or updates workload to the corresponding queue.
 // Returns whether the queue existed.
 func (m *Manager) AddOrUpdateWorkload(log logr.Logger, w *kueue.Workload, opts ...workload.InfoOption) error {
@@ -673,7 +694,7 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 // RequeueWorkload requeues the workload ensuring that the queue and the
 // workload still exist in the client cache and not admitted. It won't
 // requeue if the workload is already in the queue (possible if the workload was updated).
-func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason) bool {
+func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, statusReason string) bool {
 	m.Lock()
 	defer m.Unlock()
 
@@ -706,7 +727,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 
-	added := cq.RequeueIfNotPresent(ctx, info, reason)
+	added := cq.RequeueIfNotPresent(ctx, info, reason, statusReason)
 	reportCQPendingWorkloads(m, cq)
 	reportLQPendingWorkloads(m, q)
 	if added {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -627,21 +627,16 @@ func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) (kueue.
 func (m *Manager) GetNoFitReason(wl *kueue.Workload) (string, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	wlKey := workload.Key(wl)
-	qKey, ok := m.workloadAssignedQueues[wlKey]
+	cqName, ok := m.ClusterQueueForWorkload(wl)
 	if !ok {
 		return "", false
 	}
-	q := m.localQueues[qKey]
-	if q == nil {
-		return "", false
-	}
-	cq := m.hm.ClusterQueue(q.ClusterQueue)
+	cq := m.hm.ClusterQueue(cqName)
 	if cq == nil {
 		return "", false
 	}
-	wInfo := workload.NewInfo(wl, m.workloadInfoOptions...)
-	reason, ok := cq.GetNoFitReason(wlKey, wInfo.SchedulingHash)
+	wlKey := workload.Key(wl)
+	reason, ok := cq.GetNoFitReason(wlKey)
 	return reason, ok
 }
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -689,7 +689,10 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 // RequeueWorkload requeues the workload ensuring that the queue and the
 // workload still exist in the client cache and not admitted. It won't
 // requeue if the workload is already in the queue (possible if the workload was updated).
-func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, statusReason string) bool {
+// The quotaReservedReason parameter represents the WorkloadQuotaReserved condition reason
+// computed by the scheduler during this cycle. It must be passed explicitly because info.Obj
+// has not yet been patched with the updated condition when RequeueWorkload is called.
+func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reason RequeueReason, quotaReservedReason string) bool {
 	m.Lock()
 	defer m.Unlock()
 
@@ -722,7 +725,7 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 
-	added := cq.RequeueIfNotPresent(ctx, info, reason, statusReason)
+	added := cq.RequeueIfNotPresent(ctx, info, reason, quotaReservedReason)
 	reportCQPendingWorkloads(m, cq)
 	reportLQPendingWorkloads(m, q)
 	if added {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -627,7 +627,7 @@ func (m *Manager) ClusterQueueForWorkloadWithoutLock(wl *kueue.Workload) (kueue.
 func (m *Manager) GetNoFitReason(wl *kueue.Workload) (string, bool) {
 	m.RLock()
 	defer m.RUnlock()
-	cqName, ok := m.ClusterQueueForWorkload(wl)
+	cqName, ok := m.ClusterQueueForWorkloadWithoutLock(wl)
 	if !ok {
 		return "", false
 	}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -239,7 +239,7 @@ func TestUpdateClusterQueue(t *testing.T) {
 		if err := cl.Create(ctx, w); err != nil {
 			t.Fatalf("Failed adding workload to client: %v", err)
 		}
-		manager.RequeueWorkload(ctx, workload.NewInfo(w), RequeueReasonGeneric)
+		manager.RequeueWorkload(ctx, workload.NewInfo(w), RequeueReasonGeneric, "")
 	}
 
 	// Verify that all workloads are marked as inadmissible after creation.
@@ -318,7 +318,7 @@ func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
 	if err := fakeClient.Create(ctx, wl); err != nil {
 		t.Fatalf("Failed adding workload to client: %v", err)
 	}
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
 	manager.ResyncClusterQueueGaugeMetrics("cq1")
 
 	expectPending := func(team string, count int) {
@@ -386,7 +386,7 @@ func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
 	if err := fakeClient.Create(ctx, wl); err != nil {
 		t.Fatalf("Failed adding workload to client: %v", err)
 	}
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
 	manager.ResyncLocalQueueGaugeMetrics(queue.Key(lq))
 
 	expectPending := func(team string, count int) {
@@ -566,7 +566,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	}
 	// This test will pass with the removal of this line.
 	// Update once we find a solution to #3066.
-	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
 
 	// This method is where we do a cycle check. We call it to ensure
 	// it behaves properly when a cycle exists
@@ -719,7 +719,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 				if err := cl.Create(ctx, wl); err != nil {
 					t.Fatalf("Failed adding workload to client: %v", err)
 				}
-				manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric)
+				manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
 			}
 
 			// Reset the counter before testing. Setup operations also trigger the log.
@@ -1308,7 +1308,7 @@ func TestRequeueWorkloadStrictFIFO(t *testing.T) {
 				_ = manager.AddOrUpdateWorkload(log, tc.workload)
 			}
 			info := workload.NewInfo(tc.workload)
-			if requeued := manager.RequeueWorkload(ctx, info, RequeueReasonGeneric); requeued != tc.wantRequeued {
+			if requeued := manager.RequeueWorkload(ctx, info, RequeueReasonGeneric, ""); requeued != tc.wantRequeued {
 				t.Errorf("RequeueWorkload returned %t, want %t", requeued, tc.wantRequeued)
 			}
 		})
@@ -1787,7 +1787,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []workload.Info{
@@ -1815,7 +1815,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []workload.Info{
@@ -1847,7 +1847,7 @@ func TestHeadsAsync(t *testing.T) {
 				// Remove the initial workload from the manager.
 				mgr.Heads(ctx)
 				wg.Go(func() {
-					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination)
+					mgr.RequeueWorkload(ctx, workload.NewInfo(&wl), RequeueReasonFailedAfterNomination, "")
 				})
 			},
 			wantHeads: []workload.Info{

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1879,6 +1879,15 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		return kueue.WorkloadQuotaReservedReasonMisconfigured, admissibilityErr.Error(), nil //nolint:nilerr // admissibility validation failure does not require retry
 	case workload.HasAdmissionGate(wl):
 		return kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation]), nil
+	}
+
+	if features.Enabled(features.SchedulingEquivalenceHashing) && isPendingSchedulingOrStale(cond) {
+		if reason, ok := r.queues.GetNoFitReason(wl); ok {
+			return reason, "Bypassed scheduling evaluation because an equivalent workload recently failed", nil
+		}
+	}
+
+	switch {
 	case cond != nil && cond.Reason != "" && schedulerSetReasons.Has(cond.Reason):
 		// Preserve scheduler feedback reasons until the next scheduler cycle.
 		return cond.Reason, cond.Message, nil
@@ -1922,5 +1931,36 @@ func (r *WorkloadReconciler) getQueueBlocker(wl *kueue.Workload, lqExists, lqAct
 		return kueue.WorkloadQuotaReservedReasonSuspended, fmt.Sprintf("ClusterQueue %s is inactive", cq.Name)
 	default:
 		return "", ""
+	}
+}
+
+// isPendingSchedulingOrStale returns true if the workload is pending scheduling
+// or has a status reason that doesn't contain scheduler diagnostics.
+func isPendingSchedulingOrStale(cond *metav1.Condition) bool {
+	// A workload with no condition or no reason set is fresh and has never
+	// been evaluated by the scheduler.
+	if cond == nil || cond.Reason == "" {
+		return true
+	}
+	// We only query the equivalence cache for workloads that are pending scheduling
+	// or transitioning back to the queue (stale states).
+	// We explicitly exclude:
+	// - Statically blocked states (Misconfigured, AdmissionGated): We want to keep
+	//   these blocking reasons visible instead of hiding them behind a bypassed message.
+	// - Scheduler diagnostics (WaitingForQuota, etc.): We want to preserve the
+	//   detailed resource breakdown messages set by the scheduler.
+	//
+	// This leaves only:
+	// - PendingEvaluation / Pending (legacy): The workload is actively in the queue waiting for scheduler.
+	// - Deactivated / Suspended: The workload was blocked but is now transitioning
+	//   back to active scheduling (the previous block is resolved, so we check the cache).
+	switch cond.Reason {
+	case kueue.WorkloadDeactivated,
+		kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+		kueue.WorkloadQuotaReservedReasonSuspended,
+		kueue.WorkloadPending: //nolint:staticcheck // SA1019: legacy reason
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1881,7 +1881,7 @@ func (r *WorkloadReconciler) resolveGranularUnadmittedQuotaReservedCondition(
 		return kueue.WorkloadAdmissionGated, fmt.Sprintf("Admission is gated by: %s", wl.Annotations[constants.AdmissionGatedByAnnotation]), nil
 	}
 
-	if features.Enabled(features.SchedulingEquivalenceHashing) && isPendingSchedulingOrStale(cond) {
+	if shouldCheckEquivalenceHash(cond) {
 		if reason, ok := r.queues.GetNoFitReason(wl); ok {
 			return reason, "Bypassed scheduling evaluation because an equivalent workload recently failed", nil
 		}
@@ -1934,12 +1934,18 @@ func (r *WorkloadReconciler) getQueueBlocker(wl *kueue.Workload, lqExists, lqAct
 	}
 }
 
-// isPendingSchedulingOrStale returns true if the workload is pending scheduling
-// or has a status reason that doesn't contain scheduler diagnostics.
-func isPendingSchedulingOrStale(cond *metav1.Condition) bool {
-	// A workload with no condition or no reason set is fresh and has never
-	// been evaluated by the scheduler.
-	if cond == nil || cond.Reason == "" {
+// shouldCheckEquivalenceHash returns true if the workload is eligible to be
+// checked against the scheduling equivalence cache.
+func shouldCheckEquivalenceHash(cond *metav1.Condition) bool {
+	if !features.Enabled(features.SchedulingEquivalenceHashing) {
+		return false
+	}
+	// For newly created workloads (cond == nil), checking the equivalence cache
+	// on creation is gated by UnadmittedWorkloadsExplicitStatus.
+	if cond == nil {
+		return features.Enabled(features.UnadmittedWorkloadsExplicitStatus)
+	}
+	if cond.Reason == "" {
 		return true
 	}
 	// We only query the equivalence cache for workloads that are pending scheduling

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -55,6 +55,7 @@ import (
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -431,7 +432,7 @@ type reconcileTestCase struct {
 	wantEvents                []utiltesting.EventRecord
 	wantResult                reconcile.Result
 	reconcilerOpts            []Option
-	beforeReconcile           func(context.Context, client.Client)
+	beforeReconcile           func(context.Context, client.Client, *qcache.Manager)
 }
 
 func TestUpdateSkipsRequeueForOnHoldWorkload(t *testing.T) {
@@ -1429,7 +1430,7 @@ func TestReconcile(t *testing.T) {
 				Obj(),
 			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
-			beforeReconcile: func(ctx context.Context, cl client.Client) {
+			beforeReconcile: func(ctx context.Context, cl client.Client, _ *qcache.Manager) {
 				cq := &kueue.ClusterQueue{}
 				if err := cl.Get(ctx, types.NamespacedName{Name: "cq"}, cq); err != nil {
 					panic(err)
@@ -1500,6 +1501,126 @@ func TestReconcile(t *testing.T) {
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").
+				Obj(),
+		},
+		"reconcile bypassed workload when SchedulingEquivalenceHashing is enabled (stale status -> bypassed status)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:      true,
+				features.UnadmittedWorkloadsObservability:  true,
+				features.UnadmittedWorkloadsExplicitStatus: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			beforeReconcile: func(ctx context.Context, cl client.Client, qManager *qcache.Manager) {
+				wl := &kueue.Workload{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: "wl", Namespace: "ns"}, wl); err != nil {
+					panic(err)
+				}
+				qManager.Heads(ctx) // Pop from active heap
+				wInfo := workload.NewInfo(wl)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+					Message: "Bypassed scheduling evaluation because an equivalent workload recently failed",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"reconcile bypassed workload when SchedulingEquivalenceHashing is enabled (keep detailed scheduler message)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:      true,
+				features.UnadmittedWorkloadsObservability:  true,
+				features.UnadmittedWorkloadsExplicitStatus: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+					Message: "insufficient CPU in ClusterQueue cq",
+				}).
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			beforeReconcile: func(ctx context.Context, cl client.Client, qManager *qcache.Manager) {
+				wl := &kueue.Workload{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: "wl", Namespace: "ns"}, wl); err != nil {
+					panic(err)
+				}
+				qManager.Heads(ctx) // Pop from active heap
+				wInfo := workload.NewInfo(wl)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+					Message: "insufficient CPU in ClusterQueue cq",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Obj(),
+		},
+		"reconcile bypassed workload when SchedulingEquivalenceHashing is disabled (stale status remains pending)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:      false,
+				features.UnadmittedWorkloadsObservability:  true,
+				features.UnadmittedWorkloadsExplicitStatus: true,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			beforeReconcile: func(ctx context.Context, cl client.Client, qManager *qcache.Manager) {
+				wl := &kueue.Workload{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: "wl", Namespace: "ns"}, wl); err != nil {
+					panic(err)
+				}
+				qManager.Heads(ctx) // Pop from active heap
+				wInfo := workload.NewInfo(wl)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
 				Obj(),
 		},
 	}
@@ -1661,7 +1782,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 				}
 
 				if tc.beforeReconcile != nil {
-					tc.beforeReconcile(ctx, cl)
+					tc.beforeReconcile(ctx, cl, qManager)
 				}
 
 				gotResult, gotError := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(testWl)})

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1541,6 +1541,32 @@ func TestReconcile(t *testing.T) {
 				}).
 				Obj(),
 		},
+		"reconcile bypassed workload when SchedulingEquivalenceHashing is enabled and UnadmittedWorkloadsExplicitStatus is disabled (no status stamped on creation)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulingEquivalenceHashing:      true,
+				features.UnadmittedWorkloadsObservability:  true,
+				features.UnadmittedWorkloadsExplicitStatus: false,
+			},
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			beforeReconcile: func(ctx context.Context, cl client.Client, qManager *qcache.Manager) {
+				wl := &kueue.Workload{}
+				if err := cl.Get(ctx, types.NamespacedName{Name: "wl", Namespace: "ns"}, wl); err != nil {
+					panic(err)
+				}
+				qManager.Heads(ctx) // Pop from active heap
+				wInfo := workload.NewInfo(wl)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+			},
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+		},
 		"reconcile bypassed workload when SchedulingEquivalenceHashing is enabled (keep detailed scheduler message)": {
 			featureGates: map[featuregate.Feature]bool{
 				features.SchedulingEquivalenceHashing:      true,

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1522,7 +1522,7 @@ func TestReconcile(t *testing.T) {
 				}
 				qManager.Heads(ctx) // Pop from active heap
 				wInfo := workload.NewInfo(wl)
-				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").
@@ -1560,7 +1560,7 @@ func TestReconcile(t *testing.T) {
 				}
 				qManager.Heads(ctx) // Pop from active heap
 				wInfo := workload.NewInfo(wl)
-				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").
@@ -1592,7 +1592,7 @@ func TestReconcile(t *testing.T) {
 				}
 				qManager.Heads(ctx) // Pop from active heap
 				wInfo := workload.NewInfo(wl)
-				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").
@@ -1630,7 +1630,7 @@ func TestReconcile(t *testing.T) {
 				}
 				qManager.Heads(ctx) // Pop from active heap
 				wInfo := workload.NewInfo(wl)
-				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, kueue.WorkloadQuotaReservedReasonWaitingForQuota)
+				qManager.RequeueWorkload(ctx, wInfo, qcache.RequeueReasonNoFit, qcache.QuotaReservedReasonWaitingForQuota)
 			},
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Queue("lq").

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1020,7 +1020,7 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 		return
 	}
 
-	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason, e.quotaReservedReason)
+	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason, qcache.QuotaReservedReason(e.quotaReservedReason))
 	log.V(2).
 		Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName)), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 	if e.status == notNominated || e.status == skipped || e.status == preemptionGated {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1020,7 +1020,7 @@ func (s *Scheduler) requeueAndUpdate(ctx context.Context, e entry) {
 		return
 	}
 
-	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason)
+	added := s.queues.RequeueWorkload(ctx, &e.Info, e.requeueReason, e.quotaReservedReason)
 	log.V(2).
 		Info("Workload re-queued", "workload", klog.KObj(e.Obj), "clusterQueue", klog.KRef("", string(e.ClusterQueue)), "queue", klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName)), "requeueReason", e.requeueReason, "added", added, "status", e.status)
 	if e.status == notNominated || e.status == skipped || e.status == preemptionGated {

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1199,16 +1199,25 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 
 			ginkgo.By("reactivating the workload and making the LocalQueue active again (should transition back to WaitingForQuota)")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
-				updatedWl.Spec.Active = new(true)
-				g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
+				var fetchedLq kueue.LocalQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
+				fetchedLq.Spec.StopPolicy = ptr.To(kueue.None)
+				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				var fetchedLq kueue.LocalQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
-				fetchedLq.Spec.StopPolicy = ptr.To(kueue.None)
-				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(fetchedLq.Status.Conditions, kueue.LocalQueueActive)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(gomega.Equal("Ready"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wl2Key, &updatedWl)).To(gomega.Succeed())
+				updatedWl.Spec.Active = new(true)
+				g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -995,6 +996,72 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				delete(createdWorkload.Annotations, constants.AdmissionGatedByAnnotation)
 				g.Expect(k8sClient.Update(ctx, createdWorkload)).Should(gomega.Succeed())
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, createdWorkload)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("SchedulingEquivalenceHashing, UnadmittedWorkloadsObservability, and UnadmittedWorkloadsExplicitStatus are enabled", func() {
+		var (
+			flavor       *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.SchedulingEquivalenceHashing, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsObservability, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.UnadmittedWorkloadsExplicitStatus, true)
+
+			flavor = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, flavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).Resource(corev1.ResourceCPU, "1").Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		})
+
+		ginkgo.It("Should set bypassed status message when equivalent workload fails scheduling", func() {
+			ginkgo.By("Creating the first workload that consumes all quota")
+			wl1 := utiltestingapi.MakeWorkload("admitted-wl", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+			ginkgo.By("Creating wl2 and waiting for it to be evaluated and moved to inadmissible")
+			wl2 := utiltestingapi.MakeWorkload("pending-wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+
+			ginkgo.By("Creating wl3 and verifying it receives the bypassed scheduling evaluation status condition")
+			wl3 := utiltestingapi.MakeWorkload("pending-wl3", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl3)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var w3 kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), &w3)).Should(gomega.Succeed())
+				w3Cond := apimeta.FindStatusCondition(w3.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(w3Cond).ToNot(gomega.BeNil())
+				g.Expect(w3Cond.Message).To(gomega.Equal("Bypassed scheduling evaluation because an equivalent workload recently failed"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -1027,6 +1027,7 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
@@ -1061,8 +1062,61 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), &w3)).Should(gomega.Succeed())
 				w3Cond := apimeta.FindStatusCondition(w3.Status.Conditions, kueue.WorkloadQuotaReserved)
 				g.Expect(w3Cond).ToNot(gomega.BeNil())
+				g.Expect(w3Cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonWaitingForQuota))
 				g.Expect(w3Cond.Message).To(gomega.Equal("Bypassed scheduling evaluation because an equivalent workload recently failed"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should preserve existing detailed scheduler condition when equivalent workload fails scheduling", func() {
+			ginkgo.By("Creating the first workload that consumes all quota")
+			wl1 := utiltestingapi.MakeWorkload("admitted-wl", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+			ginkgo.By("Creating a workload with an already-populated detailed WorkloadQuotaReserved condition")
+			detailedMsg := "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 1 more needed"
+			wlPreserved := utiltestingapi.MakeWorkload("preserved-wl", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+					Message: detailedMsg,
+				}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wlPreserved)
+
+			ginkgo.By("Creating wl2 and waiting for it to be evaluated and moved to inadmissible")
+			wl2 := utiltestingapi.MakeWorkload("pending-wl2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 2)
+
+			ginkgo.By("Triggering a reconcile on the preserved workload and verifying its detailed condition is not overwritten")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var w kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlPreserved), &w)).Should(gomega.Succeed())
+				if w.Annotations == nil {
+					w.Annotations = make(map[string]string)
+				}
+				w.Annotations["trigger"] = "reconcile"
+				g.Expect(k8sClient.Update(ctx, &w)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Consistently(func(g gomega.Gomega) {
+				var w kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlPreserved), &w)).Should(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(w.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).ToNot(gomega.BeNil())
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonWaitingForQuota))
+				g.Expect(cond.Message).To(gomega.Equal(detailedMsg))
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This PR improves visibility for workloads that are bypassed during scheduling evaluation because an equivalent workload recently failed (when the `SchedulingEquivalenceHashing` feature gate is enabled).

Before this change, bypassed workloads would remain in the `PendingEvaluation` reason (or have no condition), hiding the actual reason why they couldn't be scheduled.

This PR propagates the granular failure reason (e.g., `WaitingForQuota`, `NoMatchingFlavor`) from the queue manager's equivalence cache to the workload's `QuotaReserved` condition. The condition message is updated to `"Bypassed scheduling evaluation because an equivalent workload recently failed"`.

If a workload already has a detailed scheduler-set condition (e.g., listing specific insufficient resources), it is preserved and not overwritten.

#### Which issue(s) this PR fixes:
Fixes #12769

#### Special notes for your reviewer:
1. Renamed `noFitSchedulingHashes` to `noFitSchedulingHashReasons` in `ClusterQueue` to store the string NoFit reason instead of a boolean.
2. Added a helper `isPendingSchedulingOrStale` in the workload controller to identify when it's appropriate to apply the bypassed status (i.e. only when the workload lacks active scheduler diagnostics, to prevent overwriting detailed resource breakdowns).
3. Consolidated the test hook `beforeReconcile` in `workload_controller_test.go` and added comprehensive unit tests covering the bypass logic under different feature gate combinations.

#### Does this PR introduce a user-facing change?
```release-note
Scheduling: Workloads bypassed by the scheduling equivalence cache now receive the granular failure reason (e.g., `WaitingForQuota`) and a bypass message in their `QuotaReserved` condition, improving visibility into why the workload was unadmitted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API to retrieve the stored “no fit”/bypass reason for workloads currently marked inadmissible after an equivalent recent failure.
* **Bug Fixes**
  * Improved tracking and clearing of inadmissible bulk-move reasons to ensure “skip to inadmissible” decisions use the correct, consistent rationale.
  * Extended requeue/scheduling and controller status handling to preserve the full quota-reserved reason through transitions.
* **Tests**
  * Updated unit and integration tests to cover reason lookup, bypass flows, and bulk-move reason reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->