### PR TITLE
Copy labels and annotations to workloads for custom metric labels

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -73,7 +73,7 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 
 		kp := pod.FromObject(p)
 		// Note: the recorder is not used for single pods, we can just pass nil for now.
-		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil)
+		wl, err := kp.ConstructComposableWorkload(ctx, c, nil, nil, nil)
 		if err != nil {
 			return false, fmt.Errorf("construct workload: %w", err)
 		}

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -568,6 +568,13 @@ func setupControllers(
 		}
 	}
 
+	var labelKeysToCopy, annotationsToCopy sets.Set[string]
+	if features.Enabled(features.CustomMetricLabels) {
+		labelKeysToCopy, annotationsToCopy = metrics.WorkloadCustomLabelSources(cfg.Metrics.CustomLabels)
+	} else {
+		labelKeysToCopy, annotationsToCopy = sets.New[string](), sets.New[string]()
+	}
+	labelKeysToCopy.Insert(cfg.Integrations.LabelKeysToCopy...)
 	jfOpts := []jobframework.Option{
 		jobframework.WithManageJobsWithoutQueueName(cfg.ManageJobsWithoutQueueName),
 		jobframework.WithWaitForPodsReady(cfg.WaitForPodsReady),
@@ -575,13 +582,15 @@ func setupControllers(
 		jobframework.WithEnabledFrameworks(cfg.Integrations.Frameworks),
 		jobframework.WithEnabledExternalFrameworks(cfg.Integrations.ExternalFrameworks),
 		jobframework.WithManagerName(constants.KueueName),
-		jobframework.WithLabelKeysToCopy(cfg.Integrations.LabelKeysToCopy),
+		jobframework.WithLabelKeysToCopy(labelKeysToCopy),
+		jobframework.WithAnnotationsToCopy(annotationsToCopy),
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 		jobframework.WithObjectRetentionPolicies(cfg.ObjectRetentionPolicies),
 		jobframework.WithRoleTracker(opts.RoleTracker),
 		jobframework.WithCustomLabels(opts.CustomLabels),
 	}
+
 	nsSelector, err := metav1.LabelSelectorAsSelector(cfg.ManagedJobsNamespaceSelector)
 	if err != nil {
 		return fmt.Errorf("failed to parse managedJobsNamespaceSelector: %w", err)

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -568,13 +568,7 @@ func setupControllers(
 		}
 	}
 
-	var labelKeysToCopy, annotationsToCopy sets.Set[string]
-	if features.Enabled(features.CustomMetricLabels) {
-		labelKeysToCopy, annotationsToCopy = metrics.WorkloadCustomLabelSources(cfg.Metrics.CustomLabels)
-	} else {
-		labelKeysToCopy, annotationsToCopy = sets.New[string](), sets.New[string]()
-	}
-	labelKeysToCopy.Insert(cfg.Integrations.LabelKeysToCopy...)
+	labelKeysToCopy, annotationsToCopy := getLabelsAndAnnotationsToCopy(cfg)
 	jfOpts := []jobframework.Option{
 		jobframework.WithManageJobsWithoutQueueName(cfg.ManageJobsWithoutQueueName),
 		jobframework.WithWaitForPodsReady(cfg.WaitForPodsReady),
@@ -606,6 +600,15 @@ func setupControllers(
 	}
 
 	return nil
+}
+
+func getLabelsAndAnnotationsToCopy(cfg *configapi.Configuration) (labelKeysToCopy sets.Set[string], annotationsToCopy sets.Set[string]) {
+	if !features.Enabled(features.CustomMetricLabels) {
+		return sets.New(cfg.Integrations.LabelKeysToCopy...), sets.New[string]()
+	}
+	labelKeysToCopy, annotationsToCopy = metrics.WorkloadCustomLabelSources(cfg.Metrics.CustomLabels)
+	labelKeysToCopy.Insert(cfg.Integrations.LabelKeysToCopy...)
+	return
 }
 
 // setupProbeEndpoints registers the health endpoints

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -138,7 +139,7 @@ type ComposableJob interface {
 	Run(ctx context.Context, c client.Client, wl *kueue.Workload, podSetsInfo []podset.PodSetInfo, r events.EventRecorder, msg string) error
 
 	// ConstructComposableWorkload builds a new Workload from all members of the ComposableJob.
-	ConstructComposableWorkload(ctx context.Context, c client.Client, r events.EventRecorder, labelKeysToCopy []string) (*kueue.Workload, error)
+	ConstructComposableWorkload(ctx context.Context, c client.Client, r events.EventRecorder, labelKeysToCopy, annotationsToCopy sets.Set[string]) (*kueue.Workload, error)
 
 	// ListChildWorkloads returns all workloads related to the composable job.
 	ListChildWorkloads(ctx context.Context, c client.Client, parent types.NamespacedName) (*kueue.WorkloadList, error)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -100,7 +100,8 @@ type JobReconciler struct {
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
 	waitForPodsReady             bool
-	labelKeysToCopy              []string
+	labelKeysToCopy              sets.Set[string]
+	annotationsToCopy            sets.Set[string]
 	clock                        clock.Clock
 	workloadRetentionPolicy      WorkloadRetentionPolicy
 	roleTracker                  *roletracker.RoleTracker
@@ -121,7 +122,8 @@ type Options struct {
 	EnabledFrameworks            sets.Set[string]
 	EnabledExternalFrameworks    sets.Set[string]
 	ManagerName                  string
-	LabelKeysToCopy              []string
+	LabelKeysToCopy              sets.Set[string]
+	AnnotationsToCopy            sets.Set[string]
 	Queues                       *qcache.Manager
 	Cache                        *schdcache.Cache
 	Clock                        clock.Clock
@@ -200,9 +202,16 @@ func WithManagerName(n string) Option {
 }
 
 // WithLabelKeysToCopy adds the label keys
-func WithLabelKeysToCopy(n []string) Option {
+func WithLabelKeysToCopy(s sets.Set[string]) Option {
 	return func(o *Options) {
-		o.LabelKeysToCopy = n
+		o.LabelKeysToCopy = s
+	}
+}
+
+// WithAnnotationsToCopy adds the annotation keys
+func WithAnnotationsToCopy(s sets.Set[string]) Option {
+	return func(o *Options) {
+		o.AnnotationsToCopy = s
 	}
 }
 
@@ -276,6 +285,7 @@ func NewReconciler(
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
 		waitForPodsReady:             options.WaitForPodsReady,
 		labelKeysToCopy:              options.LabelKeysToCopy,
+		annotationsToCopy:            options.AnnotationsToCopy,
 		clock:                        options.Clock,
 		workloadRetentionPolicy:      options.WorkloadRetentionPolicy,
 		roleTracker:                  options.RoleTracker,
@@ -1413,13 +1423,13 @@ func (r *JobReconciler) finalizeJob(ctx context.Context, job GenericJob) error {
 // constructWorkload will derive a workload from the corresponding job.
 func (r *JobReconciler) constructWorkload(ctx context.Context, job GenericJob) (*kueue.Workload, error) {
 	if cj, implements := job.(ComposableJob); implements {
-		wl, err := cj.ConstructComposableWorkload(ctx, r.client, r.record, r.labelKeysToCopy)
+		wl, err := cj.ConstructComposableWorkload(ctx, r.client, r.record, r.labelKeysToCopy, r.annotationsToCopy)
 		if err != nil {
 			return nil, err
 		}
 		return wl, nil
 	}
-	return ConstructWorkload(ctx, r.client, job, r.labelKeysToCopy)
+	return ConstructWorkload(ctx, r.client, job, r.labelKeysToCopy, r.annotationsToCopy)
 }
 
 // newWorkloadName generates a new workload name for the given job, incorporating the job's name, UID,
@@ -1439,7 +1449,7 @@ func newWorkloadName(job GenericJob) string {
 	return GetWorkloadNameForOwnerWithGVK(object.GetName(), object.GetUID(), job.GVK())
 }
 
-func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, labelKeysToCopy []string) (*kueue.Workload, error) {
+func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, labelKeysToCopy, annotationsToCopy sets.Set[string]) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 	object := job.Object()
 
@@ -1448,7 +1458,7 @@ func ConstructWorkload(ctx context.Context, c client.Client, job GenericJob, lab
 		return nil, err
 	}
 
-	wl := NewWorkload(newWorkloadName(job), object, podSets, labelKeysToCopy)
+	wl := NewWorkload(newWorkloadName(job), object, podSets, labelKeysToCopy, annotationsToCopy)
 	if wl.Labels == nil {
 		wl.Labels = make(map[string]string)
 	}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/clock"
 	testingclock "k8s.io/utils/clock/testing"
@@ -91,14 +92,15 @@ func TestReconcileGenericJob(t *testing.T) {
 		Priority(0)
 
 	testCases := map[string]struct {
-		featureGates  map[featuregate.Feature]bool
-		req           types.NamespacedName
-		job           *batchv1.Job
-		podSets       []kueue.PodSet
-		objs          []client.Object
-		wantWorkloads []kueue.Workload
-		wantEvents    []utiltesting.EventRecord
-		wantPodSets   []podset.PodSetInfo
+		featureGates      map[featuregate.Feature]bool
+		reconcilerOptions []Option
+		req               types.NamespacedName
+		job               *batchv1.Job
+		podSets           []kueue.PodSet
+		objs              []client.Object
+		wantWorkloads     []kueue.Workload
+		wantEvents        []utiltesting.EventRecord
+		wantPodSets       []podset.PodSetInfo
 	}{
 		"handle job with no workload (elasticJobsViaWorkloadSlicesEnabled = false)": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: false},
@@ -410,6 +412,30 @@ func TestReconcileGenericJob(t *testing.T) {
 				},
 			},
 		},
+		"handle job with annotations to copy": {
+			featureGates: map[featuregate.Feature]bool{
+				features.CustomMetricLabels: true,
+			},
+			reconcilerOptions: []Option{
+				WithLabelKeysToCopy(sets.New("toCopyKey")),
+				WithAnnotationsToCopy(sets.New("toCopyAnnotation")),
+			},
+			req: baseReq,
+			job: baseJob.Clone().
+				Label("toCopyKey", "toCopyValue").
+				Label("dontCopyKey", "dontCopyValue").
+				SetAnnotation("toCopyAnnotation", "toCopyAnnValue").
+				SetAnnotation("dontCopyAnnotation", "dontCopyAnnValue").
+				Obj(),
+			podSets: basePodSets,
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().
+					Name("job-test-job-ce737").
+					Label("toCopyKey", "toCopyValue").
+					Annotations(map[string]string{"toCopyAnnotation": "toCopyAnnValue"}).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
@@ -435,7 +461,7 @@ func TestReconcileGenericJob(t *testing.T) {
 				Build()
 
 			recorder := &utiltesting.EventRecorder{}
-			rec := NewReconciler(cl, recorder)
+			rec := NewReconciler(cl, recorder, tc.reconcilerOptions...)
 			_, err := rec.ReconcileGenericJob(ctx, controllerruntime.Request{NamespacedName: tc.req}, mgj)
 			if err != nil {
 				t.Fatalf("Failed to Reconcile GenericJob: %v", err)
@@ -937,7 +963,8 @@ func TestProcessOptions(t *testing.T) {
 				WithManageJobsWithoutQueueName(true),
 				WithWaitForPodsReady(&configapi.WaitForPodsReady{}),
 				WithKubeServerVersion(&kubeversion.ServerVersionFetcher{}),
-				WithLabelKeysToCopy([]string{"toCopyKey"}),
+				WithLabelKeysToCopy(sets.New("toCopyKey")),
+				WithAnnotationsToCopy(sets.New("toCopyAnnotation")),
 				WithClock(fakeClock),
 			},
 			wantOpts: Options{
@@ -945,7 +972,8 @@ func TestProcessOptions(t *testing.T) {
 				WaitForPodsReady:           true,
 				KubeServerVersion:          &kubeversion.ServerVersionFetcher{},
 				IntegrationOptions:         nil,
-				LabelKeysToCopy:            []string{"toCopyKey"},
+				LabelKeysToCopy:            sets.New("toCopyKey"),
+				AnnotationsToCopy:          sets.New("toCopyAnnotation"),
 				Clock:                      fakeClock,
 			},
 		},
@@ -968,6 +996,7 @@ func TestProcessOptions(t *testing.T) {
 				KubeServerVersion:          nil,
 				IntegrationOptions:         nil,
 				LabelKeysToCopy:            nil,
+				AnnotationsToCopy:          nil,
 				Clock:                      clock.RealClock{},
 			},
 		},

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -223,14 +224,18 @@ func SetMultiKueueMeta(obj client.Object, workloadName, origin string) {
 
 // NewWorkload creates a new Workload object with the specified name,
 // associated object, pod sets, and label keys to copy.
-func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKeysToCopy []string) *kueue.Workload {
+func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKeysToCopy, annotationsToCopy sets.Set[string]) *kueue.Workload {
+	annotations := admissioncheck.FilterProvReqAnnotations(obj.GetAnnotations())
+	if features.Enabled(features.CustomMetricLabels) {
+		maps.Copy(&annotations, maps.FilterKeys(obj.GetAnnotations(), annotationsToCopy.UnsortedList()))
+	}
 	return &kueue.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   obj.GetNamespace(),
-			Labels:      maps.FilterKeys(obj.GetLabels(), labelKeysToCopy),
+			Labels:      maps.FilterKeys(obj.GetLabels(), labelKeysToCopy.UnsortedList()),
 			Finalizers:  []string{kueue.ResourceInUseFinalizerName},
-			Annotations: admissioncheck.FilterProvReqAnnotations(obj.GetAnnotations()),
+			Annotations: annotations,
 		},
 		Spec: kueue.WorkloadSpec{
 			QueueName:                   QueueNameForObject(obj),

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
@@ -1261,7 +1262,7 @@ func TestReconciler(t *testing.T) {
 				Suspend(true).
 				Obj(),
 			reconcilerOptions: []jobframework.Option{
-				jobframework.WithLabelKeysToCopy([]string{"toCopyKey", "redundantToCopyKey"}),
+				jobframework.WithLabelKeysToCopy(sets.New("toCopyKey", "redundantToCopyKey")),
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("job", "ns").

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -80,7 +81,8 @@ type Reconciler struct {
 	client                       client.Client
 	logName                      string
 	record                       events.EventRecorder
-	labelKeysToCopy              []string
+	labelKeysToCopy              sets.Set[string]
+	annotationsToCopy            sets.Set[string]
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
 	roleTracker                  *roletracker.RoleTracker
@@ -97,6 +99,7 @@ func NewReconciler(_ context.Context, client client.Client, _ client.FieldIndexe
 		logName:                      "leaderworkerset-reconciler",
 		record:                       eventRecorder,
 		labelKeysToCopy:              options.LabelKeysToCopy,
+		annotationsToCopy:            options.AnnotationsToCopy,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
 		roleTracker:                  options.RoleTracker,
@@ -332,7 +335,7 @@ func (r *Reconciler) constructWorkload(lws *leaderworkersetv1.LeaderWorkerSet, w
 	if err != nil {
 		return nil, err
 	}
-	createdWorkload := podcontroller.NewGroupWorkload(workloadName, lws, podSets, r.labelKeysToCopy)
+	createdWorkload := podcontroller.NewGroupWorkload(workloadName, lws, podSets, r.labelKeysToCopy, r.annotationsToCopy)
 
 	if createdWorkload.Labels == nil {
 		createdWorkload.Labels = make(map[string]string, 1)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,7 +72,7 @@ func TestReconciler(t *testing.T) {
 
 	cases := map[string]struct {
 		featureGates            map[featuregate.Feature]bool
-		labelKeysToCopy         []string
+		labelKeysToCopy         sets.Set[string]
 		leaderWorkerSet         *leaderworkersetv1.LeaderWorkerSet
 		statefulSets            []appsv1.StatefulSet
 		workloads               []kueue.Workload

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/klog/v2"
@@ -84,11 +85,12 @@ const (
 )
 
 var (
-	gvk                          = corev1.SchemeGroupVersion.WithKind("Pod")
-	errIncorrectReconcileRequest = errors.New("event handler error: got a single pod reconcile request for a pod group")
-	errPendingOps                = jobframework.UnretryableError("waiting to observe previous operations on pods")
-	errPodGroupLabelsMismatch    = errors.New("constructing workload: pods have different label values")
-	realClock                    = clock.RealClock{}
+	gvk                            = corev1.SchemeGroupVersion.WithKind("Pod")
+	errIncorrectReconcileRequest   = errors.New("event handler error: got a single pod reconcile request for a pod group")
+	errPendingOps                  = jobframework.UnretryableError("waiting to observe previous operations on pods")
+	errPodGroupLabelsMismatch      = errors.New("constructing workload: pods have different label values")
+	errPodGroupAnnotationsMismatch = errors.New("constructing workload: pods have different annotation values")
+	realClock                      = clock.RealClock{}
 )
 
 func init() {
@@ -1076,32 +1078,36 @@ func (p *Pod) EnsureWorkloadOwnedByAllMembers(ctx context.Context, c client.Clie
 	return nil
 }
 
-func (p *Pod) getWorkloadLabels(labelKeysToCopy []string) (map[string]string, error) {
-	if len(labelKeysToCopy) == 0 {
+func (p *Pod) getByKey(
+	keysToCopy []string,
+	extractValueMap func(*corev1.Pod) map[string]string,
+	mismatchErr error,
+) (map[string]string, error) {
+	if len(keysToCopy) == 0 {
 		return nil, nil
 	}
 	if !p.isGroup {
-		return utilmaps.FilterKeys(p.Object().GetLabels(), labelKeysToCopy), nil
+		return utilmaps.FilterKeys(extractValueMap(&p.pod), keysToCopy), nil
 	}
-	workloadLabels := make(map[string]string, len(labelKeysToCopy))
+	workloadMap := make(map[string]string, len(keysToCopy))
 	for _, pod := range p.list.Items {
-		for _, labelKey := range labelKeysToCopy {
-			labelValuePod, foundInPod := pod.Labels[labelKey]
-			labelValueWorkload, foundInWorkload := workloadLabels[labelKey]
-			if foundInPod && foundInWorkload && (labelValuePod != labelValueWorkload) {
-				return nil, errPodGroupLabelsMismatch
+		for _, key := range keysToCopy {
+			valuePod, foundInPod := extractValueMap(&pod)[key]
+			valueWorkload, foundInWorkload := workloadMap[key]
+			if foundInPod && foundInWorkload && (valuePod != valueWorkload) {
+				return nil, mismatchErr
 			}
 			if foundInPod {
-				workloadLabels[labelKey] = labelValuePod
+				workloadMap[key] = valuePod
 			}
 		}
 	}
-	return workloadLabels, nil
+	return workloadMap, nil
 }
 
-func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, r events.EventRecorder, labelKeysToCopy []string) (*kueue.Workload, error) {
+func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, r events.EventRecorder, labelKeysToCopy, annotationsToCopy sets.Set[string]) (*kueue.Workload, error) {
 	if !p.isGroup {
-		return jobframework.ConstructWorkload(ctx, c, p, labelKeysToCopy)
+		return jobframework.ConstructWorkload(ctx, c, p, labelKeysToCopy, annotationsToCopy)
 	}
 
 	activePods, inactivePods := p.partitionPods()
@@ -1141,18 +1147,35 @@ func (p *Pod) ConstructComposableWorkload(ctx context.Context, c client.Client, 
 		return nil, jobframework.UnretryableError(errMsgIncorrectGroupRoleCount)
 	}
 
-	wl := NewGroupWorkload(p.workloadName(), p.Object(), podSets, nil)
+	wl := NewGroupWorkload(p.workloadName(), p.Object(), podSets, nil, nil)
 
 	for _, pod := range p.list.Items {
 		if err := controllerutil.SetOwnerReference(&pod, wl, c.Scheme()); err != nil {
 			return nil, err
 		}
 	}
-	labelsToCopy, err := p.getWorkloadLabels(labelKeysToCopy)
+
+	labelsToCopy, err := p.getByKey(
+		labelKeysToCopy.UnsortedList(),
+		func(pod *corev1.Pod) map[string]string { return pod.Labels },
+		errPodGroupLabelsMismatch,
+	)
 	if err != nil {
 		return nil, err
 	}
 	utilmaps.Copy(&wl.Labels, labelsToCopy)
+
+	if features.Enabled(features.CustomMetricLabels) {
+		annotationsToCopyList, err := p.getByKey(
+			annotationsToCopy.UnsortedList(),
+			func(pod *corev1.Pod) map[string]string { return pod.Annotations },
+			errPodGroupAnnotationsMismatch,
+		)
+		if err != nil {
+			return nil, err
+		}
+		utilmaps.Copy(&wl.Annotations, annotationsToCopyList)
+	}
 	return wl, nil
 }
 
@@ -1468,8 +1491,8 @@ func GetWorkloadNameForPod(podName string, podUID types.UID) string {
 	return jobframework.GetWorkloadNameForOwnerWithGVK(podName, podUID, gvk)
 }
 
-func NewGroupWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKeysToCopy []string) *kueue.Workload {
-	wl := jobframework.NewWorkload(name, obj, podSets, labelKeysToCopy)
+func NewGroupWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKeysToCopy, annotationsToCopy sets.Set[string]) *kueue.Workload {
+	wl := jobframework.NewWorkload(name, obj, podSets, labelKeysToCopy, annotationsToCopy)
 	wl.Annotations[podconstants.IsGroupWorkloadAnnotationKey] = podconstants.IsGroupWorkloadAnnotationValue
 
 	if features.Enabled(features.AdmissionGatedBy) {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
@@ -208,7 +209,7 @@ func TestConstructComposableWorkloadPodGroupRoleLimit(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			kClient := utiltesting.NewClientBuilder().Build()
 
-			wl, gotErr := makePodGroup(tc.roleCount).ConstructComposableWorkload(ctx, kClient, nil, nil)
+			wl, gotErr := makePodGroup(tc.roleCount).ConstructComposableWorkload(ctx, kClient, nil, nil, nil)
 
 			if tc.wantErr == "" && gotErr != nil {
 				t.Fatalf("unexpected error: %v", gotErr)
@@ -4631,7 +4632,7 @@ func TestReconciler(t *testing.T) {
 				Obj()},
 			wantPods: nil,
 			reconcilerOptions: []jobframework.Option{
-				jobframework.WithLabelKeysToCopy([]string{"toCopyKey", "keyAbsentInThePod"}),
+				jobframework.WithLabelKeysToCopy(sets.New("toCopyKey", "keyAbsentInThePod")),
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload(GetWorkloadNameForPod(basePodWrapper.GetName(), basePodWrapper.GetUID()), "ns").Finalizers(kueue.ResourceInUseFinalizerName).
@@ -4691,7 +4692,7 @@ func TestReconciler(t *testing.T) {
 			},
 			wantPods: nil,
 			reconcilerOptions: []jobframework.Option{
-				jobframework.WithLabelKeysToCopy([]string{"toCopyKey1", "toCopyKey2"}),
+				jobframework.WithLabelKeysToCopy(sets.New("toCopyKey1", "toCopyKey2")),
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
@@ -4782,11 +4783,283 @@ func TestReconciler(t *testing.T) {
 			},
 			wantPods: nil,
 			reconcilerOptions: []jobframework.Option{
-				jobframework.WithLabelKeysToCopy([]string{"toCopyKey1", "toCopyKey2"}),
+				jobframework.WithLabelKeysToCopy(sets.New("toCopyKey1", "toCopyKey2")),
 			},
 			wantWorkloads:   nil,
 			workloadCmpOpts: defaultWorkloadCmpOpts,
 			wantErr:         errPodGroupLabelsMismatch,
+		},
+		"workload is created with correct annotations for a single pod": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.CustomMetricLabels:            true,
+			},
+			pods: []corev1.Pod{*basePodWrapper.
+				Clone().
+				ManagedByKueueLabel().
+				Annotation("toCopyAnn", "toCopyValue").
+				Annotation("dontCopyAnn", "dontCopyValue").
+				KueueFinalizer().
+				KueueSchedulingGate().
+				Queue(localTestQueueName).
+				Obj()},
+			wantPods: nil,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithAnnotationsToCopy(sets.New("toCopyAnn", "keyAbsentInThePod")),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadNameForPod(basePodWrapper.GetName(), basePodWrapper.GetUID()), "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							Obj(),
+					).
+					Queue(localTestQueueName).
+					Priority(0).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					Label(controllerconsts.JobUIDLabel, "test-uid").
+					Annotations(map[string]string{
+						"toCopyAnn": "toCopyValue",
+					}).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/" + GetWorkloadNameForPod(basePodWrapper.GetName(), basePodWrapper.GetUID()),
+				},
+			},
+		},
+		"workload is created with correct annotations for pod group": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.CustomMetricLabels:            true,
+			},
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupIndex("0").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("toCopyAnn2", "toCopyValue2").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupIndex("1").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: nil,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithAnnotationsToCopy(sets.New("toCopyAnn1", "toCopyAnn2")),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							Obj(),
+					).
+					Queue(localUserQueueName).
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{
+						podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+						"toCopyAnn1": "toCopyValue1",
+						"toCopyAnn2": "toCopyValue2",
+					}).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/test-group",
+				},
+			},
+		},
+		"workload is created without annotations for pod group when CustomMetricLabels is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.CustomMetricLabels:            false,
+			},
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupIndex("0").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("toCopyAnn2", "toCopyValue2").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupIndex("1").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: nil,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithAnnotationsToCopy(sets.New("toCopyAnn1", "toCopyAnn2")),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							Obj(),
+					).
+					Queue(localUserQueueName).
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{
+						podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+					}).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/test-group",
+				},
+			},
+		},
+		"reconciler returns error in case of annotation mismatch in pod group": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.CustomMetricLabels:            true,
+			},
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "otherValue").
+					Annotation("toCopyAnn2", "toCopyValue2").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: nil,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithAnnotationsToCopy(sets.New("toCopyAnn1", "toCopyAnn2")),
+			},
+			wantWorkloads:   nil,
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantErr:         errPodGroupAnnotationsMismatch,
+		},
+		"annotations mismatch is ignored for pod group when CustomMetricLabels is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.CustomMetricLabels:            false,
+			},
+			pods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "toCopyValue1").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					Annotation("toCopyAnn1", "otherValue").
+					Annotation("toCopyAnn2", "toCopyValue2").
+					Annotation("dontCopyAnn", "dontCopyValue").
+					KueueFinalizer().
+					KueueSchedulingGate().
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Obj(),
+			},
+			wantPods: nil,
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithAnnotationsToCopy(sets.New("toCopyAnn1", "toCopyAnn2")),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("test-group", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
+							Request(corev1.ResourceCPU, "1").
+							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							Obj(),
+					).
+					Queue(localUserQueueName).
+					Priority(0).
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
+					Annotations(map[string]string{
+						podconstants.IsGroupWorkloadAnnotationKey: podconstants.IsGroupWorkloadAnnotationValue,
+					}).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/test-group",
+				},
+			},
 		},
 		"admission check message is recorded as event for a single pod": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -355,7 +355,7 @@ func (r *Reconciler) constructWorkload(sts *appsv1.StatefulSet) (*kueue.Workload
 		podSet.TopologyRequest = topologyRequest
 	}
 
