### PR TITLE
cleanup tls config unit tests

### DIFF
--- a/pkg/util/tlsconfig/tlsconfig_test.go
+++ b/pkg/util/tlsconfig/tlsconfig_test.go
@@ -22,25 +22,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 )
-
-// compareAllErrors checks that every error in wantErrs is present in got.
-func compareAllErrors(wantErrs []error, got error) bool {
-	if len(wantErrs) == 0 && got == nil {
-		return true
-	}
-	if len(wantErrs) == 0 || got == nil {
-		return false
-	}
-	for _, want := range wantErrs {
-		if !errors.Is(got, want) {
-			return false
-		}
-	}
-	return true
-}
 
 func TestParseTLSOptions(t *testing.T) {
 	tests := []struct {
@@ -390,24 +375,20 @@ func TestConvertTLSMinVersion(t *testing.T) {
 }
 
 func TestConvertCurvePreferences(t *testing.T) {
-	tests := []struct {
-		name     string
+	tests := map[string]struct {
 		input    []int32
 		expected []tls.CurveID
-		wantErr  []error
+		wantErr  error
 	}{
-		{
-			name:     "empty input",
+		"empty input": {
 			input:    []int32{},
 			expected: nil,
 		},
-		{
-			name:     "nil input",
+		"nil input": {
 			input:    nil,
 			expected: nil,
 		},
-		{
-			name:  "valid curve preferences",
+		"valid curve preferences": {
 			input: []int32{23, 24, 29}, // P256, P384, X25519
 			expected: []tls.CurveID{
 				tls.CurveP256,
@@ -415,32 +396,25 @@ func TestConvertCurvePreferences(t *testing.T) {
 				tls.X25519,
 			},
 		},
-		{
-			name:    "out of range curve ID",
+		"out of range curve ID": {
 			input:   []int32{0},
-			wantErr: []error{ErrInvalidCurvePreferences},
+			wantErr: ErrInvalidCurvePreferences,
 		},
-		{
-			name:    "duplicate curve IDs",
+		"duplicate curve IDs": {
 			input:   []int32{23, 23},
-			wantErr: []error{ErrInvalidCurvePreferences},
+			wantErr: ErrInvalidCurvePreferences,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
 			got, err := convertCurvePreferences(tt.input)
-			if !compareAllErrors(tt.wantErr, err) {
-				t.Errorf("convertCurvePreferences() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if diff := cmp.Diff(tt.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want, +got):\n%s", diff)
 			}
 
-			if err != nil {
-				return
-			}
-
-			if !cmp.Equal(got, tt.expected) {
-				t.Errorf("convertCurvePreferences() diff: %s", cmp.Diff(tt.expected, got))
+			if diff := cmp.Diff(tt.expected, got); diff != "" {
+				t.Errorf("Unexpected convertCurvePreferences() result (-want, +got):\n%s", diff)
 			}
 		})
 	}
@@ -576,8 +550,8 @@ func TestBuildTLSOptions(t *testing.T) {
 				t.Errorf("CipherSuites diff: %s", cmp.Diff(tt.wantCiphers, cfg.CipherSuites))
 			}
 
-			if !cmp.Equal(cfg.CurvePreferences, tt.wantCurves) {
-				t.Errorf("CurvePreferences diff: %s", cmp.Diff(tt.wantCurves, cfg.CurvePreferences))
+			if diff := cmp.Diff(tt.wantCurves, cfg.CurvePreferences); diff != "" {
+				t.Errorf("Unexpected CurvePreferences (-want, +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Address followups from tls curve work.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Followups for https://github.com/kubernetes-sigs/kueue/pull/11832#pullrequestreview-4647317324.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TLS configuration test coverage and assertions.
  * Refined error and result comparisons to provide clearer, more reliable test failures.
  * Updated curve preference checks for more consistent validation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->