### PR TITLE
fix: overwrite stale Kueue-owned pod template annotations on job start

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -388,7 +388,7 @@ func (c *Controller) createPodTemplate(ctx context.Context, wl *kueue.Workload, 
 		return nil, err
 	}
 
-	err = podset.Merge(ctx, &newPt.Template.ObjectMeta, &newPt.Template.Spec, psi)
+	err = podset.Merge(ctrl.LoggerFrom(ctx), &newPt.Template.ObjectMeta, &newPt.Template.Spec, psi)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -388,7 +388,7 @@ func (c *Controller) createPodTemplate(ctx context.Context, wl *kueue.Workload, 
 		return nil, err
 	}
 
-	err = podset.Merge(&newPt.Template.ObjectMeta, &newPt.Template.Spec, psi)
+	err = podset.Merge(ctx, &newPt.Template.ObjectMeta, &newPt.Template.Spec, psi)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1233,7 +1233,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 		if !found {
 			return nil
 		}
-		err := podset.Merge(&ps.Template.ObjectMeta, &ps.Template.Spec, *psi)
+		err := podset.Merge(ctx, &ps.Template.ObjectMeta, &ps.Template.Spec, *psi)
 		if err != nil {
 			return nil
 		}

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1233,7 +1233,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 		if !found {
 			return nil
 		}
-		err := podset.Merge(ctx, &ps.Template.ObjectMeta, &ps.Template.Spec, *psi)
+		err := podset.Merge(ctrl.LoggerFrom(ctx), &ps.Template.ObjectMeta, &ps.Template.Spec, *psi)
 		if err != nil {
 			return nil
 		}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -282,7 +282,7 @@ func (j *Job) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSetsIn
 			j.Spec.Completions = j.Spec.Parallelism
 		}
 	}
-	return podset.Merge(ctx, &j.Spec.Template.ObjectMeta, &j.Spec.Template.Spec, info)
+	return podset.Merge(ctrl.LoggerFrom(ctx), &j.Spec.Template.ObjectMeta, &j.Spec.Template.Spec, info)
 }
 
 func (j *Job) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -282,7 +282,7 @@ func (j *Job) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSetsIn
 			j.Spec.Completions = j.Spec.Parallelism
 		}
 	}
-	return podset.Merge(&j.Spec.Template.ObjectMeta, &j.Spec.Template.Spec, info)
+	return podset.Merge(ctx, &j.Spec.Template.ObjectMeta, &j.Spec.Template.Spec, info)
 }
 
 func (j *Job) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -332,6 +332,47 @@ func TestPodSetsInfo(t *testing.T) {
 	}
 }
 
+func TestStopDropsStaleWorkloadSliceAnnotation(t *testing.T) {
+	const userAnnotation = "example.com/user-annotation"
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	jobObj := utiltestingjob.MakeJob("job", "ns").
+		Suspend(false).
+		ResourceVersion("1").
+		PodAnnotation(kueue.WorkloadSliceNameAnnotation, "old-slice").
+		PodAnnotation(userAnnotation, "user-value").
+		Obj()
+	kClient := utiltesting.NewClientBuilder().WithObjects(jobObj.DeepCopy()).Build()
+	job := (*Job)(jobObj)
+	restoreInfo := []podset.PodSetInfo{
+		{
+			Annotations: map[string]string{
+				kueue.WorkloadSliceNameAnnotation: "old-slice",
+				userAnnotation:                    "user-value",
+			},
+		},
+	}
+
+	stopped, err := job.Stop(ctx, kClient, restoreInfo, jobframework.StopReasonWorkloadEvicted, "preempted")
+	if err != nil {
+		t.Fatalf("Stop() error: %v", err)
+	}
+	if !stopped {
+		t.Error("Stop() stopped = false, want true")
+	}
+
+	var gotJob batchv1.Job
+	if err := kClient.Get(ctx, types.NamespacedName{Name: jobObj.Name, Namespace: jobObj.Namespace}, &gotJob); err != nil {
+		t.Fatalf("Get() stopped Job: %v", err)
+	}
+	if _, found := gotJob.Spec.Template.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
+		t.Errorf("Stop() retained stale %q annotation", kueue.WorkloadSliceNameAnnotation)
+	}
+	if got := gotJob.Spec.Template.Annotations[userAnnotation]; got != "user-value" {
+		t.Errorf("Stop() user annotation = %q, want %q", got, "user-value")
+	}
+}
+
 func TestPodSets(t *testing.T) {
 	jobTemplate := utiltestingjob.MakeJob("job", "ns")
 

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -269,6 +269,31 @@ func TestPodSetsInfo(t *testing.T) {
 				},
 			},
 		},
+		"replace stale workload slice annotation": {
+			job: (*Job)(utiltestingjob.MakeJob("job", "ns").
+				Parallelism(1).
+				PodAnnotation(kueue.WorkloadSliceNameAnnotation, "old-slice").
+				Obj()),
+			runInfo: []podset.PodSetInfo{
+				{
+					Annotations: map[string]string{
+						kueue.WorkloadSliceNameAnnotation: "new-slice",
+					},
+				},
+			},
+			wantUnsuspended: utiltestingjob.MakeJob("job", "ns").
+				Parallelism(1).
+				PodAnnotation(kueue.WorkloadSliceNameAnnotation, "new-slice").
+				Suspend(false).
+				Obj(),
+			restoreInfo: []podset.PodSetInfo{
+				{
+					Annotations: map[string]string{
+						kueue.WorkloadSliceNameAnnotation: "old-slice",
+					},
+				},
+			},
+		},
 		"parallelism": {
 			job: (*Job)(utiltestingjob.MakeJob("job", "ns").
 				Parallelism(5).
@@ -329,47 +354,6 @@ func TestPodSetsInfo(t *testing.T) {
 				t.Errorf("node selectors mismatch (-want +got):\n%s", diff)
 			}
 		})
