### PR TITLE
TAS: replace nodes only on pod termination; deprecate fixed-time NotReady marking

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -46,6 +46,7 @@
     - [Node failures](#node-failures)
       - [Until v0.13](#until-v013)
       - [Since v0.14](#since-v014)
+      - [Sunsetting fixed-time marking (since v0.19)](#sunsetting-fixed-time-marking-since-v019)
       - [Workloads owned by a single Pod](#workloads-owned-by-a-single-pod)
     - [Tainted nodes treatment](#tainted-nodes-treatment)
       - [User stories](#user-stories-1)
@@ -1405,13 +1406,31 @@ Sometimes node failures are only transient and the node might recover, and so re
 immediately to NotReady condition could result in unnecessary node replacements.
 
 For that reason we introduce two heuristics for marking nodes to replace for a given workload:
-1. when the node is NotReady for over 30s (used by default)
+1. when the node is NotReady for over 30s (the default until v0.19; see
+[Sunsetting fixed-time marking](#sunsetting-fixed-time-marking-since-v019))
 2. when the node is NotReady and all of the workload's Pods scheduled on that node are terminated
 or terminating (used when the `TASReplaceNodeOnPodTermination` feature gate is enabled which is
-available starting with Kueue v0.13)
+available starting with Kueue v0.13; the only heuristic since v0.19)
 
 For the future releases we are going to consider API configuration for the approach, but first we
 would like to collect more user feedback using the feature gates while in Alpha.
+
+##### Sunsetting fixed-time marking (since v0.19)
+
+Marking a node failed after a fixed NotReady duration is premature in principle: a
+node can become Ready again after an arbitrary amount of time, and while the
+workload's Pods are still running on it, a recomputed assignment diverges from where
+the Pods actually run and corrupts per-node capacity accounting. Heuristic 2 (pod
+termination) is therefore the only marking trigger since v0.19.
+
+The fixed-time heuristic is retained behind the
+`TASReplaceNodeDueToNotReadyOverFixedTime` feature gate: Beta (enabled by default)
+in v0.17 and v0.18 backports, Deprecated (disabled by default) since v0.19, with
+removal planned in v0.21. While that gate is enabled, the interplay with
+`TASReplaceNodeOnPodTermination` is unchanged from v0.14; once it is disabled,
+`TASReplaceNodeOnPodTermination` has no effect and pod-termination marking is
+unconditional. Nodes that are deleted or lack a Ready condition are still marked
+immediately in all configurations.
 
 Kueue tries to find a replacement for a failed node until success (or until it gets
 evicted by e.g. `waitForPodsReady.recoveryTimeout`). One can limit the number of retries

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -44,6 +44,7 @@ feature-gates:
   - name: TASFailedNodeReplacement
   - name: TASFailedNodeReplacementFailFast
   - name: TASReplaceNodeOnPodTermination
+  - name: TASReplaceNodeDueToNotReadyOverFixedTime
   - name: TASBalancedPlacement
   - name: TASReplaceNodeOnNodeTaints
   - name: TASMultiLayerTopology

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -646,6 +646,7 @@ func LoadAndValidateFeatureGates(featureGateCLI string, featureGateMap map[strin
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASFailedNodeReplacement, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASFailedNodeReplacementFailFast, features.TopologyAwareScheduling, features.TASFailedNodeReplacement)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASReplaceNodeOnPodTermination, features.TopologyAwareScheduling, features.TASFailedNodeReplacement)...)
+	allErrs = append(allErrs, validateFeatureGateDependency(features.TASReplaceNodeDueToNotReadyOverFixedTime, features.TopologyAwareScheduling, features.TASFailedNodeReplacement)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASBalancedPlacement, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASReplaceNodeOnNodeTaints, features.TopologyAwareScheduling)...)
 	allErrs = append(allErrs, validateFeatureGateDependency(features.TASMultiLayerTopology, features.TopologyAwareScheduling)...)

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1517,6 +1517,31 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				},
 			},
 		},
+		"TASReplaceNodeDueToNotReadyOverFixedTime requires TASFailedNodeReplacement": {
+			featureGateMap: map[string]bool{
+				string(features.TASReplaceNodeDueToNotReadyOverFixedTime): true,
+				string(features.TopologyAwareScheduling):                  true,
+				string(features.TASFailedNodeReplacement):                 false,
+				string(features.TASFailedNodeReplacementFailFast):         false,
+				string(features.TASReplaceNodeOnPodTermination):           false,
+				string(features.TASProfileMixed):                          false,
+			},
+			gatesToRestore: map[featuregate.Feature]bool{
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: false,
+				features.TopologyAwareScheduling:                  true,
+				features.TASFailedNodeReplacement:                 true,
+				features.TASFailedNodeReplacementFailFast:         true,
+				features.TASReplaceNodeOnPodTermination:           true,
+				features.TASProfileMixed:                          false,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASReplaceNodeDueToNotReadyOverFixedTime requires TASFailedNodeReplacement to be enabled",
+				},
+			},
+		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires ElasticJobsViaWorkloadSlices": {
 			featureGateMap: map[string]bool{
 				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -154,7 +154,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		timeSinceNotReady := r.clock.Now().Sub(readyCondition.LastTransitionTime.Time)
 		remainingTime := NodeFailureDelay - timeSinceNotReady
 		timerExpired = remainingTime <= 0
-		if !timerExpired && !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+		if features.Enabled(features.TASReplaceNodeDueToNotReadyOverFixedTime) && !timerExpired && !features.Enabled(features.TASReplaceNodeOnPodTermination) {
 			return ctrl.Result{RequeueAfter: remainingTime}, nil
 		}
 	}
@@ -176,7 +176,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, err
 	}
 
-	if timerExpired {
+	if features.Enabled(features.TASReplaceNodeDueToNotReadyOverFixedTime) && timerExpired {
 		log.V(3).Info("Node is not ready and NodeFailureDelay timer expired, marking as failed")
 		evictedWorkloads, err := r.handleUnhealthyNode(ctx, req.Name, affectedWorkloads)
 		if err != nil {
@@ -383,7 +383,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 		// to catch and fail the stray pod.
 		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
 	case !ready:
-		if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+		if !replaceOnPodTermination() {
 			return workloadHealthCheck{status: workloadUnhealthy}, nil
 		}
 		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
@@ -399,7 +399,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 		untolerated, temporarilyTolerated := classifyTaints(ctx, node.Spec.Taints, podSets)
 
 		if len(untolerated) > 0 {
-			if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+			if !replaceOnPodTermination() {
 				return workloadHealthCheck{status: workloadUnhealthy}, nil
 			}
 			return r.checkPodsOnNode(ctx, nodeName, wl, true, hasTASAssignment, nodeSelectorAssignedPods)
@@ -409,6 +409,13 @@ func (r *nodeReconciler) getWorkloadStatus(
 		}
 		return workloadHealthCheck{status: workloadHealthy}, nil
 	}
+}
+
+// replaceOnPodTermination reports whether node replacement is driven by pod
+// termination. Once the fixed-time marking is sunset (gate disabled), this is
+// unconditionally true and TASReplaceNodeOnPodTermination has no effect.
+func replaceOnPodTermination() bool {
+	return features.Enabled(features.TASReplaceNodeOnPodTermination) || !features.Enabled(features.TASReplaceNodeDueToNotReadyOverFixedTime)
 }
 
 func hasSchedulingTaints(taints []corev1.Taint) bool {
@@ -477,7 +484,7 @@ func (r *nodeReconciler) checkPodsOnNode(
 		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
 	}
 
-	if hasProgressingPods && (!hasUntoleratedTaints || features.Enabled(features.TASReplaceNodeOnPodTermination)) {
+	if hasProgressingPods && (!hasUntoleratedTaints || replaceOnPodTermination()) {
 		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
 	}
 

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -228,7 +228,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			ignoreUnhealthyNodes: true,
 		},
 		"Node Found and Unhealthy (NotReady), delay not passed - not marked as unavailable": {
-			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false, features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
@@ -242,7 +242,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			wantRequeue:        NodeFailureDelay,
 		},
 		"Node Found and Unhealthy (NotReady), delay passed - marked as unavailable": {
-			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false, features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
@@ -250,6 +250,64 @@ func TestNodeFailureReconciler(t *testing.T) {
 					LastTransitionTime: earlierTime}).Obj(),
 				baseWorkload.DeepCopy(),
 				basePod.DeepCopy(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+		},
+		"Node NotReady, delay passed, pod running, fixed-time marking disabled - not marked": {
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeDueToNotReadyOverFixedTime: false},
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: earlierTime}).Obj(),
+				baseWorkload.DeepCopy(),
+				basePod.DeepCopy(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+		},
+		"Node NotReady, delay passed, pod running, fixed-time marking enabled - marked": {
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: earlierTime}).Obj(),
+				baseWorkload.DeepCopy(),
+				basePod.DeepCopy(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
+		},
+		"Node NotReady, delay passed, pod running, both gates disabled - not marked (termination-driven)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: false,
+				features.TASReplaceNodeOnPodTermination:           false,
+			},
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: earlierTime}).Obj(),
+				baseWorkload.DeepCopy(),
+				basePod.DeepCopy(),
+			},
+			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
+			wantUnhealthyNodes: nil,
+		},
+		"Node NotReady, pod terminating, both gates disabled - marked (termination-driven)": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: false,
+				features.TASReplaceNodeOnPodTermination:           false,
+			},
+			initObjs: []client.Object{
+				baseNode.Clone().StatusConditions(corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: earlierTime}).Obj(),
+				baseWorkload.DeepCopy(),
+				terminatingPod,
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
@@ -279,7 +337,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 		},
 		"Node NotReady, pod failed, ReplaceNodeOnPodTermination feature gate off, requeued": {
-			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false, features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
@@ -390,7 +448,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			wantError:            false,
 		},
 		"Two Nodes Unhealthy (NotReady), delay passed - workload evicted": {
-			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false, features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
 			initObjs: []client.Object{
 				baseNode.Clone().StatusConditions(corev1.NodeCondition{
 					Type:               corev1.NodeReady,
@@ -430,8 +488,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 			featureGates: map[featuregate.Feature]bool{
-				features.TASReplaceNodeOnNodeTaints:     true,
-				features.TASReplaceNodeOnPodTermination: false,
+				features.TASReplaceNodeOnNodeTaints:               true,
+				features.TASReplaceNodeOnPodTermination:           false,
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: true,
 			},
 		},
 		"Node has NoExecute taint with TolerationSeconds -> Healthy (wait for eviction)": {
@@ -569,8 +628,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 			featureGates: map[featuregate.Feature]bool{
-				features.TASReplaceNodeOnNodeTaints:     true,
-				features.TASReplaceNodeOnPodTermination: false,
+				features.TASReplaceNodeOnNodeTaints:               true,
+				features.TASReplaceNodeOnPodTermination:           false,
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: true,
 			},
 		},
 		"Node has NoExecute taint with TolerationSeconds, ReplaceNodeOnPodTermination off -> Healthy (wait for eviction)": {
@@ -608,8 +668,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: nil,
 			featureGates: map[featuregate.Feature]bool{
-				features.TASReplaceNodeOnNodeTaints:     true,
-				features.TASReplaceNodeOnPodTermination: false,
+				features.TASReplaceNodeOnNodeTaints:               true,
+				features.TASReplaceNodeOnPodTermination:           false,
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: true,
 			},
 		},
 		"Node has NoExecute taint with TolerationSeconds, ReplaceNodeOnPodTermination off, pod terminating -> Unhealthy": {
@@ -647,8 +708,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 			featureGates: map[featuregate.Feature]bool{
-				features.TASReplaceNodeOnNodeTaints:     true,
-				features.TASReplaceNodeOnPodTermination: false,
+				features.TASReplaceNodeOnNodeTaints:               true,
+				features.TASReplaceNodeOnPodTermination:           false,
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: true,
 			},
 		},
 		"Node has NoExecute taint and pods missing -> Unhealthy (immediate)": {
@@ -702,8 +764,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 			featureGates: map[featuregate.Feature]bool{
-				features.TASReplaceNodeOnNodeTaints:     true,
-				features.TASReplaceNodeOnPodTermination: false,
+				features.TASReplaceNodeOnNodeTaints:               true,
+				features.TASReplaceNodeOnPodTermination:           false,
+				features.TASReplaceNodeDueToNotReadyOverFixedTime: true,
 			},
 		},
 		"Node has NoSchedule taint, tolerated -> Healthy": {
@@ -1236,7 +1299,7 @@ func TestGetWorkloadStatus(t *testing.T) {
 			nodeName:     nodeName,
 			initObjs:     []client.Object{baseWorkload, basePod},
 			wantStatus:   workloadUnhealthy,
-			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false},
+			featureGates: map[featuregate.Feature]bool{features.TASReplaceNodeOnPodTermination: false, features.TASReplaceNodeDueToNotReadyOverFixedTime: true},
 		},
 		"Node NotReady, ReplaceNodeOnPodTermination enabled -> Healthy (Waiting for pod termination)": {
 			node: testingnode.MakeNode(nodeName).

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -161,6 +161,14 @@ const (
 	// topologyAssignment only diverges from the node the pod runs on.
 	SkipReassignmentForPodOwnedWorkloads featuregate.Feature = "SkipReassignmentForPodOwnedWorkloads"
 
+	// owner: @yakticus
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Mark a TAS node as failed once it has been NotReady for NodeFailureDelay,
+	// regardless of pod state. When disabled, node replacement is driven solely
+	// by pod termination. Sunset gate: deprecated and off by default from 0.19.
+	TASReplaceNodeDueToNotReadyOverFixedTime featuregate.Feature = "TASReplaceNodeDueToNotReadyOverFixedTime"
+
 	// owner: @PannagaRao
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/3589-manage-jobs-selectively
 	//
@@ -576,6 +584,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	SkipReassignmentForPodOwnedWorkloads: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TASReplaceNodeDueToNotReadyOverFixedTime: {
+		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	ManagedJobsNamespaceSelectorAlwaysRespected: {
 		{Version: version.MustParse("0.13"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -173,13 +173,23 @@ You can disable it by editing the `TASReplaceNodeOnPodTermination` feature gate.
 for instructions on configuring feature gates.
 {{% /alert %}}
 
-By default, the node is assumed to have failed if its `conditions.Status.Ready`
-is not `True` for at least 30 seconds or if the node is missing (removed from the cluster).
-Since Kueue v0.13, the `TASReplaceNodeOnPodTermination` feature, introduced an additional heuristic:
-a node is also considered failed if it is `NotReady` and the workload's Pods scheduled on that node are either terminated or terminating.
-If this happens Kueue will immediately look for replacement without waiting 30 seconds.
+By default, the node is assumed to have failed if it is missing (removed from the
+cluster), or if its `conditions.Status.Ready` is not `True` and the workload's Pods
+scheduled on that node are either terminated or terminating. A node with
+still-running Pods is not considered failed, no matter how long its
+`conditions.Status.Ready` has not been `True`: nodes can recover after an arbitrary
+amount of time, and reassigning while the Pods are alive makes the stored assignment
+diverge from where the Pods actually run.
 
-Note that those two heuristics are mutually exclusive and depend on the value of the `TASReplaceNodeOnPodTermination` feature gate.
+Before v0.19, a node was additionally assumed to have failed once its
+`conditions.Status.Ready` was not `True` for at least 30 seconds, regardless of Pod
+state. This fixed-time marking is deprecated: it remains available behind the
+`TASReplaceNodeDueToNotReadyOverFixedTime` feature gate (enabled by default in
+v0.17–v0.18, disabled by default and deprecated since v0.19) and is planned for
+removal. When that gate is enabled, disabling `TASReplaceNodeOnPodTermination`
+additionally restores the pre-v0.14 behavior of waiting for the fixed time before
+any replacement; with the gate disabled, `TASReplaceNodeOnPodTermination` has no
+effect.
 
 Note that finding a replacement node that meets all the requirements (e.g. the same type of machine placed in the rack that Kueue had previously assigned to the workload) may not always be possible.
 If a workload is big enough to cover the whole topology domain (e.g. block or rack) it's inevitable that there will be no replacement within the same domain.
@@ -327,10 +337,20 @@ The following table summarizes the behavior based on the combination of the feat
 | `FNR` | `RNO` | `FNFF` | End Behavior |
 | :---- | :---- | :---- | :----------- |
 | `false` | *any* | *any* | **Hot swap is disabled.**<br>Workloads will not have failed nodes replaced and may get stuck. |
-| `true` | `false` | `false` | **Default Hot Swap**<ul><li>**Trigger**: Node is `NotReady` for > 30 seconds.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
-| `true` | `true` | `false` | **Hot Swap with Pod Termination Trigger**<ul><li>**Trigger**: Node is `NotReady` for > 30s, OR a workload pod is terminating.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
-| `true` | `false` | `true` | **Fast Hot Swap**<ul><li>**Trigger**: Node is `NotReady` for > 30 seconds.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
-| `true` | `true` | `true` | **Fast Hot Swap with Pod Termination Trigger**<ul><li>**Trigger**: Node is `NotReady`, AND a workload pod is terminating.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
+| `true` | *any* | `false` | **Default Hot Swap**<ul><li>**Trigger**: Node is `NotReady` AND its workload pods are terminating or terminated.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
+| `true` | *any* | `true` | **Fast Hot Swap**<ul><li>**Trigger**: Node is `NotReady` AND its workload pods are terminating or terminated.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
+
+With the deprecated `TASReplaceNodeDueToNotReadyOverFixedTime` gate enabled, the
+not-ready trigger depends on `TASReplaceNodeOnPodTermination` (`RNO`):
+- `RNO` enabled: the node is treated as failed when its workload Pods are terminating
+  or terminated, or after 30 seconds of `NotReady`, whichever comes first.
+- `RNO` disabled: the node is treated as failed only after 30 seconds of `NotReady`
+  (the pre-v0.14 behavior), regardless of Pod state.
+
+With the gate disabled (the default since v0.19), `RNO` has no effect and Pod
+termination is the only not-ready trigger. Nodes that are deleted or lack a `Ready`
+condition are treated as failed immediately in all configurations. To disable node
+replacement entirely, use the `TASFailedNodeReplacement` feature gate instead.
 
 {{% alert title="Note" color="primary" %}}
 `TASReplaceNodeOnNodeTaints` adds taints as an additional failure signal on top of the

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -459,6 +459,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASReplaceNodeDueToNotReadyOverFixedTime
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.19"
 - name: TASReplaceNodeOnNodeTaints
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -459,6 +459,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASReplaceNodeDueToNotReadyOverFixedTime
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.17"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.19"
 - name: TASReplaceNodeOnNodeTaints
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1535,6 +1535,103 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
+			ginkgo.It("should mark a NotReady node only when its running pod starts terminating", framework.SlowSpec, func() {
+				var wl1 *kueue.Workload
+				var pod *corev1.Pod
+				nodeName := nodes[0].Name
+				originalAssignment := utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+					Levels: []string{corev1.LabelHostname},
+					Domains: []utiltas.TopologyDomainAssignment{
+						{Count: 1, Values: []string{"x3"}},
+						{Count: 1, Values: []string{"x1"}},
+					},
+				})
+
+				ginkgo.By("creating a workload", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 2).
+							PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					gomega.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(originalAssignment))
+				})
+
+				ginkgo.By("creating a running pod of the workload on the node", func() {
+					pod = testingpod.MakePod("wl1-pod", ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+						Finalizer("kueue.x-k8s.io/integration-test").
+						NodeName(nodeName).
+						Request(corev1.ResourceCPU, "1").
+						Obj()
+					util.MustCreate(ctx, k8sClient, pod)
+					ginkgo.DeferCleanup(func() {
+						p := &corev1.Pod{}
+						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), p); err == nil {
+							p.Finalizers = nil
+							_ = k8sClient.Update(ctx, p)
+						}
+					})
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
+						pod.Status.Phase = corev1.PodRunning
+						g.Expect(k8sClient.Status().Update(ctx, pod)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("making the node NotReady 30s in the past", func() {
+					nodeToUpdate := &corev1.Node{}
+					gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: nodeName}, nodeToUpdate)).Should(gomega.Succeed())
+
+					util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+						Type:               corev1.NodeReady,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-tas.NodeFailureDelay)),
+					})
+				})
+
+				ginkgo.By("verify the node is not marked while the pod is running", func() {
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+						g.Expect(wl1.Status.UnhealthyNodes).To(gomega.BeEmpty())
+						g.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(originalAssignment))
+					}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("deleting the pod so it becomes terminating", func() {
+					gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+				})
+
+				ginkgo.By("verify the workload has corrected TopologyAssignment", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+						g.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(
+							utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+								Levels: []string{corev1.LabelHostname},
+								Domains: []utiltas.TopologyDomainAssignment{
+									{Count: 1, Values: []string{"x1"}},
+									{Count: 1, Values: []string{"x4"}},
+								},
+							}),
+						))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("removing the pod finalizer", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
+						pod.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, pod)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
 			ginkgo.It("should update workload TopologyAssignment when node fails", framework.SlowSpec, func() {
 				var wl1 *kueue.Workload
 				nodeName := nodes[0].Name


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind deprecation
/area tas

#### What this PR does / why we need it:

Marking a TAS node as failed after a fixed `NotReady` duration (`NodeFailureDelay`, 30s) is premature in principle: a node can become Ready again after an arbitrary amount of time (cloud node-repair mechanisms are similarly unpredictable), and while the workload's Pods keep running on it, a recomputed topology assignment diverges from the node the Pods actually occupy, corrupting per-node capacity accounting in both directions — the real node is treated as free and over-admitted, while the newly assigned node is blocked for admissions it cannot serve. On our production fleet, transient `NotReady` blips with surviving Pods are far more common than real node deaths.

As proposed by @mimowo in https://github.com/kubernetes-sigs/kueue/issues/12735#issuecomment-4959559208, node replacement is now driven solely by pod termination (previously the `TASReplaceNodeOnPodTermination` behavior, Beta since 0.14). The fixed-time marking is retained behind a new sunset gate:

| `TASReplaceNodeDueToNotReadyOverFixedTime` | `TASReplaceNodeOnPodTermination` | NotReady-node marking trigger |
|---|---|---|
| enabled | enabled | pod termination OR 30s timer, whichever first (pre-0.19 default) |
| enabled | disabled | 30s timer only (pre-0.14 behavior) |
| **disabled (default since 0.19)** | *any* | **pod termination only** |

Deleted nodes and nodes without a `Ready` condition are still marked immediately in all configurations. Gate lifecycle: Beta (default on) at 0.17/0.18 for backports, Deprecated (default off) since 0.19, removal targeted for 0.21.

#### Which issue(s) this PR fixes:

Part of #13042

Related to #11858 — note this PR does **not** fix that issue: the ungater can still pin a replacement pod against a stale `TopologyAssignment` when it observes the pod before the assignment rewrite; changing the marking trigger does not remove that race.

#### Special notes for your reviewer:

- The gate spec must carry both entries on main: the feature-gate machinery rejects a gate born `Deprecated` ("must provide a 1.0 entry indicating initial state"), so the `{0.17 Beta}` entry cannot be deferred to the cherry-picks as we did for #12980.
- While the sunset gate is enabled, the `TASReplaceNodeOnPodTermination` interplay is unchanged (backport-safe); once disabled, that gate has no effect — it is effectively absorbed by the new default and can be deprecated on its own schedule (happy to do that here or in a follow-up, your call).
- The TAS integration suite passes unchanged under the new default — the timer was not load-bearing in any existing spec. New coverage: unit cases for all four gate combinations (including both-disabled, which behaves as termination-only), an integration spec with a real running Pod (node NotReady past the delay → not marked; Pod terminating → hot swap), and a config-validation case for enabling the gate without `TASFailedNodeReplacement`.
- KEP-2724 and the TAS concepts page are updated in this PR.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Added a fix for premature node replacement when a node remains NotReady while the workload's Pods are still running, which could cause the topology assignment to diverge from the actual Pod placement and corrupt per-node capacity accounting. The termination-driven behavior applies when TASReplaceNodeDueToNotReadyOverFixedTime is disabled. The gate is deprecated and disabled by default in 0.19+, and Beta and enabled by default in the 0.17 and 0.18 release branches.
```
