### PR TITLE
TAS: restore API-level rejection of negative subGroupCount

### DIFF
--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -208,6 +208,7 @@ type PodSetTopologyRequest struct {
 
 	// subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
 	// For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	SubGroupCount *int32 `json:"subGroupCount,omitempty"`
 

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -17263,6 +17263,7 @@ spec:
                               subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
                               For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
                             format: int32
+                            minimum: 0
                             type: integer
                           subGroupIndexLabel:
                             description: "subGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)\nwithin a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.\n\tThis is limited to 317 characters."

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -18253,6 +18253,7 @@ spec:
                             subGroupCount indicates the count of replicated Jobs (groups) within a PodSet.
                             For example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.
                           format: int32
+                          minimum: 0
                           type: integer
                         subGroupIndexLabel:
                           description: "subGroupIndexLabel indicates the name of the

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -84,28 +84,14 @@ var _ admission.Validator[*kueue.Workload] = &WorkloadWebhook{}
 func (w *WorkloadWebhook) ValidateCreate(ctx context.Context, wl *kueue.Workload) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
 	log.V(5).Info("Validating create")
-	return warningsForWorkload(wl), ValidateWorkload(wl, nil).ToAggregate()
+	return nil, ValidateWorkload(wl, nil).ToAggregate()
 }
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *WorkloadWebhook) ValidateUpdate(ctx context.Context, oldWL, newWL *kueue.Workload) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
 	log.V(5).Info("Validating update")
-	return warningsForWorkload(newWL), ValidateWorkloadUpdate(newWL, oldWL).ToAggregate()
-}
-
-// slated to become a hard validation error in a future release (see https://github.com/kubernetes-sigs/kueue/pull/13061#issuecomment-4979676077 for more context).
-func warningsForWorkload(wl *kueue.Workload) admission.Warnings {
-	var warnings admission.Warnings
-	specPath := field.NewPath("spec")
-	for i := range wl.Spec.PodSets {
-		tr := wl.Spec.PodSets[i].TopologyRequest
-		if tr != nil && tr.SubGroupCount != nil && *tr.SubGroupCount < 0 {
-			path := specPath.Child("podSets").Index(i).Child("topologyRequest", "subGroupCount")
-			warnings = append(warnings, fmt.Sprintf("%s: negative value %d is deprecated and will be rejected in a future release", path, *tr.SubGroupCount))
-		}
-	}
-	return warnings
+	return nil, ValidateWorkloadUpdate(newWL, oldWL).ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -425,14 +425,6 @@ func TestValidateWorkload(t *testing.T) {
 				*utiltestingapi.MakePodSet("main", 1).SubGroupCount(new(int32(0))).Obj(),
 			).Obj(),
 		},
-		"negative subGroupCount is accepted with a warning": {
-			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
-				*utiltestingapi.MakePodSet("main", 1).SubGroupCount(new(int32(-1))).Obj(),
-			).Obj(),
-			wantWarnings: admission.Warnings{
-				"spec.podSets[0].topologyRequest.subGroupCount: negative value -1 is deprecated and will be rejected in a future release",
-			},
-		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -1086,17 +1078,6 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
 				Obj(),
 			wantErr: nil,
-		},
-		"negative subGroupCount is accepted with a warning": {
-			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
-				*utiltestingapi.MakePodSet("main", 1).Obj(),
-			).Obj(),
-			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).PodSets(
-				*utiltestingapi.MakePodSet("main", 1).SubGroupCount(new(int32(-1))).Obj(),
-			).Obj(),
-			wantWarnings: admission.Warnings{
-				"spec.podSets[0].topologyRequest.subGroupCount: negative value -1 is deprecated and will be rejected in a future release",
-			},
 		},
 	}
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
TAS: restore API-level rejection of negative subGroupCount

For release 0.20 
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes-sigs/kueue/pull/13101

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: The Workload API now rejects negative `subGroupCount` values
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced non-negative values for workload topology subgroup counts.
  * Invalid negative values are now rejected through schema validation.
  * Valid zero values are accepted without warnings.
  * Updated workload validation behavior and tests to reflect the new rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->