### PR TITLE
fix: use portable POSIX shell replacement for KIND_VERSION extraction

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -42,7 +42,7 @@ export E2E_SKIP_REINSTALL="${E2E_SKIP_REINSTALL:-false}"
 # when they already exist locally / on kind worker nodes. CI mode always pulls and loads.
 export E2E_SKIP_IMAGE_RELOAD="${E2E_SKIP_IMAGE_RELOAD:-false}"
 
-export KIND_VERSION="${E2E_KIND_VERSION/"kindest/node:v"/}"
+export KIND_VERSION="${E2E_KIND_VERSION#kindest/node:v}"
 
 function build_kind_node_image {
     if [[ "$E2E_KIND_VERSION" != kindest/node:v* ]]; then


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area testing

#### What this PR does / why we need it:

This PR replaces the bash string replacement syntax (`/"kindest/node:v"/`) with the standard POSIX shell parameter expansion (`#kindest/node:v`) when extracting `KIND_VERSION` in `e2e-common.sh`.

The previous syntax exhibited parsing quirks with nested quotes when evaluated by BSD bash (the default shell on MacOS), causing the `KIND_VERSION` extraction to fail. This completely broke the E2E cluster bootstrapping script locally for developers running MacOS. This fix ensures the script is POSIX-compliant and portable across all operating systems.

#### Which issue(s) this PR fixes:

Fixes #13083

#### Special notes for your reviewer:

This fix was extracted into a dedicated PR per @mimowo's request from the MPIJob E2E implementation PR.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extraction of the Kubernetes-in-Docker version used during end-to-end testing.
  * Ensures version-dependent test behavior and node image tagging work correctly when the expected version prefix is present or absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->