### PR TITLE
Pass context to RestorePodSetsInfo and log on pod set count mismatch

### DIFF
--- a/internal/mocks/controller/jobframework/interface.go
+++ b/internal/mocks/controller/jobframework/interface.go
@@ -164,17 +164,17 @@ func (mr *MockGenericJobMockRecorder) PodsReady(ctx, c any) *gomock.Call {
 }
 
 // RestorePodSetsInfo mocks base method.
-func (m *MockGenericJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (m *MockGenericJob) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RestorePodSetsInfo", podSetsInfo)
+	ret := m.ctrl.Call(m, "RestorePodSetsInfo", ctx, podSetsInfo)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // RestorePodSetsInfo indicates an expected call of RestorePodSetsInfo.
-func (mr *MockGenericJobMockRecorder) RestorePodSetsInfo(podSetsInfo any) *gomock.Call {
+func (mr *MockGenericJobMockRecorder) RestorePodSetsInfo(ctx, podSetsInfo any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestorePodSetsInfo", reflect.TypeOf((*MockGenericJob)(nil).RestorePodSetsInfo), podSetsInfo)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestorePodSetsInfo", reflect.TypeOf((*MockGenericJob)(nil).RestorePodSetsInfo), ctx, podSetsInfo)
 }
 
 // RunWithPodSetsInfo mocks base method.

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -47,9 +47,10 @@ type GenericJob interface {
 	// from the workload into the job and unsuspends it.
 	RunWithPodSetsInfo(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo) error
 
-	// RestorePodSetsInfo restores the original node affinity and pod set counts
-	// of the job. It returns whether any change was made.
-	RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool
+	// RestorePodSetsInfo restores the original node affinity and pod set counts of the job.
+	// It returns whether any change was made. On a pod set count mismatch it logs
+	// and returns false without applying any change.
+	RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool
 
 	// Finished returns whether the job is completed or failed.
 	// The message describes the condition, and success indicates completion status.

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1393,7 +1393,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 	if err := clientutil.Patch(ctx, r.client, object, func() (bool, error) {
 		job.Suspend()
 		if info != nil {
-			job.RestorePodSetsInfo(info)
+			job.RestorePodSetsInfo(ctx, info)
 		}
 		return true, nil
 	}); err != nil {

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -180,7 +180,7 @@ func (j *AppWrapper) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 	return nil
 }
 
-func (j *AppWrapper) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *AppWrapper) RestorePodSetsInfo(_ context.Context, _ []podset.PodSetInfo) bool {
 	return awutils.ClearPodSetInfos((*awv1beta2.AppWrapper)(j))
 }
 

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -192,7 +192,7 @@ func (j *Job) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.Po
 	}
 
 	if err := clientutil.Patch(ctx, c, object, func() (bool, error) {
-		j.RestorePodSetsInfo(podSetsInfo)
+		j.RestorePodSetsInfo(ctx, podSetsInfo)
 		delete(j.Annotations, StoppingAnnotation)
 		return true, nil
 	}); err != nil {
@@ -285,7 +285,7 @@ func (j *Job) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSetsIn
 	return podset.Merge(&j.Spec.Template.ObjectMeta, &j.Spec.Template.Spec, info)
 }
 
-func (j *Job) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *Job) RestorePodSetsInfo(_ context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	if len(podSetsInfo) == 0 {
 		return false
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -323,7 +323,7 @@ func TestPodSetsInfo(t *testing.T) {
 			if diff := cmp.Diff(tc.job.Spec, tc.wantUnsuspended.Spec); diff != "" {
 				t.Errorf("node selectors mismatch (-want +got):\n%s", diff)
 			}
-			tc.job.RestorePodSetsInfo(tc.restoreInfo)
+			tc.job.RestorePodSetsInfo(t.Context(), tc.restoreInfo)
 			tc.job.Suspend()
 			if diff := cmp.Diff(tc.job.Spec, origSpec); diff != "" {
 				t.Errorf("node selectors mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -152,8 +153,13 @@ func (j *JobSet) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	return nil
 }
 
-func (j *JobSet) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *JobSet) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	if len(podSetsInfo) != len(j.Spec.ReplicatedJobs) {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", len(j.Spec.ReplicatedJobs),
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 	changed := false

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -405,7 +405,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if gotChanged := tc.jobSet.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+			if gotChanged := tc.jobSet.RestorePodSetsInfo(t.Context(), tc.podSetsInfo); gotChanged != tc.wantChanged {
 				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
 			}
 		})

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -266,7 +266,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if gotChanged := fromObject(tc.job).RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+			if gotChanged := fromObject(tc.job).RestorePodSetsInfo(t.Context(), tc.podSetsInfo); gotChanged != tc.wantChanged {
 				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
 			}
 		})

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -74,9 +75,14 @@ func (j *KubeflowJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, p
 	return nil
 }
 
