### PR TITLE
Consider workload as orphan only if the job is deleted

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -265,14 +265,16 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	log.V(2).Info("Reconcile Workload")
 
 	if isOrphanedWorkload(&wl) {
-		err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, &wl, true)
-		if err != nil {
+		if err := workload.FinishOrphanedWorkload(ctx, r.client, r.clock, &wl, true); err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := workload.RemoveFinalizer(ctx, r.client, &wl); client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
 		// If it was deleted, there is nothing to do.
 		// Otherwise, we still need to handle finished workload logic.
 		if !features.Enabled(features.FinishOrphanedWorkloads) || !wl.DeletionTimestamp.IsZero() {
-			return ctrl.Result{}, err
+			return ctrl.Result{}, nil
 		}
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -304,10 +304,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	}
 
 	if shouldFinalize {
-		if err := r.finalize(ctx, req.NamespacedName, job); err != nil {
-			return ctrl.Result{}, err
-		}
-		return ctrl.Result{}, nil
+		return r.finalize(ctx, req.NamespacedName, job)
 	}
 
 	if features.Enabled(features.ManagedJobsNamespaceSelectorAlwaysRespected) {
@@ -453,7 +450,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 
 	// 2. handle job is finished.
 	if message, success, finished := job.Finished(ctx); finished {
-		log.V(3).Info("The workload is already finished")
+		log.V(3).Info("The job is already finished")
 		if wl != nil && !workloadfinish.IsFinished(wl) {
 			reason := kueue.WorkloadFinishedReasonSucceeded
 			if !success {
@@ -651,20 +648,21 @@ func (r *JobReconciler) loadJob(ctx context.Context, key *types.NamespacedName, 
 
 // finalize removes finalizers from workloads and the job itself,
 // ensuring proper cleanup during object deletion.
-func (r *JobReconciler) finalize(ctx context.Context, key types.NamespacedName, job GenericJob) error {
+func (r *JobReconciler) finalize(ctx context.Context, key types.NamespacedName, job GenericJob) (ctrl.Result, error) {
 	// Remove workloads finalizer
 	if err := r.finalizeWorkloads(ctx, key, job); client.IgnoreNotFound(err) != nil {
-		return err
+		return ctrl.Result{}, err
 	}
 
 	// Remove job finalizer
 	if !job.Object().GetDeletionTimestamp().IsZero() {
 		if err := r.finalizeJob(ctx, job); client.IgnoreNotFound(err) != nil {
-			return err
+			return ctrl.Result{}, err
 		}
 	}
 
-	return nil
+	// Requeue in order to check if the job is actually deleted and remove workloads in this case.
+	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }
 
 // getWorkloads retrieves a list of workloads associated with the specified job.

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -695,9 +695,21 @@ func (r *JobReconciler) finalizeWorkloads(ctx context.Context, key types.Namespa
 	if err != nil {
 		return err
 	}
+	jobExists := true
+	if err := r.client.Get(ctx, key, job.Object()); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		jobExists = false
+	}
 	for i := range workloads {
 		wl := &workloads[i]
-		if err := workload.FinalizeOrphanedWorkload(ctx, r.client, r.clock, wl, controllerutil.HasControllerReference(wl)); err != nil {
+		if !jobExists {
+			if err := workload.FinishOrphanedWorkload(ctx, r.client, r.clock, wl, controllerutil.HasControllerReference(wl)); err != nil {
+				return err
+			}
+		}
+		if err := workload.RemoveFinalizer(ctx, r.client, wl); client.IgnoreNotFound(err) != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -689,13 +689,6 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").
 					ControllerReference(gvk, baseJobWrapper.GetName(), string(baseJobWrapper.GetUID())).
-					Condition(metav1.Condition{
-						Type:               kueue.WorkloadFinished,
-						Status:             metav1.ConditionTrue,
-						LastTransitionTime: metav1.NewTime(now),
-						Reason:             kueue.WorkloadFinishedReasonOwnerNotFound,
-						Message:            "The workload's owner no longer exists",
-					}).
 					Obj(),
 			},
 		},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1340,7 +1340,8 @@ func CreatePodsReadyCondition(status metav1.ConditionStatus, reason, message str
 	}
 }
 
-func FinalizeOrphanedWorkload(ctx context.Context, c client.Client, clk clock.Clock, wl *kueue.Workload, canFinish bool) error {
+// FinishOrphanedWorkload finishes the orphaned workload to release quota.
+func FinishOrphanedWorkload(ctx context.Context, c client.Client, clk clock.Clock, wl *kueue.Workload, canFinish bool) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Only Finish workloads that are not currently being deleted.
@@ -1353,13 +1354,6 @@ func FinalizeOrphanedWorkload(ctx context.Context, c client.Client, clk clock.Cl
 				return err
 			}
 			return nil
-		}
-	}
-
-	if err := RemoveFinalizer(ctx, c, wl); err != nil {
-		if client.IgnoreNotFound(err) != nil {
-			log.Error(err, "Failed to remove finalizer")
-			return err
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes: 
Fixes #12820

#### Special notes for your reviewer:
AI-assisted

#### Does this PR introduce a user-facing change?
```release-note
The Workloads for jobs with deletion timestamp are not removed by Kueue, if the job still exist.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup for orphaned workloads when their owning Job is no longer present.
  * Updated orphaned-workload finishing to follow the correct flow and ensure workload finalizers are cleared after processing.
  * Prevented unnecessary reconciliation errors and requeues when finishing is disabled or when deletion is already in progress.
  * Updated orphaned-workload status behavior so workloads don’t incorrectly receive an owner-not-found finished condition.
* **Tests**
  * Adjusted job controller expectations around orphaned workload finishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->