### PR TITLE
Correct Flavor Assignment in Pod Importer

### DIFF
--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -30,8 +30,9 @@ The importer will perform following checks:
 - The target LocalQueue exists.
 - The LocalQueues involved in the import are using an existing ClusterQueue.
 - The ClusterQueues involved have ResourceGroups that reference existing ResourceFlavors.
-- For each Pod, the check validates that every non-zero requested resource is covered by the target ClusterQueue ResourceGroups.
 - For each Pod, the check validates that Workload construction succeeds (using the same construction path used by import) before any Pod mutation.
+- For each Pod, the check validates that every non-zero resource request in the constructed Workload is covered by the target ClusterQueue ResourceGroups.
+- Pass the configured prefixes with `--exclude-resource-prefixes` so excluded resources are ignored during validation and admission.
 - If a Pod specifies a PriorityClass, the check validates that the PriorityClass exists.
 
 There are two ways the mapping from a pod to a LocalQueue can be specified:
@@ -80,6 +81,7 @@ Usage:
 
 Flags:
       --add-labels stringToString     additional label=value pairs to be added to the imported pods and created workloads (default [])
+      --exclude-resource-prefixes strings  resource name prefixes ignored by Kueue during workload quota accounting
       --burst int                     client Burst, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit (default 50)
   -c, --concurrent-workers uint       number of concurrent import workers (default 8)
       --dry-run                       don't import, check the config only (default true)

--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -30,9 +30,9 @@ The importer will perform following checks:
 - The target LocalQueue exists.
 - The LocalQueues involved in the import are using an existing ClusterQueue.
 - The ClusterQueues involved have ResourceGroups that reference existing ResourceFlavors.
-- For each Pod, the dry-run validates that every non-zero requested resource is covered by the target ClusterQueue ResourceGroups.
-- For each Pod, the dry-run validates that Workload construction succeeds (using the same construction path used by import) before any Pod mutation.
-- If a Pod specifies a PriorityClass, the dry-run validates that the PriorityClass exists.
+- For each Pod, the check validates that every non-zero requested resource is covered by the target ClusterQueue ResourceGroups.
+- For each Pod, the check validates that Workload construction succeeds (using the same construction path used by import) before any Pod mutation.
+- If a Pod specifies a PriorityClass, the check validates that the PriorityClass exists.
 
 There are two ways the mapping from a pod to a LocalQueue can be specified:
 

--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -29,7 +29,10 @@ The importer will perform following checks:
 - For every Pod a  mapping to a LocalQueue is available.
 - The target LocalQueue exists.
 - The LocalQueues involved in the import are using an existing ClusterQueue.
-- The ClusterQueues involved have at least one ResourceGroup using an existing ResourceFlavor. This ResourceFlavor is used when the importer creates the admission for the created workloads.
+- The ClusterQueues involved have ResourceGroups that reference existing ResourceFlavors.
+- For each Pod, the dry-run validates that every non-zero requested resource is covered by the target ClusterQueue ResourceGroups.
+- For each Pod, the dry-run validates that Workload construction succeeds (using the same construction path used by import) before any Pod mutation.
+- If a Pod specifies a PriorityClass, the dry-run validates that the PriorityClass exists.
 
 There are two ways the mapping from a pod to a LocalQueue can be specified:
 
@@ -172,7 +175,7 @@ Note: `dry-run` is set to `false` by default.
 
 5. (Optional) Check your config by dry-running it locally e.g.
 ```bash
-./bin/importer --dry-run=true <your-custom-flags> --queuemapping-file=cmd/importer/run-in-cluster/mapping.yaml
+./bin/importer import --dry-run=true <your-custom-flags> --queuemapping-file=cmd/importer/run-in-cluster/mapping.yaml
 ```
 
 6. Deploy the configuration:

--- a/cmd/importer/cache/cache.go
+++ b/cmd/importer/cache/cache.go
@@ -24,10 +24,12 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
 
@@ -47,6 +49,10 @@ type ImportCache struct {
 	ResourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
 	PriorityClasses map[string]*schedulingv1.PriorityClass
 	AddLabels       map[string]string
+
+	// Derived from ClusterQueues and ResourceFlavors at Load time; read-only after that.
+	FlavorValidation  map[string]error
+	FlavorsByResource map[string]map[corev1.ResourceName]kueue.ResourceFlavorReference
 }
 
 func Load(ctx context.Context, c client.Client, namespaces []string, mappingRules mapping.Rules, addLabels map[string]string) (*ImportCache, error) {
@@ -84,10 +90,67 @@ func Load(ctx context.Context, c client.Client, namespaces []string, mappingRule
 		return nil, fmt.Errorf("loading priority classes: %w", err)
 	}
 	ret.PriorityClasses = utilslices.ToRefMap(pcList.Items, func(pc *schedulingv1.PriorityClass) string { return pc.Name })
+
+	ret.FlavorValidation = make(map[string]error, len(cqList.Items))
+	ret.FlavorsByResource = make(map[string]map[corev1.ResourceName]kueue.ResourceFlavorReference, len(cqList.Items))
+	for i := range cqList.Items {
+		cq := &cqList.Items[i]
+		rgs := resourceGroupsFrom(cq)
+		ret.FlavorsByResource[cq.Name] = flavorsByResourceFrom(rgs)
+		ret.FlavorValidation[cq.Name] = validateFlavors(cq.Name, rgs, ret.ResourceFlavors)
+	}
+
 	return &ret, nil
 }
 