-	wl := podcontroller.NewGroupWorkload(GetWorkloadName(GetOwnerUID(sts), sts.Name), sts, []kueue.PodSet{podSet}, nil)
+	wl := podcontroller.NewGroupWorkload(GetWorkloadName(GetOwnerUID(sts), sts.Name), sts, []kueue.PodSet{podSet}, nil, nil)
 
 	if wl.Labels == nil {
 		wl.Labels = make(map[string]string, 1)

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -232,7 +232,7 @@ func (t *TrainJob) PodSets(ctx context.Context, c client.Client) ([]kueue.PodSet
 	// Run a dry-run patch of a throwaway workload to set the podset defaults
 	// Podsets must be defaulted because Kueue later uses them to match workloads.
 	// Workloads coming from the API server are already defaulted, so without defaulting these podsets, matching would fail.
-	wl := jobframework.NewWorkload(t.Name, t.Object(), podsets, []string{})
+	wl := jobframework.NewWorkload(t.Name, t.Object(), podsets, nil, nil)
 	if err := c.Create(ctx, wl, &client.CreateOptions{DryRun: []string{metav1.DryRunAll}}); err != nil {
 		return nil, err
 	}

--- a/pkg/metrics/custom_labels.go
+++ b/pkg/metrics/custom_labels.go
@@ -41,6 +41,24 @@ type SourceKindLabelStore struct {
 	values     *utilmaps.SyncMap[string, []string]
 }
 
+func WorkloadCustomLabelSources(entries []configapi.ControllerMetricsCustomLabel) (labels, annotations sets.Set[string]) {
+	labels, annotations = sets.New[string](), sets.New[string]()
+	for _, entry := range entries {
+		if ptr.Deref(entry.SourceKind, configapi.DefaultCustomMetricLabelSourceKind) != configapi.SourceKindWorkload {
+			continue
+		}
+		switch {
+		case entry.SourceAnnotationKey != "":
+			annotations.Insert(entry.SourceAnnotationKey)
+		case entry.SourceLabelKey != "":
+			labels.Insert(entry.SourceLabelKey)
+		default:
+			labels.Insert(entry.Name)
+		}
+	}
+	return
+}
+
 func NewCustomLabels(entries []configapi.ControllerMetricsCustomLabel) *CustomLabels {
 	if !features.Enabled(features.CustomMetricLabels) || len(entries) == 0 {
 		return nil

--- a/test/e2e/singlecluster/baseline/pod_test.go
+++ b/test/e2e/singlecluster/baseline/pod_test.go
@@ -18,24 +18,29 @@ package baseline
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	podtesting "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -625,6 +630,155 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				gKey := client.ObjectKey{Namespace: ns.Name, Name: "test-group"}
 				util.ExpectWorkloadsFinalizedOrGone(ctx, k8sClient, gKey)
 			})
+		})
+	})
+
+	ginkgo.When("Custom metric labels enabled", ginkgo.Ordered, func() {
+		var (
+			defaultKueueCfg  *config.Configuration
+			kindClusterName  = os.Getenv("KIND_CLUSTER_NAME")
+			cq               *kueue.ClusterQueue
+			lq               *kueue.LocalQueue
+			clusterQueueName string
+		)
+
+		ginkgo.BeforeAll(func() {
+			defaultKueueCfg = util.GetKueueConfiguration(ctx, k8sClient)
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				cfg.FeatureGates = map[string]bool{
+					string(features.CustomMetricLabels): true,
+				}
+				cfg.Integrations.LabelKeysToCopy = []string{"toCopyKeyIntegration"}
+				cfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
+					{
+						Name:           "custom_label_key",
+						SourceLabelKey: "toCopyKeyCustom",
+						SourceKind:     ptr.To(config.SourceKindWorkload),
+						TrackedValues:  []string{"custom_value"},
+					},
+					{
+						Name:                "custom_annotation_key",
+						SourceAnnotationKey: "toCopyAnnotation",
+						SourceKind:          ptr.To(config.SourceKindWorkload),
+						TrackedValues:       []string{"annotation_value"},
+					},
+				}
+			})
+		})
+
+		ginkgo.AfterAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName)
+		})
+
+		ginkgo.BeforeEach(func() {
+			clusterQueueName = "cq-" + ns.Name
+			cq = utiltestingapi.MakeClusterQueue(clusterQueueName).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).Resource(corev1.ResourceCPU, "5").Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllPodsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		})
+
+		ginkgo.It("should successfully copy labels and annotations for a single pod", func() {
+			testPod := podtesting.MakePod("test-pod", ns.Name).
+				Queue(lq.Name).
+				Label("toCopyKeyIntegration", "integration_value").
+				Label("toCopyKeyCustom", "custom_value").
+				Label("dontCopyKey", "ignored").
+				Annotation("toCopyAnnotation", "annotation_value").
+				Annotation("dontCopyAnnotation", "ignored").
+				Obj()
+			util.MustCreate(ctx, k8sClient, testPod)
+
+			wlLookupKey := types.NamespacedName{
+				Namespace: ns.Name,
+				Name:      pod.GetWorkloadNameForPod(testPod.Name, testPod.UID),
+			}
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Expect(createdWorkload.Labels["toCopyKeyIntegration"]).Should(gomega.Equal("integration_value"))
+			gomega.Expect(createdWorkload.Labels["toCopyKeyCustom"]).Should(gomega.Equal("custom_value"))
+			gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("dontCopyKey"))
+			gomega.Expect(createdWorkload.Annotations).Should(gomega.HaveKeyWithValue("toCopyAnnotation", "annotation_value"))
+			gomega.Expect(createdWorkload.Annotations).ShouldNot(gomega.HaveKey("dontCopyAnnotation"))
+		})
+
+		ginkgo.It("should successfully copy labels and annotations for a pod group", func() {
+			pod1 := podtesting.MakePod("test-pod1", ns.Name).
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Label("dontCopyKey", "dontCopyValue").
+				Annotation("toCopyAnnotation", "annotation_value").
+				Annotation("dontCopyAnnotation", "ignored1").
+				Obj()
+			pod2 := podtesting.MakePod("test-pod2", ns.Name).
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Label("toCopyKeyIntegration", "integration_value").
+				Label("toCopyKeyCustom", "custom_value").
+				Label("dontCopyKey", "dontCopyAnotherValue").
+				Annotation("toCopyAnnotation", "annotation_value").
+				Annotation("dontCopyAnnotation", "ignored2").
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, pod1)
+			util.MustCreate(ctx, k8sClient, pod2)
+
+			wlLookupKey := types.NamespacedName{
+				Namespace: ns.Name,
+				Name:      "test-group",
+			}
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Expect(createdWorkload.Labels["toCopyKeyIntegration"]).Should(gomega.Equal("integration_value"))
+			gomega.Expect(createdWorkload.Labels["toCopyKeyCustom"]).Should(gomega.Equal("custom_value"))
+			gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("dontCopyKey"))
+			gomega.Expect(createdWorkload.Annotations).Should(gomega.HaveKeyWithValue("toCopyAnnotation", "annotation_value"))
+			gomega.Expect(createdWorkload.Annotations).ShouldNot(gomega.HaveKey("dontCopyAnnotation"))
+		})
+
+		ginkgo.It("should not create workload for a pod group if there is a custom annotation mismatch", func() {
+			pod1 := podtesting.MakePod("test-pod1", ns.Name).
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Annotation("toCopyAnnotation", "annotation_value").
+				Obj()
+			pod2 := podtesting.MakePod("test-pod2", ns.Name).
+				GroupNameLabel("test-group").
+				GroupTotalCount("2").
+				Queue(lq.Name).
+				Annotation("toCopyAnnotation", "mismatch_value").
+				Obj()
+
+			util.MustCreate(ctx, k8sClient, pod1)
+			util.MustCreate(ctx, k8sClient, pod2)
+
+			wlLookupKey := types.NamespacedName{
+				Namespace: ns.Name,
+				Name:      "test-group",
+			}
+			createdWorkload := &kueue.Workload{}
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Satisfy(apierrors.IsNotFound))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -80,7 +81,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		fwk.StartManager(ctx, cfg, managerSetup(
 			jobframework.WithManageJobsWithoutQueueName(true),
 			jobframework.WithManagedJobsNamespaceSelector(util.NewNamespaceSelectorExcluding("unmanaged-ns")),
-			jobframework.WithLabelKeysToCopy([]string{"toCopyKey"}),
+			jobframework.WithLabelKeysToCopy(sets.New("toCopyKey")),
 		))
 		unmanagedNamespace := utiltesting.MakeNamespace("unmanaged-ns")
 		util.MustCreate(ctx, k8sClient, unmanagedNamespace)
@@ -146,7 +147,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		})
 
 		gomega.Expect(createdWorkload.Labels["toCopyKey"]).Should(gomega.Equal("toCopyValue"))
