### PR TITLE
fix: scope ClusterRole webhook and CRD permissions with resourceNames

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ manifests: controller-gen generate-code ## Generate WebhookConfiguration, Cluste
 	$(CONTROLLER_GEN) \
 		rbac:roleName=manager-role output:rbac:artifacts:config=config/components/rbac\
 		webhook output:webhook:artifacts:config=config/components/webhook\
-		paths="./pkg/controller/...;./pkg/webhooks/...;./pkg/util/cert/...;./pkg/visibility/..."
+		paths="./pkg/controller/...;./pkg/webhooks/...;./pkg/util/cert/...;./pkg/visibility/...;./pkg/config/..."
 
 .PHONY: compile-crd-manifests
 compile-crd-manifests: manifests kustomize

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -71,23 +71,50 @@ rules:
       - watch
   - apiGroups:
       - admissionregistration.k8s.io
+    resourceNames:
+      - kueue-mutating-webhook-configuration
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - admissionregistration.k8s.io
     resources:
       - mutatingwebhookconfigurations
       - validatingwebhookconfigurations
     verbs:
-      - get
       - list
-      - update
       - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resourceNames:
+      - kueue-validating-webhook-configuration
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs:
-      - get
       - list
-      - update
       - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - clusterqueues.kueue.x-k8s.io
+      - cohorts.kueue.x-k8s.io
+      - localqueues.kueue.x-k8s.io
+      - multikueueclusters.kueue.x-k8s.io
+      - workloads.kueue.x-k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - update
   - apiGroups:
       - apps
     resources:

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -72,7 +72,7 @@ rules:
   - apiGroups:
       - admissionregistration.k8s.io
     resourceNames:
-      - kueue-mutating-webhook-configuration
+      - '{{ include "kueue.fullname" . }}-mutating-webhook-configuration'
     resources:
       - mutatingwebhookconfigurations
     verbs:
@@ -89,7 +89,7 @@ rules:
   - apiGroups:
       - admissionregistration.k8s.io
     resourceNames:
-      - kueue-validating-webhook-configuration
+      - '{{ include "kueue.fullname" . }}-validating-webhook-configuration'
     resources:
       - validatingwebhookconfigurations
     verbs:

--- a/charts/kueue/templates/rbac/role.yaml
+++ b/charts/kueue/templates/rbac/role.yaml
@@ -105,6 +105,14 @@ rules:
   - apiGroups:
       - apiextensions.k8s.io
     resourceNames:
+      - clusterprofiles.multicluster.x-k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
       - clusterqueues.kueue.x-k8s.io
       - cohorts.kueue.x-k8s.io
       - localqueues.kueue.x-k8s.io

--- a/charts/kueue/tests/rbac_test.yaml
+++ b/charts/kueue/tests/rbac_test.yaml
@@ -50,6 +50,26 @@ tests:
               - list
               - watch
 
+  - it: should grant read-only access to the third-party ClusterProfile CRD
+    # MultiKueue probes this CRD to detect whether ClusterProfile support is installed.
+    # A get-only rule, kept separate so Kueue can never write a CRD it does not own. This
+    # also guards the marker itself: +kubebuilder:rbac is package-level, so attaching it to
+    # a declaration makes controller-gen drop it silently and this rule disappears.
+    release:
+      name: custom-kueue-name
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resourceNames:
+              - clusterprofiles.multicluster.x-k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+
   - it: should not prefix CRD resourceNames, which are release-independent
     release:
       name: custom-kueue-name

--- a/charts/kueue/tests/rbac_test.yaml
+++ b/charts/kueue/tests/rbac_test.yaml
@@ -1,0 +1,72 @@
+suite: test manager-role webhook and CRD resourceNames
+templates:
+  - rbac/role.yaml
+tests:
+  - it: should scope webhook configuration writes to the release-derived names
+    # The cert rotator derives these names from webhookServiceName, which
+    # manager_config_test.yaml pins to the same release prefix. If the two ever
+    # disagree the rotator is denied the CA bundle update and never reports ready.
+    release:
+      name: custom-kueue-name
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - admissionregistration.k8s.io
+            resourceNames:
+              - custom-kueue-name-mutating-webhook-configuration
+            resources:
+              - mutatingwebhookconfigurations
+            verbs:
+              - get
+              - update
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - admissionregistration.k8s.io
+            resourceNames:
+              - custom-kueue-name-validating-webhook-configuration
+            resources:
+              - validatingwebhookconfigurations
+            verbs:
+              - get
+              - update
+
+  - it: should keep list and watch unscoped, since RBAC cannot scope them by name
+    release:
+      name: custom-kueue-name
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - admissionregistration.k8s.io
+            resources:
+              - mutatingwebhookconfigurations
+              - validatingwebhookconfigurations
+            verbs:
+              - list
+              - watch
+
+  - it: should not prefix CRD resourceNames, which are release-independent
+    release:
+      name: custom-kueue-name
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resourceNames:
+              - clusterqueues.kueue.x-k8s.io
+              - cohorts.kueue.x-k8s.io
+              - localqueues.kueue.x-k8s.io
+              - multikueueclusters.kueue.x-k8s.io
+              - workloads.kueue.x-k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+              - update

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -52,23 +52,50 @@ rules:
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
+  resourceNames:
+  - kueue-mutating-webhook-configuration
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
   resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:
