### PR TITLE
Optimize FG checking when sorting domain

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1599,13 +1599,14 @@ func sortDomainsByLevelValues(domains []*domain) {
 
 func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
+	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
 		if a.leaderState != b.leaderState {
 			return cmp.Compare(b.leaderState, a.leaderState)
 		}
 
-		if features.Enabled(features.TASRespectNodeAffinityPreferred) && a.affinityScore != b.affinityScore {
+		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
 			return cmp.Compare(b.affinityScore, a.affinityScore)
 		}
 
@@ -1636,9 +1637,10 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 // `state` is always sorted ascending. This prioritizes domains that can accommodate slices with minimal leftover pod capacity.
 func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool) []*domain {
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
+	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if features.Enabled(features.TASRespectNodeAffinityPreferred) && a.affinityScore != b.affinityScore {
+		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
 			return cmp.Compare(b.affinityScore, a.affinityScore)
 		}
 

--- a/pkg/scheduler/scheduler_tas_bench_test.go
+++ b/pkg/scheduler/scheduler_tas_bench_test.go
@@ -191,7 +191,8 @@ func BenchmarkSchedulerTAS(b *testing.B) {
 			psReq := utiltestingapi.MakePodSet("main", numRequestedPods).
 				Request(corev1.ResourceCPU, requestedCPUStr).
 				Request(corev1.ResourceMemory, fmt.Sprintf("%dGi", requestedRAM)).
-				NodeSelector(map[string]string{"node-group": "group-1"})
+				NodeSelector(map[string]string{"node-group": "group-1"}).
+				UnconstrainedTopologyRequest()
 			for r := 2; r < numResources; r++ {
 				psReq.Request(corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r)), requestedCPUStr)
 			}

