### PR TITLE
Use binary search for picking preemption set

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -474,6 +474,11 @@ const (
 	// TODO(#12820): temporary workaround in the RayService integration. Remove once
 	// the generic FinishOrphanedWorkloads owner-deletion check lands.
 	DeferRayServiceFinalizationForRedisCleanup featuregate.Feature = "DeferRayServiceFinalizationForRedisCleanup"
+
+	// owner: @olekzabl
+	//
+	// Use binary search for determining the preemption set when more than 10 preemptees are necessary.
+	PreemptorBinarySearch featuregate.Feature = "PreemptorBinarySearch"
 )
 
 func init() {
@@ -730,6 +735,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	DeferRayServiceFinalizationForRedisCleanup: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	PreemptorBinarySearch: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -21,8 +21,10 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sort"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +57,9 @@ import (
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 )
 
-const parallelPreemptions = 8
+const (
+	parallelPreemptions = 8
+)
 
 type Preemptor struct {
 	clock clock.Clock
@@ -71,17 +75,19 @@ type Preemptor struct {
 	roleTracker            *roletracker.RoleTracker
 	customLabels           *metrics.CustomLabels
 	preemptionExpectations *expectations.Store
+	linearSearchThreshold  int
 }
 
 type preemptionCtx struct {
-	clock             clock.Clock
-	log               logr.Logger
-	preemptor         workload.Info
-	preemptorCQ       *schdcache.ClusterQueueSnapshot
-	snapshot          *schdcache.Snapshot
-	workloadUsage     workload.Usage
-	tasRequests       schdcache.WorkloadTASRequests
-	frsNeedPreemption sets.Set[resources.FlavorResource]
+	clock                 clock.Clock
+	log                   logr.Logger
+	preemptor             workload.Info
+	preemptorCQ           *schdcache.ClusterQueueSnapshot
+	snapshot              *schdcache.Snapshot
+	workloadUsage         workload.Usage
+	tasRequests           schdcache.WorkloadTASRequests
+	frsNeedPreemption     sets.Set[resources.FlavorResource]
+	linearSearchThreshold int
 }
 
 func New(
@@ -94,6 +100,7 @@ func New(
 	tracker *roletracker.RoleTracker,
 	preemptionExpectations *expectations.Store,
 	customLabels *metrics.CustomLabels,
+	linearSearchThreshold int,
 ) *Preemptor {
 	p := &Preemptor{
 		clock:                  clock,
@@ -106,6 +113,7 @@ func New(
 		roleTracker:            tracker,
 		customLabels:           customLabels,
 		preemptionExpectations: preemptionExpectations,
+		linearSearchThreshold:  linearSearchThreshold,
 	}
 	return p
 }
@@ -144,6 +152,7 @@ func (p *Preemptor) GetTargets(log logr.Logger, wl workload.Info, assignment fla
 			Quota: assignment.TotalRequestsFor(log, &wl),
 			TAS:   wl.TASUsage(),
 		},
+		linearSearchThreshold: p.linearSearchThreshold,
 	})
 }
 
