### PR TITLE
Refactor kueueviz workload pod indexing

### DIFF
--- a/cmd/kueueviz/backend/handlers/workloads_dashboard.go
+++ b/cmd/kueueviz/backend/handlers/workloads_dashboard.go
@@ -89,39 +89,16 @@ func (h *Handlers) fetchWorkloadsDashboardData(ctx context.Context, namespace st
 	workloadsByUID := make(map[types.UID]string, len(wql.Items))
 	processedWorkloads := make([]workloadResult, 0, len(wql.Items))
 
-	// Index pods by namespace first to keep the All namespaces view from matching
-	// pods across namespaces while still listing pods once per workload namespace.
-	workloadNamespaces := make(map[string]struct{})
-	for i := range wql.Items {
-		workloadNamespaces[wql.Items[i].Namespace] = struct{}{}
-	}
-	podsByNamespace := make(map[string]map[string][]map[string]any, len(workloadNamespaces))
-	for namespace := range workloadNamespaces {
-		pl := &corev1.PodList{}
-		err = h.client.List(ctx, pl, ctrlclient.InNamespace(namespace))
-		if err != nil {
-			return nil, fmt.Errorf("error fetching pods in namespace %s: %w", namespace, err)
-		}
-
-		podsByControllerUID := make(map[string][]map[string]any)
-		for _, pod := range pl.Items {
-			podLabels := pod.GetLabels()
-			controllerUID := podLabels["controller-uid"]
-			podDetails := map[string]any{
-				"name":   pod.GetName(),
-				"status": pod.Status,
-			}
-			podsByControllerUID[controllerUID] = append(podsByControllerUID[controllerUID], podDetails)
-		}
-		podsByNamespace[namespace] = podsByControllerUID
+	podIndex, err := buildWorkloadPodsIndex(ctx, h.client, wql.Items)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, workload := range wql.Items {
-		namespace := workload.Namespace
 		workloadName := workload.Name
 		workloadUID := workload.UID
 		jobUID := workload.Labels["kueue.x-k8s.io/job-uid"]
-		workloadPods := podsByNamespace[namespace][jobUID]
+		workloadPods := podIndex.podsFor(workload.Namespace, jobUID)
 
 		cond := meta.FindStatusCondition(workload.Status.Conditions, kueueapi.WorkloadPreempted)
 
@@ -144,4 +121,47 @@ func (h *Handlers) fetchWorkloadsDashboardData(ctx context.Context, namespace st
 	}
 
 	return workloads, nil
+}
+
+// workloadPodsIndex stores dashboard pod details by namespace and controller UID.
+// The namespace key preserves the All namespaces dashboard view semantics.
+type workloadPodsIndex struct {
+	podsByNamespace map[string]map[string][]map[string]any
+}
+
+// buildWorkloadPodsIndex lists pods once per workload namespace and indexes them
+// for lookup by each workload's job UID.
+func buildWorkloadPodsIndex(ctx context.Context, client Client, workloads []kueueapi.Workload) (workloadPodsIndex, error) {
+	workloadNamespaces := make(map[string]struct{})
+	for i := range workloads {
+		workloadNamespaces[workloads[i].Namespace] = struct{}{}
+	}
+
+	index := workloadPodsIndex{
+		podsByNamespace: make(map[string]map[string][]map[string]any, len(workloadNamespaces)),
+	}
+	for namespace := range workloadNamespaces {
+		pl := &corev1.PodList{}
+		if err := client.List(ctx, pl, ctrlclient.InNamespace(namespace)); err != nil {
+			return workloadPodsIndex{}, fmt.Errorf("error fetching pods in namespace %s: %w", namespace, err)
+		}
+
+		podsByControllerUID := make(map[string][]map[string]any)
+		for _, pod := range pl.Items {
+			podLabels := pod.GetLabels()
+			controllerUID := podLabels["controller-uid"]
+			podDetails := map[string]any{
+				"name":   pod.GetName(),
+				"status": pod.Status,
+			}
+			podsByControllerUID[controllerUID] = append(podsByControllerUID[controllerUID], podDetails)
+		}
+		index.podsByNamespace[namespace] = podsByControllerUID
+	}
+	return index, nil
+}
+
+// podsFor returns the pod details matching the workload namespace and job UID.
+func (i workloadPodsIndex) podsFor(namespace, jobUID string) []map[string]any {
+	return i.podsByNamespace[namespace][jobUID]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area dashboard
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Refactors the kueueviz workloads dashboard pod lookup logic behind a small type to keep the dashboard handler focused on assembling the response while preserving the namespace-scoped pod lookup behavior used by the All namespace view.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Ref https://github.com/kubernetes-sigs/kueue/pull/12777#discussion_r3534800966, this is a following-up cleanup for readability

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved how workload dashboard data is assembled behind the scenes.
  * Dashboard results now use a more structured lookup for related pod information, helping keep namespace-based views consistent.
  * Preserved the existing “all namespaces” dashboard behavior while simplifying the data-loading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->