### PR TITLE
docs: add hands-on guide for Topology Aware Scheduling setup

### DIFF
--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -95,7 +95,7 @@ For a step-by-step administrator guide on setting up a cluster with TAS, see [Se
 Once TAS is configured and ready to be used, you can create Jobs with the
 following annotations set at the PodTemplate level:
 - `kueue.x-k8s.io/podset-preferred-topology` - indicates that a PodSet requires
-	Topology-Aware Scheduling, but scheduling all pods within pods on nodes
+	Topology-Aware Scheduling, but scheduling all pods on nodes
 	within the same topology domain is a preference rather than requirement.
 	The levels are evaluated one-by-one going up from the level indicated by
 	the annotation. If the PodSet cannot fit within a given topology domain

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -1,5 +1,5 @@
 ---
-title: "Topology Aware Scheduling"
+title: "Topology-Aware Scheduling"
 date: 2024-04-11
 weight: 6
 description: >
@@ -29,7 +29,7 @@ different units. We say that nodes placed in different racks are more distant
 than nodes placed within the same rack. Similarly, nodes placed in different
 blocks are more distant than two nodes within the same block.
 
-In this feature (called Topology Aware Scheduling, or TAS for short) we
+In this feature (called Topology-Aware Scheduling, or TAS for short) we
 introduce a convention to represent the
 [hierarchical node topology information](#node-topology-information), and a set
 of APIs for Kueue administrators and users to utilize the information
@@ -77,17 +77,25 @@ As an admin, in order to enable the feature you need to:
 
 #### Example
 
-{{< include "examples/tas/sample-queues.yaml" "yaml" >}}
+```yaml
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: "tas-flavor"
+spec:
+  nodeLabels:
+    cloud.provider.com/node-group: "tas-group"
+  topologyName: "default"
+```
 
-An example for managing GPUs:
-{{< include "examples/tas/sample-gpu-queues.yaml" "yaml" >}}
+For a step-by-step administrator guide on setting up a cluster with TAS, see [Setup Topology-Aware Scheduling](/docs/tasks/manage/setup_topology_aware_scheduling/).
 
 ### User-facing APIs
 
 Once TAS is configured and ready to be used, you can create Jobs with the
 following annotations set at the PodTemplate level:
 - `kueue.x-k8s.io/podset-preferred-topology` - indicates that a PodSet requires
-	Topology Aware Scheduling, but scheduling all pods within pods on nodes
+	Topology-Aware Scheduling, but scheduling all pods within pods on nodes
 	within the same topology domain is a preference rather than requirement.
 	The levels are evaluated one-by-one going up from the level indicated by
 	the annotation. If the PodSet cannot fit within a given topology domain
@@ -95,11 +103,11 @@ following annotations set at the PodTemplate level:
 	at the highest topology level, then it gets admitted as distributed
 	among multiple topology domains.
 - `kueue.x-k8s.io/podset-required-topology` - indicates that a PodSet
-  requires Topology Aware Scheduling, and requires scheduling all pods on nodes
+  requires Topology-Aware Scheduling, and requires scheduling all pods on nodes
 	within the same topology domain corresponding to the topology level
 	indicated by the annotation value (e.g. within a rack or within a block).
 - `kueue.x-k8s.io/podset-unconstrained-topology` - indicates that a PodSet requires
-    Topology Aware Scheduling, and requires scheduling all pods on any nodes without
+    Topology-Aware Scheduling, and requires scheduling all pods on any nodes without
     topology considerations. In other words, this considers if all pods could be accommodated 
     within any nodes which helps to minimize fragmentation by filling the small gaps
     on nodes across the cluster.
@@ -115,11 +123,15 @@ following annotations set at the PodTemplate level:
 
 #### Example
 
-Here is an example Job a user might submit to use TAS. It assumes there exists
-a LocalQueue named `tas-user-queue` which refernces the ClusterQueue pointing
-to a TAS ResourceFlavor.
+```yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        kueue.x-k8s.io/podset-preferred-topology: "cloud.provider.com/topology-block"
+```
 
-{{< include "examples/tas/sample-job-preferred.yaml" "yaml" >}}
+For detailed instructions and full examples on running TAS workloads as a batch user, see [Run Workloads with Topology-Aware Scheduling](/docs/tasks/run/topology_aware_scheduling/).
 
 ### ClusterAutoscaler support
 
@@ -367,7 +379,7 @@ See [Replace Node on Node Taints](#replace-node-on-node-taints) for the per-tain
 
 We recommend keeping all four feature gates enabled to ensure the fastest feedback loop for workloads affected by node failures or tainted nodes.
 
-#### Balanced Placement
+### Balanced placement
 {{< feature-state state="alpha" for_version="v0.15" >}}
 {{% alert title="Note" color="primary" %}}
 `TASBalancedPlacement` is currently an alpha feature and is disabled by default.
@@ -395,7 +407,7 @@ will be maximied. Also (as a second criterion) the number of domains used on the
 minimized. However, if the Job would not fit within a single domain **one level above** the indicated level,
 Kueue will not perform the balanced placement and will fallback to the standard TAS algorithm.
 
-#### Multi-Layer Topology
+### Multi-layer topology
 {{< feature-state state="beta" for_version="v0.19" >}}
 {{% alert title="Note" color="primary" %}}
 `TASMultiLayerTopology` is currently an beta feature and is enabled by default.

--- a/site/content/en/docs/tasks/manage/setup_topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/manage/setup_topology_aware_scheduling.md
@@ -244,5 +244,5 @@ kind delete cluster
 
 - Learn about all [PodSet annotations](/docs/tasks/run/topology_aware_scheduling/) available to batch users.
 - Explore advanced features like Node Hotswap and failure recovery in [Topology-Aware Scheduling Concepts](/docs/concepts/topology_aware_scheduling).
-- Combine TAS with [MultiKueue](/docs/tasks/manage/setup_multikueue/#setup-with-topology-aware-scheduling-tas).
+- Combine TAS with [MultiKueue](/docs/tasks/manage/setup_multikueue/#create-a-sample-setup-with-tas).
 - Read about [TAS drawbacks](/docs/concepts/topology_aware_scheduling/#drawbacks).

--- a/site/content/en/docs/tasks/manage/setup_topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/manage/setup_topology_aware_scheduling.md
@@ -1,0 +1,248 @@
+---
+title: "Setup Topology-Aware Scheduling"
+date: 2026-07-03
+weight: 6
+description: >
+  A hands-on guide to configuring Topology-Aware Scheduling and observing how it places workloads.
+---
+
+This page shows how to set up
+[Topology-Aware Scheduling (TAS)](/docs/concepts/topology_aware_scheduling) as
+a cluster administrator, and how to observe the decisions Kueue makes. We use
+a local [Kind](https://kind.sigs.k8s.io/) cluster so that you can follow the
+steps on your machine, but the same steps apply to any cluster whose nodes
+carry topology labels.
+
+The intended audience for this page are [batch administrators](/docs/tasks#batch-administrator).
+If you are a batch user looking to run workloads on an already configured
+cluster, see [Run Workloads with Topology-Aware Scheduling](/docs/tasks/run/topology_aware_scheduling/).
+
+## Before you begin
+
+Make sure the following conditions are met:
+
+- The kubectl command-line tool is installed.
+- The jq command-line JSON processor is installed.
+- [Kind](https://kind.sigs.k8s.io/) is installed.
+- The `TopologyAwareScheduling` feature gate is enabled (beta, on by default).
+
+## Step 1: A cluster with topology labels
+
+TAS relies on node labels that describe the placement of each node in the
+physical hierarchy of your data center, for example its block, rack, and
+hostname. On cloud providers these labels are typically set by the provider
+(for details and cloud-specific examples, see [Node topology information](/docs/concepts/topology_aware_scheduling/#node-topology-information) and [Ecosystem Resources](/docs/ecosystem/)); on-premise,
+you have to label the nodes yourself.
+
+For this guide, create a Kind cluster with 8 worker "nodes" spread over 2
+blocks and 4 racks, simulated with labels:
+
+{{< include "examples/tas/kind-cluster.yaml" "yaml" >}}
+
+```bash
+kind create cluster --config kind-cluster.yaml
+```
+
+Then [install Kueue](/docs/installation).
+
+Verify the topology labels on the nodes:
+
+```bash
+kubectl get nodes -L cloud.provider.com/topology-block,cloud.provider.com/topology-rack
+```
+
+## Step 2: Create the Topology, ResourceFlavor and queues
+
+The `Topology` object defines the hierarchy of the labels, from the widest
+(block) to the narrowest (hostname). The `ResourceFlavor` references it via
+`topologyName`, and selects the TAS nodes via `nodeLabels`:
+
+{{< include "examples/tas/sample-queues.yaml" "yaml" >}}
+
+```bash
+kubectl apply -f https://kueue.sigs.k8s.io/examples/tas/sample-queues.yaml
+```
+
+{{% alert title="Note" color="primary" %}}
+In `sample-queues.yaml`, the `nominalQuota` is intentionally set high (100 CPUs) so that ClusterQueue quota is not a limiting factor. This guarantees that scheduling rejections during topology experiments are driven strictly by Kueue's Topology-Aware Scheduling (TAS) placement constraints rather than quota exhaustion.
+{{% /alert %}}
+
+## Step 3: Run a workload with a topology constraint
+
+Submit a Job that requests all its Pods to run within a single rack, using
+the `kueue.x-k8s.io/podset-required-topology` annotation on the Pod template:
+
+{{< include "examples/tas/sample-job-required.yaml" "yaml" >}}
+
+```bash
+kubectl create -f https://kueue.sigs.k8s.io/examples/tas/sample-job-required.yaml
+```
+
+## Step 4: Observe the placement decision
+
+Kueue records the chosen topology domains in the Workload's admission status.
+Inspect it:
+
+```bash
+kubectl get workloads
+WORKLOAD=$(kubectl get workload -o name --sort-by='.metadata.creationTimestamp' | tail -n 1)
+kubectl get $WORKLOAD -o jsonpath='{.status.admission.podSetAssignments[0].topologyAssignment}' | jq
+```
+
+The output enumerates the exact nodes assigned to the Pods, with a Pod count
+per node, for example:
+
+```json
+{
+  "levels": [
+    "kubernetes.io/hostname"
+  ],
+  "slices": [
+    {
+      "domainCount": 2,
+      "podCounts": {
+        "individual": [
+          7,
+          3
+        ]
+      },
+      "valuesPerLevel": [
+        {
+          "individual": {
+            "prefix": "kind-worker",
+            "roots": [
+              "",
+              "2"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+{{% alert title="Note" color="primary" %}}
+Kueue uses prefix compression in `valuesPerLevel` status output. In the example above, `prefix: "kind-worker"` paired with `roots: ["", "2"]` represents the node names `kind-worker` (`kind-worker` + `""`) and `kind-worker2` (`kind-worker` + `"2"`). The exact pod distribution in this example assumes worker nodes with 8 allocatable CPUs each; if your local environment allocates a different CPU capacity per node, Kueue will adjust the pod counts across nodes while strictly enforcing the single-rack topology constraint.
+{{% /alert %}}
+
+Confirm that the Pods landed on the assigned nodes, and that those nodes are
+in the same rack:
+
+```bash
+kubectl get pods -o wide
+kubectl get nodes -L cloud.provider.com/topology-block,cloud.provider.com/topology-rack
+```
+
+The Pods of a TAS workload are created with the `kueue.x-k8s.io/topology`
+[scheduling gate](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/),
+and stay gated until the assignment is computed. Kueue then enforces the
+assignment by injecting a node selector matching the assigned topology
+domains into each Pod, and removes the gate.
+
+## Step 5: Experiment with the constraint types
+
+To build intuition, try the other annotation variants in sequence and observe how Kueue handles them:
+
+### Preferred topology: multi-domain fallback
+
+The `kueue.x-k8s.io/podset-preferred-topology` annotation tells Kueue that a topology level is preferred, but allows falling back to wider levels or distributing Pods across multiple topology domains if a single domain is full:
+
+{{< include "examples/tas/sample-job-preferred.yaml" "yaml" >}}
+
+Submit the preferred Job while the initial required Job is running:
+
+```bash
+kubectl create -f https://kueue.sigs.k8s.io/examples/tas/sample-job-preferred.yaml
+```
+
+Observe that Kueue admits the Job and distributes its 40 Pods across the remaining available racks and blocks, consuming the remaining topology capacity across the cluster.
+
+### Required topology: admission control by topology placement (under sufficient quota)
+
+Submit an additional required Job that requires all Pods to fit within a single rack:
+
+```bash
+kubectl create -f https://kueue.sigs.k8s.io/examples/tas/sample-job-required.yaml
+```
+
+Because existing workloads occupy capacity across the racks, no single rack has 10 CPUs available to fit all Pods together. Even though ClusterQueue quota is sufficient (50 CPUs used out of 100 CPUs configured), Kueue's TAS engine controls resource admission directly by holding the Job in `Pending` state.
+
+Query the admission failure condition message:
+
+```bash
+PENDING_WORKLOAD=$(kubectl get workload -o name --sort-by='.metadata.creationTimestamp' | tail -n 1)
+kubectl get $PENDING_WORKLOAD -o jsonpath='{.status.conditions[?(@.type=="QuotaReserved")].message}'
+```
+
+The output is similar to:
+
+```text
+couldn't assign flavors to pod set main: topology "default" allows to fit only 4 out of 10 pod(s). Total nodes: 8; excluded: resource "cpu": 6
+```
+
+This message proves that TAS actively enforces topology domain placement rules during admission, holding the workload in queue even when ample cluster quota remains.
+
+### Unconstrained topology: fill scattered gaps & consume remaining capacity
+
+The `kueue.x-k8s.io/podset-unconstrained-topology` annotation tells Kueue to schedule Pods on any available nodes without topology domain boundaries, while still using TAS bookkeeping to pack Pods into existing partially-filled nodes:
+
+{{< include "examples/tas/sample-job-unconstrained.yaml" "yaml" >}}
+
+Submit the unconstrained Job to fill the remaining node gaps:
+
+```bash
+kubectl create -f https://kueue.sigs.k8s.io/examples/tas/sample-job-unconstrained.yaml
+```
+
+Observe that Kueue admits the Job, gathering the remaining free CPU slots across scattered nodes in the cluster to consume the remaining cluster capacity:
+
+```bash
+WORKLOAD=$(kubectl get workload -o name --sort-by='.metadata.creationTimestamp' | tail -n 1)
+kubectl get $WORKLOAD -o jsonpath='{.status.admission.podSetAssignments[0].topologyAssignment}' | jq
+```
+
+The output confirms that Pods were packed into the remaining non-full nodes across multiple domains, for example:
+
+```json
+{
+  "levels": [
+    "kubernetes.io/hostname"
+  ],
+  "slices": [
+    {
+      "domainCount": 2,
+      "podCounts": {
+        "individual": [
+          4,
+          2
+        ]
+      },
+      "valuesPerLevel": [
+        {
+          "individual": {
+            "prefix": "kind-worker",
+            "roots": [
+              "2",
+              "8"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Cleanup
+
+```bash
+kind delete cluster
+```
+
+## What's next
+
+- Learn about all [PodSet annotations](/docs/tasks/run/topology_aware_scheduling/) available to batch users.
+- Explore advanced features like Node Hotswap and failure recovery in [Topology-Aware Scheduling Concepts](/docs/concepts/topology_aware_scheduling).
+- Combine TAS with [MultiKueue](/docs/tasks/manage/setup_multikueue/#setup-with-topology-aware-scheduling-tas).
+- Read about [TAS drawbacks](/docs/concepts/topology_aware_scheduling/#drawbacks).

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -14,7 +14,7 @@ in a Kubernetes cluster with Kueue enabled. The examples use a batch Job, but
 the same annotations work with any
 [workload type that Kueue supports](/docs/concepts/workload).
 
-The intended audience for this page are [batch users](/docs/tasks#batch-user).
+This page is intended for [batch users](/docs/tasks#batch-user). If you are a [batch administrator](/docs/tasks#batch-administrator) looking to configure cluster topology and queues, see [Setup Topology-Aware Scheduling](/docs/tasks/manage/setup_topology_aware_scheduling/).
 
 For conceptual details about how Kueue models cluster topology and how the
 TAS scheduling algorithm works, see
@@ -30,55 +30,11 @@ Make sure the following conditions are met:
 - The `TopologyAwareScheduling` feature gate is enabled (beta, on by default
   since Kueue v0.14).
 - Your administrator has
-  [configured TAS](/docs/concepts/topology_aware_scheduling#admin-facing-apis)
+  [configured TAS](/docs/tasks/manage/setup_topology_aware_scheduling/)
   by creating a `Topology` object, a `ResourceFlavor` that references it via
   `spec.topologyName`, and a `ClusterQueue` that uses that flavor.
 
-If you do not already have a Kubernetes cluster, you can create a TAS-ready
-`kind` cluster with the same topology labels used by the TAS test setup:
-
-```shell
-kind create cluster --name kueue-tas --config hack/testing/kind-cluster-tas.yaml
-```
-
-When following the hosted documentation instead of a local checkout, download
-the published example config first:
-
-```shell
-curl -L https://kueue.sigs.k8s.io/examples/tas/kind-cluster.yaml -o kind-cluster-tas.yaml
-kind create cluster --name kueue-tas --config kind-cluster-tas.yaml
-```
-
-Then install Kueue. For example, to install the latest development version:
-
-```shell
-kubectl apply --server-side -k "github.com/kubernetes-sigs/kueue/config/default?ref=main"
-```
-
-### Enable the TAS feature gate if needed
-
-The `TopologyAwareScheduling` feature gate is enabled by default since Kueue
-v0.14. If your Kueue installation manages feature gates explicitly, enable it
-using the standard feature gate configuration workflow. For more details, see
-[Change the feature gates configuration](/docs/installation/#change-the-feature-gates-configuration).
-
-### Create the sample TAS setup
-
-If your cluster does not already have TAS queues configured, apply the sample
-setup:
-
-```shell
-kubectl apply -f https://kueue.sigs.k8s.io/examples/tas/sample-queues.yaml
-```
-
-This setup creates:
-
-- a `Topology` with block, rack, and hostname levels;
-- a `ResourceFlavor` named `tas-flavor` that selects the labeled `kind` nodes
-  and references that topology;
-- a `ClusterQueue` named `tas-cluster-queue` with CPU and memory quota for the
-  flavor;
-- a `LocalQueue` named `tas-user-queue` in the `default` namespace.
+If you do not already have a running cluster with TAS enabled, see [Setup Topology-Aware Scheduling](/docs/tasks/manage/setup_topology_aware_scheduling/) for a step-by-step administrator guide on setting up a local `kind` cluster and configuring TAS queues.
 
 ## 1. Identify the queues available in your namespace
 

--- a/site/static/examples/tas/sample-job-unconstrained.yaml
+++ b/site/static/examples/tas/sample-job-unconstrained.yaml
@@ -5,8 +5,8 @@ metadata:
   labels:
     kueue.x-k8s.io/queue-name: tas-user-queue
 spec:
-  parallelism: 10
-  completions: 10
+  parallelism: 6
+  completions: 6
   completionMode: Indexed
   template:
     metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind documentation
/area website
/area tas

#### What this PR does / why we need it:

This PR adds a hands-on administration guide for setting up and observing Topology-Aware Scheduling (TAS) under `docs/tasks/manage/setup_topology_aware_scheduling.md`.

The guide provides step-by-step instructions for batch administrators to:
- Configure simulated multi-tier topology labels (blocks, racks, hostnames) on Kind worker nodes.
- Define `Topology`, `ResourceFlavor`, `ClusterQueue`, and `LocalQueue` manifests with topology levels.
- Submit workloads requesting required, preferred, or unconstrained podset topology annotations.
- Inspect placement assignments using Kueue's modern compressed `slices` JSON status output.
- Observe how scheduling gates (`kueue.x-k8s.io/topology`) and injected node selectors operate in practice.

*Note: AI tool assistance (Gemini) was used to assist in organizing and auditing documentation references for this PR in accordance with the Kubernetes AI Tool Usage Policy.*

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #5626

#### Special notes for your reviewer:

- Compiled locally using Hugo with zero warnings.
- Verified local link resolution with zero broken links or missing anchors.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a step-by-step documentation guide for setting up and observing Topology-Aware Scheduling (TAS) locally with placement decision walkthroughs.
  * Added/expanded examples for required, preferred, and unconstrained topology placement, including how to interpret admission and placement outcomes.

* **Documentation**
  * Refined TAS concept formatting and updated admin/user example YAML and cross-links to the setup and run guides.
  * Updated the “run workloads” guide to clarify intended audience and streamline “Before you begin” steps with a single link.

* **Bug Fixes**
  * Reduced the unconstrained scheduling sample job parallelism/completions from 10 to 6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->