-func (ic *ImportCache) LocalQueue(p *corev1.Pod) (*kueue.LocalQueue, bool, error) {
+// resourceGroupsFrom converts cq's API resource groups to the ResourceGroup
+// representation used by pkg/util/resourcegroups.
+func resourceGroupsFrom(cq *kueue.ClusterQueue) []resourcegroups.ResourceGroup {
+	rgs := make([]resourcegroups.ResourceGroup, 0, len(cq.Spec.ResourceGroups))
+	for _, rg := range cq.Spec.ResourceGroups {
+		if len(rg.Flavors) == 0 {
+			continue
+		}
+		flavors := make([]kueue.ResourceFlavorReference, len(rg.Flavors))
+		for i, f := range rg.Flavors {
+			flavors[i] = f.Name
+		}
+		rgs = append(rgs, resourcegroups.ResourceGroup{
+			CoveredResources: sets.New(rg.CoveredResources...),
+			Flavors:          flavors,
+		})
+	}
+	return rgs
+}
+
+// flavorsByResourceFrom returns, for every resource covered by rgs, the first
+// flavor listed in its resource group.
+func flavorsByResourceFrom(rgs []resourcegroups.ResourceGroup) map[corev1.ResourceName]kueue.ResourceFlavorReference {
+	m := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+	for _, rg := range rgs {
+		for resource := range rg.CoveredResources {
+			if _, exists := m[resource]; !exists {
+				m[resource] = rg.Flavors[0]
+			}
+		}
+	}
+	return m
+}
+
+// validateFlavors checks that every ResourceFlavor referenced by rgs is known.
+func validateFlavors(cqName string, rgs []resourcegroups.ResourceGroup, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) error {
+	// Sorted for a deterministic error message; AllFlavors returns a set.
+	flavors := resourcegroups.AllFlavors(rgs).UnsortedList()
+	slices.Sort(flavors)
+	for _, flavor := range flavors {
+		if _, found := resourceFlavors[flavor]; !found {
+			return fmt.Errorf("%q flavor %q: %w", cqName, flavor, ErrCQInvalid)
+		}
+	}
+	return nil
+}
+
+func (ic *ImportCache) LocalQueueForPod(p *corev1.Pod) (*kueue.LocalQueue, bool, error) {
 	queueName, skip, found := ic.MappingRules.QueueFor(p.Spec.PriorityClassName, p.Labels)
 	if !found {
 		return nil, false, mapping.ErrNoMapping
@@ -107,17 +170,4 @@ func (ic *ImportCache) LocalQueue(p *corev1.Pod) (*kueue.LocalQueue, bool, error
 		return nil, false, fmt.Errorf("%s: %w", queueName, ErrLQNotFound)
 	}
 	return lq, false, nil
-}
-
-func (ic *ImportCache) ClusterQueue(p *corev1.Pod) (*kueue.ClusterQueue, bool, error) {
-	lq, skip, err := ic.LocalQueue(p)
-	if skip || err != nil {
-		return nil, skip, err
-	}
-	queueName := string(lq.Spec.ClusterQueue)
-	cq, found := ic.ClusterQueues[queueName]
-	if !found {
-		return nil, false, fmt.Errorf("cluster queue: %s: %w", queueName, ErrCQNotFound)
-	}
-	return cq, false, nil
 }

--- a/cmd/importer/cache/cache.go
+++ b/cmd/importer/cache/cache.go
@@ -35,6 +35,7 @@ var (
 	ErrLQNotFound = errors.New("localqueue not found")
 	ErrCQNotFound = errors.New("clusterqueue not found")
 	ErrCQInvalid  = errors.New("clusterqueue invalid")
+	ErrPodInvalid = errors.New("pod invalid")
 	ErrPCNotFound = errors.New("priorityclass not found")
 )
 

--- a/cmd/importer/cache/cache.go
+++ b/cmd/importer/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,9 +51,9 @@ type ImportCache struct {
 	PriorityClasses map[string]*schedulingv1.PriorityClass
 	AddLabels       map[string]string
 
-	// Derived from ClusterQueues and ResourceFlavors at Load time; read-only after that.
-	FlavorValidation  map[string]error
-	FlavorsByResource map[string]map[corev1.ResourceName]kueue.ResourceFlavorReference
+	// Derived from ClusterQueues and ResourceFlavors at Load time.
+	flavorValidation  map[kueue.ClusterQueueReference]error
+	flavorsByResource map[kueue.ClusterQueueReference]map[corev1.ResourceName]kueue.ResourceFlavorReference
 }
 
 func Load(ctx context.Context, c client.Client, namespaces []string, mappingRules mapping.Rules, addLabels map[string]string) (*ImportCache, error) {
@@ -91,13 +92,14 @@ func Load(ctx context.Context, c client.Client, namespaces []string, mappingRule
 	}
 	ret.PriorityClasses = utilslices.ToRefMap(pcList.Items, func(pc *schedulingv1.PriorityClass) string { return pc.Name })
 
-	ret.FlavorValidation = make(map[string]error, len(cqList.Items))
-	ret.FlavorsByResource = make(map[string]map[corev1.ResourceName]kueue.ResourceFlavorReference, len(cqList.Items))
+	ret.flavorValidation = make(map[kueue.ClusterQueueReference]error, len(cqList.Items))
+	ret.flavorsByResource = make(map[kueue.ClusterQueueReference]map[corev1.ResourceName]kueue.ResourceFlavorReference, len(cqList.Items))
 	for i := range cqList.Items {
 		cq := &cqList.Items[i]
 		rgs := resourceGroupsFrom(cq)
-		ret.FlavorsByResource[cq.Name] = flavorsByResourceFrom(rgs)
-		ret.FlavorValidation[cq.Name] = validateFlavors(cq.Name, rgs, ret.ResourceFlavors)
+		cqRef := kueue.ClusterQueueReference(cq.Name)
+		ret.flavorsByResource[cqRef] = flavorsByResourceFrom(rgs)
+		ret.flavorValidation[cqRef] = validateFlavors(cq.Name, rgs, ret.ResourceFlavors)
 	}
 
 	return &ret, nil
@@ -140,12 +142,15 @@ func flavorsByResourceFrom(rgs []resourcegroups.ResourceGroup) map[corev1.Resour
 // validateFlavors checks that every ResourceFlavor referenced by rgs is known.
 func validateFlavors(cqName string, rgs []resourcegroups.ResourceGroup, resourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) error {
 	// Sorted for a deterministic error message; AllFlavors returns a set.
-	flavors := resourcegroups.AllFlavors(rgs).UnsortedList()
-	slices.Sort(flavors)
+	flavors := sets.List(resourcegroups.AllFlavors(rgs))
+	missing := make([]kueue.ResourceFlavorReference, 0)
 	for _, flavor := range flavors {
 		if _, found := resourceFlavors[flavor]; !found {
-			return fmt.Errorf("%q flavor %q: %w", cqName, flavor, ErrCQInvalid)
+			missing = append(missing, flavor)
 		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("%q missing flavors %v: %w", cqName, missing, ErrCQInvalid)
 	}
 	return nil
 }
@@ -170,4 +175,20 @@ func (ic *ImportCache) LocalQueueForPod(p *corev1.Pod) (*kueue.LocalQueue, bool,
 		return nil, false, fmt.Errorf("%s: %w", queueName, ErrLQNotFound)
 	}
 	return lq, false, nil
+}
+
+func (ic *ImportCache) FlavorValidationForClusterQueue(cqName kueue.ClusterQueueReference) error {
+	return ic.flavorValidation[cqName]
+}
+
+func (ic *ImportCache) FlavorsByResourceForClusterQueue(cqName kueue.ClusterQueueReference) map[corev1.ResourceName]kueue.ResourceFlavorReference {
+	flavorsByResource := ic.flavorsByResource[cqName]
+	if flavorsByResource == nil {
+		return nil
+	}
+
+	ret := make(map[corev1.ResourceName]kueue.ResourceFlavorReference, len(flavorsByResource))
+	maps.Copy(ret, flavorsByResource)
+
+	return ret
 }

--- a/cmd/importer/cache/cache.go
+++ b/cmd/importer/cache/cache.go
@@ -39,7 +39,6 @@ var (
 	ErrLQNotFound = errors.New("localqueue not found")
 	ErrCQNotFound = errors.New("clusterqueue not found")
 	ErrCQInvalid  = errors.New("clusterqueue invalid")
-	ErrPodInvalid = errors.New("pod invalid")
 	ErrPCNotFound = errors.New("priorityclass not found")
 )
 

--- a/cmd/importer/cache/cache.go
+++ b/cmd/importer/cache/cache.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 var (
@@ -43,25 +44,27 @@ var (
 )
 
 type ImportCache struct {
-	Namespaces      []string
-	MappingRules    mapping.Rules
-	LocalQueues     map[string]map[string]*kueue.LocalQueue
-	ClusterQueues   map[string]*kueue.ClusterQueue
-	ResourceFlavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
-	PriorityClasses map[string]*schedulingv1.PriorityClass
-	AddLabels       map[string]string
+	Namespaces          []string
+	MappingRules        mapping.Rules
+	LocalQueues         map[string]map[string]*kueue.LocalQueue
+	ClusterQueues       map[string]*kueue.ClusterQueue
+	ResourceFlavors     map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor
+	PriorityClasses     map[string]*schedulingv1.PriorityClass
+	AddLabels           map[string]string
+	workloadInfoOptions []workload.InfoOption
 
 	// Derived from ClusterQueues and ResourceFlavors at Load time.
 	flavorValidation  map[kueue.ClusterQueueReference]error
 	flavorsByResource map[kueue.ClusterQueueReference]map[corev1.ResourceName]kueue.ResourceFlavorReference
 }
 
-func Load(ctx context.Context, c client.Client, namespaces []string, mappingRules mapping.Rules, addLabels map[string]string) (*ImportCache, error) {
+func Load(ctx context.Context, c client.Client, namespaces []string, mappingRules mapping.Rules, addLabels map[string]string, workloadInfoOptions []workload.InfoOption) (*ImportCache, error) {
 	ret := ImportCache{
-		Namespaces:   slices.Clone(namespaces),
-		MappingRules: mappingRules,
-		LocalQueues:  make(map[string]map[string]*kueue.LocalQueue),
-		AddLabels:    addLabels,
+		Namespaces:          slices.Clone(namespaces),
+		MappingRules:        mappingRules,
+		LocalQueues:         make(map[string]map[string]*kueue.LocalQueue),
+		AddLabels:           addLabels,
+		workloadInfoOptions: slices.Clone(workloadInfoOptions),
 	}
 
 	cqList := &kueue.ClusterQueueList{}
@@ -103,6 +106,10 @@ func Load(ctx context.Context, c client.Client, namespaces []string, mappingRule
 	}
 
 	return &ret, nil
+}
+
+func (ic *ImportCache) WorkloadInfoOptions() []workload.InfoOption {
+	return slices.Clone(ic.workloadInfoOptions)
 }
 
 // resourceGroupsFrom converts cq's API resource groups to the ResourceGroup

--- a/cmd/importer/cache/cache_test.go
+++ b/cmd/importer/cache/cache_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package cache
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -65,7 +67,7 @@ func TestFlavorsByResourceFrom(t *testing.T) {
 				corev1.ResourceName("nvidia.com/gpu"): "on-demand",
 			},
 		},
-		"omits resources not covered by any resource group": {
+		"returns only resources covered by resource groups": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
@@ -86,4 +88,45 @@ func TestFlavorsByResourceFrom(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateFlavors(t *testing.T) {
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("spot").
+				Resource(corev1.ResourceCPU, "10", "0").
+				Obj(),
+			*utiltestingapi.MakeFlavorQuotas("on-demand").
+				Resource(corev1.ResourceCPU, "10", "0").
+				Obj(),
+			*utiltestingapi.MakeFlavorQuotas("reserved").
+				Resource(corev1.ResourceCPU, "10", "0").
+				Obj(),
+		).Obj()
+
+	rgs := resourceGroupsFrom(cq)
+
+	t.Run("returns nil when all referenced flavors exist", func(t *testing.T) {
+		err := validateFlavors(cq.Name, rgs, map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+			"on-demand": {ObjectMeta: metav1.ObjectMeta{Name: "on-demand"}},
+			"reserved":  {ObjectMeta: metav1.ObjectMeta{Name: "reserved"}},
+			"spot":      {ObjectMeta: metav1.ObjectMeta{Name: "spot"}},
+		})
+		if err != nil {
+			t.Fatalf("validateFlavors() = %v, want nil", err)
+		}
+	})
+
+	t.Run("returns all missing flavors in deterministic order", func(t *testing.T) {
+		err := validateFlavors(cq.Name, rgs, map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+			"spot": {ObjectMeta: metav1.ObjectMeta{Name: "spot"}},
+		})
+		if !errors.Is(err, ErrCQInvalid) {
+			t.Fatalf("validateFlavors() error = %v, want wrapped %v", err, ErrCQInvalid)
+		}
+		want := "\"cq\" missing flavors [on-demand reserved]: clusterqueue invalid"
+		if got := err.Error(); got != want {
+			t.Fatalf("validateFlavors() error = %q, want %q", got, want)
+		}
+	})
 }

--- a/cmd/importer/cache/cache_test.go
+++ b/cmd/importer/cache/cache_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestFlavorsByResourceFrom(t *testing.T) {
+	cases := map[string]struct {
+		clusterQueue *kueue.ClusterQueue
+		want         map[corev1.ResourceName]kueue.ResourceFlavorReference
+	}{
+		"returns the flavor from each matching resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Resource(corev1.ResourceMemory, "10Gi", "0").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU:                    "cpu-flavor",
+				corev1.ResourceMemory:                 "cpu-flavor",
+				corev1.ResourceName("nvidia.com/gpu"): "gpu-flavor",
+			},
+		},
+		"returns the first flavor from a resource group with several flavors": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("spot").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceName("nvidia.com/gpu"): "on-demand",
+			},
+		},
+		"omits resources not covered by any resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Obj(),
+				).Obj(),
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := flavorsByResourceFrom(resourceGroupsFrom(tc.clusterQueue))
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Unexpected flavors (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}

--- a/cmd/importer/main.go
+++ b/cmd/importer/main.go
@@ -35,22 +35,24 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	"sigs.k8s.io/kueue/cmd/importer/pod"
 	"sigs.k8s.io/kueue/pkg/util/useragent"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 const (
-	NamespaceFlag        = "namespace"
-	NamespaceFlagShort   = "n"
-	QueueMappingFlag     = "queuemapping"
-	QueueMappingFileFlag = "queuemapping-file"
-	QueueLabelFlag       = "queuelabel"
-	QPSFlag              = "qps"
-	BurstFlag            = "burst"
-	VerbosityFlag        = "verbose"
-	VerboseFlagShort     = "v"
-	ConcurrencyFlag      = "concurrent-workers"
-	ConcurrencyFlagShort = "c"
-	DryRunFlag           = "dry-run"
-	AddLabelsFlag        = "add-labels"
+	NamespaceFlag               = "namespace"
+	NamespaceFlagShort          = "n"
+	QueueMappingFlag            = "queuemapping"
+	QueueMappingFileFlag        = "queuemapping-file"
+	QueueLabelFlag              = "queuelabel"
+	QPSFlag                     = "qps"
+	BurstFlag                   = "burst"
+	VerbosityFlag               = "verbose"
+	VerboseFlagShort            = "v"
+	ConcurrencyFlag             = "concurrent-workers"
+	ConcurrencyFlagShort        = "c"
+	DryRunFlag                  = "dry-run"
+	AddLabelsFlag               = "add-labels"
+	ExcludeResourcePrefixesFlag = "exclude-resource-prefixes"
 )
 
 var (
@@ -75,6 +77,7 @@ func setFlags(cmd *cobra.Command) {
 	cmd.Flags().String(QueueLabelFlag, "", "label used to identify the target local queue")
 	cmd.Flags().StringToString(QueueMappingFlag, nil, "mapping from \""+QueueLabelFlag+"\" label values to local queue names")
 	cmd.Flags().StringToString(AddLabelsFlag, nil, "additional label=value pairs to be added to the imported pods and created workloads")
+	cmd.Flags().StringSlice(ExcludeResourcePrefixesFlag, nil, "resource name prefixes ignored by Kueue during workload quota accounting")
 	cmd.Flags().String(QueueMappingFileFlag, "", "yaml file containing extra mappings from \""+QueueLabelFlag+"\" label values to local queue names")
 	cmd.Flags().Float32(QPSFlag, 50, "client QPS, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit")
 	cmd.Flags().Int(BurstFlag, 50, "client Burst, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit")
@@ -146,6 +149,10 @@ func loadMappingCache(ctx context.Context, c client.Client, cmd *cobra.Command) 
 	if err != nil {
 		return nil, err
 	}
+	excludedResourcePrefixes, err := flags.GetStringSlice(ExcludeResourcePrefixesFlag)
+	if err != nil {
+		return nil, err
+	}
 
 	var validationErrors []error
 	for name, value := range addLabels {
@@ -160,7 +167,8 @@ func loadMappingCache(ctx context.Context, c client.Client, cmd *cobra.Command) 
 		return nil, fmt.Errorf("%s: %w", AddLabelsFlag, errors.Join(validationErrors...))
 	}
 
-	return cache.Load(ctx, c, namespaces, rules, addLabels)
+	workloadInfoOptions := []workload.InfoOption{workload.WithExcludedResourcePrefixes(excludedResourcePrefixes)}
+	return cache.Load(ctx, c, namespaces, rules, addLabels, workloadInfoOptions)
 }
 
 func getKubeClient(cmd *cobra.Command) (client.Client, error) {

--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -134,7 +134,7 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	}
 	maps.Copy(wl.Labels, importCache.AddLabels)
 
-	info := workload.NewInfo(wl)
+	info := workload.NewInfo(wl, importCache.WorkloadInfoOptions()...)
 	if len(info.TotalRequests) == 0 {
 		return nil, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
 	}

--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -135,9 +135,6 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	maps.Copy(wl.Labels, importCache.AddLabels)
 
 	info := workload.NewInfo(wl, importCache.WorkloadInfoOptions()...)
-	if len(info.TotalRequests) == 0 {
-		return nil, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
-	}
 	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResourceForClusterQueue(kueue.ClusterQueueReference(cq.Name)), cq.Name, info.TotalRequests[0].Requests)
 	if err != nil {
 		return nil, err

--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
@@ -28,9 +31,21 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/importer/cache"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+// checkedWorkload is the outcome of validating a Pod against its target
+// ClusterQueue: the Workload it would produce, the flavor assigned to each
+// requested resource, and the resolved priority.
+type checkedWorkload struct {
+	workload *kueue.Workload
+	flavors  map[corev1.ResourceName]kueue.ResourceFlavorReference
+	priority int32
+}
 
 func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache, jobs uint) error {
 	ch := make(chan corev1.Pod)
@@ -44,40 +59,18 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
 		log.V(3).Info("Checking")
 
-		cq, skip, err := importCache.ClusterQueue(p)
+		lq, cq, skip, err := resolveQueues(importCache, p)
 		if skip || err != nil {
 			return skip, err
 		}
 
-		if len(cq.Spec.ResourceGroups) == 0 {
-			return false, fmt.Errorf("%q has no resource groups: %w", cq.Name, cache.ErrCQInvalid)
-		}
-		if err := validateKnownClusterQueueFlavors(cq, importCache.ResourceFlavors); err != nil {
-			return false, err
-		}
-
-		kp := pod.FromObject(p)
-		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+		checked, err := checkPodWorkload(ctx, c, importCache, p, lq.Name, cq)
 		if err != nil {
-			return false, fmt.Errorf("construct workload: %w", err)
-		}
-
-		info := workload.NewInfo(wl)
-		if len(info.TotalRequests) == 0 {
-			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
-		}
-
-		if _, err := flavorAssignmentsForRequests(cq, info.TotalRequests[0].Requests); err != nil {
 			return false, err
 		}
-		var pv int32
-		if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
-			pv = pc.Value
-		} else if p.Spec.PriorityClassName != "" {
-			return false, fmt.Errorf("%q: %w", p.Spec.PriorityClassName, cache.ErrPCNotFound)
-		}
 
-		log.V(2).Info("Successfully checked", "clusterQueue", klog.KObj(cq), "priority", pv)
+		// flavors reflects the per-resource assignments validated against the workload's requests.
+		log.V(2).Info("Successfully checked", "clusterQueue", klog.KObj(cq), "priority", checked.priority, "flavors", checked.flavors)
 		return false, nil
 	})
 
@@ -89,13 +82,121 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 	return errors.Join(summary.Errors...)
 }
 
