### PR TITLE
Fix LocalQueue metrics after selector label changes

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -283,6 +283,8 @@ func (r *LocalQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.LocalQueue
 func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue]) bool {
 	log := r.logger().WithValues("localQueue", klog.KObj(e.ObjectNew))
 	log.V(2).Info("Queue update event")
+	oldMetricsExposed := r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels())
+	newMetricsExposed := r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels())
 
 	var customLabelsChanged bool
 	if features.Enabled(features.CustomMetricLabels) {
@@ -322,13 +324,13 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 	}
 
 	// Clear after manager update to avoid race with concurrent metric reports.
-	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) && !customLabelsChanged {
+	if newMetricsExposed && !customLabelsChanged {
 		r.updateLocalQueueResourceMetrics(log, e.ObjectNew)
-	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
+	} else if oldMetricsExposed {
 		clearLocalQueueMetrics(e.ObjectOld)
 	}
 
-	if customLabelsChanged && !stoppingQueue {
+	if newMetricsExposed && (customLabelsChanged || !oldMetricsExposed) && !stoppingQueue {
 		r.resyncLocalQueueGaugeMetrics(e.ObjectNew)
 	}
 

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -661,21 +661,8 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 			g.Expect(k8sClient.Update(ctx, &updated)).To(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("Updating the workload to trigger a reconciliation and report metrics")
-		gomega.Eventually(func(g gomega.Gomega) {
-			var wl kueue.Workload
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlDynamic), &wl)).To(gomega.Succeed())
-			if wl.Annotations == nil {
-				wl.Annotations = make(map[string]string)
-			}
-			wl.Annotations["test-trigger-metrics"] = "true"
-			g.Expect(k8sClient.Update(ctx, &wl)).To(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 		ginkgo.By("Verifying metrics become available after labels are updated to matching")
-		gomega.Eventually(func(g gomega.Gomega) {
-			util.ExpectLQPendingWorkloadsMetric(queueDynamic, 1, 0)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectLQPendingWorkloadsMetric(queueDynamic, 1, 0)
 	})
 
 	ginkgo.It("Should delete local queue metrics after changing labels to not matching", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug
/kind flake
/area testing

#### What this PR does / why we need it:

Changing a LocalQueue's labels from not matching the metrics selector to matching it did not resync existing gauges.

The integration test tried to compensate by updating a Workload. Because the controllers could process these events out of order, the pending-workload metric could remain zero.

This change resyncs LocalQueue gauges after updating the cache and removes the racy Workload update from the test.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12887

#### Special notes for your reviewer:

Ran the affected integration test 10 times with the race detector

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fixed LocalQueue gauge metrics not being reported after a LocalQueue starts matching the configured metrics selector.
```
