### PR TITLE
Add integration tests for DRA resource borrowing in cohorts

### DIFF
--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -914,6 +914,21 @@ func (d *DeviceClassWrapper) ExtendedResourceName(name string) *DeviceClassWrapp
 	return d
 }
 
+// GeneratedName sets the generate name on the DeviceClass and clears the name.
+func (d *DeviceClassWrapper) GeneratedName(name string) *DeviceClassWrapper {
+	d.GenerateName = name
+	d.Name = ""
+	return d
+}
+
+// CELSelector adds a CEL device selector to the DeviceClass.
+func (d *DeviceClassWrapper) CELSelector(expression string) *DeviceClassWrapper {
+	d.Spec.Selectors = append(d.Spec.Selectors, resourcev1.DeviceSelector{
+		CEL: &resourcev1.CELDeviceSelector{Expression: expression},
+	})
+	return d
+}
+
 // Obj returns the inner DeviceClass.
 func (d *DeviceClassWrapper) Obj() *resourcev1.DeviceClass {
 	return &d.DeviceClass

--- a/test/integration/singlecluster/controller/dra/dra_pd_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_pd_test.go
@@ -600,4 +600,174 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 			)
 		})
 	})
+
+	ginkgo.When("Partitionable devices borrowing in a cohort", func() {
+		var (
+			ns             *corev1.Namespace
+			resourceFlavor *kueue.ResourceFlavor
+			prodCQ         *kueue.ClusterQueue
+			devCQ          *kueue.ClusterQueue
+			prodLQ         *kueue.LocalQueue
+			devLQ          *kueue.LocalQueue
+			migDeviceClass *resourcev1.DeviceClass
+			slice          *resourcev1.ResourceSlice
+		)
+
+		ginkgo.BeforeEach(func() {
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-pd-borrow-")
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			migDeviceClass = utiltesting.MakeDeviceClass("mig.example.com").
+				CELSelector("device.attributes['gpu.example.com'].type == 'mig'").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, migDeviceClass)).To(gomega.Succeed())
+
+			slice = utiltesting.MakeResourceSlice("pd-borrow-slice", "gpu.example.com").
+				Pool("node1-gpu0", 1, 1).
+				Device("mig-0").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-1").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-2").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-3").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-4").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-5").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Device("mig-6").Attribute("type", "mig").Attribute("profile", "1g.10gb").
+				CounterConsumption("gpu-0-counters", "memory", "10Gi").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, slice)).To(gomega.Succeed())
+
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-pd-borrow-").Obj()
+			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
+
+			prodCQ = utiltestingapi.MakeClusterQueue("").GeneratedName("pd-prod-cq-").
+				Cohort("pd-cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("gpu.memory", "30Gi").
+						Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodCQ)).To(gomega.Succeed())
+
+			devCQ = utiltestingapi.MakeClusterQueue("").GeneratedName("pd-dev-cq-").
+				Cohort("pd-cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("gpu.memory", "30Gi").
+						Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, devCQ)).To(gomega.Succeed())
+
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, prodCQ, devCQ)
+
+			prodLQ = utiltestingapi.MakeLocalQueue("pd-prod-lq", ns.Name).
+				ClusterQueue(prodCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodLQ)).To(gomega.Succeed())
+
+			devLQ = utiltestingapi.MakeLocalQueue("pd-dev-lq", ns.Name).
+				ClusterQueue(devCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, devLQ)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, prodCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, devCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, migDeviceClass, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, slice, true)
+		})
+
+		ginkgo.It("Should borrow counter-based gpu.memory quota from another ClusterQueue in the cohort", func() {
+			rct := utiltesting.MakeResourceClaimTemplate("pd-borrow-template", ns.Name).
+				DeviceRequest("mig-device", "mig.example.com", 1).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating workload requesting 5 MIG devices (50Gi > 30Gi nominal, needs borrowing)")
+			wl := utiltestingapi.MakeWorkload("pd-borrow-wl", ns.Name).
+				Queue("pd-prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 5).
+					ResourceClaimTemplate("mig-device", "pd-borrow-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is admitted and borrows from dev-cq")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodCQ.Name, wl)
+
+			ginkgo.By("Verifying correct gpu.memory charge in admission")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(updatedWl.Status.Admission.PodSetAssignments).NotTo(gomega.BeEmpty())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName("gpu.memory")))
+				memUsage := assignment.ResourceUsage["gpu.memory"]
+				g.Expect(memUsage.Cmp(resource.MustParse("50Gi"))).To(gomega.Equal(0))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying prod-cq shows borrowed gpu.memory")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedCQ kueue.ClusterQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodCQ), &updatedCQ)).To(gomega.Succeed())
+				found := false
+				for _, flavorUsage := range updatedCQ.Status.FlavorsUsage {
+					for _, ru := range flavorUsage.Resources {
+						if ru.Name == "gpu.memory" {
+							found = true
+							g.Expect(ru.Total.Cmp(resource.MustParse("50Gi"))).To(gomega.Equal(0))
+							g.Expect(ru.Borrowed.Cmp(resource.MustParse("20Gi"))).To(gomega.Equal(0))
+						}
+					}
+				}
+				g.Expect(found).To(gomega.BeTrue(), "resource gpu.memory not found in FlavorsUsage")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should not admit PD workload when cohort counter capacity is exhausted", func() {
+			rct := utiltesting.MakeResourceClaimTemplate("pd-exhaust-template", ns.Name).
+				DeviceRequest("mig-device", "mig.example.com", 1).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Filling prod-cq counter quota (3 devices = 30Gi = nominal)")
+			prodWl := utiltestingapi.MakeWorkload("pd-prod-full", ns.Name).
+				Queue("pd-prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 3).
+					ResourceClaimTemplate("mig-device", "pd-exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodWl)).To(gomega.Succeed())
+
+			ginkgo.By("Filling dev-cq counter quota (3 devices = 30Gi = nominal)")
+			devWl := utiltestingapi.MakeWorkload("pd-dev-full", ns.Name).
+				Queue("pd-dev-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 3).
+					ResourceClaimTemplate("mig-device", "pd-exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, devWl)).To(gomega.Succeed())
+
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodCQ.Name, prodWl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, devCQ.Name, devWl)
+
+			ginkgo.By("Creating a workload that exceeds total cohort counter capacity")
+			overflowWl := utiltestingapi.MakeWorkload("pd-overflow-wl", ns.Name).
+				Queue("pd-prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 1).
+					ResourceClaimTemplate("mig-device", "pd-exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, overflowWl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying overflow workload stays pending")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, overflowWl)
+		})
+	})
 })

