### PR TITLE
Automated cherry pick of #12939: Clamp AFS tick status computation and cover future LastUpdate

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -414,7 +414,14 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 
 	oldUsage := entry.Resources
 	newUsage := cacheLq.GetAdmittedUsage()
-	elapsed := now.Sub(entry.LastUpdate).Seconds()
+	// A concurrent settlement can stamp an entry's LastUpdate later than now.
+	// A negative elapsed would drive the decay alpha outside [0, 1] and inflate
+	// consumed usage, so every elapsed derived from a stored LastUpdate is
+	// clamped to a non-negative value (here, the in-lock recompute below, and
+	// updateAfsConsumedUsage). Those cache writes also keep the stored timestamp
+	// monotonic so the next decay does not over-elapse; this pre-lock path
+	// persists LastUpdate=now to the status, so it only needs the clamp.
+	elapsed := max(0, now.Sub(entry.LastUpdate).Seconds())
 	newConsumed := afs.CalculateDecayedConsumed(oldUsage, newUsage, elapsed, halfLifeTime)
 
 	if err := r.updateAdmissionFsStatus(ctx, lq, newConsumed, now); err != nil {
@@ -429,10 +436,8 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 		if !found {
 			return queueafs.ConsumedResourcesEntry{Resources: newConsumed, LastUpdate: now, StatusAccounted: true}
 		}
-		// A settlement during the status update above can stamp a LastUpdate
-		// later than now; clamp the elapsed time so alpha stays within [0, 1],
-		// and keep the stored timestamp monotonic so the next decay does not
-		// over-elapse.
+		// Clamp elapsed and keep the stored timestamp monotonic; see the
+		// canonical note above.
 		elapsed := max(0, now.Sub(old.LastUpdate).Seconds())
 		storedLastUpdate := now
 		if old.LastUpdate.After(now) {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -60,6 +60,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 		runningWls               []kueue.Workload
 		wantRequeueAfter         *time.Duration
 		initialConsumedResources queueafs.ConsumedResourcesEntry
+		pendingEntryPenalty      corev1.ResourceList
 		wantConsumedResources    *queueafs.ConsumedResourcesEntry
 	}{
 		"local queue with Hold StopPolicy": {
@@ -169,6 +170,63 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+		},
+		"clamps a future LastUpdate stamped by a concurrent settlement": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				Obj(),
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				Obj(),
+			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				// A concurrent settlement stamped a LastUpdate later than now.
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			// A pending penalty lets the tick run despite the not-yet-stale
+			// (future) LastUpdate, exercising the clamp instead of an early requeue.
+			pendingEntryPenalty: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				FairSharing(&kueue.FairSharing{
+					Weight: ptr.To(resource.MustParse("1")),
+				}).
+				FairSharingStatus(
+					&kueue.LocalQueueFairSharingStatus{
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
+								// elapsed clamps to 0, so the persisted status keeps
+								// the usage verbatim instead of inflating it via the
+								// negative-elapsed path.
+								corev1.ResourceCPU: resource.MustParse("8"),
+							},
+						},
+					}).
+				Obj(),
+			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+				Resources: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("8"),
+				},
+				// Monotonic: the stored timestamp keeps the later value.
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			afsConfig: &config.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+			},
+			// The full interval pins that the tick ran; the sampling-interval
+			// guard short-circuit would return interval minus the (negative)
+			// sinceLastUpdate instead.
+			wantRequeueAfter: ptr.To(5 * time.Minute),
 		},
 		"local queue decaying usage sums the previous state and running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -838,6 +896,11 @@ func TestLocalQueueReconcile(t *testing.T) {
 				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
 					return tc.initialConsumedResources
 				})
+			}
+			if tc.pendingEntryPenalty != nil {
+				// A pending entry penalty bypasses the sampling-interval guard so
+				// the tick runs even when the cached LastUpdate is not yet stale.
+				qManager.AfsEntryPenalties.Push(utilqueue.Key(tc.localQueue), tc.pendingEntryPenalty)
 			}
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 				WithClock(clock),

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1299,9 +1299,9 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 		if !found {
 			lastUpdate = now
 		}
-		// A concurrent writer can stamp a LastUpdate later than now; clamp the
-		// elapsed time so alpha stays within [0, 1], and keep the stored
-		// timestamp monotonic so the next decay does not over-elapse.
+		// Clamp elapsed and keep the stored timestamp monotonic against a
+		// concurrent writer stamping a future LastUpdate; see the canonical note
+		// in reconcileConsumedUsage (localqueue_controller.go).
 		elapsed := max(0, now.Sub(lastUpdate).Seconds())
 		storedLastUpdate := now
 		if lastUpdate.After(now) {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1579,6 +1579,8 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 		initialEntry        *queueafs.ConsumedResourcesEntry
 		wantCPUMilli        int64
 		wantStatusAccounted bool
+		// wantLastUpdate defaults to now when zero.
+		wantLastUpdate time.Time
 	}{
 		"creates a penalty-only entry on a cache miss": {
 			// StatusAccounted must start false so the LocalQueue seed can still
@@ -1594,6 +1596,21 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			},
 			wantCPUMilli:        10_000,
 			wantStatusAccounted: true,
+		},
+		"clamps a future LastUpdate and keeps the timestamp monotonic": {
+			// A concurrent writer stamped a LastUpdate later than now. The
+			// elapsed time must clamp to 0 so alpha stays within [0, 1]: the old
+			// usage is kept verbatim and only the 2 CPU penalty folds in (8+2=10),
+			// instead of the negative-elapsed path inflating it. The stored
+			// timestamp stays monotonic at the later value rather than rewinding.
+			initialEntry: &queueafs.ConsumedResourcesEntry{
+				Resources:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+				LastUpdate:      now.Add(5 * time.Minute),
+				StatusAccounted: true,
+			},
+			wantCPUMilli:        10_000,
+			wantStatusAccounted: true,
+			wantLastUpdate:      now.Add(5 * time.Minute),
 		},
 	}
 	for name, tc := range cases {
@@ -1638,8 +1655,12 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			if gotCPU.MilliValue() != tc.wantCPUMilli {
 				t.Errorf("unexpected consumed CPU: want %dm, got %dm", tc.wantCPUMilli, gotCPU.MilliValue())
 			}
-			if !gotEntry.LastUpdate.Equal(now) {
-				t.Errorf("unexpected LastUpdate: want %v, got %v", now, gotEntry.LastUpdate)
+			wantLastUpdate := tc.wantLastUpdate
+			if wantLastUpdate.IsZero() {
+				wantLastUpdate = now
+			}
+			if !gotEntry.LastUpdate.Equal(wantLastUpdate) {
+				t.Errorf("unexpected LastUpdate: want %v, got %v", wantLastUpdate, gotEntry.LastUpdate)
 			}
 			if gotEntry.StatusAccounted != tc.wantStatusAccounted {
 				t.Errorf("unexpected StatusAccounted: want %t, got %t", tc.wantStatusAccounted, gotEntry.StatusAccounted)


### PR DESCRIPTION
Cherry pick of #12939 on release-0.17.

#12939: Clamp AFS tick status computation and cover future LastUpdate

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
AFS: Fixed a race where a sampling tick running concurrently with workload settlement could persist a skewed ConsumedResources value in LocalQueue fair-sharing status.
```