### PR TITLE
WIP: POC for partiall admission for elastic workloads

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -976,7 +976,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		// Workload slices allow modifications only to PodSet.Count.
 		// Any other changes will result in the slice being marked as incompatible,
 		// and the workload will fall back to being processed by the original ensureOneWorkload function.
-		wl, compatible, err := workloadslicing.EnsureWorkloadSlices(ctx, r.client, r.clock, podSets, object, job.GVK())
+		wl, compatible, err := workloadslicing.EnsureWorkloadSlices(ctx, r.client, r.clock, podSets, object, job.GVK(), newWorkloadName(job))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -43,6 +43,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 var (
@@ -276,7 +277,7 @@ func (j *Job) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSetsIn
 
 	info := podSetsInfo[0]
 
-	if j.minPodsCount() != nil {
+	if j.minPodsCount() != nil && !workloadslicing.Enabled(j.Object()) {
 		j.Spec.Parallelism = new(info.Count)
 		if j.syncCompletionWithParallelism() {
 			j.Spec.Completions = j.Spec.Parallelism
@@ -292,7 +293,7 @@ func (j *Job) RestorePodSetsInfo(_ context.Context, podSetsInfo []podset.PodSetI
 
 	changed := false
 	// if the job accepts partial admission
-	if j.minPodsCount() != nil && ptr.Deref(j.Spec.Parallelism, 0) != podSetsInfo[0].Count {
+	if j.minPodsCount() != nil && !workloadslicing.Enabled(j.Object()) && ptr.Deref(j.Spec.Parallelism, 0) != podSetsInfo[0].Count {
 		changed = true
 		j.Spec.Parallelism = new(podSetsInfo[0].Count)
 		if j.syncCompletionWithParallelism() {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -49,6 +49,7 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestPodsReady(t *testing.T) {
@@ -2893,6 +2894,63 @@ func TestReconciler(t *testing.T) {
 				SetAnnotation(JobMinParallelismAnnotation, "5").
 				Suspend(false).
 				Parallelism(8).
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.LocalQueueLabel, localQueueName).
+				PodLabel(constants.ClusterQueueLabel, clusterQueueName).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("a", "ns").
+					Queue(localQueueName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).SetMinimumCount(5).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("a", "ns").
+					Queue(localQueueName).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
+							SetMinimumCount(5).
+							Request(corev1.ResourceCPU, "1").
+							Obj(),
+					).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Count(8).Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Started",
+					Message:   "Admitted by clusterQueue cq",
+				},
+			},
+		},
+		"suspended job with partial admission and elastic annotation, admitted workload is unsuspended without updating job count": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:                     false,
+				features.ManagedJobsNamespaceSelectorAlwaysRespected: false,
+				features.AssignQueueLabelsForPods:                    true,
+				features.ElasticJobsViaWorkloadSlices:                true,
+				features.PartialAdmissionForElasticJob:               true,
+			},
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+			},
+			job: baseJobWrapper.Clone().
+				SetAnnotation(JobMinParallelismAnnotation, "5").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				Obj(),
+			wantJob: *baseJobWrapper.Clone().
+				SetAnnotation(JobMinParallelismAnnotation, "5").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				Suspend(false).
+				Parallelism(10). // parallelism is NOT updated (kept 10 from baseJobWrapper)
 				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
 				PodLabel(constants.LocalQueueLabel, localQueueName).
 				PodLabel(constants.ClusterQueueLabel, clusterQueueName).

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -156,7 +156,7 @@ func (w *JobWebhook) validatePartialAdmissionCreate(job *Job) field.ErrorList {
 		} else if int32(v) >= job.podsCount() || v <= 0 {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, v, fmt.Sprintf("should be between 0 and %d", job.podsCount()-1)))
 		}
-		if workloadslicing.Enabled(job.Object()) {
+		if workloadslicing.Enabled(job.Object()) && !features.Enabled(features.PartialAdmissionForElasticJob) {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, strVal, "partial admission and elastic job cannot be used together"))
 		}
 	}

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -604,7 +604,7 @@ func TestValidateCreate(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
 		},
 		{
-			name: "partial admission and elastic job cannot be used together",
+			name: "partial admission and elastic job cannot be used together when feature gate is disabled",
 			job: testingutil.MakeJob("job", "default").
 				Parallelism(4).
 				Completions(6).
@@ -615,7 +615,22 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(minPodsCountAnnotationsPath, "2", "partial admission and elastic job cannot be used together"),
 			},
 			featureGates: map[featuregate.Feature]bool{
-				features.ElasticJobsViaWorkloadSlices: true,
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.PartialAdmissionForElasticJob: false,
+			},
+		},
+		{
+			name: "partial admission and elastic job can be used together when feature gate is enabled",
+			job: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "2").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.PartialAdmissionForElasticJob: true,
 			},
 		},
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -470,7 +470,6 @@ const (
 	// UnadmittedWorkloadsExplicitStatus gates the immediate, proactive
 	// initialization of both QuotaReserved and Admitted status conditions
 	// to False during a workload's first reconciliation.
-	// This feature gate requires UnadmittedWorkloadsObservability to be enabled to take effect.
 	UnadmittedWorkloadsExplicitStatus featuregate.Feature = "UnadmittedWorkloadsExplicitStatus"
 
 	// owner: @kevin85421
@@ -490,6 +489,10 @@ const (
 	// to be reused within a single scheduling cycle by TAS evaluations corresponding to different
 	// sets of preemption candidates.
 	TASCacheNodeMatchResults featuregate.Feature = "TASCacheNodeMatchResults"
+	// owner: @yaroslava-serdiuk
+	//
+	// Enables partial admission for elastic jobs.
+	PartialAdmissionForElasticJob featuregate.Feature = "PartialAdmiisionForElasticJob"
 )
 
 func init() {
@@ -753,6 +756,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASCacheNodeMatchResults: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	PartialAdmissionForElasticJob: {
+		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -133,7 +133,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("podSets"), variableCountPodSets, "at most one podSet can use minCount"))
 	}
 
