### PR TITLE
Graduate QuotaCheckStrategy to beta

### DIFF
--- a/keps/7513-quota-check-strategy/kep.yaml
+++ b/keps/7513-quota-check-strategy/kep.yaml
@@ -16,11 +16,12 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.17"
+latest-milestone: "v0.19"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v0.17"
+  alpha: "v0.18"
+  beta: "v0.19"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1170,9 +1170,6 @@ func TestValidate(t *testing.T) {
 					ExcludeResourcePrefixes: []string{"foo.com/device"},
 				},
 			},
-			featureGates: map[featuregate.Feature]bool{
-				features.QuotaCheckStrategy: true,
-			},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:   field.ErrorTypeInvalid,
@@ -1187,9 +1184,6 @@ func TestValidate(t *testing.T) {
 				Resources: &configapi.Resources{
 					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckIgnoreUndeclared),
 				},
-			},
-			featureGates: map[featuregate.Feature]bool{
-				features.QuotaCheckStrategy: true,
 			},
 		},
 		"quotaCheckStrategy with value blockundeclared allowed with excludeResourcePrefixes": {
@@ -1208,9 +1202,6 @@ func TestValidate(t *testing.T) {
 					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckStrategy("test")),
 				},
 			},
-			featureGates: map[featuregate.Feature]bool{
-				features.QuotaCheckStrategy: true,
-			},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeNotSupported,
@@ -1224,6 +1215,9 @@ func TestValidate(t *testing.T) {
 				Resources: &configapi.Resources{
 					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckStrategy("test")),
 				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.QuotaCheckStrategy: false,
 			},
 		},
 		"KueueDRAIntegrationExtendedResource requires KueueDRAIntegration": {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -705,6 +705,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	QuotaCheckStrategy: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MetricForWorkloadCreationLatency: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21

--- a/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
+++ b/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
@@ -470,7 +470,7 @@ The Workload obtains an effective resource requests for quota purposes:
 
 By default, administrators must specify all resources required by workloads in the ClusterQueue's `.spec.resourceGroups[*]`.
 If you want to relax that requirement and make resources declared on the workload, but not declared on the ClusterQueues to be skipped from quota management and admission process,
-you can specify the `quotaCheckStrategy: IgnoreUndeclared` in the Kueue Configuration as a cluster-level setting and enable the alpha `featureGates` `QuotaCheckStrategy`.
+you can rely on the quotaCheckStrategy feature that is enabled by default and specify the strategy `quotaCheckStrategy: IgnoreUndeclared` in the Kueue Configuration as a cluster-level setting. If needed, you can disable the feature with the `featureGates` `QuotaCheckStrategy`.
 
 Follow the [installation instructions for using a custom configuration](/docs/installation#install-a-custom-configured-released-version)
 and extend the configuration with fields similar to the following:
@@ -478,8 +478,6 @@ and extend the configuration with fields similar to the following:
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
-featureGates:
-  QuotaCheckStrategy: true
 resources:
   quotaCheckStrategy: "IgnoreUndeclared"
 ```

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -323,6 +323,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: ReclaimablePods
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -323,6 +323,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: ReclaimablePods
   versionedSpecs:
   - default: true

--- a/test/e2e/sequential/baseline/quota_check_strategy_test.go
+++ b/test/e2e/sequential/baseline/quota_check_strategy_test.go
@@ -29,7 +29,6 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -49,7 +48,6 @@ var _ = ginkgo.Describe("QuotaCheckStrategy", ginkgo.Label("feature:quotacheckst
 			if cfg.FeatureGates == nil {
 				cfg.FeatureGates = make(map[string]bool)
 			}
-			cfg.FeatureGates[string(features.QuotaCheckStrategy)] = true
 			cfg.Resources = &configapi.Resources{
 				QuotaCheckStrategy: ptr.To(configapi.QuotaCheckIgnoreUndeclared),
 			}

--- a/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
+++ b/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
@@ -60,7 +60,6 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 		})
 
 		ginkgo.BeforeEach(func() {
-			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.QuotaCheckStrategy, true)
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "quota-check-strategy-")
 
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -168,6 +167,7 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 		})
 
 		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.QuotaCheckStrategy, false)
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "quota-check-gate-off-")
 
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()


### PR DESCRIPTION

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR graduates QuotaCheckStrategy to beta.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12337

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Promoted QuotaCheckStrategy to Beta and enabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled `QuotaCheckStrategy` by default for Kubernetes version **0.19 (Beta)**. **0.18** remains **off by default** (Alpha behavior unchanged).
  * You can use `quotaCheckStrategy: IgnoreUndeclared` without manually turning on the feature gate.
* **Documentation**
  * Updated the “Change quota check strategy for admission” guide to reflect the new default and show how to disable the feature gate.
* **Tests**
  * Adjusted validation, integration, and e2e scenarios to match the updated feature-gate defaults.
* **Chores**
  * Refreshed KEP milestone versions and related versioned feature references (including compatibility docs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->