### PR TITLE
docs: document website link verification workflow

### DIFF
--- a/hack/testing/linkchecker/README.md
+++ b/hack/testing/linkchecker/README.md
@@ -1,0 +1,73 @@
+# Website link checker
+
+Kueue documentation is published at [kueue.sigs.k8s.io](https://kueue.sigs.k8s.io/) and built by Netlify. This directory contains scripts that crawl the site and report broken links.
+
+## Targets
+
+| Make target | Script | URL checked |
+|-------------|--------|-------------|
+| `make verify-website-links` | `verify.sh` | Production site (`https://kueue.sigs.k8s.io/` by default) |
+| `make verify-website-links-preview` | `verify-preview.sh` | PR Netlify deploy preview (Prow presubmit only) |
+
+Set `LINK_CHECK_URL` to override the crawl target when running `verify.sh` directly.
+
+## Local development
+
+Check the live site (same as the daily periodic job):
+
+```bash
+make verify-website-links
+```
+
+Check a specific Netlify deploy preview:
+
+```bash
+LINK_CHECK_URL="https://deploy-preview-12345--kubernetes-sigs-kueue.netlify.app/" \
+  hack/testing/linkchecker/verify.sh
+```
+
+Requirements: Docker (or Podman), network access. The checker runs inside a small container image defined by `Dockerfile`.
+
+## Pull request workflow
+
+Website changes under `site/` or `netlify.toml` trigger a Netlify deploy preview. After the `deploy/netlify` commit status succeeds on your PR head commit, run:
+
+```text
+/test pull-kueue-verify-website-links-preview-main
+```
+
+The presubmit is **optional and non-blocking**. It waits for a fresh same-commit Netlify preview, then runs the same link checker against:
+
+```text
+https://deploy-preview-<PR>--kubernetes-sigs-kueue.netlify.app/
+```
+
+The job skips (and passes) when:
+
+- the PR does not modify `site/`
+- Netlify did not publish a preview
+- the preview is not ready within the bounded wait
+- GitHub API or tooling is unavailable
+
+Broken links on a resolved preview **fail** the job.
+
+## CI integration
+
+| Job | Type | Dashboard |
+|-----|------|-----------|
+| `periodic-kueue-verify-website-links-main` | Daily periodic | [TestGrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-verify-website-links-main) |
+| `pull-kueue-verify-website-links-preview-main` | Presubmit (auto-runs on `site/` changes, optional) | [TestGrid](https://testgrid.k8s.io/sig-scheduling#pull-kueue-verify-website-links-preview-main) |
+
+Prow job definitions live in [kubernetes/test-infra](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kueue).
+
+## Environment variables
+
+| Variable | Used by | Purpose |
+|----------|---------|---------|
+| `LINK_CHECK_URL` | `verify.sh` | Base URL to crawl |
+| `PULL_NUMBER` | `verify-preview.sh` | PR number (set by Prow) |
+| `PULL_PULL_SHA` | `verify-preview.sh` | Head commit SHA (set by Prow) |
+| `PULL_BASE_SHA` | `verify-preview.sh` | Merge base SHA for `site/` diff detection |
+| `GH_TOKEN` | `verify-preview.sh` | Optional GitHub API token (raises rate limits) |
+| `PREVIEW_WAIT_ATTEMPTS` | `verify-preview.sh` | Poll attempts for `deploy/netlify` (default: 20) |
+| `PREVIEW_WAIT_DELAY` | `verify-preview.sh` | Seconds between polls (default: 30) |

--- a/site/content/en/community/contribution_guidelines/_index.md
+++ b/site/content/en/community/contribution_guidelines/_index.md
@@ -24,6 +24,7 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 - [AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance) - 🤖 Guidelines for using AI tools when contributing.
 - [Development]({{< relref "/community/contribution_guidelines/development.md" >}})
 - [Running and debugging tests]({{< relref "/community/contribution_guidelines/testing.md" >}})
+- [Website contributions]({{< relref "/community/contribution_guidelines/website.md" >}})
 
 ## Mentorship
 

--- a/site/content/en/community/contribution_guidelines/website.md
+++ b/site/content/en/community/contribution_guidelines/website.md
@@ -1,0 +1,53 @@
+---
+title: "Website contributions"
+linkTitle: "Website"
+weight: 30
+description: >
+  Build, preview, and verify links on the Kueue documentation site
+type: docs
+---
+
+The Kueue website ([kueue.sigs.k8s.io](https://kueue.sigs.k8s.io/)) is built with Hugo and published through Netlify from the [`site/`](https://github.com/kubernetes-sigs/kueue/tree/main/site) directory.
+
+## Local preview
+
+From the repository root:
+
+```bash
+make site-server
+```
+
+See [`site/README.md`](https://github.com/kubernetes-sigs/kueue/blob/main/site/README.md) for Hugo version requirements and Netlify parity notes.
+
+## Netlify deploy previews
+
+Pull requests that change `site/` or `netlify.toml` receive a Netlify deploy preview. The preview URL follows:
+
+```text
+https://deploy-preview-<PR>--kubernetes-sigs-kueue.netlify.app/
+```
+
+Wait for the `deploy/netlify` GitHub commit status to succeed on your PR head commit before relying on the preview.
+
+## Link verification
+
+Broken documentation links are checked in two ways:
+
+1. **Periodic job** — `periodic-kueue-verify-website-links-main` crawls the live site daily.
+2. **Presubmit job** — `pull-kueue-verify-website-links-preview-main` crawls your PR's Netlify preview.
+
+For website PRs, after Netlify succeeds, trigger the presubmit on your pull request:
+
+```text
+/test pull-kueue-verify-website-links-preview-main
+```
+
+The presubmit is optional and non-blocking while maintainers evaluate reliability. When your PR modifies `site/`, the job is scheduled automatically but still does not block merge.
+
+Locally:
+
+```bash
+make verify-website-links
+```
+
+For details on scripts, skip conditions, and environment variables, see [`hack/testing/linkchecker/README.md`](https://github.com/kubernetes-sigs/kueue/blob/main/hack/testing/linkchecker/README.md).


### PR DESCRIPTION
## Summary

- Documents how to run the website link checker locally and on PR Netlify previews
- Adds a contributor-facing website guide under community contribution guidelines
- Links the new page from the contribution guidelines index

## Context

#12472 added the on-demand `pull-kueue-verify-website-links-preview-main` presubmit in #12530. This PR documents the workflow for website contributors so maintainers and new contributors know when and how to trigger link verification.

A companion test-infra change (kubernetes/test-infra) auto-runs the presubmit on `site/` changes while keeping it optional.

## Test plan

- [ ] Review rendered Hugo page locally with `make site-server`
- [ ] Verify links in `hack/testing/linkchecker/README.md` and `site/content/en/community/contribution_guidelines/website.md`

Fixes #12472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for contributing to the website, including local previews and Netlify deploy previews.
  * Documented the website link-checking process for live sites and pull request previews.
  * Added instructions for running link checks locally and configuring their target URL.
  * Linked website contribution guidance from the general contribution guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```release-note
NONE
```