### PR TITLE
Automated cherry pick of #12795 upstream release 0.17 1783650658

### DIFF
--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -25,9 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
-
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -139,7 +138,7 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
-	var errs []error
+	var errs error
 	for i := range cqs.Items {
 		cq := &cqs.Items[i]
 		if !cq.DeletionTimestamp.IsZero() {
@@ -147,11 +146,11 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		if err := r.ensureLocalQueueExists(ctx, cq, &ns); err != nil {
 			log.Error(err, "Failed to ensure LocalQueue exists in namespace", "clusterQueue", klog.KObj(cq), "namespace", klog.KObj(&ns))
-			errs = append(errs, err)
+			errs = errors.Join(errs, err)
 		}
 	}
 
-	return ctrl.Result{}, utilerrors.NewAggregate(errs)
+	return ctrl.Result{}, errs
 }
 
 func (r *KueuePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/cmd/experimental/kueue-populator/pkg/controller/controller.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller.go
@@ -25,7 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/tools/record"
+
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -137,6 +139,7 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	}
 
+	var errs []error
 	for i := range cqs.Items {
 		cq := &cqs.Items[i]
 		if !cq.DeletionTimestamp.IsZero() {
@@ -144,10 +147,11 @@ func (r *KueuePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		if err := r.ensureLocalQueueExists(ctx, cq, &ns); err != nil {
 			log.Error(err, "Failed to ensure LocalQueue exists in namespace", "clusterQueue", klog.KObj(cq), "namespace", klog.KObj(&ns))
+			errs = append(errs, err)
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, utilerrors.NewAggregate(errs)
 }
 
 func (r *KueuePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -28,7 +30,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -42,6 +46,11 @@ type Event struct {
 	Message   string
 }
 
+// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
+// where a conflicting object is created between Get and Create) when
+// injected via the fake client's interceptor.
+var errCreateFailedForTest = errors.New("create failed")
+
 func TestKueuePopulatorReconciler(t *testing.T) {
 	cases := map[string]struct {
 		clusterQueues       []*kueue.ClusterQueue
@@ -50,6 +59,7 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 		globalNsSelectorStr string
 		localQueueName      string
 		req                 reconcile.Request
+		createErr           error
 		wantError           error
 		wantLQs             []kueue.LocalQueue
 		wantEvents          []Event
@@ -415,6 +425,36 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 				},
 			},
 		},
+		"should return an error and requeue when LocalQueue creation fails": {
+			clusterQueues: []*kueue.ClusterQueue{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "cq"},
+					Spec: kueue.ClusterQueueSpec{
+						NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"dep": "eng"}},
+					},
+				},
+			},
+			namespaces: []*corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "ns",
+						Labels: map[string]string{"dep": "eng"},
+					},
+				},
+			},
+			localQueueName: "default-lq",
+			req:            reconcile.Request{NamespacedName: types.NamespacedName{Name: "ns"}},
+			createErr:      errCreateFailedForTest,
+			wantError:      errCreateFailedForTest,
+			wantLQs:        []kueue.LocalQueue{},
+			wantEvents: []Event{
+				{
+					EventType: corev1.EventTypeWarning,
+					Reason:    "LocalQueueCreationFailed",
+					Message:   "Failed to create LocalQueue default-lq in namespace ns: create failed",
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -424,6 +464,13 @@ func TestKueuePopulatorReconciler(t *testing.T) {
 			_ = kueue.AddToScheme(scheme)
 
 			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tc.createErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+						return tc.createErr
+					},
+				})
+			}
 
 			for _, cq := range tc.clusterQueues {
 				builder.WithObjects(cq)

--- a/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
+++ b/cmd/experimental/kueue-populator/pkg/controller/controller_test.go
@@ -46,12 +46,12 @@ type Event struct {
 	Message   string
 }
 
-// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
-// where a conflicting object is created between Get and Create) when
-// injected via the fake client's interceptor.
-var errCreateFailedForTest = errors.New("create failed")
-
 func TestKueuePopulatorReconciler(t *testing.T) {
+	// errCreateFailedForTest simulates a transient API error (or a TOCTOU race
+	// where a conflicting object is created between Get and Create) when
+	// injected via the fake client's interceptor.
+	errCreateFailedForTest := errors.New("create failed")
+
 	cases := map[string]struct {
 		clusterQueues       []*kueue.ClusterQueue
 		namespaces          []*corev1.Namespace


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Manual cherry-pick of #12795 onto `release-0.17`, requested by @tenzen-y
since the automated cherry-pick bot hit a merge conflict on this branch.

The conflict was due to `release-0.17` predating two changes present on
`main`: this branch uses the older `k8s.io/client-go/tools/record`
EventRecorder API (rather than `k8s.io/client-go/tools/events`), and does
not yet have the `LocalQueueNameModeAsClusterQueue` naming-mode feature.
Both were resolved by keeping this branch's existing `record`-based API
and test surface unchanged, and applying only the actual fix: errors from
`ensureLocalQueueExists` are now accumulated via `errors.Join` and
returned from `Reconcile` instead of being silently logged and dropped,
so controller-runtime requeues on failure.

Verified on this branch via `go build`, `go test`
(`./cmd/experimental/kueue-populator/pkg/controller/...`, all passing
including the new regression test), and `golangci-lint run` (0 issues).

#### Which issue(s) this PR fixes:
Fixes #12569

#### Special notes for your reviewer:
Manual cherry-pick of #12795 due to merge conflicts in the automated
bot cherry-pick (import differences between `record`/`events`
EventRecorder APIs, and the absence of the AsClusterQueue naming-mode
tests on this branch). No functional changes beyond what #12795 already
introduced and reviewed.

/cc @tenzen-y

#### Does this PR introduce a user-facing change?
```release-note
kueue-populator: Fixed a bug where an error creating a LocalQueue was logged but not returned from Reconcile, 
preventing controller-runtime from retrying. LocalQueue creation failures are now aggregated and returned so the request is requeued.
```