### PR TITLE
dra: saturate counter-charge multiplication to avoid int64 overflow

### DIFF
--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
 func GetCounterResourcesForWorkload(
@@ -303,7 +304,9 @@ func computeCounterCharges(
 
 	if count > 1 {
 		intVal := maxValue.Value()
-		maxValue = *resource.NewQuantity(intVal*count, maxValue.Format)
+		// Saturate rather than let intVal*count wrap to a negative quantity,
+		// consistent with countDevicesPerClass after #12897.
+		maxValue = *resource.NewQuantity(utilmath.SaturatingMul(intVal, count), maxValue.Format)
 	}
 	return corev1.ResourceList{quotaResource: maxValue}
 }

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dra
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -158,6 +159,18 @@ func TestComputeCounterCharges(t *testing.T) {
 			},
 			count: 1,
 			want:  nil,
+		},
+		{
+			name:          "count multiplication saturates instead of overflowing int64",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("big-counter-0", "big", "8000000000000000000"),
+			},
+			count: 2,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
+			},
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`computeCounterCharges` (`pkg/dra/counters.go`) multiplied a device's counter value by the request count with a plain int64 multiply (`intVal*count`), which can wrap to a negative quantity and under-charge the counter quota resource. This uses `utilmath.SaturatingMul`, consistent with the `SaturatingAdd` applied to `countDevicesPerClass` in #12897.

This is a defense-in-depth / consistency fix. Unlike #12896, it is not reachable from the tenant trust boundary: `count` is bounded upstream by the matched-device shortage check and `intVal` is a driver-published counter value, so overflow would require a driver publishing a near-`MaxInt64` counter value together with `count > 1`. Details in #12908.

#### Which issue(s) this PR fixes:
Fixes #12908

#### Special notes for your reviewer:
Follow-up to #12897 / #12896. Adds a regression test case (`count multiplication saturates instead of overflowing int64`) to `TestComputeCounterCharges`.

#### Does this PR introduce a user-facing change?
```release-note
DRA: fixed a potential int64 overflow in the counter-based device quota charge computation that could under-count quota when a driver publishes very large counter values.
```
