### PR TITLE
Fix the flaky e2e tests for Prometheus

### DIFF
--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -187,21 +186,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
 
 			ginkgo.By("Verifying Prometheus discovers and scrapes the Kueue target")
-			gomega.Eventually(func(g gomega.Gomega) {
-				result, err := prometheusClient.Targets(ctx)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-
-				hasKueueTarget := false
-				for _, t := range result.Active {
-					if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
-						t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
-						hasKueueTarget = true
-						g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
-						break
-					}
-				}
-				g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectPrometheusTargetForKueue(ctx, prometheusClient)
 
 			ginkgo.By("Verifying admission metric is available via PromQL")
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 
@@ -38,21 +37,7 @@ const (
 
 var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:prometheus"), func() {
 	ginkgo.It("should discover Kueue target and report it as up", func() {
-		gomega.Eventually(func(g gomega.Gomega) {
-			result, err := prometheusClient.Targets(ctx)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-
-			hasKueueTarget := false
-			for _, t := range result.Active {
-				if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
-					t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
-					hasKueueTarget = true
-					g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
-					break
-				}
-			}
-			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectPrometheusTargetForKueue(ctx, prometheusClient)
 	})
 
 	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -17,13 +17,16 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"strconv"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics/testutil"
 
@@ -384,4 +387,23 @@ func ExpectPodSchedulingGateRemovalSecondsMetricLessOrEqual(name string, cqName 
 	ginkgo.GinkgoHelper()
 	matcher := gomega.Equal(count)
 	expectHistogramMetric(metrics.PodSchedulingGateRemovalSeconds, matcher, name, string(cqName), strconv.FormatBool(isGroup))
+}
+
+func ExpectPrometheusTargetForKueue(ctx context.Context, prometheusClient prometheusv1.API) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		result, err := prometheusClient.Targets(ctx)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		hasKueueTarget := false
+		for _, t := range result.Active {
+			if t.Labels["job"] == model.LabelValue(DefaultMetricsServiceName) &&
+				t.Labels["namespace"] == model.LabelValue(GetKueueNamespace()) {
+				hasKueueTarget = true
+				g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
+				break
+			}
+		}
+		g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
+	}, VeryLongTimeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION

#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13024

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of Prometheus metrics scraping over TLS by simplifying how the Kueue target is detected and verified.
  * Added centralized checks to ensure the Kueue metrics target appears among active Prometheus targets, includes the expected labels, and reports healthy status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->