### PR TITLE
Test: Converting the remaining priorityclass with workloadpriorityclass in visibility_test.go

### DIFF
--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -541,7 +541,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					},
 				}
 				for _, jobCase := range jobCases {
-					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
+					job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
 						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").

--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -24,7 +24,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,9 +53,9 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 		nsB               *corev1.Namespace
 		blockingJob       *batchv1.Job
 		sampleJob2        *batchv1.Job
-		highPriorityClass *schedulingv1.PriorityClass
-		midPriorityClass  *schedulingv1.PriorityClass
-		lowPriorityClass  *schedulingv1.PriorityClass
+		highPriorityClass *kueue.WorkloadPriorityClass
+		midPriorityClass  *kueue.WorkloadPriorityClass
+		lowPriorityClass  *kueue.WorkloadPriorityClass
 		defaultFlavor     string
 	)
 
@@ -94,13 +93,13 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 			localQueueB = utiltestingapi.MakeLocalQueue("b", nsA.Name).ClusterQueue(clusterQueue.Name).Obj()
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueueA, localQueueB)
 
-			highPriorityClass = utiltesting.MakePriorityClass("high-" + nsA.Name).PriorityValue(100).Obj()
+			highPriorityClass = utiltestingapi.MakeWorkloadPriorityClass("high-" + nsA.Name).PriorityValue(100).Obj()
 			util.MustCreate(ctx, k8sClient, highPriorityClass)
 
-			midPriorityClass = utiltesting.MakePriorityClass("mid-" + nsA.Name).PriorityValue(75).Obj()
+			midPriorityClass = utiltestingapi.MakeWorkloadPriorityClass("mid-" + nsA.Name).PriorityValue(75).Obj()
 			util.MustCreate(ctx, k8sClient, midPriorityClass)
 
-			lowPriorityClass = utiltesting.MakePriorityClass("low-" + nsA.Name).PriorityValue(50).Obj()
+			lowPriorityClass = utiltestingapi.MakeWorkloadPriorityClass("low-" + nsA.Name).PriorityValue(50).Obj()
 			util.MustCreate(ctx, k8sClient, lowPriorityClass)
 
 			ginkgo.By("Schedule a job that when admitted workload blocks the queue", func() {
@@ -110,7 +109,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					RequestAndLimit(corev1.ResourceCPU, "1").
 					TerminationGracePeriod(1).
 					BackoffLimit(0).
-					PriorityClass(highPriorityClass.Name).
+					WorkloadPriorityClass(highPriorityClass.Name).
 					Obj()
 				util.MustCreate(ctx, k8sClient, blockingJob)
 			})
@@ -150,7 +149,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 					RequestAndLimit(corev1.ResourceCPU, "1").
-					PriorityClass(lowPriorityClass.Name).
+					WorkloadPriorityClass(lowPriorityClass.Name).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob2)
 			})
@@ -198,7 +197,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 					RequestAndLimit(corev1.ResourceCPU, "1").
-					PriorityClass(lowPriorityClass.Name).
+					WorkloadPriorityClass(lowPriorityClass.Name).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob2)
 			})
@@ -260,7 +259,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
-						PriorityClass(jobCase.JobPrioClassName).
+						WorkloadPriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					util.MustCreate(ctx, k8sClient, job)
 				}
@@ -321,7 +320,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					Queue(kueue.LocalQueueName(localQueueA.Name)).
 					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 					RequestAndLimit(corev1.ResourceCPU, "1").
-					PriorityClass(lowPriorityClass.Name).
+					WorkloadPriorityClass(lowPriorityClass.Name).
 					Obj()
 				util.MustCreate(ctx, k8sClient, sampleJob2)
 			})
@@ -383,7 +382,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
-						PriorityClass(jobCase.JobPrioClassName).
+						WorkloadPriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					util.MustCreate(ctx, k8sClient, job)
 				}
@@ -467,7 +466,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 						Queue(localQueueName).
 						Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
 						RequestAndLimit(corev1.ResourceCPU, "2").
-						PriorityClass(jobCase.priority).
+						WorkloadPriorityClass(jobCase.priority).
 						TerminationGracePeriod(1).
 						Obj()
 					util.MustCreate(ctx, k8sClient, job)
@@ -542,11 +541,11 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 					},
 				}
 				for _, jobCase := range jobCases {
-					job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
+					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
 						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
 						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
 						RequestAndLimit(corev1.ResourceCPU, "1").
-						PriorityClass(jobCase.JobPrioClassName).
+						WorkloadPriorityClass(jobCase.JobPrioClassName).
 						Obj()
 					util.MustCreate(ctx, k8sClient, job)
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake
/area testing

#### What this PR does / why we need it:
Converting the remaining priorityclass with workloadpriorityclass in visibility_test.go

#### Which issue(s) this PR fixes:

Fixes #12830 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated the visibility end-to-end baseline to use the latest workload prioritization setup.
  * Adjusted pending-workload and queue position scenarios across namespaces to match current priority handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->