### PR TITLE
Cherry pick of #12052 on release-0.17 - resolved conflicts

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -89,8 +89,11 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 		return nil
 	}
 
+	orderedDomains := slices.Clone(domains)
 	if priorizeByEntropy {
-		sortDomainsByCapacityAndEntropy(domains)
+		sortDomainsByCapacityAndEntropy(orderedDomains)
+	} else {
+		sortDomainsByLevelValues(orderedDomains)
 	}
 
 	// domain_placements[i][j][k] stores a list of domains that uses 'i' domains with
@@ -101,7 +104,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	}
 	domainPlacements[0][leaderCount] = map[int32][]*domain{sliceCount * sliceSize: {}}
 
-	for _, d := range domains {
+	for _, d := range orderedDomains {
 		for i := optimalNumberOfDomains; i > 0; i-- {
 			for _, beforeLeader := range slices.Sorted(maps.Keys(domainPlacements[i-1])) {
 				for _, beforeState := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
@@ -231,7 +234,7 @@ func sortDomainsByCapacityAndEntropy(domains []*domain) {
 		if bEntropy < aEntropy {
 			return -1
 		}
-		return 0
+		return compareDomainLevelValues(a, b)
 	})
 }
 
@@ -247,7 +250,9 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 	if params.requestedLevelIdx == 0 {
 		requestedLevelDomainsToConsider = [][]*domain{slices.Collect(maps.Values(s.domainsPerLevel[0]))}
 	} else {
-		for _, higherLevelDomain := range slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1])) {
+		higherLevelDomains := slices.Collect(maps.Values(s.domainsPerLevel[params.requestedLevelIdx-1]))
+		sortDomainsByLevelValues(higherLevelDomains)
+		for _, higherLevelDomain := range higherLevelDomains {
 			requestedLevelDomainsToConsider = append(requestedLevelDomainsToConsider, higherLevelDomain.children)
 		}
 	}

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -25,11 +25,19 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
+func domainIDs(domains []*domain) []string {
+	ids := make([]string, len(domains))
+	for i, d := range domains {
+		ids[i] = string(d.id)
+	}
+	return ids
+}
+
 func TestSelectOptimalDomainSetToFit(t *testing.T) {
-	d1 := &domain{id: "d1", state: 9, sliceState: 9, leaderState: 1, stateWithLeader: 8, sliceStateWithLeader: 8}
-	d2 := &domain{id: "d2", state: 6, sliceState: 6, leaderState: 0, stateWithLeader: 6, sliceStateWithLeader: 6}
-	d3 := &domain{id: "d3", state: 4, sliceState: 4, leaderState: 1, stateWithLeader: 3, sliceStateWithLeader: 3}
-	d4 := &domain{id: "d4", state: 2, sliceState: 2, leaderState: 0, stateWithLeader: 2, sliceStateWithLeader: 2}
+	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 9, sliceState: 9, leaderState: 1, stateWithLeader: 8, sliceStateWithLeader: 8}
+	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 6, sliceState: 6, leaderState: 0, stateWithLeader: 6, sliceStateWithLeader: 6}
+	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 4, sliceState: 4, leaderState: 1, stateWithLeader: 3, sliceStateWithLeader: 3}
+	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 2, sliceState: 2, leaderState: 0, stateWithLeader: 2, sliceStateWithLeader: 2}
 
 	testCases := map[string]struct {
 		domains     []*domain
@@ -85,12 +93,78 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	}
 }
 