--- a/pkg/scheduler/scheduler_tas_bench_test.go
+++ b/pkg/scheduler/scheduler_tas_bench_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/util/routine"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+)
+
+func BenchmarkSchedulerTAS(b *testing.B) {
+	cases := []struct {
+		// nodes is the total number of nodes in the simulated cluster.
+		nodes int
+		// nodeGroups is the number of node groups (e.g. racks or zones) the nodes are divided into.
+		nodeGroups int
+		// requestedPods is the number of pods in the pending workload we try to schedule.
+		requestedPods int
+		// requestedNodeFractionPercent is the percentage of a single node's capacity
+		// (CPU and Memory) that each pod in the requested workload requires.
+		// For example, 50 means each pod requires 50% of a node's resources.
+		requestedNodeFractionPercent int
+		// numResources is the number of resources per node (CPU, Memory, plus mock custom resources).
+		numResources int
+	}{
+		{
+			nodes:                        1000,
+			nodeGroups:                   8,
+			requestedPods:                200,
+			requestedNodeFractionPercent: 50,
+			numResources:                 30,
+		},
+	}
+	for _, tc := range cases {
+		b.Run(fmt.Sprintf("nodes=%d/nodeGroups=%d/pods=%d/res=%d", tc.nodes, tc.nodeGroups, tc.requestedPods, tc.numResources), func(b *testing.B) {
+			numNodes := tc.nodes
+			numNodeGroups := tc.nodeGroups
+			numRequestedPods := tc.requestedPods
+			requestedNodeFractionPercent := tc.requestedNodeFractionPercent
+			numResources := tc.numResources
+
+			now := time.Now()
+			branchingFactor := max(int(math.Sqrt(float64(numNodes))), 1)
+
+			nodes := make([]corev1.Node, numNodes)
+
+			type nodeCap struct {
+				cpu int64
+				ram int64
+			}
+			caps := make([]nodeCap, numNodes)
+
+			blockID := 0
+			nodeID := 0
+			for i := range numNodes {
+				nodeID++
+				if nodeID == branchingFactor {
+					nodeID = 0
+					blockID++
+				}
+				host := fmt.Sprintf("node-%d-%d", blockID, nodeID)
+				gName := fmt.Sprintf("group-%d", blockID%numNodeGroups+1)
+
+				allocatable := corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("10"),
+					corev1.ResourceMemory: resource.MustParse("100Gi"),
+					corev1.ResourcePods:   resource.MustParse("110"),
+				}
+				// 0 and 1 are CPU/Memory, additional ones are mocked.
+				for r := 2; r < numResources; r++ {
+					allocatable[corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r))] = resource.MustParse("10")
+				}
+
+				nodes[i] = *testingnode.MakeNode(host).
+					Label("cloud.com/topology-block", fmt.Sprintf("b-%d", blockID)).
+					Label(corev1.LabelHostname, host).
+					Label("tas-node", "true").
+					Label("node-group", gName).
+					StatusAllocatable(allocatable).
+					Ready().
+					Obj()
+				caps[i] = nodeCap{cpu: 10, ram: 100}
+			}
+
+			var workloads []kueue.Workload
+
+			// Pre-populate the cluster with admitted workloads until it is full.
+			// These workloads will be targets for preemption later.
+			wlIdx := 1
+			for {
+				cpuReq := int64(wlIdx%10) + 1
+				ramReq := int64(wlIdx%100) + 1
+				podsCount := (wlIdx*10)%int(math.Sqrt(float64(numNodes))) + 1
+
+				podsPlaced := 0
+				assignments := make(map[string]int32)
+				capsBackup := make([]nodeCap, numNodes)
+				copy(capsBackup, caps)
+
+				for j := 0; j < numNodes && podsPlaced < podsCount; j++ {
+					for caps[j].cpu >= cpuReq && caps[j].ram >= ramReq && podsPlaced < podsCount {
+						caps[j].cpu -= cpuReq
+						caps[j].ram -= ramReq
+						podsPlaced++
+						assignments[nodes[j].Labels[corev1.LabelHostname]]++
+					}
+				}
+
+				if podsPlaced < podsCount {
+					copy(caps, capsBackup)
+					break
+				}
+
+				levels := []string{corev1.LabelHostname}
+				ta := utiltestingapi.MakeTopologyAssignment(levels)
+				for h, count := range assignments {
+					ta.Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{h}, count).Obj())
+				}
+
+				cpuReqStr := strconv.FormatInt(cpuReq, 10)
+				ps := utiltestingapi.MakePodSet("main", podsCount).
+					Request(corev1.ResourceCPU, cpuReqStr).
+					Request(corev1.ResourceMemory, fmt.Sprintf("%dGi", ramReq))
+				for r := 2; r < numResources; r++ {
+					ps.Request(corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r)), cpuReqStr)
+				}
+
+				psa := utiltestingapi.MakePodSetAssignment("main").
+					Assignment(corev1.ResourceCPU, "tas-flavor", cpuReqStr).
+					Assignment(corev1.ResourceMemory, "tas-flavor", fmt.Sprintf("%dGi", ramReq)).
+					TopologyAssignment(ta.Obj())
+				for r := 2; r < numResources; r++ {
+					psa.Assignment(corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r)), "tas-flavor", cpuReqStr)
+				}
+
+				wl := utiltestingapi.MakeWorkload(fmt.Sprintf("wl-%d", wlIdx), "default").
+					UID(types.UID(fmt.Sprintf("wl-%d", wlIdx))).
+					Queue("tas-main").
+					Priority(int32(wlIdx)).
+					PodSets(*ps.Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("tas-main").
+						PodSets(psa.Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj()
+
+				workloads = append(workloads, *wl)
+				wlIdx++
+			}
+
+			// Create a pending workload that requires a fraction of a node's capacity.
+			// Since the cluster is full, scheduling this workload will trigger preemption.
+			requestedCPU := int64(10 * requestedNodeFractionPercent / 100)
+			requestedRAM := int64(100 * requestedNodeFractionPercent / 100)
+
+			requestedCPUStr := strconv.FormatInt(requestedCPU, 10)
+			psReq := utiltestingapi.MakePodSet("main", numRequestedPods).
+				Request(corev1.ResourceCPU, requestedCPUStr).
+				Request(corev1.ResourceMemory, fmt.Sprintf("%dGi", requestedRAM)).
+				NodeSelector(map[string]string{"node-group": "group-1"})
+			for r := 2; r < numResources; r++ {
+				psReq.Request(corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r)), requestedCPUStr)
+			}
+
+			requestedWl := utiltestingapi.MakeWorkload("requested-wl", "default").
+				UID("requested-wl").
+				Queue("tas-main").
+				Priority(int32(wlIdx)).
+				PodSets(*psReq.Obj()).
+				Obj()
+
+			tasTopology := utiltestingapi.MakeTopology("tas-topology").
+				Levels("cloud.com/topology-block", corev1.LabelHostname).
+				Obj()
+			tasFlavor := utiltestingapi.MakeResourceFlavor("tas-flavor").
+				NodeLabel("tas-node", "true").
+				TopologyName("tas-topology").
+				Obj()
+
+			fq := utiltestingapi.MakeFlavorQuotas("tas-flavor").
+				Resource(corev1.ResourceCPU, "100000").
+				Resource(corev1.ResourceMemory, "1000000Gi")
+			for r := 2; r < numResources; r++ {
+				fq.Resource(corev1.ResourceName(fmt.Sprintf("example.com/res-%d", r)), "100000")
+			}
+
+			cq := utiltestingapi.MakeClusterQueue("tas-main").
+				Preemption(kueue.ClusterQueuePreemption{
+					WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+				}).
+				ResourceGroup(*fq.Obj()).
+				Obj()
+
+			lq := utiltestingapi.MakeLocalQueue("tas-main", "default").
+				ClusterQueue("tas-main").
+				Obj()
+
+			objs := []client.Object{
+				utiltesting.MakeNamespaceWrapper("default").Obj(),
+				tasTopology,
+			}
+			for i := range nodes {
+				objs = append(objs, &nodes[i])
+			}
+
+			ctx, log := utiltesting.ContextWithLog(b)
+
+			for b.Loop() {
+				b.StopTimer()
+				cb := utiltesting.NewClientBuilder(kueue.AddToScheme, corev1.AddToScheme).
+					WithObjects(objs...).
+					WithLists(
+						&kueue.WorkloadList{Items: workloads},
+						&kueue.LocalQueueList{Items: []kueue.LocalQueue{*lq}},
+						&kueue.ClusterQueueList{Items: []kueue.ClusterQueue{*cq}},
+					).
+					WithStatusSubresource(&kueue.Workload{}).
+					WithInterceptorFuncs(interceptor.Funcs{
+						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+							return nil // discard updates to speed up bench loop
+						},
+					})
+				cl := cb.Build()
+				recorder := &utiltesting.EventRecorder{}
+				cqCache := schdcache.New(cl)
+				expStore := preemptexpectations.New()
+				qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithPreemptionExpectations(expStore))
+
+				cqCache.AddOrUpdateTopology(log, tasTopology)
+				cqCache.AddOrUpdateResourceFlavor(log, tasFlavor)
+				_ = cqCache.AddClusterQueue(ctx, cq)
+				_ = qManager.AddClusterQueue(ctx, cq)
+				_ = qManager.AddLocalQueue(ctx, lq)
+
+				for i := range nodes {
+					cqCache.TASCache().SyncNode(&nodes[i])
+				}
+				for i := range workloads {
+					// Admitted workloads go to scheduling cache directly
+					_ = cqCache.AddOrUpdateWorkload(log, &workloads[i])
+				}
+
+				scheduler := New(qManager, cqCache, cl, recorder, WithPreemptionExpectations(expStore))
+				var wg sync.WaitGroup
+				scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+					func() { wg.Add(1) },
+					func() { wg.Done() },
+				))
+
+				_ = qManager.AddOrUpdateWorkload(log, requestedWl)
+
+				b.StartTimer()
+				scheduler.schedule(ctx)
+				b.StopTimer()
+
+				wg.Wait()
+
+				preemptees := sets.New[int]()
+				for _, event := range recorder.RecordedEvents {
+					if event.Reason == "Preempted" {
+						parts := strings.Split(event.Key.String(), "-")
+						idx, _ := strconv.Atoi(parts[len(parts)-1])
+						preemptees.Insert(idx)
+					}
+				}
+				b.Logf("[BENCH-DEBUG] Preempted workloads: %v", sets.List(preemptees))
+				b.StartTimer()
+			}
+		})
+	}
+}

