### PR TITLE
Automated cherry pick of #12768: Don't admit workload when WaitingForReplacementPods=True.

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -970,6 +970,10 @@ const (
 	// WorkloadDeactivationTarget means that the Workload should be deactivated.
 	// This condition is temporary, so it should be removed after deactivation.
 	WorkloadDeactivationTarget = "DeactivationTarget"
+
+	// WorkloadWaitingForReplacementPods means that Kueue doesn't observe all
+	// the Pods declared for the group.
+	WorkloadWaitingForReplacementPods = "WaitingForReplacementPods"
 )
 
 // Reasons for the WorkloadPreemptionBlocked condition.

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -509,6 +509,11 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 					return ctrl.Result{}, client.IgnoreNotFound(err)
 				}
 
+				if !workload.IsAdmissible(&wl) {
+					log.V(3).Info("Workload is inadmissible after backoff, waiting for condition change", "workload", klog.KObj(&wl))
+					return ctrl.Result{}, nil
+				}
+
 				if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy()); err != nil {
 					log.V(2).Info("failed to put the workload back into queue", "error", err)
 					return ctrl.Result{}, err

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -75,10 +75,6 @@ const (
 )
 
 const (
-	// WorkloadWaitingForReplacementPods is True when Kueue doesn't observe all
-	// the Pods declared for the group.
-	WorkloadWaitingForReplacementPods = "WaitingForReplacementPods"
-
 	// WorkloadPodsFailed means that at least one Pod are not runnable or not succeeded.
 	WorkloadPodsFailed = "PodsFailed"
 )
@@ -718,8 +714,13 @@ func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedNa
 	return !p.isFound, nil
 }
 
