### PR TITLE
[release-0.17] Reduce reclaimable pods to prevent quota leak

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -496,6 +496,10 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			log.Error(err, "Getting reclaimable pods")
 			return ctrl.Result{}, err
 		}
+		if WorkloadSliceEnabled(job) {
+			// Elastic jobs may have scaled down since admission (kueue#12958).
+			reclPods = workload.ReduceReclaimablePodsByScaleDown(log, wl, reclPods)
+		}
 		reclPods = workload.LimitReclaimablePodsToPodSetSizes(wl, reclPods)
 
 		if !workload.ReclaimablePodsAreEqual(reclPods, wl.Status.ReclaimablePods) {

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -366,18 +366,10 @@ func validateReclaimablePodsUpdate(newObj, oldObj *kueue.Workload, basePath *fie
 		knowPodSets[name] = &oldObj.Status.ReclaimablePods[i]
 	}
 
-	// For elastic workloads, a reclaimable count that already reaches (or
-	// exceeds) its podSet's current count may be lowered: after a scale-down
-	// the job's controller re-derives the value for the smaller podSet, which
-	// is a recomputation, not a reneged reclaim (see kueue#12670).
-	newPodSetCounts := workload.ExtractPodSetCountsFromWorkload(newObj)
-	loweredByScaleDown := func(name kueue.PodSetReference, oldCount int32) bool {
-		if !workloadslicing.Enabled(newObj) {
-			return false
-		}
-		count, found := newPodSetCounts[name]
-		return found && count <= oldCount
-	}
+	// A reclaimable count may legitimately decrease or be removed for a podSet
+	// that was scaled down, since its count is re-derived for the smaller
+	// podSet (see kueue#12670 and kueue#12958).
+	scaledDownPodSets := scaledDownPodSetNames(newObj)
 
 	var ret field.ErrorList
 	newNames := sets.New[kueue.PodSetReference]()
@@ -388,17 +380,35 @@ func validateReclaimablePodsUpdate(newObj, oldObj *kueue.Workload, basePath *fie
 			continue
 		}
 		oldCount, found := knowPodSets[newCount.Name]
-		if found && newCount.Count < oldCount.Count && !loweredByScaleDown(newCount.Name, oldCount.Count) {
+		if found && newCount.Count < oldCount.Count && !scaledDownPodSets.Has(newCount.Name) {
 			ret = append(ret, field.Invalid(basePath.Key(string(newCount.Name)).Child("count"), newCount.Count, fmt.Sprintf("cannot be less then %d", oldCount.Count)))
 		}
 	}
 
-	for name, oldCount := range knowPodSets {
-		if workload.HasQuotaReservation(newObj) && !newNames.Has(name) && !loweredByScaleDown(name, oldCount.Count) {
+	for name := range knowPodSets {
+		if workload.HasQuotaReservation(newObj) && !newNames.Has(name) && !scaledDownPodSets.Has(name) {
 			ret = append(ret, field.Required(basePath.Key(string(name)), "cannot be removed"))
 		}
 	}
 	return ret
+}
+
+// scaledDownPodSetNames returns the set of podSet names whose current count is
+// below the count granted at admission, i.e. those that have been scaled down.
+// Only meaningful for elastic workloads; returns empty otherwise.
+func scaledDownPodSetNames(wl *kueue.Workload) sets.Set[kueue.PodSetReference] {
+	scaledDown := sets.New[kueue.PodSetReference]()
+	if !workloadslicing.Enabled(wl) || wl.Status.Admission == nil {
+		return scaledDown
+	}
+	currentSizes := workload.ExtractPodSetCountsFromWorkload(wl)
+	for i := range wl.Status.Admission.PodSetAssignments {
+		psa := &wl.Status.Admission.PodSetAssignments[i]
+		if psa.Count != nil && *psa.Count > currentSizes[psa.Name] {
+			scaledDown.Insert(psa.Name)
+		}
+	}
+	return scaledDown
 }
 
 // validateImmutablePodSet helper to validate PodSet immutability on all fields but PodSet.Count.

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -553,14 +553,14 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("status", "reclaimablePods").Key("ps1").Child("count"), nil, ""),
 			},
 		},
-		"elastic workload: reclaimable pod count can decrease after its podSet scaled down below it": {
+		"elastic workload: reclaimable pod count can decrease after its podSet scaled down below the admitted count": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodSets(*utiltestingapi.MakePodSet("ps1", 3).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1"}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -572,11 +572,43 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 3).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1"}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
 						Obj(), now,
 				).
 				ReclaimablePods(
 					kueue.ReclaimablePod{Name: "ps1", Count: 3},
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"elastic workload: reclaimable pod count can decrease when scaled down below the admitted count even if the podSet still exceeds it": {
+			// The exact kueue#12958 scenario: admitted at 20, scaled to 10, the
+			// reconciler lowers reclaimable from 9 to 0. The podSet (10) still
+			// exceeds the reclaimable count, so only the admission count reveals
+			// the scale-down.
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(*utiltestingapi.MakePodSet("ps1", 10).Obj()).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("cluster-queue").
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](20)}).
+						Obj(), now,
+				).
+				ReclaimablePods(
+					kueue.ReclaimablePod{Name: "ps1", Count: 9},
+				).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(*utiltestingapi.MakePodSet("ps1", 10).Obj()).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("cluster-queue").
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](20)}).
+						Obj(), now,
+				).
+				ReclaimablePods(
+					kueue.ReclaimablePod{Name: "ps1", Count: 0},
 				).
 				Obj(),
 			wantErr: nil,
