### PR TITLE
MultiKueue: Incremental dispatcher now respects the cluster order in MultiKueueConfig.spec.clusters instead of sorting alphabetically

### DIFF
--- a/apis/kueue/v1beta2/multikueue_types.go
+++ b/apis/kueue/v1beta2/multikueue_types.go
@@ -148,11 +148,14 @@ type MultiKueueClusterList struct {
 // MultiKueueConfigSpec defines the desired state of MultiKueueConfig
 type MultiKueueConfigSpec struct {
 	// clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+	// The order of the list is significant: the Incremental dispatcher nominates clusters
+	// following this order, so the most preferred clusters should be listed first.
 	//
-	// +listType=set
+	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=20
 	// +kubebuilder:validation:items:MaxLength=256
+	// +kubebuilder:validation:XValidation:rule="size(self.filter(i, size(self.filter(j, j == i)) > 1)) == 0",message="must be unique"
 	// +required
 	Clusters []string `json:"clusters,omitempty,omitzero"`
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -103,14 +103,20 @@ spec:
               description: spec is the specification of the MultiKueueConfig.
               properties:
                 clusters:
-                  description: clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+                  description: |-
+                    clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+                    The order of the list is significant: the Incremental dispatcher nominates clusters
+                    following this order, so the most preferred clusters should be listed first.
                   items:
                     maxLength: 256
                     type: string
                   maxItems: 20
                   minItems: 1
                   type: array
-                  x-kubernetes-list-type: set
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: must be unique
+                      rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) == 0
                 quotaManagement:
                   description: |-
                     quotaManagement specifies the management of ClusterQueue quotas

--- a/client-go/applyconfiguration/kueue/v1beta2/multikueueconfigspec.go
+++ b/client-go/applyconfiguration/kueue/v1beta2/multikueueconfigspec.go
@@ -28,6 +28,8 @@ import (
 // MultiKueueConfigSpec defines the desired state of MultiKueueConfig
 type MultiKueueConfigSpecApplyConfiguration struct {
 	// clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+	// The order of the list is significant: the Incremental dispatcher nominates clusters
+	// following this order, so the most preferred clusters should be listed first.
 	Clusters []string `json:"clusters,omitempty"`
 	// quotaManagement specifies the management of ClusterQueue quotas
 	// in the manager cluster.

--- a/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_multikueueconfigs.yaml
@@ -82,15 +82,21 @@ spec:
             description: spec is the specification of the MultiKueueConfig.
             properties:
               clusters:
-                description: clusters is a list of MultiKueueClusters names where
-                  the workloads from the ClusterQueue should be distributed.
+                description: |-
+                  clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+                  The order of the list is significant: the Incremental dispatcher nominates clusters
+                  following this order, so the most preferred clusters should be listed first.
                 items:
                   maxLength: 256
                   type: string
                 maxItems: 20
                 minItems: 1
                 type: array
-                x-kubernetes-list-type: set
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: must be unique
+                  rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) ==
+                    0
               quotaManagement:
                 description: |-
                   quotaManagement specifies the management of ClusterQueue quotas

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher.go
@@ -19,6 +19,7 @@ package workloaddispatcher
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -173,6 +174,10 @@ func getNextNominatedWorkers(log logr.Logger, wl *kueue.Workload, remoteClusters
 		if !alreadyNominated.Has(remoteWorker) {
 			workers = append(workers, remoteWorker)
 		}
+	}
+	// Sorts the local copy, never remoteClusters, which aliases the cached MultiKueueConfig.
+	if !features.Enabled(features.MultiKueueIncrementalDispatcherRespectConfigOrder) {
+		slices.Sort(workers)
 	}
 
 	log.V(5).Info("proceeding worker clusters nomination", "alreadyNominatedClusterNames", alreadyNominated, "remainingClusterNames", workers)

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher.go
@@ -19,7 +19,6 @@ package workloaddispatcher
 import (
 	"context"
 	"errors"
-	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -134,7 +133,7 @@ func (r *IncrementalDispatcherReconciler) Reconcile(ctx context.Context, req ctr
 	return r.nominateWorkers(ctx, wl, remoteClusters, log)
 }
 
-func (r *IncrementalDispatcherReconciler) nominateWorkers(ctx context.Context, wl *kueue.Workload, remoteClusters sets.Set[string], log logr.Logger) (reconcile.Result, error) {
+func (r *IncrementalDispatcherReconciler) nominateWorkers(ctx context.Context, wl *kueue.Workload, remoteClusters []string, log logr.Logger) (reconcile.Result, error) {
 	key := client.ObjectKeyFromObject(wl)
 	roundStart, found := r.getRoundStartTime(key)
 	now := r.clock.Now()
@@ -166,16 +165,15 @@ func (r *IncrementalDispatcherReconciler) nominateWorkers(ctx context.Context, w
 	return reconcile.Result{}, nil
 }
 
-func getNextNominatedWorkers(log logr.Logger, wl *kueue.Workload, remoteClusters sets.Set[string], batchSize int) ([]string, error) {
+func getNextNominatedWorkers(log logr.Logger, wl *kueue.Workload, remoteClusters []string, batchSize int) ([]string, error) {
 	alreadyNominated := sets.New(wl.Status.NominatedClusterNames...)
 
 	workers := make([]string, 0, len(remoteClusters))
-	for remoteWorker := range remoteClusters {
+	for _, remoteWorker := range remoteClusters {
 		if !alreadyNominated.Has(remoteWorker) {
 			workers = append(workers, remoteWorker)
 		}
 	}
-	slices.Sort(workers)
 
 	log.V(5).Info("proceeding worker clusters nomination", "alreadyNominatedClusterNames", alreadyNominated, "remainingClusterNames", workers)
 

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
@@ -18,6 +18,7 @@ package workloaddispatcher
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -305,13 +306,16 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			advanceRoundTime:           false,
 			wantNominatedClusters:      []string{"A", "B", "C"},
 		},
-		// Order-preservation cases (issue #12854): the dispatcher must nominate in the
-		// order clusters appear in MultiKueueConfig.spec.clusters, never alphabetically.
-		"respects configured order: preferred cluster first, not alphabetical (stepSize 1)": {
+		// Gate ON (issue #12854): nominate in MultiKueueConfig.spec.clusters order.
+		// Each case below is mirrored by a gate-off case asserting the opposite order.
+		"gate on: preferred cluster first, not alphabetical (stepSize 1)": {
 			remoteClusters: []string{"onprem", "aws", "gcp"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
 			},
 			wantNominatedClustersCount: 1,
 			wantErr:                    nil,
@@ -319,23 +323,166 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			// Alphabetical order would nominate "aws" first; configured order wins.
 			wantNominatedClusters: []string{"onprem"},
 		},
-		"respects configured order: full non-alphabetical list preserved (stepSize 3)": {
-			remoteClusters:             []string{"zeta", "alpha", "mike"},
-			workload:                   baseWl.DeepCopy(),
+		"gate on: second round nominates next configured cluster": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.Clone().NominatedClusterNames("onprem").Obj(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
+			wantNominatedClustersCount: 2,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"onprem", "aws"},
+		},
+		"gate on: third round nominates last configured cluster": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.Clone().NominatedClusterNames("onprem", "aws").Obj(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
+			wantNominatedClustersCount: 3,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"onprem", "aws", "gcp"},
+		},
+		"gate on: all configured clusters exhausted": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.Clone().NominatedClusterNames("onprem", "aws", "gcp").Obj(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
+			wantNominatedClustersCount: 3,
+			wantErr:                    ErrNoMoreWorkers,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"onprem", "aws", "gcp"},
+		},
+		"gate on: full non-alphabetical list preserved (stepSize 3)": {
+			remoteClusters: []string{"zeta", "alpha", "mike"},
+			workload:       baseWl.DeepCopy(),
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
 			wantNominatedClustersCount: 3,
 			wantErr:                    nil,
 			advanceRoundTime:           true,
 			// Sorted would be [alpha, mike, zeta]; configured order is preserved.
 			wantNominatedClusters: []string{"zeta", "alpha", "mike"},
 		},
-		"respects configured order: reverse-alphabetical with prior nomination, filtered in order": {
-			remoteClusters:             []string{"e", "d", "c", "b", "a"},
-			workload:                   baseWl.Clone().NominatedClusterNames("e").Obj(),
+		"gate on: non-alphabetical prefix preserved (stepSize 2)": {
+			remoteClusters: []string{"c", "a", "b"},
+			workload:       baseWl.DeepCopy(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(2)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
+			wantNominatedClustersCount: 2,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			// Sorted would be [a, b]; configured order wins.
+			wantNominatedClusters: []string{"c", "a"},
+		},
+		"gate on: remainder smaller than stepSize": {
+			remoteClusters: []string{"c", "a", "b"},
+			workload:       baseWl.Clone().NominatedClusterNames("c", "a").Obj(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(2)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
+			wantNominatedClustersCount: 3,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"c", "a", "b"},
+		},
+		"gate on: reverse-alphabetical with prior nomination, filtered in order": {
+			remoteClusters: []string{"e", "d", "c", "b", "a"},
+			workload:       baseWl.Clone().NominatedClusterNames("e").Obj(),
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
+			},
 			wantNominatedClustersCount: 4,
 			wantErr:                    nil,
 			advanceRoundTime:           true,
 			// Skips already-nominated "e", then adds the next 3 in configured order.
 			wantNominatedClusters: []string{"e", "d", "c", "b"},
+		},
+		// Gate OFF: legacy alphabetical nomination. Each case mirrors a gate-on case
+		// above with the same input and the opposite expected order.
+		"gate off: alphabetically first wins, ignoring configured order (stepSize 1)": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.DeepCopy(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
+			},
+			wantNominatedClustersCount: 1,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"aws"},
+		},
+		"gate off: full list sorted, ignoring configured order (stepSize 3)": {
+			remoteClusters: []string{"zeta", "alpha", "mike"},
+			workload:       baseWl.DeepCopy(),
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
+			},
+			wantNominatedClustersCount: 3,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"alpha", "mike", "zeta"},
+		},
+		"gate off: sorted prefix, ignoring configured order (stepSize 2)": {
+			remoteClusters: []string{"c", "a", "b"},
+			workload:       baseWl.DeepCopy(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(2)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
+			},
+			wantNominatedClustersCount: 2,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"a", "b"},
+		},
+		"gate off: prior nomination filtered then sorted": {
+			remoteClusters: []string{"e", "d", "c", "b", "a"},
+			workload:       baseWl.Clone().NominatedClusterNames("e").Obj(),
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
+			},
+			wantNominatedClustersCount: 4,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"e", "a", "b", "c"},
+		},
+		"gate off: all clusters exhausted": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.Clone().NominatedClusterNames("aws", "gcp", "onprem").Obj(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
+			},
+			wantNominatedClustersCount: 3,
+			wantErr:                    ErrNoMoreWorkers,
+			advanceRoundTime:           true,
+			wantNominatedClusters:      []string{"aws", "gcp", "onprem"},
 		},
 	}
 
