### PR TITLE
feat: add DisableWaitForPodsReady feature gate

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1460,6 +1460,14 @@ func TestWaitForPodsReadyIsEnabled(t *testing.T) {
 		featureGates map[featuregate.Feature]bool
 		want         bool
 	}{
+		"waitforpodsready.Enabled() is false when WaitForPodsReady config is nil": {
+			cfg: &configapi.Configuration{},
+			featureGates: map[featuregate.Feature]bool{
+				features.DisableWaitForPodsReady: false,
+			},
+			want: false,
+		},
+
 		"waitforpodsready.Enabled() is false when DisableWaitForPodsReady feature gate is enabled": {
 			cfg: &configapi.Configuration{
 				WaitForPodsReady: defaultWaitForPodsReady,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1456,21 +1456,33 @@ func TestEncode(t *testing.T) {
 
 func TestWaitForPodsReadyIsEnabled(t *testing.T) {
 	cases := map[string]struct {
-		cfg  *configapi.Configuration
-		want bool
+		cfg          *configapi.Configuration
+		featureGates map[featuregate.Feature]bool
+		want         bool
 	}{
-		"waitforpodsready.Enabled() is false": {
-			cfg: &configapi.Configuration{},
-		},
-		"waitforpodsready.Enabled() is true": {
+		"waitforpodsready.Enabled() is false when DisableWaitForPodsReady feature gate is enabled": {
 			cfg: &configapi.Configuration{
-				WaitForPodsReady: &configapi.WaitForPodsReady{},
+				WaitForPodsReady: defaultWaitForPodsReady,
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.DisableWaitForPodsReady: true,
+			},
+			want: false,
+		},
+
+		"waitforpodsready.Enabled() is true when DisableWaitForPodsReady feature gate is disabled": {
+			cfg: &configapi.Configuration{
+				WaitForPodsReady: defaultWaitForPodsReady,
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.DisableWaitForPodsReady: false,
 			},
 			want: true,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			got := waitforpodsready.Enabled(tc.cfg.WaitForPodsReady)
 			if tc.want != got {
 				t.Errorf("Unexpected result from waitforpodsready.Enabled()\nwant:\n%v\ngot:%v\n", tc.want, got)

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -514,7 +514,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	DisableWaitForPodsReady: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	PrioritySortingWithinCohort: {
 		{Version: version.MustParse("0.6"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -45,10 +45,10 @@ const (
 	//
 	// Enables Kueue visibility on demand
 	VisibilityOnDemand featuregate.Feature = "VisibilityOnDemand"
-	//
+
 	// Allows disabling WaitForPodsReady during the migration period.
 	//
-	// Deprecated: Temporary option while WaitForPodsReady is enabled by default.
+	// Deprecated: planned to be removed in 0.21. Temporary option while WaitForPodsReady is enabled by default.
 	DisableWaitForPodsReady featuregate.Feature = "DisableWaitForPodsReady"
 	// owner: @yaroslava-serdiuk
 	// kep: https://github.com/kubernetes-sigs/kueue/issues/1283

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -45,7 +45,10 @@ const (
 	//
 	// Enables Kueue visibility on demand
 	VisibilityOnDemand featuregate.Feature = "VisibilityOnDemand"
-
+	//
+	// Allows disabling WaitForPodsReady during the migration period.
+	// temporary option while WaitForPodsReady is enabled by default.
+	DisableWaitForPodsReady featuregate.Feature = "DisableWaitForPodsReady"
 	// owner: @yaroslava-serdiuk
 	// kep: https://github.com/kubernetes-sigs/kueue/issues/1283
 	//
@@ -508,6 +511,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	VisibilityOnDemand: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
+	},
+	DisableWaitForPodsReady: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Deprecated},
 	},
 	PrioritySortingWithinCohort: {
 		{Version: version.MustParse("0.6"), Default: true, PreRelease: featuregate.Beta},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -47,6 +47,7 @@ const (
 	VisibilityOnDemand featuregate.Feature = "VisibilityOnDemand"
 	//
 	// Allows disabling WaitForPodsReady during the migration period.
+	//
 	// Deprecated: Temporary option while WaitForPodsReady is enabled by default.
 	DisableWaitForPodsReady featuregate.Feature = "DisableWaitForPodsReady"
 	// owner: @yaroslava-serdiuk

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -47,7 +47,7 @@ const (
 	VisibilityOnDemand featuregate.Feature = "VisibilityOnDemand"
 	//
 	// Allows disabling WaitForPodsReady during the migration period.
-	// temporary option while WaitForPodsReady is enabled by default.
+	// Deprecated: Temporary option while WaitForPodsReady is enabled by default.
 	DisableWaitForPodsReady featuregate.Feature = "DisableWaitForPodsReady"
 	// owner: @yaroslava-serdiuk
 	// kep: https://github.com/kubernetes-sigs/kueue/issues/1283

--- a/pkg/util/waitforpodsready/waitforpodsready.go
+++ b/pkg/util/waitforpodsready/waitforpodsready.go
@@ -18,7 +18,6 @@ package waitforpodsready
 
 import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
-
 	"sigs.k8s.io/kueue/pkg/features"
 )
 

--- a/pkg/util/waitforpodsready/waitforpodsready.go
+++ b/pkg/util/waitforpodsready/waitforpodsready.go
@@ -16,8 +16,15 @@ limitations under the License.
 
 package waitforpodsready
 
-import configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+import (
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+
+	"sigs.k8s.io/kueue/pkg/features"
+)
 
 func Enabled(cfg *configapi.WaitForPodsReady) bool {
+	if features.Enabled(features.DisableWaitForPodsReady) {
+		return false
+	}
 	return cfg != nil
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -57,10 +57,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -51,6 +51,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: DisableWaitForPodsReady
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -57,10 +57,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -51,6 +51,16 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: DisableWaitForPodsReady
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
+  - default: false
+    lockToDefault: false
+    preRelease: Deprecated
+    version: "0.20"
 - name: ElasticJobsViaWorkloadSlices
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds a temporary `DisableWaitForPodsReady` feature gate to allow WaitForPodsReady to be disabled while it is enabled by default.

#### Which issue(s) this PR fixes:

Fixes #13099

#### Special notes for your reviewer:

This PR introduces a temporary feature gate and preserves the existing
behavior by default. WaitForPodsReady remains enabled unless
DisableWaitForPodsReady is explicitly enabled.

#### Does this PR introduce a user-facing change?

```release-note
WaitForPodsReady: Introduce the `DisableWaitForPodsReady` feature gate to allow disabling WaitForPodsReady.
This is a temporary knob, and will be removed in a future release provided no feedback which requests a permanent
knob.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `DisableWaitForPodsReady` feature gate with versioned defaults to control whether the WaitForPodsReady behavior is active.
* **Bug Fixes**
  * WaitForPodsReady is now treated as disabled when `DisableWaitForPodsReady` is enabled, even if the WaitForPodsReady setting is present.
* **Tests**
  * Expanded coverage to verify all combinations of the WaitForPodsReady configuration and the new feature gate state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->