@@ -611,14 +643,14 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("status", "reclaimablePods").Key("ps1").Child("count"), nil, ""),
 			},
 		},
-		"elastic workload: reclaimable pod entry can be removed after its podSet scaled down below it": {
+		"elastic workload: reclaimable pod entry can be removed after its podSet scaled down below the admitted count": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodSets(*utiltestingapi.MakePodSet("ps1", 8).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1"}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -630,7 +662,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 1).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1"}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
 						Obj(), now,
 				).
 				Obj(),

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1336,6 +1336,45 @@ func LimitReclaimablePodsToPodSetSizes(wl *kueue.Workload, reclaimablePods []kue
 	return limited
 }
 
+// ReduceReclaimablePodsByScaleDown returns a copy of reclaimablePods with every
+// count reduced, bounded at zero, by the pods removed from its PodSet since
+// admission (the admission's granted count minus the current PodSet count).
+//
+// Without this, a job's reclaimable count derived from monotonic state (e.g. a
+// batch/Job's Status.Succeeded) would release quota for pods already removed by
+// an elastic scale-down (kueue#12958).
+func ReduceReclaimablePodsByScaleDown(log logr.Logger, wl *kueue.Workload, reclaimablePods []kueue.ReclaimablePod) []kueue.ReclaimablePod {
+	if wl.Status.Admission == nil {
+		return reclaimablePods
+	}
+	admittedSizes := make(map[kueue.PodSetReference]int32, len(wl.Status.Admission.PodSetAssignments))
+	for i := range wl.Status.Admission.PodSetAssignments {
+		psa := &wl.Status.Admission.PodSetAssignments[i]
+		if psa.Count != nil {
+			admittedSizes[psa.Name] = *psa.Count
+		}
+	}
+	currentSizes := ExtractPodSetCountsFromWorkload(wl)
+	reduced := slices.Clone(reclaimablePods)
+	for i := range reduced {
+		admitted, found := admittedSizes[reduced[i].Name]
+		if !found {
+			continue
+		}
+		if scaledDown := admitted - currentSizes[reduced[i].Name]; scaledDown > 0 {
+			newCount := max(0, reduced[i].Count-scaledDown)
+			log.V(3).Info("Reducing reclaimable pods for scaled-down podSet",
+				"podSet", reduced[i].Name,
+				"admittedCount", admitted,
+				"currentCount", currentSizes[reduced[i].Name],
+				"reclaimableFrom", reduced[i].Count,
+				"reclaimableTo", newCount)
+			reduced[i].Count = newCount
+		}
+	}
+	return reduced
+}
+
 // ReclaimablePodsAreEqual checks if two Reclaimable pods are semantically equal
 // having the same length and all keys have the same value.
 func ReclaimablePodsAreEqual(a, b []kueue.ReclaimablePod) bool {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1074,6 +1074,59 @@ func TestLimitReclaimablePodsToPodSetSizes(t *testing.T) {
 	}
 }
 
+func TestReduceReclaimablePodsByScaleDown(t *testing.T) {
+	// makeWorkload builds a workload whose PodSet has been scaled down to
+	// currentSize while its admission still records the originally granted
+	// admittedSize.
+	makeWorkload := func(admittedSize, currentSize int32) *kueue.Workload {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			PodSets(*utiltestingapi.MakePodSet("main", int(currentSize)).Obj()).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment("main").Count(admittedSize).Obj()).
+				Obj(), time.Now()).
+			Obj()
+	}
+	cases := map[string]struct {
+		wl              *kueue.Workload
+		reclaimablePods []kueue.ReclaimablePod
+		want            []kueue.ReclaimablePod
+	}{
+		"no admission is a no-op": {
+			wl:              utiltestingapi.MakeWorkload("wl", "ns").PodSets(*utiltestingapi.MakePodSet("main", 10).Obj()).Obj(),
+			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 9}},
+			want:            []kueue.ReclaimablePod{{Name: "main", Count: 9}},
+		},
+		"no scale-down leaves the count unchanged": {
+			wl:              makeWorkload(10, 10),
+			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 5}},
+			want:            []kueue.ReclaimablePod{{Name: "main", Count: 5}},
+		},
+		"scale-down larger than the count clamps to zero": {
+			wl:              makeWorkload(20, 10),
+			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 9}},
+			want:            []kueue.ReclaimablePod{{Name: "main", Count: 0}},
+		},
+		"scale-down smaller than the count reduces by the delta": {
+			wl:              makeWorkload(20, 10),
+			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 15}},
+			want:            []kueue.ReclaimablePod{{Name: "main", Count: 5}},
+		},
+		"podSet without an admission entry is left as is": {
+			wl:              makeWorkload(20, 10),
+			reclaimablePods: []kueue.ReclaimablePod{{Name: "other", Count: 4}},
+			want:            []kueue.ReclaimablePod{{Name: "other", Count: 4}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ReduceReclaimablePodsByScaleDown(logr.Discard(), tc.wl, tc.reclaimablePods)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Unexpected reclaimable pods (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestAssignmentClusterQueueState(t *testing.T) {
 	cases := map[string]struct {
 		state              *AssignmentClusterQueueState

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4417,18 +4417,104 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("the workload converges instead of wedging: podSet shrinks and reclaimablePods stays within it")
+		ginkgo.By("the workload converges instead of wedging: podSet shrinks and the scaled-down reclaimable count is corrected to 0")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			wl := &workloads.Items[0]
 			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(3)))
+			// Scaling 8->3 removes 5 pods; max(0, 4-5)=0 reclaimable remain, so
+			// quota is charged for the full shrunk podSet rather than leaked
+			// (kueue#12958).
 			g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
-				{Name: kueue.DefaultPodSetName, Count: 3},
+				{Name: kueue.DefaultPodSetName, Count: 0},
 			}))
 			g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should not release quota for reclaimable pods removed by a scale-down", framework.SlowSpec, func() {
