### PR TITLE
Update QuotaReserved reasons for integrations

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -560,9 +560,13 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 					// The requeued condition status set to true only on EvictedByPreemption
 					setRequeued := (evCond.Reason == kueue.WorkloadEvictedByPreemption) || (evCond.Reason == kueue.WorkloadEvictedDueToNodeFailures)
 					updated := workload.SetRequeuedCondition(wl, evCond.Reason, evCond.Message, setRequeued)
+					reason := workload.UnadmittedWorkloadReasonWithFallback(
+						kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+						kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+					)
 					if workload.UnsetQuotaReservationWithCondition(
 						wl,
-						kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+						reason,
 						evCond.Message,
 						r.clock.Now(),
 					) {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -19,6 +19,7 @@ package jobframework_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
@@ -1109,6 +1111,85 @@ func TestReconcileGenericJobWithWaitForPodsReady(t *testing.T) {
 				}}, tc.job)
 			if !errors.Is(err, tc.wantError) {
 				t.Errorf("unexpected reconcile error want %s got %s)", tc.wantError, err)
+			}
+		})
+	}
+}
+
+func TestReconcileGenericJob_EvictionClearsQuotaReservation(t *testing.T) {
+	scenarios := []map[featuregate.Feature]bool{
+		{
+			features.UnadmittedWorkloadsObservability: false,
+		},
+		{
+			features.UnadmittedWorkloadsObservability: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(fmt.Sprintf("UnadmittedWorkloadsObservability enabled: %t", scenario[features.UnadmittedWorkloadsObservability]), func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, scenario)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			mockctrl := gomock.NewController(t)
+
+			podSets := []kueue.PodSet{
+				*utiltestingapi.MakePodSet("main", 1).Obj(),
+			}
+
+			job := testingjob.MakeJob("job-1", "ns").Queue("cq").UID("job-1").Suspend(true).Obj()
+
+			wl := utiltestingapi.MakeWorkload("job-1", "ns").
+				PodSets(podSets...).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadEvicted,
+					Status: metav1.ConditionTrue,
+					Reason: kueue.WorkloadEvictedByPreemption,
+				}).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job-1", "job-1").
+				Obj()
+
+			mgj := mocks.NewMockGenericJob(mockctrl)
+			mgj.EXPECT().Object().Return(job).AnyTimes()
+			mgj.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+			mgj.EXPECT().IsSuspended().Return(true).AnyTimes()
+			mgj.EXPECT().IsActive().Return(false).AnyTimes()
+			mgj.EXPECT().Finished(gomock.Any()).Return("", false, false).AnyTimes()
+			mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(podSets, nil).AnyTimes()
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+			gvk := batchv1.SchemeGroupVersion.WithKind("Job")
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(job, wl, ns).
+				WithStatusSubresource(job, wl).
+				WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(gvk), indexer.WorkloadOwnerIndexFunc(gvk))
+			cl := clientBuilder.Build()
+
+			recorder := &utiltesting.EventRecorder{}
+			r := NewReconciler(cl, recorder)
+
+			req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "job-1"}}
+			_, err := r.ReconcileGenericJob(ctx, req, mgj)
+			if err != nil {
+				t.Fatalf("ReconcileGenericJob() error: %v", err)
+			}
+
+			var gotWl kueue.Workload
+			if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "job-1"}, &gotWl); err != nil {
+				t.Fatalf("failed to get workload: %v", err)
+			}
+
+			wantReason := kueue.WorkloadPending //nolint:staticcheck // SA1019: fallback
+			if scenario[features.UnadmittedWorkloadsObservability] {
+				wantReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+			}
+
+			cond := apimeta.FindStatusCondition(gotWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if cond == nil {
+				t.Fatalf("QuotaReserved condition not found")
+			}
+			if cond.Status != metav1.ConditionFalse || cond.Reason != wantReason {
+				t.Errorf("Unexpected QuotaReserved condition status/reason: got %s/%s, want False/%s", cond.Status, cond.Reason, wantReason)
 			}
 		})
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -276,11 +276,15 @@ func (r *Reconciler) clearOnHold(ctx context.Context, wl *kueue.Workload) error 
 		return nil
 	}
 	return clientutil.PatchStatus(ctx, r.client, wl, func() (bool, error) {
-		// Change the QuotaReserved reason from "OnHold" to "Pending"
+		// Change the QuotaReserved reason from "OnHold" to "PendingEvaluation" / "Pending"
 		// so the workload becomes admissible again and can be requeued.
+		reason := workload.UnadmittedWorkloadReasonWithFallback(
+			kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+			kueue.WorkloadPending, //nolint:staticcheck // SA1019: fallback
+		)
 		changed := workload.UnsetQuotaReservationWithCondition(
 			wl,
-			"Pending",
+			reason,
 			"Workload no longer on hold; waiting for quota reservation",
 			metav1.Now().Time,
 		)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package statefulset
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
@@ -653,6 +655,78 @@ func TestHandle(t *testing.T) {
 			got := r.handle(tc.obj)
 			if got != tc.want {
 				t.Errorf("handle(%T) = %v, want %v", tc.obj, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestReconciler_ClearOnHoldSetsReason(t *testing.T) {
+	scenarios := []map[featuregate.Feature]bool{
+		{
+			features.UnadmittedWorkloadsObservability: false,
+		},
+		{
+			features.UnadmittedWorkloadsObservability: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(fmt.Sprintf("UnadmittedWorkloadsObservability enabled: %t", scenario[features.UnadmittedWorkloadsObservability]), func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, scenario)
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Replicas(1).
+				Queue("lq").
+				Obj()
+
+			wl := utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: kueue.WorkloadOnHold,
+				}).
+				Obj()
+
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(sts, wl).
+				WithStatusSubresource(sts, wl)
+			indexer := utiltesting.AsIndexer(clientBuilder)
+			err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName)
+			if err != nil {
+				t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+			}
+			cl := clientBuilder.Build()
+
+			reconciler, err := NewReconciler(ctx, cl, indexer, &utiltesting.EventRecorder{})
+			if err != nil {
+				t.Fatalf("NewReconciler() error: %v", err)
+			}
+
+			req := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}}
+			_, err = reconciler.Reconcile(ctx, req)
+			if err != nil {
+				t.Fatalf("Reconcile() error: %v", err)
+			}
+
+			var gotWl kueue.Workload
+			if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: wl.Name}, &gotWl); err != nil {
+				t.Fatalf("failed to get workload: %v", err)
+			}
+
+			wantReason := kueue.WorkloadPending //nolint:staticcheck // SA1019: fallback
+			if scenario[features.UnadmittedWorkloadsObservability] {
+				wantReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+			}
+
+			cond := apimeta.FindStatusCondition(gotWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if cond == nil {
+				t.Fatalf("QuotaReserved condition not found")
+			}
+			if cond.Status != metav1.ConditionFalse || cond.Reason != wantReason {
+				t.Errorf("Unexpected QuotaReserved condition status/reason: got %s/%s, want False/%s", cond.Status, cond.Reason, wantReason)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When the `UnadmittedWorkloadsObservability` feature gate is enabled, workloads whose quota reservations are released should report granular reasons (such as `PendingEvaluation`) on their `QuotaReserved: False` status condition rather than hardcoding the legacy `Pending` reason.

This PR updates the `JobFramework` and `StatefulSet` workload integrations to use `PendingEvaluation`:
* JobFramework: when unsetting quota reservations for evicted generic/custom jobs (`ReconcileGenericJob`).
* StatefulSet: when clearing the `OnHold` status when scaling up from zero (`clearOnHold`).

#### Which issue(s) this PR fixes:

Part of #10852 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Workload: When `UnadmittedWorkloadsObservability` is enabled, releasing quota reservation in JobFramework and StatefulSet controllers reports `QuotaReserved: False` with the `PendingEvaluation` reason instead of `Pending`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed quota-reservation condition clearing after evicted workloads, now using the correct unadmitted/pending reason (including the pending-evaluation reason when observability is enabled).
  * Updated StatefulSet “clear on hold” behavior to set the quota-reservation reason based on the observability feature gate instead of always using the generic pending reason.
  * Ensured quota reservation conditions are consistently cleared/marked inactive while reporting the appropriate reason for the workload’s current state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->