### PR TITLE
Follow up #12262: MultiKueue sync pod scheduled condition when worker cluster did schedule

### DIFF
--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -170,8 +170,10 @@ func syncLocalPodWithRemote(
 			// PodScheduled=False/Unschedulable condition verbatim would make the
 			// management cluster's autoscaler treat the gated Pod as a regular
 			// unschedulable Pod and trigger a spurious scale-up. Preserve the local
-			// condition while gated; everything else (phase, container statuses, IPs)
-			// is still synced for visibility.
+			// condition while the worker Pod is not yet scheduled; once the worker Pod
+			// reports PodScheduled=True the remote condition is synced through so the
+			// manager Pod stops showing SchedulingGated while its phase is Running.
+			// Everything else (phase, container statuses, IPs) is always synced.
 			//
 			// The cluster-autoscaler classifies a Pod as Unschedulable (a scale-up
 			// candidate) purely from PodScheduled=False/reason=Unschedulable, and
@@ -180,8 +182,13 @@ func syncLocalPodWithRemote(
 			// ArrangePodsBySchedulability / isSchedulingGated in cluster-autoscaler:
 			// https://github.com/kubernetes/autoscaler/blob/94dcda068/cluster-autoscaler/utils/kubernetes/listers.go#L180-L236
 			localScheduled := findPodCondition(localPod.Status.Conditions, corev1.PodScheduled)
+			remoteScheduled := findPodCondition(remotePod.Status.Conditions, corev1.PodScheduled)
 			localPod.Status = remotePod.Status
-			if isGated(localPod) && localScheduled != nil {
+			// Keep the local SchedulingGated condition only while the worker Pod has
+			// not been scheduled yet (PodScheduled != True). Once it is scheduled, the
+			// remote PodScheduled=True condition (already copied above) is left in place.
+			remoteIsScheduled := remoteScheduled != nil && remoteScheduled.Status == corev1.ConditionTrue
+			if isGated(localPod) && localScheduled != nil && !remoteIsScheduled {
 				setPodCondition(&localPod.Status, *localScheduled)
 			}
 			return true, nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter_test.go
@@ -192,13 +192,14 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		"keeps SchedulingGated condition even when remote pod is scheduled": {
+		"overwrites SchedulingGated once the remote pod is scheduled": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
-			// The management-cluster Pod stays gated for its whole lifetime, so its
-			// PodScheduled condition is locally owned (SchedulingGated) and is never
-			// overwritten - not even by the worker's PodScheduled=True, which would be
-			// untrue locally (the manager Pod has no NodeName) and would fight the
-			// local scheduler. Other status (phase, Ready) is still synced.
+			// While the worker Pod is unscheduled the manager Pod keeps its local
+			// SchedulingGated condition (see the case above, which avoids a spurious
+			// autoscaler scale-up). Once the worker Pod reports PodScheduled=True, that
+			// condition is synced through to the manager Pod so its status reflects
+			// reality instead of showing SchedulingGated while the phase is Running.
+			// The manager Pod stays gated in its spec.
 			managersPods: []corev1.Pod{
 				*basePodBuilder.Clone().
 					KueueSchedulingGate().
@@ -230,11 +231,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 					KueueSchedulingGate().
 					StatusPhase(corev1.PodRunning).
 					StatusConditions(
-						corev1.PodCondition{
-							Type:   corev1.PodScheduled,
-							Status: corev1.ConditionFalse,
-							Reason: corev1.PodReasonSchedulingGated,
-						},
+						corev1.PodCondition{Type: corev1.PodScheduled, Status: corev1.ConditionTrue},
 						corev1.PodCondition{Type: corev1.PodReady, Status: corev1.ConditionTrue},
 					).
 					Obj(),

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -304,14 +304,16 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					Reason: finishReason,
 				},
 				{
-					// The manager-cluster Pod stays scheduling-gated for its whole
-					// lifetime, so its locally-owned PodScheduled condition is
-					// preserved (SchedulingGated) rather than overwritten by the
-					// worker's PodScheduled=True. This keeps the Pod invisible to the
-					// manager cluster's cluster-autoscaler.
+					// Once the worker Pod was scheduled, its PodScheduled=True condition
+					// is synced through to the manager Pod, overwriting the local
+					// SchedulingGated condition, so a finished Pod reports that it
+					// actually ran on the worker. (While the worker Pod is still
+					// unscheduled the local SchedulingGated condition is preserved to
+					// keep the Pod invisible to the manager cluster's cluster-autoscaler
+					// - the unit tests cover that window, and the interim running state
+					// is asserted by the spec below.)
 					Type:   corev1.PodScheduled,
-					Status: corev1.ConditionFalse,
-					Reason: corev1.PodReasonSchedulingGated,
+					Status: corev1.ConditionTrue,
 				},
 			}
 			ginkgo.By("Waiting for the pod to get status updates", func() {
@@ -321,6 +323,57 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					g.Expect(createdPod.Status.Phase).To(gomega.Equal(corev1.PodSucceeded))
 					g.Expect(createdPod.Status.Conditions).To(gomega.BeComparableTo(finishPodConditions, util.IgnorePodConditionTimestampsMessageAndObservedGeneration))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("Should overwrite the manager Pod's SchedulingGated condition once it runs on the worker", func() {
+			// A Pod that keeps running (BehaviorWaitForDeletion) lets us observe the
+			// interim manager-Pod status deterministically, instead of racing a
+			// fast-completing Pod: while the manager Pod stays scheduling-gated in its
+			// spec, its PodScheduled condition must reflect the worker's
+			// PodScheduled=True rather than the local SchedulingGated, so the status
+			// shows the Pod is actually running.
+			pod := testingpod.MakePod("running-pod", managerNs.Name).
+				RequestAndLimit(corev1.ResourceCPU, "100m").
+				RequestAndLimit(corev1.ResourceMemory, "100M").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
+				Queue(managerLq.Name).
+				Obj()
+
+			ginkgo.By("Creating the pod", func() {
+				util.MustCreate(ctx, k8sManagerClient, pod)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadpod.GetWorkloadNameForPod(pod.Name, pod.UID), Namespace: managerNs.Name}
+
+			ginkgo.By("Waiting to be admitted in worker", func() {
+				util.ExpectAdmissionCheckStateWithMessage(
+					ctx, k8sManagerClient, wlLookupKey,
+					multiKueueAc.Name,
+					kueue.CheckStateReady,
+					"",
+				)
+			})
+
+			ginkgo.By("Waiting for the running manager Pod to report PodScheduled=True while staying gated", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdPod := &corev1.Pod{}
+					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(pod), createdPod)).To(gomega.Succeed())
+					g.Expect(createdPod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+					// The manager Pod is still gated in its spec ...
+					g.Expect(utilpod.HasGate(createdPod, podconstants.SchedulingGateName)).To(gomega.BeTrue())
+					// ... but its PodScheduled condition is synced from the worker.
+					g.Expect(createdPod.Status.Conditions).To(gomega.ContainElement(gomega.SatisfyAll(
+						gomega.HaveField("Type", corev1.PodScheduled),
+						gomega.HaveField("Status", corev1.ConditionTrue),
+					)))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Deleting the pod", func() {
+				gomega.Expect(k8sManagerClient.Delete(ctx, pod)).To(gomega.Succeed())
+				util.ExpectAllPodsInNamespaceDeleted(ctx, k8sManagerClient, managerNs)
 			})
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bugfix
/feature
/kind cleanup
/area multikueue


#### What this PR does / why we need it:

#12262 prevented the synchronisation of the 

```yaml
    conditions:
    - lastProbeTime: null
      lastTransitionTime: "..."
      message: '0/4 nodes are available: ...'
      observedGeneration: 2
      reason: Unschedulable
      status: "False"
      type: PodScheduled
```

condition from the MultiKueue worker to the manager cluster, overwriting the `reason: SchedulingGated` reason, with the goal of preventing the manager cluster autoscaler from scaling up a node for the workload.

This PR is a follow up that addresses the following issue:

While the spurious scale up in the manager cluster is prevented by #12262, when the pod runs in the MultiKueue worker cluster, the pod copy in the manager cluster now shows:

```yaml
status:
    conditions:
    - message: Scheduling is blocked due to non-empty scheduling gates
      reason: SchedulingGated
      status: "False"
      type: PodScheduled
    phase: Running               # <-
```

```console
NAME                        READY   STATUS            RESTARTS   AGE
test-pod                    0/1          SchedulingGated   0          3m16s             # <- even though the pod is running in the worker
```

This PR changes the synchronisation behaviour to sync the `type: PodScheduled` condition to the manager cluster once the pod is actually scheduled. With this, we again see this in the manager cluster:

```console
NAME                        READY   STATUS            RESTARTS   AGE
test-pod                    1/1          Running   0          2m20s
```

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixes an observability bug where Pods scheduled in a worker cluster could still appear unscheduled
in the manager cluster (as `PodScheduled=False` would be preserved). The `PodScheduled` condition is now
synchronized from the worker cluster, while preserving `SchedulingGated` for unschedulable Pods to avoid spurious 
scale-ups.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pod status synchronization so a manager pod reflects `PodScheduled=True` once its worker pod has been scheduled.
  * Prevented stale scheduling-gated status from persisting after scheduling completes.
  * Improved status reporting for running and completed pods.

* **Tests**
  * Added end-to-end coverage for scheduled, running, completed, and cleaned-up pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->