### PR TITLE
Fix: Make race condition fails more descriptive in singlecluster tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -137,7 +137,7 @@ test-integration-run:
 	ENVTEST_K8S_VERSION=$(ENVTEST_K8S_VERSION) \
 	ARTIFACTS=$(ARTIFACTS) \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \
-	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS) --race --json-report=integration.json --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
+	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS) --race --json-report=integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
 
 .PHONY: test-integration-baseline


### PR DESCRIPTION
What type of PR is this?
/kind cleanup /area testing

What this PR does / why we need it:
This PR adds the --output-interceptor-mode=none flag to the Ginkgo command in the test-integration-run Makefile target (used for singlecluster integration tests).

Currently, when the Go race detector triggers during these tests, it crashes the test process abruptly. Because Ginkgo's output interceptor is enabled by default, the race detector's stack trace gets swallowed in the crash, leaving developers with a generic and unhelpful suite failure message (e.g., "There were failures detected in the following suites...").

Disabling the output interceptor forces the race trace to be written directly to the terminal's standard error stream, ensuring it is always visible in CI/local logs. This makes debugging race conditions significantly easier and matches the behavior already applied to the test-multikueue-integration target.

Which issue(s) this PR fixes:
Fixes #8070

Special notes for your reviewer:
None

Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the integration test run configuration to disable output interception for single-cluster integration tests, improving consistency during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->