### PR TITLE
Add create-release-branch ChatOps command.

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -14,11 +14,7 @@ Please do not remove items from the checklist
   At least two for minor or major releases. At least one for a patch release.
 - [ ] Verify that the changelog in this issue and the CHANGELOG folder is up-to-date
   - [ ] Use `/sync-release-notes` to generate and publish the release notes
-- [ ] For major or minor releases (v$MAJ.$MIN.0), create a new release branch.
-  - [ ] An OWNER creates a vanilla release branch with
-        `git branch release-$MAJ.$MIN main`
-  - [ ] An OWNER pushes the new release branch with
-        `git push upstream release-$MAJ.$MIN`
+- [ ] For major or minor releases (`v$MAJ.$MIN.0`), use the `/create-release-branch` ChatOps command to create a new release branch.
 - [ ] Update the release branch:
   - [ ] Ensure there are no unstaged changes in your directory (the script adds everything)
   - [ ] Run `./hack/releasing/prepare_pull.sh --target release $VERSION`

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -9,6 +9,7 @@ jobs:
     if: |
       github.event.issue.pull_request == null &&
       (contains(github.event.comment.body, '/sync-release-notes') ||
+       contains(github.event.comment.body, '/create-release-branch') ||
        contains(github.event.comment.body, '/tag-release') ||
        contains(github.event.comment.body, '/create-draft-release') ||
        contains(github.event.comment.body, '/wait-for-images') ||
@@ -67,6 +68,8 @@ jobs:
           COMMAND=""
           if printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/sync-release-notes[[:space:]]*$'; then
             COMMAND="sync-notes"
+          elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/create-release-branch[[:space:]]*$'; then
+            COMMAND="create-release-branch"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/tag-release[[:space:]]*$'; then
             COMMAND="tag-release"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/create-draft-release[[:space:]]*$'; then
@@ -120,6 +123,72 @@ jobs:
           git config --global user.email "kueue-release-bot@kubernetes.io"
           yes y | ./hack/releasing/sync-notes.sh "$VERSION"
           gh issue comment "$ISSUE_NUMBER" --body "Release notes for version $VERSION have been synced."
+
+  create-release-branch:
+    name: Create Release Branch
+    runs-on: ubuntu-latest
+    needs: authorize
+    if: ${{ needs.authorize.outputs.command == 'create-release-branch' }}
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Create and Push Release Branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          BRANCH: ${{ needs.authorize.outputs.branch }}
+        run: |
+          # Block patch releases
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.([0-9]+)$ ]]; then
+            PATCH="${BASH_REMATCH[1]}"
+            if [ "$PATCH" != "0" ]; then
+              gh issue comment "$ISSUE_NUMBER" --body "❌ Release branch creation is only supported for major and minor releases (vX.Y.0). Patch releases like \`$VERSION\` do not require a new release branch."
+              exit 0
+            fi
+          fi
+
+          # Configure git identity
+          git config --global user.name "kueue-release-bot"
+          git config --global user.email "kueue-release-bot@kubernetes.io"
+          gh auth setup-git
+
+          # Check if branch already exists
+          if git ls-remote --heads origin "$BRANCH" | grep -q "refs/heads/$BRANCH"; then
+            gh issue comment "$ISSUE_NUMBER" --body "✅ Release branch \`$BRANCH\` already exists."
+            exit 0
+          fi
+
+          # Create and push the branch from main
+          set +e
+          git checkout -b "$BRANCH" 2> err.log
+          BRANCH_EXIT=$?
+          if [ $BRANCH_EXIT -eq 0 ]; then
+            git push origin "$BRANCH" 2>> err.log
+            PUSH_EXIT=$?
+          fi
+          set -e
+
+          if [ $BRANCH_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
+            ERR_MSG=$(cat err.log)
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release branch \`$BRANCH\`.
+          
+            **Error details:**
+            \`\`\`text
+            ${ERR_MSG}
+            \`\`\`"
+            exit 1
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" --body "✅ Release branch \`$BRANCH\` has been successfully created from \`main\`."
 
   wait-for-images:
     name: Wait for Images


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add create-release-branch ChatOps command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12763

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a ChatOps command (`/create-release-branch`) to create release branches from issue comments.
  * Added automated guardrails to allow branch creation only for major/minor releases, enforcing version rules (and blocking patch releases unless applicable).
  * Added issue feedback for outcomes, including “already exists,” success, and detailed failure information.
* **Documentation**
  * Updated the release checklist to use the new command instead of manual git branch/push steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->