### PR TITLE
Optimize calculation of remaining resources

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -106,9 +106,9 @@ type leafDomain struct {
 	tasUsage resources.Requests
 
 	// cachedRemainingCapacity stores the pre-computed remaining capacity (freeCapacity - tasUsage) for this leaf.
-	// It is lazily calculated and invalidated (set to nil) when tasUsage or freeCapacity for this specific leaf
-	// domain changes. This avoids repeated map cloning and resource subtraction during capacity checks (e.g. preemption).
-	cachedRemainingCapacity resources.Requests
+	// It is lazily calculated using LazyRequests and updated incrementally during TAS usage changes, avoiding repeated
+	// map cloning and resource subtraction during capacity checks (e.g. preemption).
+	cachedRemainingCapacity resources.LazyRequests
 
 	// node at the leaf, if the lowest level is a node
 	node *corev1.Node
@@ -314,7 +314,7 @@ func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capac
 		s.leaves[domainID].freeCapacity = resources.Requests{}
 	}
 	s.leaves[domainID].freeCapacity.Add(capacity)
-	s.leaves[domainID].cachedRemainingCapacity = nil
+	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -322,7 +322,7 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
 	s.leaves[domainID].freeCapacity.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = nil
+	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
@@ -336,11 +336,13 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
-	if leaf.cachedRemainingCapacity == nil {
-		leaf.cachedRemainingCapacity = leaf.freeCapacity.Clone()
-		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
+	if !leaf.cachedRemainingCapacity.IsValid() {
+		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
+		if len(leaf.tasUsage) > 0 {
+			leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
+		}
 	}
-	return leaf.cachedRemainingCapacity
+	return leaf.cachedRemainingCapacity.Get()
 }
 
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -355,7 +357,7 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.leaves[domainID].tasUsage = resources.Requests{}
 	}
 	s.leaves[domainID].tasUsage.Add(usage)
-	s.leaves[domainID].cachedRemainingCapacity = nil
+	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -370,7 +372,7 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.leaves[domainID].tasUsage = resources.Requests{}
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = nil
+	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.Requests {
@@ -495,13 +497,7 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 		if !found {
 			return false
 		}
-		var remainingCapacity resources.LazyRequests
-		if cachingEnabled {
-			remainingCapacity = resources.NewLazyRequests(s.getRemainingCapacity(leaf))
-		} else {
-			remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-			remainingCapacity.Sub(leaf.tasUsage)
-		}
+		remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
 		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
 			return false
 		}
@@ -1884,6 +1880,20 @@ func (s *TASFlavorSnapshot) matchNode(leaf *leafDomain, requirements *topologyAs
 	return false, affinityScore, nil, exclusionNone
 }
 
+func (s *TASFlavorSnapshot) remainingCapacityForLeaf(leaf *leafDomain, simulateEmpty, cachingRemainingResourcesEnabled bool) resources.LazyRequests {
+	if cachingRemainingResourcesEnabled {
+		if simulateEmpty {
+			return resources.NewLazyRequests(leaf.freeCapacity)
+		}
+		return resources.NewLazyRequests(s.getRemainingCapacity(leaf))
+	}
+	remainingCapacity := resources.NewLazyRequests(leaf.freeCapacity)
+	if !simulateEmpty {
+		remainingCapacity.Sub(leaf.tasUsage)
+	}
+	return remainingCapacity
+}
+
 func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState, cachingRemainingResourcesEnabled bool) {
 	// While correcting the topologyAssignment with a failed node
 	// check if the leaf belongs to the required domain
@@ -1891,25 +1901,11 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		state.stats.TopologyDomain++
 		return
 	}
-
-	var remainingCapacity resources.LazyRequests
-	if cachingRemainingResourcesEnabled {
-		if requirements.simulateEmpty {
-			remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		} else {
-			remainingCapacity = resources.NewLazyRequests(s.getRemainingCapacity(leaf))
-		}
-	} else {
-		remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		if !requirements.simulateEmpty {
-			remainingCapacity.Sub(leaf.tasUsage)
-		}
-	}
+	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.simulateEmpty, cachingRemainingResourcesEnabled)
 
 	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
 		remainingCapacity.Sub(leafAssumedUsage)
 	}
-
 	var limitingRes corev1.ResourceName
 	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -498,6 +498,7 @@ type FlavorTASRequests []TASPodSetRequests
 
 // Fits checks if the snapshot has enough capacity to accommodate the workload
 func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
+	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for _, domainUsage := range flavorUsage {
 		domainID := utiltas.DomainID(domainUsage.Values)
 		leaf, found := s.leaves[domainID]
@@ -505,7 +506,7 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 			return false
 		}
 		var remainingCapacity resources.Requests
