### PR TITLE
Add Parasail to adopters

### DIFF
--- a/site/data/adopters.yaml
+++ b/site/data/adopters.yaml
@@ -154,3 +154,11 @@
   integrations: []
   contact: '@krea-ai'
   contact_url: https://twitter.com/krea_ai
+- name: Parasail
+  url: https://www.parasail.io/
+  type: End User
+  description: Inference cloud for AI-native startups
+  integrations:
+  - pod
+  contact: '@yakticus'
+  contact_url: https://github.com/yakticus


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds Parasail (GPU inference platform) to the adopters list; we run Kueue with Topology-Aware Scheduling for multi-GPU serving deployments via the pod integration.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new adopter profile for Parasail with website, description, integration support, and contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->