### PR TITLE
Cleanup: Follow up on fixed stable domain sorting for deterministic TAS placement on score ties

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -20,8 +20,6 @@ import (
 	"maps"
 	"math"
 	"slices"
-
-	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
 
 // evaluateGreedyAssignment simulates placement of a (leaderCount, sliceCount) request on the given domains.
@@ -78,17 +76,17 @@ func balanceThresholdValue(sliceCount int32, selectedDomainsCount int32, lastDom
 // the request (sliceCount, leaderCount). It uses dynamic programming to find a combination
 // of domains that can fit the requested number of leaders and slices, using the minimum number
 // of domains possible (as determined by a greedy assignment) and having the minimum total capacity.
-func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceCount int32, leaderCount int32, sliceSize int32, priorizeByEntropy bool) []*domain {
+func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceCount int32, leaderCount int32, sliceSize int32, prioritizeByEntropy bool) []*domain {
 	fit, optimalNumberOfDomains, _, _ := evaluateGreedyAssignment(s, domains, sliceCount, leaderCount)
 	if !fit {
 		return nil
 	}
 
 	orderedDomains := slices.Clone(domains)
-	if priorizeByEntropy {
-		sortDomainsByCapacityAndEntropy(orderedDomains)
+	if prioritizeByEntropy {
+		slices.SortFunc(orderedDomains, compareDomainCapacityAndEntropy)
 	} else {
-		sortDomainsByLevelValues(orderedDomains)
+		slices.SortFunc(orderedDomains, compareDomainLevelValues)
 	}
 
 	// domain_placements[i][j][k] stores a list of domains that uses 'i' domains with
@@ -186,14 +184,14 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	return resultDomains, ""
 }
 
-func calculateEntropy(blockSizes []int32) float64 {
-	if len(blockSizes) == 0 {
+func calculateDomainsEntropy(domains []*domain) float64 {
+	if len(domains) == 0 {
 		return 0.0
 	}
 
 	var total int32
-	for _, size := range blockSizes {
-		total += size
+	for _, d := range domains {
+		total += d.state
 	}
 
 	if total == 0 {
@@ -202,35 +200,31 @@ func calculateEntropy(blockSizes []int32) float64 {
 
 	var entropy float64
 	totalF := float64(total)
-	for _, size := range blockSizes {
-		if size > 0 {
-			pI := float64(size) / totalF
+	for _, d := range domains {
+		if d.state > 0 {
+			pI := float64(d.state) / totalF
 			entropy += -pI * math.Log2(pI)
 		}
 	}
 	return entropy
 }
 
-func sortDomainsByCapacityAndEntropy(domains []*domain) {
-	slices.SortFunc(domains, func(a, b *domain) int {
-		if r := b.leaderState - a.leaderState; r != 0 {
-			return int(r)
-		}
-		if r := b.sliceStateWithLeader - a.sliceStateWithLeader; r != 0 {
-			return int(r)
-		}
-		aChildrenCapacities := utilslices.Map(a.children, func(d **domain) int32 { return (*d).state })
-		bChildrenCapacities := utilslices.Map(b.children, func(d **domain) int32 { return (*d).state })
-		aEntropy := calculateEntropy(aChildrenCapacities)
-		bEntropy := calculateEntropy(bChildrenCapacities)
-		if bEntropy > aEntropy {
-			return 1
-		}
-		if bEntropy < aEntropy {
-			return -1
-		}
-		return compareDomainLevelValues(a, b)
-	})
+func compareDomainCapacityAndEntropy(a, b *domain) int {
+	if r := b.leaderState - a.leaderState; r != 0 {
+		return int(r)
+	}
+	if r := b.sliceStateWithLeader - a.sliceStateWithLeader; r != 0 {
+		return int(r)
+	}
+	aEntropy := calculateDomainsEntropy(a.children)
+	bEntropy := calculateDomainsEntropy(b.children)
+	if bEntropy > aEntropy {
+		return 1
+	}
+	if bEntropy < aEntropy {
+		return -1
+	}
+	return compareDomainLevelValues(a, b)
 }
 
 // findBestDomainsForBalancedPlacement evaluates domains for balanced placement.
@@ -246,7 +240,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 		requestedLevelDomainsToConsider = [][]*domain{slices.Collect(maps.Values(s.domainsPerLevel[0]))}
 	} else {
 		higherLevelDomains := slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1]))
-		sortDomainsByLevelValues(higherLevelDomains)
+		slices.SortFunc(higherLevelDomains, compareDomainLevelValues)
 		for _, higherLevelDomain := range higherLevelDomains {
 			requestedLevelDomainsToConsider = append(requestedLevelDomainsToConsider, higherLevelDomain.children)
 		}

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -17,21 +17,19 @@ limitations under the License.
 package scheduler
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
+	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
 func domainIDs(domains []*domain) []string {
-	ids := make([]string, len(domains))
-	for i, d := range domains {
-		ids[i] = string(d.id)
-	}
-	return ids
+	return utilslices.Map(domains, func(d **domain) string { return string((*d).id) })
 }
 
 func TestSelectOptimalDomainSetToFit(t *testing.T) {
@@ -96,13 +94,13 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 
 func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 	testCases := map[string]struct {
-		priorizeByEntropy bool
+		prioritizeByEntropy bool
 	}{
 		"balanced selection": {
-			priorizeByEntropy: false,
+			prioritizeByEntropy: false,
 		},
 		"entropy-prioritized selection": {
-			priorizeByEntropy: true,
+			prioritizeByEntropy: true,
 		},
 	}
 
@@ -114,9 +112,10 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
 				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
 				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				{id: "leaf-zz", levelValues: []string{"block-a", "host-zz"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
 			}
 
-			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.priorizeByEntropy)
+			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.prioritizeByEntropy)
 
 			if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
 				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
@@ -125,12 +124,12 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 	}
 }
 
-func TestSortDomainsByCapacityAndEntropy(t *testing.T) {
+func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 	testCases := map[string]struct {
 		domains []*domain
 		want    []string
 	}{
-		"levelValues ascending as final tiebreaker": {
+		"tie-breaking on level values when capacity and entropy are equal": {
 			domains: []*domain{
 				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
 				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
@@ -138,7 +137,7 @@ func TestSortDomainsByCapacityAndEntropy(t *testing.T) {
 			},
 			want: []string{"leaf-z", "leaf-a", "leaf-m"},
 		},
-		"capacity and entropy ranking before tiebreaker": {
+		"capacity overrides entropy, and higher entropy overrides level values": {
 			domains: []*domain{
 				{id: "lower-leader", levelValues: []string{"a"}, leaderState: 0, sliceStateWithLeader: 100, children: []*domain{{state: 50}, {state: 50}}},
 				{id: "lower-capacity", levelValues: []string{"b"}, leaderState: 1, sliceStateWithLeader: 4, children: []*domain{{state: 2}, {state: 2}}},
@@ -151,7 +150,7 @@ func TestSortDomainsByCapacityAndEntropy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			sortDomainsByCapacityAndEntropy(tc.domains)
+			slices.SortFunc(tc.domains, compareDomainCapacityAndEntropy)
 
 			if diff := cmp.Diff(tc.want, domainIDs(tc.domains)); diff != "" {
 				t.Errorf("unexpected domain order (-want,+got): %s", diff)

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -7584,6 +7584,190 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			},
 		},
+		"stable tie break on identical nodes: TASBalancedPlacement enabled": {
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x1",
+							},
+						},
+					},
+				},
+			}},
+		},
+		"stable tie break on identical nodes: TASBalancedPlacement disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: false},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x1",
+							},
+						},
+					},
+				},
+			}},
+		},
+		"stable tie break on identical nodes: reversed order, TASBalancedPlacement enabled": {
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: true},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x1",
+							},
+						},
+					},
+				},
+			}},
+		},
+		"stable tie break on identical nodes: reversed order, TASBalancedPlacement disabled": {
+			featureGates: map[featuregate.Feature]bool{features.TASBalancedPlacement: false},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(tasBlockLabel, "b1").
+					Label(tasRackLabel, "r1").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultThreeLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: ptr.To(corev1.LabelHostname),
+				},
+				requests: resources.Requests{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultOneLevel,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count: 1,
+							Values: []string{
+								"x1",
+							},
+						},
+					},
+				},
+			}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1572,7 +1572,7 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 
 func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
