### PR TITLE
test: Implement MPIJob E2E tests

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -240,7 +240,7 @@ $(TEST_E2E_SHARD_2_TARGETS): export RAY_VERSION := $(RAY_VERSION)
 $(TEST_E2E_SHARD_2_TARGETS): export RAYMINI_VERSION := $(RAYMINI_VERSION)
 
 ## Label Taxonomy:
-##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,trainjob
+##   Features: appwrapper,jaxjob,jobset,kuberay,leaderworkerset,pytorchjob,trainjob,mpijob
 ##
 ## Examples:
 ##   Run only AppWrapper tests: GINKGO_ARGS="--label-filter=feature:appwrapper" make test-e2e-extended

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -255,7 +255,7 @@ test-e2e-extended-shard-0: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSIO
 
 .PHONY: test-e2e-extended-shard-1
 test-e2e-extended-shard-1: E2E_NPROCS := 4
-test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob
+test-e2e-extended-shard-1: GINKGO_ARGS=--label-filter=feature:appwrapper,feature:jaxjob,feature:jobset,feature:leaderworkerset,feature:pytorchjob,feature:trainjob,feature:mpijob
 test-e2e-extended-shard-1: setup-e2e-env run-test-e2e-extended-$(E2E_KIND_VERSION:kindest/node:v%=%)
 
 .PHONY: test-e2e-extended-shard-2

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -42,7 +42,7 @@ export E2E_SKIP_REINSTALL="${E2E_SKIP_REINSTALL:-false}"
 # when they already exist locally / on kind worker nodes. CI mode always pulls and loads.
 export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
-export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
+export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
 
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -42,7 +42,7 @@ export E2E_SKIP_REINSTALL="${E2E_SKIP_REINSTALL:-false}"
 # when they already exist locally / on kind worker nodes. CI mode always pulls and loads.
 export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
-export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
+export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
 
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -63,6 +63,7 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should run a MPIJob if admitted", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob", ns.Name).
 				Queue("main").
+				GenericLauncherAndWorker().
 				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "500m").
 				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
@@ -132,6 +133,7 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
 				Queue("main").
+				GenericLauncherAndWorker().
 				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
 				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 			ginkgo.By("Stopping the ClusterQueue to make the MPIJob be stopped and suspended")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
-				clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				clusterQueue.Spec.StopPolicy = new(kueue.HoldAndDrain)
 				g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -1,14 +1,30 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package extended
 
 import (
+	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
-	"k8s.io/utils/ptr"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	workloadmpijob "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -63,7 +79,20 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should run a MPIJob if admitted", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob", ns.Name).
 				Queue("main").
-				GenericLauncherAndWorker().
+				MPIJobReplicaSpecs(
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:  kfmpi.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+						Image:        util.GetAgnHostImage(),
+						Args:         util.BehaviorExitFast,
+					},
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:  kfmpi.MPIReplicaTypeWorker,
+						ReplicaCount: 1,
+						Image:        util.GetAgnHostImage(),
+						Args:         util.BehaviorExitFast,
+					},
+				).
 				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "500m").
 				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
@@ -133,7 +162,20 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
 				Queue("main").
-				GenericLauncherAndWorker().
+				MPIJobReplicaSpecs(
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:  kfmpi.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+						Image:        util.GetAgnHostImage(),
+						Args:         util.BehaviorExitFast,
+					},
+					testingmpijob.MPIJobReplicaSpecRequirement{
+						ReplicaType:  kfmpi.MPIReplicaTypeWorker,
+						ReplicaCount: 1,
+						Image:        util.GetAgnHostImage(),
+						Args:         util.BehaviorExitFast,
+					},
+				).
 				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
 				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -77,86 +77,98 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 		})
