### PR TITLE
[MultiKueue] Simplify worker connection state to a single bool

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/clusterqueue.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue.go
@@ -189,8 +189,8 @@ func (r *cqReconciler) aggregateWorkerQuotas(ctx context.Context, cq *kueue.Clus
 			ctrl.LoggerFrom(ctx).V(3).Info("Worker cluster client not found, skipping it in quota aggregation", "workerCluster", workerName)
 			continue
 		}
-		if rc.connecting.Load() {
-			ctrl.LoggerFrom(ctx).V(3).Info("Worker cluster client still connecting, skipping it in quota aggregation", "workerCluster", workerName)
+		if !rc.connected.Load() {
+			ctrl.LoggerFrom(ctx).V(3).Info("Worker cluster client not connected, skipping it in quota aggregation", "workerCluster", workerName)
 			continue
 		}
 		remoteLQList := &kueue.LocalQueueList{}

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -464,7 +464,7 @@ func TestCQReconcile(t *testing.T) {
 					Build())
 				rc := newRemoteClient(c, nil, nil, nil, defaultOrigin, worker, adapters)
 				rc.client = workerClient
-				rc.connecting.Store(wState.inactive)
+				rc.connected.Store(!wState.inactive)
 				cRec.remoteClients[worker] = rc
 			}
 

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -129,8 +129,7 @@ type remoteClient struct {
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
 
-	connecting           atomic.Bool
-	disconnected         atomic.Bool
+	connected            atomic.Bool
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
@@ -166,7 +165,7 @@ func newRemoteClient(
 		adapters:     adapters,
 		clock:        clock.RealClock{},
 	}
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	return rc
 }
 
@@ -238,9 +237,8 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
-	connecting := rc.connecting.Load()
-	disconnected := rc.disconnected.Load()
-	if !configChanged && !connecting && !disconnected {
+	connected := rc.connected.Load()
+	if !configChanged && connected {
 		return nil, nil
 	}
 
@@ -251,7 +249,7 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		rc.resetFailedConnAttempt()
 	}
 
