### PR TITLE
[release-0.17] MultiKueue: don't evict admitted workloads on a transient worker watch reconnect (#12999)

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -116,8 +116,7 @@ type remoteClient struct {
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
 
-	connecting           atomic.Bool
-	disconnected         atomic.Bool
+	connected            atomic.Bool
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
@@ -148,7 +147,7 @@ func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- 
 		adapters:     adapters,
 		clock:        clock.RealClock{},
 	}
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	return rc
 }
 
@@ -196,9 +195,8 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
-	connecting := rc.connecting.Load()
-	disconnected := rc.disconnected.Load()
-	if !configChanged && !connecting && !disconnected {
+	connected := rc.connected.Load()
+	if !configChanged && connected {
 		return nil, nil
 	}
 
@@ -209,7 +207,7 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		rc.resetFailedConnAttempt()
 	}
 
-	if connecting {
+	if !connected {
 		if untilNextAttempt := rc.retryConnNextAttempt.Sub(rc.clock.Now()); untilNextAttempt > 0 {
 			return &untilNextAttempt, nil
 		}
@@ -229,10 +227,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
 
 	// Mark as connected before starting watchers to avoid a race condition.
-	// If a watcher queues an event and wlReconciler processes it before connecting=false,
+	// If a watcher queues an event and wlReconciler processes it before connected=true,
 	// the workload will be treated as unavailable and requeued after 15m.
-	rc.connecting.Store(false)
-	rc.disconnected.Store(false)
+	rc.connected.Store(true)
 
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
@@ -346,9 +343,9 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobfram
 		log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
 		// If the context is not yet Done , queue a reconcile to attempt reconnection
 		if ctx.Err() == nil {
-			oldConnecting := rc.connecting.Swap(true)
+			wasConnected := rc.connected.Swap(false)
 			// reconnect if this is the first watch failing.
-			if !oldConnecting {
+			if wasConnected {
 				log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
 				rc.queueWatchEndedEvent(ctx)
 			}
@@ -385,8 +382,7 @@ func (rc *remoteClient) StopWatchers() {
 // is now unreachable, and apply the workerLostTimeout delay before requeuing.
 func (rc *remoteClient) disconnect() {
 	rc.StopWatchers()
-	rc.connecting.Store(true)
-	rc.disconnected.Store(true)
+	rc.connected.Store(false)
 }
 
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
@@ -413,7 +409,7 @@ func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 func (rc *remoteClient) runGC(ctx context.Context) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if rc.connecting.Load() || rc.disconnected.Load() {
+	if !rc.connected.Load() {
 		log.V(5).Info("Skip disconnected client")
 		return
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -227,8 +227,16 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 	rc.setClient(remoteClient)
 
 	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
+
+	// Mark as connected before starting watchers to avoid a race condition.
+	// If a watcher queues an event and wlReconciler processes it before connecting=false,
+	// the workload will be treated as unavailable and requeued after 15m.
+	rc.connecting.Store(false)
+	rc.disconnected.Store(false)
+
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
+		rc.disconnect()
 		return rc.increaseFailedConnAttempt(), err
 	}
 
@@ -243,12 +251,11 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to start the watcher", "kind", kind)
 			// however let's not accept this for now.
+			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 
-	rc.connecting.Store(false)
-	rc.disconnected.Store(false)
 	rc.resetFailedConnAttempt()
 	return nil, nil
 }

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -27,7 +27,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -116,7 +115,8 @@ type remoteClient struct {
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
 
-	connected            atomic.Bool
+	connState connectionState
+
 	failedConnAttempts   uint
 	retryConnNextAttempt metav1.Time
 
@@ -137,6 +137,61 @@ type remoteClient struct {
 	mu sync.RWMutex
 }
 
+// connectionState holds a remote client's connection status. Its own mutex guards the fields
+// so connected and disconnectedSince are always read and updated together.
+type connectionState struct {
+	mu        sync.RWMutex
+	connected bool
+	// disconnectedSince is when the client last became disconnected: the watch dropping, or the
+	// client's creation for one that has never connected. It becomes nil only when a fully
+	// established connection (markConnected) clears it; the optimistic markConnecting does not, and
+	// it is preserved across failed reconnect attempts, so the worker-lost grace measures from the
+	// first loss, not the latest failed retry.
+	disconnectedSince *time.Time
+}
+
+func (c *connectionState) isConnected() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.connected
+}
+
+func (c *connectionState) lostSince() *time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.disconnectedSince
+}
+
+// markConnecting optimistically marks the client connected before the watchers are started,
+// preserving any recorded disconnectedSince until the connection is fully established.
+func (c *connectionState) markConnecting() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = true
+}
+
+// markConnected records a fully established connection, clearing the recorded loss time.
+func (c *connectionState) markConnected() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.connected = true
+	c.disconnectedSince = nil
+}
+
+// markDisconnected transitions to disconnected, recording now as the first-drop time only if
+// none is recorded yet (so repeated failed reconnects preserve the first loss). It returns
+// whether the client was connected, i.e. whether this call is the first drop of the streak.
+func (c *connectionState) markDisconnected(now time.Time) (wasConnected bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	wasConnected = c.connected
+	c.connected = false
+	if c.disconnectedSince == nil {
+		c.disconnectedSince = &now
+	}
+	return wasConnected
+}
+
 func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- event.GenericEvent, origin, clusterName string, adapters map[string]jobframework.MultiKueueAdapter) *remoteClient {
 	rc := &remoteClient{
 		clusterName:  clusterName,
@@ -147,7 +202,12 @@ func newRemoteClient(localClient client.Client, wlUpdateCh, watchEndedCh chan<- 
 		adapters:     adapters,
 		clock:        clock.RealClock{},
 	}
-	rc.connected.Store(false)
+	// Start in the disconnected state, tracking the loss from creation. If the worker is
+	// unreachable when the client is created (e.g. the reserving worker is down right after a
+	// manager restart, so building the client fails before it is ever marked connected), the
+	// worker-lost grace still runs from here and the workload is eventually retried, instead of
+	// the grace never starting and the workload requeuing forever.
+	rc.connState.markDisconnected(rc.clock.Now())
 	return rc
 }
 
@@ -195,7 +255,7 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
 func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context, config *clientConfig) (*time.Duration, error) {
 	configChanged := !equality.Semantic.DeepEqual(config, rc.config)
-	connected := rc.connected.Load()
+	connected := rc.connState.isConnected()
 	if !configChanged && connected {
 		return nil, nil
 	}
@@ -229,7 +289,7 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 	// Mark as connected before starting watchers to avoid a race condition.
 	// If a watcher queues an event and wlReconciler processes it before connected=true,
 	// the workload will be treated as unavailable and requeued after 15m.
-	rc.connected.Store(true)
+	rc.connState.markConnecting()
 
 	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
@@ -253,6 +313,7 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		}
 	}
 
