### PR TITLE
MultiKueue: replace "reserving" terminology with "admitting"

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -221,7 +221,7 @@ func newRemoteClient(
 		clock:        clock.RealClock{},
 	}
 	// Start in the disconnected state, tracking the loss from creation. If the worker is
-	// unreachable when the client is created (e.g. the reserving worker is down right after a
+	// unreachable when the client is created (e.g. the admitting worker is down right after a
 	// manager restart, so building the client fails before it is ever marked connected), the
 	// worker-lost grace still runs from here and the workload is eventually retried, instead of
 	// the grace never starting and the workload requeuing forever.

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -280,7 +280,7 @@ func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *k
 	})
 }
 
-func (w *wlReconciler) reservingWorkerLostSince(clusterName string) time.Time {
+func (w *wlReconciler) admittingWorkerLostSince(clusterName string) time.Time {
 	if rc, found := w.clusters.controllerFor(clusterName); found {
 		if since := rc.connState.lostSince(); since != nil {
 			return *since
@@ -534,44 +534,44 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 	}
 
-	// 6. Get the first reserving/admitted workload.
+	// 6. Get the admitting remote.
 	conditionToCheck := kueue.WorkloadAdmitted
-	remoteCond, reservingRemote := group.bestMatchByCondition(conditionToCheck)
+	remoteCond, admittingRemote := group.bestMatchByCondition(conditionToCheck)
 
-	// 6a. The reservation is no longer visible while the admission check is still Ready. The
-	// reachability of the reserving worker decides the response:
-	//   - A known reserving worker that is unreachable (e.g. its watch is reconnecting): the
+	// 6a. No admitted remote is visible while the admission check is still Ready. The
+	// reachability of the admitting worker decides the response:
+	//   - A known admitting worker that is unreachable (e.g. its watch is reconnecting): the
 	//     remote is likely still running, so keep the workload admitted and retry only once the
 	//     worker stays unreachable past workerLostTimeout, measured from when the loss was first
 	//     observed.
 	//   - An empty ClusterName: this cannot arise from normal admission, so surface it and retry.
 	//   - Otherwise (reachable with no admitted remote, e.g. its remote was deleted above as out
-	//     of sync): the reservation is gone, so retry immediately.
+	//     of sync): the admitted remote is gone, so retry immediately.
 	if remoteCond == nil && acs.State == kueue.CheckStateReady {
-		reserving := ptr.Deref(group.local.Status.ClusterName, "")
-		if reserving != "" && slices.Contains(group.unavailableClusters, reserving) {
-			lostSince := w.reservingWorkerLostSince(reserving)
+		admitting := ptr.Deref(group.local.Status.ClusterName, "")
+		if admitting != "" && slices.Contains(group.unavailableClusters, admitting) {
+			lostSince := w.admittingWorkerLostSince(admitting)
 			if remainingWaitTime := w.workerLostTimeout - w.clock.Since(lostSince); remainingWaitTime > 0 {
-				log.V(3).Info("Reserving remote temporarily unreachable, waiting before retry", "cluster", reserving, "retryAfter", remainingWaitTime)
+				log.V(3).Info("Admitting remote temporarily unreachable, waiting before retry", "cluster", admitting, "retryAfter", remainingWaitTime)
 				return reconcile.Result{RequeueAfter: remainingWaitTime}, nil
 			}
-			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Reserving remote lost")
+			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Admitting remote lost")
 		}
-		if reserving == "" {
+		if admitting == "" {
 			// Under normal operation this is unreachable: A Ready check with no ClusterName indicates a bug in Kueue
 			// (or an externally modified / stale workload), so surface it and retry instead of looping silently.
 			log.V(2).Info("Admission check Ready but ClusterName is empty; treating as misconfigured and retrying")
 			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry,
-				"Admission check is Ready but no reserving cluster is recorded; this is unexpected, please report it")
+				"Admission check is Ready but no admitting cluster is recorded; this is unexpected, please report it")
 		}
-		return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Reserving remote no longer exists or is not admitted")
+		return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Admitting remote no longer exists")
 	}
 
-	// 6b. A reserving remote is visible: converge onto it.
+	// 6b. An admitting remote is visible: converge onto it.
 	if remoteCond != nil {
 		// remove the non-selected worker workloads
 		for rem, remWl := range group.remotes {
-			if remWl != nil && rem != reservingRemote {
+			if remWl != nil && rem != admittingRemote {
 				if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, rem)); err != nil {
 					log.V(2).Error(err, "Deleting out of sync remote objects", "remote", rem)
 					return reconcile.Result{}, err
@@ -580,10 +580,10 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			}
 		}
 
-		remoteCl := group.remoteClients[reservingRemote].getClient()
-		remoteWl := group.remotes[reservingRemote]
+		remoteCl := group.remoteClients[admittingRemote].getClient()
+		remoteWl := group.remotes[admittingRemote]
 
-		log = log.WithValues("remote", reservingRemote, "remoteWorkload", klog.KObj(remoteWl))
+		log = log.WithValues("remote", admittingRemote, "remoteWorkload", klog.KObj(remoteWl))
 		ctx = ctrl.LoggerInto(ctx, log)
 
 		evictedCond := apimeta.FindStatusCondition(group.local.Status.Conditions, kueue.WorkloadEvicted)
@@ -602,7 +602,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 
 		if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
-			log.Error(err, "validating remote controller object", "cluster", reservingRemote)
+			log.Error(err, "validating remote controller object", "cluster", admittingRemote)
 			return reconcile.Result{}, err
 		}
 
@@ -613,7 +613,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			return reconcile.Result{}, err
 		}
 
-		if err := w.syncReservingRemoteState(ctx, group, reservingRemote, acs); err != nil {
+		if err := w.syncAdmittingRemoteState(ctx, group, admittingRemote, acs); err != nil {
 			return reconcile.Result{}, err
 		}
 		requeueAfter := w.workerLostTimeout
@@ -1113,10 +1113,10 @@ func needsDelayedTopologyUpdate(local, remote *kueue.Workload) bool {
 	return false
 }
 
-func (w *wlReconciler) syncReservingRemoteState(ctx context.Context, group *wlGroup, reservingRemote string, acs *kueue.AdmissionCheckState) error {
+func (w *wlReconciler) syncAdmittingRemoteState(ctx context.Context, group *wlGroup, admittingRemote string, acs *kueue.AdmissionCheckState) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	needsTopologyUpdate := needsDelayedTopologyUpdate(group.local, group.remotes[reservingRemote])
+	needsTopologyUpdate := needsDelayedTopologyUpdate(group.local, group.remotes[admittingRemote])
 	needsACUpdate := acs.State != kueue.CheckStateRetry && acs.State != kueue.CheckStateRejected
 
 	if !needsTopologyUpdate && !needsACUpdate {
@@ -1125,24 +1125,24 @@ func (w *wlReconciler) syncReservingRemoteState(ctx context.Context, group *wlGr
 
 	if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 		if needsTopologyUpdate {
-			updateDelayedTopologyRequest(wl, group.remotes[reservingRemote])
+			updateDelayedTopologyRequest(wl, group.remotes[admittingRemote])
 		}
 
 		if needsACUpdate {
 			acs.State = kueue.CheckStateReady
 			// update the message
-			acs.Message = fmt.Sprintf("The workload got reservation on %q", reservingRemote)
+			acs.Message = fmt.Sprintf("The workload was admitted on %q", admittingRemote)
 			// update the transition time since is used to detect the lost worker state.
 			acs.LastTransitionTime = metav1.NewTime(w.clock.Now())
 
 			workloadpatching.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *acs, w.clock)
-			// Set the cluster name to the reserving remote and clear the nominated clusters.
+			// Set the cluster name to the admitting remote and clear the nominated clusters.
 			// Only set ClusterName if not already set, as it is immutable once set.
 			if wl.Status.ClusterName == nil {
-				wl.Status.ClusterName = &reservingRemote
-			} else if *wl.Status.ClusterName != reservingRemote {
+				wl.Status.ClusterName = &admittingRemote
+			} else if *wl.Status.ClusterName != admittingRemote {
 				return false, fmt.Errorf("attempting to change immutable ClusterName from %q to %q",
-					*wl.Status.ClusterName, reservingRemote)
+					*wl.Status.ClusterName, admittingRemote)
 			}
 			wl.Status.NominatedClusterNames = nil
 		}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -533,7 +533,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -565,14 +565,14 @@ func TestWlReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
 					EventType: "Normal",
 					Reason:    "MultiKueue",
-					Message:   `The workload got reservation on "worker1"`,
+					Message:   `The workload was admitted on "worker1"`,
 				},
 			},
 		},
-		"reserving remote is kept when another worker's remote is out of sync": {
-			// Regression: an out-of-sync remote on a non-reserving worker is deleted, but the
-			// workload is still admitted on its reserving worker. It must converge onto that
-			// reserving remote, not retry as if the reservation were lost.
+		"admitting remote is kept when another worker's remote is out of sync": {
+			// Regression: an out-of-sync remote on a non-admitting worker is deleted, but the
+			// workload is still admitted on its admitting worker. It must converge onto that
+			// admitting remote, not retry as if the reservation were lost.
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -580,7 +580,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -611,7 +611,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -641,13 +641,13 @@ func TestWlReconcile(t *testing.T) {
 					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
 					EventType: "Normal",
 					Reason:    "MultiKueue",
-					Message:   `The workload got reservation on "worker1"`,
+					Message:   `The workload was admitted on "worker1"`,
 				},
 			},
 		},
-		"worker-lost grace applies when the reserving worker is unreachable even if another worker's remote is out of sync": {
-			// Regression: an out-of-sync deletion on a reachable, non-reserving worker must not
-			// turn a transient reconnect of the reserving worker into an immediate eviction. The
+		"worker-lost grace applies when the admitting worker is unreachable even if another worker's remote is out of sync": {
+			// Regression: an out-of-sync deletion on a reachable, non-admitting worker must not
+			// turn a transient reconnect of the admitting worker into an immediate eviction. The
 			// real cause is worker-lost, so the grace applies and the workload stays admitted.
 			featureGates:             map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor:             "wl1",
@@ -660,7 +660,7 @@ func TestWlReconcile(t *testing.T) {
 						Name:               "ac1",
 						State:              kueue.CheckStateReady,
 						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
-						Message:            `The workload got reservation on "worker1"`,
+						Message:            `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -680,7 +680,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -697,7 +697,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -736,7 +736,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -777,7 +777,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -865,7 +865,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1015,7 +1015,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1046,7 +1046,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1080,7 +1080,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1111,7 +1111,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1147,7 +1147,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStatePending,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1181,7 +1181,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStatePending,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1205,7 +1205,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1218,7 +1218,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1237,7 +1237,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1250,7 +1250,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Reserving remote lost, Previously: "Ready"`,
+						Message: `Admitting remote lost, Previously: "Ready"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1258,8 +1258,8 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"the local workload is NOT evicted when the reserving cluster is only reconnecting, even if the admission check transition time is old": {
-			// Regression test: a transient watch reconnect makes the reserving remote briefly
+		"the local workload is NOT evicted when the admitting cluster is only reconnecting, even if the admission check transition time is old": {
+			// Regression test: a transient watch reconnect makes the admitting remote briefly
 			// invisible. The workload must not be evicted; the grace is measured from when the
 			// cluster connection dropped (worker1DisconnectedSince), not from the (old)
 			// admission-check transition time.
@@ -1283,7 +1283,7 @@ func TestWlReconcile(t *testing.T) {
 						Name:               "ac1",
 						State:              kueue.CheckStateReady,
 						LastTransitionTime: metav1.NewTime(now.Add(-defaultWorkerLostTimeout * 3 / 2)),
-						Message:            `The workload got reservation on "worker1"`,
+						Message:            `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1296,7 +1296,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1318,7 +1318,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1331,7 +1331,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Reserving remote lost, Previously: "Ready"`,
+						Message: `Admitting remote lost, Previously: "Ready"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1339,8 +1339,8 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"the local workload is retried immediately when the reserving cluster is reachable but its remote workload is gone": {
-			// Case B: the reserving worker is connected (not reconnecting) yet its remote
+		"the local workload is retried immediately when the admitting cluster is reachable but its remote workload is gone": {
+			// Case B: the admitting worker is connected (not reconnecting) yet its remote
 			// Workload is absent — a genuine loss with nothing to wait for. Retry immediately,
 			// without consuming the worker-lost grace, even though the loss was only just
 			// observed (the fresh worker-lost annotation would still be within grace).
@@ -1352,7 +1352,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1365,7 +1365,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Reserving remote no longer exists or is not admitted, Previously: "Ready"`,
+						Message: `Admitting remote no longer exists, Previously: "Ready"`,
 					}).
 					ClusterName("worker1").
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
@@ -1373,7 +1373,7 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"the local workload is retried when the admission check is Ready but no reserving cluster is recorded": {
+		"the local workload is retried when the admission check is Ready but no admitting cluster is recorded": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
@@ -1382,7 +1382,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1394,7 +1394,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Admission check is Ready but no reserving cluster is recorded; this is unexpected, please report it, Previously: "Ready"`,
+						Message: `Admission check is Ready but no admitting cluster is recorded; this is unexpected, please report it, Previously: "Ready"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1451,7 +1451,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1487,7 +1487,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1525,7 +1525,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ClusterName("worker1").
@@ -1555,7 +1555,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ClusterName("worker1").
@@ -1578,7 +1578,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ClusterName("worker1").
@@ -1609,7 +1609,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
 					ClusterName("worker1").
@@ -1645,7 +1645,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateReady,
-						Message: `The workload got reservation on "worker1"`,
+						Message: `The workload was admitted on "worker1"`,
 					}).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					ClusterName("worker1").
@@ -1677,7 +1677,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Reserving remote no longer exists or is not admitted, Previously: "Ready"`,
+						Message: `Admitting remote no longer exists, Previously: "Ready"`,
 					}).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					ClusterName("worker1").

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -526,7 +526,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					fmt.Sprintf("The workload got reservation on %q", admittedWorkerName),
+					fmt.Sprintf("The workload was admitted on %q", admittedWorkerName),
 				)
 
 				ginkgo.By("ensure all pods are created", func() {
@@ -579,7 +579,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					fmt.Sprintf("The workload got reservation on %q", admittedWorkerName),
+					fmt.Sprintf("The workload was admitted on %q", admittedWorkerName),
 				)
 
 				gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/multikueue/baseline/tas_test.go
+++ b/test/e2e/multikueue/baseline/tas_test.go
@@ -260,7 +260,7 @@ var _ = ginkgo.Describe("MultiKueue with TopologyAwareScheduling", func() {
 					ctx, k8sManagerClient, wlLookupKey,
 					multiKueueAc.Name,
 					kueue.CheckStateReady,
-					fmt.Sprintf(`The workload got reservation on "%s"`, assignedClusterName),
+					fmt.Sprintf(`The workload was admitted on "%s"`, assignedClusterName),
 				)
 			})
 

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -221,7 +221,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				ctx, k8sManagerClient, wlLookupKey,
 				multiKueueAc.Name,
 				kueue.CheckStateReady,
-				fmt.Sprintf(`The workload got reservation on "%s"`, assignedClusterName),
+				fmt.Sprintf(`The workload was admitted on "%s"`, assignedClusterName),
 			)
 
 			ginkgo.By(fmt.Sprintf("Verifying workload admitted on %s has correct DRA resource usage (expecting %d devices)", assignedClusterName, expectedDeviceCount))
@@ -348,7 +348,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				ctx, k8sManagerClient, wlLookupKey,
 				multiKueueAc.Name,
 				kueue.CheckStateReady,
-				fmt.Sprintf(`The workload got reservation on "%s"`, workerCluster1.Name),
+				fmt.Sprintf(`The workload was admitted on "%s"`, workerCluster1.Name),
 			)
 
 			ginkgo.By("Verifying workload is admitted on worker1 with correct DRA resource usage")

--- a/test/integration/multikueue/cluster_role_sharing_test.go
+++ b/test/integration/multikueue/cluster_role_sharing_test.go
@@ -263,13 +263,13 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				managerTestCluster.ctx, managerTestCluster.client, wlMkLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -446,13 +446,13 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				managerTestCluster.ctx, managerTestCluster.client, wlMkLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/multikueue/dra_test.go
+++ b/test/integration/multikueue/dra_test.go
@@ -213,7 +213,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("area:multikueue", "
 					managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 					multiKueueAC.Name,
 					kueue.CheckStateReady,
-					`The workload got reservation on "worker1"`,
+					`The workload was admitted on "worker1"`,
 				)
 
 				gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/multikueue/enabled_integration_test.go
+++ b/test/integration/multikueue/enabled_integration_test.go
@@ -159,13 +159,13 @@ var _ = ginkgo.Describe("MultiKueue when not all integrations are enabled", gink
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 		})
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -241,12 +241,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -320,7 +320,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name, kueue.CheckStateReady, `The workload got reservation on "worker1"`,
+				multiKueueAC.Name, kueue.CheckStateReady, `The workload was admitted on "worker1"`,
 			)
 		})
 