-		if features.Enabled(features.TASCachingRemainingResources) {
+		if cachingEnabled {
 			remainingCapacity = s.getRemainingCapacity(leaf)
 		} else {
 			remainingCapacity = leaf.freeCapacity.Clone()
@@ -828,8 +829,9 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 }
 
 func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for domainID, usage := range usagePerDomain {
-		if features.Enabled(features.TASCachingRemainingResources) && assumedUsage[domainID] == nil {
+		if cachingEnabled && assumedUsage[domainID] == nil {
 			assumedUsage[domainID] = usage
 		} else {
 			if assumedUsage[domainID] == nil {
@@ -1794,13 +1796,13 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 		domain.leaderState = 0
 		domain.affinityScore = 0
 	}
-
+	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
 	if features.Enabled(features.TASCacheNodeMatchResults) {
 		matchingLeaves, stats := s.getMatchingLeaves(requirements)
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
 			ml.leaf.affinityScore += ml.affinityScore
-			s.fillLeafCounts(ml.leaf, requirements, state)
+			s.fillLeafCounts(ml.leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
 		for _, leaf := range s.leaves {
@@ -1814,7 +1816,7 @@ func (s *TASFlavorSnapshot) fillInCounts(requirements *topologyAssignmentPodRequ
 				}
 				leaf.affinityScore += affinityScore
 			}
-			s.fillLeafCounts(leaf, requirements, state)
+			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	}
 
@@ -1897,7 +1899,7 @@ func (s *TASFlavorSnapshot) matchNode(leaf *leafDomain, requirements *topologyAs
 	return false, affinityScore, nil, exclusionNone
 }
 
-func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) {
+func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState, cachingRemainingResourcesEnabled bool) {
 	// While correcting the topologyAssignment with a failed node
 	// check if the leaf belongs to the required domain
 	if !belongsToRequiredDomain(leaf, requirements.requiredReplacementDomain) {
@@ -1906,7 +1908,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	}
 
 	var remainingCapacity resources.Requests
-	if features.Enabled(features.TASCachingRemainingResources) {
+	if cachingRemainingResourcesEnabled {
 		leafAssumedUsage, hasAssumedUsage := requirements.assumedUsage[leaf.id]
 		hasLeaderRequests := requirements.leaderRequests != nil
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -326,22 +326,12 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
-	if features.Enabled(features.TASCachingRemainingResources) {
-		if op == add {
-			s.addTASUsage(domainID, usage)
-			s.addTASUsage(domainID, resources.Requests{corev1.ResourcePods: int64(count)})
-		} else {
-			s.removeTASUsage(domainID, usage)
-			s.removeTASUsage(domainID, resources.Requests{corev1.ResourcePods: int64(count)})
-		}
+	u := usage.Clone()
+	u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
+	if op == add {
+		s.addTASUsage(domainID, u)
 	} else {
-		u := usage.Clone()
-		u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
-		if op == add {
-			s.addTASUsage(domainID, u)
-		} else {
-			s.removeTASUsage(domainID, u)
-		}
+		s.removeTASUsage(domainID, u)
 	}
 }
 
@@ -505,14 +495,14 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 		if !found {
 			return false
 		}
-		var remainingCapacity resources.Requests
+		var remainingCapacity resources.LazyRequests
 		if cachingEnabled {
-			remainingCapacity = s.getRemainingCapacity(leaf)
+			remainingCapacity = resources.NewLazyRequests(s.getRemainingCapacity(leaf))
 		} else {
-			remainingCapacity = leaf.freeCapacity.Clone()
+			remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
 			remainingCapacity.Sub(leaf.tasUsage)
 		}
-		if domainUsage.SinglePodRequests.CountIn(remainingCapacity) < domainUsage.Count {
+		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
 			return false
 		}
 	}
@@ -829,16 +819,11 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 }
 
 func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
-	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for domainID, usage := range usagePerDomain {
-		if cachingEnabled && assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = usage
-		} else {
-			if assumedUsage[domainID] == nil {
-				assumedUsage[domainID] = resources.Requests{}
-			}
-			assumedUsage[domainID].Add(usage)
+		if assumedUsage[domainID] == nil {
+			assumedUsage[domainID] = resources.Requests{}
 		}
+		assumedUsage[domainID].Add(usage)
 	}
 }
 
@@ -1907,81 +1892,40 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		return
 	}
 
-	var remainingCapacity resources.Requests
+	var remainingCapacity resources.LazyRequests
 	if cachingRemainingResourcesEnabled {
-		leafAssumedUsage, hasAssumedUsage := requirements.assumedUsage[leaf.id]
-		hasLeaderRequests := requirements.leaderRequests != nil
-
-		// This path requires cloning the map because remainingCapacity will be locally mutated
-		// (subtraction of assumed usage or leader pod requests).
-		if hasAssumedUsage || hasLeaderRequests {
-			if requirements.simulateEmpty {
-				remainingCapacity = leaf.freeCapacity.Clone()
-			} else {
-				remainingCapacity = s.getRemainingCapacity(leaf).Clone()
-			}
-			if hasAssumedUsage {
-				remainingCapacity.Sub(leafAssumedUsage)
-			}
-			var limitingRes corev1.ResourceName
-			leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
-
-			// Track resource exclusions: if this node can't fit even one pod,
-			// identify which resource is the bottleneck.
-			if leaf.state == 0 && limitingRes != "" {
-				state.stats.recordResourceExclusion(limitingRes)
-			}
-
-			leaf.leaderState = 0
-			if hasLeaderRequests && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
-				leaf.leaderState = 1
-				remainingCapacity.Sub(*requirements.leaderRequests)
-			}
-			leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+		if requirements.simulateEmpty {
+			remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
 		} else {
-			// Fast copy-free path (0 clones / 0 allocations): no local mutations needed,
-			// so remainingCapacity is read directly from the cached map.
-			if requirements.simulateEmpty {
-				remainingCapacity = leaf.freeCapacity
-			} else {
-				remainingCapacity = s.getRemainingCapacity(leaf)
-			}
-			var limitingRes corev1.ResourceName
-			leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
-
-			// Track resource exclusions: if this node can't fit even one pod,
-			// identify which resource is the bottleneck.
-			if leaf.state == 0 && limitingRes != "" {
-				state.stats.recordResourceExclusion(limitingRes)
-			}
-			leaf.leaderState = 0
-			leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+			remainingCapacity = resources.NewLazyRequests(s.getRemainingCapacity(leaf))
 		}
 	} else {
-		remainingCapacity = leaf.freeCapacity.Clone()
+		remainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
 		if !requirements.simulateEmpty {
 			remainingCapacity.Sub(leaf.tasUsage)
 		}
-		if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
-			remainingCapacity.Sub(leafAssumedUsage)
-		}
-		var limitingRes corev1.ResourceName
-		leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
-
-		// Track resource exclusions: if this node can't fit even one pod,
-		// identify which resource is the bottleneck.
-		if leaf.state == 0 && limitingRes != "" {
-			state.stats.recordResourceExclusion(limitingRes)
-		}
-
-		leaf.leaderState = 0
-		if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
-			leaf.leaderState = 1
-			remainingCapacity.Sub(*requirements.leaderRequests)
-		}
-
-		leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
 	}
+
+	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
+		remainingCapacity.Sub(leafAssumedUsage)
+	}
+
+	var limitingRes corev1.ResourceName
+	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
+
+	// Track resource exclusions: if this node can't fit even one pod,
+	// identify which resource is the bottleneck.
+	if leaf.state == 0 && limitingRes != "" {
+		state.stats.recordResourceExclusion(limitingRes)
+	}
+
+	leaf.leaderState = 0
+	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity.Get()) > 0 {
+		leaf.leaderState = 1
+		remainingCapacity.Sub(*requirements.leaderRequests)
+	}
+
+	leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
 }
 
 func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -105,6 +105,11 @@ type leafDomain struct {
 	// tasUsage represents the usage associated with TAS workloads.
 	tasUsage resources.Requests
 
+	// cachedRemainingCapacity stores the pre-computed remaining capacity (freeCapacity - tasUsage) for this leaf.
+	// It is lazily calculated and invalidated (set to nil) when tasUsage or freeCapacity for this specific leaf
+	// domain changes. This avoids repeated map cloning and resource subtraction during capacity checks (e.g. preemption).
+	cachedRemainingCapacity resources.Requests
+
 	// node at the leaf, if the lowest level is a node
 	node *corev1.Node
 }