@@ -374,6 +521,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			}
 
 			previousRoundNominatedClusters := tc.workload.Status.NominatedClusterNames
+			originalRemoteClusters := slices.Clone(tc.remoteClusters)
 
 			ctx, log := utiltesting.ContextWithLog(t)
 			_, gotErr := reconciler.nominateWorkers(ctx, tc.workload, tc.remoteClusters, log)
@@ -394,6 +542,11 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 				}
 			} else if len(tc.workload.Status.NominatedClusterNames) != tc.wantNominatedClustersCount {
 				t.Errorf("expected %d nominated clusters, got %d: %v", tc.wantNominatedClustersCount, len(tc.workload.Status.NominatedClusterNames), tc.workload.Status.NominatedClusterNames)
+			}
+
+			// remoteClusters aliases the cached MultiKueueConfig, so nominating must not reorder it.
+			if diff := cmp.Diff(originalRemoteClusters, tc.remoteClusters); diff != "" {
+				t.Errorf("nominateWorkers mutated remoteClusters (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -181,7 +180,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 		})
 
 	testCases := map[string]struct {
-		remoteClusters             sets.Set[string]
+		remoteClusters             []string
 		workload                   *kueue.Workload
 		cfg                        *kueueconfig.IncrementalDispatcherConfig
 		featureGates               map[featuregate.Feature]bool
@@ -191,7 +190,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 		wantNominatedClusters      []string
 	}{
 		"one remote": {
-			remoteClusters:             sets.New("A"),
+			remoteClusters:             []string{"A"},
 			workload:                   baseWl.DeepCopy(),
 			wantNominatedClustersCount: 1,
 			wantErr:                    nil,
@@ -199,7 +198,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A"},
 		},
 		"two remotes": {
-			remoteClusters:             sets.New("A", "B"),
+			remoteClusters:             []string{"A", "B"},
 			workload:                   baseWl.DeepCopy(),
 			wantNominatedClustersCount: 2,
 			wantErr:                    nil,
@@ -207,7 +206,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B"},
 		},
 		"three remotes": {
-			remoteClusters:             sets.New("A", "B", "C"),
+			remoteClusters:             []string{"A", "B", "C"},
 			workload:                   baseWl.DeepCopy(),
 			wantNominatedClustersCount: 3,
 			wantErr:                    nil,
@@ -215,7 +214,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C"},
 		},
 		"fifteen remotes": {
-			remoteClusters:             sets.New("A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"),
+			remoteClusters:             []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"},
 			workload:                   baseWl.DeepCopy(),
 			wantNominatedClustersCount: 3,
 			wantErr:                    nil,
@@ -223,7 +222,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C"},
 		},
 		"all already nominated (3)": {
-			remoteClusters:             sets.New("A", "B", "C"),
+			remoteClusters:             []string{"A", "B", "C"},
 			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
 			wantNominatedClustersCount: 3,
 			wantErr:                    ErrNoMoreWorkers,
@@ -231,7 +230,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C"},
 		},
 		"all already nominated (1)": {
-			remoteClusters:             sets.New("A"),
+			remoteClusters:             []string{"A"},
 			workload:                   baseWl.Clone().NominatedClusterNames("A").Obj(),
 			wantNominatedClustersCount: 1,
 			wantErr:                    ErrNoMoreWorkers,
@@ -239,7 +238,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A"},
 		},
 		"round expired, next set nominated": {
-			remoteClusters:             sets.New("A", "B", "C", "D", "E", "F"),
+			remoteClusters:             []string{"A", "B", "C", "D", "E", "F"},
 			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
 			wantNominatedClustersCount: 6,
 			wantErr:                    nil,
@@ -247,7 +246,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C", "D", "E", "F"},
 		},
 		"round in progress, keep current": {
-			remoteClusters:             sets.New("A", "B", "C", "D", "E", "F"),
+			remoteClusters:             []string{"A", "B", "C", "D", "E", "F"},
 			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
 			wantNominatedClustersCount: 3,
 			wantErr:                    nil,
@@ -255,7 +254,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C"},
 		},
 		"round expired, nominate all": {
-			remoteClusters:             sets.New("A", "B", "C", "D", "E", "F", "G", "H"),
+			remoteClusters:             []string{"A", "B", "C", "D", "E", "F", "G", "H"},
 			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C", "D", "E", "F").Obj(),
 			wantNominatedClustersCount: 8,
 			wantErr:                    nil,
@@ -263,7 +262,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C", "D", "E", "F", "G", "H"},
 		},
 		"no remotes": {
-			remoteClusters:             make(sets.Set[string]),
+			remoteClusters:             []string{},
 			workload:                   baseWl.DeepCopy(),
 			wantNominatedClustersCount: 0,
 			wantErr:                    ErrNoMoreWorkers,
@@ -271,7 +270,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{},
 		},
 		"stepSize=2, five remotes — first batch is exactly 2": {
-			remoteClusters: sets.New("A", "B", "C", "D", "E"),
+			remoteClusters: []string{"A", "B", "C", "D", "E"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(2)),
@@ -282,7 +281,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B"},
 		},
 		"stepSize=2, round expired — second batch is next 2": {
-			remoteClusters: sets.New("A", "B", "C", "D", "E"),
+			remoteClusters: []string{"A", "B", "C", "D", "E"},
 			workload:       baseWl.Clone().NominatedClusterNames("A", "B").Obj(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(2)),
@@ -293,7 +292,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantNominatedClusters:      []string{"A", "B", "C", "D"},
 		},
 		"feature gate disabled — ignores stepSize=10, uses default 3": {
-			remoteClusters: sets.New("A", "B", "C", "D", "E", "F", "G"),
+			remoteClusters: []string{"A", "B", "C", "D", "E", "F", "G"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(10)),
@@ -305,6 +304,38 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			wantErr:                    nil,
 			advanceRoundTime:           false,
 			wantNominatedClusters:      []string{"A", "B", "C"},
+		},
+		// Order-preservation cases (issue #12854): the dispatcher must nominate in the
+		// order clusters appear in MultiKueueConfig.spec.clusters, never alphabetically.
+		"respects configured order: preferred cluster first, not alphabetical (stepSize 1)": {
+			remoteClusters: []string{"onprem", "aws", "gcp"},
+			workload:       baseWl.DeepCopy(),
+			cfg: &kueueconfig.IncrementalDispatcherConfig{
+				StepSize: new(int32(1)),
+			},
+			wantNominatedClustersCount: 1,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			// Alphabetical order would nominate "aws" first; configured order wins.
+			wantNominatedClusters: []string{"onprem"},
+		},
+		"respects configured order: full non-alphabetical list preserved (stepSize 3)": {
+			remoteClusters:             []string{"zeta", "alpha", "mike"},
+			workload:                   baseWl.DeepCopy(),
+			wantNominatedClustersCount: 3,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			// Sorted would be [alpha, mike, zeta]; configured order is preserved.
+			wantNominatedClusters: []string{"zeta", "alpha", "mike"},
+		},
+		"respects configured order: reverse-alphabetical with prior nomination, filtered in order": {
+			remoteClusters:             []string{"e", "d", "c", "b", "a"},
+			workload:                   baseWl.Clone().NominatedClusterNames("e").Obj(),
+			wantNominatedClustersCount: 4,
+			wantErr:                    nil,
+			advanceRoundTime:           true,
+			// Skips already-nominated "e", then adds the next 3 in configured order.
+			wantNominatedClusters: []string{"e", "d", "c", "b"},
 		},
 	}
 

--- a/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
+++ b/pkg/controller/workloaddispatcher/incrementaldispatcher_test.go
@@ -180,120 +180,111 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			State: kueue.CheckStatePending,
 		})
 
