### PR TITLE
dra: reject device counts whose sum overflows int64

### DIFF
--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -34,6 +34,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 )
 
@@ -109,7 +110,11 @@ func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Re
 		if dc == "" {
 			continue
 		}
-		out[dc] += q
+		// Device counts are user-controlled and effectively unbounded (the
+		// apiserver accepts up to MaxInt64), so accumulate with a saturating add
+		// (matching the scheduler's Amount arithmetic) rather than letting the
+		// sum wrap to a negative count.
+		out[dc] = utilmath.SaturatingAdd(out[dc], q)
 	}
 	return out, nil
 }

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -18,6 +18,7 @@ package dra
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -696,6 +697,45 @@ func Test_GetResourceRequests(t *testing.T) {
 				if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("GetResourceRequestsForResourceClaimTemplates() result mismatch (-want +got):\n%s", diff)
 				}
+			}
+		})
+	}
+}
+
+func exactReq(name, deviceClass string, count int64) resourcev1.DeviceRequest {
+	return resourcev1.DeviceRequest{
+		Name: name,
+		Exactly: &resourcev1.ExactDeviceRequest{
+			DeviceClassName: deviceClass,
+			AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+			Count:           count,
+		},
+	}
+}
+
+func Test_countDevicesPerClass_overflow(t *testing.T) {
+	cases := map[string]struct {
+		requests  []resourcev1.DeviceRequest
+		wantCount int64
+	}{
+		"normal sum across requests": {
+			requests:  []resourcev1.DeviceRequest{exactReq("r0", "gpu", 2), exactReq("r1", "gpu", 3)},
+			wantCount: 5,
+		},
+		"sum saturates at MaxInt64 instead of wrapping negative": {
+			requests:  []resourcev1.DeviceRequest{exactReq("r0", "gpu", math.MaxInt64), exactReq("r1", "gpu", math.MaxInt64)},
+			wantCount: math.MaxInt64,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			spec := &resourcev1.ResourceClaimSpec{Devices: resourcev1.DeviceClaim{Requests: tc.requests}}
+			out, errs := countDevicesPerClass(spec)
+			if len(errs) != 0 {
+				t.Fatalf("unexpected errors: %v", errs)
+			}
+			if got := out["gpu"]; got != tc.wantCount {
+				t.Errorf("count = %d, want %d", got, tc.wantCount)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`countDevicesPerClass` sums per-request device counts into an int64 with no overflow guard, and device counts are unbounded (the apiserver only requires `count > 0`, so it accepts up to MaxInt64). A ResourceClaimTemplate whose counts sum past MaxInt64 wraps to a negative value: the quota usage goes negative, which admits a Workload that exceeds quota and leaves a negative used-quota in the ClusterQueue status.

This accumulates with `utilmath.SaturatingAdd` (matching the `Amount` arithmetic the scheduler and cache already use), so the sum saturates at MaxInt64 instead of wrapping negative. A huge count then stays a large positive that cannot fit quota, rather than being admitted on a negative. The count is turned into a `resource.Quantity` right after this, so the saturated value is handled by overflow-safe Quantity arithmetic downstream.

A unit test covers both the normal sum and the saturation case.

#### Which issue(s) this PR fixes:

Fixes #12896

#### Special notes for your reviewer:

Switched from an explicit validation error to `SaturatingAdd` per review feedback, to match the resilient `Amount` arithmetic used across the scheduler and cache. The extended-resource path already uses Quantity arithmetic and is unaffected.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fix an integer overflow in device-count quota accounting where a ResourceClaimTemplate with very large device counts could be admitted over quota and leave a negative used-quota in the ClusterQueue status.
```