### PR TITLE
fix(website): resolve navbar overlaps and sidebar link cutoff

### DIFF
--- a/site/assets/scss/_styles_project.scss
+++ b/site/assets/scss/_styles_project.scss
@@ -96,7 +96,7 @@ footer {
       }
     }
 
-    @include media-breakpoint-down(md) {
+    @include media-breakpoint-down(lg) {
       font-size: .875rem;
       align-items: flex-start;
       .dropdown {
@@ -119,11 +119,22 @@ footer {
 .td-sidebar {
   padding-bottom: 0.5rem;
 
+  @media (min-width: 768px) {
+    padding-top: 7rem !important;
+  }
+
   .td-sidebar__inner {
     padding-top: 30px;
 
     @include media-breakpoint-down(md) {
       padding-top: 10px;
+    }
+
+    @media (min-width: 768px) {
+      @supports (position: sticky) {
+        top: 7rem !important;
+        height: calc(100vh - 8rem) !important;
+      }
     }
   }
 }
@@ -132,16 +143,24 @@ footer {
 // on desktop so the scrollbar and links never overlap the full-width footer.
 @media (min-width: 768px) {
   .td-sidebar-nav {
-    max-height: calc(100vh - 14.5rem) !important;
+    max-height: calc(100vh - 12.5rem) !important;
   }
 }
 
 .td-sidebar-toc {
   @supports (position: sticky) {
       position: sticky;
-      top: 60px;
-      height: calc(100vh - 120px);
+      top: 7rem !important;
+      height: calc(100vh - 8rem) !important;
       overflow-y: auto;
+  }
+}
+
+// Main content container top offset adjustment to clear horizontal navbar
+@media (min-width: 768px) {
+  .td-404 main,
+  .td-main main {
+    padding-top: 7rem !important;
   }
 }
 

--- a/site/assets/scss/_variables_project.scss
+++ b/site/assets/scss/_variables_project.scss
@@ -48,6 +48,14 @@ $google_font_family: "Inter:wght@300;400;500;600;700&display=swap" !default;
     radial-gradient(circle at 1px 1px, #e2e8f0 1px, transparent 0);
   background-size: 40px 40px;
   background-position: 0 0, 20px 20px;
+  
+  padding-top: 3.5rem;
+  padding-bottom: 2.5rem;
+
+  @media (min-width: 768px) {
+    padding-top: 7rem;
+    padding-bottom: 3.5rem;
+  }
 }
 
 .feature-card {

--- a/site/layouts/index.html
+++ b/site/layouts/index.html
@@ -5,7 +5,7 @@
 
 
 <!-- 1. HERO SECTION (Streamlined & Polished with Navbar Offset) -->
-<section class="hero-grid-bg bg-white border-bottom" style="padding-top: 5.5rem !important; padding-bottom: 2.5rem !important;">
+<section class="hero-grid-bg bg-white border-bottom">
   <div class="container text-center">
     <div class="mx-auto" style="max-width: 800px;">
       

--- a/site/layouts/partials/navbar.html
+++ b/site/layouts/partials/navbar.html
@@ -1,13 +1,13 @@
 {{ $cover := and (.HasShortcode "blocks/cover") (not .Site.Params.ui.navbar_translucent_over_cover_disable) }}
-<nav class="js-navbar-scroll navbar navbar-expand-md navbar-light {{ if $cover}} td-navbar-cover {{ end }} td-navbar">
+<nav class="js-navbar-scroll navbar navbar-expand-lg navbar-light {{ if $cover}} td-navbar-cover {{ end }} td-navbar">
         <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span><span class="text-uppercase font-weight-bold">{{ .Site.Title }}</span>
 	</a>
 	<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#main_navbar" aria-controls="main_navbar" aria-expanded="false" aria-label="Toggle navigation">
 		<span class="navbar-toggler-icon"></span>
 	</button>
-	<div class="collapse navbar-collapse ms-md-auto" id="main_navbar">
-		<ul class="navbar-nav ms-auto pt-4 pt-md-0 my-2 my-md-1">
+	<div class="collapse navbar-collapse ms-lg-auto" id="main_navbar">
+		<ul class="navbar-nav ms-auto pt-4 pt-lg-0 my-2 my-lg-1">
 			{{ $p := . }}
 			{{ range .Site.Menus.main }}
 			<li class="nav-item me-2 mt-1 mt-lg-0">


### PR DESCRIPTION
- Fix documentation sidebar bottom items cutoff on desktop views.
- Resolve top menu wrapping and overlap issues on iPad viewport sizes.

Refs #12602

```release-note
NONE
```