### PR TITLE
Format counter-based DRA resources with BinarySI units

### DIFF
--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -69,12 +69,13 @@ func (m *ResourceMapper) PopulateFromConfiguration(mappings []configapi.DeviceCl
 	dcToResource := make(map[corev1.ResourceName]corev1.ResourceName)
 	dcCounters := make(map[corev1.ResourceName]*deviceClassCounterConfig)
 	for _, mapping := range mappings {
-		if len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil {
+		isCounter := len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil
+		if isCounter {
 			resources.RegisterBinaryFormattedResource(mapping.Name)
 		}
 		for _, deviceClassName := range mapping.DeviceClassNames {
 			dcToResource[deviceClassName] = mapping.Name
-			if len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil {
+			if isCounter {
 				c := mapping.Sources[0].Counter
 				dcCounters[deviceClassName] = &deviceClassCounterConfig{
 					driver:         c.Driver,

--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -21,6 +21,7 @@ import (
 	resourcev1 "k8s.io/api/resource/v1"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 // deviceClassCounterConfig holds counter configuration for a specific DeviceClass.
@@ -68,6 +69,9 @@ func (m *ResourceMapper) PopulateFromConfiguration(mappings []configapi.DeviceCl
 	dcToResource := make(map[corev1.ResourceName]corev1.ResourceName)
 	dcCounters := make(map[corev1.ResourceName]*deviceClassCounterConfig)
 	for _, mapping := range mappings {
+		if len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil {
+			resources.RegisterBinaryFormattedResource(mapping.Name)
+		}
 		for _, deviceClassName := range mapping.DeviceClassNames {
 			dcToResource[deviceClassName] = mapping.Name
 			if len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil {

--- a/pkg/dra/mapper_test.go
+++ b/pkg/dra/mapper_test.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/resources"
 )
 
 func TestNewDRAResourceMapper(t *testing.T) {
@@ -361,5 +362,26 @@ func TestCreateMapperFromConfiguration(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPopulateFromConfigurationRegistersBinaryFormattedCounterResource(t *testing.T) {
+	mapper := NewResourceMapper()
+	err := mapper.PopulateFromConfiguration([]configapi.DeviceClassMapping{
+		{
+			Name:             corev1.ResourceName("gpu.memory"),
+			DeviceClassNames: []corev1.ResourceName{"gpu.example.com"},
+			Sources: []configapi.DeviceClassSourceConfig{
+				{Counter: &configapi.DeviceClassCounterSource{Driver: "gpu.example.com", Name: "memory"}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("PopulateFromConfiguration failed: %v", err)
+	}
+
+	quantity := resources.ResourceQuantity("gpu.memory", 9984*1024*1024)
+	if quantity.String() != "9984Mi" {
+		t.Fatalf("expected BinarySI formatting, got %s", quantity.String())
 	}
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -20,6 +20,7 @@ import (
 	"maps"
 	"math"
 	"strings"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -28,6 +29,20 @@ import (
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
+
+var binaryFormattedResources sync.Map
+
+// RegisterBinaryFormattedResource marks a resource name as byte-valued for display.
+// Counter-based DRA logical resources (for example gpu.memory) should be registered
+// at startup so quantities serialize with BinarySI units.
+func RegisterBinaryFormattedResource(name corev1.ResourceName) {
+	binaryFormattedResources.Store(name, struct{}{})
+}
+
+func usesBinaryFormat(name corev1.ResourceName) bool {
+	_, ok := binaryFormattedResources.Load(name)
+	return ok
+}
 
 // The following resources calculations are inspired on
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
@@ -117,7 +132,7 @@ func ResourceQuantity(name corev1.ResourceName, v int64) resource.Quantity {
 	case corev1.ResourceMemory, corev1.ResourceEphemeralStorage:
 		return newCanonicalQuantity(v, resource.BinarySI)
 	default:
-		if strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix) {
+		if strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix) || usesBinaryFormat(name) {
 			return newCanonicalQuantity(v, resource.BinarySI)
 		}
 		return *resource.NewQuantity(v, resource.DecimalSI)

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"encoding/json"
 	"math"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -317,6 +318,10 @@ func TestGreaterKeysRL(t *testing.T) {
 	}
 }
 
+func resetBinaryFormattedResources() {
+	binaryFormattedResources = sync.Map{}
+}
+
 func TestResourceQuantityRoundTrips(t *testing.T) {
 	cases := map[string]struct {
 		resource corev1.ResourceName
@@ -386,6 +391,7 @@ func TestResourceQuantityRoundTrips(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			t.Cleanup(resetBinaryFormattedResources)
 			if tc.resource == corev1.ResourceName("gpu.memory") {
 				RegisterBinaryFormattedResource(tc.resource)
 			}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -378,9 +378,17 @@ func TestResourceQuantityRoundTrips(t *testing.T) {
 			value:    10000000000,
 			expected: "9765625Ki",
 		},
+		"counter-based DRA resource": {
+			resource: corev1.ResourceName("gpu.memory"),
+			value:    9984 * 1024 * 1024,
+			expected: "9984Mi",
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			if tc.resource == corev1.ResourceName("gpu.memory") {
+				RegisterBinaryFormattedResource(tc.resource)
+			}
 			quantity := ResourceQuantity(tc.resource, tc.value)
 			initial := quantity.String()
 

--- a/test/integration/singlecluster/controller/dra/dra_pd_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_pd_test.go
@@ -155,6 +155,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName("gpu.memory")))
 				memUsage := assignment.ResourceUsage["gpu.memory"]
 				g.Expect(memUsage.Cmp(resource.MustParse("4864Mi"))).To(gomega.Equal(0))
+				g.Expect(memUsage.String()).To(gomega.Equal("4864Mi"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -203,6 +204,7 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 				memUsage := assignment.ResourceUsage["gpu.memory"]
 				expectedBytes := int64(4864 * 1024 * 1024 * 2)
 				g.Expect(memUsage.Value()).To(gomega.Equal(expectedBytes))
+				g.Expect(memUsage.String()).To(gomega.Equal("9728Mi"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
@@ -723,6 +725,8 @@ var _ = ginkgo.Describe("DRA Partitionable Devices Integration", ginkgo.Ordered,
 							found = true
 							g.Expect(ru.Total.Cmp(resource.MustParse("50Gi"))).To(gomega.Equal(0))
 							g.Expect(ru.Borrowed.Cmp(resource.MustParse("20Gi"))).To(gomega.Equal(0))
+							g.Expect(ru.Total.String()).To(gomega.Equal("50Gi"))
+							g.Expect(ru.Borrowed.String()).To(gomega.Equal("20Gi"))
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

- Register counter-based DRA logical resources for BinarySI formatting at mapper init
- Serialize byte-valued resources like `gpu.memory` as human-readable quantities in workload and ClusterQueue status
- Add unit and integration assertions for `.String()` output

## Context

#12982 reports counter-based DRA usage appears as raw byte integers (for example `10468982784`) instead of values like `9984Mi`. Values were correct internally; `ResourceQuantity()` used DecimalSI for custom resources.

## Test plan

- [x] `go test ./pkg/resources/... ./pkg/dra/... -count=1`
- [ ] `make test-integration INTEGRATION_FILTERS="--focus='DRA Partitionable Devices'"`

Fixes #12982

```release-note
DRA: Fixed a bug where byte-valued Partitionable Devices (counter-based) resources were displayed as raw byte integers in Workload and ClusterQueue status. 
These resources are formatted using human-readable BinarySI units, such as Mi and Gi.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for device resource quantities backed by byte-based counters, ensuring consistent BinarySI display (e.g., Mi/Gi).
  * GPU memory values now consistently render using binary units for both direct and counter-derived scenarios.

* **Tests**
  * Added coverage for counter-based device resources to verify expected BinarySI output (including `gpu.memory`).
  * Expanded unit and integration validations with human-readable `String()` assertions for admission, request multiplication, and cohort borrowing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->