### PR TITLE
Use strong typing for scheduling equivalence hashes

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -134,7 +134,7 @@ type ClusterQueue struct {
 	// hashToBulkMoveReason tracks scheduling equivalence classes and the reason
 	// why workloads with that hash were bulk-moved to inadmissibleWorkloads.
 	// Cleared when queueInadmissibleWorkloads runs.
-	hashToBulkMoveReason map[string]QuotaReservedReason
+	hashToBulkMoveReason map[workload.EquivalenceHash]QuotaReservedReason
 
 	finishedWorkloads sets.Set[workload.Reference]
 
@@ -263,7 +263,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 	return &ClusterQueue{
 		heap:                      *heap.New(workloadKey, lessFunc),
 		inadmissibleWorkloads:     make(inadmissibleWorkloads),
-		hashToBulkMoveReason:      make(map[string]QuotaReservedReason),
+		hashToBulkMoveReason:      make(map[workload.EquivalenceHash]QuotaReservedReason),
 		finishedWorkloads:         sets.New[workload.Reference](),
 		queueInadmissibleCycle:    -1,
 		compareFunc:               compareFunc,
@@ -612,7 +612,7 @@ func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
 // scheduling hash to inadmissibleWorkloads. Returns the number moved.
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
 // stays in the heap and must not cause equivalent workloads to be skipped.
-func (c *ClusterQueue) handleInadmissibleHash(hash string, reason QuotaReservedReason) int {
+func (c *ClusterQueue) handleInadmissibleHash(hash workload.EquivalenceHash, reason QuotaReservedReason) int {
 	if c.queueingStrategy != kueue.BestEffortFIFO {
 		return 0
 	}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -1459,15 +1459,15 @@ func TestFsAdmission(t *testing.T) {
 
 func TestRecordInadmissibleHash(t *testing.T) {
 	cases := map[string]struct {
-		hashToRecord     string
-		heapWorkloads    map[string]string // name -> schedulingHash
+		hashToRecord     workload.EquivalenceHash
+		heapWorkloads    map[string]workload.EquivalenceHash // name -> schedulingHash
 		wantMoved        int
 		wantActive       int
 		wantInadmissible int
 	}{
 		"bulk-moves matching workloads": {
 			hashToRecord: "gpu-class",
-			heapWorkloads: map[string]string{
+			heapWorkloads: map[string]workload.EquivalenceHash{
 				"gpu-1": "gpu-class",
 				"gpu-2": "gpu-class",
 				"gpu-3": "gpu-class",
@@ -1480,7 +1480,7 @@ func TestRecordInadmissibleHash(t *testing.T) {
 		},
 		"no-op for empty hash": {
 			hashToRecord: "",
-			heapWorkloads: map[string]string{
+			heapWorkloads: map[string]workload.EquivalenceHash{
 				"wl-1": "some-hash",
 			},
 			wantMoved:        0,
@@ -1489,7 +1489,7 @@ func TestRecordInadmissibleHash(t *testing.T) {
 		},
 		"no-op when no workloads match": {
 			hashToRecord: "nonexistent",
-			heapWorkloads: map[string]string{
+			heapWorkloads: map[string]workload.EquivalenceHash{
 				"wl-1": "hash-a",
 				"wl-2": "hash-b",
 			},
@@ -1534,19 +1534,19 @@ func TestRecordInadmissibleHash(t *testing.T) {
 
 func TestPushOrUpdateRespectsInadmissibleHashes(t *testing.T) {
 	cases := map[string]struct {
-		inadmissibleHashes []string
-		pushHash           string
+		inadmissibleHashes []workload.EquivalenceHash
+		pushHash           workload.EquivalenceHash
 		wantActive         int
 		wantInadmissible   int
 	}{
 		"workload with blocked hash goes to inadmissible": {
-			inadmissibleHashes: []string{"blocked"},
+			inadmissibleHashes: []workload.EquivalenceHash{"blocked"},
 			pushHash:           "blocked",
 			wantActive:         0,
 			wantInadmissible:   1,
 		},
 		"workload with non-blocked hash goes to heap": {
-			inadmissibleHashes: []string{"blocked"},
+			inadmissibleHashes: []workload.EquivalenceHash{"blocked"},
 			pushHash:           "allowed",
 			wantActive:         1,
 			wantInadmissible:   0,

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -171,7 +171,7 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	log := ctrl.LoggerFrom(ctx)
 	c.queueInadmissibleCycle = c.popCycle
 	// Clear bulk-move scheduling hashes so re-queued workloads are re-evaluated fresh.
-	c.hashToBulkMoveReason = make(map[string]QuotaReservedReason)
+	c.hashToBulkMoveReason = make(map[workload.EquivalenceHash]QuotaReservedReason)
 	if c.inadmissibleWorkloads.empty() {
 		return 0
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -71,11 +71,17 @@ const (
 	StatusFinished      = "finished"
 
 	// SchedulingHashUnknown indicates the scheduling hash could not be computed.
-	SchedulingHashUnknown = "unknown"
+	SchedulingHashUnknown EquivalenceHash = "unknown"
 )
 
 // Reference is the full reference to Workload formed as <namespace>/< kueue.WorkloadName >.
 type Reference string
+
+// EquivalenceHash represents a scheduling equivalence class key used to track
+// EquivalenceHash is a hash of a workload's scheduling-relevant shape.
+// Workloads with the same hash have identical scheduling properties
+// and will receive the same FlavorAssigner result given the same cluster state.
+type EquivalenceHash string
 
 func NewReference(namespace, name string) Reference {
 	return Reference(namespace + "/" + name)
@@ -227,7 +233,7 @@ type Info struct {
 	// SchedulingHash identifies the workload's scheduling equivalence class.
 	// Workloads with the same hash have identical scheduling-relevant shape
 	// and will receive the same FlavorAssigner result given the same cluster state.
-	SchedulingHash string
+	SchedulingHash EquivalenceHash
 
 	// NominationMapping is the mapping of PodSets resources and their flavors
 	// based on the nomination phase.
@@ -338,7 +344,7 @@ func (i *Info) rebuildTotalRequests(opts ...InfoOption) {
 // computeSchedulingHash returns a deterministic hash of the workload's
 // scheduling-relevant shape: effective workload priority, pod spec (via
 // SpecShape), effective count, minCount, and topologyRequest per PodSet.
-func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []PodSetResources) string {
+func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []PodSetResources) EquivalenceHash {
 	if !features.Enabled(features.SchedulingEquivalenceHashing) {
 		return SchedulingHashUnknown
 	}
@@ -378,7 +384,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 	if logV := log.V(5); logV.Enabled() {
 		logV.Info("Computed scheduling hash", "workload", klog.KObj(wl), "hash", hash, "shapeJSON", string(shapeJSON))
 	}
-	return hash
+	return EquivalenceHash(hash)
 }
 
 func (i *Info) CanBePartiallyAdmitted() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Use strong typing for scheduling equivalence hashes
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12868 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling consistency by using a strongly-typed equivalence hash across bulk-move and inadmissible workload re-queuing.
  * Reduced the chance of incorrect hash comparisons that could affect admission and bulk-move decisions.
  * Preserved existing behavior when scheduling hash computation is unavailable by continuing to fall back to the “unknown” value.
  * Updated and strengthened related test cases to match the new equivalence-hash handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->