### PR TITLE
dra: clamp driver counter values to [0, MaxInt64] before charging quota

### DIFF
--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -303,11 +303,18 @@ func computeCounterCharges(
 		return nil
 	}
 
+	// A driver-published counter value is an unvalidated resource.Quantity: the
+	// apiserver accepts any parseable value, including negatives and magnitudes
+	// beyond int64 (maxValue.Value() would then truncate to garbage before the
+	// saturating multiply could clamp it). Clamp with SafeValue and drop
+	// negatives so the charge stays in [0, MaxInt64] for every count, including
+	// count == 1.
+	intVal := max(utilmath.SafeValue(maxValue), 0)
 	if count > 1 {
-		intVal := maxValue.Value()
 		// Saturate rather than let intVal*count wrap to a negative quantity,
 		// consistent with countDevicesPerClass after #12897.
-		maxValue = *resource.NewQuantity(utilmath.SaturatingMul(intVal, count), maxValue.Format)
+		intVal = utilmath.SaturatingMul(intVal, count)
 	}
+	maxValue = *resource.NewQuantity(intVal, maxValue.Format)
 	return corev1.ResourceList{quotaResource: maxValue}
 }

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -172,6 +172,44 @@ func TestComputeCounterCharges(t *testing.T) {
 				"gpu.memory": *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
 			},
 		},
+		{
+			// 1e19 > MaxInt64; Value() truncates it to 0, so without SafeValue
+			// this device would silently charge nothing.
+			name:          "counter that Value() would truncate is clamped before multiply",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("truncating-0", "big", "10000000000000000000"),
+			},
+			count: 2,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
+			},
+		},
+		{
+			name:          "counter above int64 is clamped at count=1",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("overmax-0", "big", "9223372036854775808"),
+			},
+			count: 1,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(math.MaxInt64, resource.DecimalSI),
+			},
+		},
+		{
+			name:          "negative counter is clamped to zero",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("negative-0", "big", "-5"),
+			},
+			count: 2,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -62,6 +62,26 @@ func SafeMilliValue(q resource.Quantity) int64 {
 	return q.MilliValue()
 }
 
+var (
+	maxValue = *resource.NewQuantity(stdmath.MaxInt64, resource.DecimalSI)
+	minValue = *resource.NewQuantity(stdmath.MinInt64, resource.DecimalSI)
+)
+
+// SafeValue returns the integer value for the resource quantity, clamped to
+// math.MinInt64 and math.MaxInt64. It is the twin of SafeMilliValue and avoids
+// the silent truncation of resource.Quantity.Value() for magnitudes outside the
+// int64 range (Value() calls big.Int.Int64(), whose result is undefined when the
+// value does not fit).
+func SafeValue(q resource.Quantity) int64 {
+	if q.Cmp(maxValue) > 0 {
+		return stdmath.MaxInt64
+	}
+	if q.Cmp(minValue) < 0 {
+		return stdmath.MinInt64
+	}
+	return q.Value()
+}
+
 // SaturatingMul multiplies two int64s, returning math.MaxInt64 or math.MinInt64 if the
 // result would overflow or underflow.
 func SaturatingMul(a, b int64) int64 {

--- a/pkg/util/math/math_test.go
+++ b/pkg/util/math/math_test.go
@@ -19,6 +19,8 @@ package math
 import (
 	stdmath "math"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func TestSaturatingMul(t *testing.T) {
@@ -49,6 +51,28 @@ func TestSaturatingMul(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := SaturatingMul(tc.a, tc.b); got != tc.want {
 				t.Errorf("SaturatingMul(%d, %d) = %d, want %d", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSafeValue(t *testing.T) {
+	cases := map[string]struct {
+		q    resource.Quantity
+		want int64
+	}{
+		"zero":            {q: resource.MustParse("0"), want: 0},
+		"small positive":  {q: resource.MustParse("5"), want: 5},
+		"negative":        {q: resource.MustParse("-5"), want: -5},
+		"max int64":       {q: resource.MustParse("9223372036854775807"), want: stdmath.MaxInt64},
+		"above int64":     {q: resource.MustParse("9223372036854775808"), want: stdmath.MaxInt64},
+		"far above int64": {q: resource.MustParse("1e19"), want: stdmath.MaxInt64},
+		"below min int64": {q: resource.MustParse("-9223372036854775809"), want: stdmath.MinInt64},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SafeValue(tc.q); got != tc.want {
+				t.Errorf("SafeValue(%s) = %d, want %d", tc.q.String(), got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Follow-up to #12909. `computeCounterCharges` reads a counter value straight from a ResourceSlice (`ConsumesCounters[].Counters[name].Value`), which the apiserver does not validate — `validateDeviceCounter` accepts "any parsed quantity" — so a driver can publish a negative counter, or one whose magnitude exceeds `int64`.

The `SaturatingMul` added in #12909 does not cover two paths:
- `maxValue.Value()` truncates an out-of-`int64` quantity to garbage (`1e19` → `0`, `2^63` → a negative) **before** the multiply, so saturating the product cannot recover it.
- The saturating multiply is gated on `count > 1`, so a single-device request passes an out-of-`int64` or negative quantity straight through as the charge.

This adds `utilmath.SafeValue` (the twin of `SafeMilliValue`) to clamp `Value()` to `[MinInt64, MaxInt64]`, and in `computeCounterCharges` drops negatives so the charge is always in `[0, MaxInt64]` for every count, including `count == 1`. Regression tests cover the truncation, the `count == 1` path, and the negative case; each fails on the pre-fix code.

This is defense-in-depth for the driver-published counter path; it is not reachable from the tenant trust boundary.

A note on why a negative counter clamps to `0` (rather than being rejected or clamped to `MaxInt64`): a DRA driver is a node-level component inside the trust boundary — it already controls its ResourceSlice and could even misreport capacity — so a negative counter is a driver bug, not a tenant attack. Clamping to `0` fails safe (the buggy device contributes no counter charge), whereas clamping to `MaxInt64` would let a single harmless driver bug stall admission for the entire ClusterQueue.

#### Which issue(s) this PR fixes:
Follow-up to #12909.

#### Does this PR introduce a user-facing change?
```release-note
DRA: Fixed incorrect quota charging for invalid driver-published device counters by clamping them to the non-negative 
int64 range before computing quota charges.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of extreme counter values to prevent truncation and overflow.
  * Negative counter values are now treated as zero.
  * Counter values outside the supported 64-bit range are safely clamped.
  * Large multiplied counter charges now saturate instead of overflowing.

* **Tests**
  * Added coverage for oversized, undersized, negative, and multiplied counter values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
