### PR TITLE
Fix shouldn't re-admit workload with WaitingForReplacementPods=True test case.

### DIFF
--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2538,16 +2538,8 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler when waitForP
 
 			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
 
-			ginkgo.By("Checking that workload was created and admitted", func() {
-				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
-			})
-
-			ginkgo.By("Terminating a pod", func() {
-				util.SetPodsPhaseByKeys(ctx, k8sClient, corev1.PodFailed, client.ObjectKeyFromObject(pod))
-			})
-
 			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
-				util.ExpectWorkloadsToBeEvictedByKeys(ctx, k8sClient, wlKey)
+				util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, wlKey, 0)
 			})
 
 			ginkgo.By("Waiting for BackoffFinished", func() {
@@ -2600,16 +2592,8 @@ var _ = ginkgo.Describe("Pod controller interacting with scheduler when waitForP
 
 			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
 
-			ginkgo.By("Checking that workload was created and admitted", func() {
-				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
-			})
-
-			ginkgo.By("Terminating a pod", func() {
-				util.SetPodsPhaseByKeys(ctx, k8sClient, corev1.PodFailed, client.ObjectKeyFromObject(pod))
-			})
-
 			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
-				util.ExpectWorkloadsToBeEvictedByKeys(ctx, k8sClient, wlKey)
+				util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, wlKey, 0)
 			})
 
 			ginkgo.By("Waiting for BackoffFinished", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix Pod controller interacting with scheduler when waitForPodsReady enabled when pod group not ready shouldn't re-admit workload with WaitingForReplacementPods=True test case.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12886

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Streamlined two integration test cases that exercise the scheduler interaction flow when waiting for pod readiness is enabled.
  * The updated tests still confirm the workload is evicted on the PodsReady timeout, admission is not granted without replacement pods, and admission resumes successfully once replacement pods are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->