@@ -275,6 +284,7 @@ type preemptionAttemptOpts struct {
 // reverse order in which they were removed, while the incoming Workload still
 // fits
 func (p *Preemptor) classicalPreemptions(preemptionCtx *preemptionCtx) []*Target {
+	startTime := preemptionCtx.clock.Now()
 	hierarchicalReclaimCtx := &classical.HierarchicalPreemptionCtx{
 		Log:               preemptionCtx.log,
 		Wl:                preemptionCtx.preemptor.Obj,
@@ -320,7 +330,19 @@ func (p *Preemptor) classicalPreemptions(preemptionCtx *preemptionCtx) []*Target
 				Reason:       reason,
 				WorkloadCq:   preemptionCtx.snapshot.ClusterQueue(candidate.ClusterQueue),
 			})
-			if workloadFits(preemptionCtx, attemptOpts.borrowing) {
+			if len(targets) <= preemptionCtx.linearSearchThreshold {
+				if workloadFits(preemptionCtx, attemptOpts.borrowing) {
+					targets = fillBackWorkloads(preemptionCtx, targets, attemptOpts.borrowing)
+					restoreSnapshot(preemptionCtx.snapshot, targets)
+					return targets
+				}
+			}
+		}
+		if len(targets) > preemptionCtx.linearSearchThreshold {
+			if len, found := findFitTargetLength(preemptionCtx, targets, preemptionCtx.linearSearchThreshold, startTime, func() bool {
+				return workloadFits(preemptionCtx, attemptOpts.borrowing)
+			}); found {
+				targets = targets[:len]
 				targets = fillBackWorkloads(preemptionCtx, targets, attemptOpts.borrowing)
 				restoreSnapshot(preemptionCtx.snapshot, targets)
 				return targets
@@ -371,10 +393,63 @@ func parseStrategies(fs *config.FairSharing) []fairsharing.Strategy {
 	return strategies
 }
 
+// findFitTargetLength performs a binary search between minLength and len(targets) to find the minimum number of preemptions needed to fit.
+// It assumes that minLength was not enough, and that len(targets) > minLength.
+// It also assumes the given snapshot state represents all targets removed.
+// The final snapshot state is either:
+// - when found == false: same as given on input
+// - when found == true: adjusted to the found length
+func findFitTargetLength(preemptionCtx *preemptionCtx, targets []*Target, minLength int, preemptionStrategyStartTime time.Time, checkFits func() bool) (length int, found bool) {
+	numChecks := minLength
+
+	defer func() {
+		if logV := preemptionCtx.log.V(4); logV.Enabled() {
+			logV.Info("Finished non-linear scan of preemption targets",
+				"preemptionStrategyDuration", preemptionCtx.clock.Since(preemptionStrategyStartTime).String(),
+				"foundFit", found,
+				"foundLength", length,
+				"numChecks", numChecks,
+				"numTargets", len(targets))
+		}
+	}()
+
+	numChecks++
+	if !checkFits() {
+		return
+	}
+
+	pos := len(targets)
+
+	moveTo := func(newPos int) {
+		for pos > newPos {
+			pos--
+			preemptionCtx.snapshot.AddWorkload(targets[pos].WorkloadInfo)
+		}
+		for pos < newPos {
+			preemptionCtx.snapshot.RemoveWorkload(targets[pos].WorkloadInfo)
+			pos++
+		}
+	}
+
+	searchN := len(targets) - minLength
+	foundIdx := sort.Search(searchN, func(i int) bool {
+		testedPos := minLength + i + 1
+		moveTo(testedPos)
+		numChecks++
+		return checkFits()
+	})
+
+	foundPos := minLength + foundIdx + 1
+	// Adjust the snapshot to the final state
+	moveTo(foundPos)
+	return foundPos, true
+}
+
 // runFirstFsStrategy runs the first configured FairSharing strategy,
 // and returns (fits, targets, retryCandidates) retryCandidates may be
 // used if rule S2-b is configured.
 func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Info, strategy fairsharing.Strategy) (bool, []*Target, []*workload.Info) {
+	startTime := preemptionCtx.clock.Now()
 	ordering := fairsharing.MakeClusterQueueOrdering(preemptionCtx.preemptorCQ, candidates, preemptionCtx.log, preemptionCtx.clock)
 
 	var targets []*Target
@@ -397,8 +472,10 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 				Reason:       kueue.InClusterQueueReason,
 				WorkloadCq:   candCQ.GetTargetCq(),
 			})
-			if workloadFitsForFairSharing(preemptionCtx) {
-				return true, targets, nil
+			if len(targets) <= preemptionCtx.linearSearchThreshold {
+				if workloadFitsForFairSharing(preemptionCtx) {
+					return true, targets, nil
+				}
 			}
 			continue
 		}
@@ -411,8 +488,10 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 				Reason:       kueue.InCohortReclamationReason,
 				WorkloadCq:   candCQ.GetTargetCq(),
 			})
-			if workloadFitsForFairSharing(preemptionCtx) {
-				return true, targets, nil
+			if len(targets) <= preemptionCtx.linearSearchThreshold {
+				if workloadFitsForFairSharing(preemptionCtx) {
+					return true, targets, nil
+				}
 			}
 			continue
 		}