-func validateKnownClusterQueueFlavors(cq *kueue.ClusterQueue, known map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) error {
-	for _, rg := range cq.Spec.ResourceGroups {
-		for _, flavor := range rg.Flavors {
-			if _, found := known[flavor.Name]; !found {
-				return fmt.Errorf("%q flavor %q: %w", cq.Name, flavor.Name, cache.ErrCQInvalid)
-			}
-		}
+// resolveQueues returns the LocalQueue and ClusterQueue a Pod maps to. Import
+// and Check share this lookup so "queue not found" cannot diverge between them.
+func resolveQueues(importCache *cache.ImportCache, p *corev1.Pod) (*kueue.LocalQueue, *kueue.ClusterQueue, bool, error) {
+	lq, skip, err := importCache.LocalQueueForPod(p)
+	if skip || err != nil {
+		return nil, nil, skip, err
 	}
-	return nil
+	cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
+	if !ok {
+		return nil, nil, false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
+	}
+	return lq, cq, false, nil
+}
+
+// checkPodWorkload validates that p can be imported into cq and builds the
+// Workload it would produce. Check calls this and only reports the outcome;
+// Import calls this and, on success, persists Pod labels and creates/admits
+// the Workload. Keeping the validation in one place means the two commands
+// cannot silently disagree on whether a Pod is importable.
+func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.ImportCache, p *corev1.Pod, lqName string, cq *kueue.ClusterQueue) (*checkedWorkload, error) {
+	if oldLq, found := p.Labels[controllerconstants.QueueLabel]; found && oldLq != lqName {
+		return nil, &queueLabelConflictError{CurrentQueue: oldLq, ExpectedQueue: lqName}
+	}
+	if len(cq.Spec.ResourceGroups) == 0 {
+		return nil, fmt.Errorf("%q has no resource groups: %w", cq.Name, cache.ErrCQInvalid)
+	}
+	if err := importCache.FlavorValidation[cq.Name]; err != nil {
+		return nil, err
+	}
+
+	// Workload construction derives queue, name, and some spec fields from Pod labels.
+	// Build it from a copy that includes importer-added labels, while leaving the
+	// real Pod untouched until validation succeeds and those labels can be persisted.
+	podForWorkload := preparePodForWorkload(p, lqName, importCache.AddLabels)
+
+	kp := pod.FromObject(podForWorkload)
+	// Note: the recorder is not used for single pods, we can just pass nil for now.
+	wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("construct workload: %w", err)
+	}
+	if prebuiltWorkloadName := jobframework.PrebuiltWorkloadNameFor(podForWorkload); prebuiltWorkloadName != "" {
+		wl.Name = prebuiltWorkloadName
+	}
+	// Keep the resolved queue authoritative even if the real Pod has not been labeled
+	// yet or still carries a conflicting queue label that Import rejects separately.
+	wl.Spec.QueueName = kueue.LocalQueueName(lqName)
+	// Generic label copying is disabled in this importer path, so preserve the
+	// importer-added labels on the constructed Workload metadata explicitly.
+	if wl.Labels == nil {
+		wl.Labels = make(map[string]string)
+	}
+	maps.Copy(wl.Labels, importCache.AddLabels)
+
+	info := workload.NewInfo(wl)
+	if len(info.TotalRequests) == 0 {
+		return nil, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
+	}
+	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResource[cq.Name], cq.Name, info.TotalRequests[0].Requests)
+	if err != nil {
+		return nil, err
+	}
+
+	var pv int32
+	if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
+		pv = pc.Value
+		wl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(pc.Name)
+		wl.Spec.Priority = &pc.Value
+	} else if p.Spec.PriorityClassName != "" {
+		return nil, fmt.Errorf("%q: %w", p.Spec.PriorityClassName, cache.ErrPCNotFound)
+	}
+
+	return &checkedWorkload{workload: wl, flavors: flavors, priority: pv}, nil
+}
+
+// flavorAssignmentsForRequests assigns a flavor to each non-zero requested
+// resource, using the ClusterQueue's precomputed resource-to-flavor map.
+func flavorAssignmentsForRequests(
+	flavorsByResource map[corev1.ResourceName]kueue.ResourceFlavorReference,
+	cqName string,
+	requests resources.Requests,
+) (map[corev1.ResourceName]kueue.ResourceFlavorReference, error) {
+	type rq struct {
+		name corev1.ResourceName
+		qty  int64
+	}
+	pairs := make([]rq, 0, requests.Len())
+	requests.ForEach(func(name corev1.ResourceName, quantity int64) {
+		pairs = append(pairs, rq{name, quantity})
+	})
+	slices.SortFunc(pairs, func(a, b rq) int { return strings.Compare(string(a.name), string(b.name)) })
+
+	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+	for _, p := range pairs {
+		if p.qty == 0 {
+			continue
+		}
+		flv, ok := flavorsByResource[p.name]
+		if !ok {
+			return nil, &resourceNotCoveredError{Resource: p.name, ClusterQueue: cqName}
+		}
+		flavors[p.name] = flv
+	}
+
+	return flavors, nil
+}
+
+// preparePodForWorkload returns a labeled copy of p for Workload construction.
+// Callers must have already confirmed p has no conflicting queue label.
+func preparePodForWorkload(p *corev1.Pod, queue string, addLabels map[string]string) *corev1.Pod {
+	podForWorkload := p.DeepCopy()
+	if podForWorkload.Labels == nil {
+		podForWorkload.Labels = make(map[string]string)
+	}
+	maps.Copy(podForWorkload.Labels, addLabels)
+	podForWorkload.Labels[controllerconstants.QueueLabel] = queue
+	return podForWorkload
 }

--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -82,8 +82,8 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 	return errors.Join(summary.Errors...)
 }
 
-// resolveQueues returns the LocalQueue and ClusterQueue a Pod maps to. Import
-// and Check share this lookup so "queue not found" cannot diverge between them.
+// resolveQueues resolves the Pod to its LocalQueue and ClusterQueue.
+// It returns skip=true when mapping says this Pod should be skipped.
 func resolveQueues(importCache *cache.ImportCache, p *corev1.Pod) (*kueue.LocalQueue, *kueue.ClusterQueue, bool, error) {
 	lq, skip, err := importCache.LocalQueueForPod(p)
 	if skip || err != nil {
@@ -96,11 +96,9 @@ func resolveQueues(importCache *cache.ImportCache, p *corev1.Pod) (*kueue.LocalQ
 	return lq, cq, false, nil
 }
 
-// checkPodWorkload validates that p can be imported into cq and builds the
-// Workload it would produce. Check calls this and only reports the outcome;
-// Import calls this and, on success, persists Pod labels and creates/admits
-// the Workload. Keeping the validation in one place means the two commands
-// cannot silently disagree on whether a Pod is importable.
+// checkPodWorkload validates p against the target ClusterQueue and returns the
+// Workload that would be created, its resource-flavor assignments, and the
+// resolved priority.
 func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.ImportCache, p *corev1.Pod, lqName string, cq *kueue.ClusterQueue) (*checkedWorkload, error) {
 	if oldLq, found := p.Labels[controllerconstants.QueueLabel]; found && oldLq != lqName {
 		return nil, &queueLabelConflictError{CurrentQueue: oldLq, ExpectedQueue: lqName}
@@ -108,7 +106,7 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	if len(cq.Spec.ResourceGroups) == 0 {
 		return nil, fmt.Errorf("%q has no resource groups: %w", cq.Name, cache.ErrCQInvalid)
 	}
-	if err := importCache.FlavorValidation[cq.Name]; err != nil {
+	if err := importCache.FlavorValidationForClusterQueue(kueue.ClusterQueueReference(cq.Name)); err != nil {
 		return nil, err
 	}
 
@@ -140,7 +138,7 @@ func checkPodWorkload(ctx context.Context, c client.Client, importCache *cache.I
 	if len(info.TotalRequests) == 0 {
 		return nil, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
 	}
-	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResource[cq.Name], cq.Name, info.TotalRequests[0].Requests)
+	flavors, err := flavorAssignmentsForRequests(importCache.FlavorsByResourceForClusterQueue(kueue.ClusterQueueReference(cq.Name)), cq.Name, info.TotalRequests[0].Requests)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/importer/pod/check.go
+++ b/cmd/importer/pod/check.go
@@ -26,7 +26,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/importer/cache"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache, jobs uint) error {
@@ -49,17 +52,24 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 		if len(cq.Spec.ResourceGroups) == 0 {
 			return false, fmt.Errorf("%q has no resource groups: %w", cq.Name, cache.ErrCQInvalid)
 		}
-
-		if len(cq.Spec.ResourceGroups[0].Flavors) == 0 {
-			return false, fmt.Errorf("%q has no resource groups flavors: %w", cq.Name, cache.ErrCQInvalid)
+		if err := validateKnownClusterQueueFlavors(cq, importCache.ResourceFlavors); err != nil {
+			return false, err
 		}
 
-		rfName := cq.Spec.ResourceGroups[0].Flavors[0].Name
-		rf, rfFound := importCache.ResourceFlavors[rfName]
-		if !rfFound {
-			return false, fmt.Errorf("%q flavor %q: %w", cq.Name, rfName, cache.ErrCQInvalid)
+		kp := pod.FromObject(p)
+		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+		if err != nil {
+			return false, fmt.Errorf("construct workload: %w", err)
 		}
 
+		info := workload.NewInfo(wl)
+		if len(info.TotalRequests) == 0 {
+			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
+		}
+
+		if _, err := flavorAssignmentsForRequests(cq, info.TotalRequests[0].Requests); err != nil {
+			return false, err
+		}
 		var pv int32
 		if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
 			pv = pc.Value
@@ -67,7 +77,7 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 			return false, fmt.Errorf("%q: %w", p.Spec.PriorityClassName, cache.ErrPCNotFound)
 		}
 
-		log.V(2).Info("Successfully checked", "clusterQueue", klog.KObj(cq), "resourceFlavor", klog.KObj(rf), "priority", pv)
+		log.V(2).Info("Successfully checked", "clusterQueue", klog.KObj(cq), "priority", pv)
 		return false, nil
 	})
 
@@ -77,4 +87,15 @@ func Check(ctx context.Context, c client.Client, importCache *cache.ImportCache,
 		log.Info("Validation failed for Pods", "err", e, "occurrences", len(pods), "observedFirstIn", pods[0])
 	}
 	return errors.Join(summary.Errors...)
+}
+
+func validateKnownClusterQueueFlavors(cq *kueue.ClusterQueue, known map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) error {
+	for _, rg := range cq.Spec.ResourceGroups {
+		for _, flavor := range rg.Flavors {
+			if _, found := known[flavor.Name]; !found {
+				return fmt.Errorf("%q flavor %q: %w", cq.Name, flavor.Name, cache.ErrCQInvalid)
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -32,6 +32,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 const (
@@ -59,12 +60,13 @@ func TestCheckNamespace(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		pods            []corev1.Pod
-		clusterQueues   []kueue.ClusterQueue
-		localQueues     []kueue.LocalQueue
-		mapping         mapping.Rules
-		flavors         []kueue.ResourceFlavor
-		priorityClasses []schedulingv1.PriorityClass
+		pods                     []corev1.Pod
+		clusterQueues            []kueue.ClusterQueue
+		localQueues              []kueue.LocalQueue
+		mapping                  mapping.Rules
+		flavors                  []kueue.ResourceFlavor
+		priorityClasses          []schedulingv1.PriorityClass
+		excludedResourcePrefixes []string
 
 		wantError error
 	}{
@@ -137,6 +139,21 @@ func TestCheckNamespace(t *testing.T) {
 				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
 			},
 			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq1"},
+		},
+		"excluded resource request is ignored": {
+			pods:        []corev1.Pod{*basePodWrapper.Clone().Request(corev1.ResourceName("vendor.com/special"), "1").Obj()},
+			mapping:     baseMapping,
+			localQueues: []kueue.LocalQueue{*baseLocalQueue.Obj()},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").
+					ResourceGroup(*utiltestingapi.
+						MakeFlavorQuotas("rf1").
+						Resource(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			flavors:                  []kueue.ResourceFlavor{*utiltestingapi.MakeResourceFlavor("rf1").Obj()},
+			excludedResourcePrefixes: []string{"vendor.com/"},
 		},
 		"request-less pod still validates cluster queue flavors": {
 			pods: []corev1.Pod{
@@ -237,7 +254,7 @@ func TestCheckNamespace(t *testing.T) {
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, nil)
+			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, nil, []workload.InfoOption{workload.WithExcludedResourcePrefixes(tc.excludedResourcePrefixes)})
 			if err != nil {
 				t.Fatalf("Unexpected cache load error: %s", err)
 			}

--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -43,6 +43,18 @@ func TestCheckNamespace(t *testing.T) {
 	baseLocalQueue := utiltestingapi.MakeLocalQueue("lq1", testingNamespace).ClusterQueue("cq1")
 	baseClusterQueue := utiltestingapi.MakeClusterQueue("cq1")
 
+	baseMapping := mapping.Rules{
+		mapping.Rule{
+			Match: mapping.Match{
+				PriorityClassName: "",
+				Labels: map[string]string{
+					testingQueueLabel: "q1",
+				},
+			},
+			ToLocalQueue: "lq1",
+		},
+	}
+
 	cases := map[string]struct {
 		pods          []corev1.Pod
 		clusterQueues []kueue.ClusterQueue
@@ -63,34 +75,14 @@ func TestCheckNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
+			mapping:   baseMapping,
 			wantError: cache.ErrLQNotFound,
 		},
 		"no cluster queue": {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
+			mapping: baseMapping,
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
@@ -100,17 +92,7 @@ func TestCheckNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
+			mapping: baseMapping,
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
@@ -119,21 +101,63 @@ func TestCheckNamespace(t *testing.T) {
 			},
 			wantError: cache.ErrCQInvalid,
 		},
+		"known ResourceFlavor assignment with uncovered request fails assignment": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().Request(corev1.ResourceName("nvidia.com/gpu"), "1").Obj(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf1").Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq1"},
+		},
+		"request-less pod still validates cluster queue flavors": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("missing-rf").Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			flavors:   []kueue.ResourceFlavor{},
+			wantError: cache.ErrCQInvalid,
+		},
+		"resource request not covered by cq": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().Request(corev1.ResourceEphemeralStorage, "1Gi").Obj(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf1").Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceEphemeralStorage, ClusterQueue: "cq1"},
+		},
 		"all found": {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
+			mapping: baseMapping,
 			localQueues: []kueue.LocalQueue{
 				*baseLocalQueue.Obj(),
 			},
@@ -159,9 +183,12 @@ func TestCheckNamespace(t *testing.T) {
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			mpc, _ := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, nil)
-			gotErr := Check(ctx, client, mpc, 8)
+			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, nil)
+			if err != nil {
+				t.Fatalf("Unexpected cache load error: %s", err)
+			}
 
+			gotErr := Check(ctx, client, mpc, 8)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}

--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -262,6 +263,64 @@ func TestCheckNamespace(t *testing.T) {
 			gotErr := Check(ctx, client, mpc, 8)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFlavorAssignmentsForRequests(t *testing.T) {
+	const cqName = "cq"
+	flavorsByResource := map[corev1.ResourceName]kueue.ResourceFlavorReference{
+		corev1.ResourceCPU: "cpu-flavor",
+	}
+
+	cases := map[string]struct {
+		requests  resources.Requests
+		want      map[corev1.ResourceName]kueue.ResourceFlavorReference
+		wantError error
+	}{
+		"assigns covered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU: 1000,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"ignores uncovered zero-quantity resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU:                    1000,
+				corev1.ResourceName("nvidia.com/gpu"): 0,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"fails for uncovered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("nvidia.com/gpu"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq"},
+		},
+		"fails with the lexicographically first uncovered non-zero resource": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("z.example.com/resource"): 1,
+				corev1.ResourceName("a.example.com/resource"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("a.example.com/resource"), ClusterQueue: "cq"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, gotErr := flavorAssignmentsForRequests(flavorsByResource, cqName, tc.requests)
+
+			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("Unexpected flavors (-want/+got)\n%s", diff)
 			}
 		})
 	}

--- a/cmd/importer/pod/check_test.go
+++ b/cmd/importer/pod/check_test.go
@@ -22,10 +22,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -56,11 +59,12 @@ func TestCheckNamespace(t *testing.T) {
 	}
 
 	cases := map[string]struct {
-		pods          []corev1.Pod
-		clusterQueues []kueue.ClusterQueue
-		localQueues   []kueue.LocalQueue
-		mapping       mapping.Rules
-		flavors       []kueue.ResourceFlavor
+		pods            []corev1.Pod
+		clusterQueues   []kueue.ClusterQueue
+		localQueues     []kueue.LocalQueue
+		mapping         mapping.Rules
+		flavors         []kueue.ResourceFlavor
+		priorityClasses []schedulingv1.PriorityClass
 
 		wantError error
 	}{
@@ -100,6 +104,21 @@ func TestCheckNamespace(t *testing.T) {
 				*baseClusterQueue.Obj(),
 			},
 			wantError: cache.ErrCQInvalid,
+		},
+		"pod has conflicting pre-existing queue label": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "other-lq").
+					Obj(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*baseClusterQueue.Obj(),
+			},
+			wantError: &queueLabelConflictError{CurrentQueue: "other-lq", ExpectedQueue: "lq1"},
 		},
 		"known ResourceFlavor assignment with uncovered request fails assignment": {
 			pods: []corev1.Pod{
@@ -168,6 +187,40 @@ func TestCheckNamespace(t *testing.T) {
 				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
 			},
 		},
+		"pod references a known priority class": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("p-class").Obj(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf1").Resource(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
+			},
+			priorityClasses: []schedulingv1.PriorityClass{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p-class"}, Value: 100},
+			},
+		},
+		"pod references an unknown priority class": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("missing-class").Obj(),
+			},
+			mapping: baseMapping,
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq1").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf1").Resource(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("rf1").Obj(),
+			},
+			wantError: cache.ErrPCNotFound,
+		},
 	}
 
 	for name, tc := range cases {
@@ -176,9 +229,10 @@ func TestCheckNamespace(t *testing.T) {
 			cqList := kueue.ClusterQueueList{Items: tc.clusterQueues}
 			lqList := kueue.LocalQueueList{Items: tc.localQueues}
 			rfList := kueue.ResourceFlavorList{Items: tc.flavors}
+			pcList := schedulingv1.PriorityClassList{Items: tc.priorityClasses}
 
 			builder := utiltesting.NewClientBuilder()
-			builder = builder.WithLists(&podsList, &cqList, &lqList, &rfList)
+			builder = builder.WithLists(&podsList, &cqList, &lqList, &rfList, &pcList)
 
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)

--- a/cmd/importer/pod/errors.go
+++ b/cmd/importer/pod/errors.go
@@ -1,0 +1,57 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pod
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type queueLabelConflictError struct {
+	CurrentQueue  string
+	ExpectedQueue string
+}
+
+func (e *queueLabelConflictError) Error() string {
+	return fmt.Sprintf("another local queue name is set %q expecting %q", e.CurrentQueue, e.ExpectedQueue)
+}
+
+func (e *queueLabelConflictError) Is(target error) bool {
+	t, ok := target.(*queueLabelConflictError)
+	if !ok {
+		return false
+	}
+	return e.CurrentQueue == t.CurrentQueue && e.ExpectedQueue == t.ExpectedQueue
+}
+
+type resourceNotCoveredError struct {
+	Resource     corev1.ResourceName
+	ClusterQueue string
+}
+
+func (e *resourceNotCoveredError) Error() string {
+	return fmt.Sprintf("resource %q is not covered by ClusterQueue %q", e.Resource, e.ClusterQueue)
+}
+
+func (e *resourceNotCoveredError) Is(target error) bool {
+	t, ok := target.(*resourceNotCoveredError)
+	if !ok {
+		return false
+	}
+	return e.Resource == t.Resource && e.ClusterQueue == t.ClusterQueue
+}

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -82,7 +82,7 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		if err := admitWorkload(ctx, c, wl, cq, checked.flavors); err != nil {
+		if err := admitWorkload(ctx, c, wl, cq, checked.flavors, importCache.WorkloadInfoOptions()); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))
@@ -191,10 +191,17 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 	return err
 }
 