+		// Regression for kueue#12958: scaling a Job down did not lower the
+		// workload's reclaimablePods count by the number of removed pods, so
+		// Kueue kept releasing quota for pods that no longer existed. The Job's
+		// reclaimable count is re-derived from Status.Succeeded on every reconcile,
+		// so the correction must survive that recompute — this reproduces the
+		// exact scenario from the issue (podSet 20, reclaimable 9, scale to 10).
+		testJob := testingjob.MakeJob("scale-down-reclaimable-leak", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			SetAnnotation(workloadjob.JobCompletionsEqualParallelismAnnotation, "true").
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Indexed(true).
+			Parallelism(20).
+			Completions(20).
+			Obj()
+
+		ginkgo.By("creating a job")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		ginkgo.By("admitting the job's workload")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+			g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(20)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("9 pods succeed -> reclaimable 9, quota released for those 9 (11 pods charged)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Status.Succeeded = 9
+			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 9},
+			}))
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1100)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling the job down 20 -> 10 (removing 10 pods)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = ptr.To[int32](10)
+			testJob.Spec.Completions = ptr.To[int32](10)
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("reclaimable drops to max(0, 9-10)=0 and stays there; full 10 pods are charged")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl := &workloads.Items[0]
+			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(10)))
+			g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 0},
+			}))
+			g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1000)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("the corrected reclaimable count is stable (not re-inflated by the recompute)")
+		gomega.Consistently(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 0},
+			}))
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1000)))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should cap elastic pod ungating to the granted quota", framework.SlowSpec, func() {

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -1270,6 +1270,65 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				g.Expect(k8sClient.Update(ctx, wl)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+
+		ginkgo.It("Should allow elastic workload reclaimable pod count to decrease after a scale-down below the admitted count", func() {
+			// Regression for kueue#12958: after a Job scale-down the controller
+			// lowers the workload's reclaimable pod counts in a follow-up status
+			// update whose spec is already shrunk. The webhook used to reject
+			// that update, so the stale count kept releasing quota for pods
+			// removed by the scale-down. The scale-down is detected via the
+			// admission count, which stays at the admitted size (20) while the
+			// podSet is shrunk (10).
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+			ginkgo.By("Creating a new elastic Workload")
+			wl := utiltestingapi.MakeWorkload(workloadName, ns.Name).
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 20).
+					Request(corev1.ResourceCPU, "1").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("Admitting the Workload at 20 pods")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				admission := utiltestingapi.MakeAdmission("default").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "1").
+						Count(20).
+						Obj()).
+					Obj()
+				workload.SetQuotaReservation(wl, admission, util.RealClock)
+				wl.Status.Admission = admission
+
+				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Reporting 9 reclaimable pods")
+			util.UpdateReclaimablePods(ctx, k8sClient, wl, []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 9}})
+
+			ginkgo.By("Scaling the podSet down to 10 (admission count stays at 20)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				wl.Spec.PodSets[0].Count = 10
+				g.Expect(k8sClient.Update(ctx, wl)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Decreasing the reclaimable pod count while the podSet (10) still exceeds it")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				wl.Status.ReclaimablePods = []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 0}}
+				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Removing the reclaimable pod entry entirely")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				wl.Status.ReclaimablePods = nil
+				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 })
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area elastic-jobs

#### What this PR does / why we need it:

Manual cherry-pick of #13044 onto release-0.17.

#### Which issue(s) this PR fixes:

Fixes #12958

#### Special notes for your reviewer:  

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where scaling down an elastic Job could leave a stale reclaimablePods count, causing Kueue to account for less quota than the Job's remaining Pods were using.
```