-		ginkgo.When("Using resource flavors with node selectors", func() {
-			var (
-				onDemandRF       *kueue.ResourceFlavor
-				spotRF           *kueue.ResourceFlavor
-				localQueue       *kueue.LocalQueue
-				clusterQueue     *kueue.ClusterQueue
-				flavorOnDemand   string
-				flavorSpot       string
-				clusterQueueName string
-			)
-			ginkgo.BeforeEach(func() {
-				flavorOnDemand = "on-demand-" + ns.Name
-				flavorSpot = "spot-" + ns.Name
-				clusterQueueName = "cluster-queue-" + ns.Name
-				onDemandRF = utiltestingapi.MakeResourceFlavor(flavorOnDemand).
-					NodeLabel("instance-type", "on-demand").Obj()
-				util.MustCreate(ctx, k8sClient, onDemandRF)
-				spotRF = utiltestingapi.MakeResourceFlavor(flavorSpot).
-					NodeLabel("instance-type", "spot").Obj()
-				util.MustCreate(ctx, k8sClient, spotRF)
-				clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
-							Resource(corev1.ResourceCPU, "1").
-							Resource(corev1.ResourceMemory, "1Gi").
-							Obj(),
-						*utiltestingapi.MakeFlavorQuotas(flavorSpot).
-							Resource(corev1.ResourceCPU, "1").
-							Resource(corev1.ResourceMemory, "1Gi").
-							Obj(),
-					).
-					Preemption(kueue.ClusterQueuePreemption{
-						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
-					}).
-					Obj()
-				util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
-				localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueueName).Obj()
-				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.When("Using resource flavors with node selectors", func() {
+		var (
+			onDemandRF       *kueue.ResourceFlavor
+			spotRF           *kueue.ResourceFlavor
+			localQueue       *kueue.LocalQueue
+			clusterQueue     *kueue.ClusterQueue
+			flavorOnDemand   string
+			flavorSpot       string
+			clusterQueueName string
+		)
+		ginkgo.BeforeEach(func() {
+			flavorOnDemand = "on-demand-" + ns.Name
+			flavorSpot = "spot-" + ns.Name
+			clusterQueueName = "cluster-queue-" + ns.Name
+			onDemandRF = utiltestingapi.MakeResourceFlavor(flavorOnDemand).
+				NodeLabel("instance-type", "on-demand").Obj()
+			util.MustCreate(ctx, k8sClient, onDemandRF)
+			spotRF = utiltestingapi.MakeResourceFlavor(flavorSpot).
+				NodeLabel("instance-type", "spot").Obj()
+			util.MustCreate(ctx, k8sClient, spotRF)
+			clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+						Resource(corev1.ResourceCPU, "1").
+						Resource(corev1.ResourceMemory, "1Gi").
+						Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot).
+						Resource(corev1.ResourceCPU, "1").
+						Resource(corev1.ResourceMemory, "1Gi").
+						Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+				}).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueueName).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllMPIJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotRF, true)
+			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+		})
+
+		ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
+			mpiJob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
+				Queue("main").
+				RequestLauncher(corev1.ResourceCPU, "100m").
+				RequestWorker(corev1.ResourceCPU, "100m").
+				Obj()
+
+			ginkgo.By("Creating the mpiJob", func() {
+				util.MustCreate(ctx, k8sClient, mpiJob)
 			})
-			ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
-				mpijob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
-					Queue("main").
-					RequestLauncher(corev1.ResourceCPU, "100m").
-					RequestWorker(corev1.ResourceCPU, "100m").
-					Obj()
 
