### PR TITLE
Mention KEP-9270 in docs

### DIFF
--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -103,10 +103,12 @@ This approach ensures the fastest possible admission by allowing all clusters to
 
 ### Incremental:
 This mode introduces a gradual dispatching strategy where clusters are nominated in rounds.
-Initially, all worker clusters are sorted in dictionary order, and a subset of up to 3 clusters is selected from the sorted list.
+Initially, all worker clusters are sorted in dictionary order, and a batch of clusters (by default, up to 3) is selected from the sorted list.
 The Workload is copied only to these nominated clusters.
 If none of the nominated clusters admit the Workload within a fixed duration (5 minutes),
-an additional up to 3 clusters are incrementally added in subsequent rounds, following the same dictionary order.
+additional batches of clusters are incrementally added in subsequent rounds, following the same dictionary order.
+
+The default maximum batch size is 3. This can be configured by enabling the `MultiKueueIncrementalDispatcherConfig` feature gate and setting `.multiKueue.incrementalDispatcherConfig.stepSize` in the Kueue configuration.
 
 ### External (Custom implementation):
 In this mode, the selection of worker clusters is delegated to an external controller.


### PR DESCRIPTION
/kind documentation
/area multikueue

#### What this PR does / why we need it:

Updates Kueue documentation (on incremental dispatcher) to no longer claim that 3 is always the step size.
(Following #11208)

#### Which issue(s) this PR fixes:

Follow-up to #9270.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how incremental dispatching works, including cluster ordering, default batch size, and retry behavior when no cluster accepts a workload within 5 minutes.
  * Added the relevant configuration details for adjusting the incremental dispatcher settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->