### PR TITLE
dra: test count==1 rounding and log the negative driver-counter clamp

### DIFF
--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -159,7 +160,7 @@ func processCounterCharge(
 		)}
 	}
 
-	charges := computeCounterCharges(counterConfig, quotaResource, matched, count)
+	charges := computeCounterCharges(log, counterConfig, quotaResource, matched, count)
 	if len(charges) > 0 {
 		return charges, nil
 	}
@@ -278,6 +279,7 @@ func groupSlicesByPool(slices []resourcev1.ResourceSlice, driver string) map[str
 }
 
 func computeCounterCharges(
+	log logr.Logger,
 	counterConfig *deviceClassCounterConfig,
 	quotaResource corev1.ResourceName,
 	matched []resourcev1.Device,
@@ -305,11 +307,22 @@ func computeCounterCharges(
 
 	// A driver-published counter value is an unvalidated resource.Quantity: the
 	// apiserver accepts any parseable value, including negatives and magnitudes
-	// beyond int64 (maxValue.Value() would then truncate to garbage before the
-	// saturating multiply could clamp it). Clamp with SafeValue and drop
-	// negatives so the charge stays in [0, MaxInt64] for every count, including
-	// count == 1.
-	intVal := max(utilmath.SafeValue(maxValue), 0)
+	// beyond int64 (maxValue.Value() would then truncate or wrap before the
+	// saturating multiply could clamp it). SafeValue keeps the magnitude within
+	// [MinInt64, MaxInt64], and a negative value is then forced to 0 so the
+	// charge stays in [0, MaxInt64] for every count, including count == 1. The
+	// negative check uses maxValue.Sign() so it reflects the driver's value
+	// directly, independent of how Value() maps out-of-range magnitudes (Value()
+	// can even return 0 for MinInt64). A driver publishing a negative counter is
+	// misbehaving and should never happen, so log it at V(0), visible even at the
+	// most restrictive log level, matching how kueue surfaces other "unexpected
+	// negative" values (see the negative pod-count log in the scheduler cache).
+	intVal := utilmath.SafeValue(maxValue)
+	if maxValue.Sign() < 0 {
+		log.V(0).Info("Unexpected negative device counter value from driver, clamping to 0",
+			"driver", counterConfig.driver, "counter", counterConfig.counterName, "value", maxValue.String())
+		intVal = 0
+	}
 	if count > 1 {
 		// Saturate rather than let intVal*count wrap to a negative quantity,
 		// consistent with countDevicesPerClass after #12897.

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
@@ -210,15 +212,97 @@ func TestComputeCounterCharges(t *testing.T) {
 				"gpu.memory": *resource.NewQuantity(0, resource.DecimalSI),
 			},
 		},
+		{
+			// count == 1 charges the counter value through Value(), which rounds a
+			// fractional quantity up away from zero. This is conservative and
+			// consistent with the count > 1 path; pin it so it cannot silently change.
+			name:          "fractional counter rounds up at count=1",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("fractional-0", "small", "500m"),
+			},
+			count: 1,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(1, resource.DecimalSI),
+			},
+		},
+		{
+			name:          "negative counter is clamped to zero at count=1",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("negative-count1-0", "big", "-5"),
+			},
+			count: 1,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
+		{
+			// A fractional negative like -500m (Value() -1, Sign() -1) is clamped to
+			// 0 like any other negative; pin that it charges 0.
+			name:          "sub-integer negative counter is clamped to zero",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				makeDevice("negative-fractional-0", "small", "-500m"),
+			},
+			count: 1,
+			want: corev1.ResourceList{
+				"gpu.memory": *resource.NewQuantity(0, resource.DecimalSI),
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := computeCounterCharges(tc.cc, tc.quotaResource, tc.matched, tc.count)
+			got := computeCounterCharges(logr.Discard(), tc.cc, tc.quotaResource, tc.matched, tc.count)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("computeCounterCharges() mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestComputeCounterChargesLogsNegativeCounter pins that a negative driver
+// counter is not only clamped to zero but also surfaced through the logger, so
+// a misbehaving driver leaves an operator-visible trace instead of a silent
+// clamp.
+func TestComputeCounterChargesLogsNegativeCounter(t *testing.T) {
+	cc := &deviceClassCounterConfig{
+		driver:      "gpu.nvidia.com",
+		counterName: "memory",
+	}
+
+	// Verbosity 0 pins that the clamp is logged at V(0), i.e. visible even at the
+	// most restrictive log level -- a driver publishing a negative counter is an
+	// anomaly an operator must be able to see.
+	var logged []string
+	logger := funcr.New(
+		func(_, args string) { logged = append(logged, args) },
+		funcr.Options{Verbosity: 0},
+	)
+
+	got := computeCounterCharges(logger, cc, "gpu.memory", []resourcev1.Device{
+		makeDevice("negative-0", "big", "-5"),
+	}, 1)
+
+	want := corev1.ResourceList{
+		"gpu.memory": *resource.NewQuantity(0, resource.DecimalSI),
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("computeCounterCharges() mismatch (-want +got):\n%s", diff)
+	}
+
+	if len(logged) == 0 {
+		t.Fatalf("expected a V(0) log line for the negative counter, got none")
+	}
+	joined := strings.Join(logged, "\n")
+	for _, substr := range []string{"Unexpected negative device counter value", "gpu.nvidia.com", "memory", "-5"} {
+		if !strings.Contains(joined, substr) {
+			t.Errorf("expected log output to contain %q, got:\n%s", substr, joined)
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it:**

Follow-up to #12945, which clamped driver-published counter values to `[0, MaxInt64]` before charging quota. Two small gaps around that clamp remained:

- **The `count == 1` fractional-rounding path was untested.** That path charges the counter through `Value()` without the saturating multiply, so a fractional counter (for example `500m`) rounds up to `1`, which is conservative and consistent with the `count > 1` path, but nothing pinned it. This adds that case, plus companion `count == 1` negative and fractional-negative cases.
- **The negative-counter clamp was silent.** #12945 already clamped negatives to `0` but gave no signal. A driver publishing a negative counter is misbehaving and should never happen, so this logs it at `V(0)`, matching how the scheduler cache surfaces an unexpected negative pod count (`pkg/cache/scheduler/tas_non_tas_pod_cache.go`), and adds a `funcr`-based test that the clamp is surfaced. The negative check uses `maxValue.Sign()` so it reflects the driver's value directly; the charge itself is unchanged from #12945.

No change to the charge, which #12945 already clamped to `[0, MaxInt64]`. This is test coverage plus observability.

**Which issue(s) this PR fixes:**

Follow-up to #12945 (no separate issue).

**Special notes for your reviewer:**

`computeCounterCharges` gains a `logr.Logger` parameter rather than a `context.Context`, because it is a pure computation with no I/O, so a logger advertises exactly what it needs. Passing `ctx` only to extract a logger would be misleading. Happy to switch if you would prefer consistency with the `ctx`-taking helpers.

/cc @mimowo

**Does this PR introduce a user-facing change?**

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected negative device counter handling so charges are explicitly set to zero.
  - Improved computation for edge cases, including fractional values and counters equal to one (with correct rounding behavior).

- **Diagnostics**
  - Added verbosity-0 logging when a driver reports an unexpected negative device counter, including driver/counter context and the original counter value.

- **Tests**
  - Expanded coverage for negative and edge-case counter values, including assertions that the expected log message is emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->