### PR TITLE
[release-0.18] Fix AFS cache initialization and warm-start recovery (#12891)

### DIFF
--- a/pkg/cache/queue/afs/consumed_resources.go
+++ b/pkg/cache/queue/afs/consumed_resources.go
@@ -25,10 +25,15 @@ import (
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
-// ConsumedResourcesEntry stores the consumed resources for a LocalQueue with timestamp
+// ConsumedResourcesEntry stores the consumed resources for a LocalQueue with timestamp.
+// StatusAccounted records whether the LocalQueue's persisted fair-sharing status has
+// been folded into this entry: once history is merged, the entry's existence alone no
+// longer tells whether that happened, so it must be tracked explicitly. Every writer
+// must carry the flag forward (use Update), or the history would be merged repeatedly.
 type ConsumedResourcesEntry struct {
-	Resources  corev1.ResourceList
-	LastUpdate time.Time
+	Resources       corev1.ResourceList
+	LastUpdate      time.Time
+	StatusAccounted bool
 }
 
 // AfsConsumedResources manages the fair sharing consumed resources cache
@@ -43,12 +48,23 @@ func NewAfsConsumedResources() *AfsConsumedResources {
 	}
 }
 
-// Set updates the consumed resources for a LocalQueue
+// Set unconditionally replaces the entry for a LocalQueue, resetting
+// StatusAccounted. Controllers should use Update instead.
 func (a *AfsConsumedResources) Set(lqKey utilqueue.LocalQueueReference, resources corev1.ResourceList, lastUpdate time.Time) {
 	a.resources.Add(lqKey, ConsumedResourcesEntry{
 		Resources:  resources,
 		LastUpdate: lastUpdate,
 	})
+}
+
+// Update atomically rewrites the entry for a LocalQueue with the result of fn.
+// fn receives the current entry (zero-valued if absent) and whether it was
+// present. It runs under the map's write lock, so it must be pure computation:
+// it must not call back into the scheduler cache (lock ordering).
+// All controller writers should go through Update so concurrent read-modify-writes
+// cannot overwrite each other and StatusAccounted is preserved by construction.
+func (a *AfsConsumedResources) Update(lqKey utilqueue.LocalQueueReference, fn func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry) ConsumedResourcesEntry {
+	return a.resources.Update(lqKey, fn)
 }
 
 // Get retrieves the consumed resources for a LocalQueue

--- a/pkg/cache/queue/afs/consumed_resources_test.go
+++ b/pkg/cache/queue/afs/consumed_resources_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package afs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+)
+
+func TestUpdate(t *testing.T) {
+	lqKey := utilqueue.NewLocalQueueReference("default", "lq")
+	settleTime := time.Now()
+	seedTime := settleTime.Add(time.Millisecond)
+
+	seeded := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}
+	settled := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+
+	seedFn := func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry {
+		if !found {
+			return ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true}
+		}
+		return entry
+	}
+	writerFn := func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry {
+		return ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: entry.StatusAccounted}
+	}
+
+	cases := map[string]struct {
+		existing  *ConsumedResourcesEntry
+		fn        func(ConsumedResourcesEntry, bool) ConsumedResourcesEntry
+		wantEntry ConsumedResourcesEntry
+	}{
+		"passes found=false and a zero entry when absent, stores the result": {
+			fn:        seedFn,
+			wantEntry: ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
+		},
+		"passes the current entry when present": {
+			existing:  &ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime},
+			fn:        seedFn,
+			wantEntry: ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime},
+		},
+		"a writer-style update preserves StatusAccounted": {
+			existing:  &ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
+			fn:        writerFn,
+			wantEntry: ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: true},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			consumed := NewAfsConsumedResources()
+			if tc.existing != nil {
+				consumed.Update(lqKey, func(ConsumedResourcesEntry, bool) ConsumedResourcesEntry { return *tc.existing })
+			}
+
+			got := consumed.Update(lqKey, tc.fn)
+
+			if diff := cmp.Diff(tc.wantEntry, got); diff != "" {
+				t.Errorf("Update() returned entry (-want,+got):\n%s", diff)
+			}
+			stored, found := consumed.Get(lqKey)
+			if !found {
+				t.Fatal("Get() found no entry after Update()")
+			}
+			if diff := cmp.Diff(tc.wantEntry, stored); diff != "" {
+				t.Errorf("stored entry (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -345,7 +346,6 @@ func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadC
 
 	lqKey := utilqueue.Key(lq)
 	hasStatus := lq.Status.FairSharing.AdmissionFairSharingStatus != nil
-	entry, hadCache = r.queues.AfsConsumedResources.Get(lqKey)
 
 	now := r.clock.Now()
 
@@ -355,21 +355,38 @@ func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadC
 		}
 	}
 
