### PR TITLE
MultiKueue: propagate manager-driven elastic RayCluster worker replicas

### DIFF
--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -19,6 +19,7 @@ package ray
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -26,11 +27,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 type objAsPtr[T any] interface {
@@ -46,6 +50,44 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	gvk          schema.GroupVersionKind
 	getManagedBy func(PtrT) *string
 	setManagedBy func(PtrT, *string)
+	// elastic is optional. When set, the adapter propagates manager-driven,
+	// in-place worker replica changes of an elastic workload to the remote copy
+	// on the worker cluster. It is left unset for job types that do not support
+	// this (see ElasticReplicaSync).
+	elastic *ElasticReplicaSync[PtrT, T]
+}
+
+// ElasticReplicaSync carries the type-specific hooks that let the MultiKueue
+// adapter propagate manager-driven, in-place worker replica changes of an
+// elastic workload (the ElasticJobsViaWorkloadSlices feature) to the remote
+// copy on the worker cluster.
+//
+// Only job types whose worker replicas live directly on the Kueue-managed
+// object wire this. RayCluster does. RayJob and RayService do not: their worker
+// replicas belong to a child RayCluster on the worker cluster that has no
+// representation on the manager, so they keep the create-once behavior and
+// leave this unset.
+type ElasticReplicaSync[PtrT objAsPtr[T], T any] struct {
+	// SyncReplicas copies the worker replica counts from src into dst, returning
+	// whether dst changed.
+	SyncReplicas func(dst, src PtrT) bool
+	// WorkerReplicas returns the per-worker-group replica counts keyed by PodSet
+	// reference. Used to detect a replica change and its direction.
+	WorkerReplicas func(PtrT) map[kueue.PodSetReference]int32
+	// WorkloadNameExtraPart mirrors ElasticWorkloadNameProvider for the type; it
+	// is used to compute the workload name of the object's current slice.
+	WorkloadNameExtraPart func(PtrT) string
+}
+
+// Option configures a Ray MultiKueue adapter.
+type Option[PtrT objAsPtr[T], T any] func(*adapter[PtrT, T])
+
+// WithElasticReplicaSync enables manager-driven elastic replica propagation
+// over MultiKueue for job types that support it (see ElasticReplicaSync).
+func WithElasticReplicaSync[PtrT objAsPtr[T], T any](e *ElasticReplicaSync[PtrT, T]) Option[PtrT, T] {
+	return func(a *adapter[PtrT, T]) {
+		a.elastic = e
+	}
 }
 
 type fullInterface interface {
@@ -64,8 +106,9 @@ func NewMKAdapter[PtrT objAsPtr[T], T any](
 	gvk schema.GroupVersionKind,
 	getManagedBy func(PtrT) *string,
 	setManagedBy func(PtrT, *string),
+	opts ...Option[PtrT, T],
 ) fullInterface {
-	return &adapter[PtrT, T]{
+	a := &adapter[PtrT, T]{
 		copySpec:     copySpec,
 		copyStatus:   copyStatus,
 		emptyList:    emptyList,
@@ -73,6 +116,10 @@ func NewMKAdapter[PtrT objAsPtr[T], T any](
 		getManagedBy: getManagedBy,
 		setManagedBy: setManagedBy,
 	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
 }
 
 func (a *adapter[PtrT, T]) GVK() schema.GroupVersionKind {
@@ -112,12 +159,19 @@ func (a *adapter[PtrT, T]) SyncJob(
 		return false, err
 	}
 
-	// if the remote exists, just copy the status
+	// if the remote exists, copy the status and, for elastic workloads,
+	// propagate any manager-driven worker replica change to the remote.
 	if err == nil {
-		return false, clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
+		if err := clientutil.PatchStatus(ctx, localClient, localJob, func() (bool, error) {
 			a.copyStatus(localJob, remoteJob)
 			return true, nil
-		})
+		}); err != nil {
+			return false, err
+		}
+		if a.needElasticSync(ctx, workloadName, localJob, remoteJob) {
+			return false, a.syncElastic(ctx, remoteClient, workloadName, localJob, remoteJob)
+		}
+		return false, nil
 	}
 
 	remoteJob = PtrT(new(T))
@@ -130,6 +184,61 @@ func (a *adapter[PtrT, T]) SyncJob(
 	a.setManagedBy(remoteJob, nil)
 
 	return false, remoteClient.Create(ctx, remoteJob)
+}
+
+// needElasticSync reports whether the remote object must be updated to reflect
+// a manager-driven worker replica change of an elastic workload. It mirrors the
+// batch/Job adapter, including the stale scale-up guard.
+func (a *adapter[PtrT, T]) needElasticSync(ctx context.Context, workloadName string, localJob, remoteJob PtrT) bool {
+	if a.elastic == nil {
+		return false
+	}
+	if !features.Enabled(features.ElasticJobsViaWorkloadSlices) || !workloadslicing.Enabled(localJob) {
+		return false
+	}
+
+	oldCounts := a.elastic.WorkerReplicas(remoteJob)
+	newCounts := a.elastic.WorkerReplicas(localJob)
+
+	// Skip stale local Workload updates caused by a scale-up event. During
+	// scale-up the GenericJobReconciler creates a new, larger Workload slice that
+	// finalizes the old one. If this reconcile still observes the old slice
+	// (workloadName) while the local object's replicas have already grown, the
+	// observed state is stale and must not be propagated to the worker cluster.
+	newWorkloadName := jobframework.GenerateWorkloadNameWithExtra(
+		localJob.GetName(), localJob.GetUID(), a.gvk, a.elastic.WorkloadNameExtraPart(localJob))
+	if totalReplicas(oldCounts) < totalReplicas(newCounts) && workloadName != newWorkloadName {
+		ctrl.LoggerFrom(ctx).V(2).Info("Skipping stale ElasticWorkload sync",
+			"observedWorkloadName", workloadName, "currentWorkloadName", newWorkloadName)
+		return false
+	}
+
+	return !maps.Equal(oldCounts, newCounts) || jobframework.PrebuiltWorkloadNameFor(remoteJob) != workloadName
+}
+
+// syncElastic patches the remote object's worker replicas and prebuilt workload
+// label to match the local (manager) object. It should only be called when
+// needElasticSync returns true.
+func (a *adapter[PtrT, T]) syncElastic(ctx context.Context, remoteClient client.Client, workloadName string, localJob, remoteJob PtrT) error {
+	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
+		changed := a.elastic.SyncReplicas(remoteJob, localJob)
+		if jobframework.PrebuiltWorkloadNameFor(remoteJob) != workloadName {
+			jobframework.SetPrebuiltWorkloadName(remoteJob, workloadName)
+			changed = true
+		}
+		return changed, nil
+	}); err != nil {
+		return fmt.Errorf("failed to patch remote %s: %w", a.gvk.Kind, err)
+	}
+	return nil
+}
+
+func totalReplicas(counts map[kueue.PodSetReference]int32) int32 {
+	var total int32
+	for _, c := range counts {
+		total += c
+	}
+	return total
 }
 
 func (a *adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, _ client.Client, remoteClient client.Client, key types.NamespacedName) error {

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -67,6 +67,12 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 // replicas belong to a child RayCluster on the worker cluster that has no
 // representation on the manager, so they keep the create-once behavior and
 // leave this unset.
+//
+// Scope: detection compares the effective per-group pod count (WorkerReplicas)
+// of worker groups that exist on both the manager and the remote. Changes that
+// keep the count equal but reshape its inputs (e.g. replicas vs. NumOfHosts for
+// RayCluster), and worker groups present only on the manager, are out of scope:
+// the PodSet count is what Kueue admits, so only the effective count matters.
 type ElasticReplicaSync[PtrT objAsPtr[T], T any] struct {
 	// SyncReplicas copies the worker replica counts from src into dst, returning
 	// whether dst changed.

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -57,6 +57,21 @@ const (
 	RayClusterGenerationAnnotation = "kueue.x-k8s.io/raycluster-generation"
 )
 
+// effectiveWorkerCount returns the effective worker pod count for a worker
+// group: Replicas scaled by NumOfHosts, with Replicas defaulting to 1 when
+// unset. BuildPodSets, UpdatePodSets, and the MultiKueue elastic replica sync
+// all call this so the per-group count derivation stays in one place.
+func effectiveWorkerCount(wgs *rayv1.WorkerGroupSpec) int32 {
+	count := int32(1)
+	if wgs.Replicas != nil {
+		count = *wgs.Replicas
+	}
+	if wgs.NumOfHosts > 1 {
+		count *= wgs.NumOfHosts
+	}
+	return count
+}
+
 // BuildPodSets builds PodSets from RayClusterSpec.
 func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]string) ([]kueue.PodSet, error) {
 	podSets := make([]kueue.PodSet, 0)
@@ -94,17 +109,10 @@ func BuildPodSets(rayClusterSpec *rayv1.RayClusterSpec, annotations map[string]s
 	// workers
 	for index := range rayClusterSpec.WorkerGroupSpecs {
 		wgs := &rayClusterSpec.WorkerGroupSpecs[index]
-		count := int32(1)
-		if wgs.Replicas != nil {
-			count = *wgs.Replicas
-		}
-		if wgs.NumOfHosts > 1 {
-			count *= wgs.NumOfHosts
-		}
 		workerPodSet := kueue.PodSet{
 			Name:     kueue.NewPodSetReference(wgs.GroupName),
 			Template: *wgs.Template.DeepCopy(),
-			Count:    count,
+			Count:    effectiveWorkerCount(wgs),
 		}
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(&wgs.Template.ObjectMeta).Build()
@@ -223,11 +231,7 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 						continue
 					}
 
-					// Calculate the count based on RayCluster's worker group replicas
-					count := *wgs.Replicas
-					if wgs.NumOfHosts > 1 {
-						count *= wgs.NumOfHosts
-					}
+					count := effectiveWorkerCount(wgs)
 
 					// Update the count in the PodSet only if it's different
 					if podSet.Count != count {

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -47,13 +47,14 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:      SetupIndexes,
-		NewJob:            NewJob,
-		NewReconciler:     NewReconciler,
-		SetupWebhook:      SetupRayClusterWebhook,
-		JobType:           &rayv1.RayCluster{},
-		AddToScheme:       rayv1.AddToScheme,
-		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
+		SetupIndexes:  SetupIndexes,
+		NewJob:        NewJob,
+		NewReconciler: NewReconciler,
+		SetupWebhook:  SetupRayClusterWebhook,
+		JobType:       &rayv1.RayCluster{},
+		AddToScheme:   rayv1.AddToScheme,
+		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+			ray.WithElasticReplicaSync(elasticReplicaSync())),
 	}))
 }
 

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -80,26 +80,40 @@ func workerReplicaCounts(rc *rayv1.RayCluster) map[kueue.PodSetReference]int32 {
 	return counts
 }
 
