### PR TITLE
Fix elastic stress-job flake caused by same-second workload slice misordering

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -481,7 +481,6 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err := r.handleJobWithNoWorkload(ctx, job, object)
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
-				log.V(3).Info("Handling job with no workload found an existing workload")
 				return ctrl.Result{}, err
 			}
 			if IsUnretryableError(err) {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -482,7 +482,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		if err != nil {
 			if apierrors.IsAlreadyExists(err) {
 				log.V(3).Info("Handling job with no workload found an existing workload")
-				return ctrl.Result{RequeueAfter: time.Nanosecond}, nil
+				return ctrl.Result{}, err
 			}
 			if IsUnretryableError(err) {
 				log.V(3).Info("Handling job with no workload", "unretryableError", err)

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -18,6 +18,7 @@ limitations under the License.
 package workloadslicing
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
@@ -36,7 +37,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
-	cmputil "sigs.k8s.io/kueue/pkg/util/cmp"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
@@ -110,27 +110,12 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 		return nil, err
 	}
 
-	// Sort workloads by creation timestamp, oldest first.
-	// In the rare case that two workload slices have identical creationTimestamp values
-	// (due to RFC3339 second-level precision), use WorkloadSliceReplacementFor
-	// as a tiebreaker. This edge case is uncommon in production but can occur in
-	// integration or e2e tests where the original and scaled-up workloads are created
-	// in rapid succession.
+	// Sort oldest-first; break same-second ties by UID for stable ordering.
 	slices.SortFunc(list.Items, func(a, b kueue.Workload) int {
-		return cmputil.LazyOr(
-			func() int {
-				return a.CreationTimestamp.Compare(b.CreationTimestamp.Time)
-			},
-			func() int {
-				if b.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&a)) {
-					return -1
-				}
-				if a.Annotations[WorkloadSliceReplacementFor] == string(workload.Key(&b)) {
-					return 1
-				}
-				return 0
-			},
-		)
+		if c := a.CreationTimestamp.Compare(b.CreationTimestamp.Time); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.UID, b.UID)
 	})
 
 	// Filter out workloads with activated "Finished" condition.
@@ -142,9 +127,7 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 // FindLatestActiveWorkload returns the newest non-finished workload slice owned
 // by the provided job object/gvk that holds a quota reservation, or nil if none
 // qualifies. This is the chain's "active" slice: its granted PodSet counts