+func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
+	testCases := map[string]struct {
+		priorizeByEntropy bool
+	}{
+		"balanced selection": {
+			priorizeByEntropy: false,
+		},
+		"entropy-prioritized selection": {
+			priorizeByEntropy: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+			domains := []*domain{
+				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+			}
+
+			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.priorizeByEntropy)
+
+			if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
+				t.Errorf("unexpected optimal domain set (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
+func TestSortDomainsByCapacityAndEntropy(t *testing.T) {
+	testCases := map[string]struct {
+		domains []*domain
+		want    []string
+	}{
+		"levelValues ascending as final tiebreaker": {
+			domains: []*domain{
+				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			},
+			want: []string{"leaf-z", "leaf-a", "leaf-m"},
+		},
+		"capacity and entropy ranking before tiebreaker": {
+			domains: []*domain{
+				{id: "lower-leader", levelValues: []string{"a"}, leaderState: 0, sliceStateWithLeader: 100, children: []*domain{{state: 50}, {state: 50}}},
+				{id: "lower-capacity", levelValues: []string{"b"}, leaderState: 1, sliceStateWithLeader: 4, children: []*domain{{state: 2}, {state: 2}}},
+				{id: "low-entropy", levelValues: []string{"c"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 4}, {state: 0}}},
+				{id: "high-entropy", levelValues: []string{"d"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			},
+			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			sortDomainsByCapacityAndEntropy(tc.domains)
+
+			if diff := cmp.Diff(tc.want, domainIDs(tc.domains)); diff != "" {
+				t.Errorf("unexpected domain order (-want,+got): %s", diff)
+			}
+		})
+	}
+}
+
 func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
-	d1 := &domain{id: "d1", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d2 := &domain{id: "d2", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d3 := &domain{id: "d3", state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d4 := &domain{id: "d4", state: 10, sliceState: 10, stateWithLeader: 10, leaderState: 0, sliceStateWithLeader: 10}
-	d5 := &domain{id: "d5", state: 2, sliceState: 2, stateWithLeader: 2, leaderState: 0, sliceStateWithLeader: 2}
+	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
+	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 10, sliceState: 10, stateWithLeader: 10, leaderState: 0, sliceStateWithLeader: 10}
+	d5 := &domain{id: "d5", levelValues: []string{"d5"}, state: 2, sliceState: 2, stateWithLeader: 2, leaderState: 0, sliceStateWithLeader: 2}
 
 	testCases := map[string]struct {
 		domains     []*domain
@@ -168,5 +242,22 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	s := newTASFlavorSnapshot(log, "dummy", []string{}, nil)
+	domains := []*domain{
+		{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+		{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+	}
+
+	got, reason := placeSlicesOnDomainsBalanced(s, domains, 1, 0, 1, 1)
+
+	if reason != "" {
+		t.Fatalf("unexpected placement failure: %s", reason)
+	}
+	if diff := cmp.Diff([]string{"leaf-z"}, domainIDs(got)); diff != "" {
+		t.Errorf("unexpected domain order (-want,+got): %s", diff)
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1512,9 +1512,7 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 
 func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
-	slices.SortFunc(domains, func(a, b *domain) int {
-		return slices.Compare(a.levelValues, b.levelValues)
-	})
+	sortDomainsByLevelValues(domains)
 	levelIdx := 0
 	// assign only hostname values if topology defines it
 	if s.isLowestLevelNode {
@@ -1529,6 +1527,14 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 		result = append(result, domain.children...)
 	}
 	return result
+}
+
+func compareDomainLevelValues(a, b *domain) int {
+	return slices.Compare(a.levelValues, b.levelValues)
+}
+
+func sortDomainsByLevelValues(domains []*domain) {
+	slices.SortFunc(domains, compareDomainLevelValues)
 }
 
 func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
@@ -1552,7 +1558,7 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 			return cmp.Compare(a.stateWithLeader, b.stateWithLeader)
 		}
 
-		return slices.Compare(a.levelValues, b.levelValues)
+		return compareDomainLevelValues(a, b)
 	})
 	return result
 }
@@ -1581,7 +1587,7 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 			return cmp.Compare(a.state, b.state)
 		}
 
-		return slices.Compare(a.levelValues, b.levelValues)
+		return compareDomainLevelValues(a, b)
 	})
 	return result
 }


### PR DESCRIPTION
  #### What type of PR is this?

   /kind feature
   /area tas

   #### What this PR does / why we need it:
   Cherry pick of #12052 on release-0.17.

   #12052: feat: stable domain sorting for deterministic TAS placement on score ties

   For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

   #### Which issue(s) this PR fixes:
   Fixes https://github.com/kubernetes-sigs/kueue/pull/12052#issuecomment-4969032104

   #### Special notes for your reviewer:
   The automated cherry-pick failed due to a merge conflict in `pkg/cache/scheduler/tas_balanced_placement_test.go`. 

   I manually resolved the conflict by bringing in the test cases

   #### Does this PR introduce a user-facing change?
   ```release-note
   TAS: Improved the TASBalancedPlacement algorithm to ensure deterministic domain selection by using domain names as a stable tie-breaker when capacities and entropies are tied.
   ```