-// syncWorkerReplicas copies each worker group's Replicas from src into dst,
-// matching groups by name, and returns whether dst changed.
+// syncWorkerReplicas copies each worker group's Replicas and NumOfHosts from
+// src into dst, matching groups by name, and returns whether dst changed. Both
+// fields feed the effective per-group pod count that needElasticSync compares
+// (see workerReplicaCounts), so both must be propagated to keep the remote in
+// sync when either changes.
 func syncWorkerReplicas(dst, src *rayv1.RayCluster) bool {
-	srcReplicas := make(map[string]*int32, len(src.Spec.WorkerGroupSpecs))
+	type groupSize struct {
+		replicas   *int32
+		numOfHosts int32
+	}
+	srcSizes := make(map[string]groupSize, len(src.Spec.WorkerGroupSpecs))
 	for i := range src.Spec.WorkerGroupSpecs {
-		srcReplicas[src.Spec.WorkerGroupSpecs[i].GroupName] = src.Spec.WorkerGroupSpecs[i].Replicas
+		wgs := &src.Spec.WorkerGroupSpecs[i]
+		srcSizes[wgs.GroupName] = groupSize{replicas: wgs.Replicas, numOfHosts: wgs.NumOfHosts}
 	}
 	changed := false
 	for i := range dst.Spec.WorkerGroupSpecs {
 		wgs := &dst.Spec.WorkerGroupSpecs[i]
-		want, ok := srcReplicas[wgs.GroupName]
-		if !ok || ptr.Equal(wgs.Replicas, want) {
+		want, ok := srcSizes[wgs.GroupName]
+		if !ok {
 			continue
 		}
-		if want == nil {
-			wgs.Replicas = nil
-		} else {
-			wgs.Replicas = ptr.To(*want)
+		if !ptr.Equal(wgs.Replicas, want.replicas) {
+			if want.replicas == nil {
+				wgs.Replicas = nil
+			} else {
+				wgs.Replicas = ptr.To(*want.replicas)
+			}
+			changed = true
 		}
-		changed = true
+		if wgs.NumOfHosts != want.numOfHosts {
+			wgs.NumOfHosts = want.numOfHosts
+			changed = true
+		}
 	}
 	return changed
 }

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -106,7 +106,7 @@ func syncWorkerReplicas(dst, src *rayv1.RayCluster) bool {
 			if want.replicas == nil {
 				wgs.Replicas = nil
 			} else {
-				wgs.Replicas = ptr.To(*want.replicas)
+				wgs.Replicas = new(*want.replicas)
 			}
 			changed = true
 		}

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -18,14 +18,20 @@ package raycluster
 
 import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/api"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
-var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
+var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(
+	copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+	ray.WithElasticReplicaSync(elasticReplicaSync()),
+)
 
 func copyJobStatus(dst, src *rayv1.RayCluster) {
 	dst.Status = src.Status
@@ -36,6 +42,66 @@ func copyJobSpec(dst, src *rayv1.RayCluster) {
 		ObjectMeta: api.CloneObjectMetaForCreation(&src.ObjectMeta),
 		Spec:       *src.Spec.DeepCopy(),
 	}
+	// An elastic RayCluster over MultiKueue is scaled by the manager: the
+	// manager's worker replica counts are the source of truth and are propagated
+	// to this remote copy on each sync. The remote must therefore not run the
+	// in-tree Ray autoscaler, which would otherwise fight the manager by editing
+	// worker replicas on the worker cluster.
+	if workloadslicing.Enabled(src) {
+		dst.Spec.EnableInTreeAutoscaling = nil
+	}
+}
+
+// elasticReplicaSync wires the RayCluster-specific hooks used by the shared Ray
+// MultiKueue adapter to propagate manager-driven worker replica changes.
+func elasticReplicaSync() *ray.ElasticReplicaSync[*rayv1.RayCluster, rayv1.RayCluster] {
+	return &ray.ElasticReplicaSync[*rayv1.RayCluster, rayv1.RayCluster]{
+		SyncReplicas:          syncWorkerReplicas,
+		WorkerReplicas:        workerReplicaCounts,
+		WorkloadNameExtraPart: func(rc *rayv1.RayCluster) string { return GetWorkloadNameExtraPart(rc) },
+	}
+}
+
+// workerReplicaCounts returns the effective worker pod count per worker group,
+// matching how BuildPodSets derives PodSet counts (replicas scaled by NumOfHosts).
+func workerReplicaCounts(rc *rayv1.RayCluster) map[kueue.PodSetReference]int32 {
+	counts := make(map[kueue.PodSetReference]int32, len(rc.Spec.WorkerGroupSpecs))
+	for i := range rc.Spec.WorkerGroupSpecs {
+		wgs := &rc.Spec.WorkerGroupSpecs[i]
+		count := int32(1)
+		if wgs.Replicas != nil {
+			count = *wgs.Replicas
+		}
+		if wgs.NumOfHosts > 1 {
+			count *= wgs.NumOfHosts
+		}
+		counts[kueue.NewPodSetReference(wgs.GroupName)] = count
+	}
+	return counts
+}
+
+// syncWorkerReplicas copies each worker group's Replicas from src into dst,
+// matching groups by name, and returns whether dst changed.
+func syncWorkerReplicas(dst, src *rayv1.RayCluster) bool {
+	srcReplicas := make(map[string]*int32, len(src.Spec.WorkerGroupSpecs))
+	for i := range src.Spec.WorkerGroupSpecs {
+		srcReplicas[src.Spec.WorkerGroupSpecs[i].GroupName] = src.Spec.WorkerGroupSpecs[i].Replicas
+	}
+	changed := false
+	for i := range dst.Spec.WorkerGroupSpecs {
+		wgs := &dst.Spec.WorkerGroupSpecs[i]
+		want, ok := srcReplicas[wgs.GroupName]
+		if !ok || ptr.Equal(wgs.Replicas, want) {
+			continue
+		}
+		if want == nil {
+			wgs.Replicas = nil
+		} else {
+			wgs.Replicas = ptr.To(*want)
+		}
+		changed = true
+	}
+	return changed
 }
 
 func getEmptyList() client.ObjectList {

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -68,14 +68,7 @@ func workerReplicaCounts(rc *rayv1.RayCluster) map[kueue.PodSetReference]int32 {
 	counts := make(map[kueue.PodSetReference]int32, len(rc.Spec.WorkerGroupSpecs))
 	for i := range rc.Spec.WorkerGroupSpecs {
 		wgs := &rc.Spec.WorkerGroupSpecs[i]
-		count := int32(1)
-		if wgs.Replicas != nil {
-			count = *wgs.Replicas
-		}
-		if wgs.NumOfHosts > 1 {
-			count *= wgs.NumOfHosts
-		}
-		counts[kueue.NewPodSetReference(wgs.GroupName)] = count
+		counts[kueue.NewPodSetReference(wgs.GroupName)] = effectiveWorkerCount(wgs)
 	}
 	return counts
 }
@@ -96,6 +89,14 @@ func syncWorkerReplicas(dst, src *rayv1.RayCluster) bool {
 		srcSizes[wgs.GroupName] = groupSize{replicas: wgs.Replicas, numOfHosts: wgs.NumOfHosts}
 	}
 	changed := false
+	// Re-assert that the remote autoscaler stays off. copyJobSpec clears this
+	// at create time; re-asserting here keeps the "manager owns replicas"
+	// invariant reconciled, since the elastic sync path patches the remote in
+	// place rather than re-copying the full spec.
+	if dst.Spec.EnableInTreeAutoscaling != nil {
+		dst.Spec.EnableInTreeAutoscaling = nil
+		changed = true
+	}
 	for i := range dst.Spec.WorkerGroupSpecs {
 		wgs := &dst.Spec.WorkerGroupSpecs[i]
 		want, ok := srcSizes[wgs.GroupName]

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -347,6 +348,38 @@ func TestMultiKueueAdapter(t *testing.T) {
 			wantWorkerRayClusters: []rayv1.RayCluster{
 				*elasticBuilder.Clone().
 					PrebuiltWorkloadLabel("stale-wl").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(1).
+					Obj(),
+			},
+		},
+		// The elastic sync path must keep the remote autoscaler off, not just
+		// at create time. Here the worker copy has EnableInTreeAutoscaling set
+		// (e.g. re-enabled out-of-band); a scale-down sync should clear it so the
+		// manager stays the sole replica driver.
+		"elastic sync re-asserts that the remote autoscaler stays off": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(3).
+					WithEnableAutoscaling(ptr.To(true)).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					ScaleFirstWorkerGroup(1).
 					Obj(),

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -367,7 +366,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					PrebuiltWorkloadLabel("wl1").
 					Label(kueue.MultiKueueOriginLabel, "origin1").
 					ScaleFirstWorkerGroup(3).
-					WithEnableAutoscaling(ptr.To(true)).
+					WithEnableAutoscaling(new(true)).
 					Obj(),
 			},
 			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 const (
@@ -51,6 +52,17 @@ func TestMultiKueueAdapter(t *testing.T) {
 	}
 
 	rayClusterBuilder := utiltestingraycluster.MakeCluster("raycluster1", TestNamespace).Suspend(false)
+
+	// elasticBuilder is workload-slicing enabled (elastic-job annotation set).
+	elasticBuilder := rayClusterBuilder.Clone().
+		SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue)
+
+	// scaleUpManager is the manager copy after a scale-up to 3 worker replicas.
+	// scaleUpWorkloadName is the workload name of the slice that reflects it; the
+	// MultiKueue controller calls SyncJob with this name once that slice is admitted.
+	scaleUpManager := elasticBuilder.Clone().ScaleFirstWorkerGroup(3).Obj()
+	scaleUpWorkloadName := jobframework.GenerateWorkloadNameWithExtra(
+		scaleUpManager.Name, scaleUpManager.UID, gvk, GetWorkloadNameExtraPart(scaleUpManager))
 
 	cases := map[string]struct {
 		managersRayClusters []rayv1.RayCluster
@@ -226,6 +238,114 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"elastic scale-down propagates reduced worker replicas to the remote": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(3).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(1).
+					Obj(),
+			},
+		},
+		"elastic scale-up with the current slice name propagates replicas and updates the workload label": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*scaleUpManager.DeepCopy(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(1).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, scaleUpWorkloadName, "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*scaleUpManager.DeepCopy(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel(scaleUpWorkloadName).
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(3).
+					Obj(),
+			},
+		},
+		"elastic scale-up observing a stale old slice is skipped": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(3).Obj(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("stale-wl").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(1).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "stale-wl", "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(3).Obj(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("stale-wl").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(1).
+					Obj(),
+			},
+		},
+		"non-elastic raycluster does not sync worker replicas even with the feature enabled": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(3).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*rayClusterBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(3).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -241,7 +361,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+				ray.WithElasticReplicaSync(elasticReplicaSync()))
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -265,6 +265,39 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		// A change confined to NumOfHosts still alters the effective per-group pod
+		// count that needElasticSync compares, so it must be propagated. Here the
+		// effective count decreases (4 -> 2), which avoids the scale-up stale guard,
+		// isolating the NumOfHosts propagation with Replicas held equal.
+		"elastic NumOfHosts change propagates to the remote worker group": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
+			managersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(2).WithNumOfHosts("workers-group-0", 1).Obj(),
+			},
+			workerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(2).
+					WithNumOfHosts("workers-group-0", 2).
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+			wantManagersRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().ScaleFirstWorkerGroup(2).WithNumOfHosts("workers-group-0", 1).Obj(),
+			},
+			wantWorkerRayClusters: []rayv1.RayCluster{
+				*elasticBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					ScaleFirstWorkerGroup(2).
+					WithNumOfHosts("workers-group-0", 1).
+					Obj(),
+			},
+		},
 		"elastic scale-up with the current slice name propagates replicas and updates the workload label": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -39,6 +39,7 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadaw "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	workloadpytorchjob "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