-	if connecting {
+	if !connected {
 		if untilNextAttempt := rc.getRetryConnNextAttempt().Sub(rc.clock.Now()); untilNextAttempt > 0 {
 			return &untilNextAttempt, nil
 		}
@@ -271,10 +269,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 	rc.setClient(remoteClient)
 
 	// Mark as connected before starting watchers to avoid a race condition.
-	// If a watcher queues an event and wlReconciler processes it before connecting=false,
+	// If a watcher queues an event and wlReconciler processes it before connected=true,
 	// the workload will be treated as unavailable and requeued after 15m.
-	rc.connecting.Store(false)
-	rc.disconnected.Store(false)
+	rc.connected.Store(true)
 
 	err = rc.startWatcher(watchCtx, kueue.SchemeGroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
@@ -395,9 +392,9 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobfram
 		log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
 		// If the context is not yet Done , queue a reconcile to attempt reconnection
 		if ctx.Err() == nil {
-			oldConnecting := rc.connecting.Swap(true)
+			wasConnected := rc.connected.Swap(false)
 			// reconnect if this is the first watch failing.
-			if !oldConnecting {
+			if wasConnected {
 				log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
 				rc.queueWatchEndedEvent(ctx)
 			}
@@ -527,8 +524,7 @@ func (rc *remoteClient) StopWatchers() {
 // is now unreachable, and apply the workerLostTimeout delay before requeuing.
 func (rc *remoteClient) disconnect() {
 	rc.StopWatchers()
-	rc.connecting.Store(true)
-	rc.disconnected.Store(true)
+	rc.connected.Store(false)
 }
 
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
@@ -555,7 +551,7 @@ func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 func (rc *remoteClient) runGC(ctx context.Context) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if rc.connecting.Load() || rc.disconnected.Load() {
+	if !rc.connected.Load() {
 		log.V(5).Info("Skip disconnected client")
 		return
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -99,7 +99,7 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 
 func setReconnectState(rc *remoteClient, a uint) *remoteClient {
 	rc.failedConnAttempts = a
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	return rc
 }
 
@@ -910,7 +910,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 
 	rc := newTestClient(ctx, []byte(kubeconfig), nil, nil)
 	rc.builderOverride = reconciler.builderOverride
-	rc.disconnected.Store(true)
+	rc.connected.Store(false)
 	reconciler.remoteClients["worker1"] = rc
 	defer rc.StopWatchers()
 
@@ -921,11 +921,8 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	if buildCalls != 1 {
 		t.Fatalf("builder invocations: want 1, got %d", buildCalls)
 	}
-	if rc.connecting.Load() {
-		t.Error("connecting should be cleared after successful reconnect")
-	}
-	if rc.disconnected.Load() {
-		t.Error("disconnected should be cleared after successful reconnect")
+	if connected := rc.connected.Load(); !connected {
+		t.Errorf("expected state to be connected")
 	}
 }
 
@@ -1038,7 +1035,7 @@ func TestRemoteClientGC(t *testing.T) {
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 			w1remoteClient.client = worker1Client
-			w1remoteClient.connecting.Store(false)
+			w1remoteClient.connected.Store(true)
 
 			w1remoteClient.runGC(ctx)
 
@@ -1551,7 +1548,7 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 	rc.adapters = map[string]jobframework.MultiKueueAdapter{}
 
 	// Seed an initial client so the first read has a client to observe.
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	if _, err := rc.updateConfigAndRefreshWatchers(ctx, rc.config); err != nil {
 		t.Fatalf("seeding initial client: %v", err)
 	}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -284,7 +284,7 @@ func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.Admi
 	}
 	availableClients = make(map[string]*remoteClient, len(cfg.Spec.Clusters))
 	for _, clusterName := range cfg.Spec.Clusters {
-		if client, found := w.clusters.controllerFor(clusterName); found && !client.connecting.Load() && !client.disconnected.Load() {
+		if client, found := w.clusters.controllerFor(clusterName); found && client.connected.Load() {
 			availableClients[clusterName] = client
 		} else {
 			unavailableClusters = append(unavailableClusters, clusterName)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1702,7 +1702,7 @@ func TestWlReconcile(t *testing.T) {
 
 				w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 				w1remoteClient.client = worker1Client
-				w1remoteClient.connecting.Store(false)
+				w1remoteClient.connected.Store(true)
 				cRec.remoteClients["worker1"] = w1remoteClient
 
 				var worker2Client SelectivelyCachingClient
@@ -1734,7 +1734,7 @@ func TestWlReconcile(t *testing.T) {
 					w2remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 					w2remoteClient.client = worker2Client
 					if !tc.worker2Reconnecting {
-						w2remoteClient.connecting.Store(false)
+						w2remoteClient.connected.Store(true)
 					}
 					cRec.remoteClients["worker2"] = w2remoteClient
 				}
@@ -1880,7 +1880,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		WithStatusSubresource(&kueue.Workload{}).
 		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 		Build())
-	w1remoteClient.connecting.Store(false)
+	w1remoteClient.connected.Store(true)
 	cRec.remoteClients["worker1"] = w1remoteClient
 
 	worker2Client := NewNeverCachingClient(getClientBuilder(ctx).
@@ -1890,7 +1890,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		Build())
 	w2remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 	w2remoteClient.client = worker2Client
-	w2remoteClient.connecting.Store(true)
+	w2remoteClient.connected.Store(false)
 	cRec.remoteClients["worker2"] = w2remoteClient
 
 	helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
@@ -1926,7 +1926,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	}
 
 	// Step 2: worker2 finishes reconnecting — reconcile should clean up the orphaned workload.
-	w2remoteClient.connecting.Store(false)
+	w2remoteClient.connected.Store(true)
 
 	result, err = reconciler.Reconcile(ctx, req)
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

`disconnected atomic.Bool` was added in #11559  alongside `connecting atomic.Bool`, which IMO deserves a cleanup for two reasons:

- The overall semantics is confusing, at least for me. When a client is "disconnected", is it "connecting" or not?
  (Answer: It's considered "connecting". The combination of "disconnected, not connecting" does not exist).
- Both vars were typically used in concord; that alone suggested to turn them into one.

Actually, it seems a single `connected` bool can do.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker cluster connectivity handling so quotas, reconciliation, and cleanup now only run when a cluster is fully connected.
  * Made reconnect behavior more reliable after disconnects or configuration updates.
  * Reduced cases where workloads or quotas could be treated as available before a remote cluster is actually ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->