### PR TITLE
[release-0.17] RayService: defer Workload finalization while GCS FT Redis cleanup is pending

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,7 @@ updates:
       - "/hack/testing/linkchecker"
       - "/hack/testing/ray"
       - "/hack/testing/ray-mini"
+      - "/hack/testing/redis"
       - "/hack/testing/secretreader"
       - "/hack/testing/shellcheck"
       - "/hack/testing/spark"

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -232,6 +232,10 @@ fi
 if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
     export KUBERAY_MANIFEST="${ROOT_DIR}/dep-crds/ray-operator/default/"
     export KUBERAY_IMAGE=quay.io/kuberay/operator:${KUBERAY_VERSION}
+    # Redis backend for the GCS fault-tolerance e2e test. Pull by digest and strip it
+    # only for the tag referenced by kind and the pod spec.
+    E2E_TEST_REDIS_IMAGE_WITH_SHA=$(grep '^FROM' "${ROOT_DIR}/hack/testing/redis/Dockerfile" | awk '{print $2}')
+    export E2E_TEST_REDIS_IMAGE=${E2E_TEST_REDIS_IMAGE_WITH_SHA%%@*}
 fi
 
 if [[ -n ${LEADERWORKERSET_VERSION:-} && ("$GINKGO_ARGS" =~ feature:(leaderworkerset|managejobswithoutqueuename|workloadidentifierannotations) || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
@@ -577,6 +581,8 @@ function prepare_docker_images {
     fi
     if [[ -n ${KUBERAY_VERSION:-} && ("$GINKGO_ARGS" =~ feature:kuberay || ! "$GINKGO_ARGS" =~ "--label-filter") ]]; then
         e2e_docker_pull_if_needed "${KUBERAY_IMAGE}"
+        e2e_docker_pull_if_needed "${E2E_TEST_REDIS_IMAGE_WITH_SHA}"
+        docker tag "${E2E_TEST_REDIS_IMAGE_WITH_SHA}" "${E2E_TEST_REDIS_IMAGE}"
         determine_kuberay_ray_image
         if [[ "${USE_RAY_FOR_TESTS:-}" == "ray" ]]; then
             e2e_docker_pull_if_needed "${KUBERAY_RAY_IMAGE}"
@@ -1122,6 +1128,7 @@ function install_kuberay {
 
     cluster_kind_load_image "$name" "${KUBERAY_RAY_IMAGE}"
     cluster_kind_load_image "$name" "${KUBERAY_IMAGE}"
+    cluster_kind_load_image "$name" "${E2E_TEST_REDIS_IMAGE}"
     # In E2E_MODE=dev we keep and reuse the kind cluster between runs.
     #
     # "kubectl create -k" is used instead of apply (https://github.com/ray-project/kuberay/issues/504),

--- a/hack/testing/redis/Dockerfile
+++ b/hack/testing/redis/Dockerfile
@@ -1,0 +1,1 @@
+FROM redis:7.4-alpine@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -127,6 +127,7 @@ var _ jobframework.GenericJob = (*RayService)(nil)
 var _ jobframework.JobWithCustomAnnotations = (*RayService)(nil)
 var _ jobframework.JobWithManagedBy = (*RayService)(nil)
 var _ jobframework.ElasticWorkloadNameProvider = (*RayService)(nil)
+var _ jobframework.JobWithSkip = (*RayService)(nil)
 
 func (j *RayService) Object() client.Object {
 	return (*rayv1.RayService)(j)
@@ -142,6 +143,17 @@ func (j *RayService) IsActive() bool {
 
 func (j *RayService) Suspend() {
 	j.Spec.RayClusterSpec.Suspend = ptr.To(true)
+}
+
+// If GCS fault tolerance is enabled, a Redis cleanup K8s Job may be created to clean up the RayCluster's Redis namespace.
+// Defer the finalization of the RayService's Workload until the cleanup Job completes, to avoid the Redis cleanup Job hanging.
+//
+// TODO(#12820): this is gated by DeferRayServiceFinalizationForRedisCleanup as a temporary workaround. Remove the gate
+// once the generic FinishOrphanedWorkloads owner-deletion check lands.
+func (j *RayService) Skip(context.Context) bool {
+	return features.Enabled(features.DeferRayServiceFinalizationForRedisCleanup) &&
+		!j.DeletionTimestamp.IsZero() &&
+		rayutils.IsGCSFaultToleranceEnabled(&j.Spec.RayClusterSpec, j.Annotations)
 }
 
 func (j *RayService) GVK() schema.GroupVersionKind {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -393,6 +393,17 @@ const (
 	//
 	// Enable re-computing the assignment within the same scheduling cycle when a TAS workload doesn't fit.
 	TASRecomputeAssignmentWithinSchedulingCycle featuregate.Feature = "TASRecomputeAssignmentWithinSchedulingCycle"
+
+	// owner: @kevin85421
+	//
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12820
+	// Defers finalizing a deleting GCS fault-tolerant RayService's Workload until
+	// KubeRay's Redis cleanup Job completes, so the cleanup Job is not gated forever
+	// and can purge the RayCluster's Redis metadata namespace.
+	//
+	// TODO(#12820): temporary workaround in the RayService integration. Remove once
+	// the generic FinishOrphanedWorkloads owner-deletion check lands.
+	DeferRayServiceFinalizationForRedisCleanup featuregate.Feature = "DeferRayServiceFinalizationForRedisCleanup"
 )
 
 func init() {
@@ -600,6 +611,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.16"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TASRecomputeAssignmentWithinSchedulingCycle: {
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	DeferRayServiceFinalizationForRedisCleanup: {
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/pkg/util/testingjobs/rayservice/wrappers.go
+++ b/pkg/util/testingjobs/rayservice/wrappers.go
@@ -209,6 +209,16 @@ func (j *ServiceWrapper) WithServeConfigV2(config string) *ServiceWrapper {
 	return j
 }
 
+// GCSFaultTolerance enables GCS fault tolerance backed by the Redis instance at
+// redisAddress. On deletion KubeRay runs a Redis cleanup Job to purge the RayCluster's
+// GCS metadata namespace.
+func (j *ServiceWrapper) GCSFaultTolerance(redisAddress string) *ServiceWrapper {
+	j.Spec.RayClusterSpec.GcsFaultToleranceOptions = &rayv1.GcsFaultToleranceOptions{
+		RedisAddress: redisAddress,
+	}
+	return j
+}
+
 // Clone returns a deep copy of the RayService.
 func (j *ServiceWrapper) Clone() *ServiceWrapper {
 	return &ServiceWrapper{*j.DeepCopy()}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -35,6 +35,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: DeferRayServiceFinalizationForRedisCleanup
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: DRAExtendedResources
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -35,6 +35,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: DeferRayServiceFinalizationForRedisCleanup
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
 - name: DRAExtendedResources
   versionedSpecs:
   - default: false

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -21,12 +21,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -869,6 +871,112 @@ app = HelloWorld.bind()`,
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(strings.TrimSpace(string(body))).To(gomega.ContainSubstring("Hello, World!"))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should run the Redis cleanup Job when a GCS fault-tolerant RayService is deleted", ginkgo.Label("shard:kuberay-a", "requires:fullray"), func() {
+		kuberayTestImage := util.GetKuberayTestImage()
+
+		// Deploy an in-cluster Redis backing the RayCluster's GCS fault tolerance.
+		redisLabels := map[string]string{"app": "redis-gcs-ft"}
+		redisDeployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: ns.Name},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: redisLabels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: redisLabels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:            "redis",
+							Image:           util.GetRedisTestImage(),
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Ports:           []corev1.ContainerPort{{ContainerPort: 6379}},
+						}},
+					},
+				},
+			},
+		}
+		redisService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: ns.Name},
+			Spec: corev1.ServiceSpec{
+				Selector: redisLabels,
+				Ports:    []corev1.ServicePort{{Port: 6379}},
+			},
+		}
+		ginkgo.By("Deploying Redis", func() {
+			gomega.Expect(k8sClient.Create(ctx, redisDeployment)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Create(ctx, redisService)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(redisDeployment), redisDeployment)).To(gomega.Succeed())
+				g.Expect(redisDeployment.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		rayService := testingrayservice.MakeService("rayservice-gcs-ft", ns.Name).
+			Suspend(true).
+			Queue(localQueueName).
+			GCSFaultTolerance("redis:6379").
+			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "600m").
+			Image(rayv1.HeadNode, kuberayTestImage).
+			Image(rayv1.WorkerNode, kuberayTestImage).
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			TerminationGracePeriod(1).
+			Obj()
+
+		ginkgo.By("Creating the RayService", func() {
+			gomega.Expect(k8sClient.Create(ctx, rayService)).To(gomega.Succeed())
+		})
+
+		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: ns.Name}
+		createdWorkload := &kueue.Workload{}
+		ginkgo.By("Checking the workload is created and admitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, createdWorkload)
+		})
+
+		ginkgo.By("Waiting for the RayCluster to be provisioned with the GCS cleanup finalizer", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				clusters := &rayv1.RayClusterList{}
+				g.Expect(k8sClient.List(ctx, clusters, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				g.Expect(clusters.Items).To(gomega.HaveLen(1))
+				g.Expect(clusters.Items[0].Finalizers).To(gomega.ContainElement("ray.io/gcs-ft-redis-cleanup-finalizer"))
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// redisDBSize returns the number of keys in the Redis backing store by running
+		// redis-cli in the Redis pod.
+		redisDBSize := func(g gomega.Gomega) int {
+			pods := &corev1.PodList{}
+			g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), client.MatchingLabels{"app": "redis-gcs-ft"})).To(gomega.Succeed())
+			g.Expect(pods.Items).To(gomega.HaveLen(1))
+			out, _, err := util.KExecute(ctx, cfg, restClient, ns.Name, pods.Items[0].Name, "redis", []string{"redis-cli", "DBSIZE"})
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			size, err := strconv.Atoi(strings.TrimSpace(string(out)))
+			g.Expect(err).NotTo(gomega.HaveOccurred())
+			return size
+		}
+
+		ginkgo.By("Checking GCS fault tolerance populated Redis", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(redisDBSize(g)).To(gomega.BeNumerically(">", 0))
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("Deleting the RayService", func() {
+			gomega.Expect(k8sClient.Delete(ctx, rayService)).To(gomega.Succeed())
+		})
+
+		// Deferred finalization keeps the parent Workload admitted while KubeRay's Redis
+		// cleanup Job runs, so the Job purges the RayCluster's GCS metadata namespace.
+		// Without it the cleanup Job is gated forever and these keys leak until KubeRay's
+		// ~300s safety timeout force-removes the finalizer.
+		ginkgo.By("Checking Redis is cleaned up after the RayService is deleted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(redisDBSize(g)).To(gomega.Equal(0))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -108,4 +108,7 @@ var (
 
 	agnHostImageOnce sync.Once
 	agnHostImage     string
+
+	redisTestImageOnce sync.Once
+	redisTestImage     string
 )

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -114,6 +114,10 @@ func GetSparkTestImage() string {
 	return getCachedDockerImage(&sparkTestImageOnce, &sparkTestImage, "E2E_TEST_SPARK_IMAGE", "spark")
 }
 
+func GetRedisTestImage() string {
+	return getCachedDockerImage(&redisTestImageOnce, &redisTestImage, "E2E_TEST_REDIS_IMAGE", "redis")
+}
+
 // getCachedDockerImage resolves a test image exactly once via the supplied sync.Once,
 // caching the result in *cache. It returns the value of envVar if set, otherwise the
 // image parsed from hack/testing/<dir>/Dockerfile.


### PR DESCRIPTION
Cherry-pick of #12778 onto `release-0.17`.

/kind bug
/area integrations

#### What this PR does / why we need it:

Manual cherry-pick of #12778 (the automated cherry-pick bot failed to apply due to feature-gate conflicts). Fixes the GCS fault-tolerant RayService Redis-cleanup deadlock: on deletion Kueue finalized the RayService's Workload while it was only held by KubeRay's `ray.io/rayservice-finalizer`, gating KubeRay's Redis cleanup Job forever and leaking the RayCluster's Redis metadata namespace.

#### Cherry-pick notes:

- The `DeferRayServiceFinalizationForRedisCleanup` feature gate is registered at version `0.17` on this branch (it is `0.19` on `main`), so it is active on 0.17 binaries. Kept `Beta`, default-on to match `main`.
- Dropped the unrelated `UnadmittedWorkloadsExplicitStatus` gate that appeared in the squashed diff context (it does not exist on `release-0.17`).
- Regenerated `versioned_feature_list.yaml` for this branch.

#### Note on reachability on `release-0.17`:

The root-cause finalize path is guarded by `FinishOrphanedWorkloads`, which on `release-0.17` is `Alpha` and **default-off** (on `release-0.18`/`main` it is `Beta`, default-on). So on a default 0.17 install the deadlock is not reachable; it only occurs when a user explicitly enables `FinishOrphanedWorkloads`. The fix is still safe with the gate off (it only defers finalization for a deleting GCS fault-tolerant RayService), and it prevents the deadlock for users who have enabled `FinishOrphanedWorkloads`. Please confirm whether backporting to 0.17 is desired given this, or whether the gate default should differ here.

AI usage disclosure (per the [Kubernetes AI tool usage policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance)): this cherry-pick was prepared with assistance from Claude, an AI tool. All changes were reviewed by the author.

```release-note
RayService: Fixed a bug where deleting a Kueue-managed RayService with GCS fault tolerance enabled left KubeRay's Redis cleanup Job suspended forever, leaking the RayCluster's Redis metadata namespace. Kueue now defers finalizing the RayService's Workload until the cleanup Job completes.
```
