### PR TITLE
[release-0.17] Fix LocalQueue metrics after selector label changes

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -289,6 +289,8 @@ func (r *LocalQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.LocalQueue
 func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue]) bool {
 	log := r.logger().WithValues("localQueue", klog.KObj(e.ObjectNew))
 	log.V(2).Info("Queue update event")
+	oldMetricsExposed := r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels())
+	newMetricsExposed := r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels())
 
 	if features.Enabled(features.CustomMetricLabels) {
 		r.customLabels.LQStoreAndClear(utilqueue.Key(e.ObjectNew),
@@ -298,9 +300,9 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 			})
 	}
 
-	if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectNew.GetLabels()) {
+	if newMetricsExposed {
 		updateLocalQueueResourceMetrics(e.ObjectNew, r.roleTracker, r.customLabels)
-	} else if r.lqMetrics.ShouldExposeLocalQueueMetrics(e.ObjectOld.GetLabels()) {
+	} else if oldMetricsExposed {
 		clearLocalQueueMetrics(e.ObjectOld)
 	}
 
@@ -315,6 +317,9 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 		}
 		if err := r.cache.UpdateLocalQueue(e.ObjectOld, e.ObjectNew); err != nil {
 			log.Error(err, "Failed to update localQueue in the cache")
+		}
+		if newMetricsExposed && !oldMetricsExposed {
+			r.resyncLocalQueueGaugeMetrics(e.ObjectNew)
 		}
 		return true
 	}
@@ -440,6 +445,27 @@ func clearLocalQueueMetrics(lq *kueue.LocalQueue) {
 	metrics.ClearLocalQueueMetrics(lqRef)
 	metrics.ClearLocalQueueCacheMetrics(lqRef)
 	metrics.ClearLocalQueueResourceMetrics(lqRef)
+}
+
+func (r *LocalQueueReconciler) resyncLocalQueueGaugeMetrics(lq *kueue.LocalQueue) {
+	lqKey := utilqueue.Key(lq)
+	clearLocalQueueMetrics(lq)
+	r.queues.ResyncGaugeMetrics()
+	r.cache.ResyncGaugeMetrics()
+
+	if !r.lqMetrics.ShouldExposeLocalQueueMetrics(lq.GetLabels()) {
+		return
+	}
+	condition := meta.FindStatusCondition(lq.Status.Conditions, kueue.LocalQueueActive)
+	if condition == nil {
+		return
+	}
+	metrics.ReportLocalQueueStatus(
+		localQueueReferenceFromLocalQueue(lq),
+		condition.Status,
+		r.customLabels.LQGet(lqKey),
+		r.roleTracker,
+	)
 }
 
 func (r *LocalQueueReconciler) Generic(e event.TypedGenericEvent[*kueue.LocalQueue]) bool {

--- a/test/integration/singlecluster/controller/core/localqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/localqueue_controller_test.go
@@ -661,21 +661,8 @@ var _ = ginkgo.Describe("Queue controller metrics filtering", ginkgo.Label("cont
 			g.Expect(k8sClient.Update(ctx, &updated)).To(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("Updating the workload to trigger a reconciliation and report metrics")
-		gomega.Eventually(func(g gomega.Gomega) {
-			var wl kueue.Workload
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlDynamic), &wl)).To(gomega.Succeed())
-			if wl.Annotations == nil {
-				wl.Annotations = make(map[string]string)
-			}
-			wl.Annotations["test-trigger-metrics"] = "true"
-			g.Expect(k8sClient.Update(ctx, &wl)).To(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 		ginkgo.By("Verifying metrics become available after labels are updated to matching")
-		gomega.Eventually(func(g gomega.Gomega) {
-			util.ExpectLQPendingWorkloadsMetric(queueDynamic, 1, 0)
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectLQPendingWorkloadsMetric(queueDynamic, 1, 0)
 	})
 
 	ginkgo.It("Should delete local queue metrics after changing labels to not matching", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
/area testing

#### What this PR does / why we need it:

This is a manual cherry-pick of #12894. The bot could not apply it to
`release-0.17`:
https://github.com/kubernetes-sigs/kueue/pull/12894#issuecomment-4927906691

This branch predates the targeted LocalQueue gauge-resync helpers used on
`main`. The backport resolves the conflict by using the branch's existing
queue and cache `ResyncGaugeMetrics` methods after updating cached labels.

/assign @mimowo

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

This is a manual cherry-pick because of the controller conflict described
above. Generative AI assisted with conflict resolution and PR preparation.

Verified with the controller unit tests and the affected integration test
under the race detector.

#### Does this PR introduce a user-facing change?

```release-note
Observability: Fixed LocalQueue gauge metrics not being reported after a LocalQueue starts matching the configured metrics selector.
```