-				ginkgo.By("Creating the jobSet", func() {
-					util.MustCreate(ctx, k8sClient, mpiJob)
-				})
-
-				ginkgo.By("Waiting for the jobSet to be unsuspended", func() {
-					jobKey := client.ObjectKeyFromObject(mpiJob)
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
-						g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(false)))
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("Verify the mpiJob has nodeSelector set", func() {
-					gomega.Expect(mpiJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).To(gomega.Equal(
-						map[string]string{
-							"instance-type": "on-demand",
-						},
-					))
-				})
-
-				ginkgo.By("Stopping the ClusterQueue to make the MPIJob be stopped and suspended")
+			ginkgo.By("Waiting for the mpiJob to be unsuspended", func() {
+				jobKey := client.ObjectKeyFromObject(mpiJob)
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
-					clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
-					g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
+					g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
+					g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(false)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
 
-				ginkgo.By("Waiting for the mpiJob to be suspended", func() {
-					jobKey := client.ObjectKeyFromObject(mpiJob)
-					gomega.Eventually(func(g gomega.Gomega) {
-						g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
-						g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(true)))
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
+			ginkgo.By("Verify the mpiJob has nodeSelector set", func() {
+				gomega.Expect(mpiJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).To(gomega.Equal(
+					map[string]string{
+						"instance-type": "on-demand",
+					},
+				))
+			})
+
+			ginkgo.By("Stopping the ClusterQueue to make the MPIJob be stopped and suspended")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+				clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Waiting for the mpiJob to be suspended", func() {
+				jobKey := client.ObjectKeyFromObject(mpiJob)
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
+					g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(true)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -90,8 +90,8 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 						Args:         util.BehaviorExitFast,
 					},
 				).
-				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "500m").
-				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "500m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
 
 			ginkgo.By("Creating the MPIJob", func() {

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -45,16 +45,14 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 
 	ginkgo.When("Creating a MPIJob", func() {
 		var (
-			defaultRf        *kueue.ResourceFlavor
-			localQueue       *kueue.LocalQueue
-			clusterQueue     *kueue.ClusterQueue
-			flavorDefault    string
-			clusterQueueName string
+			defaultRf    *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
 		)
 
 		ginkgo.BeforeEach(func() {
-			flavorDefault = "default-" + ns.Name
-			clusterQueueName = "cluster-queue-" + ns.Name
+			flavorDefault := "default-" + ns.Name
+			clusterQueueName := "cluster-queue-" + ns.Name
 			defaultRf = utiltestingapi.MakeResourceFlavor(flavorDefault).Obj()
 			util.MustCreate(ctx, k8sClient, defaultRf)
 			clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
@@ -70,10 +68,9 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteAllMPIJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultRf, true)
-			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 		})
 
 		ginkgo.It("Should run a MPIJob if admitted", func() {
@@ -97,13 +94,13 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
 
-			ginkgo.By("Creating the jobSet", func() {
+			ginkgo.By("Creating the MPIJob", func() {
 				util.MustCreate(ctx, k8sClient, mpiJob)
 			})
 
 			wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpiJob.Name, mpiJob.UID), Namespace: ns.Name}
 
-			ginkgo.By("Waiting for the jobSet to finish", func() {
+			ginkgo.By("Waiting for the MPIJob to finish", func() {
 				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
 			})
 		})
@@ -111,18 +108,15 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 
 	ginkgo.When("Using resource flavors with node selectors", func() {
 		var (
-			onDemandRF       *kueue.ResourceFlavor
-			spotRF           *kueue.ResourceFlavor
-			localQueue       *kueue.LocalQueue
-			clusterQueue     *kueue.ClusterQueue
-			flavorOnDemand   string
-			flavorSpot       string
-			clusterQueueName string
+			onDemandRF   *kueue.ResourceFlavor
+			spotRF       *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
 		)
 		ginkgo.BeforeEach(func() {
-			flavorOnDemand = "on-demand-" + ns.Name
-			flavorSpot = "spot-" + ns.Name
-			clusterQueueName = "cluster-queue-" + ns.Name
+			flavorOnDemand := "on-demand-" + ns.Name
+			flavorSpot := "spot-" + ns.Name
+			clusterQueueName := "cluster-queue-" + ns.Name
 			onDemandRF = utiltestingapi.MakeResourceFlavor(flavorOnDemand).
 				NodeLabel("instance-type", "on-demand").Obj()
 			util.MustCreate(ctx, k8sClient, onDemandRF)
@@ -152,14 +146,13 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteAllMPIJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
 			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
-			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandRF, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotRF, true)
-			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 		})
 
-		ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
+		ginkgo.It("Should allow to suspend a MPIJob when the ClusterQueue is stopped with the HoldAndDrain policy", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
 				Queue("main").
 				MPIJobReplicaSpecs(
@@ -176,8 +169,8 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 						Args:         util.BehaviorExitFast,
 					},
 				).
-				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
-				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
+				RequestAndLimit(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
 
 			ginkgo.By("Creating the mpiJob", func() {

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -1,0 +1,163 @@
+package extended
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kfmpi "github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	"k8s.io/utils/ptr"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	workloadmpijob "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mpijob"), func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-")
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.When("Creating a MPIJob", func() {
+		var (
+			defaultRf        *kueue.ResourceFlavor
+			localQueue       *kueue.LocalQueue
+			clusterQueue     *kueue.ClusterQueue
+			flavorDefault    string
+			clusterQueueName string
+		)
+
+		ginkgo.BeforeEach(func() {
+			flavorDefault = "default-" + ns.Name
+			clusterQueueName = "cluster-queue-" + ns.Name
+			defaultRf = utiltestingapi.MakeResourceFlavor(flavorDefault).Obj()
+			util.MustCreate(ctx, k8sClient, defaultRf)
+			clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorDefault).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueueName).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllMPIJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultRf, true)
+			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+		})
+
+		ginkgo.It("Should run a MPIJob if admitted", func() {
+			mpiJob := testingmpijob.MakeMPIJob("mpijob", ns.Name).
+				Queue("main").
+				RequestLauncher(corev1.ResourceCPU, "500m").
+				RequestWorker(corev1.ResourceCPU, "100m").
+				Obj()
+
+			ginkgo.By("Creating the jobSet", func() {
+				util.MustCreate(ctx, k8sClient, mpiJob)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpiJob.Name, mpiJob.UID), Namespace: ns.Name}
+
+			ginkgo.By("Waiting for the jobSet to finish", func() {
+				util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+			})
+		})
+		ginkgo.When("Using resource flavors with node selectors", func() {
+			var (
+				onDemandRF       *kueue.ResourceFlavor
+				spotRF           *kueue.ResourceFlavor
+				localQueue       *kueue.LocalQueue
+				clusterQueue     *kueue.ClusterQueue
+				flavorOnDemand   string
+				flavorSpot       string
+				clusterQueueName string
+			)
+			ginkgo.BeforeEach(func() {
+				flavorOnDemand = "on-demand-" + ns.Name
+				flavorSpot = "spot-" + ns.Name
+				clusterQueueName = "cluster-queue-" + ns.Name
+				onDemandRF = utiltestingapi.MakeResourceFlavor(flavorOnDemand).
+					NodeLabel("instance-type", "on-demand").Obj()
+				util.MustCreate(ctx, k8sClient, onDemandRF)
+				spotRF = utiltestingapi.MakeResourceFlavor(flavorSpot).
+					NodeLabel("instance-type", "spot").Obj()
+				util.MustCreate(ctx, k8sClient, spotRF)
+				clusterQueue = utiltestingapi.MakeClusterQueue(clusterQueueName).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
+							Resource(corev1.ResourceCPU, "1").
+							Resource(corev1.ResourceMemory, "1Gi").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas(flavorSpot).
+							Resource(corev1.ResourceCPU, "1").
+							Resource(corev1.ResourceMemory, "1Gi").
+							Obj(),
+					).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+					}).
+					Obj()
+				util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+				localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueueName).Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+			})
+			ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
+				mpijob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
+					Queue("main").
+					RequestLauncher(corev1.ResourceCPU, "100m").
+					RequestWorker(corev1.ResourceCPU, "100m").
+					Obj()
+
+				ginkgo.By("Creating the jobSet", func() {
+					util.MustCreate(ctx, k8sClient, mpiJob)
+				})
+
+				ginkgo.By("Waiting for the jobSet to be unsuspended", func() {
+					jobKey := client.ObjectKeyFromObject(mpiJob)
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
+						g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(false)))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Verify the mpiJob has nodeSelector set", func() {
+					gomega.Expect(mpiJob.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec.NodeSelector).To(gomega.Equal(
+						map[string]string{
+							"instance-type": "on-demand",
+						},
+					))
+				})
+
+				ginkgo.By("Stopping the ClusterQueue to make the MPIJob be stopped and suspended")
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+					clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+					g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Waiting for the mpiJob to be suspended", func() {
+					jobKey := client.ObjectKeyFromObject(mpiJob)
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, jobKey, mpiJob)).To(gomega.Succeed())
+						g.Expect(mpiJob.Spec.RunPolicy.Suspend).Should(gomega.BeEquivalentTo(new(true)))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+		})
+	})
+})

