### PR TITLE
Add Netflix to adopters

### DIFF
--- a/site/data/adopters.yaml
+++ b/site/data/adopters.yaml
@@ -162,6 +162,14 @@
   - pod
   contact: '@yakticus'
   contact_url: https://github.com/yakticus
+- name: Netflix, Inc.
+  url: https://www.netflix.com/
+  type: End User
+  description: Netflix Batch compute platform
+  integrations:
+  - pod
+  contact: '@baoalvin1'
+  contact_url: https://github.com/baoalvin1
 - name: Office of AI Affairs, NYCU
   url: https://ai.winlab.tw/
   type: End User


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

Adds Netflix to the adopters list as an End User. Netflix uses Kueue as part of its Batch compute platform (pod integration).

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Follows the existing `site/data/adopters.yaml` End User format.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Netflix to the list of adopters, including its website, description, integration details, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->