-	if !hadCache {
-		currentUsage := r.getCurrentUsageForLocalQueue(lq.Spec.ClusterQueue, lqKey)
-		r.queues.AfsConsumedResources.Set(lqKey, currentUsage, now)
-		entry = queueafs.ConsumedResourcesEntry{Resources: currentUsage, LastUpdate: now}
+	// Seed only from persisted state, never from live admitted usage: a live
+	// snapshot can include a concurrently-admitted Workload that its still-pending
+	// entry penalty already prices, double-counting it (#12783). An empty seed is
+	// correct for a fresh LocalQueue: entry penalties cover its early admissions.
+	// LastUpdate=now keeps the first sampling tick at ~zero elapsed, so it folds
+	// no live usage and the seed stays independent of in-flight admissions.
+	// If settlement created the entry first (post-restart admission), the persisted
+	// history is merged into it exactly once per process, tracked by StatusAccounted.
+	// The merge can slightly over-count: a second settlement before this reconcile
+	// folds alpha(elapsed) of live usage, which after a restart overlaps the persisted
+	// status; bounded by the short pre-reconcile window and decaying within a half-life.
+	seeded := corev1.ResourceList{}
+	if hasStatus {
+		seeded = lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources.DeepCopy()
 	}
+	entry = r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+		hadCache = found
+		switch {
+		case !found:
+			return queueafs.ConsumedResourcesEntry{Resources: seeded, LastUpdate: now, StatusAccounted: true}
+		case !old.StatusAccounted:
+			return queueafs.ConsumedResourcesEntry{
+				Resources:       utilresource.MergeResourceListKeepSum(old.Resources, seeded),
+				LastUpdate:      old.LastUpdate,
+				StatusAccounted: true,
+			}
+		default:
+			return old
+		}
+	})
 
 	return hadCache, entry
-}
-
-func (r *LocalQueueReconciler) getCurrentUsageForLocalQueue(cqName kueue.ClusterQueueReference, lqKey utilqueue.LocalQueueReference) corev1.ResourceList {
-	cacheLq, err := r.cache.GetCacheLocalQueue(cqName, lqKey)
-	if err != nil {
-		return corev1.ResourceList{}
-	}
-	return cacheLq.GetAdmittedUsage()
 }
 
 func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *kueue.LocalQueue) error {
@@ -383,7 +400,9 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 			log.V(2).Info("Failed to reset LocalQueue status", "namespace", lq.Namespace, "name", lq.Name, "error", err)
 			return err
 		}
-		r.queues.AfsConsumedResources.Set(lqKey, corev1.ResourceList{}, now)
+		r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+			return queueafs.ConsumedResourcesEntry{Resources: corev1.ResourceList{}, LastUpdate: now, StatusAccounted: old.StatusAccounted || !found}
+		})
 		log.V(2).Info("Reset AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name)
 		return nil
 	}
@@ -404,8 +423,30 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 		log.V(2).Info("Failed to update LocalQueue status", "namespace", lq.Namespace, "name", lq.Name, "error", err)
 		return err
 	}
-	r.queues.AfsConsumedResources.Set(lqKey, newConsumed, now)
-	log.V(2).Info("Updated AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name, "consumedResources", newConsumed)
+	// Recompute inside the lock rather than storing newConsumed: a settlement can
+	// land between the Get above and this write (the status update is an API call),
+	// and its folded penalty must not be overwritten. The persisted status may lag
+	// the stored value by one interval in that case; the next tick converges it.
+	stored := r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+		if !found {
+			return queueafs.ConsumedResourcesEntry{Resources: newConsumed, LastUpdate: now, StatusAccounted: true}
+		}
+		// A settlement during the status update above can stamp a LastUpdate
+		// later than now; clamp the elapsed time so alpha stays within [0, 1],
+		// and keep the stored timestamp monotonic so the next decay does not
+		// over-elapse.
+		elapsed := max(0, now.Sub(old.LastUpdate).Seconds())
+		storedLastUpdate := now
+		if old.LastUpdate.After(now) {
+			storedLastUpdate = old.LastUpdate
+		}
+		return queueafs.ConsumedResourcesEntry{
+			Resources:       afs.CalculateDecayedConsumed(old.Resources, newUsage, elapsed, halfLifeTime),
+			LastUpdate:      storedLastUpdate,
+			StatusAccounted: old.StatusAccounted,
+		}
+	})
+	log.V(2).Info("Updated AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name, "consumedResources", stored.Resources)
 	return nil
 }
 

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -60,6 +60,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 		runningWls               []kueue.Workload
 		wantRequeueAfter         *time.Duration
 		initialConsumedResources queueafs.ConsumedResourcesEntry