-func (j *KubeflowJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *KubeflowJob) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	orderedReplicaTypes := j.OrderedReplicaTypes()
 	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", len(orderedReplicaTypes),
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 	changed := false

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -152,9 +153,14 @@ func (j *MPIJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	return nil
 }
 
-func (j *MPIJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *MPIJob) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	orderedReplicaTypes := orderedReplicaTypes(&j.Spec)
 	if len(podSetsInfo) != len(orderedReplicaTypes) {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", len(orderedReplicaTypes),
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 	changed := false

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -385,7 +385,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			if gotChanged := tc.job.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+			if gotChanged := tc.job.RestorePodSetsInfo(t.Context(), tc.podSetsInfo); gotChanged != tc.wantChanged {
 				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -348,7 +348,7 @@ func (p *Pod) RunWithPodSetsInfo(_ context.Context, _ client.Client, _ []podset.
 }
 
 // RestorePodSetsInfo will restore the original node affinity and podSet counts of the job.
-func (p *Pod) RestorePodSetsInfo(_ []podset.PodSetInfo) bool {
+func (p *Pod) RestorePodSetsInfo(_ context.Context, _ []podset.PodSetInfo) bool {
 	// Not implemented since Pods cannot be updated, they can only be terminated.
 	return false
 }

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -266,8 +266,13 @@ func UpdateRayClusterSpecToRunWithPodSetsInfo(rayClusterSpec *rayv1.RayClusterSp
 	return nil
 }
 
-func RestorePodSetsInfo(rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) bool {
-	if len(podSetsInfo) != ExpectedPodSetsCount(rayClusterSpec) {
+func RestorePodSetsInfo(ctx context.Context, rayClusterSpec *rayv1.RayClusterSpec, podSetsInfo []podset.PodSetInfo) bool {
+	if expected := ExpectedPodSetsCount(rayClusterSpec); len(podSetsInfo) != expected {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", expected,
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -996,7 +996,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotChanged := RestorePodSetsInfo(tc.rayClusterSpec, tc.podSetsInfo)
+			gotChanged := RestorePodSetsInfo(t.Context(), tc.rayClusterSpec, tc.podSetsInfo)
 
 			if gotChanged != tc.wantChanged {
 				t.Errorf("Expected changed=%v, got changed=%v", tc.wantChanged, gotChanged)

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -121,8 +121,8 @@ func (j *RayCluster) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 	return nil
 }
 
-func (j *RayCluster) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	return RestorePodSetsInfo(&j.Spec, podSetsInfo)
+func (j *RayCluster) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
+	return RestorePodSetsInfo(ctx, &j.Spec, podSetsInfo)
 }
 
 func (j *RayCluster) Finished(ctx context.Context) (message string, success, finished bool) {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -190,14 +191,19 @@ func (j *RayJob) RunWithPodSetsInfo(ctx context.Context, _ client.Client, podSet
 	return nil
 }
 
-func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	if len(podSetsInfo) != j.expectedPodSetsCount() {
+func (j *RayJob) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
+	if expected := j.expectedPodSetsCount(); len(podSetsInfo) != expected {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", expected,
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 
 	// RayCluster pod sets come first, the optional submitter pod set is last.
 	rayClusterLen := raycluster.ExpectedPodSetsCount(j.Spec.RayClusterSpec)
-	changed := raycluster.RestorePodSetsInfo(j.Spec.RayClusterSpec, podSetsInfo[:rayClusterLen])
+	changed := raycluster.RestorePodSetsInfo(ctx, j.Spec.RayClusterSpec, podSetsInfo[:rayClusterLen])
 
 	// submitter
 	if j.Spec.SubmissionMode == rayv1.K8sJobMode {

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -901,7 +901,7 @@ func TestNodeSelectors(t *testing.T) {
 
 			if tc.wantRunError == nil {
 				genJob.Suspend()
-				genJob.RestorePodSetsInfo(tc.restoreInfo)
+				genJob.RestorePodSetsInfo(t.Context(), tc.restoreInfo)
 				if diff := cmp.Diff(tc.wantFinal, tc.job); diff != "" {
 					t.Errorf("Unexpected job after restore (-want/+got): %s", diff)
 				}
@@ -966,7 +966,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			genJob := (*RayJob)(tc.job)
-			if gotChanged := genJob.RestorePodSetsInfo(tc.podSetsInfo); gotChanged != tc.wantChanged {
+			if gotChanged := genJob.RestorePodSetsInfo(t.Context(), tc.podSetsInfo); gotChanged != tc.wantChanged {
 				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
 			}
 		})

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -199,8 +199,8 @@ func (j *RayService) RunWithPodSetsInfo(ctx context.Context, _ client.Client, po
 	return nil
 }
 
-func (j *RayService) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
-	return raycluster.RestorePodSetsInfo(&j.Spec.RayClusterSpec, podSetsInfo)
+func (j *RayService) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
+	return raycluster.RestorePodSetsInfo(ctx, &j.Spec.RayClusterSpec, podSetsInfo)
 }
 
 func (j *RayService) Finished(ctx context.Context) (message string, success, finished bool) {

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -223,9 +224,14 @@ func (j *SparkApplication) RunWithPodSetsInfo(ctx context.Context, _ client.Clie
 	return nil
 }
 
-func (j *SparkApplication) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
+func (j *SparkApplication) RestorePodSetsInfo(ctx context.Context, podSetsInfo []podset.PodSetInfo) bool {
 	expectedLength := 2 // driver + executor
 	if len(podSetsInfo) != expectedLength {
+		ctrl.LoggerFrom(ctx).V(2).Info(
+			"Skipping pod set info restore because the pod set count does not match the admitted workload",
+			"expectedCount", expectedLength,
+			"gotCount", len(podSetsInfo),
+		)
 		return false
 	}
 

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -608,7 +608,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			kSparkApp := (*SparkApplication)(tc.sparkApp)
-			changed := kSparkApp.RestorePodSetsInfo(tc.podsetsInfo)
+			changed := kSparkApp.RestorePodSetsInfo(t.Context(), tc.podsetsInfo)
 			if diff := cmp.Diff(tc.wantChanged, changed); diff != "" {
 				t.Errorf("changed mismatch (-want,+got):\n%s", diff)
 				return

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -302,7 +302,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 	}
 
 	if err := clientutil.Patch(ctx, c, t.Object(), func() (bool, error) {
-		if !t.RestorePodSetsInfo(podSetsInfo) {
+		if !t.RestorePodSetsInfo(ctx, podSetsInfo) {
 			return false, errors.New("error restoring info to the trainjob")
 		}
 		return true, nil
@@ -312,7 +312,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 	return true, nil
 }
 
-func (t *TrainJob) RestorePodSetsInfo(_ []podset.PodSetInfo) bool {
+func (t *TrainJob) RestorePodSetsInfo(_ context.Context, _ []podset.PodSetInfo) bool {
 	kueueRuntimePatch := getKueueRuntimePatch(t)
 	if kueueRuntimePatch == nil {
 		return false

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -356,7 +356,7 @@ func TestRestorePodSetsInfo(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			kTrainJob := (*TrainJob)(tc.trainJob)
-			ret := kTrainJob.RestorePodSetsInfo([]podset.PodSetInfo{})
+			ret := kTrainJob.RestorePodSetsInfo(t.Context(), []podset.PodSetInfo{})
 			if ret != tc.wantReturn {
 				t.Errorf("RunWithPodSetsInfo() unexpected return value. got: %v. want :%v", ret, tc.wantReturn)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
RestorePodSetsInfo returns false and skips the restore when a job's pod set count does not match its admitted Workload, for example after a worker group is added to a running RayCluster. It did so silently, so operators had no signal when a restore was skipped.

This threads context.Context through RestorePodSetsInfo, mirroring RunWithPodSetsInfo, and logs the mismatch at V(2) with the expected and actual pod set counts in the integrations that guard on it: JobSet, MPIJob, Kubeflow Trainer, SparkApplication, RayJob, RayCluster, and RayService.

Follow-up to #13025.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ACTION REQUIRED: if you maintain an in-house integration you will need to modify the code
to pass the k8s context when calling the `RestorePodSetsInfo` function.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of workload pod settings during job suspension/resumption by consistently propagating the reconciliation context across supported controllers.
  * Added diagnostic V(2) log messages when pod-set info cannot be restored due to missing/mismatched pod-set counts.

* **Tests**
  * Updated unit tests and generated mocks to use the new context-aware restore method signature while keeping the same behavioral assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->