--- a/test/e2e/singlecluster/extended/mpijob_test.go
+++ b/test/e2e/singlecluster/extended/mpijob_test.go
@@ -63,8 +63,8 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should run a MPIJob if admitted", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob", ns.Name).
 				Queue("main").
-				RequestLauncher(corev1.ResourceCPU, "500m").
-				RequestWorker(corev1.ResourceCPU, "100m").
+				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "500m").
+				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
 
 			ginkgo.By("Creating the jobSet", func() {
@@ -132,8 +132,8 @@ var _ = ginkgo.Describe("MPIJob", ginkgo.Label("area:singlecluster", "feature:mp
 		ginkgo.It("Should allow to suspend a MPIJob when injected nodeSelector", func() {
 			mpiJob := testingmpijob.MakeMPIJob("mpijob-suspend", ns.Name).
 				Queue("main").
-				RequestLauncher(corev1.ResourceCPU, "100m").
-				RequestWorker(corev1.ResourceCPU, "100m").
+				Request(kfmpi.MPIReplicaTypeLauncher, corev1.ResourceCPU, "100m").
+				Request(kfmpi.MPIReplicaTypeWorker, corev1.ResourceCPU, "100m").
 				Obj()
 
 			ginkgo.By("Creating the mpiJob", func() {

--- a/test/e2e/singlecluster/extended/suite_test.go
+++ b/test/e2e/singlecluster/extended/suite_test.go
@@ -63,6 +63,9 @@ var _ = ginkgo.BeforeSuite(func() {
 	if ginkgo.Label("feature:appwrapper").MatchesLabelFilter(labelFilter) {
 		util.WaitForAppWrapperAvailability(ctx, k8sClient)
 	}
+	if ginkgo.Label("feature:mpijob").MatchesLabelFilter(labelFilter) {
+		util.WaitForKubeFlowMPIOperatorAvailability(ctx, k8sClient)
+	}
 	if ginkgo.Label("feature:jaxjob", "feature:pytorchjob").MatchesLabelFilter(labelFilter) {
 		util.WaitForKubeFlowTrainingOperatorAvailability(ctx, k8sClient)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area testing
/area integrations

#### What this PR does / why we need it:
This PR implements the End-to-End (E2E) testing suite for `MPIJob` workloads in single-cluster environments. 

Specifically, this PR:
1. Adds `test/e2e/singlecluster/extended/mpijob_test.go` to test basic MPIJob admission and NodeSelector injection (preemption/suspension).
2. Updates `suite_test.go` to wait for `KubeFlowMPIOperatorAvailability` when the `feature:mpijob` label is provided.
3. Adds the `feature:mpijob` label to the `GINKGO_ARGS` in `Makefile-test.mk` to ensure these tests are executed in CI.
4. Fixes a small bash string replacement bug in `hack/testing/e2e-common.sh` that was breaking `KIND_VERSION` extraction when pulling node images.

#### Which issue(s) this PR fixes:
Fixes #8518

#### Special notes for your reviewer:
The E2E tests for `MPIJob` currently act as smoke tests for admission and suspension, as the majority of edge cases (topology aware scheduling, parent/child workloads, label propagation) are already thoroughly covered by the `envtest` integration suite (`test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go`).

*(Note: This PR was developed with the assistance of an AI tool following the Kubernetes AI Tool Usage Policy).*

#### Does this PR introduce a user-facing change?
```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an extended end-to-end MPIJob test suite covering creation/cleanup, workload completion, and resource-flavor node selection.
  * Verified MPIJob suspension behavior when a ClusterQueue stop policy is set to **HoldAndDrain**.
  * Updated extended E2E test sharding to include the **MPIJob** feature label and to conditionally wait for the Kubeflow MPI Operator.
* **Bug Fixes**
  * Improved Kind version parsing to strip only the expected `kindest/node:v` prefix for more reliable extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->