### PR TITLE
Add in-scope/out-of-scope to SECURITY-INSIGHTS.yaml

### DIFF
--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -1,6 +1,6 @@
 header:
   schema-version: 1.0.0
-  expiration-date: '2024-09-28T01:00:00.000Z'
+  expiration-date: '2027-07-10T01:00:00.000Z'
   last-updated: '2026-07-10'
   last-reviewed: '2026-07-10'
   commit-hash: "afd60c37e0c86de83dc0e708f76016b8debe1498"
@@ -57,6 +57,26 @@ vulnerability-reporting:
   Security-policy: 'https://kubernetes.io/security/'
   bug-bounty-available: true
   bug-bounty-url: 'https://hackerone.com/kubernetes'
+  in-scope:
+    - Privilege escalation or RBAC bypass allowing viewing or editing of
+      restricted information managed by Kueue (for example, viewing restricted
+      information via KueueViz)
+    - Workload quota bypass at admission time or post-admission (for example,
+      admitting a workload within quota and later increasing its resource usage
+      beyond what was admitted)
+    - Quota hijacking, or otherwise consuming resources that were not granted,
+      without admin access, even when other tenants' quotas and workloads are
+      not affected
+    - Tenant isolation breakout across ClusterQueues, LocalQueues, and Cohorts
+      (for example, quota borrowing or preemption affecting workloads of another
+      tenant)
+    - Insecure RBAC defaults in the shipped manifests or Helm chart
+  out-scope:
+    - Vulnerabilities in Kubernetes core, which are delegated to the upstream
+      Kubernetes security process at https://kubernetes.io/security/
+    - Issues that only affect unsupported Kueue releases
+    - Insecure configuration in a consuming cluster
+    - Reports that require pre-existing privileged (cluster-admin) access
 dependencies:
   third-party-packages: true
   dependencies-lists:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig release

**What this PR does / why we need it:**

This re-applies, cleanly off current `main`, the change from #12669, which was
closed due to extensive rebase conflicts against the vendor tree. It adds the
`in-scope`/`out-scope` subsections to the `vulnerability-reporting` section of
`SECURITY-INSIGHTS.yaml`, which have been missing since the file was first added
in #1469 where they were intentionally deferred.

The scope wording is the consensus reached with @mimowo and @dkaluza in the
review thread of #12669 — descriptive items with concrete examples, kept for the
benefit of contributors, security specialists, and automated tooling that parses
this OpenSSF metadata:

**In-scope:**
- Privilege escalation or RBAC bypass allowing viewing or editing of restricted
  information managed by Kueue (e.g. viewing restricted information via KueueViz)
- Workload quota bypass at admission time or post-admission
- Quota hijacking without admin access, even when other tenants are not affected
- Tenant isolation breakout across ClusterQueues, LocalQueues, and Cohorts
- Insecure RBAC defaults in the shipped manifests or Helm chart

**Out-of-scope:**
- Vulnerabilities in Kubernetes core (delegated to the upstream Kubernetes
  security process)
- Issues that only affect unsupported Kueue releases
- Insecure configuration in a consuming cluster
- Reports requiring pre-existing privileged (cluster-admin) access

While here, this also refreshes the expired `header.expiration-date` (was
2024-09-28), which CLOMonitor flags.

**Which issue(s) this PR fixes:**

Fixes #1473

**Special notes for your reviewer:**

Replacement for #12669 (cc @mimowo @dkaluza @kannon92). The content is the final
agreed wording from that thread; please re-apply `/lgtm` + `/approve` if it still
matches your intent.

AI usage disclosure (per the project's AI contribution policy): I used an AI
assistant to help draft the scope wording and this PR prose. The technical
content reflects my own review of Kueue's architecture, and I take responsibility
for the change.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Extended the security policy expiration date through July 2027.
  * Expanded vulnerability reporting guidance with additional in-scope examples, including privilege escalation, quota bypass, tenant isolation, and insecure default configurations.
  * Clarified out-of-scope reports, including Kubernetes core issues, unsupported releases, consumer-side configuration problems, and findings requiring existing cluster-admin access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->