@@ -393,12 +393,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1087,13 +1087,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1200,13 +1200,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1393,13 +1393,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
 				g.Expect(acs).NotTo(gomega.BeNil())
 				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
-				g.Expect(acs.Message).To(gomega.Equal(`The workload got reservation on "worker1"`))
+				g.Expect(acs.Message).To(gomega.Equal(`The workload was admitted on "worker1"`))
 				g.Expect(apimeta.IsStatusConditionTrue(createdWorkload.Status.Conditions, kueue.WorkloadAdmitted)).To(gomega.BeTrue())
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1681,7 +1681,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
-	ginkgo.It("Should not evict admitted workloads when the connection to the reserving worker is briefly lost", framework.SlowSpec, func() {
+	ginkgo.It("Should not evict admitted workloads when the connection to the admitting worker is briefly lost", framework.SlowSpec, func() {
 		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
 
 		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
@@ -1692,7 +1692,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
-	ginkgo.It("Should not immediately evict admitted workloads after a manager restart while the reserving worker is unreachable", framework.SlowSpec, func() {
+	ginkgo.It("Should not immediately evict admitted workloads after a manager restart while the admitting worker is unreachable", framework.SlowSpec, func() {
 		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
 
 		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
@@ -1923,12 +1923,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			manager.ctx, manager.client, workloadKey,
 			multiKueueAC.Name,
 			kueue.CheckStateReady,
-			`The workload got reservation on "worker1"`,
+			`The workload was admitted on "worker1"`,
 		)
 		util.ExpectEventAppeared(manager.ctx, manager.client, eventsv1.Event{
 			Reason: "MultiKueue",
 			Type:   corev1.EventTypeNormal,
-			Note:   `The workload got reservation on "worker1"`,
+			Note:   `The workload was admitted on "worker1"`,
 		})
 
 		ginkgo.By("observe: job is synced to the worker1 cluster and is active", func() {
@@ -2041,12 +2041,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			manager.ctx, manager.client, newWorkloadKey,
 			multiKueueAC.Name,
 			kueue.CheckStateReady,
-			`The workload got reservation on "worker1"`,
+			`The workload was admitted on "worker1"`,
 		)
 		util.ExpectEventAppeared(manager.ctx, manager.client, eventsv1.Event{
 			Reason: "MultiKueue",
 			Type:   corev1.EventTypeNormal,
-			Note:   `The workload got reservation on "worker1"`,
+			Note:   `The workload was admitted on "worker1"`,
 		})
 
 		ginkgo.By("observe: job changes are synced to the worker1 cluster", func() {
@@ -2182,12 +2182,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 				multiKueueAC.Name,
 				kueue.CheckStateReady,
-				`The workload got reservation on "worker1"`,
+				`The workload was admitted on "worker1"`,
 			)
 			util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 				Reason: "MultiKueue",
 				Type:   corev1.EventTypeNormal,
-				Note:   `The workload got reservation on "worker1"`,
+				Note:   `The workload was admitted on "worker1"`,
 			})
 
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -2471,12 +2471,12 @@ func admitWorkloadAndCheckWorkerCopies(acName string, wlLookupKey types.Namespac
 			managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
 			acName,
 			kueue.CheckStateReady,
-			`The workload got reservation on "worker2"`,
+			`The workload was admitted on "worker2"`,
 		)
 		util.ExpectEventAppeared(managerTestCluster.ctx, managerTestCluster.client, eventsv1.Event{
 			Reason: "MultiKueue",
 			Type:   corev1.EventTypeNormal,
-			Note:   `The workload got reservation on "worker2"`,
+			Note:   `The workload was admitted on "worker2"`,
 		})
 
 		gomega.Eventually(func(g gomega.Gomega) {

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -265,7 +265,7 @@ func CleanMultiKueueSecret(ctx context.Context, c client.Client, namespace strin
 
 // GetMultiKueueClusterNameFromAdmissionCheckMessage extracts the cluster name
 // from a MultiKueue admission check message of the form
-// "The workload got reservation on \"<clusterName>\"".
+// "The workload was admitted on \"<clusterName>\"".
 func GetMultiKueueClusterNameFromAdmissionCheckMessage(message string) string {
 	regex := regexp.MustCompile(`"([^"]*)"`)
 	match := regex.FindStringSubmatch(message)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1683,7 +1683,7 @@ func ExpectWorkloadAdmittedWithCheck(ctx context.Context, wlLookupKey types.Name
 		ctx, client, wlLookupKey,
 		acName,
 		kueue.CheckStateReady,
-		fmt.Sprintf(`The workload got reservation on "%s"`, clusterName),
+		fmt.Sprintf(`The workload was admitted on "%s"`, clusterName),
 	)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

The MultiKueue admission-check controller still used the word "reserving" in
code and user-facing strings, even though the remote it converges onto is
selected by the `WorkloadAdmitted` condition (`bestMatchByCondition` with
`kueue.WorkloadAdmitted`), not by a quota reservation. Selection moved to the
admitted condition when `MultiKueueWaitForWorkloadAdmitted` was promoted to
stable in #10656, but the "reserving" wording was left behind, so it no longer
matches the semantics and misleads maintainers reading the code and operators
reading `AdmissionCheckState` messages and logs.

This renames throughout `pkg/controller/admissionchecks/multikueue/`:

- identifiers: `reservingRemote` → `admittingRemote`, `syncReservingRemoteState`
  → `syncAdmittingRemoteState`, `reservingWorkerLostSince` →
  `admittingWorkerLostSince`, and the local `reserving` → `admitting`;
- `AdmissionCheckState` and log messages: `"Reserving remote lost"`,
  `"Reserving remote temporarily unreachable …"`, `"Reserving remote no longer
  exists or is not admitted"` (→ `"Admitting remote no longer exists"`), and
  `"… no reserving cluster is recorded …"`;
- the reservation-flavored success message `"The workload got reservation on %q"`
  → `"The workload was admitted on %q"`, updated at every assertion site in the
  integration, e2e and `test/util` helpers.

Pure terminology change; no behavior change. The core "reserving quota"
terminology (metrics, scheduler, cache, `apis/kueue`) is a different concept and
is left intact.

Note: the `WorkerLostTimeout` config field doc in `apis/config` (and its
generated reference / KEP mirror) still says "reserving worker cluster". That
lives outside the admission-check controller package this issue scopes, so it is
intentionally left for a separate follow-up to keep this cleanup focused.

#### Which issue(s) this PR fixes:

Addresses #13080. Deferred from #12999 to keep that PR focused.

#### Special notes for your reviewer:

Diff is symmetric (equal insertions/deletions) — renames only, no logic change.

Validated locally:
- `gofmt -l` clean; `go build ./...`; `go vet` on the multikueue controller,
  integration, e2e and `test/util` packages — all clean.
- MultiKueue unit tests pass.

_(Drafted with AI assistance.)_

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Renamed the admission-check controller's "reserving" terminology to "admitting" to match the underlying `WorkloadAdmitted` condition. The AdmissionCheckState messages and events now read "The workload was admitted on <cluster>", "Admitting remote lost", "Admitting remote no longer exists", and "Admitting remote temporarily unreachable" instead of their "reserving"/"got reservation on" wording.
```