-func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue, flavors map[corev1.ResourceName]kueue.ResourceFlavorReference) error {
+func admitWorkload(
+	ctx context.Context,
+	c client.Client,
+	wl *kueue.Workload,
+	cq *kueue.ClusterQueue,
+	flavors map[corev1.ResourceName]kueue.ResourceFlavorReference,
+	workloadInfoOptions []workload.InfoOption,
+) error {
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
-		info := workload.NewInfo(wl)
+		info := workload.NewInfo(wl, workloadInfoOptions...)
 		if len(info.TotalRequests) == 0 {
 			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
 		}

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -43,6 +45,23 @@ import (
 )
 
 var realClock = clock.RealClock{}
+
+type resourceNotCoveredError struct {
+	Resource     corev1.ResourceName
+	ClusterQueue string
+}
+
+func (e *resourceNotCoveredError) Error() string {
+	return fmt.Sprintf("resource %q is not covered by ClusterQueue %q", e.Resource, e.ClusterQueue)
+}
+
+func (e *resourceNotCoveredError) Is(target error) bool {
+	t, ok := target.(*resourceNotCoveredError)
+	if !ok {
+		return false
+	}
+	return e.Resource == t.Resource && e.ClusterQueue == t.ClusterQueue
+}
 
 func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache, jobs uint) error {
 	ch := make(chan corev1.Pod)
@@ -61,6 +80,46 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return skip, err
 		}
 
+		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
+		if !ok {
+			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
+		}
+		if err := validateKnownClusterQueueFlavors(cq, importCache.ResourceFlavors); err != nil {
+			return false, err
+		}
+
+		// Workload construction derives queue, name, and some spec fields from Pod labels.
+		// Build it from a copy that includes importer-added labels, while leaving the
+		// real Pod untouched until validation succeeds and those labels can be persisted.
+		podForWorkload := preparePodForWorkload(p, lq.Name, importCache.AddLabels)
+
+		kp := pod.FromObject(podForWorkload)
+		// Note: the recorder is not used for single pods, we can just pass nil for now.
+		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+		if err != nil {
+			return false, fmt.Errorf("construct workload: %w", err)
+		}
+		if prebuiltWorkloadName := jobframework.PrebuiltWorkloadNameFor(podForWorkload); prebuiltWorkloadName != "" {
+			wl.Name = prebuiltWorkloadName
+		}
+		// Keep the resolved queue authoritative even if the real Pod has not been labeled
+		// yet or still carries a conflicting queue label that will be rejected below.
+		wl.Spec.QueueName = kueue.LocalQueueName(lq.Name)
+		// Generic label copying is disabled in this importer path, so preserve the
+		// importer-added labels on the created Workload metadata explicitly.
+		maps.Copy(wl.Labels, importCache.AddLabels)
+
+		info := workload.NewInfo(wl)
+		if len(info.TotalRequests) == 0 {
+			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
+		}
+		var flavors map[corev1.ResourceName]kueue.ResourceFlavorReference
+		if flavors, err = flavorAssignmentsForRequests(cq, info.TotalRequests[0].Requests); err != nil {
+			return false, err
+		}
+
+		// Validate and persist importer-managed labels against the real Pod state only
+		// after the workload construction inputs have passed import validation.
 		oldLq, found := p.Labels[controllerconstants.QueueLabel]
 		if !found {
 			if err := addLabels(ctx, c, p, lq.Name, importCache.AddLabels); err != nil {
@@ -70,30 +129,16 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return false, fmt.Errorf("another local queue name is set %q expecting %q", oldLq, lq.Name)
 		}
 
-		kp := pod.FromObject(p)
-		// Note: the recorder is not used for single pods, we can just pass nil for now.
-		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
-		if err != nil {
-			return false, fmt.Errorf("construct workload: %w", err)
-		}
-
-		maps.Copy(wl.Labels, importCache.AddLabels)
-
 		if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
 			wl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(pc.Name)
 			wl.Spec.Priority = &pc.Value
-		}
-
-		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
-		if !ok {
-			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
 		}
 
 		if err := createWorkload(ctx, c, wl); err != nil {
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		if err := admitWorkload(ctx, c, wl, cq); err != nil {
+		if err := admitWorkload(ctx, c, wl, cq, flavors); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))
@@ -178,28 +223,21 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 	return err
 }
 
-func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue) error {
+func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue, flavors map[corev1.ResourceName]kueue.ResourceFlavorReference) error {
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
 		// make its admission and update its status
 		info := workload.NewInfo(wl)
-
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{
 				{
 					Name:          info.TotalRequests[0].Name,
-					Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
+					Flavors:       flavors,
 					ResourceUsage: info.TotalRequests[0].Requests.ToResourceList(resourceFormatter),
 					Count:         new(int32(1)),
 				},
 			},
-		}
-		flv := cq.Spec.ResourceGroups[0].Flavors[0].Name
-		if info.TotalRequests[0].Requests != nil {
-			info.TotalRequests[0].Requests.ForEach(func(name corev1.ResourceName, val int64) {
-				admission.PodSetAssignments[0].Flavors[name] = flv
-			})
 		}
 
 		wl.Status.Admission = &admission
@@ -239,4 +277,58 @@ func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq 
 	}
 
 	return nil
+}
+
+func preparePodForWorkload(p *corev1.Pod, queue string, addLabels map[string]string) *corev1.Pod {
+	podForWorkload := p.DeepCopy()
+	if podForWorkload.Labels == nil {
+		podForWorkload.Labels = make(map[string]string)
+	}
+	maps.Copy(podForWorkload.Labels, addLabels)
+	if _, found := podForWorkload.Labels[controllerconstants.QueueLabel]; !found {
+		podForWorkload.Labels[controllerconstants.QueueLabel] = queue
+	}
+	return podForWorkload
+}
+
+// resourceFlavorForResource returns the first flavor from the first resource group
+// that covers the requested resource. It skips groups with no flavors and returns
+// an empty string when no matching group exists.
+func resourceFlavorForResource(cq *kueue.ClusterQueue, resource corev1.ResourceName) kueue.ResourceFlavorReference {
+	for _, rg := range cq.Spec.ResourceGroups {
+		if len(rg.Flavors) == 0 {
+			continue
+		}
+
+		if slices.Contains(rg.CoveredResources, resource) {
+			return rg.Flavors[0].Name
+		}
+	}
+	return ""
+}
+
+func flavorAssignmentsForRequests(cq *kueue.ClusterQueue, requests resources.Requests) (map[corev1.ResourceName]kueue.ResourceFlavorReference, error) {
+	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+
+	resourceNames := make([]corev1.ResourceName, 0, requests.Len())
+	requestQuantities := make(map[corev1.ResourceName]int64, requests.Len())
+	requests.ForEach(func(name corev1.ResourceName, quantity int64) {
+		requestQuantities[name] = quantity
+		resourceNames = append(resourceNames, name)
+	})
+	slices.Sort(resourceNames)
+
+	for _, name := range resourceNames {
+		if requestQuantities[name] == 0 {
+			continue
+		}
+
+		flv := resourceFlavorForResource(cq, name)
+		if flv == "" {
+			return nil, &resourceNotCoveredError{Resource: name, ClusterQueue: cq.Name}
+		}
+		flavors[name] = flv
+	}
+
+	return flavors, nil
 }

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -44,6 +46,23 @@ import (
 )
 
 var realClock = clock.RealClock{}