@@ -63,6 +64,7 @@ import (
 	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
 	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -795,6 +797,81 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 						g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
 						g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
 						g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("Should scale an elastic RayCluster on worker if admitted", func() {
+				kuberayTestImage := util.GetKuberayTestImage()
+				raycluster := testingraycluster.MakeCluster("raycluster-elastic", managerNs.Name).
+					Suspend(true).
+					SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Queue(managerLq.Name).
+					ScaleFirstWorkerGroup(1).
+					RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "200m").
+					RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "200m").
+					Image(rayv1.HeadNode, kuberayTestImage, []string{}).
+					Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
+					Obj()
+
+				ginkgo.By("Creating the elastic RayCluster", func() {
+					util.MustCreate(ctx, k8sManagerClient, raycluster)
+				})
+
+				// Elastic (workload-slicing) RayCluster workloads are named with the
+				// object's generation, so fetch the created object to derive the name
+				// of its current slice.
+				gomega.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), raycluster)).To(gomega.Succeed())
+				wlLookupKey := types.NamespacedName{
+					Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(raycluster.Name, raycluster.UID, rayv1.GroupVersion.WithKind("RayCluster"), raycluster.GetGeneration()),
+					Namespace: managerNs.Name,
+				}
+				admittedWorker := util.ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx, k8sManagerClient, wlLookupKey, multiKueueAc.Name)
+				ginkgo.GinkgoLogr.Info(fmt.Sprintf("elastic RayCluster %s/%s is admitted in worker cluster %s", raycluster.Name, raycluster.Namespace, admittedWorker))
+
+				// The assertions below check DesiredWorkerReplicas, which KubeRay derives
+				// directly from the worker cluster's RayCluster spec. This is exactly what
+				// the manager-driven elastic sync propagates, and it does not depend on the
+				// Ray runtime becoming healthy (Ray pod readiness is KubeRay's own concern).
+				ginkgo.By("Checking the RayCluster starts with one worker on the worker cluster", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Scaling the first worker group up to three on the manager", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](3)
+						g.Expect(k8sManagerClient.Update(ctx, createdRayCluster)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking the scaled-up worker replicas propagate to the worker cluster", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(3)))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Scaling the first worker group back down to one on the manager", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](1)
+						g.Expect(k8sManagerClient.Update(ctx, createdRayCluster)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking the reduced worker replicas propagate to the worker cluster", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayCluster := &rayv1.RayCluster{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
+						g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
 					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 			})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2208,12 +2208,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		ginkgo.By("admit the workload on the worker1 cluster")
 		util.SetQuotaReservation(worker1.ctx, worker1.client, workloadKey, admission().Obj())
 
