### PR TITLE
Fix the flaky perf tas test

### DIFF
--- a/test/performance/scheduler/configs/tas/rangespec.yaml
+++ b/test/performance/scheduler/configs/tas/rangespec.yaml
@@ -17,7 +17,7 @@ cmd:
 # Thresholds: mean − 7%, rounded down to 0.1%
 # Class  min usage%    mean / stddev / CV%
 clusterQueueClassesMinUsage:
-  cq:  58.0          # 62.41 / 0.30 / 0.48%
+  cq:  57.0          # 62.41 / 0.30 / 0.48% (reduced due to flakes)
 
 # Workload admission time limits
 # Thresholds: mean + 20% rounded up to 1000ms


### PR DESCRIPTION

#### What type of PR is this?
/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

We have the perf tas test flaking which is probably due to new stronger machines rather than a code change.

https://testgrid.k8s.io/sig-scheduling#periodic-kueue-test-tas-scheduling-perf-main

<img width="2397" height="701" alt="image" src="https://github.com/user-attachments/assets/27262277-5900-40a6-8220-75c100d5c83d" />

from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kueue-test-tas-scheduling-perf-main/2073757754912149504
```
{Failed  === RUN   TestScalability/ClusterQueueClasses/cq
    checker_test.go:98: Usage 57.73% is less then expected 58.00%
--- FAIL: TestScalability/ClusterQueueClasses/cq (0.00s)
}
```
and from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/periodic-kueue-test-tas-scheduling-perf-main/2073576302073352192
```
{Failed  === RUN   TestScalability/ClusterQueueClasses/cq
    checker_test.go:98: Usage 57.83% is less then expected 58.00%
--- FAIL: TestScalability/ClusterQueueClasses/cq (0.00s)
}
```

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted a performance test threshold to reduce flaky failures in scheduler runs.
  * Updated the related note to reflect the lowered usage limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->