+
+type resourceNotCoveredError struct {
+	Resource     corev1.ResourceName
+	ClusterQueue string
+}
+
+func (e *resourceNotCoveredError) Error() string {
+	return fmt.Sprintf("resource %q is not covered by ClusterQueue %q", e.Resource, e.ClusterQueue)
+}
+
+func (e *resourceNotCoveredError) Is(target error) bool {
+	t, ok := target.(*resourceNotCoveredError)
+	if !ok {
+		return false
+	}
+	return e.Resource == t.Resource && e.ClusterQueue == t.ClusterQueue
+}
 
 func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache, jobs uint) error {
 	ch := make(chan corev1.Pod)
@@ -62,6 +81,46 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return skip, err
 		}
 
+		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
+		if !ok {
+			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
+		}
+		if err := validateKnownClusterQueueFlavors(cq, importCache.ResourceFlavors); err != nil {
+			return false, err
+		}
+
+		// Workload construction derives queue, name, and some spec fields from Pod labels.
+		// Build it from a copy that includes importer-added labels, while leaving the
+		// real Pod untouched until validation succeeds and those labels can be persisted.
+		podForWorkload := preparePodForWorkload(p, lq.Name, importCache.AddLabels)
+
+		kp := pod.FromObject(podForWorkload)
+		// Note: the recorder is not used for single pods, we can just pass nil for now.
+		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+		if err != nil {
+			return false, fmt.Errorf("construct workload: %w", err)
+		}
+		if prebuiltWorkloadName := jobframework.PrebuiltWorkloadNameFor(podForWorkload); prebuiltWorkloadName != "" {
+			wl.Name = prebuiltWorkloadName
+		}
+		// Keep the resolved queue authoritative even if the real Pod has not been labeled
+		// yet or still carries a conflicting queue label that will be rejected below.
+		wl.Spec.QueueName = kueue.LocalQueueName(lq.Name)
+		// Generic label copying is disabled in this importer path, so preserve the
+		// importer-added labels on the created Workload metadata explicitly.
+		maps.Copy(wl.Labels, importCache.AddLabels)
+
+		info := workload.NewInfo(wl)
+		if len(info.TotalRequests) == 0 {
+			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
+		}
+		var flavors map[corev1.ResourceName]kueue.ResourceFlavorReference
+		if flavors, err = flavorAssignmentsForRequests(cq, info.TotalRequests[0].Requests); err != nil {
+			return false, err
+		}
+
+		// Validate and persist importer-managed labels against the real Pod state only
+		// after the workload construction inputs have passed import validation.
 		oldLq, found := p.Labels[controllerconstants.QueueLabel]
 		if !found {
 			if err := addLabels(ctx, c, p, lq.Name, importCache.AddLabels); err != nil {
@@ -71,30 +130,16 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return false, fmt.Errorf("another local queue name is set %q expecting %q", oldLq, lq.Name)
 		}
 
-		kp := pod.FromObject(p)
-		// Note: the recorder is not used for single pods, we can just pass nil for now.
-		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
-		if err != nil {
-			return false, fmt.Errorf("construct workload: %w", err)
-		}
-
-		maps.Copy(wl.Labels, importCache.AddLabels)
-
 		if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
 			wl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(pc.Name)
 			wl.Spec.Priority = &pc.Value
-		}
-
-		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
-		if !ok {
-			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
 		}
 
 		if err := createWorkload(ctx, c, wl); err != nil {
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		if err := admitWorkload(ctx, c, wl, cq); err != nil {
+		if err := admitWorkload(ctx, c, wl, cq, flavors); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))
@@ -179,28 +224,21 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 	return err
 }
 
-func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue) error {
+func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue, flavors map[corev1.ResourceName]kueue.ResourceFlavorReference) error {
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
 		// make its admission and update its status
 		info := workload.NewInfo(wl)
-
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{
 				{
 					Name:          info.TotalRequests[0].Name,
-					Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
+					Flavors:       flavors,
 					ResourceUsage: info.TotalRequests[0].Requests.ToResourceList(resourceFormatter),
 					Count:         ptr.To[int32](1),
 				},
 			},
-		}
-		flv := cq.Spec.ResourceGroups[0].Flavors[0].Name
-		if info.TotalRequests[0].Requests != nil {
-			info.TotalRequests[0].Requests.ForEach(func(name corev1.ResourceName, val int64) {
-				admission.PodSetAssignments[0].Flavors[name] = flv
-			})
 		}
 
 		wl.Status.Admission = &admission
@@ -240,4 +278,58 @@ func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq 
 	}
 
 	return nil
+}
+
+func preparePodForWorkload(p *corev1.Pod, queue string, addLabels map[string]string) *corev1.Pod {
+	podForWorkload := p.DeepCopy()
+	if podForWorkload.Labels == nil {
+		podForWorkload.Labels = make(map[string]string)
+	}
+	maps.Copy(podForWorkload.Labels, addLabels)
+	if _, found := podForWorkload.Labels[controllerconstants.QueueLabel]; !found {
+		podForWorkload.Labels[controllerconstants.QueueLabel] = queue
+	}
+	return podForWorkload
+}
+
+// resourceFlavorForResource returns the first flavor from the first resource group
+// that covers the requested resource. It skips groups with no flavors and returns
+// an empty string when no matching group exists.
+func resourceFlavorForResource(cq *kueue.ClusterQueue, resource corev1.ResourceName) kueue.ResourceFlavorReference {
+	for _, rg := range cq.Spec.ResourceGroups {
+		if len(rg.Flavors) == 0 {
+			continue
+		}
+
+		if slices.Contains(rg.CoveredResources, resource) {
+			return rg.Flavors[0].Name
+		}
+	}
+	return ""
+}
+
+func flavorAssignmentsForRequests(cq *kueue.ClusterQueue, requests resources.Requests) (map[corev1.ResourceName]kueue.ResourceFlavorReference, error) {
+	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
+
+	resourceNames := make([]corev1.ResourceName, 0, requests.Len())
+	requestQuantities := make(map[corev1.ResourceName]int64, requests.Len())
+	requests.ForEach(func(name corev1.ResourceName, quantity int64) {
+		requestQuantities[name] = quantity
+		resourceNames = append(resourceNames, name)
+	})
+	slices.Sort(resourceNames)
+
+	for _, name := range resourceNames {
+		if requestQuantities[name] == 0 {
+			continue
+		}
+
+		flv := resourceFlavorForResource(cq, name)
+		if flv == "" {
+			return nil, &resourceNotCoveredError{Resource: name, ClusterQueue: cq.Name}
+		}
+		flavors[name] = flv
+	}
+
+	return flavors, nil
 }

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -37,31 +36,12 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 )
 
 var realClock = clock.RealClock{}
-
-type resourceNotCoveredError struct {
-	Resource     corev1.ResourceName
-	ClusterQueue string
-}
-
-func (e *resourceNotCoveredError) Error() string {
-	return fmt.Sprintf("resource %q is not covered by ClusterQueue %q", e.Resource, e.ClusterQueue)
-}
-
-func (e *resourceNotCoveredError) Is(target error) bool {
-	t, ok := target.(*resourceNotCoveredError)
-	if !ok {
-		return false
-	}
-	return e.Resource == t.Resource && e.ClusterQueue == t.ClusterQueue
-}
 
 func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache, jobs uint) error {
 	ch := make(chan corev1.Pod)
@@ -75,70 +55,34 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(p))
 		log.V(3).Info("Importing")
 
-		lq, skip, err := importCache.LocalQueue(p)
+		lq, cq, skip, err := resolveQueues(importCache, p)
 		if skip || err != nil {
 			return skip, err
 		}
 
-		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
-		if !ok {
-			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
-		}
-		if err := validateKnownClusterQueueFlavors(cq, importCache.ResourceFlavors); err != nil {
-			return false, err
-		}
-
-		// Workload construction derives queue, name, and some spec fields from Pod labels.
-		// Build it from a copy that includes importer-added labels, while leaving the
-		// real Pod untouched until validation succeeds and those labels can be persisted.
-		podForWorkload := preparePodForWorkload(p, lq.Name, importCache.AddLabels)
-
-		kp := pod.FromObject(podForWorkload)
-		// Note: the recorder is not used for single pods, we can just pass nil for now.
-		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
+		// Import shares its Pod/ClusterQueue validation and Workload construction
+		// with Check, so the two commands cannot disagree on what is importable.
+		checked, err := checkPodWorkload(ctx, c, importCache, p, lq.Name, cq)
 		if err != nil {
-			return false, fmt.Errorf("construct workload: %w", err)
-		}
-		if prebuiltWorkloadName := jobframework.PrebuiltWorkloadNameFor(podForWorkload); prebuiltWorkloadName != "" {
-			wl.Name = prebuiltWorkloadName
-		}
-		// Keep the resolved queue authoritative even if the real Pod has not been labeled
-		// yet or still carries a conflicting queue label that will be rejected below.
-		wl.Spec.QueueName = kueue.LocalQueueName(lq.Name)
-		// Generic label copying is disabled in this importer path, so preserve the
-		// importer-added labels on the created Workload metadata explicitly.
-		maps.Copy(wl.Labels, importCache.AddLabels)
-
-		info := workload.NewInfo(wl)
-		if len(info.TotalRequests) == 0 {
-			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
-		}
-		var flavors map[corev1.ResourceName]kueue.ResourceFlavorReference
-		if flavors, err = flavorAssignmentsForRequests(cq, info.TotalRequests[0].Requests); err != nil {
 			return false, err
 		}
+		wl := checked.workload
 