-	}
-}
-
-func TestStopDropsStaleWorkloadSliceAnnotation(t *testing.T) {
-	const userAnnotation = "example.com/user-annotation"
-
-	ctx, _ := utiltesting.ContextWithLog(t)
-	jobObj := utiltestingjob.MakeJob("job", "ns").
-		Suspend(false).
-		ResourceVersion("1").
-		PodAnnotation(kueue.WorkloadSliceNameAnnotation, "old-slice").
-		PodAnnotation(userAnnotation, "user-value").
-		Obj()
-	kClient := utiltesting.NewClientBuilder().WithObjects(jobObj.DeepCopy()).Build()
-	job := (*Job)(jobObj)
-	restoreInfo := []podset.PodSetInfo{
-		{
-			Annotations: map[string]string{
-				kueue.WorkloadSliceNameAnnotation: "old-slice",
-				userAnnotation:                    "user-value",
-			},
-		},
-	}
-
-	stopped, err := job.Stop(ctx, kClient, restoreInfo, jobframework.StopReasonWorkloadEvicted, "preempted")
-	if err != nil {
-		t.Fatalf("Stop() error: %v", err)
-	}
-	if !stopped {
-		t.Error("Stop() stopped = false, want true")
-	}
-
-	var gotJob batchv1.Job
-	if err := kClient.Get(ctx, types.NamespacedName{Name: jobObj.Name, Namespace: jobObj.Namespace}, &gotJob); err != nil {
-		t.Fatalf("Get() stopped Job: %v", err)
-	}
-	if _, found := gotJob.Spec.Template.Annotations[kueue.WorkloadSliceNameAnnotation]; found {
-		t.Errorf("Stop() retained stale %q annotation", kueue.WorkloadSliceNameAnnotation)
-	}
-	if got := gotJob.Spec.Template.Annotations[userAnnotation]; got != "user-value" {
-		t.Errorf("Stop() user annotation = %q, want %q", got, "user-value")
 	}
 }
 

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -178,6 +178,7 @@ func TestPodsReady(t *testing.T) {
 
 func TestPodSetsInfo(t *testing.T) {
 	testcases := map[string]struct {
+		featureGates         map[featuregate.Feature]bool
 		job                  *Job
 		runInfo, restoreInfo []podset.PodSetInfo
 		wantUnsuspended      *batchv1.Job
@@ -270,6 +271,7 @@ func TestPodSetsInfo(t *testing.T) {
 			},
 		},
 		"replace stale workload slice annotation": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			job: (*Job)(utiltestingjob.MakeJob("job", "ns").
 				Parallelism(1).
 				PodAnnotation(kueue.WorkloadSliceNameAnnotation, "old-slice").
@@ -336,6 +338,7 @@ func TestPodSetsInfo(t *testing.T) {
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
 			origSpec := *tc.job.Spec.DeepCopy()
 

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -145,7 +145,7 @@ func (j *JobSet) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	for index := range j.Spec.ReplicatedJobs {
 		template := &j.Spec.ReplicatedJobs[index].Template.Spec.Template
 		info := podSetsInfo[index]
-		if err := podset.Merge(&template.ObjectMeta, &template.Spec, info); err != nil {
+		if err := podset.Merge(ctx, &template.ObjectMeta, &template.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -142,10 +143,11 @@ func (j *JobSet) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 
 	// If there are Jobs already created by the JobSet, their node selectors will be updated by the JobSet controller
 	// before unsuspending the individual Jobs.
+	log := ctrl.LoggerFrom(ctx)
 	for index := range j.Spec.ReplicatedJobs {
 		template := &j.Spec.ReplicatedJobs[index].Template.Spec.Template
 		info := podSetsInfo[index]
-		if err := podset.Merge(ctx, &template.ObjectMeta, &template.Spec, info); err != nil {
+		if err := podset.Merge(log, &template.ObjectMeta, &template.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -67,7 +67,7 @@ func (j *KubeflowJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, p
 		replicaType := orderedReplicaTypes[index]
 		info := podSetsInfo[index]
 		replica := &j.KFJobControl.ReplicaSpecs()[replicaType].Template
-		if err := podset.Merge(&replica.ObjectMeta, &replica.Spec, info); err != nil {
+		if err := podset.Merge(ctx, &replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -63,11 +64,12 @@ func (j *KubeflowJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, p
 	}
 	// The node selectors are provided in the same order as the generated list of
 	// podSets, use the same ordering logic to restore them.
+	log := ctrl.LoggerFrom(ctx)
 	for index := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
 		info := podSetsInfo[index]
 		replica := &j.KFJobControl.ReplicaSpecs()[replicaType].Template
-		if err := podset.Merge(ctx, &replica.ObjectMeta, &replica.Spec, info); err != nil {
+		if err := podset.Merge(log, &replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -145,7 +145,7 @@ func (j *MPIJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 		replicaType := orderedReplicaTypes[index]
 		info := podSetsInfo[index]
 		replica := &j.Spec.MPIReplicaSpecs[replicaType].Template
-		if err := podset.Merge(&replica.ObjectMeta, &replica.Spec, info); err != nil {
+		if err := podset.Merge(ctx, &replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -141,11 +142,12 @@ func (j *MPIJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 
 	// The node selectors are provided in the same order as the generated list of
 	// podSets, use the same ordering logic to restore them.
+	log := ctrl.LoggerFrom(ctx)
 	for index := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]
 		info := podSetsInfo[index]
 		replica := &j.Spec.MPIReplicaSpecs[replicaType].Template
-		if err := podset.Merge(ctx, &replica.ObjectMeta, &replica.Spec, info); err != nil {
+		if err := podset.Merge(log, &replica.ObjectMeta, &replica.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -275,7 +276,7 @@ func (p *Pod) Run(ctx context.Context, c client.Client, wl *kueue.Workload, podS
 		}
 
 		if err := clientutil.Patch(ctx, c, &p.pod, func() (bool, error) {
-			return true, prepare(ctx, &p.pod, podSetsInfo[0])
+			return true, prepare(log, &p.pod, podSetsInfo[0])
 		}); err != nil {
 			return err
 		}
@@ -307,7 +308,7 @@ func (p *Pod) Run(ctx context.Context, c client.Client, wl *kueue.Workload, podS
 				return false, fmt.Errorf("%w: podSetInfo with the name '%s' is not found", podset.ErrInvalidPodsetInfo, roleHash)
 			}
 
-			err = prepare(ctx, pod, podSetsInfo[podSetIndex])
+			err = prepare(log, pod, podSetsInfo[podSetIndex])
 			if err != nil {
 				return false, err
 			}
@@ -1482,8 +1483,8 @@ func isGated(pod *corev1.Pod) bool {
 	return utilpod.HasGate(pod, podconstants.SchedulingGateName)
 }
 
-func prepare(ctx context.Context, pod *corev1.Pod, info podset.PodSetInfo) error {
-	if err := podset.Merge(ctx, &pod.ObjectMeta, &pod.Spec, info); err != nil {
+func prepare(log logr.Logger, pod *corev1.Pod, info podset.PodSetInfo) error {
+	if err := podset.Merge(log, &pod.ObjectMeta, &pod.Spec, info); err != nil {
 		return err
 	}
 	utilpod.Ungate(pod, podconstants.SchedulingGateName)

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -275,7 +275,7 @@ func (p *Pod) Run(ctx context.Context, c client.Client, wl *kueue.Workload, podS
 		}
 
 		if err := clientutil.Patch(ctx, c, &p.pod, func() (bool, error) {
-			return true, prepare(&p.pod, podSetsInfo[0])
+			return true, prepare(ctx, &p.pod, podSetsInfo[0])
 		}); err != nil {
 			return err
 		}
@@ -307,7 +307,7 @@ func (p *Pod) Run(ctx context.Context, c client.Client, wl *kueue.Workload, podS
 				return false, fmt.Errorf("%w: podSetInfo with the name '%s' is not found", podset.ErrInvalidPodsetInfo, roleHash)
 			}
 
-			err = prepare(pod, podSetsInfo[podSetIndex])
+			err = prepare(ctx, pod, podSetsInfo[podSetIndex])
 			if err != nil {
 				return false, err
 			}
@@ -1482,8 +1482,8 @@ func isGated(pod *corev1.Pod) bool {
 	return utilpod.HasGate(pod, podconstants.SchedulingGateName)
 }
 
-func prepare(pod *corev1.Pod, info podset.PodSetInfo) error {
-	if err := podset.Merge(&pod.ObjectMeta, &pod.Spec, info); err != nil {
+func prepare(ctx context.Context, pod *corev1.Pod, info podset.PodSetInfo) error {
+	if err := podset.Merge(ctx, &pod.ObjectMeta, &pod.Spec, info); err != nil {
 		return err
 	}
 	utilpod.Ungate(pod, podconstants.SchedulingGateName)

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -246,11 +246,11 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 	return podSets, nil
 }
 
-func UpdateRayClusterSpecToRunWithPodSetsInfo(rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) error {
+func UpdateRayClusterSpecToRunWithPodSetsInfo(ctx context.Context, rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) error {
 	// head
 	headPod := &rayClusterSpec.HeadGroupSpec.Template
 	info := podSetsInfo[0]
-	if err := podset.Merge(&headPod.ObjectMeta, &headPod.Spec, info); err != nil {
+	if err := podset.Merge(ctx, &headPod.ObjectMeta, &headPod.Spec, info); err != nil {
 		return err
 	}
 
@@ -258,7 +258,7 @@ func UpdateRayClusterSpecToRunWithPodSetsInfo(rayClusterSpec *rayv1.RayClusterSp
 	for index := range rayClusterSpec.WorkerGroupSpecs {
 		workerPod := &rayClusterSpec.WorkerGroupSpecs[index].Template
 		info := podSetsInfo[index+1]
-		if err := podset.Merge(&workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
+		if err := podset.Merge(ctx, &workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/go-logr/logr"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -246,11 +247,11 @@ func UpdatePodSets(ctx context.Context, podSets []kueue.PodSet, c client.Client,
 	return podSets, nil
 }
 
-func UpdateRayClusterSpecToRunWithPodSetsInfo(ctx context.Context, rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) error {
+func UpdateRayClusterSpecToRunWithPodSetsInfo(log logr.Logger, rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) error {
 	// head
 	headPod := &rayClusterSpec.HeadGroupSpec.Template
 	info := podSetsInfo[0]
-	if err := podset.Merge(ctx, &headPod.ObjectMeta, &headPod.Spec, info); err != nil {
+	if err := podset.Merge(log, &headPod.ObjectMeta, &headPod.Spec, info); err != nil {
 		return err
 	}
 
@@ -258,7 +259,7 @@ func UpdateRayClusterSpecToRunWithPodSetsInfo(ctx context.Context, rayClusterSpe
 	for index := range rayClusterSpec.WorkerGroupSpecs {
 		workerPod := &rayClusterSpec.WorkerGroupSpecs[index].Template
 		info := podSetsInfo[index+1]
-		if err := podset.Merge(ctx, &workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
+		if err := podset.Merge(log, &workerPod.ObjectMeta, &workerPod.Spec, info); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
@@ -806,7 +807,7 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := UpdateRayClusterSpecToRunWithPodSetsInfo(t.Context(), tc.rayClusterSpec, tc.podSetsInfo)
+			err := UpdateRayClusterSpecToRunWithPodSetsInfo(utiltesting.NewLogger(t), tc.rayClusterSpec, tc.podSetsInfo)
 
 			if tc.wantErr {
 				if err == nil {

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -806,7 +806,7 @@ func TestUpdateRayClusterSpecToRunWithPodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			err := UpdateRayClusterSpecToRunWithPodSetsInfo(tc.rayClusterSpec, tc.podSetsInfo)
+			err := UpdateRayClusterSpecToRunWithPodSetsInfo(t.Context(), tc.rayClusterSpec, tc.podSetsInfo)
 
 			if tc.wantErr {
 				if err == nil {

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -113,7 +113,7 @@ func (j *RayCluster) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 
 	j.Spec.Suspend = new(false)
 
-	err := UpdateRayClusterSpecToRunWithPodSetsInfo(&j.Spec, podSetsInfo)
+	err := UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, &j.Spec, podSetsInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -113,7 +114,7 @@ func (j *RayCluster) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 
 	j.Spec.Suspend = new(false)
 
-	err := UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, &j.Spec, podSetsInfo)
+	err := UpdateRayClusterSpecToRunWithPodSetsInfo(ctrl.LoggerFrom(ctx), &j.Spec, podSetsInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -164,7 +165,8 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 
 	j.Spec.Suspend = false
 
-	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, j.Spec.RayClusterSpec, podSetsInfo)
+	log := ctrl.LoggerFrom(ctx)
+	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(log, j.Spec.RayClusterSpec, podSetsInfo)
 	if err != nil {
 		return err
 	}
@@ -173,7 +175,7 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	if j.Spec.SubmissionMode == rayv1.K8sJobMode {
 		submitterPod := getSubmitterTemplate(j)
 		info := podSetsInfo[expectedLen-1]
-		if err := podset.Merge(ctx, &submitterPod.ObjectMeta, &submitterPod.Spec, info); err != nil {
+		if err := podset.Merge(log, &submitterPod.ObjectMeta, &submitterPod.Spec, info); err != nil {
 			return err
 		}
 		if j.Spec.SubmitterPodTemplate == nil {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -164,7 +164,7 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 
 	j.Spec.Suspend = false
 
-	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(j.Spec.RayClusterSpec, podSetsInfo)
+	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, j.Spec.RayClusterSpec, podSetsInfo)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	if j.Spec.SubmissionMode == rayv1.K8sJobMode {
 		submitterPod := getSubmitterTemplate(j)
 		info := podSetsInfo[expectedLen-1]
-		if err := podset.Merge(&submitterPod.ObjectMeta, &submitterPod.Spec, info); err != nil {
+		if err := podset.Merge(ctx, &submitterPod.ObjectMeta, &submitterPod.Spec, info); err != nil {
 			return err
 		}
 		if j.Spec.SubmitterPodTemplate == nil {

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -191,7 +191,7 @@ func (j *RayService) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 	j.Spec.RayClusterSpec.Suspend = new(false)
 
 	rayClusterSpec := &j.Spec.RayClusterSpec
-	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, rayClusterSpec, podSetsInfo)
+	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(ctrl.LoggerFrom(ctx), rayClusterSpec, podSetsInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -191,7 +191,7 @@ func (j *RayService) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 	j.Spec.RayClusterSpec.Suspend = new(false)
 
 	rayClusterSpec := &j.Spec.RayClusterSpec
-	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(rayClusterSpec, podSetsInfo)
+	err := raycluster.UpdateRayClusterSpecToRunWithPodSetsInfo(ctx, rayClusterSpec, podSetsInfo)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -450,7 +450,7 @@ func (r *nodeReconciler) podSetsWithEffectiveTolerationsOnNode(ctx context.Conte
 				}
 			}
 		}
-		if err := podsetinfo.Merge(ctx, &effective.Template.ObjectMeta, &effective.Template.Spec, info); err != nil {
+		if err := podsetinfo.Merge(ctrl.LoggerFrom(ctx), &effective.Template.ObjectMeta, &effective.Template.Spec, info); err != nil {
 			return nil, err
 		}
 		result = append(result, *effective)

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -450,7 +450,7 @@ func (r *nodeReconciler) podSetsWithEffectiveTolerationsOnNode(ctx context.Conte
 				}
 			}
 		}
-		if err := podsetinfo.Merge(&effective.Template.ObjectMeta, &effective.Template.Spec, info); err != nil {
+		if err := podsetinfo.Merge(ctx, &effective.Template.ObjectMeta, &effective.Template.Spec, info); err != nil {
 			return nil, err
 		}
 		result = append(result, *effective)

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -157,20 +157,29 @@ func (podSetInfo *PodSetInfo) AddOrUpdateLabel(k, v string) {
 	}
 }
 
-// kueueManagedAnnotations lists pod template annotations owned by Kueue.
-// Their values are injected on job start and may legitimately differ from
-// the values injected by a previous admission (e.g. the workload slice name
-// changes when a new slice chain starts after preemption), so Merge
-// overwrites them instead of reporting a conflict.
-var kueueManagedAnnotations = []string{
-	kueue.WorkloadAnnotation,
-	kueue.WorkloadSliceNameAnnotation,
+// overrideableAnnotations returns the Kueue-owned pod template annotations
+// that Merge may overwrite instead of reporting a conflict. For elastic jobs
+// their values may legitimately change between admissions (e.g. when a new
+// slice chain starts), so overwriting is restricted to elastic flows:
+//  1. the workload-slice-name annotation, whenever the
+//     ElasticJobsViaWorkloadSlices feature is enabled, and
+//  2. the workload annotation, only for an elastic admission, identified by
+//     the workload-slice-name annotation being part of the injected info.
+func overrideableAnnotations(info PodSetInfo) []string {
+	if !features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		return nil
+	}
+	annotations := []string{kueue.WorkloadSliceNameAnnotation}
+	if _, elastic := info.Annotations[kueue.WorkloadSliceNameAnnotation]; elastic {
+		annotations = append(annotations, kueue.WorkloadAnnotation)
+	}
+	return annotations
 }
 
 // Merge updates or appends the replica metadata & spec fields based on PodSetInfo.
 // It returns error if there is a conflict.
 func Merge(log logr.Logger, meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
-	for _, key := range kueueManagedAnnotations {
+	for _, key := range overrideableAnnotations(info) {
 		newValue, found := info.Annotations[key]
 		if !found {
 			continue

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -168,9 +169,18 @@ var kueueManagedAnnotations = []string{
 
 // Merge updates or appends the replica metadata & spec fields based on PodSetInfo.
 // It returns error if there is a conflict.
-func Merge(meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
+func Merge(ctx context.Context, meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
 	for _, key := range kueueManagedAnnotations {
-		if _, found := info.Annotations[key]; found {
+		newValue, found := info.Annotations[key]
+		if !found {
+			continue
+		}
+		if oldValue, found := meta.Annotations[key]; found && oldValue != newValue {
+			// A leftover value from a previous admission is anomalous, e.g. the
+			// previous Workload was deleted manually and the replacement got a
+			// different name.
+			ctrl.LoggerFrom(ctx).Info("Overwriting stale Kueue-managed annotation on the pod template",
+				"annotation", key, "oldValue", oldValue, "newValue", newValue)
 			delete(meta.Annotations, key)
 		}
 	}

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -23,12 +23,12 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -169,7 +169,7 @@ var kueueManagedAnnotations = []string{
 
 // Merge updates or appends the replica metadata & spec fields based on PodSetInfo.
 // It returns error if there is a conflict.
-func Merge(ctx context.Context, meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
+func Merge(log logr.Logger, meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
 	for _, key := range kueueManagedAnnotations {
 		newValue, found := info.Annotations[key]
 		if !found {
@@ -179,7 +179,7 @@ func Merge(ctx context.Context, meta *metav1.ObjectMeta, spec *corev1.PodSpec, i
 			// A leftover value from a previous admission is anomalous, e.g. the
 			// previous Workload was deleted manually and the replacement got a
 			// different name.
-			ctrl.LoggerFrom(ctx).Info("Overwriting stale Kueue-managed annotation on the pod template",
+			log.Info("Overwriting stale Kueue-managed annotation on the pod template",
 				"annotation", key, "oldValue", oldValue, "newValue", newValue)
 			delete(meta.Annotations, key)
 		}

--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -156,9 +156,24 @@ func (podSetInfo *PodSetInfo) AddOrUpdateLabel(k, v string) {
 	}
 }
 
+// kueueManagedAnnotations lists pod template annotations owned by Kueue.
+// Their values are injected on job start and may legitimately differ from
+// the values injected by a previous admission (e.g. the workload slice name
+// changes when a new slice chain starts after preemption), so Merge
+// overwrites them instead of reporting a conflict.
+var kueueManagedAnnotations = []string{
+	kueue.WorkloadAnnotation,
+	kueue.WorkloadSliceNameAnnotation,
+}
+
 // Merge updates or appends the replica metadata & spec fields based on PodSetInfo.
 // It returns error if there is a conflict.
 func Merge(meta *metav1.ObjectMeta, spec *corev1.PodSpec, info PodSetInfo) error {
+	for _, key := range kueueManagedAnnotations {
+		if _, found := info.Annotations[key]; found {
+			delete(meta.Annotations, key)
+		}
+	}
 	tmp := PodSetInfo{
 		Annotations:     meta.Annotations,
 		Labels:          meta.Labels,

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -410,6 +410,24 @@ func TestMergeRestore(t *testing.T) {
 			},
 			wantError: true,
 		},
+		"updated workload slice annotation": {
+			podSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadSliceNameAnnotation: "old-slice",
+				}).
+				Obj(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					kueue.WorkloadSliceNameAnnotation: "new-slice",
+				},
+			},
+			wantPodSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadSliceNameAnnotation: "new-slice",
+				}).
+				Obj(),
+			wantRestoreChanges: true,
+		},
 		"conflicting node selector": {
 			podSet: basePodSet.DeepCopy(),
 			info: PodSetInfo{

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -285,6 +285,7 @@ func TestMergeRestore(t *testing.T) {
 		Obj()
 
 	cases := map[string]struct {
+		featureGates       map[featuregate.Feature]bool
 		podSet             *kueue.PodSet
 		info               PodSetInfo
 		wantError          bool
@@ -411,6 +412,7 @@ func TestMergeRestore(t *testing.T) {
 			wantError: true,
 		},
 		"updated workload slice annotation": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			podSet: utiltestingapi.MakePodSet("", 1).
 				Annotations(map[string]string{
 					kueue.WorkloadSliceNameAnnotation: "old-slice",
@@ -427,6 +429,56 @@ func TestMergeRestore(t *testing.T) {
 				}).
 				Obj(),
 			wantRestoreChanges: true,
+		},
+		"updated workload slice annotation; feature disabled": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
+			podSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadSliceNameAnnotation: "old-slice",
+				}).
+				Obj(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					kueue.WorkloadSliceNameAnnotation: "new-slice",
+				},
+			},
+			wantError: true,
+		},
+		"updated workload and workload slice annotations for an elastic admission": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			podSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadAnnotation:          "old-slice",
+					kueue.WorkloadSliceNameAnnotation: "old-slice",
+				}).
+				Obj(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					kueue.WorkloadAnnotation:          "new-slice",
+					kueue.WorkloadSliceNameAnnotation: "new-slice",
+				},
+			},
+			wantPodSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadAnnotation:          "new-slice",
+					kueue.WorkloadSliceNameAnnotation: "new-slice",
+				}).
+				Obj(),
+			wantRestoreChanges: true,
+		},
+		"updated workload annotation for a non-elastic admission": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			podSet: utiltestingapi.MakePodSet("", 1).
+				Annotations(map[string]string{
+					kueue.WorkloadAnnotation: "old-workload",
+				}).
+				Obj(),
+			info: PodSetInfo{
+				Annotations: map[string]string{
+					kueue.WorkloadAnnotation: "new-workload",
+				},
+			},
+			wantError: true,
 		},
 		"conflicting node selector": {
 			podSet: basePodSet.DeepCopy(),
@@ -494,6 +546,7 @@ func TestMergeRestore(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			orig := tc.podSet.DeepCopy()
 
 			gotError := Merge(utiltesting.NewLogger(t), &tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, tc.info)

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -496,7 +496,7 @@ func TestMergeRestore(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			orig := tc.podSet.DeepCopy()
 
-			gotError := Merge(t.Context(), &tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, tc.info)
+			gotError := Merge(utiltesting.NewLogger(t), &tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, tc.info)
 
 			if tc.wantError != (gotError != nil) {
 				t.Errorf("Unexpected error status want: %v", tc.wantError)

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -496,7 +496,7 @@ func TestMergeRestore(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			orig := tc.podSet.DeepCopy()
 
-			gotError := Merge(&tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, tc.info)
+			gotError := Merge(t.Context(), &tc.podSet.Template.ObjectMeta, &tc.podSet.Template.Spec, tc.info)
 
 			if tc.wantError != (gotError != nil) {
 				t.Errorf("Unexpected error status want: %v", tc.wantError)

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4975,6 +4975,90 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should resume with the same slice chain after eviction by a stopped ClusterQueue", func() {
+		// Companion to the stale-annotation test above, using an eviction (here
+		// via ClusterQueue stopPolicy=HoldAndDrain) instead of a deletion. The
+		// workload slice survives, so the slice chain identity is preserved,
+		// but after a scale-up the pod template still carries the workload
+		// annotation of the first slice. Re-admitting the replacement slice
+		// used to fail permanently (FailedToStart) on that annotation conflict.
+		testJob := testingjob.MakeJob("evicted-slice", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(3).
+			Obj()
+
+		ginkgo.By("creating an elastic job")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		ginkgo.By("admitting the original workload slice")
+		workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)
+		originalSlice := workloads[0].DeepCopy()
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, originalSlice)
+
+		ginkgo.By("scaling the job up to create a replacement slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = ptr.To[int32](2)
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		replacementSlice := util.ExpectNewWorkloadSlice(ctx, k8sClient, originalSlice)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, replacementSlice)
+		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(originalSlice))
+
+		ginkgo.By("the unsuspended job's pod template carries the original slice name")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, true)).Should(gomega.BeFalse())
+			g.Expect(testJob.Spec.Template.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, originalSlice.Name))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("draining the ClusterQueue to evict the workload without deleting it")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).Should(gomega.Succeed())
+			clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+			g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the workload slice is evicted and the job is suspended")
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replacementSlice), wl)).Should(gomega.Succeed())
+			g.Expect(wl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, kueue.WorkloadEvictedByClusterQueueStopped))
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, false)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("resuming the ClusterQueue")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).Should(gomega.Succeed())
+			clusterQueue.Spec.StopPolicy = ptr.To(kueue.None)
+			g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the same workload slice is re-admitted and the job restarts with the same slice name")
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, replacementSlice)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, true)).Should(gomega.BeFalse())
+			g.Expect(testJob.Spec.Template.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, originalSlice.Name))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("no new slice chain is started and the slice is not finished")
+		gomega.Consistently(func(g gomega.Gomega) {
+			wlList := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			// Only the finished original slice and the re-admitted replacement exist.
+			g.Expect(wlList.Items).Should(gomega.HaveLen(2))
+			wl := &kueue.Workload{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replacementSlice), wl)).Should(gomega.Succeed())
+			g.Expect(workloadfinish.IsFinished(wl)).Should(gomega.BeFalse())
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should handle rapid scale cycles without quota leaks", framework.SlowSpec, func() {
 		testJob := testingjob.MakeJob("stress-job", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4941,17 +4941,12 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("a workload for a new slice chain is created with a different slice name")
 		var newChainSlice *kueue.Workload
 		gomega.Eventually(func(g gomega.Gomega) {
-			newChainSlice = nil
 			wlList := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).Should(gomega.Succeed())
-			for i := range wlList.Items {
-				wl := &wlList.Items[i]
-				if !workloadfinish.IsFinished(wl) && wl.Name != originalSlice.Name && wl.Name != replacementSlice.Name {
-					newChainSlice = wl
-					break
-				}
-			}
-			g.Expect(newChainSlice).ShouldNot(gomega.BeNil())
+			active := util.FindNonFinishedWorkloads(wlList.Items)
+			g.Expect(active).Should(gomega.HaveLen(1))
+			newChainSlice = &active[0]
+			g.Expect(newChainSlice.Name).ShouldNot(gomega.BeElementOf(originalSlice.Name, replacementSlice.Name))
 			g.Expect(newChainSlice.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, newChainSlice.Name))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1039,6 +1039,81 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 				gomega.Expect(createdJob.Spec.Template.Labels).Should(gomega.HaveKeyWithValue("label-key", "old-label-value"))
 			})
 		})
+
+		ginkgo.It("should not admit workload if there is a conflict in annotations", framework.SlowSpec, func() {
+			// Negative counterpart of the stale workload-slice annotation scenario:
+			// only Kueue-managed annotations are overwritten on job start; a conflict
+			// on a user-provided annotation remains a permanent failure.
+			createdJob := &batchv1.Job{}
+			createdWorkload := &kueue.Workload{}
+			job := testingjob.MakeJob(jobName, ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Request(corev1.ResourceCPU, "5").
+				PodAnnotation("ann-key", "old-ann-value").
+				Obj()
+
+			ginkgo.By("creating the job with a pod annotation", func() {
+				util.MustCreate(ctx, k8sClient, job)
+			})
+
+			wlLookupKey := &types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+			ginkgo.By("fetch the created job & workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, *jobLookupKey, createdJob)).Should(gomega.Succeed())
+					g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(new(true)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("add a conflicting annotation to the admission check in PodSetUpdates", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var newWL kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(createdWorkload), &newWL)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&newWL.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:  "check",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{
+							{
+								Name: kueue.DefaultPodSetName,
+								Annotations: map[string]string{
+									"ann-key": "new-ann-value",
+								},
+							},
+						},
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &newWL)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("attempt to admit the workload", func() {
+				admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueAc.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "test-flavor", "1").
+						Count(createdWorkload.Spec.PodSets[0].Count).
+						Obj()).
+					Obj()
+				util.SetQuotaReservation(ctx, k8sClient, *wlLookupKey, admission)
+				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+			})
+
+			ginkgo.By("verify the workload is finished with FailedToStart", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, *wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Conditions).Should(
+						utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, jobframework.FailedToStartFinishedReason))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the job stays suspended with the old annotation value", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, *jobLookupKey, createdJob)).Should(gomega.Succeed())
+					g.Expect(createdJob.Spec.Suspend).Should(gomega.Equal(new(true)))
+					g.Expect(createdJob.Spec.Template.Annotations).Should(gomega.HaveKeyWithValue("ann-key", "old-ann-value"))
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
 	})
 })
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4816,6 +4816,90 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(oldWorkloadSlice))
 	})
 
+	ginkgo.It("Should overwrite a stale workload-slice annotation when a new slice chain starts", func() {
+		// Regression test for kueue#12993: after the active workload slice is
+		// deleted manually, the job's pod template retains the slice-name
+		// annotation of the old chain. The replacement workload starts a new
+		// chain with a different slice name; starting the job used to fail
+		// permanently (FailedToStart) on the annotation conflict.
+		testJob := testingjob.MakeJob("stale-slice-annotation", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(3).
+			Obj()
+
+		ginkgo.By("creating an elastic job")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		ginkgo.By("admitting the original workload slice")
+		workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, ns.Name, 1)
+		originalSlice := workloads[0].DeepCopy()
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, originalSlice)
+
+		ginkgo.By("the unsuspended job's pod template carries the original slice name")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, true)).Should(gomega.BeFalse())
+			g.Expect(testJob.Spec.Template.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, originalSlice.Name))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling the job up to create a replacement slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = ptr.To[int32](2)
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		replacementSlice := util.ExpectNewWorkloadSlice(ctx, k8sClient, originalSlice)
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, replacementSlice)
+		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(originalSlice))
+
+		ginkgo.By("the replacement slice's pod template contains the original slice annotation")
+		gomega.Expect(replacementSlice.Spec.PodSets[0].Template.Annotations).
+			Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, originalSlice.Name))
+
+		ginkgo.By("deleting the replacement workload manually")
+		gomega.Expect(k8sClient.Delete(ctx, replacementSlice)).Should(gomega.Succeed())
+
+		ginkgo.By("a workload for a new slice chain is created with a different slice name")
+		var newChainSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			newChainSlice = nil
+			wlList := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, wlList, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			for i := range wlList.Items {
+				wl := &wlList.Items[i]
+				if !workloadfinish.IsFinished(wl) && wl.Name != originalSlice.Name && wl.Name != replacementSlice.Name {
+					newChainSlice = wl
+					break
+				}
+			}
+			g.Expect(newChainSlice).ShouldNot(gomega.BeNil())
+			g.Expect(newChainSlice.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, newChainSlice.Name))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the new slice's pod template still contains the stale annotation of the old chain")
+		gomega.Expect(newChainSlice.Spec.PodSets[0].Template.Annotations).
+			Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, originalSlice.Name))
+
+		ginkgo.By("the job restarts with the stale annotation overwritten by the new slice name")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			g.Expect(ptr.Deref(testJob.Spec.Suspend, true)).Should(gomega.BeFalse())
+			g.Expect(testJob.Spec.Template.Annotations).Should(gomega.HaveKeyWithValue(kueue.WorkloadSliceNameAnnotation, newChainSlice.Name))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the new slice stays admitted and is not marked finished")
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, newChainSlice)
+		gomega.Consistently(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(newChainSlice), wl)).Should(gomega.Succeed())
+			g.Expect(workloadfinish.IsFinished(wl)).Should(gomega.BeFalse())
+		}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should handle rapid scale cycles without quota leaks", framework.SlowSpec, func() {
 		testJob := testingjob.MakeJob("stress-job", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

Kueue-owned annotations injected at admission time (`kueue.x-k8s.io/workload` and `kueue.x-k8s.io/workload-slice-name`) may legitimately change between admissions of an elastic job. There are two confirmed triggers:

- the active workload slice is deleted (e.g. manually), so the replacement workload starts a new slice chain under a different name; or
- the job is evicted without workload deletion (preemption, ClusterQueue `stopPolicy: HoldAndDrain`) after at least one scale-up — the scale-up replaces the workload slice without restarting the job, so the `kueue.x-k8s.io/workload` annotation stamped on the pod template still names the first slice while the re-admitted workload is the replacement.

In both cases `podset.Merge` treated the leftover value on the job's pod template as a conflict, which resulted in a permanent `FailedToStart` state.

This PR makes the template-level `podset.Merge` overwrite these Kueue-owned annotations when the incoming `PodSetInfo` carries a new value, instead of reporting a conflict. The overwrite only applies to elastic flows: the `workload-slice-name` annotation when the `ElasticJobsViaWorkloadSlices` feature gate is enabled, and the `workload` annotation only for an elastic admission. Behavior for regular jobs is unchanged, as are user annotations, labels, node selectors, and the strict merge used for AdmissionCheck PodSetUpdates.

Includes regression tests in `pkg/podset` and `pkg/controller/jobs/job` that fail without the fix.

#### Which issue(s) this PR fixes:

Fixes #12993

#### Special notes for your reviewer:

An earlier revision of this PR contained only the failing tests. The fix deliberately does not strip the annotation in the stop/restore path: a stale value left on a stopped job is harmless now, since it gets overwritten on the next start.

Integration tests cover both triggers: workload deletion starting a new slice chain, and eviction of a scaled-up job via `stopPolicy: HoldAndDrain`. Both fail without the fix (the eviction test fails on the `kueue.x-k8s.io/workload` conflict even with the slice-name overwrite in place).

AI disclosure: This change was developed with assistance from an AI coding tool. All changes were reviewed by the submitter.

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where an elastic job could permanently fail to start (FailedToStart) due to stale Kueue-owned annotations on the pod template, e.g. after its workload was deleted, or after eviction of a previously scaled-up job.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PodSet merging so Kueue-managed workload-slice and workload-name annotations are updated even when stale template annotation values exist, preventing admission/merge conflicts when new slice data is applied.

* **Tests**
  * Added regression coverage for overwriting stale workload-slice annotations when a new slice chain starts, including verification after restore/re-suspend behavior.
  * Added coverage ensuring workloads are not admitted when PodSet annotation updates conflict with existing user-provided values (fail to start).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