@@ -438,8 +517,10 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 					Reason:       kueue.InCohortFairSharingReason,
 					WorkloadCq:   candCQ.GetTargetCq(),
 				})
-				if workloadFitsForFairSharing(preemptionCtx) {
-					return true, targets, nil
+				if len(targets) <= preemptionCtx.linearSearchThreshold {
+					if workloadFitsForFairSharing(preemptionCtx) {
+						return true, targets, nil
+					}
 				}
 				// Might need to pick a different CQ due to changing values.
 				break
@@ -448,13 +529,24 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			}
 		}
 	}
+
+	if len(targets) > preemptionCtx.linearSearchThreshold {
+		if len, found := findFitTargetLength(preemptionCtx, targets, preemptionCtx.linearSearchThreshold, startTime, func() bool {
+			return workloadFitsForFairSharing(preemptionCtx)
+		}); found {
+			return true, targets[:len], nil
+		}
+	}
+
 	return false, targets, retryCandidates
 }
 
 // runSecondFsStrategy implements Fair Sharing Rule S2-b. It returns
 // (fits, targets).
 func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemptionCtx, targets []*Target) (bool, []*Target) {
+	startTime := preemptionCtx.clock.Now()
 	ordering := fairsharing.MakeClusterQueueOrdering(preemptionCtx.preemptorCQ, retryCandidates, preemptionCtx.log, preemptionCtx.clock)
+	initialLen := len(targets)
 	for candCQ := range ordering.Iter() {
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
 		passed := fairsharing.LessThanInitialShare(preemptorNewShare, targetOldShare, fairsharing.TargetNewShare{})
@@ -477,14 +569,27 @@ func runSecondFsStrategy(retryCandidates []*workload.Info, preemptionCtx *preemp
 				Reason:       kueue.InCohortFairSharingReason,
 				WorkloadCq:   candCQ.GetTargetCq(),
 			})
-			if workloadFitsForFairSharing(preemptionCtx) {
-				return true, targets
+			if len(targets) <= preemptionCtx.linearSearchThreshold {
+				if workloadFitsForFairSharing(preemptionCtx) {
+					return true, targets
+				}
 			}
 		}
 		// There doesn't seem to be an scenario where
 		// it's possible to apply rule S2-b more than once in a CQ.
 		ordering.DropQueue(candCQ)
 	}
+
+	// Up to initialLen we've already checked every value.
+	minLen := max(initialLen, preemptionCtx.linearSearchThreshold)
+	if len(targets) > minLen {
+		if len, found := findFitTargetLength(preemptionCtx, targets, minLen, startTime, func() bool {
+			return workloadFitsForFairSharing(preemptionCtx)
+		}); found {
+			return true, targets[:len]
+		}
+	}
+
 	return false, targets
 }
 

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -974,7 +974,7 @@ func TestFairPreemptions(t *testing.T) {
 			recorder := &utiltesting.EventRecorder{}
 			preemptor := New(cl, workload.Ordering{}, recorder, &config.FairSharing{
 				PreemptionStrategies: tc.strategies,
-			}, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
+			}, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil, 10)
 
 			beforeSnapshot, err := cqCache.Snapshot(ctx)
 			if err != nil {

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -1840,7 +1840,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 				}
 
 				recorder := &utiltesting.EventRecorder{}
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil, 10)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -4128,7 +4128,7 @@ func TestPreemption(t *testing.T) {
 				}
 
 				recorder := &utiltesting.EventRecorder{}
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil, 10)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {
@@ -4345,7 +4345,7 @@ func TestPreemptionWhenWorkloadModifiedConcurrently(t *testing.T) {
 				}
 
 				recorder := &utiltesting.EventRecorder{}
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil, 10)
 
 				beforeSnapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {
@@ -4449,7 +4449,7 @@ func TestIssuePreemptionsCountsFailures(t *testing.T) {
 
 	recorder := &utiltesting.EventRecorder{}
 	store := preemptexpectations.New()
-	preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil)
+	preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil, 10)
 
 	snapshot, err := cqCache.Snapshot(ctx)
 	if err != nil {
@@ -4567,7 +4567,7 @@ func TestIssuePreemptionsSkipsDuplicate(t *testing.T) {
 				}
 
 				recorder := &utiltesting.EventRecorder{}
-				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil)
+				preemptor := New(cl, workload.Ordering{}, recorder, nil, false, clocktesting.NewFakeClock(now), nil, store, nil, 10)
 
 				snapshot, err := cqCache.Snapshot(ctx)
 				if err != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 	"testing"