@@ -309,6 +314,7 @@ func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capac
 		s.leaves[domainID].freeCapacity = resources.Requests{}
 	}
 	s.leaves[domainID].freeCapacity.Add(capacity)
+	s.leaves[domainID].cachedRemainingCapacity = nil
 }
 
 func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -316,16 +322,35 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
 	s.leaves[domainID].freeCapacity.Sub(usage)
+	s.leaves[domainID].cachedRemainingCapacity = nil
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
-	u := usage.Clone()
-	u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
-	if op == add {
-		s.addTASUsage(domainID, u)
+	if features.Enabled(features.TASCachingRemainingResources) {
+		if op == add {
+			s.addTASUsage(domainID, usage)
+			s.addTASUsage(domainID, resources.Requests{corev1.ResourcePods: int64(count)})
+		} else {
+			s.removeTASUsage(domainID, usage)
+			s.removeTASUsage(domainID, resources.Requests{corev1.ResourcePods: int64(count)})
+		}
 	} else {
-		s.removeTASUsage(domainID, u)
+		u := usage.Clone()
+		u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
+		if op == add {
+			s.addTASUsage(domainID, u)
+		} else {
+			s.removeTASUsage(domainID, u)
+		}
 	}
+}
+
+func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
+	if leaf.cachedRemainingCapacity == nil {
+		leaf.cachedRemainingCapacity = leaf.freeCapacity.Clone()
+		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
+	}
+	return leaf.cachedRemainingCapacity
 }
 
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -340,6 +365,7 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.leaves[domainID].tasUsage = resources.Requests{}
 	}
 	s.leaves[domainID].tasUsage.Add(usage)
