### PR TITLE
Update RayService with GCS fault-tolerant test

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -1049,6 +1049,10 @@ app = HelloWorld.bind()`,
 			gomega.Expect(k8sClient.Delete(ctx, rayService)).To(gomega.Succeed())
 		})
 
+		ginkgo.By("Verifying that the RayService is actually deleted", func() {
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rayService, false, util.LongTimeout)
+		})
+
 		// Deferred finalization keeps the parent Workload admitted while KubeRay's Redis
 		// cleanup Job runs, so the Job purges the RayCluster's GCS metadata namespace.
 		// Without it the cleanup Job is gated forever and these keys leak until KubeRay's


### PR DESCRIPTION
/area ray-integration

#### What this PR does / why we need it:
Currently the test is checking that Delete call for RayService is successful, however we need to check that actual deletion is successful.

Related to https://github.com/kubernetes-sigs/kueue/issues/8443

#### Special notes for your reviewer:
AI-assisted

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test coverage by explicitly verifying that the RayService resource is deleted before continuing with Redis cleanup checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->