+		wantConsumedResources    *queueafs.ConsumedResourcesEntry
 	}{
 		"local queue with Hold StopPolicy": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
@@ -146,7 +147,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
-				LastUpdate: now.Add(-5 * time.Minute),
+				LastUpdate:      now.Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
 				ClusterQueue("cq").
@@ -183,7 +185,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -231,7 +234,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 					corev1.ResourceCPU: resource.MustParse("8"),
 					resourceGPU:        resource.MustParse("16"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -291,7 +295,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -338,7 +343,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -375,7 +381,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					resourceGPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -422,7 +429,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					resourceGPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-5 * time.Minute),
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
 				ClusterQueue("cq").
@@ -473,7 +481,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
-				LastUpdate: clock.Now().Add(-4 * time.Minute),
+				LastUpdate:      clock.Now().Add(-4 * time.Minute),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
 				ClusterQueue("cq").
@@ -526,7 +535,10 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
 		},
-		"local queue with uninitialized cache captures current usage": {
+		"local queue with uninitialized cache and no prior status seeds empty usage": {
+			// The admitted workload must not be counted at full weight here:
+			// its entry penalty is added by the workload reconciler, and a
+			// full-usage seed would double-count the admission (#12783).
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
 				Active(metav1.ConditionTrue).
 				Obj(),
@@ -558,11 +570,203 @@ func TestLocalQueueReconcile(t *testing.T) {
 						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
 							LastUpdate: metav1.NewTime(clock.Now()),
 							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("4"),
+								corev1.ResourceCPU: resource.MustParse("0"),
 							},
 						},
 					}).
 				Obj(),
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		"local queue with uninitialized cache seeds from persisted status usage": {
+			// Restart recovery: the persisted status EMA (8 CPU) is restored
+			// verbatim; the first tick after seeding folds no live usage, so the
+			// rebuilt entry stays 8 CPU and converges toward current usage (4 CPU) over ticks.
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("lq").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("cq", "rf", clock.Now()).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now()),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		"local queue seed merges persisted status into a settlement-created entry": {
+			// Restart recovery when settlement wins the race: the entry (2 CPU,
+			// StatusAccounted=false) was created by workload settlement before the
+			// LocalQueue's first reconcile; the seed merges the persisted history
+			// (8 CPU) into it exactly once -> 10 CPU, and the tick then decays
+			// toward live usage (4 CPU) over one half-life: 10*0.5 + 4*0.5 = 7.
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: false,
+			},
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("lq").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("cq", "rf", clock.Now()).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now()),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("7"),
+							},
+						},
+					}).
+				Obj(),
+			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("7"),
+				},
+				LastUpdate:      clock.Now(),
+				StatusAccounted: true,
+			},
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+		},
+		"local queue seed does not re-merge persisted status into an accounted entry": {
+			// Same shape as above but the entry is already StatusAccounted: the
+			// persisted 8 CPU must not be added again; the tick decays the entry
+			// (2 CPU) toward live usage (4 CPU): 2*0.5 + 4*0.5 = 3.
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now().Add(-5 * time.Minute)),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("2"),
+				},
+				LastUpdate:      clock.Now().Add(-5 * time.Minute),
+				StatusAccounted: true,
+			},
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("lq").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("cq", "rf", clock.Now()).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							LastUpdate: metav1.NewTime(clock.Now()),
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceCPU: resource.MustParse("3"),
+							},
+						},
+					}).
+				Obj(),
+			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("3"),
+				},
+				LastUpdate:      clock.Now(),
+				StatusAccounted: true,
+			},
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
@@ -584,7 +788,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 					corev1.ResourceCPU: resource.MustParse("500m"),
 				},
 				// 1s ago: within the 5s sampling interval, so reconcile should skip.