+// fastAdmission determines if the pod is configured for fast admission based on specific annotations.
+func (p *Pod) fastAdmission() bool {
+	return p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey] == podconstants.GroupFastAdmissionAnnotationValue
+}
+
 func (p *Pod) constructGroupPodSets() ([]kueue.PodSet, error) {
-	if _, useFastAdmission := p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey]; useFastAdmission {
+	if p.fastAdmission() {
 		tc, err := p.groupTotalCount()
 		if err != nil {
 			return nil, err
@@ -833,9 +834,8 @@ func (p *Pod) validatePodGroupMetadata(r events.EventRecorder, activePods []core
 	}
 
 	originalQueue := jobframework.QueueName(p)
-	_, useFastAdmission := p.pod.GetAnnotations()[podconstants.GroupFastAdmissionAnnotationKey]
 
-	if !useFastAdmission && len(activePods) < groupTotalCount {
+	if !p.fastAdmission() && len(activePods) < groupTotalCount {
 		errMsg := fmt.Sprintf("'%s' group has fewer runnable pods than expected", GetPodGroupName(&p.pod))
 		r.Eventf(p.Object(), nil, corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, "ErrWorkloadCompose", errMsg)
 		return jobframework.UnretryableError(errMsg)
@@ -1248,9 +1248,7 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 			return nil, nil, fmt.Errorf("failed to calculate pod role hash: %w", errors.Join(roleHashErrors...))
 		}
 
-		if absentCount := int(ps.Count) - len(roleActivePods); absentCount > 0 {
-			absentPods += absentCount
-		}
+		absentPods += p.countAbsentPods(ps, len(roleActivePods))
 
 		if excessCount := len(roleActivePods) - int(ps.Count); excessCount > 0 {
 			sortActivePods(roleActivePods)
@@ -1297,6 +1295,16 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 		return nil, nil, err
 	}
 	return workload, []*kueue.Workload{}, nil
+}
+
+func (p *Pod) countAbsentPods(ps kueue.PodSet, activePods int) int {
+	if p.fastAdmission() {
+		if ps.Count > 0 && activePods == 0 {
+			return 1
+		}
+		return 0
+	}
+	return max(0, int(ps.Count)-activePods)
 }
 
 func (p *Pod) equivalentToWorkload(wl *kueue.Workload, jobPodSets []kueue.PodSet) bool {
@@ -1390,7 +1398,7 @@ func (p *Pod) waitingForReplacementPodsCondition(wl *kueue.Workload) (*metav1.Co
 		return nil, false
 	}
 
-	replCond := apimeta.FindStatusCondition(wl.Status.Conditions, WorkloadWaitingForReplacementPods)
+	replCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadWaitingForReplacementPods)
 	replCondStatus := p.absentPods > 0
 
 	// Nothing to change.
@@ -1402,7 +1410,7 @@ func (p *Pod) waitingForReplacementPodsCondition(wl *kueue.Workload) (*metav1.Co
 
 	if replCond == nil {
 		replCond = &metav1.Condition{
-			Type: WorkloadWaitingForReplacementPods,
+			Type: kueue.WorkloadWaitingForReplacementPods,
 		}
 		updated = true
 	} else {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -1718,7 +1718,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1737,7 +1737,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1862,7 +1862,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Pods succeeded: 1/2. Pods failed: 1/2",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -1887,7 +1887,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Pods succeeded: 1/2. Pods failed: 1/2",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2067,7 +2067,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2087,7 +2087,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2385,7 +2385,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2412,7 +2412,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2465,7 +2465,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2513,7 +2513,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -2666,7 +2666,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2686,7 +2686,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2732,7 +2732,7 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -2754,7 +2754,7 @@ func TestReconciler(t *testing.T) {
 					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3000,7 +3000,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3025,7 +3025,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3126,7 +3126,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3152,7 +3152,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					ReclaimablePods(kueue.ReclaimablePod{Name: "4ebdd4a6", Count: 1}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3245,7 +3245,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3270,7 +3270,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod3", "test-uid").
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3484,7 +3484,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3506,7 +3506,7 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3932,7 +3932,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -3953,7 +3953,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4057,7 +4057,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -4084,7 +4084,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -4153,7 +4153,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Workload evicted due to a PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "PodsReadyTimeout",
 						Message: "Workload evicted due to a PodsReady timeout",
@@ -4177,7 +4177,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Workload evicted due to a PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "PodsReadyTimeout",
 						Message: "Workload evicted due to a PodsReady timeout",
@@ -4338,7 +4338,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4362,7 +4362,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4574,7 +4574,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -4595,7 +4595,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5217,7 +5217,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5301,7 +5301,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5398,7 +5398,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5452,7 +5452,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Exceeded the PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadEvictedByPreemption,
 						Message: "Preempted to accommodate a higher priority Workload",
@@ -5500,7 +5500,7 @@ func TestReconciler(t *testing.T) {
 						Message: "Exceeded the PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
 						Message: "Exceeded the PodsReady timeout",
@@ -5553,7 +5553,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5603,7 +5603,7 @@ func TestReconciler(t *testing.T) {
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
-						Type:               WorkloadWaitingForReplacementPods,
+						Type:               kueue.WorkloadWaitingForReplacementPods,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: metav1.NewTime(now),
 						Reason:             kueue.WorkloadEvictedByPreemption,
@@ -5650,7 +5650,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  WorkloadPodsFailed,
 						Message: "Some Failed pods need replacement",
@@ -5692,7 +5692,7 @@ func TestReconciler(t *testing.T) {
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).PodSets(utiltestingapi.MakePodSetAssignment(kueue.NewPodSetReference(podUID)).Count(2).Obj()).Obj(), now).
 					AdmittedAt(true, now).
 					Condition(metav1.Condition{
-						Type:    WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadPodsReady,
 						Message: "No pods need replacement",

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1383,7 +1383,8 @@ func IsActive(w *kueue.Workload) bool {
 
 // IsAdmissible returns true if the workload can be added to the queue.
 func IsAdmissible(w *kueue.Workload) bool {
-	return !HasAdmissionGate(w) && !IsFinished(w) && IsActive(w) && !HasQuotaReservation(w) && !IsOnHold(w)
+	return !HasAdmissionGate(w) && !IsFinished(w) && IsActive(w) && !HasQuotaReservation(w) && !IsOnHold(w) &&
+		!apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadWaitingForReplacementPods)
 }
 
 // HasAdmissionGate returns true if the workload has an admission gate annotation and the AdmissionGatedBy feature is on

--- a/test/e2e/singlecluster/baseline/pod_test.go
+++ b/test/e2e/singlecluster/baseline/pod_test.go
@@ -228,7 +228,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    pod.WorkloadWaitingForReplacementPods,
+							Type:    kueue.WorkloadWaitingForReplacementPods,
 							Status:  metav1.ConditionTrue,
 							Reason:  pod.WorkloadPodsFailed,
 							Message: "Some Failed pods need replacement",
@@ -272,7 +272,7 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 					g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 						gomega.BeComparableTo(metav1.Condition{
-							Type:    pod.WorkloadWaitingForReplacementPods,
+							Type:    kueue.WorkloadWaitingForReplacementPods,
 							Status:  metav1.ConditionFalse,
 							Reason:  kueue.WorkloadPodsReady,
 							Message: "No pods need replacement",

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -891,7 +891,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  "ByTest",
 								Message: "by test",
@@ -946,7 +946,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1017,7 +1017,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  podcontroller.WorkloadPodsFailed,
 								Message: "Some Failed pods need replacement",
@@ -1042,7 +1042,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1062,7 +1062,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  podcontroller.WorkloadPodsFailed,
 								Message: "Some Failed pods need replacement",
@@ -1085,7 +1085,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 						g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -1504,7 +1504,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 								Message: "The workload is admitted",
 							}, util.IgnoreConditionTimestampsAndObservedGeneration),
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionTrue,
 								Reason:  kueue.WorkloadPreempted,
 								Message: "By test",
@@ -1529,7 +1529,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 						g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 						g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
-								Type:    podcontroller.WorkloadWaitingForReplacementPods,
+								Type:    kueue.WorkloadWaitingForReplacementPods,
 								Status:  metav1.ConditionFalse,
 								Reason:  kueue.WorkloadPodsReady,
 								Message: "No pods need replacement",
@@ -2391,7 +2391,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 						Message: "The workload backoff was finished",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
-						Type:    podcontroller.WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "PodsReadyTimeout",
 						Message: fmt.Sprintf("Exceeded the PodsReady timeout %s", wlKey.String()),
@@ -2435,7 +2435,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 						Message: "The workload has no reservation",
 					}, util.IgnoreConditionTimestampsAndObservedGeneration),
 					gomega.BeComparableTo(metav1.Condition{
-						Type:    podcontroller.WorkloadWaitingForReplacementPods,
+						Type:    kueue.WorkloadWaitingForReplacementPods,
 						Status:  metav1.ConditionTrue,
 						Reason:  "DeactivatedDueToRequeuingLimitExceeded",
 						Message: "The workload is deactivated due to exceeding the maximum number of re-queuing retries",

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -917,16 +917,21 @@ func AwaitAndVerifyCreatedWorkload(ctx context.Context, client client.Client, wl
 	return createdWorkload
 }
 
-func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, pods ...*corev1.Pod) {
+func SetPodsPhaseByKeys(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, keys ...client.ObjectKey) {
 	ginkgo.GinkgoHelper()
-	for _, p := range pods {
+	for _, key := range keys {
 		updatedPod := corev1.Pod{}
 		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), &updatedPod)).To(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, key, &updatedPod)).To(gomega.Succeed())
 			updatedPod.Status.Phase = phase
 			g.Expect(k8sClient.Status().Update(ctx, &updatedPod)).To(gomega.Succeed())
 		}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Failed to set pod phase", &updatedPod))
 	}
+}
+
+func SetPodsPhase(ctx context.Context, k8sClient client.Client, phase corev1.PodPhase, pods ...*corev1.Pod) {
+	ginkgo.GinkgoHelper()
+	SetPodsPhaseByKeys(ctx, k8sClient, phase, podKeys(pods)...)
 }
 
 func BindPodWithNode(ctx context.Context, k8sClient client.Client, nodeName string, pods ...*corev1.Pod) {
@@ -1497,6 +1502,14 @@ func workloadKeys(wls []*kueue.Workload) []client.ObjectKey {
 		wlKeys = append(wlKeys, client.ObjectKeyFromObject(wl))
 	}
 	return wlKeys
+}
+
+func podKeys(pods []*corev1.Pod) []client.ObjectKey {
+	keys := make([]client.ObjectKey, 0, len(pods))
+	for _, p := range pods {
+		keys = append(keys, client.ObjectKeyFromObject(p))
+	}
+	return keys
 }
 
 func uniqueKeys(keys []client.ObjectKey) []client.ObjectKey {


### PR DESCRIPTION
Cherry pick of #12768 on release-0.18.

#12768: Don't admit workload when WaitingForReplacementPods=True.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
PodGroup integration: Fixed a bug that allowed Workloads corresponding to PodGroups with the `WaitingForReplacementPods=True` condition to be re-admitted immediately.
```