+	s.leaves[domainID].cachedRemainingCapacity = nil
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -354,6 +380,7 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.leaves[domainID].tasUsage = resources.Requests{}
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
+	s.leaves[domainID].cachedRemainingCapacity = nil
 }
 
 func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.Requests {
@@ -477,8 +504,13 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 		if !found {
 			return false
 		}
-		remainingCapacity := leaf.freeCapacity.Clone()
-		remainingCapacity.Sub(leaf.tasUsage)
+		var remainingCapacity resources.Requests
+		if features.Enabled(features.TASCachingRemainingResources) {
+			remainingCapacity = s.getRemainingCapacity(leaf)
+		} else {
+			remainingCapacity = leaf.freeCapacity.Clone()
+			remainingCapacity.Sub(leaf.tasUsage)
+		}
 		if domainUsage.SinglePodRequests.CountIn(remainingCapacity) < domainUsage.Count {
 			return false
 		}
@@ -797,10 +829,14 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 
 func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	for domainID, usage := range usagePerDomain {
-		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.Requests{}
+		if features.Enabled(features.TASCachingRemainingResources) && assumedUsage[domainID] == nil {
+			assumedUsage[domainID] = usage
+		} else {
+			if assumedUsage[domainID] == nil {
+				assumedUsage[domainID] = resources.Requests{}
+			}
+			assumedUsage[domainID].Add(usage)
 		}
-		assumedUsage[domainID].Add(usage)
 	}
 }
 
@@ -1869,29 +1905,81 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		return
 	}
 
-	remainingCapacity := leaf.freeCapacity.Clone()
-	if !requirements.simulateEmpty {
-		remainingCapacity.Sub(leaf.tasUsage)
-	}
-	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
-		remainingCapacity.Sub(leafAssumedUsage)
-	}
-	var limitingRes corev1.ResourceName
-	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
+	var remainingCapacity resources.Requests
+	if features.Enabled(features.TASCachingRemainingResources) {
+		leafAssumedUsage, hasAssumedUsage := requirements.assumedUsage[leaf.id]
+		hasLeaderRequests := requirements.leaderRequests != nil
 
-	// Track resource exclusions: if this node can't fit even one pod,
-	// identify which resource is the bottleneck.
-	if leaf.state == 0 && limitingRes != "" {
-		state.stats.recordResourceExclusion(limitingRes)
-	}
+		// This path requires cloning the map because remainingCapacity will be locally mutated
+		// (subtraction of assumed usage or leader pod requests).
+		if hasAssumedUsage || hasLeaderRequests {
+			if requirements.simulateEmpty {
+				remainingCapacity = leaf.freeCapacity.Clone()
+			} else {
+				remainingCapacity = s.getRemainingCapacity(leaf).Clone()
+			}
+			if hasAssumedUsage {
+				remainingCapacity.Sub(leafAssumedUsage)
+			}
+			var limitingRes corev1.ResourceName
+			leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
 
-	leaf.leaderState = 0
-	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
-		leaf.leaderState = 1
-		remainingCapacity.Sub(*requirements.leaderRequests)
-	}
+			// Track resource exclusions: if this node can't fit even one pod,
+			// identify which resource is the bottleneck.
+			if leaf.state == 0 && limitingRes != "" {
+				state.stats.recordResourceExclusion(limitingRes)
+			}
 
-	leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+			leaf.leaderState = 0
+			if hasLeaderRequests && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
+				leaf.leaderState = 1
+				remainingCapacity.Sub(*requirements.leaderRequests)
+			}
+			leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+		} else {
+			// Fast copy-free path (0 clones / 0 allocations): no local mutations needed,
+			// so remainingCapacity is read directly from the cached map.
+			if requirements.simulateEmpty {
+				remainingCapacity = leaf.freeCapacity
+			} else {
+				remainingCapacity = s.getRemainingCapacity(leaf)
+			}
+			var limitingRes corev1.ResourceName
+			leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
+
+			// Track resource exclusions: if this node can't fit even one pod,
+			// identify which resource is the bottleneck.
+			if leaf.state == 0 && limitingRes != "" {
+				state.stats.recordResourceExclusion(limitingRes)
+			}
+			leaf.leaderState = 0
+			leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+		}
+	} else {
+		remainingCapacity = leaf.freeCapacity.Clone()
+		if !requirements.simulateEmpty {
+			remainingCapacity.Sub(leaf.tasUsage)
+		}
+		if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
+			remainingCapacity.Sub(leafAssumedUsage)
+		}
+		var limitingRes corev1.ResourceName
+		leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity)
+
+		// Track resource exclusions: if this node can't fit even one pod,
+		// identify which resource is the bottleneck.
+		if leaf.state == 0 && limitingRes != "" {
+			state.stats.recordResourceExclusion(limitingRes)
+		}
+
+		leaf.leaderState = 0
+		if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity) > 0 {
+			leaf.leaderState = 1
+			remainingCapacity.Sub(*requirements.leaderRequests)
+		}
+
+		leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity)
+	}
 }
 
 func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/klog/v2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -952,7 +951,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			g := gomega.NewWithT(t)
 			features.SetFeatureGateDuringTest(t, features.TASCachingRemainingResources, enableCaching)
 
