### PR TITLE
Fix race condition in multikueue watcher establishment

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -270,8 +270,15 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 
 	rc.setClient(remoteClient)
 
+	// Mark as connected before starting watchers to avoid a race condition.
+	// If a watcher queues an event and wlReconciler processes it before connecting=false,
+	// the workload will be treated as unavailable and requeued after 15m.
+	rc.connecting.Store(false)
+	rc.disconnected.Store(false)
+
 	err = rc.startWatcher(watchCtx, kueue.SchemeGroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
+		rc.disconnect()
 		return rc.increaseFailedConnAttempt(), err
 	}
 
@@ -286,18 +293,18 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to start the watcher", "kind", kind)
 			// however let's not accept this for now.
+			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 	if features.Enabled(features.MultiKueueManagerQuotaAutomation) {
 		err = rc.startQueueWatchers(watchCtx)
 		if err != nil {
+			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 
-	rc.connecting.Store(false)
-	rc.disconnected.Store(false)
 	rc.resetFailedConnAttempt()
 	return nil, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
When a worker cluster's connection is restored, `updateConfigAndRefreshWatchers` establishes new watchers via `startWatcher()`. This spawns a goroutine that immediately begins queuing `Added` events for remote workloads. Previously, `rc.connecting.Store(false)` was executed at the very end of the function. If the `wlReconciler` processed a queued workload event before `connecting=false` was set, it would incorrectly assume the cluster was still unavailable, skip the deletion of the orphaned remote workload, and requeue for 15 minutes, causing the test's `Eventually` block to time out.

This PR moves `rc.connecting.Store(false)` to execute immediately after setting the client, but before starting the watchers. This guarantees that when the `wlReconciler` processes the watch events, the cluster is correctly evaluated as available and remote workloads are cleaned up immediately.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12801 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed a bug where a remote could be marked connected too late, causing early workload events to be handled incorrectly (as if the remote was unreachable).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-cluster startup handling by marking the remote connection as connected immediately after switching clients, reducing races that could trigger missed or out-of-order events.
  * Added safer recovery when watcher initialization fails: the system now disconnects cleanly before backing off and retrying.
  * Treated adapter and queue watcher startup failures as fatal during setup to prevent watchers from continuing in a partially connected state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->