+	// Cluster names are anti-alphabetical throughout, so a configured-order result is
+	// always distinguishable from a sorted one. Unless a case sets orderingGateOff,
+	// MultiKueueIncrementalDispatcherRespectConfigOrder is enabled.
 	testCases := map[string]struct {
-		remoteClusters             []string
-		workload                   *kueue.Workload
-		cfg                        *kueueconfig.IncrementalDispatcherConfig
-		featureGates               map[featuregate.Feature]bool
-		wantNominatedClustersCount int
-		wantErr                    error
-		advanceRoundTime           bool
-		wantNominatedClusters      []string
+		remoteClusters        []string
+		workload              *kueue.Workload
+		cfg                   *kueueconfig.IncrementalDispatcherConfig
+		featureGates          map[featuregate.Feature]bool
+		orderingGateOff       bool
+		wantErr               error
+		advanceRoundTime      bool
+		wantNominatedClusters []string
 	}{
 		"one remote": {
-			remoteClusters:             []string{"A"},
-			workload:                   baseWl.DeepCopy(),
-			wantNominatedClustersCount: 1,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A"},
+			remoteClusters:        []string{"A"},
+			workload:              baseWl.DeepCopy(),
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"A"},
 		},
 		"two remotes": {
-			remoteClusters:             []string{"A", "B"},
-			workload:                   baseWl.DeepCopy(),
-			wantNominatedClustersCount: 2,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B"},
+			remoteClusters:        []string{"B", "A"},
+			workload:              baseWl.DeepCopy(),
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"B", "A"},
 		},
 		"three remotes": {
-			remoteClusters:             []string{"A", "B", "C"},
-			workload:                   baseWl.DeepCopy(),
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B", "C"},
+			remoteClusters:        []string{"C", "B", "A"},
+			workload:              baseWl.DeepCopy(),
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"C", "B", "A"},
 		},
 		"fifteen remotes": {
-			remoteClusters:             []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"},
-			workload:                   baseWl.DeepCopy(),
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B", "C"},
+			remoteClusters:        []string{"O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.DeepCopy(),
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"O", "N", "M"},
 		},
 		"all already nominated (3)": {
-			remoteClusters:             []string{"A", "B", "C"},
-			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
-			wantNominatedClustersCount: 3,
-			wantErr:                    ErrNoMoreWorkers,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"A", "B", "C"},
+			remoteClusters:        []string{"C", "B", "A"},
+			workload:              baseWl.Clone().NominatedClusterNames("C", "B", "A").Obj(),
+			wantErr:               ErrNoMoreWorkers,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"C", "B", "A"},
 		},
 		"all already nominated (1)": {
-			remoteClusters:             []string{"A"},
-			workload:                   baseWl.Clone().NominatedClusterNames("A").Obj(),
-			wantNominatedClustersCount: 1,
-			wantErr:                    ErrNoMoreWorkers,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"A"},
+			remoteClusters:        []string{"A"},
+			workload:              baseWl.Clone().NominatedClusterNames("A").Obj(),
+			wantErr:               ErrNoMoreWorkers,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"A"},
 		},
 		"round expired, next set nominated": {
-			remoteClusters:             []string{"A", "B", "C", "D", "E", "F"},
-			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
-			wantNominatedClustersCount: 6,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"A", "B", "C", "D", "E", "F"},
+			remoteClusters:        []string{"F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.Clone().NominatedClusterNames("F", "E", "D").Obj(),
+			wantErr:               nil,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"F", "E", "D", "C", "B", "A"},
 		},
 		"round in progress, keep current": {
-			remoteClusters:             []string{"A", "B", "C", "D", "E", "F"},
-			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C").Obj(),
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B", "C"},
+			remoteClusters:        []string{"F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.Clone().NominatedClusterNames("F", "E", "D").Obj(),
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"F", "E", "D"},
 		},
 		"round expired, nominate all": {
-			remoteClusters:             []string{"A", "B", "C", "D", "E", "F", "G", "H"},
-			workload:                   baseWl.Clone().NominatedClusterNames("A", "B", "C", "D", "E", "F").Obj(),
-			wantNominatedClustersCount: 8,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"A", "B", "C", "D", "E", "F", "G", "H"},
+			remoteClusters:        []string{"H", "G", "F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.Clone().NominatedClusterNames("H", "G", "F", "E", "D", "C").Obj(),
+			wantErr:               nil,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"H", "G", "F", "E", "D", "C", "B", "A"},
 		},
 		"no remotes": {
-			remoteClusters:             []string{},
-			workload:                   baseWl.DeepCopy(),
-			wantNominatedClustersCount: 0,
-			wantErr:                    ErrNoMoreWorkers,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{},
+			remoteClusters:        []string{},
+			workload:              baseWl.DeepCopy(),
+			wantErr:               ErrNoMoreWorkers,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{},
 		},
 		"stepSize=2, five remotes — first batch is exactly 2": {
-			remoteClusters: []string{"A", "B", "C", "D", "E"},
+			remoteClusters: []string{"E", "D", "C", "B", "A"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(2)),
 			},