-		gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.ContainElement("doNotCopyValue"))
+		gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("doNotCopyValue"))
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
 		var jobQueueName kueue.LocalQueueName = "test-queue"
@@ -5451,5 +5452,72 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 				g.Expect(createdWorkloads.Items).To(gomega.HaveLen(1))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+	})
+})
+
+var _ = ginkgo.Describe("Job controller with CustomMetricLabels", ginkgo.Label("job:batch", "area:jobs"), func() {
+	var (
+		ns *corev1.Namespace
+	)
+
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
+		configuration := &configapi.Configuration{
+			ControllerManager: configapi.ControllerManager{
+				Metrics: configapi.ControllerMetrics{
+					CustomLabels: []configapi.ControllerMetricsCustomLabel{
+						{
+							Name:           "custom_label_key",
+							SourceLabelKey: "job-label",
+							SourceKind:     ptr.To(configapi.SourceKindWorkload),
+							TrackedValues:  []string{"label-value"},
+						},
+						{
+							Name:                "custom_annotation_key",
+							SourceAnnotationKey: "job-annotation",
+							SourceKind:          ptr.To(configapi.SourceKindWorkload),
+							TrackedValues:       []string{"annotation-value"},
+						},
+					},
+				},
+			},
+		}
+
+		labelKeysToCopy, annotationsToCopy := metrics.WorkloadCustomLabelSources(configuration.Metrics.CustomLabels)
+		fwk.StartManager(ctx, cfg, managerAndControllersSetup(false, false, configuration,
+			jobframework.WithLabelKeysToCopy(labelKeysToCopy),
+			jobframework.WithAnnotationsToCopy(annotationsToCopy),
+		))
+
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "custom-metric-labels-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("should create workloads with copied labels and annotations based on CustomMetricLabels configuration", func() {
+		ginkgo.By("creating a job with configured labels and annotations")
+		job := testingjob.MakeJob("test-job-custom-labels", ns.Name).
+			Queue("foo").
+			Label("job-label", "label-value").
+			Label("dont-copy-label", "ignored").
+			SetAnnotation("job-annotation", "annotation-value").
+			SetAnnotation("dont-copy-annotation", "ignored").
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
+
+		ginkgo.By("verifying the workload is created with the copied label and annotation")
+		wl := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, wl)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Expect(wl.Labels).Should(gomega.HaveKeyWithValue("job-label", "label-value"))
+		gomega.Expect(wl.Labels).ShouldNot(gomega.HaveKey("dont-copy-label"))
+		gomega.Expect(wl.Annotations).Should(gomega.HaveKeyWithValue("job-annotation", "annotation-value"))
+		gomega.Expect(wl.Annotations).ShouldNot(gomega.HaveKey("dont-copy-annotation"))
 	})
 })

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -27,9 +28,11 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -91,7 +94,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				jobframework.WithManageJobsWithoutQueueName(false),
 				jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
 				jobframework.WithKubeServerVersion(serverVersionFetcher),
