### PR TITLE
Refactor nodeInfo usage

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -117,7 +116,7 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 }
 
 func (c *TASFlavorCache) snapshot(
-	log logr.Logger, nodes []*nodeInfo, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
 ) *TASFlavorSnapshot {
 	c.RLock()
 	defer c.RUnlock()
@@ -189,43 +188,5 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 			c.usage[domainID].Add(tr.TotalRequests())
 			c.usage[domainID].Add(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
 		}
-	}
-}
-
-type nodeInfo struct {
-	// Name holds the node's name, used to evaluate node affinity.
-	Name string
-
-	// Labels are used to match Topology levels and NodeSelectors.
-	Labels map[string]string
-
-	// Taints are used to check tolerations.
-	Taints []corev1.Taint
-
-	// Allocatable capacity from Status.Allocatable.
-	Allocatable corev1.ResourceList
-}
-
-func newNodeInfo(node *corev1.Node) *nodeInfo {
-	return &nodeInfo{
-		Name:        node.Name,
-		Labels:      node.Labels,
-		Taints:      node.Spec.Taints,
-		Allocatable: node.Status.Allocatable,
-	}
-}
-
-func (ni *nodeInfo) toNode() *corev1.Node {
-	return &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   ni.Name,
-			Labels: ni.Labels,
-		},
-		Spec: corev1.NodeSpec{
-			Taints: ni.Taints,
-		},
-		Status: corev1.NodeStatus{
-			Allocatable: ni.Allocatable,
-		},
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -104,7 +104,7 @@ type leafDomain struct {
 	tasUsage resources.Requests
 
 	// node at the leaf, if the lowest level is a node
-	node *nodeInfo
+	node *corev1.Node
 }
 
 type domainByID map[utiltas.TopologyDomainID]*domain
@@ -180,7 +180,7 @@ func newTASFlavorSnapshot(log logr.Logger, topologyName kueue.TopologyReference,
 	return snapshot
 }
 
-func (s *TASFlavorSnapshot) addNode(node *nodeInfo) utiltas.TopologyDomainID {
+func (s *TASFlavorSnapshot) addNode(node *corev1.Node) utiltas.TopologyDomainID {
 	var levelValues []string
 	var domainID utiltas.TopologyDomainID
 	var leafFound bool
@@ -212,7 +212,7 @@ func (s *TASFlavorSnapshot) addNode(node *nodeInfo) utiltas.TopologyDomainID {
 		}
 		s.leaves[domainID] = &leafDomain
 	}
-	capacity := resources.NewRequests(node.Allocatable)
+	capacity := resources.NewRequests(node.Status.Allocatable)
 	s.addCapacity(domainID, capacity)
 	return domainID
 }
@@ -1679,7 +1679,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		// Gather node level information only when the node is the lowest level of the topology
 		if s.isLowestLevelNode {
 			// 1. Check Tolerations against Node Taints
-			nodeTaints := leaf.node.Taints
+			nodeTaints := leaf.node.Spec.Taints
 			taint, untolerated := corev1helpers.FindMatchingUntoleratedTaint(s.log, nodeTaints, requirements.tolerations, func(t *corev1.Taint) bool {
 				return t.Effect == corev1.TaintEffectNoSchedule || t.Effect == corev1.TaintEffectNoExecute
 			}, true)
@@ -1702,8 +1702,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 			}
 
 			// 3. Check Node against Affinity Node Selector
-			nodeObj := leaf.node.toNode()
-			if requirements.affinitySelector != nil && !requirements.affinitySelector.Match(nodeObj) {
+			if requirements.affinitySelector != nil && !requirements.affinitySelector.Match(leaf.node) {
 				s.log.V(5).Info("excluding node that doesn't match requiredDuringSchedulingIgnoredDuringExecution affinity", "domainID", leaf.id)
 				state.stats.Affinity++
 				continue
@@ -1711,7 +1710,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 
 			// 4. Calculate Affinity Score
 			if features.Enabled(features.TASRespectNodeAffinityPreferred) && requirements.preferredSchedulingTerms != nil {
-				leaf.affinityScore += requirements.preferredSchedulingTerms.Score(nodeObj)
+				leaf.affinityScore += requirements.preferredSchedulingTerms.Score(leaf.node)
 			}
 		}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -111,7 +111,7 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 				)
 			}
 
