### PR TITLE
docs: add Topology Aware Scheduling examples for JobSet

### DIFF
--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -67,6 +67,46 @@ The first [PriorityClassName](https://kubernetes.io/docs/concepts/scheduling-evi
               priorityClassName: high-priority
 ```
 
+### d. Topology-Aware Scheduling
+
+You can use [Topology-Aware Scheduling (TAS)](/docs/concepts/topology_aware_scheduling) to schedule `ReplicatedJobs` within specific topology domains (like racks or zones) to minimize network latency. Kueue supports three TAS placement scenarios for JobSets using annotations on the Pod template:
+
+**1. Same-domain placement (Just PodSet TAS)**
+Force the entire `ReplicatedJob` to be scheduled in a single topology domain.
+```yaml
+    - template:
+        spec:
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
+```
+
+**2. Sliced placement (Just PodSet-Slice TAS)**
+Split the `ReplicatedJob` into smaller slices, where each slice must fit in a single topology domain, but different slices can be in different domains.
+```yaml
+    - template:
+        spec:
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+                kueue.x-k8s.io/podset-slice-size: "4"
+```
+
+**3. Combined constraint (Both PodSet and PodSet-Slice TAS)**
+Force the entire `ReplicatedJob` into a larger domain (e.g. block), but allow it to be sliced across smaller domains (e.g. rack) within that block. *(Note: This is different from Kueue's Multi-Layer Topology feature, which uses the `podset-slice-required-topology-constraints` annotation).*
+```yaml
+    - template:
+        spec:
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-block"
+                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+                kueue.x-k8s.io/podset-slice-size: "4"
+```
+
 ## Example JobSet
 
 {{< include "examples/jobs/sample-jobset.yaml" "yaml" >}}

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -69,6 +69,10 @@ The first [PriorityClassName](https://kubernetes.io/docs/concepts/scheduling-evi
 
 ### d. Topology-Aware Scheduling
 
+{{% alert title="Note" color="primary" %}}
+The following examples require your cluster to be configured for Topology-Aware Scheduling. This includes having appropriate labels on your nodes, a configured `Topology` object, and a `ResourceFlavor` referencing that topology. Please refer to the [Topology-Aware Scheduling guide](/docs/concepts/topology_aware_scheduling) for full cluster setup instructions before running these examples.
+{{% /alert %}}
+
 You can use [Topology-Aware Scheduling (TAS)](/docs/concepts/topology_aware_scheduling) to schedule `ReplicatedJobs` within specific topology domains (like racks or zones) to minimize network latency. Kueue supports three TAS placement scenarios for JobSets using annotations on the Pod template:
 
 **1. Same-domain placement (Just PodSet TAS)**

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -73,101 +73,20 @@ You can use [Topology-Aware Scheduling (TAS)](/docs/concepts/topology_aware_sche
 
 **1. Same-domain placement (Just PodSet TAS)**
 Force the entire `ReplicatedJob` to be scheduled in a single topology domain.
-```yaml
-apiVersion: jobset.x-k8s.io/v1alpha2
-kind: JobSet
-metadata:
-  name: jobset-tas-required
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-spec:
-  replicatedJobs:
-  - name: workers
-    replicas: 1
-    template:
-      spec:
-        parallelism: 4
-        completions: 4
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
-          spec:
-            containers:
-            - name: sleep
-              image: bash:5
-              command: ["sleep", "60"]
-```
+
+{{< include "examples/jobs/sample-jobset-tas-required.yaml" "yaml" >}}
 
 **2. Sliced placement (Just PodSet-Slice TAS)**
 Split the `ReplicatedJob` into smaller slices, where each slice must fit in a single topology domain, but different slices can be in different domains.
-```yaml
-apiVersion: jobset.x-k8s.io/v1alpha2
-kind: JobSet
-metadata:
-  name: jobset-tas-sliced
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-spec:
-  replicatedJobs:
-  - name: workers
-    replicas: 1
-    template:
-      spec:
-        parallelism: 8
-        completions: 8
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
-              kueue.x-k8s.io/podset-slice-size: "4"
-          spec:
-            containers:
-            - name: sleep
-              image: bash:5
-              command: ["sleep", "60"]
-```
+
+{{< include "examples/jobs/sample-jobset-tas-sliced.yaml" "yaml" >}}
 
 **3. Combined constraint (Both PodSet and PodSet-Slice TAS)**
 Force the entire `ReplicatedJob` into a larger domain (e.g. block), but allow it to be sliced across smaller domains (e.g. rack) within that block. *(Note: This is different from Kueue's Multi-Layer Topology feature, which uses the `podset-slice-required-topology-constraints` annotation).*
-```yaml
-apiVersion: jobset.x-k8s.io/v1alpha2
-kind: JobSet
-metadata:
-  name: jobset-tas-combined
-  labels:
-    kueue.x-k8s.io/queue-name: user-queue
-spec:
-  replicatedJobs:
-  - name: workers
-    replicas: 1
-    template:
-      spec:
-        parallelism: 8
-        completions: 8
-        template:
-          metadata:
-            annotations:
-              kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-block"
-              kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
-              kueue.x-k8s.io/podset-slice-size: "4"
-          spec:
-            containers:
-            - name: sleep
-              image: bash:5
-              command: ["sleep", "60"]
-```
 
-## Example JobSet
+{{< include "examples/jobs/sample-jobset-tas-combined.yaml" "yaml" >}}
 
-{{< include "examples/jobs/sample-jobset.yaml" "yaml" >}}
 
-You can run this JobSet with the following commands:
-
-```sh
-# To monitor the queue and admission of the jobs, you can run this example multiple times:
-kubectl create -f sample-jobset.yaml
-```
 
 ## Multikueue
 Check [the Multikueue](docs/tasks/run/multikueue) for details on running Jobsets in MultiKueue environment.

--- a/site/content/en/docs/tasks/run/jobsets.md
+++ b/site/content/en/docs/tasks/run/jobsets.md
@@ -74,37 +74,88 @@ You can use [Topology-Aware Scheduling (TAS)](/docs/concepts/topology_aware_sche
 **1. Same-domain placement (Just PodSet TAS)**
 Force the entire `ReplicatedJob` to be scheduled in a single topology domain.
 ```yaml
-    - template:
-        spec:
-          template:
-            metadata:
-              annotations:
-                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-required
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+  - name: workers
+    replicas: 1
+    template:
+      spec:
+        parallelism: 4
+        completions: 4
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
+          spec:
+            containers:
+            - name: sleep
+              image: bash:5
+              command: ["sleep", "60"]
 ```
 
 **2. Sliced placement (Just PodSet-Slice TAS)**
 Split the `ReplicatedJob` into smaller slices, where each slice must fit in a single topology domain, but different slices can be in different domains.
 ```yaml
-    - template:
-        spec:
-          template:
-            metadata:
-              annotations:
-                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
-                kueue.x-k8s.io/podset-slice-size: "4"
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-sliced
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+  - name: workers
+    replicas: 1
+    template:
+      spec:
+        parallelism: 8
+        completions: 8
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+              kueue.x-k8s.io/podset-slice-size: "4"
+          spec:
+            containers:
+            - name: sleep
+              image: bash:5
+              command: ["sleep", "60"]
 ```
 
 **3. Combined constraint (Both PodSet and PodSet-Slice TAS)**
 Force the entire `ReplicatedJob` into a larger domain (e.g. block), but allow it to be sliced across smaller domains (e.g. rack) within that block. *(Note: This is different from Kueue's Multi-Layer Topology feature, which uses the `podset-slice-required-topology-constraints` annotation).*
 ```yaml
-    - template:
-        spec:
-          template:
-            metadata:
-              annotations:
-                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-block"
-                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
-                kueue.x-k8s.io/podset-slice-size: "4"
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-combined
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+  - name: workers
+    replicas: 1
+    template:
+      spec:
+        parallelism: 8
+        completions: 8
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-block"
+              kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+              kueue.x-k8s.io/podset-slice-size: "4"
+          spec:
+            containers:
+            - name: sleep
+              image: bash:5
+              command: ["sleep", "60"]
 ```
 
 ## Example JobSet

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -238,7 +238,7 @@ additional placement behavior:
   single domain, using `kueue.x-k8s.io/podset-slice-required-topology` and
   `kueue.x-k8s.io/podset-slice-size`. See the
   [Topology-Aware Scheduling concepts](/docs/concepts/topology_aware_scheduling)
-  page.
+  page and the [JobSet TAS examples](/docs/tasks/run/jobsets#d-topology-aware-scheduling).
 - **Multi-layer topology** - express slice constraints at up to three
   topology layers in one annotation using
   `kueue.x-k8s.io/podset-slice-required-topology-constraints`. This is

--- a/site/static/examples/jobs/sample-jobset-tas-combined.yaml
+++ b/site/static/examples/jobs/sample-jobset-tas-combined.yaml
@@ -1,0 +1,34 @@
+# sample-jobset-tas-combined.yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-combined
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 8
+          completions: 8
+          backoffLimit: 0
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-block"
+                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+                kueue.x-k8s.io/podset-slice-size: "4"
+            spec:
+              containers:
+                - name: sleep
+                  image: busybox
+                  resources:
+                    requests:
+                      cpu: 1
+                      memory: "200Mi"
+                  command:
+                    - sleep
+                  args:
+                    - 100s

--- a/site/static/examples/jobs/sample-jobset-tas-required.yaml
+++ b/site/static/examples/jobs/sample-jobset-tas-required.yaml
@@ -1,0 +1,32 @@
+# sample-jobset-tas-required.yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-required
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 4
+          completions: 4
+          backoffLimit: 0
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-required-topology: "cloud.provider.com/topology-rack"
+            spec:
+              containers:
+                - name: sleep
+                  image: busybox
+                  resources:
+                    requests:
+                      cpu: 1
+                      memory: "200Mi"
+                  command:
+                    - sleep
+                  args:
+                    - 100s

--- a/site/static/examples/jobs/sample-jobset-tas-sliced.yaml
+++ b/site/static/examples/jobs/sample-jobset-tas-sliced.yaml
@@ -1,0 +1,33 @@
+# sample-jobset-tas-sliced.yaml
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: jobset-tas-sliced
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+    - name: workers
+      replicas: 1
+      template:
+        spec:
+          parallelism: 8
+          completions: 8
+          backoffLimit: 0
+          template:
+            metadata:
+              annotations:
+                kueue.x-k8s.io/podset-slice-required-topology: "cloud.provider.com/topology-rack"
+                kueue.x-k8s.io/podset-slice-size: "4"
+            spec:
+              containers:
+                - name: sleep
+                  image: busybox
+                  resources:
+                    requests:
+                      cpu: 1
+                      memory: "200Mi"
+                  command:
+                    - sleep
+                  args:
+                    - 100s


### PR DESCRIPTION
This adds documentation for 3 TAS placement scenarios using JobSets:
- podset required topology
- podset slice required topology
- multi-level topology

*(Note: This PR was developed with the assistance of an AI tool as per the Kubernetes AI Tool Usage Policy).*

#### What type of PR is this?

/kind documentation
/area tas
/area integrations

#### What this PR does / why we need it:
This PR explicitly documents the three supported Topology-Aware Scheduling scenarios for JobSets. It adds a new sub-section under JobSet definition containing the required annotations for each scenario, and cross-links to it from the advanced TAS topics page. This fulfills the request to provide concrete examples for users utilizing two-level scheduling with TAS and JobSets.

#### Which issue(s) this PR fixes:
Fixes #8038

#### Special notes for your reviewer:
The three documented scenarios were manually verified against a local `kind` cluster running Kueue and the JobSet operator (`v0.12.0`).

#### Does this PR introduce a user-facing change?
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Documentation**
  * Added a “Topology-Aware Scheduling” subsection for JobSet definition, covering same-domain placement, sliced placement, and combined constraint scenarios.
  * Updated topology-aware scheduling “Advanced topics” to link directly to the JobSet TAS examples.
  * Removed the previously placed “Example JobSet” section so the flow continues directly into the “Multikueue” section.

* **Examples**
  * Added new JobSet example manifests for topology-aware scheduling: required-topology, sliced, and combined configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->