### PR TITLE
site: add Office of AI Affairs (NYCU) to the adopters list

### DIFF
--- a/site/data/adopters.yaml
+++ b/site/data/adopters.yaml
@@ -162,3 +162,11 @@
   - pod
   contact: '@yakticus'
   contact_url: https://github.com/yakticus
+- name: Office of AI Affairs, NYCU
+  url: https://ai.winlab.tw/
+  type: End User
+  description: Student AI research and teaching experiments on Kueue
+  integrations:
+  - batch/job
+  contact: '@thc1006'
+  contact_url: https://github.com/thc1006


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it:**

Adds the Office of AI Affairs, National Yang Ming Chiao Tung University (NYCU) to the adopters list. We run Kueue for student AI research and teaching experiments.

/cc @mimowo (thanks for the invitation to add us)

**Does this PR introduce a user-facing change?**

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Office of AI Affairs, NYCU to the adopters directory, including its website, description, integrations, and contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->