-  - get
   - list
-  - update
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resourceNames:
+  - kueue-validating-webhook-configuration
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - update
 - apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
-  - get
   - list
-  - update
   - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
+  - clusterqueues.kueue.x-k8s.io
+  - cohorts.kueue.x-k8s.io
+  - localqueues.kueue.x-k8s.io
+  - multikueueclusters.kueue.x-k8s.io
+  - workloads.kueue.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - update
 - apiGroups:
   - apps
   resources:

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -86,6 +86,14 @@ rules:
 - apiGroups:
   - apiextensions.k8s.io
   resourceNames:
+  - clusterprofiles.multicluster.x-k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - apiextensions.k8s.io
+  resourceNames:
   - clusterqueues.kueue.x-k8s.io
   - cohorts.kueue.x-k8s.io
   - localqueues.kueue.x-k8s.io

--- a/config/components/rbac/role.yaml
+++ b/config/components/rbac/role.yaml
@@ -53,7 +53,7 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - kueue-mutating-webhook-configuration
+  - mutating-webhook-configuration
   resources:
   - mutatingwebhookconfigurations
   verbs:
@@ -70,7 +70,7 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resourceNames:
-  - kueue-validating-webhook-configuration
+  - validating-webhook-configuration
   resources:
   - validatingwebhookconfigurations
   verbs:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,10 @@ transformers:
 # Sets the namespace for the role binding as kube-system instead of default kueue-system
 - role_binding_visibility_transformer.yaml
 
+configurations:
+# Keeps the manager role's resourceNames in step with the webhook configurations namePrefix renames
+- webhook_name_reference.yaml
+
 patches:
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/default/webhook_name_reference.yaml
+++ b/config/default/webhook_name_reference.yaml
@@ -1,0 +1,21 @@
+# Teaches kustomize that a ClusterRole's rules[].resourceNames can refer to a webhook
+# configuration, so namePrefix rewrites those references along with the objects themselves.
+# Kustomize's built-in reference table covers this path only for ConfigMap, Secret and
+# PersistentVolume, so without this the manager role keeps naming the unprefixed
+# {mutating,validating}-webhook-configuration and the cert rotator is denied the update it
+# needs to inject the CA bundle.
+nameReference:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+    fieldSpecs:
+      - path: rules/resourceNames
+        group: rbac.authorization.k8s.io
+        kind: ClusterRole
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    version: v1
+    fieldSpecs:
+      - path: rules/resourceNames
+        group: rbac.authorization.k8s.io
+        kind: ClusterRole

--- a/hack/processing-plan.yaml
+++ b/hack/processing-plan.yaml
@@ -58,6 +58,16 @@ files:
       - type: UPDATE
         key: .subjects.[].namespace
         value: '"{{ .Release.Namespace }}"'
+      # Webhook configurations are named after the release, so the names the manager role
+      # grants must be prefixed to match; CRD names must not be, hence onItemCondition.
+      # addKeyIfMissing bypasses a precheck that cannot parse the trailing []; onFileCondition
+      # then stops that bypass adding an empty rules list to the bindings and service account.
+      - type: APPEND
+        key: .rules.[].resourceNames.[]
+        value: '"{{ include \"kueue.fullname\" . }}-"'
+        onFileCondition: '.rules != null'
+        onItemCondition: '.resourceNames != null and (.resources.[0] == "mutatingwebhookconfigurations" or .resources.[0] == "validatingwebhookconfigurations")'
+        addKeyIfMissing: true
     postOperations:
       - type: INSERT_TEXT
         key: .metadata.labels

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -235,6 +235,11 @@ func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, configapi.Co
 	return options, cfg, err
 }
 
