### PR TITLE
Bound visibility pending-workloads limit to prevent OOM and panic fro…

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -42,6 +42,12 @@ const (
 
 	DefaultPendingWorkloadsLimit = 1000
 
+	// MaxPendingWorkloadsLimit is the maximum number of pending workloads the
+	// visibility API will return in a single request. It bounds the size of a
+	// single response (and its allocation) regardless of the user-provided limit,
+	// so an authorized caller cannot request an arbitrarily large page.
+	MaxPendingWorkloadsLimit = 100_000
+
 	// ManagedByKueueLabelKey label that signalize that an object is managed by Kueue
 	ManagedByKueueLabelKey   = "kueue.x-k8s.io/managed"
 	ManagedByKueueLabelValue = "true"

--- a/pkg/visibility/storage/pending_workloads_cq.go
+++ b/pkg/visibility/storage/pending_workloads_cq.go
@@ -65,14 +65,13 @@ func (m *pendingWorkloadsInCqREST) Get(_ context.Context, name string, opts runt
 	if !ok {
 		return nil, fmt.Errorf("invalid options object: %#v", opts)
 	}
-	limit := pendingWorkloadOpts.Limit
-	offset := pendingWorkloadOpts.Offset
+	limit, offset := boundedLimitOffset(pendingWorkloadOpts.Limit, pendingWorkloadOpts.Offset)
 
-	wls := make([]visibility.PendingWorkload, 0, limit)
 	pendingWorkloadsInfo := m.queueMgr.PendingWorkloadsInfo(kueue.ClusterQueueReference(name))
 	if pendingWorkloadsInfo == nil {
 		return nil, errors.NewNotFound(visibility.Resource("clusterqueue"), name)
 	}
+	wls := make([]visibility.PendingWorkload, 0, min(limit, int64(len(pendingWorkloadsInfo))))
 
 	localQueuePositions := make(map[kueue.LocalQueueName]int32, 0)
 

--- a/pkg/visibility/storage/pending_workloads_cq_test.go
+++ b/pkg/visibility/storage/pending_workloads_cq_test.go
@@ -296,6 +296,68 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 					}},
 			},
 		},
+		"negative limit is clamped to zero and returns no workloads without panicking": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			req: &req{
+				queueName: cqNameA,
+				queryParams: &visibility.PendingWorkloadOptions{
+					Limit: -1,
+				},
+			},
+			wantResp: &resp{},
+		},
+		"excessive limit returns all pending workloads without over-allocating": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", nsName).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			req: &req{
+				queueName: cqNameA,
+				queryParams: &visibility.PendingWorkloadOptions{
+					Limit: 2000000000,
+				},
+			},
+			wantResp: &resp{
+				wantPendingWorkloads: []visibility.PendingWorkload{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "a",
+							Namespace:         nsName,
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 0,
+						PositionInLocalQueue:   0,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "b",
+							Namespace:         nsName,
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 1,
+						PositionInLocalQueue:   1,
+					}},
+			},
+		},
 		"empty cluster queue": {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),

--- a/pkg/visibility/storage/pending_workloads_lq.go
+++ b/pkg/visibility/storage/pending_workloads_lq.go
@@ -67,8 +67,7 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 	if !ok {
 		return nil, fmt.Errorf("invalid options object: %#v", opts)
 	}
-	limit := pendingWorkloadOpts.Limit
-	offset := pendingWorkloadOpts.Offset
+	limit, offset := boundedLimitOffset(pendingWorkloadOpts.Limit, pendingWorkloadOpts.Offset)
 
 	namespace := genericapirequest.NamespaceValue(ctx)
 	lqName := kueue.LocalQueueName(name)
@@ -77,9 +76,10 @@ func (m *pendingWorkloadsInLqREST) Get(ctx context.Context, name string, opts ru
 		return nil, errors.NewNotFound(visibility.Resource("localqueue"), name)
 	}
 
-	wls := make([]visibility.PendingWorkload, 0, limit)
+	pendingWorkloadsInfo := m.queueMgr.PendingWorkloadsInfo(cqName)
+	wls := make([]visibility.PendingWorkload, 0, min(limit, int64(len(pendingWorkloadsInfo))))
 	skippedWls := 0
-	for index, wlInfo := range m.queueMgr.PendingWorkloadsInfo(cqName) {
+	for index, wlInfo := range pendingWorkloadsInfo {
 		if len(wls) >= int(limit) {
 			break
 		}

--- a/pkg/visibility/storage/pending_workloads_lq_test.go
+++ b/pkg/visibility/storage/pending_workloads_lq_test.go
@@ -423,6 +423,71 @@ func TestPendingWorkloadsInLQ(t *testing.T) {
 				},
 			},
 		},
+		"negative limit is clamped to zero and returns no workloads without panicking": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue(lqNameA, nsNameA).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", nsNameA).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", nsNameA).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			req: &req{
+				nsName:    nsNameA,
+				queueName: lqNameA,
+				queryParams: &visibility.PendingWorkloadOptions{
+					Limit: -1,
+				},
+			},
+			wantResp: &resp{},
+		},
+		"excessive limit returns all pending workloads without over-allocating": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue(lqNameA, nsNameA).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", nsNameA).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", nsNameA).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			req: &req{
+				nsName:    nsNameA,
+				queueName: lqNameA,
+				queryParams: &visibility.PendingWorkloadOptions{
+					Limit: 2000000000,
+				},
+			},
+			wantResp: &resp{
+				wantPendingWorkloads: []visibility.PendingWorkload{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "a",
+							Namespace:         nsNameA,
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 0,
+						PositionInLocalQueue:   0,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "b",
+							Namespace:         nsNameA,
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 1,
+						PositionInLocalQueue:   1,
+					},
+				},
+			},
+		},
 		"nonexistent queue name": {
 			req: &req{
 				queueName:   "nonexistent-queue",

--- a/pkg/visibility/storage/utils.go
+++ b/pkg/visibility/storage/utils.go
@@ -20,8 +20,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+func boundedLimitOffset(limit, offset int64) (int64, int64) {
+	limit = max(limit, 0)
+	limit = min(limit, constants.MaxPendingWorkloadsLimit)
+	offset = max(offset, 0)
+	return limit, offset
+}
 
 func newPendingWorkload(wlInfo *workload.Info, positionInLq int32, positionInCq int) *visibility.PendingWorkload {
 	ownerReferences := make([]metav1.OwnerReference, 0, len(wlInfo.Obj.OwnerReferences))


### PR DESCRIPTION
…m a malicious limit query param

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Bound visibility pending-workloads limit to prevent OOM and panic from a malicious limit query param
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [RepoInspector] HIGH: Denial of Service (OOM) via unconstrained 'limit' parameter in Visibility API in pkg/visibility/storage/pending_workloads_lq.go

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
VisibilityOnDemand: Fixed a bug where a large or negative `limit` query parameter on the pending-workloads endpoints could crash the Kueue controller manager via memory exhaustion or a panic. The `limit` is now capped at 100000.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-workload pagination by clamping negative limits to zero and normalizing offsets to valid values.
  * Enforced a hard upper bound on the number of pending workloads returned per visibility request to prevent excessive pagination sizes.
  * Improved response handling and sizing to return only the available pending workloads without unnecessary over-allocation.
* **Tests**
  * Added coverage for negative and extremely large limits (including empty responses and full result sets) for both queue types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->