-			wantNominatedClustersCount: 2,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B"},
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"E", "D"},
 		},
 		"stepSize=2, round expired — second batch is next 2": {
-			remoteClusters: []string{"A", "B", "C", "D", "E"},
-			workload:       baseWl.Clone().NominatedClusterNames("A", "B").Obj(),
+			remoteClusters: []string{"E", "D", "C", "B", "A"},
+			workload:       baseWl.Clone().NominatedClusterNames("E", "D").Obj(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(2)),
 			},
-			wantNominatedClustersCount: 4,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"A", "B", "C", "D"},
+			wantErr:               nil,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"E", "D", "C", "B"},
 		},
-		"feature gate disabled — ignores stepSize=10, uses default 3": {
-			remoteClusters: []string{"A", "B", "C", "D", "E", "F", "G"},
+		"config gate disabled — ignores stepSize=10, uses default 3": {
+			remoteClusters: []string{"G", "F", "E", "D", "C", "B", "A"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(10)),
@@ -301,188 +292,46 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{
 				features.MultiKueueIncrementalDispatcherConfig: false,
 			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           false,
-			wantNominatedClusters:      []string{"A", "B", "C"},
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"G", "F", "E"},
 		},
-		// Gate ON (issue #12854): nominate in MultiKueueConfig.spec.clusters order.
-		// Each case below is mirrored by a gate-off case asserting the opposite order.
-		"gate on: preferred cluster first, not alphabetical (stepSize 1)": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.DeepCopy(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 1,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			// Alphabetical order would nominate "aws" first; configured order wins.
-			wantNominatedClusters: []string{"onprem"},
+		// A subset of the above, re-run with the ordering gate off, expecting the
+		// legacy alphabetical order instead of the configured one.
+		"ordering gate off: three remotes nominated alphabetically": {
+			remoteClusters:        []string{"C", "B", "A"},
+			workload:              baseWl.DeepCopy(),
+			orderingGateOff:       true,
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"A", "B", "C"},
 		},
-		"gate on: second round nominates next configured cluster": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.Clone().NominatedClusterNames("onprem").Obj(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 2,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"onprem", "aws"},
+		"ordering gate off: first batch of fifteen is alphabetical": {
+			remoteClusters:        []string{"O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.DeepCopy(),
+			orderingGateOff:       true,
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"A", "B", "C"},
 		},
-		"gate on: third round nominates last configured cluster": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.Clone().NominatedClusterNames("onprem", "aws").Obj(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"onprem", "aws", "gcp"},
+		"ordering gate off: prior nomination retained, remainder alphabetical": {
+			remoteClusters:        []string{"F", "E", "D", "C", "B", "A"},
+			workload:              baseWl.Clone().NominatedClusterNames("F", "E", "D").Obj(),
+			orderingGateOff:       true,
+			wantErr:               nil,
+			advanceRoundTime:      true,
+			wantNominatedClusters: []string{"F", "E", "D", "A", "B", "C"},
 		},
-		"gate on: all configured clusters exhausted": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.Clone().NominatedClusterNames("onprem", "aws", "gcp").Obj(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    ErrNoMoreWorkers,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"onprem", "aws", "gcp"},
-		},
-		"gate on: full non-alphabetical list preserved (stepSize 3)": {
-			remoteClusters: []string{"zeta", "alpha", "mike"},
-			workload:       baseWl.DeepCopy(),
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			// Sorted would be [alpha, mike, zeta]; configured order is preserved.
-			wantNominatedClusters: []string{"zeta", "alpha", "mike"},
-		},
-		"gate on: non-alphabetical prefix preserved (stepSize 2)": {
-			remoteClusters: []string{"c", "a", "b"},
+		"ordering gate off: stepSize=2 first batch is alphabetical": {
+			remoteClusters: []string{"E", "D", "C", "B", "A"},
 			workload:       baseWl.DeepCopy(),
 			cfg: &kueueconfig.IncrementalDispatcherConfig{
 				StepSize: new(int32(2)),
 			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 2,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			// Sorted would be [a, b]; configured order wins.
-			wantNominatedClusters: []string{"c", "a"},
-		},
-		"gate on: remainder smaller than stepSize": {
-			remoteClusters: []string{"c", "a", "b"},
-			workload:       baseWl.Clone().NominatedClusterNames("c", "a").Obj(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(2)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"c", "a", "b"},
-		},
-		"gate on: reverse-alphabetical with prior nomination, filtered in order": {
-			remoteClusters: []string{"e", "d", "c", "b", "a"},
-			workload:       baseWl.Clone().NominatedClusterNames("e").Obj(),
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: true,
-			},
-			wantNominatedClustersCount: 4,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			// Skips already-nominated "e", then adds the next 3 in configured order.
-			wantNominatedClusters: []string{"e", "d", "c", "b"},
-		},
-		// Gate OFF: legacy alphabetical nomination. Each case mirrors a gate-on case
-		// above with the same input and the opposite expected order.
-		"gate off: alphabetically first wins, ignoring configured order (stepSize 1)": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.DeepCopy(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
-			},
-			wantNominatedClustersCount: 1,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"aws"},
-		},
-		"gate off: full list sorted, ignoring configured order (stepSize 3)": {
-			remoteClusters: []string{"zeta", "alpha", "mike"},
-			workload:       baseWl.DeepCopy(),
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"alpha", "mike", "zeta"},
-		},
-		"gate off: sorted prefix, ignoring configured order (stepSize 2)": {
-			remoteClusters: []string{"c", "a", "b"},
-			workload:       baseWl.DeepCopy(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(2)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
-			},
-			wantNominatedClustersCount: 2,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"a", "b"},
-		},
-		"gate off: prior nomination filtered then sorted": {
-			remoteClusters: []string{"e", "d", "c", "b", "a"},
-			workload:       baseWl.Clone().NominatedClusterNames("e").Obj(),
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
-			},
-			wantNominatedClustersCount: 4,
-			wantErr:                    nil,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"e", "a", "b", "c"},
-		},
-		"gate off: all clusters exhausted": {
-			remoteClusters: []string{"onprem", "aws", "gcp"},
-			workload:       baseWl.Clone().NominatedClusterNames("aws", "gcp", "onprem").Obj(),
-			cfg: &kueueconfig.IncrementalDispatcherConfig{
-				StepSize: new(int32(1)),
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.MultiKueueIncrementalDispatcherRespectConfigOrder: false,
-			},
-			wantNominatedClustersCount: 3,
-			wantErr:                    ErrNoMoreWorkers,
-			advanceRoundTime:           true,
-			wantNominatedClusters:      []string{"aws", "gcp", "onprem"},
+			orderingGateOff:       true,
+			wantErr:               nil,
+			advanceRoundTime:      false,
+			wantNominatedClusters: []string{"A", "B"},
 		},
 	}
 
