### PR TITLE
Automated cherry pick of #12953: Fix milli value handling in resource transformations [0.18]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.20.0
+	gopkg.in/inf.v0 v0.9.1
 	k8s.io/api v0.36.1
 	k8s.io/apiextensions-apiserver v0.36.1
 	k8s.io/apimachinery v0.36.1
@@ -156,7 +157,6 @@ require (
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/code-generator v0.36.1 // indirect

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -31,7 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/api/resource"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
@@ -556,12 +556,12 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	return output
 }
 
-func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {
+func multiplyResourceQuantities(value, mul apiresource.Quantity) apiresource.Quantity {
 	value = value.DeepCopy()
 	mul = mul.DeepCopy()
 	product := inf.Dec{}
 	product.Mul(value.AsDec(), mul.AsDec())
-	return *resource.NewDecimalQuantity(product, value.Format)
+	return *apiresource.NewDecimalQuantity(product, value.Format)
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -27,9 +27,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
@@ -533,13 +535,12 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 			// the value of the resource specified in MultiplyBy.
 			if mapping.MultiplyBy != "" {
 				if q, ok := input[mapping.MultiplyBy]; ok {
-					inputQuantity.Mul(q.Value())
+					inputQuantity = multiplyResourceQuantities(inputQuantity, q)
 				}
 			}
 
 			for outputName, baseFactor := range mapping.Outputs {
-				outputQuantity := baseFactor.DeepCopy()
-				outputQuantity.Mul(inputQuantity.Value())
+				outputQuantity := multiplyResourceQuantities(inputQuantity, baseFactor)
 				if accumulated, ok := output[outputName]; ok {
 					outputQuantity.Add(accumulated)
 				}
@@ -553,6 +554,14 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		}
 	}
 	return output
+}
+
+func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {
+	value = value.DeepCopy()
+	mul = mul.DeepCopy()
+	product := inf.Dec{}
+	product.Mul(value.AsDec(), mul.AsDec())
+	return *resource.NewDecimalQuantity(product, value.Format)
 }
 
 func CanBePartiallyAdmitted(wl *kueue.Workload) bool {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -658,6 +658,46 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		"transformMilliValues": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("", 1).
+						Request(corev1.ResourceCPU, "100m").
+						Request(corev1.ResourceMemory, "100M").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:    corev1.ResourceCPU,
+					Strategy: ptr.To(config.Replace),
+					Outputs: corev1.ResourceList{
+						"example.com/cpu-credits": resource.MustParse("3000"),
+					},
+				},
+				{
+					Input:    corev1.ResourceMemory,
+					Strategy: ptr.To(config.Replace),
+					Outputs: corev1.ResourceList{
+						"example.com/memory-credits": resource.MustParse("3m"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "",
+						Requests: resources.Requests{
+							// 100m * 3000 = 300
+							corev1.ResourceName("example.com/cpu-credits"): 300,
+							// 100M * 3m = 300k
+							corev1.ResourceName("example.com/memory-credits"): 300 * 1000,
+						},
+						Count: 1,
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #12953 on release-0.18.

#12953: Fix milli value handling in resource transformations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?


```release-note
ResourceTransformations: Fixed a bug where milli-valued quantities were rounded before
resource transformation multiplication. For example, multiplying `300m` CPU by `1000`
now correctly produces `300` instead of `3000`.
```