+	rc.connState.markConnected()
 	rc.resetFailedConnAttempt()
 	return nil, nil
 }
@@ -343,9 +404,8 @@ func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobfram
 		log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
 		// If the context is not yet Done , queue a reconcile to attempt reconnection
 		if ctx.Err() == nil {
-			wasConnected := rc.connected.Swap(false)
 			// reconnect if this is the first watch failing.
-			if wasConnected {
+			if wasConnected := rc.connState.markDisconnected(rc.clock.Now()); wasConnected {
 				log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
 				rc.queueWatchEndedEvent(ctx)
 			}
@@ -382,7 +442,7 @@ func (rc *remoteClient) StopWatchers() {
 // is now unreachable, and apply the workerLostTimeout delay before requeuing.
 func (rc *remoteClient) disconnect() {
 	rc.StopWatchers()
-	rc.connected.Store(false)
+	rc.connState.markDisconnected(rc.clock.Now())
 }
 
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
@@ -409,7 +469,7 @@ func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 func (rc *remoteClient) runGC(ctx context.Context) {
 	log := ctrl.LoggerFrom(ctx)
 
-	if !rc.connected.Load() {
+	if !rc.connState.isConnected() {
 		log.V(5).Info("Skip disconnected client")
 		return
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -100,7 +100,7 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 
 func setReconnectState(rc *remoteClient, a uint) *remoteClient {
 	rc.failedConnAttempts = a
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	return rc
 }
 
@@ -893,7 +893,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 
 	rc := newTestClient(ctx, []byte(kubeconfig), nil, nil)
 	rc.builderOverride = reconciler.builderOverride
-	rc.disconnected.Store(true)
+	rc.connected.Store(false)
 	reconciler.remoteClients["worker1"] = rc
 	defer rc.StopWatchers()
 
@@ -904,11 +904,8 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	if buildCalls != 1 {
 		t.Fatalf("builder invocations: want 1, got %d", buildCalls)
 	}
-	if rc.connecting.Load() {
-		t.Error("connecting should be cleared after successful reconnect")
-	}
-	if rc.disconnected.Load() {
-		t.Error("disconnected should be cleared after successful reconnect")
+	if connected := rc.connected.Load(); !connected {
+		t.Errorf("expected state to be connected")
 	}
 }
 
@@ -1021,7 +1018,7 @@ func TestRemoteClientGC(t *testing.T) {
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 			w1remoteClient.client = worker1Client
-			w1remoteClient.connecting.Store(false)
+			w1remoteClient.connected.Store(true)
 
 			w1remoteClient.runGC(ctx)
 
@@ -1425,7 +1422,7 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 	rc.adapters = map[string]jobframework.MultiKueueAdapter{}
 
 	// Seed an initial client so the first read has a client to observe.
-	rc.connecting.Store(true)
+	rc.connected.Store(false)
 	if _, err := rc.updateConfigAndRefreshWatchers(ctx, rc.config); err != nil {
 		t.Fatalf("seeding initial client: %v", err)
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -95,12 +95,14 @@ func newTestClient(ctx context.Context, kubeconfig []byte, restConfig *rest.Conf
 
 		builderOverride: fakeClientBuilder(ctx),
 	}
+	// Match newRemoteClient's initial state: a client that has never connected still records
+	// the loss from creation, so connState never sits in the illegal disconnected/nil combination.
+	ret.connState.markDisconnected(ret.clock.Now())
 	return ret
 }
 
 func setReconnectState(rc *remoteClient, a uint) *remoteClient {
 	rc.failedConnAttempts = a
-	rc.connected.Store(false)
 	return rc
 }
 
@@ -893,7 +895,6 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 
 	rc := newTestClient(ctx, []byte(kubeconfig), nil, nil)
 	rc.builderOverride = reconciler.builderOverride
-	rc.connected.Store(false)
 	reconciler.remoteClients["worker1"] = rc
 	defer rc.StopWatchers()
 
@@ -904,8 +905,72 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	if buildCalls != 1 {
 		t.Fatalf("builder invocations: want 1, got %d", buildCalls)
 	}
-	if connected := rc.connected.Load(); !connected {
+	if !rc.connState.isConnected() {
 		t.Errorf("expected state to be connected")
+	}
+}
+
+func TestConnectionStateTransitions(t *testing.T) {
+	now := time.Now()
+	fakeClock := testingclock.NewFakeClock(now)
+	cs := &connectionState{}
+
+	if was := cs.markDisconnected(now); was {
+		t.Fatal("want wasConnected=false for the initial disconnect")
+	}
+	if cs.isConnected() {
+		t.Fatal("want disconnected initially")
+	}
+	if s := cs.lostSince(); s == nil || !s.Equal(now) {
+		t.Fatalf("initial disconnect must record now (%v), got %v", now, s)
+	}
+
+	// Fully connected: clears the recorded loss.
+	cs.markConnected()
+	if !cs.isConnected() || cs.lostSince() != nil {
+		t.Fatalf("after markConnected want connected with nil disconnectedSince, got connected=%v since=%v", cs.isConnected(), cs.lostSince())
+	}
+
+	// A drop from a connected client records the loss time and reports the transition.
+	if was := cs.markDisconnected(now); !was {
+		t.Fatal("want wasConnected=true when dropping from connected")
+	}
+	if s := cs.lostSince(); s == nil || !s.Equal(now) {
+		t.Fatalf("drop from connected must record now (%v), got %v", now, s)
+	}
+
+	// Optimistic reconnect (before watchers) preserves the first-drop time.
+	fakeClock.Step(time.Minute)
+	cs.markConnecting()
+	if !cs.isConnected() {
+		t.Fatal("want connected after markConnecting")
+	}
+	if s := cs.lostSince(); s == nil || !s.Equal(now) {
+		t.Fatalf("markConnecting must preserve the first-drop time (%v), got %v", now, s)
+	}
+
+	// A failed reconnect (disconnect after the optimistic connect) must NOT reset the loss time.
+	fakeClock.Step(time.Minute)
+	if was := cs.markDisconnected(fakeClock.Now()); !was {
+		t.Fatal("want wasConnected=true (was optimistically connected)")
+	}
+	if s := cs.lostSince(); s == nil || !s.Equal(now) {
+		t.Fatalf("markDisconnected must preserve the first-drop time across a failed reconnect (%v), got %v", now, s)
+	}
+
+	// A repeated drop while already disconnected reports no transition and preserves the time.
+	fakeClock.Step(time.Minute)
+	if was := cs.markDisconnected(fakeClock.Now()); was {
+		t.Fatal("want wasConnected=false when already disconnected")
+	}
+	if s := cs.lostSince(); s == nil || !s.Equal(now) {
+		t.Fatalf("want preserved first-drop time (%v), got %v", now, s)
+	}
+
+	// A fully successful reconnect clears the recorded loss.
+	cs.markConnected()
+	if !cs.isConnected() || cs.lostSince() != nil {
+		t.Fatalf("after reconnect want connected with nil disconnectedSince, got connected=%v since=%v", cs.isConnected(), cs.lostSince())
 	}
 }
 
@@ -1018,7 +1083,7 @@ func TestRemoteClientGC(t *testing.T) {
 			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 			w1remoteClient.client = worker1Client
-			w1remoteClient.connected.Store(true)
+			w1remoteClient.connState.markConnected()
 
 			w1remoteClient.runGC(ctx)
 
@@ -1422,7 +1487,6 @@ func hammerSetConfigWithReader(t *testing.T, reader func(ctx context.Context, rc
 	rc.adapters = map[string]jobframework.MultiKueueAdapter{}
 
 	// Seed an initial client so the first read has a client to observe.
-	rc.connected.Store(false)
 	if _, err := rc.updateConfigAndRefreshWatchers(ctx, rc.config); err != nil {
 		t.Fatalf("seeding initial client: %v", err)
 	}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -257,6 +257,15 @@ func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *k
 	})
 }
 
+func (w *wlReconciler) reservingWorkerLostSince(clusterName string) time.Time {
+	if rc, found := w.clusters.controllerFor(clusterName); found {
+		if since := rc.connState.lostSince(); since != nil {
+			return *since
+		}
+	}
+	return w.clock.Now()
+}
+
 func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.AdmissionCheckReference) (availableClients map[string]*remoteClient, unavailableClusters []string, err error) {
 	cfg, err := w.helper.ConfigForAdmissionCheck(ctx, acName)
 	if err != nil {
@@ -264,7 +273,7 @@ func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.Admi
 	}
 	availableClients = make(map[string]*remoteClient, len(cfg.Spec.Clusters))
 	for _, clusterName := range cfg.Spec.Clusters {
-		if client, found := w.clusters.controllerFor(clusterName); found && client.connected.Load() {
+		if client, found := w.clusters.controllerFor(clusterName); found && client.connState.isConnected() {
 			availableClients[clusterName] = client
 		} else {
 			unavailableClusters = append(unavailableClusters, clusterName)
@@ -498,7 +507,39 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	if !features.Enabled(features.MultiKueueWaitForWorkloadAdmitted) {
 		conditionToCheck = kueue.WorkloadQuotaReserved
 	}
-	if remoteCond, reservingRemote := group.bestMatchByCondition(conditionToCheck); remoteCond != nil {
+	remoteCond, reservingRemote := group.bestMatchByCondition(conditionToCheck)
+
+	// 6a. The reservation is no longer visible while the admission check is still Ready. The
+	// reachability of the reserving worker decides the response:
+	//   - A known reserving worker that is unreachable (e.g. its watch is reconnecting): the
+	//     remote is likely still running, so keep the workload admitted and retry only once the
+	//     worker stays unreachable past workerLostTimeout, measured from when the loss was first
+	//     observed.
+	//   - An empty ClusterName: this cannot arise from normal admission, so surface it and retry.
+	//   - Otherwise (reachable with no admitted remote, e.g. its remote was deleted above as out
+	//     of sync): the reservation is gone, so retry immediately.
+	if remoteCond == nil && acs.State == kueue.CheckStateReady {
+		reserving := ptr.Deref(group.local.Status.ClusterName, "")
+		if reserving != "" && slices.Contains(group.unavailableClusters, reserving) {
+			lostSince := w.reservingWorkerLostSince(reserving)
+			if remainingWaitTime := w.workerLostTimeout - w.clock.Since(lostSince); remainingWaitTime > 0 {
+				log.V(3).Info("Reserving remote temporarily unreachable, waiting before retry", "cluster", reserving, "retryAfter", remainingWaitTime)
+				return reconcile.Result{RequeueAfter: remainingWaitTime}, nil
+			}
+			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Reserving remote lost")
+		}
+		if reserving == "" {
+			// Under normal operation this is unreachable: A Ready check with no ClusterName indicates a bug in Kueue
+			// (or an externally modified / stale workload), so surface it and retry instead of looping silently.
+			log.V(2).Info("Admission check Ready but ClusterName is empty; treating as misconfigured and retrying")
+			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry,
+				"Admission check is Ready but no reserving cluster is recorded; this is unexpected, please report it")
+		}
+		return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Reserving remote no longer exists or is not admitted")
+	}
+
+	// 6b. A reserving remote is visible: converge onto it.
+	if remoteCond != nil {
 		// remove the non-selected worker workloads
 		for rem, remWl := range group.remotes {
 			if remWl != nil && rem != reservingRemote {
@@ -546,16 +587,6 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{RequeueAfter: w.workerLostTimeout}, nil
-	} else if acs.State == kueue.CheckStateReady {
-		// If there is no reserving and the AC is ready, the connection with the reserving remote might
-		// be lost, keep the workload admitted for keepReadyTimeout and put it back in the queue after that.
-		remainingWaitTime := w.workerLostTimeout - time.Since(acs.LastTransitionTime.Time)
-		if remainingWaitTime > 0 {
-			log.V(3).Info("Reserving remote lost, retry", "retryAfter", remainingWaitTime)
-			return reconcile.Result{RequeueAfter: remainingWaitTime}, nil
-		} else {
-			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Reserving remote lost")
-		}
 	}
 
 	// 7. Open the preemption gate if applicable

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -264,7 +264,7 @@ func (w *wlReconciler) remoteClientsForAC(ctx context.Context, acName kueue.Admi
 	}
 	availableClients = make(map[string]*remoteClient, len(cfg.Spec.Clusters))
 	for _, clusterName := range cfg.Spec.Clusters {
-		if client, found := w.clusters.controllerFor(clusterName); found && !client.connecting.Load() && !client.disconnected.Load() {
+		if client, found := w.clusters.controllerFor(clusterName); found && client.connected.Load() {
 			availableClients[clusterName] = client
 		} else {
 			unavailableClusters = append(unavailableClusters, clusterName)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -85,16 +85,19 @@ func TestWlReconcile(t *testing.T) {
 		managersDeletedWorkloads []*kueue.Workload
 		worker1Workloads         []kueue.Workload
 		worker1Jobs              []batchv1.Job
+		worker1Reconnecting      bool
+		worker1DisconnectedSince *time.Time
 		dispatcherName           *string
 
 		// second worker
-		useSecondWorker      bool
-		worker2Reconnecting  bool
-		worker2OnDeleteError error
-		worker2OnGetError    error
-		worker2OnCreateError error
-		worker2Workloads     []kueue.Workload
-		worker2Jobs          []batchv1.Job
+		useSecondWorker          bool
+		worker2Reconnecting      bool
+		worker2DisconnectedSince *time.Time
+		worker2OnDeleteError     error
+		worker2OnGetError        error
+		worker2OnCreateError     error
+		worker2Workloads         []kueue.Workload
+		worker2Jobs              []batchv1.Job
 
 		wantError             error
 		wantResult            *reconcile.Result
@@ -194,9 +197,10 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
-			useSecondWorker:     true,
-			worker2Reconnecting: true,
-			worker2OnGetError:   errFake,
+			useSecondWorker:          true,
+			worker2Reconnecting:      true,
+			worker2DisconnectedSince: ptr.To(now),
+			worker2OnGetError:        errFake,
 		},
 		"missing workload (in deleted workload cache), no remote objects": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -303,9 +307,10 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			useSecondWorker:     true,
-			worker2Reconnecting: true,
-			worker2OnGetError:   errFake,
+			useSecondWorker:          true,
+			worker2Reconnecting:      true,
+			worker2DisconnectedSince: ptr.To(now),
+			worker2OnGetError:        errFake,
 
 			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			wantManagersWorkloads: []kueue.Workload{
@@ -327,9 +332,10 @@ func TestWlReconcile(t *testing.T) {
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					Obj(),
 			},
-			useSecondWorker:     true,
-			worker2Reconnecting: true,
-			worker2OnGetError:   errFake,
+			useSecondWorker:          true,
+			worker2Reconnecting:      true,
+			worker2DisconnectedSince: ptr.To(now),
+			worker2OnGetError:        errFake,
 			worker2Workloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
@@ -760,6 +766,126 @@ func TestWlReconcile(t *testing.T) {
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+		},
+		"reserving remote is kept when another worker's remote is out of sync": {
+			// Regression: an out-of-sync remote on a non-reserving worker is deleted, but the
+			// workload is still admitted on its reserving worker. It must converge onto that
+			// reserving remote, not retry as if the reservation were lost.
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					ClusterName("worker1").
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Obj(),
+			},
+			useSecondWorker: true,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					PodSets(*utiltestingapi.MakePodSet("different-name", 1).Obj()). // out of sync vs. the manager spec
+					Obj(),
+			},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					ClusterName("worker1").
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Normal",
+					Reason:    "MultiKueue",
+					Message:   `The workload got reservation on "worker1"`,
+				},
+			},
+		},
+		"worker-lost grace applies when the reserving worker is unreachable even if another worker's remote is out of sync": {
+			// Regression: an out-of-sync deletion on a reachable, non-reserving worker must not
+			// turn a transient reconnect of the reserving worker into an immediate eviction. The
+			// real cause is worker-lost, so the grace applies and the workload stays admitted.
+			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor:             "wl1",
+			worker1Reconnecting:      true,
+			worker1DisconnectedSince: ptr.To(now),
+			managersJobs:             []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:               "ac1",
+						State:              kueue.CheckStateReady,
+						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
+						Message:            `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			useSecondWorker: true,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					PodSets(*utiltestingapi.MakePodSet("different-name", 1).Obj()). // out of sync vs. the manager spec
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantResult: &reconcile.Result{RequeueAfter: defaultWorkerLostTimeout},
 		},
 		"handle workload evicted on manager cluster": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
@@ -1343,18 +1469,20 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"the local workload admission check Ready if the remote WorkerLostTimeout is not exceeded": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
-			reconcileFor: "wl1",
-			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+		"the local workload admission check stays Ready if the reservation was lost less than WorkerLostTimeout ago": {
+			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor:             "wl1",
+			worker1Reconnecting:      true,
+			worker1DisconnectedSince: ptr.To(now.Add(-defaultWorkerLostTimeout / 2)),
+			managersJobs:             []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
 					AdmissionCheck(kueue.AdmissionCheckState{
-						Name:               "ac1",
-						State:              kueue.CheckStateReady,
-						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout / 2)), // 50% of the timeout
-						Message:            `The workload got reservation on "worker1"`,
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
 					}).
+					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
@@ -1367,23 +1495,26 @@ func TestWlReconcile(t *testing.T) {
 						State:   kueue.CheckStateReady,
 						Message: `The workload got reservation on "worker1"`,
 					}).
+					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
 			},
 		},
-		"the local workload's admission check is set to Retry if the WorkerLostTimeout is exceeded": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
-			reconcileFor: "wl1",
-			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+		"the local workload's admission check is set to Retry if the reservation was lost more than WorkerLostTimeout ago": {
+			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor:             "wl1",
+			worker1Reconnecting:      true,
+			worker1DisconnectedSince: ptr.To(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
+			managersJobs:             []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
 			managersWorkloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
 					AdmissionCheck(kueue.AdmissionCheckState{
-						Name:               "ac1",
-						State:              kueue.CheckStateReady,
-						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout * 3 / 2)), // 150% of the timeout
-						Message:            `The workload got reservation on "worker1"`,
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
 					}).
+					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					Obj(),
@@ -1395,6 +1526,150 @@ func TestWlReconcile(t *testing.T) {
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
 						Message: `Reserving remote lost, Previously: "Ready"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+		},
+		"the local workload is NOT evicted when the reserving cluster is only reconnecting, even if the admission check transition time is old": {
+			// Regression test: a transient watch reconnect makes the reserving remote briefly
+			// invisible. The workload must not be evicted; the grace is measured from when the
+			// cluster connection dropped (worker1DisconnectedSince), not from the (old)
+			// admission-check transition time.
+			//
+			// This also covers a manager restart during the outage: disconnectedSince is only
+			// tracked in memory, so on restart the remote client is recreated already disconnected
+			// with disconnectedSince set to ~now (its creation time; modeled here by
+			// worker1DisconnectedSince=now). The grace therefore restarts from the restart instead
+			// of evicting immediately, and it always runs to completion rather than requeuing
+			// forever (worst case, when the restart lands just as the first grace is about to
+			// fire, a genuinely lost worker waits up to 2x workerLostTimeout plus the manager
+			// restart time) - the safe direction, with no mass eviction.
+			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor:             "wl1",
+			worker1Reconnecting:      true,
+			worker1DisconnectedSince: ptr.To(now),
+			managersJobs:             []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:               "ac1",
+						State:              kueue.CheckStateReady,
+						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
+						Message:            `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantResult: &reconcile.Result{RequeueAfter: defaultWorkerLostTimeout},
+		},
+		"the local workload IS retried when the reservation stays lost past the WorkerLostTimeout": {
+			// A genuinely lost worker (reservation missing longer than the grace) must be
+			// retried: evict and requeue so the workload can be re-dispatched.
+			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor:             "wl1",
+			worker1Reconnecting:      true,
+			worker1DisconnectedSince: ptr.To(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
+			managersJobs:             []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateRetry,
+						Message: `Reserving remote lost, Previously: "Ready"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+		},
+		"the local workload is retried immediately when the reserving cluster is reachable but its remote workload is gone": {
+			// Case B: the reserving worker is connected (not reconnecting) yet its remote
+			// Workload is absent — a genuine loss with nothing to wait for. Retry immediately,
+			// without consuming the worker-lost grace, even though the loss was only just
+			// observed (the fresh worker-lost annotation would still be within grace).
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateRetry,
+						Message: `Reserving remote no longer exists or is not admitted, Previously: "Ready"`,
+					}).
+					ClusterName("worker1").
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+		},
+		"the local workload is retried when the admission check is Ready but no reserving cluster is recorded": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload got reservation on "worker1"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateRetry,
+						Message: `Admission check is Ready but no reserving cluster is recorded; this is unexpected, please report it, Previously: "Ready"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1762,7 +2037,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Reserving remote lost, Previously: "Ready"`,
+						Message: `Reserving remote no longer exists or is not admitted, Previously: "Ready"`,
 					}).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					ClusterName("worker1").
@@ -2288,7 +2563,8 @@ func TestWlReconcile(t *testing.T) {
 
 				w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 				w1remoteClient.client = worker1Client
-				w1remoteClient.connected.Store(true)
+				w1remoteClient.connState.connected = !tc.worker1Reconnecting
+				w1remoteClient.connState.disconnectedSince = tc.worker1DisconnectedSince
 				cRec.remoteClients["worker1"] = w1remoteClient
 
 				var worker2Client client.WithWatch
@@ -2320,9 +2596,8 @@ func TestWlReconcile(t *testing.T) {
 
 					w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 					w2remoteClient.client = worker2Client
-					if !tc.worker2Reconnecting {
-						w2remoteClient.connected.Store(true)
-					}
+					w2remoteClient.connState.connected = !tc.worker2Reconnecting
+					w2remoteClient.connState.disconnectedSince = tc.worker2DisconnectedSince
 					cRec.remoteClients["worker2"] = w2remoteClient
 				}
 
@@ -2468,7 +2743,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		WithStatusSubresource(&kueue.Workload{}).
 		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 		Build()
-	w1remoteClient.connected.Store(true)
+	w1remoteClient.connState.markConnected()
 	cRec.remoteClients["worker1"] = w1remoteClient
 
 	worker2Client := getClientBuilder(ctx).
@@ -2478,7 +2753,6 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		Build()
 	w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 	w2remoteClient.client = worker2Client
-	w2remoteClient.connected.Store(false)
 	cRec.remoteClients["worker2"] = w2remoteClient
 
 	helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
@@ -2514,7 +2788,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	}
 
 	// Step 2: worker2 finishes reconnecting — reconcile should clean up the orphaned workload.
-	w2remoteClient.connected.Store(true)
+	w2remoteClient.connState.markConnected()
 
 	result, err = reconciler.Reconcile(ctx, req)
 	if err != nil {
@@ -2664,7 +2938,9 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 
 			remoteClients := make(map[string]*remoteClient, len(tt.remotes))
 			for remote, builder := range remoteClientBuilders {
-				remoteClients[remote] = &remoteClient{client: builder.Build(), origin: remote}
+				rc := &remoteClient{client: builder.Build(), origin: remote}
+				rc.connState.markDisconnected(time.Now())
+				remoteClients[remote] = rc
 			}
 
 			if tt.cond != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2288,7 +2288,7 @@ func TestWlReconcile(t *testing.T) {
 
 				w1remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 				w1remoteClient.client = worker1Client
-				w1remoteClient.connecting.Store(false)
+				w1remoteClient.connected.Store(true)
 				cRec.remoteClients["worker1"] = w1remoteClient
 
 				var worker2Client client.WithWatch
@@ -2321,7 +2321,7 @@ func TestWlReconcile(t *testing.T) {
 					w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 					w2remoteClient.client = worker2Client
 					if !tc.worker2Reconnecting {
-						w2remoteClient.connecting.Store(false)
+						w2remoteClient.connected.Store(true)
 					}
 					cRec.remoteClients["worker2"] = w2remoteClient
 				}
@@ -2468,7 +2468,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		WithStatusSubresource(&kueue.Workload{}).
 		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
 		Build()
-	w1remoteClient.connecting.Store(false)
+	w1remoteClient.connected.Store(true)
 	cRec.remoteClients["worker1"] = w1remoteClient
 
 	worker2Client := getClientBuilder(ctx).
@@ -2478,7 +2478,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		Build()
 	w2remoteClient := newRemoteClient(managerClient, nil, nil, defaultOrigin, "", adapters)
 	w2remoteClient.client = worker2Client
-	w2remoteClient.connecting.Store(true)
+	w2remoteClient.connected.Store(false)
 	cRec.remoteClients["worker2"] = w2remoteClient
 
 	helper, _ := admissioncheck.NewMultiKueueStoreHelper(managerClient)
@@ -2514,7 +2514,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	}
 
 	// Step 2: worker2 finishes reconnecting — reconcile should clean up the orphaned workload.
-	w2remoteClient.connecting.Store(false)
+	w2remoteClient.connected.Store(true)
 
 	result, err = reconciler.Reconcile(ctx, req)
 	if err != nil {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1677,6 +1677,36 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("Should not evict admitted workloads when the connection to the reserving worker is briefly lost", framework.SlowSpec, func() {
+		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
+
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+		restoreConnection()
+
+		ginkgo.By("no admitted workload is evicted after the brief connection loss", func() {
+			expectNoEviction(keys, multiKueueAC.Name, testingWorkerLostTimeout*2)
+		})
+	})
+
+	ginkgo.It("Should not immediately evict admitted workloads after a manager restart while the reserving worker is unreachable", framework.SlowSpec, func() {
+		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
+
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+
+		ginkgo.By("restarting the manager while worker2 is unreachable", func() {
+			managerTestCluster.fwk.StopManager(managerTestCluster.ctx)
+			managerTestCluster.fwk.StartManager(managerTestCluster.ctx, managerTestCluster.cfg, func(ctx context.Context, mgr manager.Manager) {
+				managerAndMultiKueueSetup(ctx, mgr, 2*time.Second, defaultEnabledIntegrations, config.MultiKueueDispatcherModeAllAtOnce)
+			})
+		})
+
+		ginkgo.By("the restarted manager re-anchors the grace and does not immediately evict", func() {
+			expectNoEviction(keys, multiKueueAC.Name, testingWorkerLostTimeout*2/3)
+		})
+
+		restoreConnection()
+	})
+
 	ginkgo.It("Should run a RayJob on worker if admitted", func() {
 		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
 			kueue.PodSetAssignment{
@@ -2439,6 +2469,52 @@ func admitWorkloadAndCheckWorkerCopies(acName string, wlLookupKey types.Namespac
 			g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
+}
+
+func admitJobsAndAgeAdmissionCheck(managerNsName, lqName, cqName, acName string, count int) []types.NamespacedName {
+	ginkgo.GinkgoHelper()
+	keys := make([]types.NamespacedName, 0, count)
+	for i := range count {
+		job := testingjob.MakeJob(fmt.Sprintf("job-%d", i), managerNsName).
+			Queue(kueue.LocalQueueName(lqName)).
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+		key := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNsName}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cqName))
+		admitWorkloadAndCheckWorkerCopies(acName, key, admission)
+		keys = append(keys, key)
+	}
+
+	ginkgo.By("waiting until each admission check's transition time is older than the worker-lost timeout", func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			for _, key := range keys {
+				wl := &kueue.Workload{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, key, wl)).To(gomega.Succeed())
+				acs := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName))
+				g.Expect(acs).NotTo(gomega.BeNil())
+				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
+				g.Expect(time.Since(acs.LastTransitionTime.Time)).To(gomega.BeNumerically(">", testingWorkerLostTimeout))
+			}
+		}, testingWorkerLostTimeout*3, util.Interval).Should(gomega.Succeed())
+	})
+	return keys
+}
+
+// expectNoEviction asserts that, for the given duration, none of the workloads lose their quota
+// reservation or have their MultiKueue admission check moved off Ready.
+func expectNoEviction(keys []types.NamespacedName, acName string, within time.Duration) {
+	ginkgo.GinkgoHelper()
+	gomega.Consistently(func(g gomega.Gomega) {
+		for _, key := range keys {
+			wl := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, key, wl)).To(gomega.Succeed())
+			g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+			acs := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
+			g.Expect(ptr.Deref(acs.RetryCount, 0)).To(gomega.BeZero())
+		}
+	}, within, util.Interval).Should(gomega.Succeed())
 }
 
 func waitForWorkloadToFinishAndRemoteWorkloadToBeDeleted(wlLookupKey types.NamespacedName, finishJobReason string) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

Cherry-pick of #12999 to `release-0.17`.

`release-0.17` still carries the older two-bool MultiKueue connection model
(`connecting` + `disconnected` atomic flags), whereas #12999 is written on top
of the single connection-state model introduced on `main` by #12837, which in
turn builds on #12824. A clean backport therefore requires bringing those two
prerequisites along, so this PR is a three-commit chain:

1. `Fix race condition in multikueue watcher establishment (#12824)` — marks the
   client connected before starting watchers to avoid a false "unavailable"
   window.
2. `Replace connecting/disconnected with single enum (#12837)` — the connection
   model refactor #12999 assumes.
3. `MultiKueue: don't evict admitted workloads on a transient worker watch reconnect (#12999)` — the actual fix.

`release-0.17` has diverged more than `release-0.18`, so the backport required a
few branch-specific adaptations while preserving the fix behavior exactly:

- Kept `release-0.17`'s `kueue.GroupVersion` (it does not carry the
  `SchemeGroupVersion` rename from #12738).
- Dropped the ClusterQueue-watch / quota-automation code paths that do not exist
  on `release-0.17` (`startQueueWatchers`, `cqUpdateCh`, and the
  `multikueuecluster` `clusterqueue.go` file), and kept `newRemoteClient`'s
  existing signature.
- Kept the `MultiKueueWaitForWorkloadAdmitted` feature gate in `reconcileGroup`
  (removed on `main`) and dropped the `syncDeferred` requeue optimization that
  `release-0.17` does not have.
- Anchored the reconnect logic on the `connectionState` introduced by #12999
  while continuing to use `release-0.17`'s direct `retryConnNextAttempt` field
  (no getter accessors on this branch).
- Test-only: used `ptr.To(...)` instead of the Go 1.26 `new(expr)` form
  (`release-0.17` targets Go 1.25), and used a flavor-less admission in the new
  worker-lost integration tests to match this branch's MultiKueue suite setup.

#### Which issue(s) this PR fixes:

Backport of #12999.

#### Special notes for your reviewer:

Validated locally on `release-0.17`:
- `go build ./...` and `go vet` (unit + integration packages) — clean
- MultiKueue unit tests pass
- The two new MultiKueue integration specs added by #12999 (transient
  connection loss, and manager restart during the outage) pass under envtest.

Each commit preserves its original author and carries a single
`Signed-off-by` plus a `(cherry picked from commit ...)` provenance line.

_(Drafted with AI assistance.)_

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a transient watch reconnect to a worker cluster could evict a running admitted workload. Kueue now measures the worker-lost grace from when the worker cluster's connection first dropped, rather than from the admission check's transition time, and retries immediately only when the reserving worker is reachable but its remote workload is gone.
```
