### PR TITLE
Clamp AFS tick status computation and cover future LastUpdate

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -415,7 +415,14 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 
 	oldUsage := entry.Resources
 	newUsage := cacheLq.GetAdmittedUsage()
-	elapsed := now.Sub(entry.LastUpdate).Seconds()
+	// A concurrent settlement can stamp an entry's LastUpdate later than now.
+	// A negative elapsed would drive the decay alpha outside [0, 1] and inflate
+	// consumed usage, so every elapsed derived from a stored LastUpdate is
+	// clamped to a non-negative value (here, the in-lock recompute below, and
+	// updateAfsConsumedUsage). Those cache writes also keep the stored timestamp
+	// monotonic so the next decay does not over-elapse; this pre-lock path
+	// persists LastUpdate=now to the status, so it only needs the clamp.
+	elapsed := max(0, now.Sub(entry.LastUpdate).Seconds())
 	newConsumed := afs.CalculateDecayedConsumed(oldUsage, newUsage, elapsed, halfLifeTime)
 
 	if err := r.updateAdmissionFsStatus(ctx, lq, newConsumed, now); err != nil {
@@ -430,10 +437,8 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 		if !found {
 			return queueafs.ConsumedResourcesEntry{Resources: newConsumed, LastUpdate: now, StatusAccounted: true}
 		}
-		// A settlement during the status update above can stamp a LastUpdate
-		// later than now; clamp the elapsed time so alpha stays within [0, 1],
-		// and keep the stored timestamp monotonic so the next decay does not
-		// over-elapse.
+		// Clamp elapsed and keep the stored timestamp monotonic; see the
+		// canonical note above.
 		elapsed := max(0, now.Sub(old.LastUpdate).Seconds())
 		storedLastUpdate := now
 		if old.LastUpdate.After(now) {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -63,6 +63,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 		runningWls               []kueue.Workload
 		wantRequeueAfter         *time.Duration
 		initialConsumedResources queueafs.ConsumedResourcesEntry
+		pendingEntryPenalty      corev1.ResourceList
 		wantConsumedResources    *queueafs.ConsumedResourcesEntry
 	}{
 		"local queue with Hold StopPolicy": {
@@ -172,6 +173,63 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+		},
+		"clamps a future LastUpdate stamped by a concurrent settlement": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				// A concurrent settlement stamped a LastUpdate later than now.
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			// A pending penalty lets the tick run despite the not-yet-stale
+			// (future) LastUpdate, exercising the clamp instead of an early requeue.
+			pendingEntryPenalty: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: new(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								// elapsed clamps to 0, so the persisted status keeps
+								// the usage verbatim instead of inflating it via the
+								// negative-elapsed path.
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				// Monotonic: the stored timestamp keeps the later value.
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+			// The full interval pins that the tick ran; the sampling-interval
+			// guard short-circuit would return interval minus the (negative)
+			// sinceLastUpdate instead.
+			wantRequeueAfter: ptr.To(5 * time.Minute),
 		},
 		"local queue decaying usage sums the previous state and running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -841,6 +899,11 @@ func TestLocalQueueReconcile(t *testing.T) {
 				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
 					return tc.initialConsumedResources
 				})
+			}
+			if tc.pendingEntryPenalty != nil {
+				// A pending entry penalty bypasses the sampling-interval guard so
+				// the tick runs even when the cached LastUpdate is not yet stale.
+				qManager.AfsEntryPenalties.Push(utilqueue.Key(tc.localQueue), tc.pendingEntryPenalty)
 			}
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 				WithClock(clock),

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1434,9 +1434,9 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 		if !found {
 			lastUpdate = now
 		}
-		// A concurrent writer can stamp a LastUpdate later than now; clamp the
-		// elapsed time so alpha stays within [0, 1], and keep the stored
-		// timestamp monotonic so the next decay does not over-elapse.
+		// Clamp elapsed and keep the stored timestamp monotonic against a
+		// concurrent writer stamping a future LastUpdate; see the canonical note
+		// in reconcileConsumedUsage (localqueue_controller.go).
 		elapsed := max(0, now.Sub(lastUpdate).Seconds())
 		storedLastUpdate := now
 		if lastUpdate.After(now) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2133,6 +2133,8 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 		initialEntry        *queueafs.ConsumedResourcesEntry
 		wantCPUMilli        int64
 		wantStatusAccounted bool