-		// Validate and persist importer-managed labels against the real Pod state only
-		// after the workload construction inputs have passed import validation.
-		oldLq, found := p.Labels[controllerconstants.QueueLabel]
-		if !found {
+		// checkPodWorkload already rejects a conflicting pre-existing queue label,
+		// so a Pod reaching here either has none or one that already matches lq.Name.
+		// It may still be missing the managed-by label or importCache.AddLabels,
+		// e.g. on a re-run with a new --add-labels value.
+		if podNeedsLabels(p, lq.Name, importCache.AddLabels) {
 			if err := addLabels(ctx, c, p, lq.Name, importCache.AddLabels); err != nil {
 				return false, fmt.Errorf("cannot add queue label: %w", err)
 			}
-		} else if oldLq != lq.Name {
-			return false, fmt.Errorf("another local queue name is set %q expecting %q", oldLq, lq.Name)
-		}
-
-		if pc, found := importCache.PriorityClasses[p.Spec.PriorityClassName]; found {
-			wl.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef(pc.Name)
-			wl.Spec.Priority = &pc.Value
 		}
 
 		if err := createWorkload(ctx, c, wl); err != nil {
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		if err := admitWorkload(ctx, c, wl, cq, flavors); err != nil {
+		if err := admitWorkload(ctx, c, wl, cq, checked.flavors); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))
@@ -165,24 +109,57 @@ func checkError(err error) (retry, reload bool, timeout time.Duration) {
 	return false, false, 0
 }
 
-func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string, addLabels map[string]string) error {
-	if p.Labels == nil {
-		p.Labels = make(map[string]string)
+// waitForRetry blocks for timeout, or returns early with an error if ctx is
+// done first. A negative timeout returns immediately.
+func waitForRetry(ctx context.Context, timeout time.Duration) error {
+	if timeout < 0 {
+		return nil
 	}
-	p.Labels[controllerconstants.QueueLabel] = queue
-	p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
-	maps.Copy(p.Labels, addLabels)
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return errors.New("context canceled")
+	case <-t.C:
+		return nil
+	}
+}
 
+// importLabels merges queue, the managed-by label, and the configured extra
+// labels into the full label set a Pod must carry after import.
+func importLabels(queue string, addLabels map[string]string) map[string]string {
+	labels := make(map[string]string, len(addLabels)+2)
+	maps.Copy(labels, addLabels)
+	labels[controllerconstants.QueueLabel] = queue
+	labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
+	return labels
+}
+
+// podNeedsLabels reports whether p is missing, or has a stale value for, any label from importLabels.
+func podNeedsLabels(p *corev1.Pod, queue string, addLabels map[string]string) bool {
+	for k, v := range importLabels(queue, addLabels) {
+		if p.Labels[k] != v {
+			return true
+		}
+	}
+	return false
+}
+
+func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string, addLabels map[string]string) error {
+	applyLabels := func() {
+		if p.Labels == nil {
+			p.Labels = make(map[string]string)
+		}
+		maps.Copy(p.Labels, importLabels(queue, addLabels))
+	}
+
+	applyLabels()
 	err := c.Update(ctx, p)
 	retry, reload, timeout := checkError(err)
 
 	for retry {
-		if timeout >= 0 {
-			select {
-			case <-ctx.Done():
-				return errors.New("context canceled")
-			case <-time.After(timeout):
-			}
+		if err := waitForRetry(ctx, timeout); err != nil {
+			return err
 		}
 		if reload {
 			err = c.Get(ctx, client.ObjectKeyFromObject(p), p)
@@ -190,12 +167,7 @@ func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string
 				retry, reload, timeout = checkError(err)
 				continue
 			}
-			if p.Labels == nil {
-				p.Labels = make(map[string]string)
-			}
-			p.Labels[controllerconstants.QueueLabel] = queue
-			p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
-			maps.Copy(p.Labels, addLabels)
+			applyLabels()
 		}
 		err = c.Update(ctx, p)
 		retry, reload, timeout = checkError(err)
@@ -210,12 +182,8 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 	}
 	retry, _, timeout := checkError(err)
 	for retry {
-		if timeout >= 0 {
-			select {
-			case <-ctx.Done():
-				return errors.New("context canceled")
-			case <-time.After(timeout):
-			}
+		if err := waitForRetry(ctx, timeout); err != nil {
+			return err
 		}
 		err = c.Create(ctx, wl)
 		retry, _, timeout = checkError(err)
@@ -226,8 +194,10 @@ func createWorkload(ctx context.Context, c client.Client, wl *kueue.Workload) er
 func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq *kueue.ClusterQueue, flavors map[corev1.ResourceName]kueue.ResourceFlavorReference) error {
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
-		// make its admission and update its status
 		info := workload.NewInfo(wl)
+		if len(info.TotalRequests) == 0 {
+			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
+		}
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{
@@ -239,96 +209,38 @@ func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq 
 				},
 			},
 		}
-
+		msg := fmt.Sprintf("Imported into ClusterQueue %s", cq.Name)
 		wl.Status.Admission = &admission
-		reservedCond := metav1.Condition{
+		apimeta.SetStatusCondition(&wl.Status.Conditions, metav1.Condition{
 			Type:    kueue.WorkloadQuotaReserved,
 			Status:  metav1.ConditionTrue,
 			Reason:  "Imported",
-			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
-		}
-		apimeta.SetStatusCondition(&wl.Status.Conditions, reservedCond)
-		admittedCond := metav1.Condition{
+			Message: msg,
+		})
+		apimeta.SetStatusCondition(&wl.Status.Conditions, metav1.Condition{
 			Type:    kueue.WorkloadAdmitted,
 			Status:  metav1.ConditionTrue,
 			Reason:  "Imported",
-			Message: fmt.Sprintf("Imported into ClusterQueue %s", cq.Name),
-		}
-		apimeta.SetStatusCondition(&wl.Status.Conditions, admittedCond)
+			Message: msg,
+		})
 		return true, nil
 	}
 
-	for {
+	const maxAttempts = 5
+	for range maxAttempts {
 		err := workloadpatching.PatchAdmissionStatus(ctx, c, wl, realClock, update, workloadpatching.WithForceApply())
-		retry, _, timeout := checkError(err)
+		retry, reload, timeout := checkError(err)
 		if !retry {
-			if err != nil {
-				return err
-			}
-			break
+			return err
 		}
-		if timeout >= 0 {
-			select {
-			case <-ctx.Done():
-				return errors.New("context canceled")
-			case <-time.After(timeout):
+		if waitErr := waitForRetry(ctx, timeout); waitErr != nil {
+			return waitErr
+		}
+		if reload {
+			if getErr := c.Get(ctx, client.ObjectKeyFromObject(wl), wl); getErr != nil {
+				return getErr
 			}
 		}
 	}
-
-	return nil
-}
-
-func preparePodForWorkload(p *corev1.Pod, queue string, addLabels map[string]string) *corev1.Pod {
-	podForWorkload := p.DeepCopy()
-	if podForWorkload.Labels == nil {
-		podForWorkload.Labels = make(map[string]string)
-	}
-	maps.Copy(podForWorkload.Labels, addLabels)
-	if _, found := podForWorkload.Labels[controllerconstants.QueueLabel]; !found {
-		podForWorkload.Labels[controllerconstants.QueueLabel] = queue
-	}
-	return podForWorkload
-}
-
-// resourceFlavorForResource returns the first flavor from the first resource group
-// that covers the requested resource. It skips groups with no flavors and returns
-// an empty string when no matching group exists.
-func resourceFlavorForResource(cq *kueue.ClusterQueue, resource corev1.ResourceName) kueue.ResourceFlavorReference {
-	for _, rg := range cq.Spec.ResourceGroups {
-		if len(rg.Flavors) == 0 {
-			continue
-		}
-
-		if slices.Contains(rg.CoveredResources, resource) {
-			return rg.Flavors[0].Name
-		}
-	}
-	return ""
-}
-
-func flavorAssignmentsForRequests(cq *kueue.ClusterQueue, requests resources.Requests) (map[corev1.ResourceName]kueue.ResourceFlavorReference, error) {
-	flavors := make(map[corev1.ResourceName]kueue.ResourceFlavorReference)
-
-	resourceNames := make([]corev1.ResourceName, 0, requests.Len())
-	requestQuantities := make(map[corev1.ResourceName]int64, requests.Len())
-	requests.ForEach(func(name corev1.ResourceName, quantity int64) {
-		requestQuantities[name] = quantity
-		resourceNames = append(resourceNames, name)
-	})
-	slices.Sort(resourceNames)
-
-	for _, name := range resourceNames {
-		if requestQuantities[name] == 0 {
-			continue
-		}
-
-		flv := resourceFlavorForResource(cq, name)
-		if flv == "" {
-			return nil, &resourceNotCoveredError{Resource: name, ClusterQueue: cq.Name}
-		}
-		flavors[name] = flv
-	}
-
-	return flavors, nil
+	return fmt.Errorf("admitting workload %s: too many conflicts", klog.KObj(wl))
 }

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -110,9 +110,9 @@ func checkError(err error) (retry, reload bool, timeout time.Duration) {
 }
 
 // waitForRetry blocks for timeout, or returns early with an error if ctx is
-// done first. A negative timeout returns immediately.
+// done first. A non-positive timeout returns immediately.
 func waitForRetry(ctx context.Context, timeout time.Duration) error {
-	if timeout < 0 {
+	if timeout <= 0 {
 		return nil
 	}
 	t := time.NewTimer(timeout)
@@ -202,9 +202,6 @@ func admitWorkload(
 	resourceFormatter := resources.NewResourceFormatter()
 	update := func(wl *kueue.Workload) (bool, error) {
 		info := workload.NewInfo(wl, workloadInfoOptions...)
-		if len(info.TotalRequests) == 0 {
-			return false, fmt.Errorf("workload has no total requests: %w", cache.ErrPodInvalid)
-		}
 		admission := kueue.Admission{
 			ClusterQueue: kueue.ClusterQueueReference(cq.Name),
 			PodSetAssignments: []kueue.PodSetAssignment{
@@ -236,6 +233,9 @@ func admitWorkload(
 	const maxAttempts = 5
 	for range maxAttempts {
 		err := workloadpatching.PatchAdmissionStatus(ctx, c, wl, realClock, update, workloadpatching.WithForceApply())
+		if err == nil {
+			return nil
+		}
 		retry, reload, timeout := checkError(err)
 		if !retry {
 			return err

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -152,14 +153,15 @@ func TestImportNamespace(t *testing.T) {
 	}}
 
 	cases := map[string]struct {
-		pods          []corev1.Pod
-		clusterQueue  kueue.ClusterQueue
-		localQueue    kueue.LocalQueue
-		addLabels     map[string]string
-		flavors       []kueue.ResourceFlavor
-		wantPods      []corev1.Pod
-		wantWorkloads []kueue.Workload
-		wantError     error
+		pods            []corev1.Pod
+		clusterQueue    kueue.ClusterQueue
+		localQueue      kueue.LocalQueue
+		addLabels       map[string]string
+		flavors         []kueue.ResourceFlavor
+		priorityClasses []schedulingv1.PriorityClass
+		wantPods        []corev1.Pod
+		wantWorkloads   []kueue.Workload
+		wantError       error
 	}{
 		"create one": {
 			pods: []corev1.Pod{
@@ -183,6 +185,33 @@ func TestImportNamespace(t *testing.T) {
 		"create one, add labels": {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			addLabels: map[string]string{
+				"new.lbl": "val",
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
+					Label("new.lbl", "val").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWlWrapper.Clone().
+					Label("new.lbl", "val").
+					Obj(),
+			},
+		},
+		"pod already carries matching queue label but is missing managed-by and add-labels": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "lq1").
+					Obj(),
 			},
 			localQueue:   *baseLocalQueue.Obj(),
 			clusterQueue: *baseClusterQueue.Obj(),
@@ -234,6 +263,25 @@ func TestImportNamespace(t *testing.T) {
 					MaximumExecutionTimeSeconds(3600).
 					Obj(),
 			},
+		},
+		"pod has conflicting pre-existing queue label": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "other-lq").
+					Obj(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "other-lq").
+					Obj(),
+			},
+			wantError:     &queueLabelConflictError{CurrentQueue: "other-lq", ExpectedQueue: "lq1"},
+			wantWorkloads: []kueue.Workload{},
 		},
 		"missing cluster queue": {
 			pods: []corev1.Pod{
@@ -300,9 +348,55 @@ func TestImportNamespace(t *testing.T) {
 			flavors: []kueue.ResourceFlavor{
 				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
 			},
-			wantError: &resourceNotCoveredError{Resource: corev1.ResourceCPU, ClusterQueue: "cq1"},
+			wantError: cache.ErrCQInvalid,
 			wantPods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
+		},
+		"imports a pod referencing a known priority class": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("p-class").Obj(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			priorityClasses: []schedulingv1.PriorityClass{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p-class"}, Value: 100},
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("p-class").
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWlWrapper.Clone().
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Image("img").
+						Request(corev1.ResourceCPU, "1").
+						PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+						PriorityClass("p-class").
+						Obj()).
+					PodPriorityClassRef("p-class").
+					Priority(100).
+					Obj(),
+			},
+		},
+		"returns an error without mutating pod or creating workload when priority class is unknown": {
+			pods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("missing-class").Obj(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			wantError: cache.ErrPCNotFound,
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().PriorityClass("missing-class").Obj(),
 			},
 			wantWorkloads: []kueue.Workload{},
 		},
@@ -314,10 +408,11 @@ func TestImportNamespace(t *testing.T) {
 			cqList := kueue.ClusterQueueList{Items: []kueue.ClusterQueue{tc.clusterQueue}}
 			lqList := kueue.LocalQueueList{Items: []kueue.LocalQueue{tc.localQueue}}
 			rfList := kueue.ResourceFlavorList{Items: tc.flavors}
+			pcList := schedulingv1.PriorityClassList{Items: tc.priorityClasses}
 
 			builder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).WithStatusSubresource(&kueue.Workload{}).
-				WithLists(&podsList, &cqList, &lqList, &rfList)
+				WithLists(&podsList, &cqList, &lqList, &rfList, &pcList)
 
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -352,71 +447,11 @@ func TestImportNamespace(t *testing.T) {
 	}
 }
 
-func TestResourceFlavorForResource(t *testing.T) {
-	cases := map[string]struct {
-		clusterQueue *kueue.ClusterQueue
-		resource     corev1.ResourceName
-		wantFlavor   kueue.ResourceFlavorReference
-	}{
-		"returns the flavor from the matching resource group": {
-			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
-						Resource(corev1.ResourceCPU, "10", "0").
-						Resource(corev1.ResourceMemory, "10Gi", "0").
-						Obj(),
-				).
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
-						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
-						Obj(),
-				).Obj(),
-			resource:   corev1.ResourceName("nvidia.com/gpu"),
-			wantFlavor: "gpu-flavor",
-		},
-		"returns the first flavor from the matching resource group": {
-			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("on-demand").
-						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
-						Obj(),
-					*utiltestingapi.MakeFlavorQuotas("spot").
-						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
-						Obj(),
-				).Obj(),
-			resource:   corev1.ResourceName("nvidia.com/gpu"),
-			wantFlavor: "on-demand",
-		},
-		"returns an empty string when the resource is not covered by any resource group": {
-			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
-						Resource(corev1.ResourceCPU, "10", "0").
-						Obj(),
-				).Obj(),
-			resource:   corev1.ResourceName("nvidia.com/gpu"),
-			wantFlavor: "",
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			gotFlavor := resourceFlavorForResource(tc.clusterQueue, tc.resource)
-
-			if gotFlavor != tc.wantFlavor {
-				t.Fatalf("Unexpected flavor, got %q want %q", gotFlavor, tc.wantFlavor)
-			}
-		})
-	}
-}
-
 func TestFlavorAssignmentsForRequests(t *testing.T) {
-	cq := utiltestingapi.MakeClusterQueue("cq").
-		ResourceGroup(
-			*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
-				Resource(corev1.ResourceCPU, "10", "0").
-				Obj(),
-		).Obj()
+	const cqName = "cq"
+	flavorsByResource := map[corev1.ResourceName]kueue.ResourceFlavorReference{
+		corev1.ResourceCPU: "cpu-flavor",
+	}
 
 	cases := map[string]struct {
 		requests  resources.Requests
@@ -457,7 +492,7 @@ func TestFlavorAssignmentsForRequests(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, gotErr := flavorAssignmentsForRequests(cq, tc.requests)
+			got, gotErr := flavorAssignmentsForRequests(flavorsByResource, cqName, tc.requests)
 
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	controllerpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
-	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -442,64 +441,6 @@ func TestImportNamespace(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantWorkloads, wlList.Items, wlCmpOpts...); diff != "" {
 				t.Errorf("Unexpected workloads (-want/+got)\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestFlavorAssignmentsForRequests(t *testing.T) {
-	const cqName = "cq"
-	flavorsByResource := map[corev1.ResourceName]kueue.ResourceFlavorReference{
-		corev1.ResourceCPU: "cpu-flavor",
-	}
-
-	cases := map[string]struct {
-		requests  resources.Requests
-		want      map[corev1.ResourceName]kueue.ResourceFlavorReference
-		wantError error
-	}{
-		"assigns covered non-zero resources": {
-			requests: resources.MapRequests{
-				corev1.ResourceCPU: 1000,
-			},
-			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-				corev1.ResourceCPU: "cpu-flavor",
-			},
-		},
-		"ignores uncovered zero-quantity resources": {
-			requests: resources.MapRequests{
-				corev1.ResourceCPU:                    1000,
-				corev1.ResourceName("nvidia.com/gpu"): 0,
-			},
-			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-				corev1.ResourceCPU: "cpu-flavor",
-			},
-		},
-		"fails for uncovered non-zero resources": {
-			requests: resources.MapRequests{
-				corev1.ResourceName("nvidia.com/gpu"): 1,
-			},
-			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq"},
-		},
-		"fails with the lexicographically first uncovered non-zero resource": {
-			requests: resources.MapRequests{
-				corev1.ResourceName("z.example.com/resource"): 1,
-				corev1.ResourceName("a.example.com/resource"): 1,
-			},
-			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("a.example.com/resource"), ClusterQueue: "cq"},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got, gotErr := flavorAssignmentsForRequests(flavorsByResource, cqName, tc.requests)
-
-			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
-				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
-			}
-
-			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
-				t.Fatalf("Unexpected flavors (-want/+got)\n%s", diff)
 			}
 		})
 	}

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -31,6 +32,8 @@ import (
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	controllerpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -77,6 +80,61 @@ func TestImportNamespace(t *testing.T) {
 		ResourceGroup(
 			*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "1", "0").Obj())
 
+	baseGpuPodWrapper := testingpod.MakePod("pod-gpu", testingNamespace).
+		UID("pod-gpu").
+		Label(testingQueueLabel, "q1").
+		Image("img", nil).
+		Request(corev1.ResourceCPU, "1").
+		Request(corev1.ResourceName("nvidia.com/gpu"), "1")
+	baseGpuManagedPodWrapper := baseGpuPodWrapper.Clone().
+		Label(controllerconstants.QueueLabel, "lq1").
+		ManagedByKueueLabel()
+
+	baseGpuWlWrapper := utiltestingapi.MakeWorkload(controllerpod.GetWorkloadNameForPod("pod-gpu", types.UID("pod-gpu")), testingNamespace).
+		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-gpu", "pod-gpu").
+		Label(controllerconstants.JobUIDLabel, "pod-gpu").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Queue("lq1").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Image("img").
+			Request(corev1.ResourceCPU, "1").
+			Request(corev1.ResourceName("nvidia.com/gpu"), "1").
+			PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+			Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, "cpu-flavor", "1").
+				Assignment(corev1.ResourceName("nvidia.com/gpu"), "gpu-flavor", "1").
+				Obj()).
+			Obj(), now).
+		Condition(metav1.Condition{
+			Type:    kueue.WorkloadQuotaReserved,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: "Imported into ClusterQueue cq1",
+		}).
+		Condition(metav1.Condition{
+			Type:    kueue.WorkloadAdmitted,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: "Imported into ClusterQueue cq1",
+		})
+
+	cpuOnlyClusterQueue :=
+		*utiltestingapi.MakeClusterQueue("cq1").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+					Resource(corev1.ResourceCPU, "10", "0").
+					Obj(),
+			)
+
+	cpuAndGpuClusterQueue :=
+		cpuOnlyClusterQueue.Clone().ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
+				Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+				Obj(),
+		)
+
 	podCmpOpts := cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
