### PR TITLE
Address Partitionable Devices beta graduation criteria

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1549,21 +1549,18 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 ##### KueueDRAIntegrationPartitionableDevices
 
 - feature gate enabled by default
-- re-evaluate extending ResourceSlice indexing to CEL validation path. Counter processing
-  already uses the driver-based index but CEL validation lists all ResourceSlices unfiltered.
-- re-evaluate handling of devices with multiple ConsumesCounters entries referencing
-  different counter sets. Currently only the first matching entry is used.
-- re-evaluate MAX-based counter charging semantics for heterogeneous device profiles
-  within the same pool, such as mixed MIG sizes where charging the maximum value
-  across all matched devices may overcharge.
-- re-evaluate pool-aware flavor assignment for counter resources
-- re-evaluate caching `deviceSelector` evaluation results to avoid repeated ResourceSlice
-  evaluation
-- re-evaluate consolidating ResourceSlice listing between CEL validation and counter
-  processing into a shared layer
-- re-evaluate multi-counter tracking, such as memory and compute as separate quota resources
-  for the same DeviceClass, by relaxing the DeviceClass uniqueness constraint across
-  mappings or the single counter source limitation within a mapping
+- consolidate ResourceSlice listing between CEL validation and counter processing
+  into a shared request-scoped cache, eliminating duplicate API calls within a
+  single workload reconciliation.
+- extend CEL validation path to use driver-based indexed ResourceSlice listing for
+  DeviceClasses with counter sources, instead of listing all ResourceSlices
+  unfiltered. When a broader listing is already cached, per-driver requests filter
+  from cached results.
+- iterate all ConsumesCounters entries per device, consistent with the upstream K8s
+  allocator behavior. Takes MAX across all matching counter sets per device.
+- support multi-counter tracking by relaxing the DeviceClass uniqueness constraint
+  across mappings when both have counter sources with different counter names,
+  allowing memory and compute as separate quota resources for the same DeviceClass
 
 #### GA
 
@@ -1585,6 +1582,13 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 
 - the feature gate in stable
 - user adoption feedback with MIG workloads confirms counter-based quota accuracy
+- re-evaluate MAX-based counter charging for heterogeneous device profiles. Accurate
+  charging requires knowing which device the scheduler will allocate. Depends on
+  scheduler-library integration ([#12422](https://github.com/kubernetes-sigs/kueue/issues/12422)).
+- re-evaluate pool-aware flavor assignment for counter resources. Connecting
+  ResourceSlice pools to flavors requires scheduler-library awareness of which
+  node a workload will land on. Depends on scheduler-library integration
+  ([#12422](https://github.com/kubernetes-sigs/kueue/issues/12422)).
 
 ## Implementation History
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -478,6 +478,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 
 	seenResourceNames := make(sets.Set[corev1.ResourceName])
 	deviceClassToResource := make(map[corev1.ResourceName]corev1.ResourceName)
+	deviceClassCounterNames := make(map[corev1.ResourceName]sets.Set[string])
 
 	for idx, mapping := range mappings {
 		mappingPath := dynamicResourceAllocationPath.Index(idx)
@@ -524,13 +525,30 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 				seenDeviceClassNames.Insert(deviceClass)
 			}
 
+			counterName := counterNameForMapping(mapping)
 			if existingResource, exists := deviceClassToResource[deviceClass]; exists {
 				if existingResource != mapping.Name {
-					allErrs = append(allErrs, field.Invalid(dcPath, deviceClass,
-						fmt.Sprintf("device class already mapped to resource %s", existingResource)))
+					// Allow same DeviceClass in multiple mappings only when both have
+					// counter sources with different counter names — each mapping tracks
+					// a different counter dimension (e.g., gpu.memory and gpu.compute).
+					existingCounters := deviceClassCounterNames[deviceClass]
+					switch {
+					case counterName == "" || existingCounters.Len() == 0:
+						allErrs = append(allErrs, field.Invalid(dcPath, deviceClass,
+							fmt.Sprintf("device class already mapped to resource %s", existingResource)))
+					case existingCounters.Has(counterName):
+						allErrs = append(allErrs, field.Invalid(dcPath, deviceClass,
+							fmt.Sprintf("device class already has a counter source for counter %q", counterName)))
+					default:
+						deviceClassCounterNames[deviceClass].Insert(counterName)
+					}
 				}
 			} else {
 				deviceClassToResource[deviceClass] = mapping.Name
+				deviceClassCounterNames[deviceClass] = sets.New[string]()
+				if counterName != "" {
+					deviceClassCounterNames[deviceClass].Insert(counterName)
+				}
 			}
 		}
 
@@ -803,4 +821,11 @@ func validateQualifiedName(fldPath *field.Path, value string) field.ErrorList {
 		return field.ErrorList{field.Invalid(fldPath, value, strings.Join(errs, "; "))}
 	}
 	return nil
+}
+
+func counterNameForMapping(mapping configapi.DeviceClassMapping) string {
+	if len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil {
+		return mapping.Sources[0].Counter.Name
+	}
+	return ""
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1297,6 +1297,150 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"multi-counter: same DeviceClass with different counter names allowed": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+						{
+							Name:             "gpu.compute",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "multiprocessors",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"multi-counter: same DeviceClass with same counter name rejected": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+						{
+							Name:             "gpu.memory2",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[1].deviceClassNames[0]",
+				},
+			},
+		},
+		"multi-counter: whole-device and counter for same DeviceClass rejected": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[1].deviceClassNames[0]",
+				},
+			},
+		},
+		"multi-counter: counter then whole-device for same DeviceClass rejected": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+						{
+							Name:             "gpu",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[1].deviceClassNames[0]",
+				},
+			},
+		},
 		"sources configured but KueueDRAIntegrationPartitionableDevices disabled": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -393,8 +393,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 		log.V(3).Info("Processing DRA resources for workload")
 