-	if variableCountPodSets > 0 && workloadslicing.Enabled(obj) {
+	if variableCountPodSets > 0 && workloadslicing.Enabled(obj) && !features.Enabled(features.PartialAdmissionForElasticJob) {
 		allErrs = append(allErrs, field.Invalid(specPath.Child("podSets"), variableCountPodSets, "partial admission and elastic job cannot be used together"))
 	}
 

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -410,8 +410,11 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(field.NewPath("metadata", "annotations").Key(constants.AdmissionGatedByAnnotation), "valid.com/gate,invalid gate.com/controller", ""),
 			}.ToAggregate(),
 		},
-		"partial admission and elastic job cannot be used together": {
-			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+		"partial admission and elastic job cannot be used together when feature gate is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.PartialAdmissionForElasticJob: false,
+			},
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodSets(*utiltestingapi.MakePodSet("main", 10).SetMinimumCount(5).Obj()).
@@ -432,6 +435,17 @@ func TestValidateWorkload(t *testing.T) {
 			wantWarnings: admission.Warnings{
 				"spec.podSets[0].topologyRequest.subGroupCount: negative value -1 is deprecated and will be rejected in a future release",
 			},
+		},
+		"partial admission and elastic job can be used together when feature gate is enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:  true,
+				features.PartialAdmissionForElasticJob: true,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(*utiltestingapi.MakePodSet("main", 10).SetMinimumCount(5).Obj()).
+				Obj(),
+			wantErr: nil,
 		},
 	}
 	for name, tc := range testCases {

--- a/pkg/workload/podsetscounts.go
+++ b/pkg/workload/podsetscounts.go
@@ -19,6 +19,8 @@ package workload
 import (
 	"maps"
 
+	"k8s.io/utils/ptr"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
@@ -86,4 +88,23 @@ func ApplyPodSetCounts(wl *kueue.Workload, counts PodSetsCounts) {
 			wl.Spec.PodSets[i].Count = count
 		}
 	}
+}
+
+// ExtractAdmittedPodSetCounts returns a PodSetsCounts map derived from the admitted pod set counts in the status.
+func ExtractAdmittedPodSetCounts(wl *kueue.Workload) PodSetsCounts {
+	if wl.Status.Admission == nil {
+		return nil
+	}
+	counts := make(PodSetsCounts)
+	for _, assignment := range wl.Status.Admission.PodSetAssignments {
+		var specCount int32
+		for _, ps := range wl.Spec.PodSets {
+			if ps.Name == assignment.Name {
+				specCount = ps.Count
+				break
+			}
+		}
+		counts[assignment.Name] = ptr.Deref(assignment.Count, specCount)
+	}
+	return counts
 }

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -169,6 +169,7 @@ func EnsureWorkloadSlices(
 	jobPodSets []kueue.PodSet,
 	jobObject client.Object,
 	jobObjectGVK schema.GroupVersionKind,
+	expectedWorkloadName string,
 ) (*kueue.Workload, bool, error) {
 	jobPodSetsCounts := workload.ExtractPodSetCounts(jobPodSets)
 
@@ -190,6 +191,19 @@ func EnsureWorkloadSlices(
 		// Check if pod sets are structurally compatible (same number and names).
 		if !jobPodSetsCounts.HasSamePodSetKeys(wlPodSetsCounts) {
 			return nil, false, nil
+		}
+
+		// Update workload to match admitted pod sets counts. This is needed to
+		// construct the correct delta in the next call.
+		if wl.Name == expectedWorkloadName {
+			wlAdmittedCounts := workload.ExtractAdmittedPodSetCounts(wl)
+			if workload.HasQuotaReservation(wl) && !wlPodSetsCounts.EqualTo(wlAdmittedCounts) {
+				workload.ApplyPodSetCounts(wl, wlAdmittedCounts)
+				if err := clnt.Update(ctx, wl); err != nil {
+					return nil, true, fmt.Errorf("failed to update partially admitted workload's pod sets counts: %w", err)
+				}
+			}
+			return wl, true, nil
 		}
 
 		// If counts match, return the existing workload slice.

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -337,10 +337,11 @@ func TestFindNotFinishedWorkloads(t *testing.T) {
 
 func TestEnsureWorkloadSlices(t *testing.T) {
 	type args struct {
-		clnt         client.Client
-		jobPodSets   []kueue.PodSet
-		jobObject    client.Object
-		jobObjectGVK schema.GroupVersionKind
+		clnt                 client.Client
+		jobPodSets           []kueue.PodSet
+		jobObject            client.Object
+		jobObjectGVK         schema.GroupVersionKind
+		expectedWorkloadName string
 	}
 	type want struct {
 		workload   *kueue.Workload
@@ -983,11 +984,38 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 				compatible: true,
 			},
 		},
+		"OneWorkload_AdmittedPartially_UpdateSpecCount": {
+			args: args{
+				clnt: testWorkloadClientBuilder().WithObjects(
+					utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).
+						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
+						ResourceVersion("1").
+						Creation(fiveMinutesAgo).
+						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
+						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj()).Obj(), now).
+						Obj()).
+					Build(),
+				jobPodSets:           []kueue.PodSet{*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()},
+				jobObject:            testJobObject,
+				jobObjectGVK:         testJobGVK,
+				expectedWorkloadName: testJobObject.Name + "-1",
+			},
+			want: want{
+				compatible: true,
+				workload: utiltestingapi.MakeWorkload(testJobObject.Name+"-1", testJobObject.Namespace).
+					OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
+					ResourceVersion("2").
+					Creation(fiveMinutesAgo).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Count(3).Obj()).Obj(), now).
+					Obj(),
+			},
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			gotWorkload, gotCompatible, gotError := EnsureWorkloadSlices(ctx, tt.args.clnt, fakeClock, tt.args.jobPodSets, tt.args.jobObject, tt.args.jobObjectGVK)
+			gotWorkload, gotCompatible, gotError := EnsureWorkloadSlices(ctx, tt.args.clnt, fakeClock, tt.args.jobPodSets, tt.args.jobObject, tt.args.jobObjectGVK, tt.args.expectedWorkloadName)
 			if (gotError != nil) != tt.want.error {
 				t.Errorf("EnsureWorkloadSlices() error = %v, wantErr %v", gotError, tt.want.error)
 				return

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5198,6 +5198,57 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 				gomega.BeNumerically("<=", int64(cpuNominalQuota)*1000))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("Should allow partial admission for scale-up slice when queue capacity is limited", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PartialAdmissionForElasticJob, true)
+
+		ginkgo.By("creating an elastic job with partial admission annotation")
+		elasticJob := testingjob.MakeJob("job-partial-admission-elastic", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(workloadjob.JobMinParallelismAnnotation, "2").
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Parallelism(3).
+			Completions(3).
+			Obj()
+		util.MustCreate(ctx, k8sClient, elasticJob)
+
+		ginkgo.By("waiting for original workload slice to be admitted")
+		workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, elasticJob.Namespace, 1)
+		oldWorkloadSlice := &workloads[0]
+		util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, oldWorkloadSlice)
+		util.ExpectJobUnsuspended(ctx, k8sClient, client.ObjectKeyFromObject(elasticJob))
+
+		ginkgo.By("scaling the job up beyond queue's total capacity (nominal quota is cpuNominalQuota = 5)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
+			elasticJob.Spec.Parallelism = ptr.To[int32](7)
+			g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("verifying the new slice is admitted at count 5 (partial admission)")
+		var newWorkloadSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			newWorkloadSlice = util.ExpectNewWorkloadSlice(ctx, k8sClient, oldWorkloadSlice)
+			g.Expect(newWorkloadSlice).ShouldNot(gomega.BeNil())
+			g.Expect(workload.IsAdmitted(newWorkloadSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Expect(newWorkloadSlice.Spec.PodSets[0].Count).To(gomega.BeEquivalentTo(5))
+		gomega.Expect(newWorkloadSlice.Spec.PodSets[0].MinCount).ToNot(gomega.BeNil())
+		gomega.Expect(*newWorkloadSlice.Spec.PodSets[0].MinCount).To(gomega.BeEquivalentTo(2))
+		gomega.Expect(newWorkloadSlice.Status.Admission.PodSetAssignments[0].Count).To(gomega.HaveValue(gomega.BeEquivalentTo(5)))
+
+		ginkgo.By("verifying that the job count is not updated and remains at its original value")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
+			g.Expect(*elasticJob.Spec.Parallelism).To(gomega.BeEquivalentTo(7))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("old workload slice is finished")
+		util.ExpectWorkloadToFinish(ctx, k8sClient, client.ObjectKeyFromObject(oldWorkloadSlice))
+	})
 })
 
 var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {


### PR DESCRIPTION
#### What this PR does / why we need it:
Related to [#12100](https://github.com/kubernetes-sigs/kueue/issues/12100)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for partial admission of elastic jobs when the corresponding feature gate is enabled.
  - Elastic jobs using workload slicing can now retain their requested parallelism while workload slices are admitted according to available capacity.
  - Workload status now accurately reflects admitted pod-set counts.

- **Bug Fixes**
  - Improved workload-slice reconciliation for partially admitted workloads.
  - Updated validation to allow supported combinations of partial admission and elastic jobs.

- **Configuration**
  - Added the `PartialAdmissionForElasticJob` alpha feature gate, disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->