### PR TITLE
Allos to run ChatOps in the middle of comment.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -6,7 +6,7 @@ jobs:
   sync-notes:
     name: Sync Release Notes
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.event.comment.body, '/sync-release-notes') }}
+    if: ${{ contains(github.event.comment.body, '/sync-release-notes') }}
     permissions:
       contents: read
       issues: write
@@ -42,8 +42,8 @@ jobs:
           BODY: ${{ github.event.comment.body }}
           TITLE: ${{ github.event.issue.title }}
         run: |
-          if [[ ! "$BODY" =~ ^/sync-release-notes[[:space:]]*$ ]]; then
-            echo "Error: Invalid command format. Use /sync-release-notes without arguments."
+          if ! printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/sync-release-notes[[:space:]]*$'; then
+            echo "Error: Invalid command format. Use /sync-release-notes on its own line without arguments."
             exit 1
           fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Allos to run ChatOps in the middle of comment.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of the `/sync-release-notes` command in comments.
  * Added stricter validation to ensure the command appears on its own line.
  * Updated error messaging for invalid command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->