### PR TITLE
Automated cherry pick of #13025: Guard RestorePodSetsInfo against pod set length mismatch

### DIFF
--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -153,7 +153,7 @@ func (j *JobSet) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podset.Po
 }
 
 func (j *JobSet) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	if len(podSetsInfo) == 0 {
+	if len(podSetsInfo) != len(j.Spec.ReplicatedJobs) {
 		return false
 	}
 	changed := false

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -36,6 +36,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjobset "sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
@@ -371,6 +372,46 @@ var (
 		cmpopts.IgnoreFields(kueue.PodSet{}, "Template"),
 	}
 )
+
+func TestRestorePodSetsInfo(t *testing.T) {
+	baseJobSet := testingjobset.MakeJobSet("jobset", "ns").ReplicatedJobs(
+		testingjobset.ReplicatedJobRequirements{Name: "job1", Replicas: 1, Parallelism: 1, Completions: 1},
+		testingjobset.ReplicatedJobRequirements{Name: "job2", Replicas: 1, Parallelism: 1, Completions: 1},
+	)
+
+	testCases := map[string]struct {
+		jobSet      *JobSet
+		podSetsInfo []podset.PodSetInfo
+		wantChanged bool
+	}{
+		"fewer podSetsInfo than replicated jobs is a no-op": {
+			jobSet:      (*JobSet)(baseJobSet.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{{}},
+			wantChanged: false,
+		},
+		"more podSetsInfo than replicated jobs is a no-op": {
+			jobSet:      (*JobSet)(baseJobSet.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{{}, {}, {}},
+			wantChanged: false,
+		},
+		"matching length restores pod sets": {
+			jobSet: (*JobSet)(baseJobSet.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if gotChanged := tc.jobSet.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
+			}
+		})
+	}
+}
 
 func TestReconciler(t *testing.T) {
 	baseWPCWrapper := utiltestingapi.MakeWorkloadPriorityClass("test-wpc").

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
@@ -220,6 +221,53 @@ func TestOrderedReplicaTypes(t *testing.T) {
 			gotReplicaTypes := pytorchJob.OrderedReplicaTypes()
 			if diff := cmp.Diff(tc.wantReplicaTypes, gotReplicaTypes); len(diff) != 0 {
 				t.Errorf("Unexpected response (-want, +got): %v", diff)
+			}
+		})
+	}
+}
+
+func TestRestorePodSetsInfo(t *testing.T) {
+	baseJob := testingpytorchjob.MakePyTorchJob("pytorchjob", "ns").
+		PyTorchReplicaSpecs(
+			testingpytorchjob.PyTorchReplicaSpecRequirement{
+				ReplicaType:  kftraining.PyTorchJobReplicaTypeMaster,
+				ReplicaCount: 1,
+			},
+			testingpytorchjob.PyTorchReplicaSpecRequirement{
+				ReplicaType:  kftraining.PyTorchJobReplicaTypeWorker,
+				ReplicaCount: 1,
+			},
+		)
+
+	testCases := map[string]struct {
+		job         *kftraining.PyTorchJob
+		podSetsInfo []podset.PodSetInfo
+		wantChanged bool
+	}{
+		"more podSetsInfo than replica types is a no-op": {
+			job:         baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{{}, {}, {}},
+			wantChanged: false,
+		},
+		"fewer podSetsInfo than replica types is a no-op": {
+			job:         baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{{}},
+			wantChanged: false,
+		},
+		"matching length restores pod sets": {
+			job: baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if gotChanged := fromObject(tc.job).RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
 			}
 		})
 	}

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -76,6 +76,9 @@ func (j *KubeflowJob) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []pods
 
 func (j *KubeflowJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 	orderedReplicaTypes := j.OrderedReplicaTypes()
+	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		return false
+	}
 	changed := false
 	for index, info := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -154,6 +154,9 @@ func (j *MPIJob) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podset.Po
 
 func (j *MPIJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 	orderedReplicaTypes := orderedReplicaTypes(&j.Spec)
+	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		return false
+	}
 	changed := false
 	for index, info := range podSetsInfo {
 		replicaType := orderedReplicaTypes[index]

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -34,6 +34,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/podset"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
@@ -354,6 +355,43 @@ var (
 		cmpopts.IgnoreFields(kueue.PodSet{}, "Template"),
 	}
 )