-			flavorNodes := make([][]*nodeInfo, len(flavorCaches))
+			flavorNodes := make([][]*corev1.Node, len(flavorCaches))
 			for i, flavorCache := range flavorCaches {
 				flavorNodes[i] = tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels)
 			}

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -348,7 +348,7 @@ func TestMergeTopologyAssignments(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			s := newTASFlavorSnapshot(log, "dummy", levels)
 			for i := range nodes {
-				s.addNode(newNodeInfo(&nodes[i]))
+				s.addNode(&nodes[i])
 			}
 			s.initialize()
 

--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -20,18 +20,19 @@ import (
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
 type nodesCache struct {
 	lock  sync.RWMutex
-	nodes map[string]*nodeInfo
+	nodes map[string]*corev1.Node
 }
 
 func newNodesCache() *nodesCache {
 	return &nodesCache{
-		nodes: make(map[string]*nodeInfo),
+		nodes: make(map[string]*corev1.Node),
 	}
 }
 
@@ -43,7 +44,7 @@ func (t *nodesCache) sync(node *corev1.Node) {
 	defer t.lock.Unlock()
 
 	if schedulableAndReady {
-		t.nodes[node.Name] = newNodeInfo(node)
+		t.nodes[node.Name] = copyAndStripNode(node)
 	} else {
 		t.deleteWithoutLock(node.Name)
 	}
@@ -59,14 +60,34 @@ func (t *nodesCache) deleteWithoutLock(nodeName string) {
 	delete(t.nodes, nodeName)
 }
 
-func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*nodeInfo {
+func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*corev1.Node {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
-	filteredNodes := make([]*nodeInfo, 0, len(t.nodes))
+	filteredNodes := make([]*corev1.Node, 0, len(t.nodes))
 	for _, node := range t.nodes {
 		if utiltas.NodeMatchesFlavor(node.Labels, nodeLabels, levels) {
 			filteredNodes = append(filteredNodes, node)
 		}
 	}
 	return filteredNodes
+}
+
+// copyAndStripNode creates a minimal copy of the Node object containing only the
+// fields required for TAS scheduling (Name, Labels, Taints, and Allocatable).
+// This reduces the memory footprint and, more importantly, minimizes the number
+// of pointer fields the garbage collector needs to traverse in a large cluster
+// with frequent scheduling activity.
+func copyAndStripNode(node *corev1.Node) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   node.Name,
+			Labels: node.Labels,
+		},
+		Spec: corev1.NodeSpec{
+			Taints: node.Spec.Taints,
+		},
+		Status: corev1.NodeStatus{
+			Allocatable: node.Status.Allocatable,
+		},
+	}
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -79,14 +79,14 @@ func TestNodesCache(t *testing.T) {
 			nc := newNodesCache()
 
 			for i := range tc.nodes {
-				nc.nodes[tc.nodes[i].Name] = newNodeInfo(&tc.nodes[i])
+				nc.nodes[tc.nodes[i].Name] = copyAndStripNode(&tc.nodes[i])
 			}
 
 			tc.op(nc)
 
-			wantNodesMap := make(map[string]*nodeInfo, len(tc.wantNodes))
+			wantNodesMap := make(map[string]*corev1.Node, len(tc.wantNodes))
 			for i := range tc.wantNodes {
-				wantNodesMap[tc.wantNodes[i].Name] = newNodeInfo(&tc.wantNodes[i])
+				wantNodesMap[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
 			}
 
 			if diff := cmp.Diff(wantNodesMap, nc.nodes); diff != "" {
@@ -110,40 +110,40 @@ func TestNodesCacheFind(t *testing.T) {
 	nodes := []corev1.Node{*node1, *node2, *node3, *node4}
 
 	for i := range nodes {
-		nc.nodes[nodes[i].Name] = newNodeInfo(&nodes[i])
+		nc.nodes[nodes[i].Name] = copyAndStripNode(&nodes[i])
 	}
 
 	testCases := map[string]struct {
 		nodeLabels map[string]string
 		levels     []string
-		wantNodes  []*nodeInfo
+		wantNodes  []*corev1.Node
 	}{
 		"no nodeLabels and levels": {
-			wantNodes: []*nodeInfo{
-				newNodeInfo(node1),
-				newNodeInfo(node2),
-				newNodeInfo(node3),
-				newNodeInfo(node4),
+			wantNodes: []*corev1.Node{
+				copyAndStripNode(node1),
+				copyAndStripNode(node2),
+				copyAndStripNode(node3),
+				copyAndStripNode(node4),
 			},
 		},
 		"match labels": {
 			nodeLabels: map[string]string{"cloud.provider.com/zone": "us-east-1a"},
-			wantNodes:  []*nodeInfo{newNodeInfo(node2), newNodeInfo(node3)},
+			wantNodes:  []*corev1.Node{copyAndStripNode(node2), copyAndStripNode(node3)},
 		},
 		"match levels": {
 			levels:    []string{"cloud.provider.com/topology-block"},
-			wantNodes: []*nodeInfo{newNodeInfo(node3)},
+			wantNodes: []*corev1.Node{copyAndStripNode(node3)},
 		},
 		"match labels and levels": {
 			nodeLabels: map[string]string{"cloud.provider.com/zone": "us-east-1a"},
 			levels:     []string{"cloud.provider.com/topology-block"},
-			wantNodes:  []*nodeInfo{newNodeInfo(node3)},
+			wantNodes:  []*corev1.Node{copyAndStripNode(node3)},
 		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			gotNodes := nc.find(tc.nodeLabels, tc.levels)
-			if diff := cmp.Diff(tc.wantNodes, gotNodes, cmpopts.SortSlices(func(a, b *nodeInfo) bool {
+			if diff := cmp.Diff(tc.wantNodes, gotNodes, cmpopts.SortSlices(func(a, b *corev1.Node) bool {
 				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

Refactors the TAS flavor cache to use `*corev1.Node` directly instead of the custom `nodeInfo` struct.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

https://github.com/kubernetes-sigs/kueue/pull/13110/changes/786f45aae0c9da084e8024b7802e8a1306e4d9a0#r3598810929

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node capacity, taint, and affinity handling during scheduling.
  * Ensured cached node information consistently reflects allocatable resources and scheduling-relevant metadata.

* **Performance**
  * Reduced the amount of node data retained in scheduling caches, helping improve cache efficiency without affecting scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->