### PR TITLE
Automated cherry pick of #13026: Fix the flaky e2e tests for Prometheus [0.18]

### DIFF
--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -187,21 +186,7 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, workload)
 
 			ginkgo.By("Verifying Prometheus discovers and scrapes the Kueue target")
-			gomega.Eventually(func(g gomega.Gomega) {
-				result, err := prometheusClient.Targets(ctx)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-
-				hasKueueTarget := false
-				for _, t := range result.Active {
-					if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
-						t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
-						hasKueueTarget = true
-						g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
-						break
-					}
-				}
-				g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectPrometheusTargetForKueue(ctx, prometheusClient)
 
 			ginkgo.By("Verifying admission metric is available via PromQL")
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/singlecluster/baseline/prometheus_test.go
+++ b/test/e2e/singlecluster/baseline/prometheus_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
 
@@ -38,21 +37,7 @@ const (
 
 var _ = ginkgo.Describe("Prometheus", ginkgo.Label("area:prometheus", "feature:prometheus"), func() {
 	ginkgo.It("should discover Kueue target and report it as up", func() {
-		gomega.Eventually(func(g gomega.Gomega) {
-			result, err := prometheusClient.Targets(ctx)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-
-			hasKueueTarget := false
-			for _, t := range result.Active {
-				if t.Labels["job"] == model.LabelValue(util.DefaultMetricsServiceName) &&
-					t.Labels["namespace"] == model.LabelValue(util.GetKueueNamespace()) {
-					hasKueueTarget = true
-					g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
-					break
-				}
-			}
-			g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
-		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		util.ExpectPrometheusTargetForKueue(ctx, prometheusClient)
 	})
 
 	ginkgo.It("should scrape kueue_build_info metric via PromQL", func() {

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -17,12 +17,15 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics/testutil"
 
@@ -377,4 +380,23 @@ func ExpectClusterQueueInfoMetric(cqName, parentCohort, rootCohort string, count
 	ginkgo.GinkgoHelper()
 	lvs := append([]string{cqName, parentCohort, rootCohort, roletracker.RoleStandalone}, customLabels...)
 	expectGaugeMetric(metrics.ClusterQueueInfo, lvs, gomega.Equal(count))
+}
+
+func ExpectPrometheusTargetForKueue(ctx context.Context, prometheusClient prometheusv1.API) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		result, err := prometheusClient.Targets(ctx)
+		g.Expect(err).NotTo(gomega.HaveOccurred())
+
+		hasKueueTarget := false
+		for _, t := range result.Active {
+			if t.Labels["job"] == model.LabelValue(DefaultMetricsServiceName) &&
+				t.Labels["namespace"] == model.LabelValue(GetKueueNamespace()) {
+				hasKueueTarget = true
+				g.Expect(t.Health).To(gomega.Equal(prometheusv1.HealthGood))
+				break
+			}
+		}
+		g.Expect(hasKueueTarget).To(gomega.BeTrue(), "Kueue target not found. Active targets: %v", result.Active)
+	}, VeryLongTimeout, Interval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
Cherry pick of #13026 on release-0.18.

#13026: Fix the flaky e2e tests for Prometheus

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```