-				jobframework.WithLabelKeysToCopy([]string{"toCopyKey"}),
+				jobframework.WithLabelKeysToCopy(sets.New("toCopyKey")),
 				jobframework.WithEnabledFrameworks([]string{"pod"}),
 			))
 			util.MustCreate(ctx, k8sClient, defaultFlavor)
@@ -849,7 +852,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 					))
 					ginkgo.By("Checking the workload gets assigned the correct labels.")
 					gomega.Expect(createdWorkload.Labels["toCopyKey"]).Should(gomega.Equal("toCopyValue"))
-					gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.ContainElement("doNotCopyValue"))
+					gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("doNotCopyValue"))
 				})
 
 				ginkgo.By("checking that pod group is finalized when all pods in the group succeed", func() {
@@ -3351,3 +3354,218 @@ var _ = ginkgo.Describe("Pod controller with deployment-owned pods and waitForPo
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })
+
+var _ = ginkgo.Describe("Pod controller with CustomMetricLabels", ginkgo.Ordered, func() {
+	var (
+		ns            *corev1.Namespace
+		fl            *kueue.ResourceFlavor
+		cq            *kueue.ClusterQueue
+		lq            *kueue.LocalQueue
+		defaultFlavor = utiltestingapi.MakeResourceFlavor("default").NodeLabel(corev1.LabelArchStable, "arm64").Obj()
+		clusterQueue  = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "1").Obj(),
+			).Obj()
+	)
+
+	ginkgo.BeforeAll(func() {
+		features.SetFeatureGateDuringTest(staticNameTB{TB: ginkgo.GinkgoTB(), name: "pod-custom-metric-labels"}, features.CustomMetricLabels, true)
+		fwk.StartManager(ctx, cfg, managerSetup(
+			false,
+			false,
+			nil,
+			jobframework.WithManageJobsWithoutQueueName(false),
+			jobframework.WithLabelKeysToCopy(sets.New("toCopyKey")),
+			jobframework.WithAnnotationsToCopy(sets.New("toCopyAnnotation")),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+		util.MustCreate(ctx, k8sClient, defaultFlavor)
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+	})
+
+	ginkgo.AfterAll(func() {
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-custom-")
+
+		fl = utiltestingapi.MakeResourceFlavor("fl").Obj()
+		util.MustCreate(ctx, k8sClient, fl)
+
+		cq = utiltestingapi.MakeClusterQueue("cq").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(fl.Name).
+				Resource(corev1.ResourceCPU, "9").
+				Resource(corev1.ResourceMemory, "36").
+				Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, fl, true)
+	})
+
+	ginkgo.It("Should copy labels and annotations for a single pod", func() {
+		pod := testingpod.MakePod("test-pod", ns.Name).
+			Queue(lq.Name).
+			Label("toCopyKey", "toCopyValue").
+			Label("dontCopyKey", "ignored").
+			Annotation("toCopyAnnotation", "toCopyValue").
+			Annotation("dontCopyAnnotation", "ignored").
+			Obj()
+		util.MustCreate(ctx, k8sClient, pod)
+
+		wlLookupKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      podcontroller.GetWorkloadNameForPod(pod.Name, pod.UID),
+		}
+		createdWorkload := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Expect(createdWorkload.Labels["toCopyKey"]).Should(gomega.Equal("toCopyValue"))
+		gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("dontCopyKey"))
+		gomega.Expect(createdWorkload.Annotations).Should(gomega.HaveKeyWithValue("toCopyAnnotation", "toCopyValue"))
+		gomega.Expect(createdWorkload.Annotations).ShouldNot(gomega.HaveKey("dontCopyAnnotation"))
+	})
+
+	ginkgo.It("Should copy labels and annotations for a pod group", func() {
+		pod1 := testingpod.MakePod("test-pod1", ns.Name).
+			GroupNameLabel("test-group").
+			GroupTotalCount("2").
+			Queue(lq.Name).
+			Label("dontCopyKey", "dontCopyValue").
+			Annotation("toCopyAnnotation", "toCopyValue").
+			Annotation("dontCopyAnnotation", "ignored1").
+			Obj()
+		pod2 := testingpod.MakePod("test-pod2", ns.Name).
+			GroupNameLabel("test-group").
+			GroupTotalCount("2").
+			Queue(lq.Name).
+			Label("toCopyKey", "toCopyValue").
+			Label("dontCopyKey", "dontCopyAnotherValue").
+			Annotation("toCopyAnnotation", "toCopyValue").
+			Annotation("dontCopyAnnotation", "ignored2").
+			Obj()
+
+		util.MustCreate(ctx, k8sClient, pod1)
+		util.MustCreate(ctx, k8sClient, pod2)
+
+		wlLookupKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      "test-group",
+		}
+		createdWorkload := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Expect(createdWorkload.Labels["toCopyKey"]).Should(gomega.Equal("toCopyValue"))
+		gomega.Expect(createdWorkload.Labels).ShouldNot(gomega.HaveKey("doNotCopyValue"))
+		gomega.Expect(createdWorkload.Annotations).Should(gomega.HaveKeyWithValue("toCopyAnnotation", "toCopyValue"))
+		gomega.Expect(createdWorkload.Annotations).ShouldNot(gomega.HaveKey("dontCopyAnnotation"))
+	})
+
+	ginkgo.It("Should not create workload for a pod group if there is an annotation mismatch", func() {
+		pod1 := testingpod.MakePod("test-pod1", ns.Name).
+			GroupNameLabel("test-group").
+			GroupTotalCount("2").
+			Queue(lq.Name).
+			Annotation("toCopyAnnotation", "value1").
+			Obj()
+		pod2 := testingpod.MakePod("test-pod2", ns.Name).
+			GroupNameLabel("test-group").
+			GroupTotalCount("2").
+			Queue(lq.Name).
+			Annotation("toCopyAnnotation", "value2").
+			Obj()
+
+		util.MustCreate(ctx, k8sClient, pod1)
+		util.MustCreate(ctx, k8sClient, pod2)
+
+		wlLookupKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      "test-group",
+		}
+		createdWorkload := &kueue.Workload{}
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Satisfy(apierrors.IsNotFound))
+		}, 3*time.Second, util.Interval).Should(gomega.Succeed())
+	})
+})
+
+var _ = ginkgo.Describe("Pod controller with CustomMetricLabels disabled", ginkgo.Ordered, func() {
+	var (
+		ns            *corev1.Namespace
+		defaultFlavor = utiltestingapi.MakeResourceFlavor("default").NodeLabel(corev1.LabelArchStable, "arm64").Obj()
+		clusterQueue  = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "1").Obj(),
+			).Obj()
+	)
+
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(staticNameTB{TB: ginkgo.GinkgoTB(), name: "pod-custom-metric-labels-disabled"}, features.CustomMetricLabels, false)
+		fwk.StartManager(ctx, cfg, managerSetup(
+			false,
+			false,
+			nil,
+			jobframework.WithManageJobsWithoutQueueName(false),
+			jobframework.WithLabelKeysToCopy(sets.New("toCopyKey")),
+			jobframework.WithAnnotationsToCopy(sets.New("toCopyAnnotation")),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+		util.MustCreate(ctx, k8sClient, defaultFlavor)
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "pod-custom-disabled-")
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultFlavor, true)
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("Should not copy annotations when the feature gate is disabled", func() {
+		lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, lq)
+
+		pod := testingpod.MakePod("test-pod", ns.Name).
+			Queue(lq.Name).
+			Label("toCopyKey", "toCopyValue").
+			Annotation("toCopyAnnotation", "toCopyValue").
+			Obj()
+		util.MustCreate(ctx, k8sClient, pod)
+
+		wlLookupKey := types.NamespacedName{
+			Namespace: ns.Name,
+			Name:      podcontroller.GetWorkloadNameForPod(pod.Name, pod.UID),
+		}
+		createdWorkload := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		gomega.Expect(createdWorkload.Labels["toCopyKey"]).Should(gomega.Equal("toCopyValue"))
+		gomega.Expect(createdWorkload.Annotations).ShouldNot(gomega.HaveKey("toCopyAnnotation"))
+	})
+})
+
+type staticNameTB struct {
+	testing.TB
+	name string
+}
+
+func (tb staticNameTB) Name() string {
+	return tb.name
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Ensures labels and annotations serving as sources for custom label values on workloads are copied form corresponding jobs.
Completes alpha implementetion of KEP-7066 as of the date of this PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Progresses https://github.com/kubernetes-sigs/kueue/issues/12629

#### Special notes for your reviewer:
Built on top of https://github.com/kubernetes-sigs/kueue/pull/12713
AI used for test creation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: When enabling custom metric labels, workloads will automatically copy appropriate labels
and annotations from underlying jobs. PodSets must match annotation and label values defined as custom
metric label value sources across component Pods if feature enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for copying configured workload annotations alongside labels.
  * Custom metric annotations are copied when enabled, including for pod groups.
  * Pod groups with inconsistent configured annotation values are rejected to prevent ambiguous workloads.

* **Bug Fixes**
  * Preserved existing label-copying behavior while improving metadata handling across workload types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->