-			log := klog.Background()
+			_, log := utiltesting.ContextWithLog(t)
 			snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{"hostname"})
 			nodeObj := node.MakeNode("node-a").
 				Label("hostname", "node-a").

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,11 +17,15 @@ limitations under the License.
 package scheduler
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog/v2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -29,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func TestFreeCapacityPerDomain(t *testing.T) {
@@ -937,6 +942,58 @@ func TestTruncateAssignment(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("TruncateAssignment() mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
+	for _, enableCaching := range []bool{true, false} {
+		t.Run(fmt.Sprintf("enableCaching=%t", enableCaching), func(t *testing.T) {
+			g := gomega.NewWithT(t)
+			features.SetFeatureGateDuringTest(t, features.TASCachingRemainingResources, enableCaching)
+
+			log := klog.Background()
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{"hostname"})
+			nodeObj := node.MakeNode("node-a").
+				Label("hostname", "node-a").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("10Gi"),
+				}).
+				Ready().
+				Obj()
+			domainID := snapshot.addNode(nodeObj)
+
+			leaf := snapshot.leaves[domainID]
+			g.Expect(leaf).ToNot(gomega.BeNil())
+
+			flavorUsage := workload.TASFlavorUsage{
+				{
+					Values: []string{"node-a"},
+					SinglePodRequests: resources.Requests{
+						corev1.ResourceCPU: 5000,
+					},
+					Count: 1,
+				},
+			}
+
+			// Warm the Fits cache before adding TAS usage
+			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
+
+			// Add TAS usage of 4 CPU (4000m), leaving 4 CPU (8000m - 4000m = 4000m) remaining
+			usage := resources.Requests{
+				corev1.ResourceCPU: 4000,
+			}
+			snapshot.updateTASUsage(domainID, usage, add, 1)
+
+			// Fits should now return false because 5 CPU > 4 CPU remaining
+			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeFalse())
+
+			// Remove TAS usage
+			snapshot.updateTASUsage(domainID, usage, subtract, 1)
+
+			// Fits should now return true again after cache invalidation / re-evaluation
+			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
 		})
 	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -490,6 +490,11 @@ const (
 	// to be reused within a single scheduling cycle by TAS evaluations corresponding to different
 	// sets of preemption candidates.
 	TASCacheNodeMatchResults featuregate.Feature = "TASCacheNodeMatchResults"
+
+	// owner: @j-skiba
+	//
+	// Enables caching of remaining capacity and clone reduction in TAS Flavor Snapshot.
+	TASCachingRemainingResources featuregate.Feature = "TASCachingRemainingResources"
 )
 
 func init() {
@@ -752,6 +757,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	TASCacheNodeMatchResults: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	TASCachingRemainingResources: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -252,6 +252,11 @@ func NewLazyRequests(base Requests) LazyRequests {
 	return LazyRequests{base: base}
 }
 
+// IsValid returns true if either the base or cached map is initialized.
+func (l *LazyRequests) IsValid() bool {
+	return l.base != nil || l.cached != nil
+}
+
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
 func (l *LazyRequests) Get() Requests {
 	if l.cached != nil {

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -240,3 +240,54 @@ func (r Requests) CountInWithLimitingResource(capacity Requests) (int32, corev1.
 	}
 	return ptr.Deref(result, 0), limitingResource
 }
+
+// LazyRequests wraps a base Requests map and performs copy-on-write
+// (lazy cloning) when mutations occur.
+type LazyRequests struct {
+	base   Requests
+	cached Requests
+}
+
+func NewLazyRequests(base Requests) LazyRequests {
+	return LazyRequests{base: base}
+}
+
+// Get returns the underlying Requests (either the cached clone if mutated, or base).
+func (l *LazyRequests) Get() Requests {
+	if l.cached != nil {
+		return l.cached
+	}
+	return l.base
+}
+
+// Sub subtracts subRequests from the underlying Requests map,
+// cloning base on first write.
+func (l *LazyRequests) Sub(subRequests Requests) {
+	if len(subRequests) == 0 {
+		return
+	}
+	if l.cached == nil {
+		if l.base == nil {
+			l.cached = Requests{}
+		} else {
+			l.cached = l.base.Clone()
+		}
+	}
+	l.cached.Sub(subRequests)
+}
+
+// Add adds addRequests to the underlying Requests map,
+// cloning base on first write.
+func (l *LazyRequests) Add(addRequests Requests) {
+	if len(addRequests) == 0 {
+		return
+	}
+	if l.cached == nil {
+		if l.base == nil {
+			l.cached = Requests{}
+		} else {
+			l.cached = l.base.Clone()
+		}
+	}
+	l.cached.Add(addRequests)
+}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -413,3 +413,103 @@ func TestResourceQuantityRoundTrips(t *testing.T) {
 		})
 	}
 }