+
+func TestRestorePodSetsInfo(t *testing.T) {
+	baseJob := testingmpijob.MakeMPIJob("mpijob", "ns").GenericLauncherAndWorker()
+
+	testCases := map[string]struct {
+		job         *MPIJob
+		podSetsInfo []podset.PodSetInfo
+		wantChanged bool
+	}{
+		"more podSetsInfo than replica types is a no-op": {
+			job:         (*MPIJob)(baseJob.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{{}, {}, {}},
+			wantChanged: false,
+		},
+		"fewer podSetsInfo than replica types is a no-op": {
+			job:         (*MPIJob)(baseJob.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{{}},
+			wantChanged: false,
+		},
+		"matching length restores pod sets": {
+			job: (*MPIJob)(baseJob.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if gotChanged := tc.job.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
+			}
+		})
+	}
+}
 
 func TestReconciler(t *testing.T) {
 	baseWPCWrapper := utiltestingapi.MakeWorkloadPriorityClass("test-wpc").

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -224,6 +224,10 @@ func UpdateRayClusterSpecToRunWithPodSetsInfo(rayClusterSpec *rayv1.RayClusterSp
 }
 
 func RestorePodSetsInfo(rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) bool {
+	if len(podSetsInfo) != ExpectedPodSetsCount(rayClusterSpec) {
+		return false
+	}
+
 	// head
 	headPod := &rayClusterSpec.HeadGroupSpec.Template
 	changed := podset.RestorePodSpec(&headPod.ObjectMeta, &headPod.Spec, podSetsInfo[0])

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -843,6 +843,66 @@ func TestRestorePodSetsInfo(t *testing.T) {
 				},
 			},
 		},
+		"no restore when podSetsInfo is shorter than the pod set count": {
+			rayClusterSpec: &rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "head"}},
+						},
+					},
+				},
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+					{
+						GroupName: "group1",
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "worker1"}},
+							},
+						},
+					},
+					{
+						GroupName: "group2",
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "worker2"}},
+							},
+						},
+					},
+				},
+			},
+			// Expected 3 pod sets (head + 2 worker groups) but only 2 are provided, as
+			// happens when a running RayCluster's spec drifts from its admitted Workload.
+			podSetsInfo: []podset.PodSetInfo{{}, {}},
+			wantChanged: false,
+			wantSpec: &rayv1.RayClusterSpec{
+				HeadGroupSpec: rayv1.HeadGroupSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "head"}},
+						},
+					},
+				},
+				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+					{
+						GroupName: "group1",
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "worker1"}},
+							},
+						},
+					},
+					{
+						GroupName: "group2",
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "worker2"}},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -123,10 +123,6 @@ func (j *RayCluster) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podse
 }
 
 func (j *RayCluster) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	if len(podSetsInfo) != ExpectedPodSetsCount(&j.Spec) {
-		return false
-	}
-
 	return RestorePodSetsInfo(&j.Spec, podSetsInfo)
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -192,12 +192,18 @@ func (j *RayJob) PodSets(ctx context.Context) ([]kueue.PodSet, error) {
 	return podSets, nil
 }
 