+// Grants get on the ClusterProfile CRD object, which the function below reads at startup to
+// decide whether MultiKueue's ClusterProfile support can be enabled. Without it the read
+// returns Forbidden instead of NotFound and the manager exits.
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,resourceNames=clusterprofiles.multicluster.x-k8s.io,verbs=get
+
 // ConfigureClusterProfileCache creates the CRD client from kubeConfig and delegates
 // to ConfigureClusterProfileCacheWithClient. Keeping this wrapper preserves the
 // original API while enabling dependency injection via the WithClient function.

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -37,9 +37,12 @@ const (
 	webhookServiceSuffix = "-webhook-service"
 )
 
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;update
-// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=list;watch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,resourceNames=kueue-mutating-webhook-configuration,verbs=get;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=list;watch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,resourceNames=kueue-validating-webhook-configuration,verbs=get;update
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;watch
+// +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,resourceNames=clusterqueues.kueue.x-k8s.io;cohorts.kueue.x-k8s.io;localqueues.kueue.x-k8s.io;multikueueclusters.kueue.x-k8s.io;workloads.kueue.x-k8s.io,verbs=get;update
 
 // BootstrapCerts creates a minimal manager to generate certificates and inject CA bundles.
 // This function blocks until certificates are ready and CA bundles are injected into CRDs.

--- a/pkg/util/cert/cert.go
+++ b/pkg/util/cert/cert.go
@@ -37,10 +37,16 @@ const (
 	webhookServiceSuffix = "-webhook-service"
 )
 
+// The webhook configuration resourceNames are deliberately unprefixed: each installer adds
+// its own prefix, kustomize via namePrefix (config/default/webhook_name_reference.yaml) and
+// Helm via kueue.fullname (hack/processing-plan.yaml). Hardcoding "kueue-" here denies the
+// rotator its CA-bundle update on any install named otherwise. CRD names carry no prefix
+// from either installer, so those are spelled in full. list and watch cannot be name-scoped
+// by RBAC and the rotator's informers need them, hence the separate unscoped rules.
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=list;watch
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,resourceNames=kueue-mutating-webhook-configuration,verbs=get;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,resourceNames=mutating-webhook-configuration,verbs=get;update
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=list;watch
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,resourceNames=kueue-validating-webhook-configuration,verbs=get;update
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,resourceNames=validating-webhook-configuration,verbs=get;update
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;watch
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,resourceNames=clusterqueues.kueue.x-k8s.io;cohorts.kueue.x-k8s.io;localqueues.kueue.x-k8s.io;multikueueclusters.kueue.x-k8s.io;workloads.kueue.x-k8s.io,verbs=get;update
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The controller ClusterRole grants `get/list/watch/update` on **all** `MutatingWebhookConfigurations` `ValidatingWebhookConfigurations`, and `CustomResourceDefinitions` cluster-wide. The only legitimate need is CA-bundle injection into Kueue's own webhook configs and the 5 CRDs with conversion webhooks.
  
This PR adds `resourceNames` to the kubebuilder RBAC markers in `pkg/util/cert/cert.go`, scoping access to only Kueue's own resources. The issue's remediation suggested a kustomize patch since "controller-gen does not emit resourceNames from markers," but this was fixed in [controller-tools#413](https://github.com/kubernetes-sigs/controller-tools/pull/413) (v0.2.8) - Kueue uses v0.20.1, so the markers work directly.

The webhook configuration names are install-dependent, so the markers carry the **unprefixed** name and each installer applies its own prefix: Helm via `kueue.fullname` (the same expression `webhook/manifests.yaml` uses), kustomize via `namePrefix` plus a `nameReference` declaration. A non-default kustomize `namePrefix` works as a result. `list`/`watch` stay unscoped — RBAC cannot restrict them by name and the cert rotator's informers need them.

Also grants `get` on `clusterprofiles.multicluster.x-k8s.io`: `pkg/config` reads that CRD to detect whether ClusterProfile support is installed, and scoping CRD access had revoked it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12836

#### Special notes for your reviewer:

Verified locally that `make manifests` generates the expected `resourceNames` in `config/components/rbac/role.yaml`. No code logic changes — only static RBAC manifest and Helm chart updates.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed overly broad ClusterRole permissions by scoping webhook configuration and CRD access to only Kueue's own resources using `resourceNames`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Further tightened RBAC for admission webhooks by scoping access to specific mutating/validating webhook configurations, limiting `get`/`update` accordingly.
  * Kept `list`/`watch` broad for webhook configurations while restricting name-sensitive access.
  * Reduced CRD permissions by limiting `get`/`update` to only the required Kueue custom resources (plus `clusterprofiles`).
  * Added kustomize wiring to keep webhook-related `resourceNames` aligned after name changes.
* **Tests**
  * Added RBAC tests to validate webhook and CRD `resourceNames` scoping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->