--- a/pkg/scheduler/scheduler_tas_bench_test.go
+++ b/pkg/scheduler/scheduler_tas_bench_test.go
@@ -262,16 +262,24 @@ func BenchmarkSchedulerTAS(b *testing.B) {
 
 				cqCache.AddOrUpdateTopology(log, tasTopology)
 				cqCache.AddOrUpdateResourceFlavor(log, tasFlavor)
-				_ = cqCache.AddClusterQueue(ctx, cq)
-				_ = qManager.AddClusterQueue(ctx, cq)
-				_ = qManager.AddLocalQueue(ctx, lq)
+				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+					b.Fatalf("Failed to add ClusterQueue to cqCache: %v", err)
+				}
+				if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+					b.Fatalf("Failed to add ClusterQueue to qManager: %v", err)
+				}
+				if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+					b.Fatalf("Failed to add LocalQueue to qManager: %v", err)
+				}
 
 				for i := range nodes {
 					cqCache.TASCache().SyncNode(&nodes[i])
 				}
 				for i := range workloads {
 					// Admitted workloads go to scheduling cache directly
-					_ = cqCache.AddOrUpdateWorkload(log, &workloads[i])
+					if !cqCache.AddOrUpdateWorkload(log, &workloads[i]) {
+						b.Fatalf("Failed to add workload %s to cqCache", workloads[i].Name)
+					}
 				}
 
 				scheduler := New(qManager, cqCache, cl, recorder, WithPreemptionExpectations(expStore))
