### PR TITLE
Graduate ManagedJobsNamespaceSelectorAlwaysRespected to GA

### DIFF
--- a/keps/3589-manage-jobs-selectively/README.md
+++ b/keps/3589-manage-jobs-selectively/README.md
@@ -8,6 +8,7 @@
 - [Proposal](#proposal)
   - [Until v0.12](#until-v012)
   - [Since Kueue v0.13](#since-kueue-v013)
+  - [Since Kueue v0.19](#since-kueue-v019)
   - [User Stories (Optional)](#user-stories-optional)
     - [Story 1](#story-1)
     - [Story 2](#story-2)
@@ -114,6 +115,13 @@ This change brings the Job integration into consistent alignment with Pod, Deplo
 and StatefulSet integrations, which already do not act on resources in non-opted-in namespaces.
 
 We deprecate `podOptions.namespaceSelector` and remove it in a future release.
+
+### Since Kueue v0.19
+
+The `ManagedJobsNamespaceSelectorAlwaysRespected` feature gate is graduated to GA and locked 
+to enabled. The `managedJobsNamespaceSelector` now always restricts the reconciliation of all 
+workloads regardless of whether they have a `kueue.x-k8s.io/queue-name` label. The legacy 
+behavior (gate disabled) is no longer available.
 
 ### User Stories (Optional)
 

--- a/keps/3589-manage-jobs-selectively/kep.yaml
+++ b/keps/3589-manage-jobs-selectively/kep.yaml
@@ -17,12 +17,12 @@ stage: stable
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.13"
+latest-milestone: "v0.19"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  beta: "v0.10"
-  stable: "v0.13"
+  beta: "v0.15"
+  stable: "v0.19"
 
 feature-gates:
   - name: ManagedJobsNamespaceSelector

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -310,23 +310,21 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	if features.Enabled(features.ManagedJobsNamespaceSelectorAlwaysRespected) {
-		ns := corev1.Namespace{}
-		if err := r.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
-			if apierrors.IsNotFound(err) {
-				log.V(2).Info("Namespace not found; skipping selector check", "namespace", req.Namespace)
-				return ctrl.Result{}, nil
-			}
-			log.Error(err, "failed to get namespace for selector check")
-			return ctrl.Result{}, err
-		}
-
-		if r.managedJobsNamespaceSelector == nil {
-			log.V(2).Info("ManagedJobsNamespaceSelector is nil; skipping selector enforcement")
-		} else if !r.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
-			log.V(2).Info("Namespace not opted in for Kueue management", "namespace", ns.Name)
+	ns := corev1.Namespace{}
+	if err := r.client.Get(ctx, client.ObjectKey{Name: req.Namespace}, &ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.V(2).Info("Namespace not found; skipping selector check", "namespace", req.Namespace)
 			return ctrl.Result{}, nil
 		}
+		log.Error(err, "failed to get namespace for selector check")
+		return ctrl.Result{}, err
+	}
+
+	if r.managedJobsNamespaceSelector == nil {
+		log.V(2).Info("ManagedJobsNamespaceSelector is nil; skipping selector enforcement")
+	} else if !r.managedJobsNamespaceSelector.Matches(labels.Set(ns.GetLabels())) {
+		log.V(2).Info("Namespace not opted in for Kueue management", "namespace", ns.Name)
+		return ctrl.Result{}, nil
 	}
 
 	var (

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -701,9 +701,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to False before Workload is Admitted": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -727,9 +727,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to False after Workload is Admitted but not all Pods reached readiness": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -753,9 +753,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to False after Workload is Admitted, some Pods became ready but not all Pods reached readiness": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -793,9 +793,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -829,9 +829,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to True after Workload is Admitted and all Pods reached readiness without previous PodsReady condition": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -859,9 +859,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to False after Workload is running and one pod failed": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -897,9 +897,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady continues to be False after a pod failed and workload is still recovering": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -937,9 +937,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to True after failing pod recovered": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -973,9 +973,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady=False has the new Reason if there was the old one before (pre v0.11.0)": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -1005,9 +1005,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady=True has the new Reason if there was the old one before (pre v0.11.0)": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -1041,9 +1041,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodsReady is set to False if there's an invalid Reason (pre v0.11.0)": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
@@ -1073,9 +1073,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"PodSet label and Workload annotation are set when Job is starting; TopologyAwareScheduling enabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     true,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: true,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -1110,9 +1110,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"Pod queue labels are not set when AssignQueueLabelsForPods is disabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    false,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: false,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1140,9 +1140,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"Pod cluster queue label is not set when cluster queue name is too long": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1179,9 +1179,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is created, it has its owner ProvReq annotations": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				SetAnnotation(controllerconsts.ProvReqAnnotationPrefix+"test-annotation", "test-val").
@@ -1216,9 +1216,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is created, it has correct labels set": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Label("toCopyKey", "toCopyValue").
@@ -1256,9 +1256,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted the PodSetUpdates are propagated to job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -1313,9 +1313,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to spec.active field being false, job gets suspended and quota is unset": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -1400,9 +1400,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is active after deactivation; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
@@ -1495,9 +1495,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is manually deactivated; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should not delete the job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
@@ -1590,9 +1590,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
@@ -1688,9 +1688,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has not expired": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
@@ -1783,9 +1783,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=60; retention period has expired": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithObjectRetentionPolicies(&configapi.ObjectRetentionPolicies{
@@ -1881,9 +1881,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to pods ready timeout, job gets suspended and quota is unset": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -1942,9 +1942,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to admission check, job gets suspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -2027,9 +2027,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to cluster queue stopped, job gets suspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -2112,9 +2112,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to local queue stopped, job gets suspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -2197,9 +2197,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted due to preemption, job gets suspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(false).
@@ -2283,9 +2283,9 @@ func TestReconciler(t *testing.T) {
 		"when job is initially suspended, the Workload has active=false and it's not admitted, " +
 			"it should not get an evicted condition, but the job should remain suspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(true).
@@ -2358,9 +2358,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on labels, the workload is finished with failure": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2433,9 +2433,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on annotations, the workload is finished with failure": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2508,9 +2508,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission checks on nodeSelector, the workload is finished with failure": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2583,9 +2583,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted and PodSetUpdates conflict between admission check nodeSelector and current node selector, the workload is finished with failure": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				NodeSelector("provisioning", "spot").
@@ -2637,9 +2637,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is admitted the PodSetUpdates values matching for key": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			wantJob: *baseJobWrapper.Clone().
@@ -2750,9 +2750,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"suspended job with matching admitted workload is unsuspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -2786,9 +2786,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"non-matching admitted workload is deleted": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -2814,9 +2814,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"non-matching non-admitted workload is updated": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -2850,9 +2850,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"suspended job with partial admission and admitted workload is unsuspended": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -2903,9 +2903,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"unsuspended job with partial admission and non-matching admitted workload is suspended and workload is deleted": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -2949,9 +2949,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is created when queue name is set": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -2992,9 +2992,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is updated when queue name has changed for suspended job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3032,9 +3032,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is updated when priority class has changed for suspended job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3085,9 +3085,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"shouldn't update workload when priority class no changes": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3130,9 +3130,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload without uid label is created when job's uid is longer than 63 characters": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3171,9 +3171,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is not created when queue name is not set": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: utiltestingjob.MakeJob("job", "ns").
 				Suspend(false).
@@ -3184,9 +3184,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"non-standalone job is suspended if its parent workload is not found": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3218,9 +3218,9 @@ func TestReconciler(t *testing.T) {
 				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
 			},
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3257,9 +3257,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"non-standalone job is suspended if its parent workload is found and not admitted": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -3305,9 +3305,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"non-standalone job is not suspended if its parent workload is admitted and queue name is set": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3348,9 +3348,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"checking a second non-matching workload is deleted": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManageJobsWithoutQueueName(true),
@@ -3435,9 +3435,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted but suspended, reset startTime and restore node affinity": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(true).
@@ -3470,9 +3470,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when workload is evicted, suspended and startTime is reset, restore node affinity": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(true).
@@ -3504,9 +3504,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when job completes, workload is marked as finished": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{
@@ -3552,9 +3552,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when the workload is finished, its finalizer is removed": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.DeepCopy(),
 			workloads: []kueue.Workload{
@@ -3596,9 +3596,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3645,9 +3645,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is created when queue name is set, with PriorityClass": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3694,9 +3694,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is created when queue name is set, with workloadPriorityClass and PriorityClass": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3745,9 +3745,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload shouldn't be recreated for the completed job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
@@ -3760,9 +3760,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when the prebuilt workload is missing, no new one is created, the job is suspended and prebuilt workload not found error is returned": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3787,9 +3787,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when the prebuilt workload exists its owner info is updated": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3835,9 +3835,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when the prebuilt workload is owned by another object": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3882,9 +3882,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"when the prebuilt workload is not equivalent to the job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.
 				Clone().
@@ -3937,9 +3937,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is not admitted, tolerations and node selector change": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
@@ -4006,9 +4006,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is admitted, tolerations and node selector change": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
@@ -4085,9 +4085,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the workload is admitted, job still suspended and tolerations change": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().Toleration(corev1.Toleration{
 				Key:      "tolerationkey2",
@@ -4140,9 +4140,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"admission check message is emitted as event for job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(true).
@@ -4195,9 +4195,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"multiple admission check messages are emitted as a single event for job": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Suspend(true).
@@ -4260,9 +4260,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the maximum execution time is passed to the created workload": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
@@ -4291,9 +4291,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"the maximum execution time is updated in the workload": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			job: baseJobWrapper.Clone().
 				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
@@ -4332,9 +4332,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"job with queue name is not reconciled in unlabelled namespace when AlwaysRespected is enabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{
@@ -4355,9 +4355,9 @@ func TestReconciler(t *testing.T) {
 		},
 		"job with queue name is reconciled in labelled namespace when AlwaysRespected is enabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.TopologyAwareScheduling:                     false,
-				features.ManagedJobsNamespaceSelectorAlwaysRespected: true,
-				features.AssignQueueLabelsForPods:                    true,
+				features.TopologyAwareScheduling: false,
+
+				features.AssignQueueLabelsForPods: true,
 			},
 			reconcilerOptions: []jobframework.Option{
 				jobframework.WithManagedJobsNamespaceSelector(labels.SelectorFromSet(map[string]string{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -580,6 +580,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	ManagedJobsNamespaceSelectorAlwaysRespected: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	},
 	TASBalancedPlacement: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/tasks/manage/enforce_job_management/opt_in_namespace_management.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/opt_in_namespace_management.md
@@ -72,26 +72,15 @@ Configure the `managedJobsNamespaceSelector` in your Kueue Configuration with `m
 
    Exclusion of `kube-system` and `kueue-system` is the default behaviour of kueue. For production environments consider explicitly selecting the namespaces you want kueue to manage, otherwise you have to exclude all system components your cluster (CNI, CSI, monitoring, gitops, etc).
 
-### Step 3: Enable the Feature Gate
+## How It Works
 
-This step is optional if you're using Kueue v0.15 or later, as the `ManagedJobsNamespaceSelectorAlwaysRespected` feature gate is enabled by default. If you're using an older version of Kueue, you need to explicitly enable this feature gate. See the [feature gates for alpha and beta features](/docs/installation/#feature-gates-for-alpha-and-beta-features) section for the feature gate status.
+The `managedJobsNamespaceSelector` restricts the reconciliation of all workloads, regardless of whether they have a `kueue.x-k8s.io/queue-name` label.
 
-## Feature Gate Details
-
-The `ManagedJobsNamespaceSelectorAlwaysRespected` feature gate controls whether the `managedJobsNamespaceSelector` restricts the reconciliation of all workloads, regardless of whether they have a `kueue.x-k8s.io/queue-name` label.
-
-### How It Works
-
-When this feature gate is **enabled**:
 - The namespace selector check happens **first**, before any other reconciliation logic.
 - If a workload's namespace does not match the `managedJobsNamespaceSelector` (and the selector is not nil), the workload will not be reconciled by Kueue — regardless of whether it has a `queue-name` label or the value of `manageJobsWithoutQueueName`.
 - If a workload's namespace matches the selector (or if `managedJobsNamespaceSelector` is nil), normal reconciliation logic applies:
   - If `manageJobsWithoutQueueName=false`: Kueue will manage exactly those instances of supported Kinds that have a `queue-name` label.
   - If `manageJobsWithoutQueueName=true`: Kueue will manage all instances of supported Kinds with or without `queue-name` label.
-
-When this feature gate is **disabled** (default behavior prior to v0.13):
-- If `manageJobsWithoutQueueName` is false, `managedJobsNamespaceSelector` has no effect: Kueue will manage exactly those instances of supported Kinds that have a `queue-name` label.
-- If `manageJobsWithoutQueueName` is true, then Kueue will (a) manage all instances of supported Kinds that have a `queue-name` label and (b) will manage all instances of supported Kinds that do not have a `queue-name` label if they are in namespaces that match `managedJobsNamespaceSelector`.
 
 ## Related Documentation
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -171,6 +171,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.19"
 - name: MetricForWorkloadCreationLatency
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -171,6 +171,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.19"
 - name: MetricForWorkloadCreationLatency
   versionedSpecs:
   - default: true

--- a/test/e2e/sequential/baseline/reconcile_test.go
+++ b/test/e2e/sequential/baseline/reconcile_test.go
@@ -26,7 +26,6 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -53,7 +52,6 @@ var _ = ginkgo.Describe(
 
 		ginkgo.BeforeAll(func() {
 			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
-				cfg.FeatureGates = map[string]bool{string(features.ManagedJobsNamespaceSelectorAlwaysRespected): true}
 				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
 						{

--- a/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/extended/managejobswithoutqueuename_test.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
-	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -617,7 +616,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 	})
 })
 
-var _ = ginkgo.Describe("ManageJobsWithoutQueueName with ManagedJobsNamespaceSelectorAlwaysRespected=false", ginkgo.Label("feature:managejobswithoutqueuename"), func() {
+var _ = ginkgo.Describe("ManageJobsWithoutQueueName with namespace selector excluding test namespace", ginkgo.Label("feature:managejobswithoutqueuename"), func() {
 	var (
 		ns           *corev1.Namespace
 		defaultRf    *kueue.ResourceFlavor
@@ -644,7 +643,6 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName with ManagedJobsNamespaceSel
 		// Unfortunately, we can't move it to BeforeAll, due to we need to know the namespace name.
 		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
 			cfg.ManageJobsWithoutQueueName = true
-			cfg.FeatureGates = map[string]bool{string(features.ManagedJobsNamespaceSelectorAlwaysRespected): false}
 			cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{{
 					Key:      "kubernetes.io/metadata.name",

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4933,65 +4933,35 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 		fwk.StopManager(ctx)
 	})
 
-	ginkgo.When("ManagedJobsNamespaceSelectorAlwaysRespected enabled", func() {
-		ginkgo.BeforeEach(func() {
-			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ManagedJobsNamespaceSelectorAlwaysRespected, true)
-		})
+	ginkgo.It("should not reconcile a job in an unmanaged namespace", func() {
+		job := testingjob.MakeJob("unmanaged-job", unmanagedNs.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Suspend(true).
+			Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+			Obj()
 
-		ginkgo.It("should not reconcile a job in an unmanaged namespace", func() {
-			job := testingjob.MakeJob("unmanaged-job", unmanagedNs.Name).
-				Queue(kueue.LocalQueueName(lq.Name)).
-				Suspend(true).
-				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
-				Obj()
+		gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 
-			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
-
-			wls := &kueue.WorkloadList{}
-			gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
-			gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
-		})
-
-		ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {
-			job := testingjob.MakeJob("managed-job", managedNs.Name).
-				Queue(kueue.LocalQueueName(lq.Name)).
-				Suspend(true).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Obj()
-
-			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
-
-			ginkgo.By("check that only one workload is created", func() {
-				createdWorkloads := &kueue.WorkloadList{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.List(ctx, createdWorkloads, client.InNamespace(managedNs.Name))).To(gomega.Succeed())
-					g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
+		wls := &kueue.WorkloadList{}
+		gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
+		gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
 	})
 
-	ginkgo.When("ManagedJobsNamespaceSelectorAlwaysRespected disabled", func() {
-		ginkgo.BeforeEach(func() {
-			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ManagedJobsNamespaceSelectorAlwaysRespected, false)
-		})
+	ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {
+		job := testingjob.MakeJob("managed-job", managedNs.Name).
+			Queue(kueue.LocalQueueName(lq.Name)).
+			Suspend(true).
+			Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+			Obj()
 
-		ginkgo.It("should reconcile a job in an unmanaged namespace with queue name set and create a workload", func() {
-			job := testingjob.MakeJob("unmanaged-job-with-queue-name", unmanagedNs.Name).
-				Queue(kueue.LocalQueueName(lq.Name)).
-				Suspend(true).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Obj()
+		gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 
-			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
-
-			ginkgo.By("check that only one workload is created", func() {
-				createdWorkloads := &kueue.WorkloadList{}
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.List(ctx, createdWorkloads, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
-					g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
+		ginkgo.By("check that only one workload is created", func() {
+			createdWorkloads := &kueue.WorkloadList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.List(ctx, createdWorkloads, client.InNamespace(managedNs.Name))).To(gomega.Succeed())
+				g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 })


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially Fixes #12927 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduate ManagedJobsNamespaceSelectorAlwaysRespected to GA
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace selectors are now always enforced when determining which workloads are reconciled, independent of `queue-name` labeling.
  * The namespace-selector behavior is now GA and permanently enabled (locked) as of Kueue v0.19.
  * Workloads in namespaces that don’t match the selector are no longer reconciled.

* **Documentation**
  * Updated the guide to describe the always-enforced namespace selector behavior and simplified the page structure.

* **Tests**
  * Updated and broadened test coverage to run without feature-gate scoping and validate the new default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->