### PR TITLE
TAS: address review follow-ups for the fixed-time marking sunset

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1428,8 +1428,7 @@ The fixed-time heuristic is retained behind the
 in v0.17 and v0.18 backports, Deprecated (disabled by default) since v0.19, with
 removal planned in v0.21. While that gate is enabled, the interplay with
 `TASReplaceNodeOnPodTermination` is unchanged from v0.14; once it is disabled,
-`TASReplaceNodeOnPodTermination` has no effect and pod-termination marking is
-unconditional. Nodes that are deleted or lack a Ready condition are still marked
+disabling `TASReplaceNodeOnPodTermination` retains the fixed-time marking. Nodes that are deleted or lack a Ready condition are still marked
 immediately in all configurations.
 
 Kueue tries to find a replacement for a failed node until success (or until it gets

--- a/pkg/controller/tas/node_controller.go
+++ b/pkg/controller/tas/node_controller.go
@@ -154,7 +154,7 @@ func (r *nodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		timeSinceNotReady := r.clock.Now().Sub(readyCondition.LastTransitionTime.Time)
 		remainingTime := NodeFailureDelay - timeSinceNotReady
 		timerExpired = remainingTime <= 0
-		if features.Enabled(features.TASReplaceNodeDueToNotReadyOverFixedTime) && !timerExpired && !features.Enabled(features.TASReplaceNodeOnPodTermination) {
+		if !timerExpired && !features.Enabled(features.TASReplaceNodeOnPodTermination) {
 			return ctrl.Result{RequeueAfter: remainingTime}, nil
 		}
 	}
@@ -383,7 +383,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 		// to catch and fail the stray pod.
 		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
 	case !ready:
-		if !replaceOnPodTermination() {
+		if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
 			return workloadHealthCheck{status: workloadUnhealthy}, nil
 		}
 		return r.checkPodsOnNode(ctx, nodeName, wl, false, hasTASAssignment, nodeSelectorAssignedPods)
@@ -399,7 +399,7 @@ func (r *nodeReconciler) getWorkloadStatus(
 		untolerated, temporarilyTolerated := classifyTaints(ctx, node.Spec.Taints, podSets)
 
 		if len(untolerated) > 0 {
-			if !replaceOnPodTermination() {
+			if !features.Enabled(features.TASReplaceNodeOnPodTermination) {
 				return workloadHealthCheck{status: workloadUnhealthy}, nil
 			}
 			return r.checkPodsOnNode(ctx, nodeName, wl, true, hasTASAssignment, nodeSelectorAssignedPods)
@@ -409,13 +409,6 @@ func (r *nodeReconciler) getWorkloadStatus(
 		}
 		return workloadHealthCheck{status: workloadHealthy}, nil
 	}
-}
-
-// replaceOnPodTermination reports whether node replacement is driven by pod
-// termination. Once the fixed-time marking is sunset (gate disabled), this is
-// unconditionally true and TASReplaceNodeOnPodTermination has no effect.
-func replaceOnPodTermination() bool {
-	return features.Enabled(features.TASReplaceNodeOnPodTermination) || !features.Enabled(features.TASReplaceNodeDueToNotReadyOverFixedTime)
 }
 
 func hasSchedulingTaints(taints []corev1.Taint) bool {
@@ -484,7 +477,7 @@ func (r *nodeReconciler) checkPodsOnNode(
 		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
 	}
 
-	if hasProgressingPods && (!hasUntoleratedTaints || replaceOnPodTermination()) {
+	if hasProgressingPods && (!hasUntoleratedTaints || features.Enabled(features.TASReplaceNodeOnPodTermination)) {
 		return workloadHealthCheck{status: workloadHealthy, podsToTerminate: podsToTerminate}, nil
 	}
 

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -280,7 +280,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
 			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 		},
-		"Node NotReady, delay passed, pod running, both gates disabled - not marked (termination-driven)": {
+		"Node NotReady, delay passed, pod running, both gates disabled - marked at the fixed time": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TASReplaceNodeDueToNotReadyOverFixedTime: false,
 				features.TASReplaceNodeOnPodTermination:           false,
@@ -294,9 +294,9 @@ func TestNodeFailureReconciler(t *testing.T) {
 				basePod.DeepCopy(),
 			},
 			reconcileRequests:  []reconcile.Request{{NamespacedName: types.NamespacedName{Name: nodeName}}},
-			wantUnhealthyNodes: nil,
+			wantUnhealthyNodes: []kueue.UnhealthyNode{{Name: nodeName}},
 		},
-		"Node NotReady, pod terminating, both gates disabled - marked (termination-driven)": {
+		"Node NotReady, pod terminating, both gates disabled - marked": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TASReplaceNodeDueToNotReadyOverFixedTime: false,
 				features.TASReplaceNodeOnPodTermination:           false,

--- a/site/content/en/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/docs/concepts/topology_aware_scheduling.md
@@ -186,10 +186,8 @@ Before v0.19, a node was additionally assumed to have failed once its
 state. This fixed-time marking is deprecated: it remains available behind the
 `TASReplaceNodeDueToNotReadyOverFixedTime` feature gate (enabled by default in
 v0.17–v0.18, disabled by default and deprecated since v0.19) and is planned for
-removal. When that gate is enabled, disabling `TASReplaceNodeOnPodTermination`
-additionally restores the pre-v0.14 behavior of waiting for the fixed time before
-any replacement; with the gate disabled, `TASReplaceNodeOnPodTermination` has no
-effect.
+removal. Disabling `TASReplaceNodeOnPodTermination` retains the pre-v0.14 behavior of
+marking the node after the fixed time regardless of Pod state.
 
 Note that finding a replacement node that meets all the requirements (e.g. the same type of machine placed in the rack that Kueue had previously assigned to the workload) may not always be possible.
 If a workload is big enough to cover the whole topology domain (e.g. block or rack) it's inevitable that there will be no replacement within the same domain.
@@ -347,8 +345,9 @@ not-ready trigger depends on `TASReplaceNodeOnPodTermination` (`RNO`):
 - `RNO` disabled: the node is treated as failed only after 30 seconds of `NotReady`
   (the pre-v0.14 behavior), regardless of Pod state.
 
-With the gate disabled (the default since v0.19), `RNO` has no effect and Pod
-termination is the only not-ready trigger. Nodes that are deleted or lack a `Ready`
+With the gate disabled (the default since v0.19), Pod termination is the only
+not-ready trigger while `RNO` remains enabled (its default); disabling `RNO`
+retains the fixed-time marking. Nodes that are deleted or lack a `Ready`
 condition are treated as failed immediately in all configurations. To disable node
 replacement entirely, use the `TASFailedNodeReplacement` feature gate instead.
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -29,6 +29,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,6 +38,7 @@ import (
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -1572,11 +1574,17 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Obj()
 					util.MustCreate(ctx, k8sClient, pod)
 					ginkgo.DeferCleanup(func() {
-						p := &corev1.Pod{}
-						if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), p); err == nil {
-							p.Finalizers = nil
-							_ = k8sClient.Update(ctx, p)
-						}
+						gomega.Eventually(func(g gomega.Gomega) {
+							p := &corev1.Pod{}
+							err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), p)
+							if apierrors.IsNotFound(err) {
+								return
+							}
+							g.Expect(err).To(gomega.Succeed())
+							if controllerutil.RemoveFinalizer(p, "kueue.x-k8s.io/integration-test") {
+								g.Expect(k8sClient.Update(ctx, p)).To(gomega.Succeed())
+							}
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
 					})
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
@@ -1626,8 +1634,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("removing the pod finalizer", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
-						pod.Finalizers = nil
-						g.Expect(k8sClient.Update(ctx, pod)).To(gomega.Succeed())
+						if controllerutil.RemoveFinalizer(pod, "kueue.x-k8s.io/integration-test") {
+							g.Expect(k8sClient.Update(ctx, pod)).To(gomega.Succeed())
+						}
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

Addresses the review comments on #13043 that landed after merge:

- Uses `replaceOnPodTermination()` at the requeue guard (https://github.com/kubernetes-sigs/kueue/pull/13043#discussion_r3585590867).
- Restricts `replaceOnPodTermination()` to the `TASReplaceNodeOnPodTermination` gate (https://github.com/kubernetes-sigs/kueue/pull/13043#discussion_r3590968049): disabling that gate now always retains the fixed-time marking rather than being implicitly overridden when `TASReplaceNodeDueToNotReadyOverFixedTime` is disabled. Unit cases and the docs/KEP wording are updated accordingly.
- Uses `controllerutil.RemoveFinalizer` in the node-failure integration test cleanup (https://github.com/kubernetes-sigs/kueue/pull/13043#discussion_r3585303557).

#### Which issue(s) this PR fixes:

Part of #13042

#### Special notes for your reviewer:

The explicit finalizer-removal step at the end of the integration spec is kept alongside the `DeferCleanup`: cleanup nodes run after the suite-level `AfterEach`, so without the in-spec step the namespace teardown waits out the pod finalizer. The `DeferCleanup` remains as the backstop when the spec fails before reaching that step.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - Node replacement/marking now follows the configured strategy more consistently.
  - If pod-termination-driven replacement is disabled, nodes are marked after the fixed “NotReady” duration (even if no pod termination is happening).
  - Deleted nodes and nodes without a Ready condition are still marked immediately.
- **Documentation**
  - Updated TAS hot-swap and feature gate interaction guidance to reflect the corrected deprecated fixed-time marking behavior.
- **Tests**
  - Adjusted unit and integration scenarios to match the updated node-marking logic and improved finalizer cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->