-				LastUpdate: clock.Now().Add(-1 * time.Second),
+				LastUpdate:      clock.Now().Add(-1 * time.Second),
+				StatusAccounted: true,
 			},
 			wantLocalQueue: utiltestingapi.MakeLocalQueue("lq-afs-skip", "default").
 				ClusterQueue("cq-afs-skip").
@@ -630,7 +835,9 @@ func TestLocalQueueReconcile(t *testing.T) {
 			_ = qManager.AddLocalQueue(ctxWithLogger, tc.localQueue)
 			if tc.initialConsumedResources.Resources != nil {
 				lqKey := utilqueue.Key(tc.localQueue)
-				qManager.AfsConsumedResources.Set(lqKey, tc.initialConsumedResources.Resources, tc.initialConsumedResources.LastUpdate)
+				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
+					return tc.initialConsumedResources
+				})
 			}
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 				WithClock(clock),
@@ -669,6 +876,22 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantLocalQueue, gotLocalQueue, cmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
+			}
+
+			if tc.wantConsumedResources != nil {
+				gotEntry, found := qManager.AfsConsumedResources.Get(utilqueue.Key(tc.localQueue))
+				if !found {
+					t.Fatal("expected an AfsConsumedResources entry after reconcile")
+				}
+				if diff := cmp.Diff(tc.wantConsumedResources.Resources, gotEntry.Resources, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected consumed resources in cache entry (-want,+got):\n%s", diff)
+				}
+				if !gotEntry.LastUpdate.Equal(tc.wantConsumedResources.LastUpdate) {
+					t.Errorf("unexpected cache entry LastUpdate: want %v, got %v", tc.wantConsumedResources.LastUpdate, gotEntry.LastUpdate)
+				}
+				if gotEntry.StatusAccounted != tc.wantConsumedResources.StatusAccounted {
+					t.Errorf("unexpected cache entry StatusAccounted: want %t, got %t", tc.wantConsumedResources.StatusAccounted, gotEntry.StatusAccounted)
+				}
 			}
 		})
 	}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -53,6 +53,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
@@ -1402,28 +1403,40 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 	penalty := afs.CalculateEntryPenalty(workload.NewInfo(wl).SumTotalRequests(), r.admissionFSConfig)
 	now := r.clock.Now()
 
-	oldEntry, found := r.queues.AfsConsumedResources.Get(lqKey)
-	if !found {
-		oldEntry.LastUpdate = now
-	}
-
 	cacheLq, err := r.cache.GetCacheLocalQueue(wl.Status.Admission.ClusterQueue, lqKey)
 	if err != nil {
 		log.V(2).Info("Failed to get cache LocalQueue", "error", err)
 		return
 	}
-
-	oldUsage := oldEntry.Resources
+	// Read live usage before taking the entry lock: the scheduler snapshot reads
+	// AfsConsumedResources while holding the scheduler-cache lock, so the Update
+	// closure must not call back into the cache.
 	newUsage := cacheLq.GetAdmittedUsage()
-	elapsed := now.Sub(oldEntry.LastUpdate).Seconds()
-	newConsumed := afs.CalculateDecayedConsumed(oldUsage, newUsage, elapsed, r.admissionFSConfig.UsageHalfLifeTime.Seconds())
-	newConsumed = resource.MergeResourceListKeepSum(newConsumed, penalty)
 
-	r.queues.AfsConsumedResources.Set(lqKey, newConsumed, now)
+	updated := r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+		lastUpdate := old.LastUpdate
+		if !found {
+			lastUpdate = now
+		}
+		// A concurrent writer can stamp a LastUpdate later than now; clamp the
+		// elapsed time so alpha stays within [0, 1], and keep the stored
+		// timestamp monotonic so the next decay does not over-elapse.
+		elapsed := max(0, now.Sub(lastUpdate).Seconds())
+		storedLastUpdate := now
+		if lastUpdate.After(now) {
+			storedLastUpdate = lastUpdate
+		}
+		newConsumed := afs.CalculateDecayedConsumed(old.Resources, newUsage, elapsed, r.admissionFSConfig.UsageHalfLifeTime.Seconds())
+		return queueafs.ConsumedResourcesEntry{
+			Resources:       resource.MergeResourceListKeepSum(newConsumed, penalty),
+			LastUpdate:      storedLastUpdate,
+			StatusAccounted: old.StatusAccounted,
+		}
+	})
 	r.queues.AfsEntryPenalties.Sub(lqKey, penalty)
 	log.V(3).Info("Entry penalty subtracted from localQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "penalty", penalty, "remaining", r.queues.AfsEntryPenalties.Peek(lqKey))
 
-	log.V(2).Info("Updated AFS consumed usage", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "consumed", newConsumed)
+	log.V(2).Info("Updated AFS consumed usage", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "consumed", updated.Resources)
 }
 
 func (r *WorkloadReconciler) notifyWatchers(oldWl, newWl *kueue.Workload) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -31,6 +31,7 @@ import (
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -45,6 +46,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/constants"
 	utilindexer "sigs.k8s.io/kueue/pkg/controller/core/indexer"
@@ -1563,4 +1565,86 @@ func setupDRACache(objs []client.Object) *dra.ExtendedResourceCache {
 		}
 	}
 	return draCache