-	sortDomainsByLevelValues(domains)
+	slices.SortFunc(domains, compareDomainLevelValues)
 	levelIdx := 0
 	// assign only hostname values if topology defines it
 	if s.isLowestLevelNode {
@@ -1591,10 +1591,6 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 
 func compareDomainLevelValues(a, b *domain) int {
 	return slices.Compare(a.levelValues, b.levelValues)
-}
-
-func sortDomainsByLevelValues(domains []*domain) {
-	slices.SortFunc(domains, compareDomainLevelValues)
 }
 
 func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {


### PR DESCRIPTION
  #### What type of PR is this?

   /kind feature
   /area tas

   #### What this PR does / why we need it:
   This PR is a follow up on #12052 to fix comments there

   **Changes from original PR #12052:**
   I have addressed all the outstanding reviewer comments from the original PR:
   - Replaced wrapper sort functions with `compareDomainLevelValues` and `compareDomainCapacityAndEntropy` helpers, passing them directly to `slices.SortFunc` (@mimowo).
   - Explicitly ensured that the domain name (`levelValues`) is included as the final stable tie-breaker after capacity and entropy checks (@mwielgus).
   - Removed a redundant in-place sort of the original `domains` slice to prevent accidentally mutating the caller's array.
   - Converted unit tests (`TestSelectOptimalDomainSetToFitStableTieBreak`, `TestSortDomainsByCapacityAndEntropy`) into table-driven test suites (@pajakd).
   - Expanded test coverage: added a new leaf (`leaf-zz`) to the unit tests to explicitly verify the lexicographical tie-breaker logic, and added an end-to-end `findTopologyAssignment` test case in `tas_cache_test.go` to guarantee stable tie-breaking across completely identical
   nodes in the full assignment flow (@dkaluza).
   - Fixed a minor `priorizeByEntropy` spelling typo to `prioritizeByEntropy`.

   CC reviewers from the original PR: @mimowo @sohankunkerkar @mwielgus @pajakd @dkaluza

   #### Which issue(s) this PR fixes:
   Fixes #11910
   Closes #12052

   #### Special notes for your reviewer:
   `selectOptimalDomainSetToFit` clones the input slice before sorting, so the change cannot reorder the caller's view of domains. The test suites have been expanded and refactored to be table-driven.

   #### Does this PR introduce a user-facing change?
   No


```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deterministic balanced placement when domains or nodes are tied on capacity and entropy.
  * Preserved the original domain input order by selecting based on a sorted copy.
  * Corrected entropy prioritization and tie-breaking to consistently use the unified capacity/entropy logic.
  * Ensured higher-level candidate domains are consistently ordered before generating placement options.

* **Tests**
  * Expanded coverage for deterministic hostname-domain assignment with identical nodes under varied ordering and configuration.
  * Updated and refactored comparison tests for the new capacity/entropy ordering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->