+
+func TestLazyRequests(t *testing.T) {
+	cases := map[string]struct {
+		base              Requests
+		op                func(*LazyRequests)
+		wantResult        Requests
+		wantCachedCreated bool
+	}{
+		"no operation preserves base": {
+			base:              Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			op:                nil,
+			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantCachedCreated: false,
+		},
+		"subtraction creates clone and updates result": {
+			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			op: func(l *LazyRequests) {
+				l.Sub(Requests{corev1.ResourceCPU: 3})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: 7, corev1.ResourceMemory: 100},
+			wantCachedCreated: true,
+		},
+		"addition creates clone and updates result": {
+			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			op: func(l *LazyRequests) {
+				l.Add(Requests{corev1.ResourceCPU: 5})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: 15, corev1.ResourceMemory: 100},
+			wantCachedCreated: true,
+		},
+		"subtraction with empty map short circuits": {
+			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			op: func(l *LazyRequests) {
+				l.Sub(Requests{})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantCachedCreated: false,
+		},
+		"addition with empty map short circuits": {
+			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			op: func(l *LazyRequests) {
+				l.Add(Requests{})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantCachedCreated: false,
+		},
+		"nil base input with non-empty addition": {
+			base: nil,
+			op: func(l *LazyRequests) {
+				l.Add(Requests{corev1.ResourceCPU: 5})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: 5},
+			wantCachedCreated: true,
+		},
+		"nil base input with empty addition short circuits": {
+			base: nil,
+			op: func(l *LazyRequests) {
+				l.Add(Requests{})
+			},
+			wantResult:        nil,
+			wantCachedCreated: false,
+		},
+		"nil base input with non-empty subtraction": {
+			base: nil,
+			op: func(l *LazyRequests) {
+				l.Sub(Requests{corev1.ResourceCPU: 5})
+			},
+			wantResult:        Requests{corev1.ResourceCPU: -5},
+			wantCachedCreated: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var originalBase Requests
+			if tc.base != nil {
+				originalBase = tc.base.Clone()
+			}
+
+			lazy := NewLazyRequests(tc.base)
+
+			if tc.op != nil {
+				tc.op(&lazy)
+			}
+
+			if (lazy.cached != nil) != tc.wantCachedCreated {
+				t.Errorf("expected cachedCreated=%t, got cached=%v", tc.wantCachedCreated, lazy.cached)
+			}
+
+			gotResult := lazy.Get()
+			if !cmp.Equal(gotResult, tc.wantResult) {
+				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", cmp.Diff(gotResult, tc.wantResult))
+			}
+
+			if tc.base != nil && !cmp.Equal(tc.base, originalBase) {
+				t.Errorf("base map was mutated! diff (-got +want):\n%s", cmp.Diff(tc.base, originalBase))
+			}
+		})
+	}
+}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -420,12 +420,14 @@ func TestLazyRequests(t *testing.T) {
 		op                func(*LazyRequests)
 		wantResult        Requests
 		wantCachedCreated bool
+		wantValid         bool
 	}{
 		"no operation preserves base": {
 			base:              Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op:                nil,
 			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
+			wantValid:         true,
 		},
 		"subtraction creates clone and updates result": {
 			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -434,6 +436,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: 7, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
+			wantValid:         true,
 		},
 		"addition creates clone and updates result": {
 			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -442,6 +445,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: 15, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
+			wantValid:         true,
 		},
 		"subtraction with empty map short circuits": {
 			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -450,6 +454,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
+			wantValid:         true,
 		},
 		"addition with empty map short circuits": {
 			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -458,6 +463,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
+			wantValid:         true,
 		},
 		"nil base input with non-empty addition": {
 			base: nil,
@@ -466,6 +472,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: 5},
 			wantCachedCreated: true,
+			wantValid:         true,
 		},
 		"nil base input with empty addition short circuits": {
 			base: nil,
@@ -474,6 +481,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        nil,
 			wantCachedCreated: false,
+			wantValid:         false,
 		},
 		"nil base input with non-empty subtraction": {
 			base: nil,
@@ -482,6 +490,14 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        Requests{corev1.ResourceCPU: -5},
 			wantCachedCreated: true,
+			wantValid:         true,
+		},
+		"zero-value LazyRequests is not valid": {
+			base:              nil,
+			op:                nil,
+			wantResult:        nil,
+			wantCachedCreated: false,
+			wantValid:         false,
 		},
 	}
 