+}
+
+func TestUpdateAfsConsumedUsage(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	// With halfLifeTime == samplingInterval the entry penalty is half of the
+	// request, so the 4 CPU workload settles a 2 CPU penalty.
+	cases := map[string]struct {
+		initialEntry        *queueafs.ConsumedResourcesEntry
+		wantCPUMilli        int64
+		wantStatusAccounted bool
+	}{
+		"creates a penalty-only entry on a cache miss": {
+			// StatusAccounted must start false so the LocalQueue seed can still
+			// merge the persisted history into this entry.
+			wantCPUMilli:        2_000,
+			wantStatusAccounted: false,
+		},
+		"folds into an existing entry and preserves StatusAccounted": {
+			initialEntry: &queueafs.ConsumedResourcesEntry{
+				Resources:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+				LastUpdate:      now,
+				StatusAccounted: true,
+			},
+			wantCPUMilli:        10_000,
+			wantStatusAccounted: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fakeClock := testingclock.NewFakeClock(now)
+			cl := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cl)
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, &utiltesting.EventRecorder{}, WithAdmissionFairSharing(afsConfig))
+			reconciler.clock = fakeClock
+
+			ctx, log := utiltesting.ContextWithLog(t)
+			cq := utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj()
+			setupClusterQueue(ctx, t, cl, qManager, cqCache, cq, false)
+			lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+			setupLocalQueue(ctx, t, cl, qManager, lq, false)
+			if err := cqCache.AddLocalQueue(lq); err != nil {
+				t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+			}
+
+			wl := utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "4").
+				SimpleReserveQuota("cq", "rf", now).
+				AdmittedAt(true, now).
+				Obj()
+
+			lqKey := utilqueue.KeyFromWorkload(wl)
+			if tc.initialEntry != nil {
+				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
+					return *tc.initialEntry
+				})
+			}
+
+			reconciler.updateAfsConsumedUsage(log, wl)
+
+			gotEntry, found := qManager.AfsConsumedResources.Get(lqKey)
+			if !found {
+				t.Fatal("expected an AfsConsumedResources entry after settlement")
+			}
+			gotCPU := gotEntry.Resources[corev1.ResourceCPU]
+			if gotCPU.MilliValue() != tc.wantCPUMilli {
+				t.Errorf("unexpected consumed CPU: want %dm, got %dm", tc.wantCPUMilli, gotCPU.MilliValue())
+			}
+			if !gotEntry.LastUpdate.Equal(now) {
+				t.Errorf("unexpected LastUpdate: want %v, got %v", now, gotEntry.LastUpdate)
+			}
+			if gotEntry.StatusAccounted != tc.wantStatusAccounted {
+				t.Errorf("unexpected StatusAccounted: want %t, got %t", tc.wantStatusAccounted, gotEntry.StatusAccounted)
+			}
+		})
+	}
 }

--- a/pkg/util/maps/maps.go
+++ b/pkg/util/maps/maps.go
@@ -132,3 +132,16 @@ func (dwc *SyncMap[K, V]) Swap(k K, v V) (V, bool) {
 	dwc.m[k] = v
 	return old, existed
 }
+
+// Update atomically replaces the value for k with the result of fn. fn
+// receives the current value (the zero value if absent) and whether it was
+// present; its result is stored and returned. fn runs under the map's write
+// lock, so it must not acquire other locks or block.
+func (dwc *SyncMap[K, V]) Update(k K, fn func(v V, found bool) V) V {
+	dwc.lock.Lock()
+	defer dwc.lock.Unlock()
+	old, found := dwc.m[k]
+	updated := fn(old, found)
+	dwc.m[k] = updated
+	return updated
+}

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1426,6 +1426,86 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 		})
 	})
 
