### PR TITLE
Automated cherry pick of #12888: Fix shouldn't re-admit workload with WaitingForReplacementPods=True test case.

### DIFF
--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -2447,6 +2447,185 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 	})
 })
 
+var _ = ginkgo.Describe("Pod controller interacting with scheduler when waitForPodsReady enabled", ginkgo.Label("job:pod", "area:jobs"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	const (
+		backoffBaseSeconds = 1
+	)
+
+	var (
+		ns *corev1.Namespace
+		fl *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		waitForPodsReady := &configapi.WaitForPodsReady{
+			Timeout: metav1.Duration{Duration: util.ShortTimeout},
+			RequeuingStrategy: &configapi.RequeuingStrategy{
+				Timestamp:          ptr.To(configapi.EvictionTimestamp),
+				BackoffLimitCount:  ptr.To(int32(2)),
+				BackoffBaseSeconds: ptr.To(int32(backoffBaseSeconds)),
+			},
+		}
+		nsSelector := &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      corev1.LabelMetadataName,
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"kube-system", "kueue-system"},
+				},
+			},
+		}
+		mjnsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		fwk.StartManager(ctx, cfg, managerSetup(
+			false,
+			true,
+			&configapi.Configuration{WaitForPodsReady: waitForPodsReady},
+			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+	})
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-")
+
+		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
+		util.MustCreate(ctx, k8sClient, fl)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(fl.Name).
+				Resource(corev1.ResourceCPU, "9").
+				Resource(corev1.ResourceMemory, "36").
+				Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+	})
+
+	ginkgo.When("pod group not ready", func() {
+		ginkgo.It("shouldn't re-admit workload with WaitingForReplacementPods=True", func() {
+			podGroupName := "pod-group"
+			pod := testingpod.MakePod("pod", ns.Name).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("1").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating pod", func() {
+				util.MustCreate(ctx, k8sClient, pod)
+			})
+
+			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
+
+			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
+				util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, wlKey, 0)
+			})
+
+			ginkgo.By("Waiting for BackoffFinished", func() {
+				wl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadRequeued, kueue.WorkloadBackoffFinished))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the workload isn't admitted due to don't have pod replacements", func() {
+				wl := &kueue.Workload{}
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(workload.IsActive(wl)).Should(gomega.BeTrue())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadAdmitted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadWaitingForReplacementPods))
+				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("1").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating replacement pod", func() {
+				util.MustCreate(ctx, k8sClient, replacementPod)
+			})
+
+			ginkgo.By("Checking that workload was admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+		})
+
+		ginkgo.It("shouldn't re-admit workload with WaitingForReplacementPods=True and fast admission", func() {
+			podGroupName := "pod-group"
+			pod := testingpod.MakePod("pod", ns.Name).
+				Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating pod", func() {
+				util.MustCreate(ctx, k8sClient, pod)
+			})
+
+			wlKey := types.NamespacedName{Name: podGroupName, Namespace: pod.Namespace}
+
+			ginkgo.By("Checking that workload was evicted due to pods ready timeout", func() {
+				util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, wlKey, 0)
+			})
+
+			ginkgo.By("Waiting for BackoffFinished", func() {
+				wl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadRequeued, kueue.WorkloadBackoffFinished))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the workload isn't admitted due to don't have pod replacements", func() {
+				wl := &kueue.Workload{}
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+					g.Expect(workload.IsActive(wl)).Should(gomega.BeTrue())
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusFalse(kueue.WorkloadAdmitted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadEvicted))
+					g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadWaitingForReplacementPods))
+				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
+				Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+				GroupNameLabel(podGroupName).
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			ginkgo.By("Creating replacement pod", func() {
+				util.MustCreate(ctx, k8sClient, replacementPod)
+			})
+
+			ginkgo.By("Checking that workload was admitted", func() {
+				util.ExpectWorkloadsToBeAdmittedByKeys(ctx, k8sClient, wlKey)
+			})
+		})
+	})
+})
+
 var _ = ginkgo.Describe("Pod controller with TopologyAwareScheduling", ginkgo.Label("job:pod", "area:jobs", "feature:tas"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
 	const (
 		nodeGroupLabel = "node-group"


### PR DESCRIPTION
Cherry pick of #12888 on release-0.17.

#12888: Fix shouldn't re-admit workload with WaitingForReplacementPods=True test case.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind failing-test
/kind flake


```release-note
NONE
```