-		ginkgo.By("observe: the local admission check reflects the reservation on the worker1 cluster")
+		ginkgo.By("observe: the local admission check reflects the admission on the worker1 cluster")
 		util.ExpectAdmissionCheckStateWithMessage(
 			manager.ctx, manager.client, workloadKey,
 			multiKueueAC.Name,
 			kueue.CheckStateReady,
-			`The workload got reservation on "worker1"`,
+			`The workload was admitted on "worker1"`,
 		)
 
 		ginkgo.By("observe: the RayCluster is synced to the worker1 cluster and is not suspended", func() {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2144,6 +2144,179 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("Should scale an elastic RayCluster on the worker if admitted", func() {
+		manager := managerTestCluster
+		worker1 := worker1TestCluster
+		worker2 := worker2TestCluster
+
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		rayGVK := rayv1.GroupVersion.WithKind("RayCluster")
+		headPodSet := utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()
+		workerPodSet := utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()
+		admission := func() *utiltestingapi.AdmissionWrapper {
+			return utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(headPodSet, workerPodSet)
+		}
+
+		getRayCluster := func(ctx context.Context, clnt client.Client, rc *rayv1.RayCluster) {
+			ginkgo.GinkgoHelper()
+			gomega.Expect(clnt.Get(ctx, client.ObjectKeyFromObject(rc), rc)).To(gomega.Succeed())
+		}
+		getWorkloadKey := func(rc *rayv1.RayCluster) types.NamespacedName {
+			ginkgo.GinkgoHelper()
+			getRayCluster(manager.ctx, manager.client, rc)
+			return types.NamespacedName{Name: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(rc.Name, rc.UID, rayGVK, rc.GetGeneration()), Namespace: rc.Namespace}
+		}
+		getWorkload := func(g gomega.Gomega, ctx context.Context, clnt client.Client, key types.NamespacedName) *kueue.Workload {
+			ginkgo.GinkgoHelper()
+			wl := &kueue.Workload{}
+			g.Expect(clnt.Get(ctx, key, wl)).To(gomega.Succeed())
+			return wl
+		}
+
+		raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(managerLq.Name).
+			ScaleFirstWorkerGroup(1).
+			Obj()
+		util.MustCreate(manager.ctx, manager.client, raycluster)
+
+		ginkgo.By("observe: the elastic RayCluster is created suspended in the manager cluster", func() {
+			getRayCluster(manager.ctx, manager.client, raycluster)
+			gomega.Expect(raycluster.Spec.Suspend).To(gomega.Equal(new(true)))
+		})
+
+		ginkgo.By("observe: a workload is created in the manager cluster")
+		workloadKey := getWorkloadKey(raycluster)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, workloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("admit the workload on the manager cluster")
+		util.SetQuotaReservation(manager.ctx, manager.client, workloadKey, admission().Obj())
+
+		ginkgo.By("observe: the workload is created on all worker clusters", func() {
+			localWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(wl.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+				wl = getWorkload(g, worker2.ctx, worker2.client, workloadKey)
+				g.Expect(wl.Spec).To(gomega.BeComparableTo(localWorkload.Spec))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admit the workload on the worker1 cluster")
+		util.SetQuotaReservation(worker1.ctx, worker1.client, workloadKey, admission().Obj())
+
+		ginkgo.By("observe: the local admission check reflects the reservation on the worker1 cluster")
+		util.ExpectAdmissionCheckStateWithMessage(
+			manager.ctx, manager.client, workloadKey,
+			multiKueueAC.Name,
+			kueue.CheckStateReady,
+			`The workload got reservation on "worker1"`,
+		)
+
+		ginkgo.By("observe: the RayCluster is synced to the worker1 cluster and is not suspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remote := raycluster.DeepCopy()
+				getRayCluster(worker1.ctx, worker1.client, remote)
+				g.Expect(remote.Spec.Suspend).To(gomega.Equal(new(false)))
+				g.Expect(remote.Spec.WorkerGroupSpecs[0].Replicas).To(gomega.BeEquivalentTo(new(int32(1))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the workload is removed from the worker2 cluster")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(worker2.client.Get(worker2.ctx, workloadKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		/*
+			Scale-up Section.
+		*/
+		ginkgo.By("scale-up the RayCluster's first worker group to 3", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				getRayCluster(manager.ctx, manager.client, raycluster)
+				raycluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(3))
+				g.Expect(manager.client.Update(manager.ctx, raycluster)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: a new workload slice is created in the manager cluster")
+		newWorkloadKey := getWorkloadKey(raycluster)
+		gomega.Eventually(func(g gomega.Gomega) {
+			getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("emulate the scheduler: copy clusterName from the old slice to the new slice", func() {
+			oldWorkload := getWorkload(gomega.Default, manager.ctx, manager.client, workloadKey)
+			gomega.Eventually(func(g gomega.Gomega) {
+				newWorkload := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+				newWorkload.Status.ClusterName = oldWorkload.Status.ClusterName
+				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("emulate the scheduler: admit the new slice and finish the old slice in the manager cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				oldWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
+				g.Expect(workloadfinish.Finish(manager.ctx, manager.client, oldWorkload, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice", util.RealClock)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, admission().Obj())
+		})
+
+		ginkgo.By("emulate the scheduler: admit the new slice and finish the old slice in the worker1 cluster", func() {
+			util.SetQuotaReservation(worker1.ctx, worker1.client, newWorkloadKey, admission().Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := getWorkload(g, worker1.ctx, worker1.client, workloadKey)
+				g.Expect(workloadfinish.Finish(worker1.ctx, worker1.client, wl, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice", util.RealClock)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the increased worker replicas are synced to the worker1 cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remote := raycluster.DeepCopy()
+				getRayCluster(worker1.ctx, worker1.client, remote)
+				g.Expect(remote.Spec.WorkerGroupSpecs[0].Replicas).To(gomega.BeEquivalentTo(new(int32(3))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		/*
+			Scale-down Section.
+			Note: Scaling down does not create a new workload slice, so we continue using newWorkloadKey.
+		*/
+		ginkgo.By("scale-down the RayCluster's first worker group to 1", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				getRayCluster(manager.ctx, manager.client, raycluster)
+				raycluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(1))
+				g.Expect(manager.client.Update(manager.ctx, raycluster)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: no new workload is created in response to scale-down in the manager cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := getWorkload(g, manager.ctx, manager.client, newWorkloadKey)
+				g.Expect(wl.Spec.PodSets[1].Count).To(gomega.BeEquivalentTo(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			list := &kueue.WorkloadList{}
+			gomega.Expect(manager.client.List(manager.ctx, list, client.InNamespace(raycluster.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+
+		ginkgo.By("observe: the reduced worker replicas are synced to the worker1 cluster", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remote := raycluster.DeepCopy()
+				getRayCluster(worker1.ctx, worker1.client, remote)
+				g.Expect(remote.Spec.WorkerGroupSpecs[0].Replicas).To(gomega.BeEquivalentTo(new(int32(1))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: there are still no workloads in the worker2 cluster", func() {
+			workloads := &kueue.WorkloadList{}
+			gomega.Expect(worker2.client.List(worker2.ctx, workloads, client.InNamespace(raycluster.Namespace))).To(gomega.Succeed())
+			gomega.Expect(workloads.Items).To(gomega.BeEmpty())
+		})
+	})
+
 	ginkgo.It("Should redo the admission process once the workload loses Admission in the worker cluster", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area multikueue
/area integrations

#### What this PR does / why we need it:

The Ray MultiKueue adapter creates the remote object once and then only copies
status back, so an in-place worker-replica change of an elastic
(`ElasticJobsViaWorkloadSlices`) RayCluster on the management cluster never
reaches the worker cluster. `batch/Job` already handles this via
`needElasticJobSync` / `syncElasticJob`; this PR gives the shared Ray adapter the
same capability.

- An optional `ElasticReplicaSync` hook is added to the generic Ray adapter and
  wired only for `RayCluster`. When the feature gate is on and the workload is
  slicing-enabled, `SyncJob` detects a worker-replica change on the manager and
  patches the remote object's per-worker-group replicas (and the prebuilt
  workload label), reusing `batch/Job`'s stale scale-up guard.
- `RayJob` and `RayService` leave the hook unset: their worker replicas live on a
  child `RayCluster` on the worker cluster that has no representation on the
  manager, so they keep the create-once behavior.
- Because scaling is manager-driven, the remote copy must not run the in-tree Ray
  autoscaler (which would otherwise fight the manager by editing replicas on the
  worker cluster); the adapter clears `enableInTreeAutoscaling` on the remote copy
  of an elastic RayCluster.
- `NumOfHosts` is synced alongside `Replicas`, since `needElasticSync` compares the
  effective per-group pod count (`Replicas * NumOfHosts`).

Covered by unit, integration, and e2e tests for the manager-driven scale up/down
path.

#### Which issue(s) this PR fixes:

This is a new capability; there is no linked issue.

#### Special notes for your reviewer:

AI disclosure: per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance), this change was developed with the assistance of an AI coding tool. All code was authored, reviewed, and tested by the submitter.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Elastic RayCluster worker-group replica changes made on the management cluster (via the `ElasticJobsViaWorkloadSlices` feature gate) now propagate to the RayCluster on the admitting worker cluster. Previously the remote RayCluster was created once and never resized.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional elastic worker replica synchronization for Ray workloads under MultiKueue, gated by the elastic workload-slicing feature and propagating admitted scale changes to worker clusters.
  * Keeps the remote elastic workload aligned with the active elastic workload slice, including updating the workload identity label.

* **Bug Fixes**
  * Prevents propagating stale slice/replica state during elastic scale-up.
  * Ensures in-tree Ray autoscaling remains disabled on destination clusters while workload slicing is enabled.

* **Tests**
  * Expanded unit, integration, and E2E coverage for elastic scale-up/down, stale-slice skipping, and correct behavior for non-elastic RayClusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->