@@ -175,6 +176,10 @@ func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recor
 	wo := workload.Ordering{
 		PodsReadyRequeuingTimestamp: options.podsReadyRequeuingTimestamp,
 	}
+	linearSearchThr := math.MaxInt
+	if features.Enabled(features.PreemptorBinarySearch) {
+		linearSearchThr = 10
+	}
 	s := &Scheduler{
 		fairSharing: options.fairSharing,
 		queues:      queues,
@@ -191,6 +196,7 @@ func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recor
 			options.roleTracker,
 			options.preemptionExpectations,
 			options.customLabels,
+			linearSearchThr,
 		),
 		admissionRoutineWrapper: routine.DefaultWrapper,
 		workloadOrdering:        wo,

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -305,6 +305,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: PreemptorBinarySearch
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: PriorityBoost
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

This PR refactors the `for` loops determining "how many workloads we need to preempt" (in `preemption.go`) into binary search.

This is intended as a quick mitigation for a customer who's just recently observed **700+ iterations** inside one of these loops in practice. Given the "rich" TAS fit check inside each iteration, this slowed down the whole scheduling cycle to take multiple seconds, which is not aacceptable.

#### Which issue(s) this PR fixes:

Intended as a quick mitigation for the problem described above (which I think doesn't yet have a corresponding issue).

#### Special notes for your reviewer:

1. Binary search may not be best as a long-term solution, for a number of reasons:

   1. It may be considered overly complex.
   2. When the number of necessary preemptees is *way below* the number of all candidates, binary search can actually *slow down* the search, compared to naive iteration.
      * To remedy that, this PR actually initiates a binary search only after we've considered (unsuccessfully) the first 10 preemption candidates.
        As a result, as long as there's < 1M workloads, this PR is guaranteed to slow down the search by at most 3x.
       (While, in scenarios like the abovementioned "700 iterations", it should speed it up by >30x).
   3. [cc @brejman] In general, whether a new Pod can fit does **not** depend "monotonically" on the set of preempted Pods.
   This is caused by the Kubernetes inter-pod affinity constraints.
      * Kueue currently does not understand such constraints and effectively ignores them when making scheduling decisions.
      * However, once the proposed integration with Scheduling Library happens, things may change.
     In that case, using binary search would become non-trivial (if not incorrect) for Kueue behavior, and we may be forced to revert it.

2. The proposed strategy of acting:

   1. For the start, use binary search in order to substantially reduce the user-observed scheduler slowness.
   2. Emit logs to gather more information for fine-tuning the fix, for example:
      * Did the 700+ loop iterations go over _all_ preemption candidates, or just some?
      * How many loop iterations happen typically?
   3. Fine-tune in a follow-up.
      (Where one alternative is: drop binary search completely; instead, just quickly make a check of "would I fit if all *valid* preemption candidates were removed".
      Even though we currently have an analogous check on an "empty cluster" without TAS usage, that one seems not accurate enough to prevent long iterating).

3. This draft PR has currently *no test coverage* - as test are left (almost) intact, and the functionality is hidden behind an Alpha FG.
   However, on commit [`c767c99`](https://github.com/kubernetes-sigs/kueue/commit/c767c9904c5b61f5d85ac62a82e2c7032a6d57db) tests did pass while the FG was marked Beta (and so enabled). 
   (The only test failing then was a linter complaining about the FG being Beta :)
   So, this is rudimentarily tested.

#### Does this PR introduce a user-facing change?

```release-note
TBD
```