-// define the admitted capacity. It builds on FindNotFinishedWorkloads, so the
-// returned slice respects the same ordering (newest last, with
-// WorkloadSliceReplacementFor as a tiebreaker on equal creation timestamps).
+// define the admitted capacity.
 func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
 	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
 	if err != nil {
@@ -266,8 +249,6 @@ func EnsureWorkloadSlices(
 //   - When no non-evicted admitted workload exists, the newest non-evicted
 //     workload is kept
 //   - Evicted workloads are always finished (they hold quota that must be released)
-//
-// The input slice must be sorted oldest-first.
 func normalizeActiveSlices(
 	ctx context.Context,
 	clnt client.Client,
@@ -276,32 +257,43 @@ func normalizeActiveSlices(
 ) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
-	var latestWithQuotaReservation, pendingReplacement, latestNonEvicted *kueue.Workload
-	for i, _ := range slices.Backward(workloads) {
+	// Index replacements by the workload they replace. On duplicate claims
+	// (race-created forks), prefer the admitted one.
+	replacements := make(map[workload.Reference]*kueue.Workload)
+	for i := range workloads {
 		wl := &workloads[i]
-		if workloadevict.IsEvicted(wl) {
-			continue
-		}
-		if latestNonEvicted == nil {
-			latestNonEvicted = wl
-		}
-		if workload.HasQuotaReservation(wl) {
-			if latestWithQuotaReservation == nil {
-				latestWithQuotaReservation = wl
+		if replKey := ReplacementForKey(wl); replKey != nil && !workloadevict.IsEvicted(wl) {
+			if existing, ok := replacements[*replKey]; !ok || (!workload.HasQuotaReservation(existing) && workload.HasQuotaReservation(wl)) {
+				replacements[*replKey] = wl
 			}
 		}
 	}
 
+	// Find the admitted workload at the head of the replacement chain: the one
+	// whose replacement (if any) is not itself admitted.
+	var latestWithQuotaReservation, pendingReplacement, latestNonEvicted *kueue.Workload
+	for i := range workloads {
+		wl := &workloads[i]
+		if workloadevict.IsEvicted(wl) {
+			continue
+		}
+		if latestNonEvicted == nil || wl.CreationTimestamp.After(latestNonEvicted.CreationTimestamp.Time) {
+			latestNonEvicted = wl
+		}
+		if !workload.HasQuotaReservation(wl) {
+			continue
+		}
+		// Skip if replaced by another admitted workload.
+		if repl, ok := replacements[workload.Key(wl)]; ok && workload.HasQuotaReservation(repl) {
+			continue
+		}
+		latestWithQuotaReservation = wl
+	}
+
 	if latestWithQuotaReservation != nil {
-		latestWithQuotaReservationKey := workload.Key(latestWithQuotaReservation)
-		for i, _ := range slices.Backward(workloads) {
-			wl := &workloads[i]
-			if workload.HasQuotaReservation(wl) || workloadevict.IsEvicted(wl) {
-				continue
-			}
-			if replKey := ReplacementForKey(wl); replKey != nil && *replKey == latestWithQuotaReservationKey {
-				pendingReplacement = wl
-				break
+		if repl, ok := replacements[workload.Key(latestWithQuotaReservation)]; ok {
+			if !workload.HasQuotaReservation(repl) {
+				pendingReplacement = repl
 			}
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1104,6 +1104,41 @@ func TestNormalizeActiveSlices(t *testing.T) {
 			},
 			want: want{survivor: "wl-c", keptAdmitted: "wl-a"},
 		},
+		"four same-second slices, chained replacements, admitted slice survives": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+				*admitted(utiltestingapi.MakeWorkload("wl-c", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-d", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-c").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-d", keptAdmitted: "wl-c"},
+		},
+		"forked claim in adversarial order, admitted fork wins over pending": {
+			workloads: []kueue.Workload{
+				// Adversarial iteration order: wl-c before wl-b before wl-a.
+				// wl-b and wl-c both claim to replace wl-a (forked chain from a race).
+				// wl-c is admitted and has a pending replacement wl-d.
+				*admitted(utiltestingapi.MakeWorkload("wl-c", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-a").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-d", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-c").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-d", keptAdmitted: "wl-c"},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
  Two fixes for the elastic stress-job integration test flake:

  1. Replace `RequeueAfter: time.Nanosecond` with `return err` on `AlreadyExists` in `handleJobWithNoWorkload`, letting controller-runtime's exponential backoff handle retries instead of busy-looping.

  2. Fix `normalizeActiveSlices` to find the chain-latest admitted workload by walking replacement links instead of relying on sort order. The old sort tiebreaker only worked for pairs that directly replaced each other. With 3+ slices created in the same second, unrelated pairs tied at 0, the sort order was random, and the backward walk picked the wrong workload as "latest," killing the one that was actually admitted.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/12730

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ElasticJobsViaWorkloadSlices: Fix workload slice misordering that could finish a correctly-admitted elastic workload slice when 3+ slices were created within the same second.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job reconciliation behavior: existing-workload detection no longer causes an immediate requeue, and errors are surfaced properly.
  * Workload slice ordering is now stable when creation timestamps match (using unique identifiers as a tie-breaker).
  * Refined active slice normalization to correctly resolve chained/conflicting replacements, ensuring the intended admitted slice is retained.
* **Tests**
  * Added additional scenarios covering chained replacement and forked ordering behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->