@@ -281,7 +289,9 @@ func BenchmarkSchedulerTAS(b *testing.B) {
 					func() { wg.Done() },
 				))
 
-				_ = qManager.AddOrUpdateWorkload(log, requestedWl)
+				if err := qManager.AddOrUpdateWorkload(log, requestedWl); err != nil {
+					b.Fatalf("Failed to add requested workload to qManager: %v", err)
+				}
 
 				b.StartTimer()
 				scheduler.schedule(ctx)
@@ -293,9 +303,15 @@ func BenchmarkSchedulerTAS(b *testing.B) {
 				for _, event := range recorder.RecordedEvents {
 					if event.Reason == "Preempted" {
 						parts := strings.Split(event.Key.String(), "-")
-						idx, _ := strconv.Atoi(parts[len(parts)-1])
+						idx, err := strconv.Atoi(parts[len(parts)-1])
+						if err != nil {
+							b.Fatalf("Failed to parse workload index from event key %q: %v", event.Key.String(), err)
+						}
 						preemptees.Insert(idx)
 					}
+				}
+				if preemptees.Len() == 0 {
+					b.Fatal("Expected at least one preemptee to be recorded, but found none")
 				}
 				b.Logf("[BENCH-DEBUG] Preempted workloads: %v", sets.List(preemptees))
 				b.StartTimer()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

https://github.com/kubernetes-sigs/kueue/pull/13110#issuecomment-5001768439

Improve performance when sorting domains

FG check outside sorting:
```bash
BenchmarkSchedulerTAS/nodes=1000/nodeGroups=8/pods=200/res=30-64         	      44	 293890497 ns/op
PASS
ok  	sigs.k8s.io/kueue/pkg/scheduler	16.667s
```

Main
```bash
BenchmarkSchedulerTAS/nodes=1000/nodeGroups=8/pods=200/res=30-64         	      34	 341227288 ns/op
PASS
ok  	sigs.k8s.io/kueue/pkg/scheduler	14.357s
```

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fix a performance bug where repeatedly checking the enablement of the `TASRespectNodeAffinityPreferred` feature gate inside a hot sorting loop could significantly increase the scheduling time (14% by the attached benchmark).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when ordering domains by preferred node affinity behavior by evaluating the feature setting once per sort operation.

* **Tests**
  * Added a new scheduler performance benchmark that simulates TAS preemption at scale, measures scheduling runtime, and verifies that preemption occurs under the configured workload and cluster conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->