@@ -496,6 +512,10 @@ func TestLazyRequests(t *testing.T) {
 
 			if tc.op != nil {
 				tc.op(&lazy)
+			}
+
+			if gotValid := lazy.IsValid(); gotValid != tc.wantValid {
+				t.Errorf("unexpected IsValid() result, want=%t, got=%t", tc.wantValid, gotValid)
 			}
 
 			if (lazy.cached != nil) != tc.wantCachedCreated {

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3331,37 +3331,43 @@ func TestScheduleForTAS(t *testing.T) {
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         false,
+			features.TASCachingRemainingResources:     false,
 		},
 	}
 
 	for name, tc := range cases {
 		for _, scenario := range scenarios {
 			t.Run(
-				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t",
+				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t cachingRemainingResources:%t",
 					name,
 					scenario[features.WorkloadRequestUseMergePatch],
 					scenario[features.UnadmittedWorkloadsObservability],
 					scenario[features.TASCacheNodeMatchResults],
+					scenario[features.TASCachingRemainingResources],
 				),
 				func(t *testing.T) {
 					features.SetFeatureGatesDuringTest(t, scenario)
@@ -3559,37 +3565,43 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         false,
+			features.TASCachingRemainingResources:     false,
 		},
 	}
 
 	for name, tc := range cases {
 		for _, scenario := range scenarios {
 			t.Run(
-				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t",
+				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t cachingRemainingResources:%t",
 					name,
 					scenario[features.WorkloadRequestUseMergePatch],
 					scenario[features.UnadmittedWorkloadsObservability],
 					scenario[features.TASCacheNodeMatchResults],
+					scenario[features.TASCachingRemainingResources],
 				),
 				func(t *testing.T) {
 					features.SetFeatureGatesDuringTest(t, scenario)

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
@@ -306,7 +307,12 @@ func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.R
 	usage := make(map[TopologyDomainID]resources.Requests)
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
-		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
+		var domainUsage resources.Requests
+		if features.Enabled(features.TASCachingRemainingResources) && domain.Count == 1 {
+			domainUsage = singlePodRequests.Clone()
+		} else {
+			domainUsage = singlePodRequests.ScaledUp(int64(domain.Count))
+		}
 		domainUsage.Add(resources.Requests{corev1.ResourcePods: int64(domain.Count)})
 		usage[domainID] = domainUsage
 	}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -305,10 +305,11 @@ func TruncateAssignment(ta *TopologyAssignment, newCount int32) *TopologyAssignm
 // ComputeUsagePerDomain calculates resource usage per topology domain from an assignment.
 func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.Requests) map[TopologyDomainID]resources.Requests {
 	usage := make(map[TopologyDomainID]resources.Requests)
+	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
 		var domainUsage resources.Requests
-		if features.Enabled(features.TASCachingRemainingResources) && domain.Count == 1 {
+		if cachingEnabled && domain.Count == 1 {
 			domainUsage = singlePodRequests.Clone()
 		} else {
 			domainUsage = singlePodRequests.ScaledUp(int64(domain.Count))

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 )
 
@@ -305,15 +304,9 @@ func TruncateAssignment(ta *TopologyAssignment, newCount int32) *TopologyAssignm
 // ComputeUsagePerDomain calculates resource usage per topology domain from an assignment.
 func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.Requests) map[TopologyDomainID]resources.Requests {
 	usage := make(map[TopologyDomainID]resources.Requests)
-	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
-		var domainUsage resources.Requests
-		if cachingEnabled && domain.Count == 1 {
-			domainUsage = singlePodRequests.Clone()
-		} else {
-			domainUsage = singlePodRequests.ScaledUp(int64(domain.Count))
-		}
+		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
 		domainUsage.Add(resources.Requests{corev1.ResourcePods: int64(domain.Count)})
 		usage[domainID] = domainUsage
 	}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -403,6 +403,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASCachingRemainingResources
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: TASFailedNodeReplacement
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -403,6 +403,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASCachingRemainingResources
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: TASFailedNodeReplacement
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

This PR optimizes TAS preemption and capacity evaluation by introducing fine-grained per-leaf remaining capacity caching and clone reduction in `TASFlavorSnapshot`.

Key Optimizations:
1. Per-Leaf Remaining Capacity Caching: Added `cachedRemainingCapacity` (`resources.Requests`) on `leafDomain`. Rather than recalculating `freeCapacity - tasUsage` via map clone and subtraction on every leaf domain visit, the result is cached lazily and invalidated (`cachedRemainingCapacity = nil`) only when usage or allocatable capacity for that specific leaf domain changes (`addTASUsage`, `removeTASUsage`, `addNonTASUsage`, `addCapacity`). During preemption candidate evaluations across 1,000-nodes clusters, unaffected nodes retain their cached capacity, achieving high cache hit rate.
2. Copy-Free Read Path: `fillLeafCounts` now distinguishes between nodes requiring local mutations (in-flight `assumedUsage` or leader pod requests) and nodes requiring read-only evaluation. Read-only nodes bypass `.Clone()` completely, eliminating thousands of heap map allocations per preemption cycle.
3. Feature Gate Control: All optimizations are hidden behind the `TASCachingRemainingResources` feature gate (enabled by default). When disabled, the snapshot falls back to the exact unoptimized code path.

FG enabled:
```bash
BenchmarkSchedulerTAS/nodes=1000/nodeGroups=8/pods=200/res=30-64         	      58	 210750966 ns/op
PASS
ok  	sigs.k8s.io/kueue/pkg/scheduler	17.527s
```
<img width="2560" height="828" alt="fg-on" src="https://github.com/user-attachments/assets/6afe3f68-e77a-4750-8b29-a13ad29e68d7" />


FG disabled:
```bash
BenchmarkSchedulerTAS/nodes=1000/nodeGroups=8/pods=200/res=30-64         	      39	 286298506 ns/op
PASS
ok  	sigs.k8s.io/kueue/pkg/scheduler	14.776s
```
<img width="2559" height="867" alt="Screenshot 2026-07-17 at 15 45 09" src="https://github.com/user-attachments/assets/c57d4ffd-29c4-427f-99ba-d87e530748dc" />



Main:
```bash
BenchmarkSchedulerTAS/nodes=1000/nodeGroups=8/pods=200/res=30-64         	      39	 269946450 ns/op
PASS
ok  	sigs.k8s.io/kueue/pkg/scheduler	14.050s
```
<img width="2560" height="850" alt="Screenshot 2026-07-17 at 15 28 16" src="https://github.com/user-attachments/assets/aed572b6-ebcd-4c54-a9d5-2971b36117da" />


#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a performance bug that caused remaining capacity to be repeatedly recalculated and resource maps to be unnecessarily copied during workload evaluation, particularly when evaluating multiple preemption candidate sets in
large clusters. The fix is guarded by the Beta `TASCachingRemainingResources` feature gate, which is enabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beta, default-enabled feature gate for caching remaining TAS capacity.
  * Enhanced TAS capacity evaluation to optionally reuse cached remaining-capacity calculations.
  * Introduced lazy request updates to reduce unnecessary copying until mutations occur.
* **Bug Fixes**
  * Ensure TAS capacity fitting results are correctly refreshed after TAS usage changes, keeping cached decisions consistent.
* **Tests**
  * Expanded TAS scheduling tests to cover both cached and non-cached capacity paths.
  * Added targeted coverage for the new feature gate’s cache invalidation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->