+	ginkgo.When("Restarting the manager", func() {
+		var (
+			cq *kueue.ClusterQueue
+			lq *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-restart").
+				Cohort("all").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "16").Obj()).
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			cqs = append(cqs, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq-restart", ns.Name).
+				FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
+				ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, lq)
+			lqs = append(lqs, lq)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+		})
+
+		ginkgo.It("should retain the LocalQueue's historical usage across a restart", func() {
+			ginkgo.By("Accumulating usage on the LocalQueue")
+			wl1 := createWorkload("lq-restart", "8")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lq), ">", 7_000)
+
+			ginkgo.By("Finishing the workload and stopping the manager")
+			util.FinishWorkloads(ctx, k8sClient, wl1)
+			fwk.StopManager(ctx)
+
+			ginkgo.By("Reading the persisted usage frozen by the shutdown")
+			frozenLq := &kueue.LocalQueue{}
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), frozenLq)).To(gomega.Succeed())
+			gomega.Expect(frozenLq.Status.FairSharing).NotTo(gomega.BeNil())
+			gomega.Expect(frozenLq.Status.FairSharing.AdmissionFairSharingStatus).NotTo(gomega.BeNil())
+			frozenUsage := frozenLq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
+			gomega.Expect(frozenUsage.MilliValue()).To(gomega.BeNumerically(">", 2_000),
+				"persisted usage decayed too much before the manager stopped")
+
+			// The long half-life freezes the accounting for the assertion
+			// window, and the finished workload is gone from live usage: a
+			// status written after the restart can only stay near the frozen
+			// value if the seed recovered the persisted history.
+			ginkgo.By("Restarting the manager with a long half-life")
+			restartTime := time.Now()
+			fwk.StartManager(ctx, cfg, managerAndSchedulerSetup(
+				afsConfig(metav1.Duration{Duration: time.Second}, metav1.Duration{Duration: time.Hour}),
+			))
+
+			ginkgo.By("Admitting a new workload right after the restart")
+			wl2 := createWorkload("lq-restart", "1")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+
+			ginkgo.By("Checking that a status written after the restart retains the historical usage")
+			gomega.Eventually(func(g gomega.Gomega) {
+				updatedLq := &kueue.LocalQueue{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), updatedLq)).To(gomega.Succeed())
+				afsStatus := updatedLq.Status.FairSharing.AdmissionFairSharingStatus
+				g.Expect(afsStatus).NotTo(gomega.BeNil())
+				// LastUpdate is second-granular, so writes within restartTime's
+				// own second are rejected here; the 1s ticks converge right after.
+				g.Expect(afsStatus.LastUpdate.Time).To(gomega.BeTemporally(">", restartTime),
+					"the status was not written by the restarted manager yet")
+				usage := afsStatus.ConsumedResources[corev1.ResourceCPU]
+				g.Expect(usage.MilliValue()).To(gomega.BeNumerically(">", frozenUsage.MilliValue()*7/10))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Checking that the recovered usage is retained rather than overwritten later")
+			gomega.Consistently(func(g gomega.Gomega) {
+				updatedLq := &kueue.LocalQueue{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), updatedLq)).To(gomega.Succeed())
+				usage := updatedLq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources[corev1.ResourceCPU]
+				g.Expect(usage.MilliValue()).To(gomega.BeNumerically(">", frozenUsage.MilliValue()*7/10))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("Self-triggered reconciles do not truncate CPU", func() {
 		ginkgo.It("should maintain non-zero CPU ConsumedResources across sampling intervals", func() {
 			ginkgo.By("Creating a ClusterQueue and LocalQueue with AFS enabled")


### PR DESCRIPTION
* Seed AFS consumed-resources cache from persisted status instead of live usage

* Seed AFS cache with SetIfAbsent to avoid overwriting concurrent settlement

* Guarantee AFS warm-start recovery via atomic Update and StatusAccounted

(cherry picked from commit 6f08701fc15de200a91c6c3e3f305832aba15dd6)

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

cheery-pick of https://github.com/kubernetes-sigs/kueue/pull/12891

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AFS: Fixed consumed-resources cache initialization and warm-start recovery so LocalQueue usage is not over-counted during cache seeding, and persisted historical usage is preserved after manager restarts when workload settlement runs before LocalQueue reconciliation.
```