+		// wantLastUpdate defaults to now when zero.
+		wantLastUpdate time.Time
 	}{
 		"creates a penalty-only entry on a cache miss": {
 			// StatusAccounted must start false so the LocalQueue seed can still
@@ -2148,6 +2150,21 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			},
 			wantCPUMilli:        10_000,
 			wantStatusAccounted: true,
+		},
+		"clamps a future LastUpdate and keeps the timestamp monotonic": {
+			// A concurrent writer stamped a LastUpdate later than now. The
+			// elapsed time must clamp to 0 so alpha stays within [0, 1]: the old
+			// usage is kept verbatim and only the 2 CPU penalty folds in (8+2=10),
+			// instead of the negative-elapsed path inflating it. The stored
+			// timestamp stays monotonic at the later value rather than rewinding.
+			initialEntry: &queueafs.ConsumedResourcesEntry{
+				Resources:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			wantCPUMilli:        10_000,
+			wantStatusAccounted: true,
+			wantLastUpdate:      now.Add(5 * time.Minute),
 		},
 	}
 	for name, tc := range cases {
@@ -2192,8 +2209,12 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			if gotCPU.MilliValue() != tc.wantCPUMilli {
 				t.Errorf("unexpected consumed CPU: want %dm, got %dm", tc.wantCPUMilli, gotCPU.MilliValue())
 			}
-			if !gotEntry.LastUpdate.Equal(now) {
-				t.Errorf("unexpected LastUpdate: want %v, got %v", now, gotEntry.LastUpdate)
+			wantLastUpdate := tc.wantLastUpdate
+			if wantLastUpdate.IsZero() {
+				wantLastUpdate = now
+			}
+			if !gotEntry.LastUpdate.Equal(wantLastUpdate) {
+				t.Errorf("unexpected LastUpdate: want %v, got %v", wantLastUpdate, gotEntry.LastUpdate)
 			}
 			if gotEntry.StatusAccounted != tc.wantStatusAccounted {
 				t.Errorf("unexpected StatusAccounted: want %t, got %t", tc.wantStatusAccounted, gotEntry.StatusAccounted)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This is a follow-up to the review discussion in https://github.com/kubernetes-sigs/kueue/pull/12891#discussion_r3554510089, which asked for unit coverage of the future-`LastUpdate` / elapsed-clamp guard added on the settlement side.

This PR has two commits:

1. add unit coverage for the AFS settlement-side future-`LastUpdate` guard;
2. fix one remaining call site with the same shape: the sampling tick's pre-lock
   status computation.

#12891 clamps elapsed time in the workload-settlement path and in the sampling tick's in-lock cache recompute. While adding the settlement-side test, I noticed that the tick's pre-lock status computation still used raw elapsed time. That value is persisted to the LocalQueue fair-sharing status.

If a concurrent writer stamps `LastUpdate` later than the tick's captured `now`, the raw elapsed time becomes negative and the decay factor can go outside the expected range. This PR applies the same `max(0, elapsed)` clamp there.

The new tests assert the settlement-side guard and the tick status-computation guard, including persisted status, cached entry, and timestamp monotonicity.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #12891

#### Special notes for your reviewer:

Two cases intentionally do not get separate test rows:

- the settlement cache-miss branch cannot have a future `LastUpdate`, because `!found` initializes `lastUpdate` from `now`
- the half-life-zero reset path is unaffected by negative elapsed, because the decay factor is constant there

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AFS: Fixed a race where a sampling tick running concurrently with workload settlement could persist a skewed ConsumedResources value in LocalQueue fair-sharing status.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed consumed-usage decay when timestamps from concurrent updates are in the future.
  * Prevented inflated usage calculations and preserved the latest valid update timestamp.
  * Ensured pending usage penalties are incorporated correctly in these scenarios.

* **Tests**
  * Added coverage for future timestamp handling during queue reconciliation and workload usage updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->