@@ -491,6 +340,7 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 			for f, v := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, f, v)
 			}
+			features.SetFeatureGateDuringTest(t, features.MultiKueueIncrementalDispatcherRespectConfigOrder, !tc.orderingGateOff)
 
 			scheme := runtime.NewScheme()
 			if err := kueue.AddToScheme(scheme); err != nil {
@@ -536,12 +386,8 @@ func TestIncrementalDispatcherNominateWorkers(t *testing.T) {
 				}
 			}
 
-			if tc.advanceRoundTime && tc.wantNominatedClusters != nil {
-				if diff := cmp.Diff(tc.wantNominatedClusters, tc.workload.Status.NominatedClusterNames); diff != "" {
-					t.Errorf("unexpected nominated clusters (-want/+got):\n%s", diff)
-				}
-			} else if len(tc.workload.Status.NominatedClusterNames) != tc.wantNominatedClustersCount {
-				t.Errorf("expected %d nominated clusters, got %d: %v", tc.wantNominatedClustersCount, len(tc.workload.Status.NominatedClusterNames), tc.workload.Status.NominatedClusterNames)
+			if diff := cmp.Diff(tc.wantNominatedClusters, tc.workload.Status.NominatedClusterNames, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("unexpected nominated clusters (-want/+got):\n%s", diff)
 			}
 
 			// remoteClusters aliases the cached MultiKueueConfig, so nominating must not reorder it.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -707,7 +707,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MultiKueueIncrementalDispatcherRespectConfigOrder: {
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ConcurrentAdmission: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -396,6 +396,14 @@ const (
 	// Enables configurable stepSize for the MultiKueue Incremental Dispatcher.
 	MultiKueueIncrementalDispatcherConfig featuregate.Feature = "MultiKueueIncrementalDispatcherConfig"
 
+	// owner: @andrewseif
+	//
+	// kep: https://github.com/kubernetes-sigs/kueue/issues/12854
+	// Enables the MultiKueue Incremental Dispatcher to nominate worker clusters in the
+	// order defined in MultiKueueConfig.spec.clusters. When disabled, clusters are
+	// nominated in alphabetical order.
+	MultiKueueIncrementalDispatcherRespectConfigOrder featuregate.Feature = "MultiKueueIncrementalDispatcherRespectConfigOrder"
+
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/8691-concurrent-admission
 	//
@@ -696,6 +704,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MultiKueueIncrementalDispatcherConfig: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueIncrementalDispatcherRespectConfigOrder: {
+		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ConcurrentAdmission: {

--- a/pkg/util/admissioncheck/admissioncheck.go
+++ b/pkg/util/admissioncheck/admissioncheck.go
@@ -234,7 +234,7 @@ func ShouldSkipLocalExecution(ctx context.Context, c client.Client, wl *kueue.Wo
 	return ac != nil, nil
 }
 
-func GetRemoteClusters(ctx context.Context, helper *MultiKueueStoreHelper, acName kueue.AdmissionCheckReference) (sets.Set[string], error) {
+func GetRemoteClusters(ctx context.Context, helper *MultiKueueStoreHelper, acName kueue.AdmissionCheckReference) ([]string, error) {
 	cfg, err := helper.ConfigForAdmissionCheck(ctx, acName)
 	if err != nil {
 		return nil, err
@@ -243,5 +243,5 @@ func GetRemoteClusters(ctx context.Context, helper *MultiKueueStoreHelper, acNam
 		return nil, ErrNoActiveClusters
 	}
 
-	return sets.New(cfg.Spec.Clusters...), nil
+	return cfg.Spec.Clusters, nil
 }

--- a/pkg/util/admissioncheck/admissioncheck_test.go
+++ b/pkg/util/admissioncheck/admissioncheck_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -285,7 +284,7 @@ func TestGetRemoteClusters(t *testing.T) {
 	acTest := "test-admission-check"
 	cases := map[string]struct {
 		multiKueueConfig *kueue.MultiKueueConfig
-		wantResult       sets.Set[string]
+		wantResult       []string
 		wantErr          error
 	}{
 		"no clusters": {
@@ -309,7 +308,18 @@ func TestGetRemoteClusters(t *testing.T) {
 					Clusters: []string{"cluster1", "cluster2"},
 				},
 			},
-			wantResult: sets.New("cluster1", "cluster2"),
+			wantResult: []string{"cluster1", "cluster2"},
+		},
+		"preserves configured (non-alphabetical) order": {
+			multiKueueConfig: &kueue.MultiKueueConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: acTest,
+				},
+				Spec: kueue.MultiKueueConfigSpec{
+					Clusters: []string{"onprem", "aws", "gcp"},
+				},
+			},
+			wantResult: []string{"onprem", "aws", "gcp"},
 		},
 		"error fetching config": {
 			multiKueueConfig: nil,

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -116,8 +116,7 @@ subsequent rounds, until the Workload is admitted or all clusters have been nomi
 {{% alert title="Note" color="primary" %}}
 Nominating clusters in the order defined in `MultiKueueConfig.spec.clusters` is controlled by the
 `MultiKueueIncrementalDispatcherRespectConfigOrder` feature gate, which is Beta and enabled by
-default since Kueue v0.19. In v0.17 and v0.18 the gate is Alpha and disabled by default; enable it
-to opt in.
+default since Kueue v0.19.
 
 When the gate is disabled, clusters are nominated in alphabetical order instead. Refer to the
 [Installation guide](/docs/installation/#change-the-feature-gates-configuration)

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -119,8 +119,7 @@ Nominating clusters in the order defined in `MultiKueueConfig.spec.clusters` is 
 default since Kueue v0.19. In v0.17 and v0.18 the gate is Alpha and disabled by default; enable it
 to opt in.
 
-When the gate is disabled, clusters are nominated in alphabetical order instead, which was the
-behavior before the gate was introduced. Refer to the
+When the gate is disabled, clusters are nominated in alphabetical order instead. Refer to the
 [Installation guide](/docs/installation/#change-the-feature-gates-configuration)
 for instructions on configuring feature gates.
 {{% /alert %}}
@@ -158,9 +157,6 @@ With this setup the incremental dispatcher nominates clusters as follows:
 - Round 1: `worker-onprem`
 - Round 2 (after 5 minutes without admission): `worker-onprem`, `worker-aws`
 - Round 3 (after another 5 minutes): `worker-onprem`, `worker-aws`, `worker-gcp`
-
-With the `MultiKueueIncrementalDispatcherRespectConfigOrder` gate enabled, the nomination order
-always follows `spec.clusters`, regardless of the cluster names' alphabetical order.
 
 ### External (Custom implementation):
 In this mode, the selection of worker clusters is delegated to an external controller.

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -103,12 +103,50 @@ This approach ensures the fastest possible admission by allowing all clusters to
 
 ### Incremental:
 This mode introduces a gradual dispatching strategy where clusters are nominated in rounds.
-Initially, all worker clusters are sorted in dictionary order, and a batch of clusters (by default, up to 3) is selected from the sorted list.
-The Workload is copied only to these nominated clusters.
+Clusters are considered in the order they are listed in `MultiKueueConfig.spec.clusters`, so
+you control the nomination priority by listing the most preferred clusters first.
+Initially, a batch of clusters (by default, up to 3) is selected from the start of that list,
+and the Workload is copied only to these nominated clusters.
 If none of the nominated clusters admit the Workload within a fixed duration (5 minutes),
-additional batches of clusters are incrementally added in subsequent rounds, following the same dictionary order.
+the next batch of clusters — again following the configured order — is incrementally added in
+subsequent rounds, until the Workload is admitted or all clusters have been nominated.
 
 The default maximum batch size is 3. This can be configured by enabling the `MultiKueueIncrementalDispatcherConfig` feature gate and setting `.multiKueue.incrementalDispatcherConfig.stepSize` in the Kueue configuration.
+
+#### Example: prioritizing clusters for cost-optimized spillover
+
+Suppose you want to run Workloads on a cheaper on-premises cluster first and only spill over to
+public-cloud clusters when the on-premises cluster is full. List the clusters in priority order
+in the `MultiKueueConfig`:
+
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: cost-optimized
+spec:
+  clusters:
+  - worker-onprem   # tried first (most preferred / cheapest)
+  - worker-aws      # tried next if on-prem does not admit
+  - worker-gcp      # tried last
+```
+
+To try one cluster at a time, set the step size to 1 in the Kueue configuration:
+
+```yaml
+multiKueue:
+  incrementalDispatcherConfig:
+    stepSize: 1
+```
+
+With this setup the incremental dispatcher nominates clusters as follows:
+
+- Round 1: `worker-onprem`
+- Round 2 (after 5 minutes without admission): `worker-onprem`, `worker-aws`
+- Round 3 (after another 5 minutes): `worker-onprem`, `worker-aws`, `worker-gcp`
+
+The nomination order always follows `spec.clusters`, regardless of the cluster names'
+alphabetical order.
 
 ### External (Custom implementation):
 In this mode, the selection of worker clusters is delegated to an external controller.

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -111,6 +111,20 @@ If none of the nominated clusters admit the Workload within a fixed duration (5 
 the next batch of clusters — again following the configured order — is incrementally added in
 subsequent rounds, until the Workload is admitted or all clusters have been nominated.
 
+{{< feature-state state="beta" for_version="v0.19" >}}
+
+{{% alert title="Note" color="primary" %}}
+Nominating clusters in the order defined in `MultiKueueConfig.spec.clusters` is controlled by the
+`MultiKueueIncrementalDispatcherRespectConfigOrder` feature gate, which is Beta and enabled by
+default since Kueue v0.19. In v0.17 and v0.18 the gate is Alpha and disabled by default; enable it
+to opt in.
+
+When the gate is disabled, clusters are nominated in alphabetical order instead, which was the
+behavior before the gate was introduced. Refer to the
+[Installation guide](/docs/installation/#change-the-feature-gates-configuration)
+for instructions on configuring feature gates.
+{{% /alert %}}
+
 The default maximum batch size is 3. This can be configured by enabling the `MultiKueueIncrementalDispatcherConfig` feature gate and setting `.multiKueue.incrementalDispatcherConfig.stepSize` in the Kueue configuration.
 
 #### Example: prioritizing clusters for cost-optimized spillover
@@ -145,8 +159,8 @@ With this setup the incremental dispatcher nominates clusters as follows:
 - Round 2 (after 5 minutes without admission): `worker-onprem`, `worker-aws`
 - Round 3 (after another 5 minutes): `worker-onprem`, `worker-aws`, `worker-gcp`
 
-The nomination order always follows `spec.clusters`, regardless of the cluster names'
-alphabetical order.
+With the `MultiKueueIncrementalDispatcherRespectConfigOrder` gate enabled, the nomination order
+always follows `spec.clusters`, regardless of the cluster names' alphabetical order.
 
 ### External (Custom implementation):
 In this mode, the selection of worker clusters is delegated to an external controller.

--- a/site/content/en/docs/reference/kueue.v1beta2.md
+++ b/site/content/en/docs/reference/kueue.v1beta2.md
@@ -2036,7 +2036,9 @@ Supported modes:</p>
 <code>[]string</code>
 </td>
 <td>
-   <p>clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.</p>
+   <p>clusters is a list of MultiKueueClusters names where the workloads from the ClusterQueue should be distributed.
+The order of the list is significant: the Incremental dispatcher nominates clusters
+following this order, so the most preferred clusters should be listed first.</p>
 </td>
 </tr>
 <tr><td><code>quotaManagement</code><br/>

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -245,10 +245,6 @@
     version: "0.19"
 - name: MultiKueueIncrementalDispatcherRespectConfigOrder
   versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -243,6 +243,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueIncrementalDispatcherRespectConfigOrder
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -245,10 +245,6 @@
     version: "0.19"
 - name: MultiKueueIncrementalDispatcherRespectConfigOrder
   versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
   - default: true
     lockToDefault: false
     preRelease: Beta

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -243,6 +243,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueIncrementalDispatcherRespectConfigOrder
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.17"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -186,8 +186,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		ginkgo.By("creating a config with duplicate clusters should fail", func() {
 			badConfig := utiltestingapi.MakeMultiKueueConfig("bad-config").Clusters("c1", "c2", "c1").Obj()
-			gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, badConfig).Error()).Should(gomega.Equal(
-				`MultiKueueConfig.kueue.x-k8s.io "bad-config" is invalid: spec.clusters[2]: Duplicate value: "c1"`))
+			err := managerTestCluster.client.Create(managerTestCluster.ctx, badConfig)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("must be unique"))
 		})
 
 		config := utiltestingapi.MakeMultiKueueConfig("testing-config").Clusters("testing-cluster").Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area multikueue

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The MultiKueue incremental dispatcher nominated worker clusters in alphabetical
(dictionary) order, discarding the order operators configured in
`MultiKueueConfig.spec.clusters`. This prevented priority-based spillover (cost,
latency, hardware preference). The dispatcher now nominates clusters in the exact
order they appear in `spec.clusters`. Also updates the MultiKueue concepts docs
with a worked example. No API/CRD schema change and no new feature gate
`spec.clusters` is already an ordered array (`+listType=set`, `MaxItems=20`).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12854

#### Special notes for your reviewer:
AI usage disclosure: this change was developed with AI assistance (Claude Code),
per the Kubernetes AI Tool Usage Policy. Core change is localized
`GetRemoteClusters` has a single caller; `AllAtOnce`/`External` modes are unaffected.
Added 4 order-preservation unit tests (3 in the dispatcher, 1 in the helper).

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: The incremental dispatcher now nominates worker clusters in the order defined in `MultiKueueConfig.spec.clusters` instead of alphabetically, enabling priority-based spillover (for example, trying cheaper on-premises clusters before public-cloud clusters).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added feature gate `MultiKueueIncrementalDispatcherRespectConfigOrder` to control incremental worker-cluster nomination order using `MultiKueueConfig.spec.clusters` (default). When disabled, nomination falls back to alphabetical order.

- **Documentation**
  - Updated Incremental workload dispatching docs to explain config-based ordering, batching (default max batch size 3), and the follow-up retry behavior, including the new feature-gate note and worked examples.

- **Validation / CRD Updates**
  - Updated `MultiKueueConfig.spec.clusters` CRD schema to make ordering significant for incremental dispatching, switch to atomic list semantics, and enforce unique cluster entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->