@@ -88,47 +146,36 @@ func TestImportNamespace(t *testing.T) {
 		cmpopts.IgnoreFields(metav1.Condition{}, "ObservedGeneration", "LastTransitionTime"),
 	}
 
+	baseMapping := mapping.Rules{{
+		Match:        mapping.Match{Labels: map[string]string{testingQueueLabel: "q1"}},
+		ToLocalQueue: "lq1",
+	}}
+
 	cases := map[string]struct {
 		pods          []corev1.Pod
-		clusterQueues []kueue.ClusterQueue
-		localQueues   []kueue.LocalQueue
-		mapping       mapping.Rules
+		clusterQueue  kueue.ClusterQueue
+		localQueue    kueue.LocalQueue
 		addLabels     map[string]string
-
+		flavors       []kueue.ResourceFlavor
 		wantPods      []corev1.Pod
 		wantWorkloads []kueue.Workload
 		wantError     error
 	}{
-
 		"create one": {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
 			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: []kueue.ClusterQueue{
-				*baseClusterQueue.Obj(),
-			},
-
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
 					Label(controllerconstants.QueueLabel, "lq1").
 					ManagedByKueueLabel().
 					Obj(),
 			},
-
 			wantWorkloads: []kueue.Workload{
 				*baseWlWrapper.DeepCopy(),
 			},
@@ -137,27 +184,14 @@ func TestImportNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: []kueue.ClusterQueue{
-				*baseClusterQueue.Obj(),
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
 			},
 			addLabels: map[string]string{
 				"new.lbl": "val",
 			},
-
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
 					Label(controllerconstants.QueueLabel, "lq1").
@@ -165,10 +199,39 @@ func TestImportNamespace(t *testing.T) {
 					Label("new.lbl", "val").
 					Obj(),
 			},
-
 			wantWorkloads: []kueue.Workload{
 				*baseWlWrapper.Clone().
 					Label("new.lbl", "val").
+					Obj(),
+			},
+		},
+		"create one, add labels visible during workload construction": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			addLabels: map[string]string{
+				controllerconstants.MaxExecTimeSecondsLabel: "3600",
+				controllerconstants.PrebuiltWorkloadLabel:   "prebuilt-wl",
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
+					Label(controllerconstants.MaxExecTimeSecondsLabel, "3600").
+					Label(controllerconstants.PrebuiltWorkloadLabel, "prebuilt-wl").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWlWrapper.Clone().
+					Name("prebuilt-wl").
+					Label(controllerconstants.MaxExecTimeSecondsLabel, "3600").
+					Label(controllerconstants.PrebuiltWorkloadLabel, "prebuilt-wl").
+					MaximumExecutionTimeSeconds(3600).
 					Obj(),
 			},
 		},
@@ -176,53 +239,100 @@ func TestImportNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: nil, // intentionally omit cluster queues to trigger ErrCQNotFound
-
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: kueue.ClusterQueue{}, // use a zero-value ClusterQueue; LocalQueue still points to cq1, so lookup triggers ErrCQNotFound
 			wantPods: []corev1.Pod{
-				*basePodWrapper.Clone().
-					Label(controllerconstants.QueueLabel, "lq1").
-					ManagedByKueueLabel().
-					Obj(),
+				*basePodWrapper.DeepCopy(),
 			},
 			wantError: cache.ErrCQNotFound,
+		},
+		"imports a pod requesting cpu and gpu and assigns each resource to its matching resource-group flavor": {
+			pods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *cpuAndGpuClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("cpu-flavor").Obj(),
+				*utiltestingapi.MakeResourceFlavor("gpu-flavor").Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*baseGpuManagedPodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseGpuWlWrapper.DeepCopy(),
+			},
+		},
+		"returns an error without mutating pod or creating workload when a requested resource is not covered by the cluster queue": {
+			pods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *cpuOnlyClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("cpu-flavor").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq1"},
+			wantPods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
+		},
+		"returns an error without mutating pod or creating workload when cluster queue references a missing resource flavor": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors:      []kueue.ResourceFlavor{},
+			wantError:    cache.ErrCQInvalid,
+			wantPods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
+		},
+		"returns an error without mutating pod or creating workload when cluster queue has no resource groups": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *utiltestingapi.MakeClusterQueue("cq1").Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceCPU, ClusterQueue: "cq1"},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			podsList := corev1.PodList{Items: tc.pods}
-			cqList := kueue.ClusterQueueList{Items: tc.clusterQueues}
-			lqList := kueue.LocalQueueList{Items: tc.localQueues}
+			cqList := kueue.ClusterQueueList{Items: []kueue.ClusterQueue{tc.clusterQueue}}
+			lqList := kueue.LocalQueueList{Items: []kueue.LocalQueue{tc.localQueue}}
+			rfList := kueue.ResourceFlavorList{Items: tc.flavors}
 
 			builder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).WithStatusSubresource(&kueue.Workload{}).
-				WithLists(&podsList, &cqList, &lqList)
+				WithLists(&podsList, &cqList, &lqList, &rfList)
 
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			mpc, _ := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, tc.addLabels)
-			gotErr := Import(ctx, client, mpc, 8)
+			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, baseMapping, tc.addLabels)
+			if err != nil {
+				t.Fatalf("Unexpected cache load error: %s", err)
+			}
 
+			gotErr := Import(ctx, client, mpc, 8)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 
-			err := client.List(ctx, &podsList)
+			err = client.List(ctx, &podsList)
 			if err != nil {
 				t.Errorf("Unexpected list pod error: %s", err)
 			}
@@ -237,6 +347,124 @@ func TestImportNamespace(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantWorkloads, wlList.Items, wlCmpOpts...); diff != "" {
 				t.Errorf("Unexpected workloads (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResourceFlavorForResource(t *testing.T) {
+	cases := map[string]struct {
+		clusterQueue *kueue.ClusterQueue
+		resource     corev1.ResourceName
+		wantFlavor   kueue.ResourceFlavorReference
+	}{
+		"returns the flavor from the matching resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Resource(corev1.ResourceMemory, "10Gi", "0").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "gpu-flavor",
+		},
+		"returns the first flavor from the matching resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("spot").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "on-demand",
+		},
+		"returns an empty string when the resource is not covered by any resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotFlavor := resourceFlavorForResource(tc.clusterQueue, tc.resource)
+
+			if gotFlavor != tc.wantFlavor {
+				t.Fatalf("Unexpected flavor, got %q want %q", gotFlavor, tc.wantFlavor)
+			}
+		})
+	}
+}
+
+func TestFlavorAssignmentsForRequests(t *testing.T) {
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+				Resource(corev1.ResourceCPU, "10", "0").
+				Obj(),
+		).Obj()
+
+	cases := map[string]struct {
+		requests  resources.Requests
+		want      map[corev1.ResourceName]kueue.ResourceFlavorReference
+		wantError error
+	}{
+		"assigns covered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU: 1000,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"ignores uncovered zero-quantity resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU:                    1000,
+				corev1.ResourceName("nvidia.com/gpu"): 0,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"fails for uncovered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("nvidia.com/gpu"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq"},
+		},
+		"fails with the lexicographically first uncovered non-zero resource": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("z.example.com/resource"): 1,
+				corev1.ResourceName("a.example.com/resource"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("a.example.com/resource"), ClusterQueue: "cq"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, gotErr := flavorAssignmentsForRequests(cq, tc.requests)
+
+			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("Unexpected flavors (-want/+got)\n%s", diff)
 			}
 		})
 	}

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -417,7 +417,7 @@ func TestImportNamespace(t *testing.T) {
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, baseMapping, tc.addLabels)
+			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, baseMapping, tc.addLabels, nil)
 			if err != nil {
 				t.Fatalf("Unexpected cache load error: %s", err)
 			}

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -24,12 +24,16 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/cmd/importer/cache"
 	"sigs.k8s.io/kueue/cmd/importer/mapping"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	controllerpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -76,6 +80,61 @@ func TestImportNamespace(t *testing.T) {
 		ResourceGroup(
 			*utiltestingapi.MakeFlavorQuotas("f1").Resource(corev1.ResourceCPU, "1", "0").Obj())
 
+	baseGpuPodWrapper := testingpod.MakePod("pod-gpu", testingNamespace).
+		UID("pod-gpu").
+		Label(testingQueueLabel, "q1").
+		Image("img", nil).
+		Request(corev1.ResourceCPU, "1").
+		Request(corev1.ResourceName("nvidia.com/gpu"), "1")
+	baseGpuManagedPodWrapper := baseGpuPodWrapper.Clone().
+		Label(controllerconstants.QueueLabel, "lq1").
+		ManagedByKueueLabel()
+
+	baseGpuWlWrapper := utiltestingapi.MakeWorkload(controllerpod.GetWorkloadNameForPod("pod-gpu", types.UID("pod-gpu")), testingNamespace).
+		ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod-gpu", "pod-gpu").
+		Label(controllerconstants.JobUIDLabel, "pod-gpu").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Queue("lq1").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			Image("img").
+			Request(corev1.ResourceCPU, "1").
+			Request(corev1.ResourceName("nvidia.com/gpu"), "1").
+			PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+			Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, "cpu-flavor", "1").
+				Assignment(corev1.ResourceName("nvidia.com/gpu"), "gpu-flavor", "1").
+				Obj()).
+			Obj(), now).
+		Condition(metav1.Condition{
+			Type:    kueue.WorkloadQuotaReserved,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: "Imported into ClusterQueue cq1",
+		}).
+		Condition(metav1.Condition{
+			Type:    kueue.WorkloadAdmitted,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Imported",
+			Message: "Imported into ClusterQueue cq1",
+		})
+
+	cpuOnlyClusterQueue :=
+		*utiltestingapi.MakeClusterQueue("cq1").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+					Resource(corev1.ResourceCPU, "10", "0").
+					Obj(),
+			)
+
+	cpuAndGpuClusterQueue :=
+		cpuOnlyClusterQueue.Clone().ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
+				Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+				Obj(),
+		)
+
 	podCmpOpts := cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
