### PR TITLE
Graduate KueueDRAIntegrationExtendedResource to Beta

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1602,6 +1602,7 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - `KueueDRARejectWorkloadsWhenDRADisabled` feature gate added: May 2026 by @kannon92 — rejects DRA workloads
   when the `DynamicResourceAllocation` feature gate is disabled to prevent silent quota bypass
   (see [#10504](https://github.com/kubernetes-sigs/kueue/issues/10504))
+- Promoted KueueDRAIntegrationExtendedResource to Beta: July 2026 by @PannagaRao
 
 **Key Design Evolution:**
 - **Original Design**: Standalone DynamicResourceAllocationConfig CRD with runtime ambiguity resolution

--- a/keps/2941-DRA/kep.yaml
+++ b/keps/2941-DRA/kep.yaml
@@ -25,7 +25,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.18"
+latest-milestone: "v0.19"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1265,6 +1265,7 @@ func TestValidate(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegrationPartitionableDevices: true,
 				features.KueueDRAIntegration:                     false,
+				features.KueueDRAIntegrationExtendedResource:     false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1468,18 +1469,21 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGatesCLI: "",
 		},
 		"feature gate cli": {
-			featureGatesCLI: string(features.KueueDRAIntegration) + "=false",
+			featureGatesCLI: string(features.KueueDRAIntegration) + "=false," + string(features.KueueDRAIntegrationExtendedResource) + "=false",
 			gatesToRestore: map[featuregate.Feature]bool{
-				features.KueueDRAIntegration: false,
+				features.KueueDRAIntegration:                 false,
+				features.KueueDRAIntegrationExtendedResource: false,
 			},
 		},
 		"cannot specify both feature gates": {
 			featureGatesCLI: string(features.KueueDRAIntegration) + "=false",
 			featureGateMap: map[string]bool{
-				string(features.KueueDRAIntegration): false,
+				string(features.KueueDRAIntegration):                 false,
+				string(features.KueueDRAIntegrationExtendedResource): false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
-				features.KueueDRAIntegration: false,
+				features.KueueDRAIntegration:                 false,
+				features.KueueDRAIntegrationExtendedResource: false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -47,7 +47,9 @@ func NeedsDRAReconcile(wl *kueue.Workload, erCache *ExtendedResourceCache) bool 
 	if workload.HasDRA(wl) {
 		return true
 	}
-	if !features.Enabled(features.KueueDRAIntegrationExtendedResource) {
+	// erCache is always set when the gate is enabled; nil only occurs in tests
+	// that don't configure the full DRA stack.
+	if !features.Enabled(features.KueueDRAIntegrationExtendedResource) || erCache == nil {
 		return false
 	}
 	for i := range wl.Spec.PodSets {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -591,6 +591,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	KueueDRAIntegrationExtendedResource: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KueueDRARejectWorkloadsWhenDRADisabled: {

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -59,24 +59,24 @@ For setup instructions, see
 
 ## How the extended resource path works
 
-{{< feature-state state="alpha" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.19" >}}
 
 When a Pod requests an extended resource backed by DRA (e.g.,
 `nvidia.com/gpu: 1`), the kube-scheduler auto-creates a `ResourceClaim`.
-Without the `KueueDRAIntegrationExtendedResource` feature gate enabled, Kueue would charge
-quota for both the `resources.requests` entry **and** the auto-created claim,
-double counting the same device.
+Kueue detects the matching `DeviceClass`, uses `extendedResourceName` as the
+quota key, and drops the auto-created claim from accounting. This prevents
+quota from being charged for both the `resources.requests` entry **and** the
+auto-created claim, which would double count the same device. No
+`deviceClassMappings` configuration is needed; the mapping is discovered
+from the `DeviceClass` automatically.
 
-With `KueueDRAIntegrationExtendedResource` enabled, Kueue detects the matching `DeviceClass`,
-uses `extendedResourceName` as the quota key, and drops the auto-created claim
-from accounting. No `deviceClassMappings` configuration is needed — the
-mapping is discovered from the `DeviceClass` automatically.
+This behavior is controlled by the `KueueDRAIntegrationExtendedResource`
+feature gate, which is enabled by default since v0.19.
 
 {{% alert title="Note" color="info" %}}
 The extended resource path additionally requires the Kubernetes
 `DRAExtendedResource` feature gate on kube-apiserver and kube-scheduler
-(beta in Kubernetes 1.36), in addition to Kueue's
-`KueueDRAIntegrationExtendedResource` feature gate.
+(beta in Kubernetes 1.36).
 {{% /alert %}}
 
 ## Path separation

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -100,28 +100,17 @@ field in `deviceClassMappings`. Each device request referencing a mapped
 
 ## Set up the extended resource path
 
-{{< feature-state state="alpha" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.19" >}}
 
 Use this path when your users submit workloads using the standard
 `resources.requests` syntax (e.g., `nvidia.com/gpu: 1`) and a `DeviceClass`
-with `spec.extendedResourceName` exists in the cluster.
+with `spec.extendedResourceName` exists in the cluster. Both
+`KueueDRAIntegration` and `KueueDRAIntegrationExtendedResource` feature gates
+are enabled by default since v0.19. The Kubernetes cluster also needs the
+`DRAExtendedResource` feature gate enabled on kube-apiserver and kube-scheduler
+(beta in Kubernetes 1.36).
 
-### 1. Enable the feature gates
-
-Install or reconfigure Kueue with both feature gates enabled:
-
-```yaml
-apiVersion: config.kueue.x-k8s.io/v1beta2
-kind: Configuration
-featureGates:
-  KueueDRAIntegration: true
-  KueueDRAIntegrationExtendedResource: true
-```
-
-The Kubernetes cluster also needs the `DRAExtendedResource` feature gate
-enabled on kube-apiserver and kube-scheduler (beta in Kubernetes 1.36).
-
-### 2. Verify the DeviceClass
+### 1. Verify the DeviceClass
 
 Ensure the `DeviceClass` has `spec.extendedResourceName` set. This is
 typically configured by the DRA driver or cluster administrator:
@@ -148,7 +137,7 @@ spec:
 No `deviceClassMappings` configuration is needed for this path. Kueue
 auto-discovers the mapping by indexing `DeviceClass` objects.
 
-### 3. Add the extended resource to your ClusterQueue
+### 2. Add the extended resource to your ClusterQueue
 
 The `coveredResources` must include the extended resource name that matches
 `spec.extendedResourceName` on the `DeviceClass`:
@@ -180,10 +169,10 @@ name in the ClusterQueue, so the workload stays inadmissible.
 
 ### Why this path exists
 
-Without the `KueueDRAIntegrationExtendedResource` feature gate, Kueue charges quota for both
-the `resources.requests` entry and the auto-created `ResourceClaim`, double
-counting the same device. With the feature gate enabled, Kueue detects the
-matching `DeviceClass` and charges quota only for the extended resource.
+When a Pod requests an extended resource backed by DRA, the kube-scheduler
+auto-creates a `ResourceClaim`. Kueue detects the matching `DeviceClass` and
+charges quota only for the extended resource backed by DRA, preventing double
+counting of both the `resources.requests` entry and the auto-created claim.
 
 ## Set up counter-based quota (partitionable devices)
 

--- a/site/content/en/docs/tasks/run/dra.md
+++ b/site/content/en/docs/tasks/run/dra.md
@@ -144,9 +144,10 @@ If the Workload stays in `Pending` state:
 ### Double counting (extended resource path)
 
 If quota usage shows double the expected value (e.g., `2` instead of `1` for
-a single GPU), the `KueueDRAIntegrationExtendedResource` feature gate may not be enabled.
-Ask your administrator to verify the
-[DRA setup](/docs/tasks/manage/setup_dra).
+a single GPU), verify that `KueueDRAIntegrationExtendedResource` has not been
+explicitly disabled. This gate is enabled by default since v0.19 and ensures
+Kueue charges quota only once for extended resources backed by DRA, instead of
+counting them as both a standard resource request and a DRA device.
 
 ### Missing DeviceClass
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -125,6 +125,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: KueueDRAIntegrationPartitionableDevices
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -125,6 +125,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: KueueDRAIntegrationPartitionableDevices
   versionedSpecs:
   - default: false

--- a/test/e2e/config/dra/whole-device/controller_manager_config.yaml
+++ b/test/e2e/config/dra/whole-device/controller_manager_config.yaml
@@ -19,9 +19,6 @@ integrations:
   frameworks:
   - "batch/job"
   - "pod"
-featureGates:
-  KueueDRAIntegration: true
-  KueueDRAIntegrationExtendedResource: true
 resources:
   deviceClassMappings:
   - name: gpu


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Graduates `KueueDRAIntegrationExtendedResource` from Alpha to Beta (default enabled) in v0.19. Adds a nil guard in `NeedsDRAReconcile` for the extended resource cache since the gate is now on by default.

#### Which issue(s) this PR fixes:

Partially Fixes #11903

#### Special notes for your reviewer:

Based on initial work in #13039 by @ekam-walia.

#### Does this PR introduce a user-facing change?

```release-note
Graduate KueueDRAIntegrationExtendedResource to Beta (enabled by default)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DRA extended-resource integration is now **Beta** and **enabled by default in v0.19**.
  * Extended-resource quota accounting automatically finds matching device classes (no manual device-class mappings needed).
  * Added safeguards to avoid extended-resource reconciliation when required supporting data/cache is unavailable.
* **Documentation**
  * Updated DRA concepts, setup, and troubleshooting to reflect the v0.19 default/beta behavior.
* **Tests**
  * Expanded feature-gate validation and CLI/restore expectations to cover both DRA integration gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->