--- a/test/integration/singlecluster/controller/dra/dra_pd_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_pd_test.go
@@ -72,52 +72,25 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 		)
 
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "dra-pd-",
-				},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-pd-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			migDeviceClass = &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "mig.example.com",
-				},
-				Spec: resourcev1.DeviceClassSpec{
-					Selectors: []resourcev1.DeviceSelector{
-						{CEL: &resourcev1.CELDeviceSelector{Expression: "device.attributes['gpu.example.com'].type == 'mig'"}},
-					},
-				},
-			}
+			migDeviceClass = utiltesting.MakeDeviceClass("mig.example.com").
+				CELSelector("device.attributes['gpu.example.com'].type == 'mig'").
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, migDeviceClass)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-pd-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-pd-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "pd-cq-",
-				},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{
-						{
-							CoveredResources: []corev1.ResourceName{"cpu", "memory", "gpu.memory"},
-							Flavors: []kueue.FlavorQuotas{
-								{
-									Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-									Resources: []kueue.ResourceQuota{
-										{Name: "cpu", NominalQuota: resource.MustParse("8")},
-										{Name: "memory", NominalQuota: resource.MustParse("16Gi")},
-										{Name: "gpu.memory", NominalQuota: resource.MustParse("160Gi")},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("pd-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("cpu", "8").
+						Resource("memory", "16Gi").
+						Resource("gpu.memory", "160Gi").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -341,11 +314,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 			})
 
 			ginkgo.By("Creating a DeviceClass for whole GPUs")
-			dc := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "gpu.example.com",
-				},
-			}
+			dc := utiltesting.MakeDeviceClass("gpu.example.com").Obj()
 			gomega.Expect(k8sClient.Create(ctx, dc)).To(gomega.Succeed())
 			ginkgo.DeferCleanup(func() {
 				gomega.Expect(k8sClient.Delete(ctx, dc)).To(gomega.Succeed())
@@ -505,11 +474,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 			})
 
 			ginkgo.By("Creating a DeviceClass for whole GPUs")
-			dc := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "gpu.example.com",
-				},
-			}
+			dc := utiltesting.MakeDeviceClass("gpu.example.com").Obj()
 			gomega.Expect(k8sClient.Create(ctx, dc)).To(gomega.Succeed())
 			ginkgo.DeferCleanup(func() {
 				gomega.Expect(k8sClient.Delete(ctx, dc)).To(gomega.Succeed())
@@ -550,14 +515,9 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegrationExtendedResource, true)
 
 			ginkgo.By("Creating a DeviceClass with extendedResourceName and counters mapping")
-			dc := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "gpu-er-counter.example.com",
-				},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: new("example.com/gpu-counter"),
-				},
-			}
+			dc := utiltesting.MakeDeviceClass("gpu-er-counter.example.com").
+				ExtendedResourceName("example.com/gpu-counter").
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, dc)).To(gomega.Succeed())
 			ginkgo.DeferCleanup(func() {
 				gomega.Expect(k8sClient.Delete(ctx, dc)).To(gomega.Succeed())

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -1487,4 +1487,138 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
+
+	ginkgo.When("DRA resources in a cohort", func() {
+		var (
+			ns             *corev1.Namespace
+			resourceFlavor *kueue.ResourceFlavor
+			prodCQ         *kueue.ClusterQueue
+			devCQ          *kueue.ClusterQueue
+			prodLQ         *kueue.LocalQueue
+			devLQ          *kueue.LocalQueue
+			deviceClass    *resourcev1.DeviceClass
+		)
+
+		ginkgo.BeforeEach(func() {
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-borrow-")
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			deviceClass = utiltesting.MakeDeviceClass("foo.example.com").Obj()
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-borrow-").Obj()
+			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
+
+			prodCQ = utiltestingapi.MakeClusterQueue("").GeneratedName("prod-cq-").
+				Cohort("dra-cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("foo", "5").
+						Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodCQ)).To(gomega.Succeed())
+
+			devCQ = utiltestingapi.MakeClusterQueue("").GeneratedName("dev-cq-").
+				Cohort("dra-cohort").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("foo", "5").
+						Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, devCQ)).To(gomega.Succeed())
+
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, prodCQ, devCQ)
+
+			prodLQ = utiltestingapi.MakeLocalQueue("prod-lq", ns.Name).
+				ClusterQueue(prodCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodLQ)).To(gomega.Succeed())
+
+			devLQ = utiltestingapi.MakeLocalQueue("dev-lq", ns.Name).
+				ClusterQueue(devCQ.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, devLQ)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, prodCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, devCQ, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+		})
+
+		ginkgo.It("Should borrow DRA quota from another ClusterQueue in the cohort", func() {
+			rct := utiltesting.MakeResourceClaimTemplate("borrow-template", ns.Name).
+				DeviceRequest("gpu", "foo.example.com", 1).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating a workload that exceeds prod-cq nominal quota (needs borrowing)")
+			wl := utiltestingapi.MakeWorkload("borrow-wl", ns.Name).
+				Queue("prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 7).
+					ResourceClaimTemplate("gpu", "borrow-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is admitted and borrows from dev-cq")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodCQ.Name, wl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedCQ kueue.ClusterQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodCQ), &updatedCQ)).To(gomega.Succeed())
+				found := false
+				for _, flavorUsage := range updatedCQ.Status.FlavorsUsage {
+					for _, ru := range flavorUsage.Resources {
+						if ru.Name == "foo" {
+							found = true
+							g.Expect(ru.Total.Value()).To(gomega.Equal(int64(7)))
+							g.Expect(ru.Borrowed.Value()).To(gomega.Equal(int64(2)))
+						}
+					}
+				}
+				g.Expect(found).To(gomega.BeTrue(), "resource foo not found in FlavorsUsage")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should not admit DRA workload when cohort capacity is exhausted", func() {
+			rct := utiltesting.MakeResourceClaimTemplate("exhaust-template", ns.Name).
+				DeviceRequest("gpu", "foo.example.com", 1).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Filling prod-cq quota")
+			prodWl := utiltestingapi.MakeWorkload("prod-full", ns.Name).
+				Queue("prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 5).
+					ResourceClaimTemplate("gpu", "exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, prodWl)).To(gomega.Succeed())
+
+			ginkgo.By("Filling dev-cq quota")
+			devWl := utiltestingapi.MakeWorkload("dev-full", ns.Name).
+				Queue("dev-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 5).
+					ResourceClaimTemplate("gpu", "exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, devWl)).To(gomega.Succeed())
+
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, prodCQ.Name, prodWl)
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, devCQ.Name, devWl)
+
+			ginkgo.By("Creating a workload that exceeds total cohort capacity")
+			overflowWl := utiltestingapi.MakeWorkload("overflow-wl", ns.Name).
+				Queue("prod-lq").
+				PodSets(*utiltestingapi.MakePodSet("main", 1).
+					ResourceClaimTemplate("gpu", "exhaust-template").
+					Obj()).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, overflowWl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying overflow workload stays pending")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, overflowWl)
+		})
+	})
 })

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -63,45 +63,21 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		)
 		ginkgo.BeforeEach(func() {
 			resourceSlices = nil
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "dra-",
-				},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			deviceClass = &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo.example.com",
-				},
-			}
+			deviceClass = utiltesting.MakeDeviceClass("foo.example.com").Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-cq-",
-				},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{
-						{
-							CoveredResources: []corev1.ResourceName{"foo"},
-							Flavors: []kueue.FlavorQuotas{
-								{
-									Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-									Resources: []kueue.ResourceQuota{
-										{Name: "foo", NominalQuota: resource.MustParse("10")},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("test-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource("foo", "10").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 			localQueue = utiltestingapi.MakeLocalQueue("test-lq", ns.Name).
@@ -861,48 +837,23 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "dra-ext-",
-				},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-ext-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			deviceClass = &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "gpu-ext-",
-				},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass = utiltesting.MakeDeviceClass("").GeneratedName("gpu-ext-").
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-ext-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-ext-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "ext-cq-",
-				},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{
-						{
-							CoveredResources: []corev1.ResourceName{corev1.ResourceName(extendedResourceName)},
-							Flavors: []kueue.FlavorQuotas{
-								{
-									Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-									Resources: []kueue.ResourceQuota{
-										{Name: corev1.ResourceName(extendedResourceName), NominalQuota: resource.MustParse("4")},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("ext-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(corev1.ResourceName(extendedResourceName), "4").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -959,12 +910,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegration, true)
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegrationExtendedResource, true)
 
-			deviceClass = &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass = utiltesting.MakeDeviceClass("gpu.example.com").
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
 			fwk.StopManager(ctx)
@@ -983,31 +931,18 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "dra-unified-"},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-unified-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-unified-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-unified-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "unified-cq-"},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{{
-						CoveredResources: []corev1.ResourceName{logicalName},
-						Flavors: []kueue.FlavorQuotas{{
-							Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-							Resources: []kueue.ResourceQuota{{
-								Name:         logicalName,
-								NominalQuota: resource.MustParse("8"),
-							}},
-						}},
-					}},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("unified-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(logicalName, "8").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -1065,38 +1000,18 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "dra-gate-off-",
-				},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-gate-off-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-gate-off-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-gate-off-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "gate-off-cq-",
-				},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{
-						{
-							CoveredResources: []corev1.ResourceName{extendedResourceName},
-							Flavors: []kueue.FlavorQuotas{
-								{
-									Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-									Resources: []kueue.ResourceQuota{
-										{Name: extendedResourceName, NominalQuota: resource.MustParse("4")},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("gate-off-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(extendedResourceName, "4").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -1143,39 +1058,19 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		ginkgo.BeforeEach(func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegration, false)
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRARejectWorkloadsWhenDRADisabled, true)
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "dra-reject-",
-				},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-reject-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-reject-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-reject-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "reject-cq-",
-				},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{
-						{
-							CoveredResources: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory},
-							Flavors: []kueue.FlavorQuotas{
-								{
-									Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-									Resources: []kueue.ResourceQuota{
-										{Name: corev1.ResourceCPU, NominalQuota: resource.MustParse("4")},
-										{Name: corev1.ResourceMemory, NominalQuota: resource.MustParse("4Gi")},
-									},
-								},
-							},
-						},
-					},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("reject-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(corev1.ResourceCPU, "4").
+						Resource(corev1.ResourceMemory, "4Gi").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -1283,31 +1178,18 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 		})
 
 		ginkgo.BeforeEach(func() {
-			ns = &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "dra-dc-tracking-"},
-			}
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-dc-tracking-")
 			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
 
-			resourceFlavor = utiltestingapi.MakeResourceFlavor("").Obj()
-			resourceFlavor.GenerateName = "rf-dc-tracking-"
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-dc-tracking-").Obj()
 			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
 
-			clusterQueue = &kueue.ClusterQueue{
-				ObjectMeta: metav1.ObjectMeta{GenerateName: "dc-tracking-cq-"},
-				Spec: kueue.ClusterQueueSpec{
-					NamespaceSelector: &metav1.LabelSelector{},
-					ResourceGroups: []kueue.ResourceGroup{{
-						CoveredResources: []corev1.ResourceName{logicalName},
-						Flavors: []kueue.FlavorQuotas{{
-							Name: kueue.ResourceFlavorReference(resourceFlavor.Name),
-							Resources: []kueue.ResourceQuota{{
-								Name:         logicalName,
-								NominalQuota: resource.MustParse("8"),
-							}},
-						}},
-					}},
-				},
-			}
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("dc-tracking-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(logicalName, "8").
+						Obj(),
+				).Obj()
 			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
 			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
 
@@ -1334,12 +1216,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
 
 			ginkgo.By("Creating DeviceClass with extendedResourceName")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 			defer func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
@@ -1360,12 +1239,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should not admit new workload after DeviceClass is deleted", func() {
 			ginkgo.By("Creating DeviceClass")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
 			ginkgo.By("Creating first workload and verifying admission")
@@ -1398,12 +1274,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should requeue inadmissible workload when DeviceClass is deleted", func() {
 			ginkgo.By("Creating DeviceClass")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
 			ginkgo.By("Creating first workload to fill quota")
@@ -1444,12 +1317,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should clear stale DRA TotalRequests when admitted workload is requeued after DeviceClass deletion", func() {
 			ginkgo.By("Creating DeviceClass")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 
 			ginkgo.By("Creating workload and verifying it is admitted with DRA-translated quota key")
@@ -1490,12 +1360,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			const newExtendedResourceName = "example.com/tpu"
 
 			ginkgo.By("Creating DeviceClass with extendedResourceName for gpu")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 			defer func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
@@ -1534,12 +1401,9 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			const newExtendedResourceName = "example.com/other-accelerator"
 
 			ginkgo.By("Creating DeviceClass with extendedResourceName for gpu")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec: resourcev1.DeviceClassSpec{
-					ExtendedResourceName: ptr.To(extendedResourceName),
-				},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 			defer func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
@@ -1588,10 +1452,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 
 		ginkgo.It("Should requeue inadmissible workload when DeviceClass extendedResourceName is added", func() {
 			ginkgo.By("Creating DeviceClass without extendedResourceName")
-			deviceClass := &resourcev1.DeviceClass{
-				ObjectMeta: metav1.ObjectMeta{Name: deviceClassName},
-				Spec:       resourcev1.DeviceClassSpec{},
-			}
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).Obj()
 			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
 			defer func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration test coverage for cohort-scoped DRA quota borrowing for partitionable (MIG) devices, including shared flavor accounting and cohort capacity exhaustion behavior.
* **Tests**
  * Verified workloads can be admitted by borrowing quota across `ClusterQueue`s within the same cohort with correct `gpu.memory` flavor usage reporting.
  * Added scenarios where combined cohort capacity is exhausted and the overflow workload remains pending.
* **Refactor**
  * Improved test setup/readability by using fluent builders for DRA resources and device class selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->