+		sliceCache := dra.NewResourceSliceCache(r.client)
+
 		// Process ResourceClaimTemplates (existing DRA path)
-		draResources, fieldErrs := dra.GetResourceRequestsForResourceClaimTemplates(ctx, r.client, r.draMapper, &wl)
+		draResources, fieldErrs := dra.GetResourceRequestsForResourceClaimTemplates(ctx, r.client, sliceCache, r.draMapper, &wl)
 		if len(fieldErrs) > 0 {
 			err := fieldErrs.ToAggregate()
 			log.Error(err, "Failed to process DRA resources for workload")
@@ -459,7 +461,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 
 		// Process counter-based resources for partitionable devices
 		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
-			counterResources, counterFieldErrs := dra.GetCounterResourcesForWorkload(ctx, r.client, r.draMapper, &wl)
+			counterResources, counterFieldErrs := dra.GetCounterResourcesForWorkload(ctx, r.client, sliceCache, r.draMapper, &wl)
 			if len(counterFieldErrs) > 0 {
 				err := counterFieldErrs.ToAggregate()
 				log.Error(err, "Failed to process DRA counter resources for workload")

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -155,6 +155,7 @@ func getClaimSpec(ctx context.Context, cl client.Client, namespace string, prc c
 func GetResourceRequestsForResourceClaimTemplates(
 	ctx context.Context,
 	cl client.Client,
+	sliceCache *ResourceSliceCache,
 	mapper *ResourceMapper,
 	wl *kueue.Workload) (map[kueue.PodSetReference]corev1.ResourceList, field.ErrorList) {
 	perPodSet := make(map[kueue.PodSetReference]corev1.ResourceList)
@@ -196,7 +197,7 @@ func GetResourceRequestsForResourceClaimTemplates(
 
 			// Validate CEL selectors against actual devices in the cluster.
 			celBasePath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j)
-			if celErrs := validateCELSelectorsAgainstDevices(ctx, cl, spec, celBasePath); len(celErrs) > 0 {
+			if celErrs := validateCELSelectorsAgainstDevices(ctx, cl, sliceCache, mapper, spec, celBasePath); len(celErrs) > 0 {
 				for _, celErr := range celErrs {
 					allErrs = append(allErrs, &field.Error{
 						Type:     celErr.Type,
@@ -217,7 +218,7 @@ func GetResourceRequestsForResourceClaimTemplates(
 					))
 					return nil, allErrs
 				}
-				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && mapper.getCounterConfig(dc) != nil {
+				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(dc)) > 0 {
 					continue
 				}
 				aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{logical: resource.MustParse(strconv.FormatInt(qty, 10))})
@@ -408,18 +409,51 @@ func countMatchingDevices(ctx context.Context, devices []dracel.Device, classSel
 // If fewer devices match than requested, it returns field errors indicating the
 // workload is unsatisfiable, preventing quota from being matchedDevices by workloads
 // whose pods can never be scheduled.
-func validateCELSelectorsAgainstDevices(ctx context.Context, cl client.Client, claimSpec *resourcev1.ResourceClaimSpec, basePath *field.Path) field.ErrorList {
+func validateCELSelectorsAgainstDevices(
+	ctx context.Context,
+	cl client.Client,
+	sliceCache *ResourceSliceCache,
+	mapper *ResourceMapper,
+	claimSpec *resourcev1.ResourceClaimSpec,
+	basePath *field.Path,
+) field.ErrorList {
 	celReqs := extractCELRequests(claimSpec)
 	if len(celReqs) == 0 {
 		return nil
 	}
 
-	var sliceList resourcev1.ResourceSliceList
-	if err := cl.List(ctx, &sliceList); err != nil {
-		return field.ErrorList{field.InternalError(basePath, fmt.Errorf("failed to list ResourceSlices: %w", err))}
+	var collectedSlices []resourcev1.ResourceSlice
+	needsAll := false
+	for _, cr := range celReqs {
+		if len(mapper.getCounterConfigs(corev1.ResourceName(cr.deviceClassName))) == 0 {
+			needsAll = true
+			break
+		}
+	}
+	if needsAll {
+		slices, err := sliceCache.ListAll(ctx)
+		if err != nil {
+			return field.ErrorList{field.InternalError(basePath, fmt.Errorf("failed to list ResourceSlices: %w", err))}
+		}
+		collectedSlices = slices
+	} else {
+		seenDrivers := sets.New[string]()
+		for _, cr := range celReqs {
+			for _, cc := range mapper.getCounterConfigs(corev1.ResourceName(cr.deviceClassName)) {
+				if seenDrivers.Has(cc.driver) {
+					continue
+				}
+				seenDrivers.Insert(cc.driver)
+				slices, err := sliceCache.ListByDriver(ctx, cc.driver)
+				if err != nil {
+					return field.ErrorList{field.InternalError(basePath, fmt.Errorf("failed to list ResourceSlices for driver %s: %w", cc.driver, err))}
+				}
+				collectedSlices = append(collectedSlices, slices...)
+			}
+		}
 	}
 
-	clusterDevices := buildDeviceListFromSlices(sliceList.Items)
+	clusterDevices := buildDeviceListFromSlices(collectedSlices)
 	classCache := make(map[string]*resourcev1.DeviceClass)
 	matchedDevices := sets.New[int]()
 

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -702,7 +702,11 @@ func Test_GetResourceRequests(t *testing.T) {
 					objs = append(objs, o.(client.Object))
 				}
 			}
-			baseClient := utiltesting.NewClientBuilder().WithObjects(objs...).Build()
+			baseClient := utiltesting.NewClientBuilder().
+				WithIndex(&resourcev1.ResourceSlice{}, "spec.driver", func(obj client.Object) []string {
+					return []string{obj.(*resourcev1.ResourceSlice).Spec.Driver}
+				}).
+				WithObjects(objs...).Build()
 
 			wlCopy := wl.DeepCopy()
 			if tc.modifyWL != nil {
@@ -713,7 +717,8 @@ func Test_GetResourceRequests(t *testing.T) {
 			if testMapper == nil {
 				testMapper = NewResourceMapper()
 			}
-			got, err := GetResourceRequestsForResourceClaimTemplates(ctx, baseClient, testMapper, wlCopy)
+			sliceCache := NewResourceSliceCache(baseClient)
+			got, err := GetResourceRequestsForResourceClaimTemplates(ctx, baseClient, sliceCache, testMapper, wlCopy)
 
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.IgnoreFields(field.Error{}, "Detail", "BadValue")); diff != "" {
 				t.Errorf("GetResourceRequestsForResourceClaimTemplates() error mismatch (-want +got):\n%s", diff)

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -36,6 +36,7 @@ import (
 func GetCounterResourcesForWorkload(
 	ctx context.Context,
 	cl client.Client,
+	sliceCache *ResourceSliceCache,
 	mapper *ResourceMapper,
 	wl *kueue.Workload,
 ) (map[kueue.PodSetReference]corev1.ResourceList, field.ErrorList) {
@@ -71,30 +72,34 @@ func GetCounterResourcesForWorkload(
 					continue
 				}
 				deviceClass := corev1.ResourceName(req.Exactly.DeviceClassName)
-				quotaResource, found := mapper.Lookup(deviceClass)
-				if !found {
+				counterConfigs := mapper.getCounterConfigs(deviceClass)
+				if len(counterConfigs) == 0 {
 					continue
 				}
-				counterConfig := mapper.getCounterConfig(deviceClass)
-				if counterConfig == nil {
-					continue
-				}
-
-				log.V(4).Info("Processing counter charge", "podSet", ps.Name, "deviceClass", deviceClass, "quotaResource", quotaResource, "count", req.Exactly.Count)
 
 				reqPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j).Child("devices", "requests").Index(reqIdx)
 
-				charges, errs := processCounterCharge(ctx, cl, counterConfig, quotaResource, req.Exactly.DeviceClassName, req.Exactly.Selectors, req.Exactly.Count, classCache, reqPath)
+				classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, reqPath)
 				if len(errs) > 0 {
 					allErrs = append(allErrs, errs...)
 					return nil, allErrs
 				}
-				for resName, qty := range charges {
-					existing := aggregated[resName]
-					existing.Add(qty)
-					aggregated[resName] = existing
+
+				for _, cc := range counterConfigs {
+					log.V(4).Info("Processing counter charge", "podSet", ps.Name, "deviceClass", deviceClass, "quotaResource", cc.quotaResource, "count", req.Exactly.Count)
+
+					charges, errs := processCounterCharge(ctx, sliceCache, &cc, cc.quotaResource, classSelectors, requestSelectors, req.Exactly.Count, reqPath)
+					if len(errs) > 0 {
+						allErrs = append(allErrs, errs...)
+						return nil, allErrs
+					}
+					for resName, qty := range charges {
+						existing := aggregated[resName]
+						existing.Add(qty)
+						aggregated[resName] = existing
+					}
+					log.V(4).Info("Counter charge computed", "podSet", ps.Name, "deviceClass", deviceClass, "charges", charges)
 				}
-				log.V(4).Info("Counter charge computed", "podSet", ps.Name, "deviceClass", deviceClass, "charges", charges)
 			}
 		}
 
@@ -107,15 +112,35 @@ func GetCounterResourcesForWorkload(
 	return perPodSet, nil
 }
 
-func processCounterCharge(
+func prepareCounterCharge(
 	ctx context.Context,
 	cl client.Client,
-	counterConfig *deviceClassCounterConfig,
-	quotaResource corev1.ResourceName,
 	deviceClassName string,
 	selectors []resourcev1.DeviceSelector,
-	count int64,
 	classCache map[string]*resourcev1.DeviceClass,
+	reqPath *field.Path,
+) ([]dracel.CompilationResult, []dracel.CompilationResult, field.ErrorList) {
+	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, reqPath, 0)
+	if classErr != nil {
+		return nil, nil, field.ErrorList{classErr}
+	}
+
+	requestSelectors, compErrs := compileCELSelectors(selectors, reqPath.Child("exactly", "selectors"), "CEL compilation failed")
+	if len(compErrs) > 0 {
+		return nil, nil, compErrs
+	}
+
+	return classSelectors, requestSelectors, nil
+}
+
+func processCounterCharge(
+	ctx context.Context,
+	sliceCache *ResourceSliceCache,
+	counterConfig *deviceClassCounterConfig,
+	quotaResource corev1.ResourceName,
+	classSelectors []dracel.CompilationResult,
+	requestSelectors []dracel.CompilationResult,
+	count int64,
 	reqPath *field.Path,
 ) (corev1.ResourceList, field.ErrorList) {
 	log := ctrl.LoggerFrom(ctx)
@@ -128,28 +153,18 @@ func processCounterCharge(
 		return nil, compErrs
 	}
 
-	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, reqPath, 0)
-	if classErr != nil {
-		return nil, field.ErrorList{classErr}
-	}
-
-	requestSelectors, compErrs := compileCELSelectors(selectors, reqPath.Child("exactly", "selectors"), "CEL compilation failed")
-	if len(compErrs) > 0 {
-		return nil, compErrs
-	}
-
-	var sliceList resourcev1.ResourceSliceList
-	if err := cl.List(ctx, &sliceList, client.MatchingFields{"spec.driver": counterConfig.driver}); err != nil {
+	sliceList, err := sliceCache.ListByDriver(ctx, counterConfig.driver)
+	if err != nil {
 		return nil, field.ErrorList{field.InternalError(reqPath, fmt.Errorf("failed to list ResourceSlices: %w", err))}
 	}
-	pools := groupSlicesByPool(sliceList.Items, counterConfig.driver)
-	log.V(4).Info("Listed ResourceSlices for counter processing", "driver", counterConfig.driver, "pools", len(pools), "slices", len(sliceList.Items))
+	pools := groupSlicesByPool(sliceList, counterConfig.driver)
+	log.V(4).Info("Listed ResourceSlices for counter processing", "driver", counterConfig.driver, "pools", len(pools), "slices", len(sliceList))
 
 	matched, errs := matchDevicesWithSelectors(ctx, pools, counterConfig.driver, selectorSelectors, classSelectors, requestSelectors, reqPath)
 	if len(errs) > 0 {
 		return nil, errs
 	}
-	log.V(4).Info("Matched devices for counter charge", "deviceClass", deviceClassName, "matched", len(matched), "requested", count)
+	log.V(4).Info("Matched devices for counter charge", "matched", len(matched), "requested", count)
 
 	if int64(len(matched)) < count {
 		// Cluster-state shortage: retryable until matching ResourceSlices appear.
@@ -296,7 +311,6 @@ func computeCounterCharges(
 					maxValue = v.Value.DeepCopy()
 					found = true
 				}
-				break
 			}
 		}
 	}

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -153,6 +153,34 @@ func TestComputeCounterCharges(t *testing.T) {
 			},
 		},
 		{
+			name:          "multiple ConsumesCounters entries, MAX across counter sets",
+			cc:            defaultCC,
+			quotaResource: "gpu.memory",
+			matched: []resourcev1.Device{
+				{
+					Name: "multi-set-device",
+					ConsumesCounters: []resourcev1.DeviceCounterConsumption{
+						{
+							CounterSet: "set-a",
+							Counters: map[string]resourcev1.Counter{
+								"memory": {Value: resource.MustParse("10Gi")},
+							},
+						},
+						{
+							CounterSet: "set-b",
+							Counters: map[string]resourcev1.Counter{
+								"memory": {Value: resource.MustParse("30Gi")},
+							},
+						},
+					},
+				},
+			},
+			count: 1,
+			want: corev1.ResourceList{
+				"gpu.memory": resource.MustParse("30Gi"),
+			},
+		},
+		{
 			name:          "no consumesCounters, no deviceSelector",
 			cc:            defaultCC,
 			quotaResource: "gpu.memory",

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -123,7 +123,7 @@ func resolveContainerExtendedResources(
 		for _, dc := range dcList.Items {
 			if logicalName, found := mapper.Lookup(corev1.ResourceName(dc.Name)); found {
 				quotaKey = logicalName
-				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && mapper.getCounterConfig(corev1.ResourceName(dc.Name)) != nil {
+				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(dc.Name))) > 0 {
 					errs = append(errs, field.Invalid(
 						containerPath,
 						resourceName,

--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -26,6 +26,7 @@ import (
 
 // deviceClassCounterConfig holds counter configuration for a specific DeviceClass.
 type deviceClassCounterConfig struct {
+	quotaResource  corev1.ResourceName
 	driver         string
 	counterName    string
 	deviceSelector resourcev1.DeviceSelector
@@ -35,18 +36,20 @@ type deviceClassCounterConfig struct {
 // based on Configuration API DRA settings. Initialized once at startup, immutable during runtime.
 type ResourceMapper struct {
 	deviceClassToResource map[corev1.ResourceName]corev1.ResourceName
-	deviceClassCounters   map[corev1.ResourceName]*deviceClassCounterConfig
+	deviceClassCounters   map[corev1.ResourceName][]deviceClassCounterConfig
 }
 
 // NewResourceMapper creates a new empty ResourceMapper instance.
 func NewResourceMapper() *ResourceMapper {
 	return &ResourceMapper{
 		deviceClassToResource: make(map[corev1.ResourceName]corev1.ResourceName),
-		deviceClassCounters:   make(map[corev1.ResourceName]*deviceClassCounterConfig),
+		deviceClassCounters:   make(map[corev1.ResourceName][]deviceClassCounterConfig),
 	}
 }
 
 // Lookup returns the logical resource name for a device class.
+// For DeviceClasses with counter sources, the quota resource name is on each
+// counter config instead.
 func (m *ResourceMapper) Lookup(deviceClass corev1.ResourceName) (corev1.ResourceName, bool) {
 	if m == nil {
 		return "", false
@@ -55,9 +58,9 @@ func (m *ResourceMapper) Lookup(deviceClass corev1.ResourceName) (corev1.Resourc
 	return logicalResource, found
 }
 
-// getCounterConfig returns the counter configuration for a DeviceClass, or nil if
+// getCounterConfigs returns the counter configurations for a DeviceClass, or nil if
 // the DeviceClass does not use counter-based quota.
-func (m *ResourceMapper) getCounterConfig(deviceClass corev1.ResourceName) *deviceClassCounterConfig {
+func (m *ResourceMapper) getCounterConfigs(deviceClass corev1.ResourceName) []deviceClassCounterConfig {
 	return m.deviceClassCounters[deviceClass]
 }
 
@@ -67,21 +70,24 @@ func (m *ResourceMapper) PopulateFromConfiguration(mappings []configapi.DeviceCl
 		return nil
 	}
 	dcToResource := make(map[corev1.ResourceName]corev1.ResourceName)
-	dcCounters := make(map[corev1.ResourceName]*deviceClassCounterConfig)
+	dcCounters := make(map[corev1.ResourceName][]deviceClassCounterConfig)
 	for _, mapping := range mappings {
 		isCounter := len(mapping.Sources) > 0 && mapping.Sources[0].Counter != nil
 		if isCounter {
 			resources.RegisterBinaryFormattedResource(mapping.Name)
 		}
 		for _, deviceClassName := range mapping.DeviceClassNames {
-			dcToResource[deviceClassName] = mapping.Name
+			if _, exists := dcToResource[deviceClassName]; !exists {
+				dcToResource[deviceClassName] = mapping.Name
+			}
 			if isCounter {
 				c := mapping.Sources[0].Counter
-				dcCounters[deviceClassName] = &deviceClassCounterConfig{
+				dcCounters[deviceClassName] = append(dcCounters[deviceClassName], deviceClassCounterConfig{
+					quotaResource:  mapping.Name,
 					driver:         c.Driver,
 					counterName:    c.Name,
 					deviceSelector: c.DeviceSelector,
-				}
+				})
 			}
 		}
 	}

--- a/pkg/dra/mapper_test.go
+++ b/pkg/dra/mapper_test.go
@@ -272,11 +272,16 @@ func TestDRAResourceMapper_PopulateFromConfiguration(t *testing.T) {
 }
 
 func TestCreateMapperFromConfiguration(t *testing.T) {
+	type wantCounterConfig struct {
+		quotaResource corev1.ResourceName
+		counterName   string
+		driver        string
+	}
 	tests := []struct {
-		name                string
-		deviceClassMappings []configapi.DeviceClassMapping
-		wantDeviceLookup    map[corev1.ResourceName]corev1.ResourceName
-		wantCounterConfigs  map[corev1.ResourceName]string
+		name                   string
+		deviceClassMappings    []configapi.DeviceClassMapping
+		wantDeviceLookup       map[corev1.ResourceName]corev1.ResourceName
+		wantCounterConfigsList map[corev1.ResourceName][]wantCounterConfig
 	}{
 		{
 			name:             "nil mappings",
@@ -305,8 +310,35 @@ func TestCreateMapperFromConfiguration(t *testing.T) {
 			wantDeviceLookup: map[corev1.ResourceName]corev1.ResourceName{
 				"mig.nvidia.com": "gpu.memory",
 			},
-			wantCounterConfigs: map[corev1.ResourceName]string{
-				"mig.nvidia.com": "gpu.nvidia.com",
+			wantCounterConfigsList: map[corev1.ResourceName][]wantCounterConfig{
+				"mig.nvidia.com": {
+					{quotaResource: "gpu.memory", counterName: "memory", driver: "gpu.nvidia.com"},
+				},
+			},
+		},
+		{
+			name: "multi-counter tracking for same DeviceClass",
+			deviceClassMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "gpu.memory",
+					DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+					Sources: []configapi.DeviceClassSourceConfig{
+						{Counter: &configapi.DeviceClassCounterSource{Name: "memory", Driver: "gpu.nvidia.com"}},
+					},
+				},
+				{
+					Name:             "gpu.compute",
+					DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+					Sources: []configapi.DeviceClassSourceConfig{
+						{Counter: &configapi.DeviceClassCounterSource{Name: "multiprocessors", Driver: "gpu.nvidia.com"}},
+					},
+				},
+			},
+			wantCounterConfigsList: map[corev1.ResourceName][]wantCounterConfig{
+				"mig.nvidia.com": {
+					{quotaResource: "gpu.memory", counterName: "memory", driver: "gpu.nvidia.com"},
+					{quotaResource: "gpu.compute", counterName: "multiprocessors", driver: "gpu.nvidia.com"},
+				},
 			},
 		},
 		{
@@ -324,9 +356,13 @@ func TestCreateMapperFromConfiguration(t *testing.T) {
 				"gpu.nvidia.com": "gpu.memory",
 				"mig.nvidia.com": "gpu.memory",
 			},
-			wantCounterConfigs: map[corev1.ResourceName]string{
-				"gpu.nvidia.com": "gpu.nvidia.com",
-				"mig.nvidia.com": "gpu.nvidia.com",
+			wantCounterConfigsList: map[corev1.ResourceName][]wantCounterConfig{
+				"gpu.nvidia.com": {
+					{quotaResource: "gpu.memory", counterName: "memory", driver: "gpu.nvidia.com"},
+				},
+				"mig.nvidia.com": {
+					{quotaResource: "gpu.memory", counterName: "memory", driver: "gpu.nvidia.com"},
+				},
 			},
 		},
 	}
@@ -346,18 +382,27 @@ func TestCreateMapperFromConfiguration(t *testing.T) {
 					t.Errorf("Device class %s: want %s, got %s", dc, wantResource, got)
 				}
 			}
-			for dc, wantDriver := range tt.wantCounterConfigs {
-				cc := mapper.getCounterConfig(dc)
-				if cc == nil {
-					t.Errorf("Expected counter config for %s, got nil", dc)
-				} else if cc.driver != wantDriver {
-					t.Errorf("Counter config for %s: want driver %s, got %s", dc, wantDriver, cc.driver)
+			if tt.wantCounterConfigsList == nil {
+				for dc := range tt.wantDeviceLookup {
+					if ccs := mapper.getCounterConfigs(dc); len(ccs) > 0 {
+						t.Errorf("Expected no counter config for %s, got %+v", dc, ccs)
+					}
 				}
 			}
-			if tt.wantCounterConfigs == nil {
-				for dc := range tt.wantDeviceLookup {
-					if cc := mapper.getCounterConfig(dc); cc != nil {
-						t.Errorf("Expected no counter config for %s, got %+v", dc, cc)
+			for dc, wantConfigs := range tt.wantCounterConfigsList {
+				ccs := mapper.getCounterConfigs(dc)
+				if len(ccs) != len(wantConfigs) {
+					t.Fatalf("Counter configs for %s: want %d, got %d", dc, len(wantConfigs), len(ccs))
+				}
+				for i, want := range wantConfigs {
+					if ccs[i].quotaResource != want.quotaResource {
+						t.Errorf("Counter config[%d] for %s: want quotaResource %s, got %s", i, dc, want.quotaResource, ccs[i].quotaResource)
+					}
+					if ccs[i].counterName != want.counterName {
+						t.Errorf("Counter config[%d] for %s: want counterName %s, got %s", i, dc, want.counterName, ccs[i].counterName)
+					}
+					if ccs[i].driver != want.driver {
+						t.Errorf("Counter config[%d] for %s: want driver %s, got %s", i, dc, want.driver, ccs[i].driver)
 					}
 				}
 			}

--- a/pkg/dra/resourceslice_cache.go
+++ b/pkg/dra/resourceslice_cache.go
@@ -1,0 +1,84 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"context"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const allDriversKey = ""
+
+// ResourceSliceCache is a request-scoped cache for ResourceSlice listings.
+// It is created once per workload reconciliation and passed to both the CEL
+// validation and counter processing paths to avoid duplicate API calls and
+// ensure a consistent snapshot of ResourceSlices within a single reconciliation.
+type ResourceSliceCache struct {
+	client       client.Client
+	cachedSlices map[string][]resourcev1.ResourceSlice
+}
+
+// NewResourceSliceCache creates a new ResourceSliceCache.
+func NewResourceSliceCache(cl client.Client) *ResourceSliceCache {
+	return &ResourceSliceCache{
+		client:       cl,
+		cachedSlices: make(map[string][]resourcev1.ResourceSlice),
+	}
+}
+
+// ListByDriver returns ResourceSlices for the given driver, using the spec.driver
+// field index for efficient listing. Results are cached for subsequent calls with
+// the same driver within the same reconciliation.
+func (c *ResourceSliceCache) ListByDriver(ctx context.Context, driver string) ([]resourcev1.ResourceSlice, error) {
+	if slices, ok := c.cachedSlices[driver]; ok {
+		return slices, nil
+	}
+	if allSlices, ok := c.cachedSlices[allDriversKey]; ok {
+		var filtered []resourcev1.ResourceSlice
+		for i := range allSlices {
+			if allSlices[i].Spec.Driver == driver {
+				filtered = append(filtered, allSlices[i])
+			}
+		}
+		c.cachedSlices[driver] = filtered
+		return filtered, nil
+	}
+	var sliceList resourcev1.ResourceSliceList
+	if err := c.client.List(ctx, &sliceList, client.MatchingFields{"spec.driver": driver}); err != nil {
+		return nil, err
+	}
+	c.cachedSlices[driver] = sliceList.Items
+	return sliceList.Items, nil
+}
+
+// ListAll returns all ResourceSlices in the cluster without filtering.
+// Used as a fallback when the driver is not known (e.g., whole-device
+// DeviceClasses without counter sources). Results are cached for subsequent
+// calls within the same reconciliation.
+func (c *ResourceSliceCache) ListAll(ctx context.Context) ([]resourcev1.ResourceSlice, error) {
+	if slices, ok := c.cachedSlices[allDriversKey]; ok {
+		return slices, nil
+	}
+	var sliceList resourcev1.ResourceSliceList
+	if err := c.client.List(ctx, &sliceList); err != nil {
+		return nil, err
+	}
+	c.cachedSlices[allDriversKey] = sliceList.Items
+	return sliceList.Items, nil
+}

--- a/pkg/dra/resourceslice_cache_test.go
+++ b/pkg/dra/resourceslice_cache_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+func newSlice(name, driver, pool string) *resourcev1.ResourceSlice {
+	return &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver: driver,
+			Pool: resourcev1.ResourcePool{
+				Name:               pool,
+				Generation:         1,
+				ResourceSliceCount: 1,
+			},
+		},
+	}
+}
+
+func TestResourceSliceCache_ListByDriver(t *testing.T) {
+	gpuSlice1 := newSlice("gpu-slice-1", "gpu.nvidia.com", "node1")
+	gpuSlice2 := newSlice("gpu-slice-2", "gpu.nvidia.com", "node2")
+	nicSlice := newSlice("nic-slice", "nic.mellanox.com", "node1")
+
+	cl := utiltesting.NewClientBuilder().
+		WithIndex(&resourcev1.ResourceSlice{}, "spec.driver", func(obj client.Object) []string {
+			return []string{obj.(*resourcev1.ResourceSlice).Spec.Driver}
+		}).
+		WithObjects(gpuSlice1, gpuSlice2, nicSlice).
+		Build()
+
+	ctx := t.Context()
+	cache := NewResourceSliceCache(cl)
+
+	t.Run("returns only requested driver slices", func(t *testing.T) {
+		got, err := cache.ListByDriver(ctx, "gpu.nvidia.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected 2 gpu slices, got %d", len(got))
+		}
+	})
+
+	t.Run("second call returns cached result", func(t *testing.T) {
+		got1, _ := cache.ListByDriver(ctx, "gpu.nvidia.com")
+		got2, _ := cache.ListByDriver(ctx, "gpu.nvidia.com")
+		if diff := cmp.Diff(got1, got2, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+			t.Errorf("cached result mismatch (-first +second):\n%s", diff)
+		}
+	})
+
+	t.Run("different driver returns different slices", func(t *testing.T) {
+		got, err := cache.ListByDriver(ctx, "nic.mellanox.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 1 {
+			t.Errorf("expected 1 nic slice, got %d", len(got))
+		}
+	})
+}
+
+func TestResourceSliceCache_ListAll(t *testing.T) {
+	gpuSlice := newSlice("gpu-slice", "gpu.nvidia.com", "node1")
+	nicSlice := newSlice("nic-slice", "nic.mellanox.com", "node1")
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(gpuSlice, nicSlice).
+		Build()
+
+	ctx := t.Context()
+	cache := NewResourceSliceCache(cl)
+
+	t.Run("returns all slices", func(t *testing.T) {
+		got, err := cache.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Errorf("expected 2 slices, got %d", len(got))
+		}
+	})
+
+	t.Run("second call returns cached result", func(t *testing.T) {
+		got1, _ := cache.ListAll(ctx)
+		got2, _ := cache.ListAll(ctx)
+		if diff := cmp.Diff(got1, got2, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
+			t.Errorf("cached result mismatch (-first +second):\n%s", diff)
+		}
+	})
+}
+
+func TestResourceSliceCache_ListAllThenListByDriver(t *testing.T) {
+	gpuSlice1 := newSlice("gpu-slice-1", "gpu.nvidia.com", "node1")
+	gpuSlice2 := newSlice("gpu-slice-2", "gpu.nvidia.com", "node2")
+	nicSlice := newSlice("nic-slice", "nic.mellanox.com", "node1")
+
+	listCallCount := 0
+	cl := utiltesting.NewClientBuilder().
+		WithIndex(&resourcev1.ResourceSlice{}, "spec.driver", func(obj client.Object) []string {
+			return []string{obj.(*resourcev1.ResourceSlice).Spec.Driver}
+		}).
+		WithObjects(gpuSlice1, gpuSlice2, nicSlice).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listCallCount++
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	ctx := t.Context()
+	cache := NewResourceSliceCache(cl)
+
+	// First call: ListAll fetches everything
+	allSlices, err := cache.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("ListAll failed: %v", err)
+	}
+	if len(allSlices) != 3 {
+		t.Errorf("expected 3 slices from ListAll, got %d", len(allSlices))
+	}
+	if listCallCount != 1 {
+		t.Errorf("expected 1 API call after ListAll, got %d", listCallCount)
+	}
+
+	// Second call: ListByDriver filters from cached all-slices, no extra API call
+	gpuSlices, err := cache.ListByDriver(ctx, "gpu.nvidia.com")
+	if err != nil {
+		t.Fatalf("ListByDriver failed: %v", err)
+	}
+	if len(gpuSlices) != 2 {
+		t.Errorf("expected 2 gpu slices from ListByDriver, got %d", len(gpuSlices))
+	}
+	if listCallCount != 1 {
+		t.Errorf("expected still 1 API call after ListByDriver (should use cache), got %d", listCallCount)
+	}
+}
+
+func TestResourceSliceCache_ListByDriverThenListByDriverDifferent(t *testing.T) {
+	gpuSlice := newSlice("gpu-slice", "gpu.nvidia.com", "node1")
+	nicSlice := newSlice("nic-slice", "nic.mellanox.com", "node1")
+
+	listCallCount := 0
+	cl := utiltesting.NewClientBuilder().
+		WithIndex(&resourcev1.ResourceSlice{}, "spec.driver", func(obj client.Object) []string {
+			return []string{obj.(*resourcev1.ResourceSlice).Spec.Driver}
+		}).
+		WithObjects(gpuSlice, nicSlice).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				listCallCount++
+				return cl.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	ctx := t.Context()
+	cache := NewResourceSliceCache(cl)
+
+	_, _ = cache.ListByDriver(ctx, "gpu.nvidia.com")
+	if listCallCount != 1 {
+		t.Errorf("expected 1 API call, got %d", listCallCount)
+	}
+
+	_, _ = cache.ListByDriver(ctx, "nic.mellanox.com")
+	if listCallCount != 2 {
+		t.Errorf("expected 2 API calls for different drivers, got %d", listCallCount)
+	}
+
+	// Same driver again — should be cached
+	_, _ = cache.ListByDriver(ctx, "gpu.nvidia.com")
+	if listCallCount != 2 {
+		t.Errorf("expected still 2 API calls (gpu cached), got %d", listCallCount)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

#### What type of PR is this?
/kind feature
/area dra

#### What this PR does / why we need it:
Addresses PD beta graduation criteria from https://github.com/kubernetes-sigs/kueue/issues/11903
- **ResourceSliceCache** : request-scoped cache shared between CEL validation and counter processing, with driver-indexed listing for counter DeviceClasses and fallback to `ListAll()` for others. Eliminates duplicate API calls within a single workload reconciliation.
- **ConsumesCounters iteration**: removed `break` to iterate all entries per device, consistent with the upstream K8s allocator.
- **Multi-counter tracking**: relaxed DeviceClass uniqueness constraint to allow the same DeviceClass in multiple mappings when both have counter sources with different counter names. Rejects mixing whole-device and counter paths, and rejects duplicate counter names.

#### Which issue(s) this PR fixes:
Partially addresses https://github.com/kubernetes-sigs/kueue/issues/11903

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
DRA Partitionable Devices: support multi-counter tracking by allowing the same DeviceClass in multiple deviceClassMappings with different counter sources. Add ResourceSliceCache for consolidated ResourceSlice listing. 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected partitionable-device quota charging when multiple counter sources are present by using the maximum applicable counter value across counter sets.
  * Improved validation for device class mappings: allow reusing the same device class with different counter names, while rejecting incompatible duplicate/mixed whole-device vs counter-backed configurations.
  * Strengthened pool-aware counter handling to improve accurate resource assignment for partitionable devices.
* **Performance**
  * Reduced repeated resource discovery during workload processing by reusing a request-scoped cache of ResourceSlices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->