### PR TITLE
chart: disable internal cert management when cert-manager is enabled

### DIFF
--- a/charts/kueue/templates/manager/manager-config.yaml
+++ b/charts/kueue/templates/manager/manager-config.yaml
@@ -24,13 +24,14 @@ metadata:
 data:
   controller_manager_config.yaml: |
 {{- $config := .Values.managerConfig.controllerManagerConfigYaml | fromYaml }}
-{{- if not .Values.enableCertManager }}
-  {{- $defaultInternalCert := dict
-        "enable" true
-        "webhookServiceName" (printf "%s-webhook-service" (include "kueue.fullname" .))
-        "webhookSecretName" (printf "%s-webhook-server-cert" (include "kueue.fullname" .)) }}
-  {{- if not $config.internalCertManagement }}
-    {{- $_ := set $config "internalCertManagement" $defaultInternalCert }}
-  {{- end }}
+{{- $defaultInternalCert := dict
+      "enable" true
+      "webhookServiceName" (printf "%s-webhook-service" (include "kueue.fullname" .))
+      "webhookSecretName" (printf "%s-webhook-server-cert" (include "kueue.fullname" .)) }}
+{{- if .Values.enableCertManager }}
+  {{- $defaultInternalCert = dict "enable" false }}
+{{- end }}
+{{- if not $config.internalCertManagement }}
+  {{- $_ := set $config "internalCertManagement" $defaultInternalCert }}
 {{- end }}
 {{ $config | toYaml | indent 4 }}

--- a/charts/kueue/tests/manager_config_test.yaml
+++ b/charts/kueue/tests/manager_config_test.yaml
@@ -71,7 +71,7 @@ tests:
           path: data["controller_manager_config.yaml"]
           pattern: "internalCertManagement:\n  enable: false\n  webhookSecretName: bar\n  webhookServiceName: foo"
 
-  - it: should not add internalCertManagement when enableCertManager is true and controllerManagerConfigYaml is provided
+  - it: should disable internalCertManagement when enableCertManager is true and controllerManagerConfigYaml is provided
     set:
       enableCertManager: true
       managerConfig:
@@ -87,9 +87,11 @@ tests:
       - matchRegex:
           path: data["controller_manager_config.yaml"]
           pattern: "metrics:\n  bindAddress: 0.0.0.0:8080"
-      - notMatchRegex:
+      - matchRegex:
           path: data["controller_manager_config.yaml"]
-          pattern: "internalCertManagement:"
+          pattern: |
+            internalCertManagement:
+              enable: false
 
   - it: should handle an empty controllerManagerConfigYaml
     release:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind regression

#### What this PR does / why we need it:

Disable internal certificate management when cert-manager is enabled in the helm chart. Without this, the manager pod attempts to write the key/cert pair to a read-only file it has mounted from a secret and fails.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Helm: Fix helm chart failing to install with a manager CrashLoopBackoff when cert-manager integration is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default certificate management settings in the controller manager configuration.
  * The internal certificate management block is now applied consistently even when cert-manager support is enabled, ensuring the manager starts with the expected certificate behavior.
  * Updated chart tests to validate the new default behavior when custom manager configuration is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->