@@ -87,47 +146,36 @@ func TestImportNamespace(t *testing.T) {
 		cmpopts.IgnoreFields(metav1.Condition{}, "ObservedGeneration", "LastTransitionTime"),
 	}
 
+	baseMapping := mapping.Rules{{
+		Match:        mapping.Match{Labels: map[string]string{testingQueueLabel: "q1"}},
+		ToLocalQueue: "lq1",
+	}}
+
 	cases := map[string]struct {
 		pods          []corev1.Pod
-		clusterQueues []kueue.ClusterQueue
-		localQueues   []kueue.LocalQueue
-		mapping       mapping.Rules
+		clusterQueue  kueue.ClusterQueue
+		localQueue    kueue.LocalQueue
 		addLabels     map[string]string
-
+		flavors       []kueue.ResourceFlavor
 		wantPods      []corev1.Pod
 		wantWorkloads []kueue.Workload
 		wantError     error
 	}{
-
 		"create one": {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
 			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: []kueue.ClusterQueue{
-				*baseClusterQueue.Obj(),
-			},
-
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
 					Label(controllerconstants.QueueLabel, "lq1").
 					ManagedByKueueLabel().
 					Obj(),
 			},
-
 			wantWorkloads: []kueue.Workload{
 				*baseWlWrapper.DeepCopy(),
 			},
@@ -136,27 +184,14 @@ func TestImportNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: []kueue.ClusterQueue{
-				*baseClusterQueue.Obj(),
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
 			},
 			addLabels: map[string]string{
 				"new.lbl": "val",
 			},
-
 			wantPods: []corev1.Pod{
 				*basePodWrapper.Clone().
 					Label(controllerconstants.QueueLabel, "lq1").
@@ -164,10 +199,39 @@ func TestImportNamespace(t *testing.T) {
 					Label("new.lbl", "val").
 					Obj(),
 			},
-
 			wantWorkloads: []kueue.Workload{
 				*baseWlWrapper.Clone().
 					Label("new.lbl", "val").
+					Obj(),
+			},
+		},
+		"create one, add labels visible during workload construction": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			addLabels: map[string]string{
+				controllerconstants.MaxExecTimeSecondsLabel: "3600",
+				controllerconstants.PrebuiltWorkloadLabel:   "prebuilt-wl",
+			},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
+					Label(controllerconstants.MaxExecTimeSecondsLabel, "3600").
+					Label(controllerconstants.PrebuiltWorkloadLabel, "prebuilt-wl").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseWlWrapper.Clone().
+					Name("prebuilt-wl").
+					Label(controllerconstants.MaxExecTimeSecondsLabel, "3600").
+					Label(controllerconstants.PrebuiltWorkloadLabel, "prebuilt-wl").
+					MaximumExecutionTimeSeconds(3600).
 					Obj(),
 			},
 		},
@@ -175,53 +239,100 @@ func TestImportNamespace(t *testing.T) {
 			pods: []corev1.Pod{
 				*basePodWrapper.DeepCopy(),
 			},
-			mapping: mapping.Rules{
-				mapping.Rule{
-					Match: mapping.Match{
-						PriorityClassName: "",
-						Labels: map[string]string{
-							testingQueueLabel: "q1",
-						},
-					},
-					ToLocalQueue: "lq1",
-				},
-			},
-			localQueues: []kueue.LocalQueue{
-				*baseLocalQueue.Obj(),
-			},
-			clusterQueues: nil, // intentionally omit cluster queues to trigger ErrCQNotFound
-
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: kueue.ClusterQueue{}, // use a zero-value ClusterQueue; LocalQueue still points to cq1, so lookup triggers ErrCQNotFound
 			wantPods: []corev1.Pod{
-				*basePodWrapper.Clone().
-					Label(controllerconstants.QueueLabel, "lq1").
-					ManagedByKueueLabel().
-					Obj(),
+				*basePodWrapper.DeepCopy(),
 			},
 			wantError: cache.ErrCQNotFound,
+		},
+		"imports a pod requesting cpu and gpu and assigns each resource to its matching resource-group flavor": {
+			pods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *cpuAndGpuClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("cpu-flavor").Obj(),
+				*utiltestingapi.MakeResourceFlavor("gpu-flavor").Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*baseGpuManagedPodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*baseGpuWlWrapper.DeepCopy(),
+			},
+		},
+		"returns an error without mutating pod or creating workload when a requested resource is not covered by the cluster queue": {
+			pods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *cpuOnlyClusterQueue.Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("cpu-flavor").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq1"},
+			wantPods: []corev1.Pod{
+				*baseGpuPodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
+		},
+		"returns an error without mutating pod or creating workload when cluster queue references a missing resource flavor": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *baseClusterQueue.Obj(),
+			flavors:      []kueue.ResourceFlavor{},
+			wantError:    cache.ErrCQInvalid,
+			wantPods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
+		},
+		"returns an error without mutating pod or creating workload when cluster queue has no resource groups": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			localQueue:   *baseLocalQueue.Obj(),
+			clusterQueue: *utiltestingapi.MakeClusterQueue("cq1").Obj(),
+			flavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("f1").Obj(),
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceCPU, ClusterQueue: "cq1"},
+			wantPods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			wantWorkloads: []kueue.Workload{},
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			podsList := corev1.PodList{Items: tc.pods}
-			cqList := kueue.ClusterQueueList{Items: tc.clusterQueues}
-			lqList := kueue.LocalQueueList{Items: tc.localQueues}
+			cqList := kueue.ClusterQueueList{Items: []kueue.ClusterQueue{tc.clusterQueue}}
+			lqList := kueue.LocalQueueList{Items: []kueue.LocalQueue{tc.localQueue}}
+			rfList := kueue.ResourceFlavorList{Items: tc.flavors}
 
 			builder := utiltesting.NewClientBuilder().
 				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).WithStatusSubresource(&kueue.Workload{}).
-				WithLists(&podsList, &cqList, &lqList)
+				WithLists(&podsList, &cqList, &lqList, &rfList)
 
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			mpc, _ := cache.Load(ctx, client, []string{testingNamespace}, tc.mapping, tc.addLabels)
-			gotErr := Import(ctx, client, mpc, 8)
+			mpc, err := cache.Load(ctx, client, []string{testingNamespace}, baseMapping, tc.addLabels)
+			if err != nil {
+				t.Fatalf("Unexpected cache load error: %s", err)
+			}
 
+			gotErr := Import(ctx, client, mpc, 8)
 			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 
-			err := client.List(ctx, &podsList)
+			err = client.List(ctx, &podsList)
 			if err != nil {
 				t.Errorf("Unexpected list pod error: %s", err)
 			}
@@ -236,6 +347,124 @@ func TestImportNamespace(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantWorkloads, wlList.Items, wlCmpOpts...); diff != "" {
 				t.Errorf("Unexpected workloads (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResourceFlavorForResource(t *testing.T) {
+	cases := map[string]struct {
+		clusterQueue *kueue.ClusterQueue
+		resource     corev1.ResourceName
+		wantFlavor   kueue.ResourceFlavorReference
+	}{
+		"returns the flavor from the matching resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Resource(corev1.ResourceMemory, "10Gi", "0").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("gpu-flavor").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "gpu-flavor",
+		},
+		"returns the first flavor from the matching resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas("spot").
+						Resource(corev1.ResourceName("nvidia.com/gpu"), "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "on-demand",
+		},
+		"returns an empty string when the resource is not covered by any resource group": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+						Resource(corev1.ResourceCPU, "10", "0").
+						Obj(),
+				).Obj(),
+			resource:   corev1.ResourceName("nvidia.com/gpu"),
+			wantFlavor: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotFlavor := resourceFlavorForResource(tc.clusterQueue, tc.resource)
+
+			if gotFlavor != tc.wantFlavor {
+				t.Fatalf("Unexpected flavor, got %q want %q", gotFlavor, tc.wantFlavor)
+			}
+		})
+	}
+}
+
+func TestFlavorAssignmentsForRequests(t *testing.T) {
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("cpu-flavor").
+				Resource(corev1.ResourceCPU, "10", "0").
+				Obj(),
+		).Obj()
+
+	cases := map[string]struct {
+		requests  resources.Requests
+		want      map[corev1.ResourceName]kueue.ResourceFlavorReference
+		wantError error
+	}{
+		"assigns covered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU: 1000,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"ignores uncovered zero-quantity resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceCPU:                    1000,
+				corev1.ResourceName("nvidia.com/gpu"): 0,
+			},
+			want: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+				corev1.ResourceCPU: "cpu-flavor",
+			},
+		},
+		"fails for uncovered non-zero resources": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("nvidia.com/gpu"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("nvidia.com/gpu"), ClusterQueue: "cq"},
+		},
+		"fails with the lexicographically first uncovered non-zero resource": {
+			requests: resources.MapRequests{
+				corev1.ResourceName("z.example.com/resource"): 1,
+				corev1.ResourceName("a.example.com/resource"): 1,
+			},
+			wantError: &resourceNotCoveredError{Resource: corev1.ResourceName("a.example.com/resource"), ClusterQueue: "cq"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, gotErr := flavorAssignmentsForRequests(cq, tc.requests)
+
+			if diff := cmp.Diff(tc.wantError, gotErr, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("Unexpected error (-want/+got)\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("Unexpected flavors (-want/+got)\n%s", diff)
 			}
 		})
 	}

--- a/test/integration/singlecluster/importer/importer_test.go
+++ b/test/integration/singlecluster/importer/importer_test.go
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe("Importer", func() {
 			})
 
 			ginkgo.By("Running the import", func() {
-				mapping, err := importercache.Load(ctx, k8sClient, []string{ns1.Name}, importermapping.RulesForLabel("src.lbl", map[string]string{"src-val": lqName}), nil)
+				mapping, err := importercache.Load(ctx, k8sClient, []string{ns1.Name}, importermapping.RulesForLabel("src.lbl", map[string]string{"src-val": lqName}), nil, nil)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(mapping).ToNot(gomega.BeNil())
 
@@ -185,7 +185,7 @@ var _ = ginkgo.Describe("Importer", func() {
 		var err error
 
 		ginkgo.By("Importing across all namespaces", func() {
-			mapping, err = importercache.Load(ctx, k8sClient, []string{ns1.Name, ns2.Name}, importermapping.RulesForLabel("src.lbl", map[string]string{"src-val": lqName}), nil)
+			mapping, err = importercache.Load(ctx, k8sClient, []string{ns1.Name, ns2.Name}, importermapping.RulesForLabel("src.lbl", map[string]string{"src-val": lqName}), nil, nil)
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			gomega.Expect(mapping).ToNot(gomega.BeNil())
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

This PR improves behavior of Flavor Assignment in Pod Importer and test coverage for additional resources.

It introduces structured error handling for uncovered resources, keeps resource-to-flavor selection deterministic, and consolidates importer tests into a cleaner table-driven structure.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Importer: Fixed a bug where the Pod importer picked a single ResourceFlavor for the whole Pod, so Pods whose resources map to different flavors could be imported with a wrong flavor assignment. Flavors are now resolved per requested resource.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod imports now assign admission flavors per requested resource, including mixed CPU/GPU workloads.
  * Imports reject missing flavors, uncovered resources, conflicting queue labels, empty requests, and unknown priority classes.
  * Invalid workloads no longer create resources or mutate the original Pod.
  * Admission retries now handle conflicts and cancellation reliably, with terminal errors after repeated failures.
  * Pod validation consistently checks queues, flavors, resource coverage, workload requests, and priority metadata.

* **Documentation**
  * Updated importer validation guidance and the local dry-run command.

* **Tests**
  * Added coverage for GPU workloads, queue conflicts, priority classes, missing flavors, uncovered resources, and deterministic errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->