-func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) error {
-	expectedLen := raycluster.ExpectedPodSetsCount(j.Spec.RayClusterSpec)
+// expectedPodSetsCount returns the number of pod sets for the RayJob:
+// the RayCluster pod sets plus the submitter pod set when submissionMode is K8sJobMode.
+func (j *RayJob) expectedPodSetsCount() int {
+	count := raycluster.ExpectedPodSetsCount(j.Spec.RayClusterSpec)
 	if j.Spec.SubmissionMode == rayv1.K8sJobMode {
-		expectedLen++
+		count++
 	}
+	return count
+}
 
+func (j *RayJob) RunWithPodSetsInfo(_ context.Context, podSetsInfo []podset.PodSetInfo) error {
+	expectedLen := j.expectedPodSetsCount()
 	if len(podSetsInfo) != expectedLen {
 		return podset.BadPodSetsInfoLenError(expectedLen, len(podSetsInfo))
 	}
@@ -225,21 +231,18 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podset.Po
 }
 
 func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	expectedLen := raycluster.ExpectedPodSetsCount(j.Spec.RayClusterSpec)
-	if j.Spec.SubmissionMode == rayv1.K8sJobMode {
-		expectedLen++
-	}
-
-	if len(podSetsInfo) != expectedLen {
+	if len(podSetsInfo) != j.expectedPodSetsCount() {
 		return false
 	}
 
-	changed := raycluster.RestorePodSetsInfo(j.Spec.RayClusterSpec, podSetsInfo)
+	// RayCluster pod sets come first, the optional submitter pod set is last.
+	rayClusterLen := raycluster.ExpectedPodSetsCount(j.Spec.RayClusterSpec)
+	changed := raycluster.RestorePodSetsInfo(j.Spec.RayClusterSpec, podSetsInfo[:rayClusterLen])
 
 	// submitter
 	if j.Spec.SubmissionMode == rayv1.K8sJobMode {
 		submitterPod := getSubmitterTemplate(j)
-		info := podSetsInfo[expectedLen-1]
+		info := podSetsInfo[len(podSetsInfo)-1]
 		changed = podset.RestorePodSpec(&submitterPod.ObjectMeta, &submitterPod.Spec, info) || changed
 	}
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -910,6 +910,69 @@ func TestNodeSelectors(t *testing.T) {
 	}
 }
 
+func TestRestorePodSetsInfo(t *testing.T) {
+	// head + 2 worker groups => ExpectedPodSetsCount is 3; with K8sJobMode a
+	// submitter pod set is appended, so the expected length becomes 4.
+	baseJob := testingrayutil.MakeJob("rayjob", "ns").
+		WithHeadGroupSpec(rayv1.HeadGroupSpec{Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "head", Image: "ray:latest"}}},
+		}}).
+		WithWorkerGroups(
+			rayv1.WorkerGroupSpec{GroupName: "group1", Template: corev1.PodTemplateSpec{}},
+			rayv1.WorkerGroupSpec{GroupName: "group2", Template: corev1.PodTemplateSpec{}},
+		)
+
+	testCases := map[string]struct {
+		job         *rayv1.RayJob
+		podSetsInfo []podset.PodSetInfo
+		wantChanged bool
+	}{
+		"fewer podSetsInfo than expected is a no-op": {
+			job:         baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{{}, {}},
+			wantChanged: false,
+		},
+		"more podSetsInfo than expected is a no-op": {
+			job:         baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{{}, {}, {}, {}},
+			wantChanged: false,
+		},
+		"matching length without submitter restores pod sets": {
+			job: baseJob.Clone().Obj(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged: true,
+		},
+		"K8sJobMode with a missing submitter pod set is a no-op": {
+			job:         baseJob.Clone().WithSubmissionMode(rayv1.K8sJobMode).Obj(),
+			podSetsInfo: []podset.PodSetInfo{{}, {}, {}},
+			wantChanged: false,
+		},
+		"K8sJobMode with matching length restores pod sets including the submitter": {
+			job: baseJob.Clone().WithSubmissionMode(rayv1.K8sJobMode).Obj(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			genJob := (*RayJob)(tc.job)
+			if gotChanged := genJob.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
+			}
+		})
+	}
+}
+
 func Test_RayJobFinished(t *testing.T) {
 	testcases := []struct {
 		name             string

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -201,10 +201,6 @@ func (j *RayService) RunWithPodSetsInfo(ctx context.Context, podSetsInfo []podse
 }
 
 func (j *RayService) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	if len(podSetsInfo) != raycluster.ExpectedPodSetsCount(&j.Spec.RayClusterSpec) {
-		return false
-	}
-
 	return raycluster.RestorePodSetsInfo(&j.Spec.RayClusterSpec, podSetsInfo)
 }
 


### PR DESCRIPTION
Cherry pick of #13025 on release-0.17.

#13025: Guard RestorePodSetsInfo against pod set length mismatch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
RayJob, RayCluster, RayService, JobSet, MPIJob, and Kubeflow Trainer jobs: Fixed a bug where changing a running job's pod set count, for example adding a worker group to a running RayCluster, could crash the Kueue controller during reconciliation.
```