### PR TITLE
Add e2e test for visibility API pending-workloads namespace isolation

### DIFF
--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -233,36 +233,11 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 
 		ginkgo.It("Should allow fetching information about position of pending workloads in ClusterQueue", func() {
 			ginkgo.By("Schedule three different jobs with different priorities and two different LocalQueues", func() {
-				jobCases := []struct {
-					JobName          string
-					JobPrioClassName string
-					LocalQueueName   string
-				}{
-					{
-						JobName:          "lq-a-high-prio",
-						JobPrioClassName: highPriorityClass.Name,
-						LocalQueueName:   localQueueA.Name,
-					},
-					{
-						JobName:          "lq-b-mid-prio",
-						JobPrioClassName: midPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-					},
-					{
-						JobName:          "lq-b-low-prio",
-						JobPrioClassName: lowPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-					},
-				}
-				for _, jobCase := range jobCases {
-					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
-						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
-						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-						RequestAndLimit(corev1.ResourceCPU, "1").
-						WorkloadPriorityClass(jobCase.JobPrioClassName).
-						Obj()
-					util.MustCreate(ctx, k8sClient, job)
-				}
+				createPendingJobs([]pendingJobCase{
+					{JobName: "lq-a-high-prio", JobPrioClassName: highPriorityClass.Name, LocalQueueName: localQueueA.Name, nsName: nsA.Name},
+					{JobName: "lq-b-mid-prio", JobPrioClassName: midPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsA.Name},
+					{JobName: "lq-b-low-prio", JobPrioClassName: lowPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsA.Name},
+				})
 			})
 
 			ginkgo.By("Verify their positions and priorities", func() {
@@ -356,36 +331,11 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 
 		ginkgo.It("Should allow fetching information about position of pending workloads from different LocalQueues", func() {
 			ginkgo.By("Schedule three different jobs with different priorities and two different LocalQueues", func() {
-				jobCases := []struct {
-					JobName          string
-					JobPrioClassName string
-					LocalQueueName   string
-				}{
-					{
-						JobName:          "lq-a-high-prio",
-						JobPrioClassName: highPriorityClass.Name,
-						LocalQueueName:   localQueueA.Name,
-					},
-					{
-						JobName:          "lq-b-mid-prio",
-						JobPrioClassName: midPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-					},
-					{
-						JobName:          "lq-b-low-prio",
-						JobPrioClassName: lowPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-					},
-				}
-				for _, jobCase := range jobCases {
-					job := testingjob.MakeJob(jobCase.JobName, nsA.Name).
-						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
-						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-						RequestAndLimit(corev1.ResourceCPU, "1").
-						WorkloadPriorityClass(jobCase.JobPrioClassName).
-						Obj()
-					util.MustCreate(ctx, k8sClient, job)
-				}
+				createPendingJobs([]pendingJobCase{
+					{JobName: "lq-a-high-prio", JobPrioClassName: highPriorityClass.Name, LocalQueueName: localQueueA.Name, nsName: nsA.Name},
+					{JobName: "lq-b-mid-prio", JobPrioClassName: midPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsA.Name},
+					{JobName: "lq-b-low-prio", JobPrioClassName: lowPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsA.Name},
+				})
 			})
 
 			ginkgo.By("Verify their positions and priorities in LocalQueueA", func() {
@@ -515,40 +465,11 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 			})
 
 			ginkgo.By("Schedule three different jobs with different priorities and different LocalQueues in different Namespaces", func() {
-				jobCases := []struct {
-					JobName          string
-					JobPrioClassName string
-					LocalQueueName   string
-					nsName           string
-				}{
-					{
-						JobName:          "lq-a-high-prio",
-						JobPrioClassName: highPriorityClass.Name,
-						LocalQueueName:   localQueueA.Name,
-						nsName:           nsA.Name,
-					},
-					{
-						JobName:          "lq-b-mid-prio",
-						JobPrioClassName: midPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-						nsName:           nsB.Name,
-					},
-					{
-						JobName:          "lq-b-low-prio",
-						JobPrioClassName: lowPriorityClass.Name,
-						LocalQueueName:   localQueueB.Name,
-						nsName:           nsB.Name,
-					},
-				}
-				for _, jobCase := range jobCases {
-					job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
-						Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
-						Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-						RequestAndLimit(corev1.ResourceCPU, "1").
-						WorkloadPriorityClass(jobCase.JobPrioClassName).
-						Obj()
-					util.MustCreate(ctx, k8sClient, job)
-				}
+				createPendingJobs([]pendingJobCase{
+					{JobName: "lq-a-high-prio", JobPrioClassName: highPriorityClass.Name, LocalQueueName: localQueueA.Name, nsName: nsA.Name},
+					{JobName: "lq-b-mid-prio", JobPrioClassName: midPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsB.Name},
+					{JobName: "lq-b-low-prio", JobPrioClassName: lowPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsB.Name},
+				})
 			})
 
 			ginkgo.By("Verify their positions and priorities in LocalQueueA", func() {
@@ -601,6 +522,68 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.When("A subject is bound to kueue-batch-user-role, but not to kueue-batch-admin-role, and reads a LocalQueue sharing a ClusterQueue across Namespaces", func() {
+			var roleBinding *rbacv1.RoleBinding
+
+			ginkgo.BeforeEach(func() {
+				ginkgo.By("Create a LocalQueue in a different Namespace sharing the same ClusterQueue", func() {
+					localQueueB = utiltestingapi.MakeLocalQueue("b", nsB.Name).ClusterQueue(clusterQueue.Name).Obj()
+					util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueueB)
+				})
+
+				ginkgo.By("Schedule a pending job in each Namespace against the shared ClusterQueue", func() {
+					createPendingJobs([]pendingJobCase{
+						{JobName: "lq-a-low-prio", JobPrioClassName: lowPriorityClass.Name, LocalQueueName: localQueueA.Name, nsName: nsA.Name},
+						{JobName: "lq-b-mid-prio", JobPrioClassName: midPriorityClass.Name, LocalQueueName: localQueueB.Name, nsName: nsB.Name},
+					})
+				})
+
+				roleBinding = mustCreateBatchUserRoleBinding(nsA.Name)
+				ginkgo.By("Wait for ResourceNotFound error instead of Forbidden to make sure the role binding works", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
+						g.Expect(err).Should(utiltesting.BeNotFoundError())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.AfterEach(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, roleBinding, true)
+			})
+
+			ginkgo.It("Should only expose pending workloads from the caller's own Namespace", func() {
+				ginkgo.By("Verifying the user only sees their own Namespace's pending workload in LocalQueueA", func() {
+					wantPendingWorkloads := []visibility.PendingWorkload{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:       nsA.Name,
+								OwnerReferences: defaultOwnerReferenceForJob("lq-a-low-prio"),
+							},
+							Priority:               lowPriorityClass.Value,
+							PositionInLocalQueue:   0,
+							PositionInClusterQueue: 1,
+							LocalQueueName:         kueue.LocalQueueName(localQueueA.Name),
+						},
+					}
+					gomega.Eventually(func(g gomega.Gomega) {
+						info, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, localQueueA.Name, metav1.GetOptions{})
+						g.Expect(err).NotTo(gomega.HaveOccurred())
+						g.Expect(info.Items).Should(gomega.BeComparableTo(wantPendingWorkloads, pendingWorkloadsCmpOpts...))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Verifying the user is Forbidden from a LocalQueue in a different Namespace", func() {
+					_, err := impersonatedVisibilityClient.LocalQueues(nsB.Name).GetPendingWorkloadsSummary(ctx, localQueueB.Name, metav1.GetOptions{})
+					gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+				})
+
+				ginkgo.By("Verifying the user is Forbidden from the cluster-scoped ClusterQueue endpoint", func() {
+					_, err := impersonatedVisibilityClient.ClusterQueues().GetPendingWorkloadsSummary(ctx, clusterQueue.Name, metav1.GetOptions{})
+					gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+				})
+			})
+		})
 	})
 
 	ginkgo.When("A subject is bound to kueue-batch-admin-role", func() {
@@ -624,7 +607,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 		})
 
 		ginkgo.AfterEach(func() {
-			gomega.Expect(k8sClient.Delete(ctx, clusterRoleBinding)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterRoleBinding, true)
 		})
 
 		ginkgo.It("Should return an appropriate error", func() {
@@ -643,11 +626,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 		var roleBinding *rbacv1.RoleBinding
 
 		ginkgo.BeforeEach(func() {
-			roleBinding = utiltesting.MakeRoleBinding("read-pending-workloads", nsA.Name).
-				RoleRef(rbacv1.GroupName, "ClusterRole", "kueue-batch-user-role").
-				Subject(rbacv1.ServiceAccountKind, "default", kueueNS).
-				Obj()
-			util.MustCreate(ctx, k8sClient, roleBinding)
+			roleBinding = mustCreateBatchUserRoleBinding(nsA.Name)
 			ginkgo.By("Wait for ResourceNotFound error instead of Forbidden to make sure the role bindings work", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					_, err := impersonatedVisibilityClient.LocalQueues(nsA.Name).GetPendingWorkloadsSummary(ctx, "non-existent", metav1.GetOptions{})
@@ -657,7 +636,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 		})
 
 		ginkgo.AfterEach(func() {
-			gomega.Expect(k8sClient.Delete(ctx, roleBinding)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, roleBinding, true)
 		})
 
 		ginkgo.It("Should return an appropriate error", func() {
@@ -689,3 +668,31 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 		})
 	})
 })
+
+type pendingJobCase struct {
+	JobName          string
+	JobPrioClassName string
+	LocalQueueName   string
+	nsName           string
+}
+
+func createPendingJobs(jobCases []pendingJobCase) {
+	for _, jobCase := range jobCases {
+		job := testingjob.MakeJob(jobCase.JobName, jobCase.nsName).
+			Queue(kueue.LocalQueueName(jobCase.LocalQueueName)).
+			Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+			RequestAndLimit(corev1.ResourceCPU, "1").
+			WorkloadPriorityClass(jobCase.JobPrioClassName).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+	}
+}
+
+func mustCreateBatchUserRoleBinding(ns string) *rbacv1.RoleBinding {
+	roleBinding := utiltesting.MakeRoleBinding("read-pending-workloads", ns).
+		RoleRef(rbacv1.GroupName, "ClusterRole", "kueue-batch-user-role").
+		Subject(rbacv1.ServiceAccountKind, "default", kueueNS).
+		Obj()
+	util.MustCreate(ctx, k8sClient, roleBinding)
+	return roleBinding
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

Adds a baseline e2e test asserting the tenancy boundary of the pending-workloads
visibility endpoints when two namespaces share a ClusterQueue.

A subject bound to `kueue-batch-user-role` in one namespace:
- sees only its own namespace's pending workload via the LocalQueue endpoint, never the other namespace's workload;
- is Forbidden from a LocalQueue in a different namespace;
- is Forbidden from the cluster-scoped ClusterQueue endpoint.

The existing e2e tests cover the authorization *errors* (Forbidden/NotFound) but
never assert the *contents* returned to a namespace-scoped tenant. This closes the
RBAC/tenancy coverage described in KEP-168-2 with a positive data-isolation
assertion, confirming the ClusterQueue endpoint is admin-only by design and the
LocalQueue endpoint is correctly scoped to the caller's namespace.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end RBAC visibility scenario for users with only a namespace-scoped role binding (no admin role).
  * Verified pending-workload visibility is limited to the caller’s own namespace when using a shared cluster queue with multiple local queues.
  * Confirmed requests for a non-existent local queue return “not found” instead of “forbidden”.
  * Ensured access is denied for cross-namespace local queue reads and for cluster-wide pending workload queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->