### PR TITLE
Graduate KueueDRAIntegrationPartitionableDevices to Beta

### DIFF
--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -654,7 +654,7 @@ type DeviceClassMapping struct {
 	// Each source defines how quota is tracked for this DeviceClass.
 	// Extended resource requests that resolve to a DeviceClass with sources
 	// configured are marked inadmissible.
-	// Counter sources require KueueDRAIntegrationPartitionableDevices.
+	// Counter sources require KueueDRAIntegrationPartitionableDevices (enabled by default since v0.19).
 	// Capacity sources require KueueDRAIntegrationConsumableCapacity.
 	// +optional
 	Sources []DeviceClassSourceConfig `json:"sources,omitempty"`
@@ -679,8 +679,8 @@ type DeviceClassSourceConfig struct {
 // DeviceClassCounterSource identifies where to read counter data from and which counter to track.
 type DeviceClassCounterSource struct {
 	// Name is the counter name within the device's consumesCounters
-	// entries to track for quota. Must match a counter name published by
-	// the driver in ResourceSlice devices' consumesCounters field.
+	// entries to track for quota. Must be a DNS label and match a counter
+	// name published by the driver in ResourceSlice devices' consumesCounters field.
 	// Counter set names are per-device identifiers (e.g., gpu-0-counter-set,
 	// gpu-1-counter-set), so name matches across all counter sets
 	// for a given driver without requiring one mapping per device.
@@ -689,7 +689,7 @@ type DeviceClassCounterSource struct {
 	Name string `json:"name"`
 
 	// Driver is the DRA driver name used to filter relevant ResourceSlices.
-	// Must match the spec.driver field on ResourceSlice objects.
+	// Must be a lowercase DNS subdomain and match the spec.driver field on ResourceSlice objects.
 	// The total length must not exceed 63 characters.
 	// +required
 	Driver string `json:"driver"`

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1417,6 +1417,7 @@ borrowing only operates within the same resource.
   existence at config load time.
 - `KueueDRAIntegrationPartitionableDevices` requires `KueueDRAIntegration` to be enabled. Validated
   at startup in `pkg/config/validation.go`.
+- Tightened driver name max length from 253 to 63 to match resourcev1.DriverNameMaxLength since Kueue v0.19.0
 
 ### Consumable Capacity
 
@@ -1985,6 +1986,7 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - Promoted KueueDRAIntegrationExtendedResource to Beta: July 2026 by @PannagaRao
 - Consumable capacity design: July 2026 by @sohankunkerkar — added KEP-5075 integration
   for software-level device sharing
+- Promoted KueueDRAIntegrationPartitionableDevices to Beta: July 2026 by @PannagaRao
 
 **Key Design Evolution:**
 - **Original Design**: Standalone DynamicResourceAllocationConfig CRD with runtime ambiguity resolution

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -892,13 +892,15 @@ func validateDeviceClassSource(name, driver string, selector *resourcev1.DeviceS
 	var allErrs field.ErrorList
 	if name == "" {
 		allErrs = append(allErrs, field.Required(path.Child("name"), ""))
-	} else if len(name) > 63 {
-		allErrs = append(allErrs, field.Invalid(path.Child("name"), name, "must not exceed 63 characters"))
+	} else if errs := apimachineryutilvalidation.IsDNS1123Label(name); len(errs) != 0 {
+		allErrs = append(allErrs, field.Invalid(path.Child("name"), name, strings.Join(errs, ",")))
 	}
 	if driver == "" {
 		allErrs = append(allErrs, field.Required(path.Child("driver"), ""))
+	} else if len(driver) > resourcev1.DriverNameMaxLength {
+		allErrs = append(allErrs, field.Invalid(path.Child("driver"), driver, fmt.Sprintf("must not exceed %d characters", resourcev1.DriverNameMaxLength)))
 	} else if errs := apimachineryutilvalidation.IsDNS1123Subdomain(driver); len(errs) != 0 {
-		allErrs = append(allErrs, field.Invalid(path.Child("driver"), driver, strings.Join(errs, "; ")))
+		allErrs = append(allErrs, field.Invalid(path.Child("driver"), driver, strings.Join(errs, ",")))
 	}
 	selectorPath := path.Child("deviceSelector", "cel", "expression")
 	if selector.CEL == nil || selector.CEL.Expression == "" {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1226,8 +1226,9 @@ func TestValidate(t *testing.T) {
 				Integrations: defaultIntegrations,
 			},
 			featureGates: map[featuregate.Feature]bool{
-				features.KueueDRAIntegrationExtendedResource: true,
-				features.KueueDRAIntegration:                 false,
+				features.KueueDRAIntegrationExtendedResource:     true,
+				features.KueueDRAIntegration:                     false,
+				features.KueueDRAIntegrationPartitionableDevices: false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1458,6 +1459,7 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: false},
 			wantErr: field.ErrorList{
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
@@ -1520,6 +1522,93 @@ func TestValidate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeRequired,
 					Field: "resources.deviceClassMappings[0].sources[0].counter.name",
+				},
+			},
+		},
+		"sources: invalid counter name format": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "INVALID_NAME",
+									Driver: "gpu.nvidia.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].counter.name",
+				},
+			},
+		},
+		"sources: invalid driver name format": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "NOT_VALID!!",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].counter.driver",
+				},
+			},
+		},
+		"sources: driver name exceeds max length": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"mig.nvidia.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Counter: &configapi.DeviceClassCounterSource{
+									Name:   "memory",
+									Driver: "gpu-accelerator.nvidia-corporation.datacenter.example.com.internal",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.nvidia.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].counter.driver",
 				},
 			},
 		},
@@ -1730,9 +1819,10 @@ func TestValidate(t *testing.T) {
 		},
 		"CC gate requires DRA base gate": {
 			featureGates: map[featuregate.Feature]bool{
-				features.KueueDRAIntegration:                   false,
-				features.KueueDRAIntegrationExtendedResource:   false,
-				features.KueueDRAIntegrationConsumableCapacity: true,
+				features.KueueDRAIntegration:                     false,
+				features.KueueDRAIntegrationExtendedResource:     false,
+				features.KueueDRAIntegrationPartitionableDevices: false,
+				features.KueueDRAIntegrationConsumableCapacity:   true,
 			},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
@@ -1768,21 +1858,30 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGatesCLI: "",
 		},
 		"feature gate cli": {
-			featureGatesCLI: string(features.KueueDRAIntegration) + "=false," + string(features.KueueDRAIntegrationExtendedResource) + "=false",
+			featureGatesCLI: string(
+				features.KueueDRAIntegration,
+			) + "=false," + string(
+				features.KueueDRAIntegrationExtendedResource,
+			) + "=false," + string(
+				features.KueueDRAIntegrationPartitionableDevices,
+			) + "=false",
 			gatesToRestore: map[featuregate.Feature]bool{
-				features.KueueDRAIntegration:                 false,
-				features.KueueDRAIntegrationExtendedResource: false,
+				features.KueueDRAIntegration:                     false,
+				features.KueueDRAIntegrationExtendedResource:     false,
+				features.KueueDRAIntegrationPartitionableDevices: false,
 			},
 		},
 		"cannot specify both feature gates": {
 			featureGatesCLI: string(features.KueueDRAIntegration) + "=false",
 			featureGateMap: map[string]bool{
-				string(features.KueueDRAIntegration):                 false,
-				string(features.KueueDRAIntegrationExtendedResource): false,
+				string(features.KueueDRAIntegration):                     false,
+				string(features.KueueDRAIntegrationExtendedResource):     false,
+				string(features.KueueDRAIntegrationPartitionableDevices): false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
-				features.KueueDRAIntegration:                 false,
-				features.KueueDRAIntegrationExtendedResource: false,
+				features.KueueDRAIntegration:                     false,
+				features.KueueDRAIntegrationExtendedResource:     false,
+				features.KueueDRAIntegrationPartitionableDevices: false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1962,12 +2061,14 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"KueueDRAIntegrationExtendedResource requires KueueDRAIntegration": {
 			featureGateMap: map[string]bool{
-				string(features.KueueDRAIntegrationExtendedResource): true,
-				string(features.KueueDRAIntegration):                 false,
+				string(features.KueueDRAIntegrationExtendedResource):     true,
+				string(features.KueueDRAIntegration):                     false,
+				string(features.KueueDRAIntegrationPartitionableDevices): false,
 			},
 			gatesToRestore: map[featuregate.Feature]bool{
-				features.KueueDRAIntegrationExtendedResource: false,
-				features.KueueDRAIntegration:                 true,
+				features.KueueDRAIntegrationExtendedResource:     false,
+				features.KueueDRAIntegration:                     true,
+				features.KueueDRAIntegrationPartitionableDevices: true,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -154,7 +154,7 @@ func processCapacityCharge(
 	count := exactly.Count
 
 	for _, capCfg := range capacityConfigs {
-		matched, errs := matchDevicesForSource(ctx, sliceCache, capCfg.driver, capCfg.deviceSelector, classSelectors, requestSelectors, reqPath)
+		matched, errs := matchDevicesForSource(ctx, sliceCache, DriverReference(capCfg.driver), capCfg.deviceSelector, classSelectors, requestSelectors, reqPath)
 		if len(errs) > 0 {
 			return nil, errs
 		}

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -440,7 +440,7 @@ func validateCELSelectorsAgainstDevices(
 		}
 		collectedSlices = slices
 	} else {
-		seenDrivers := sets.New[string]()
+		seenDrivers := sets.New[DriverReference]()
 		for _, cr := range celReqs {
 			dc := corev1.ResourceName(cr.deviceClassName)
 			for _, cc := range mapper.getCounterConfigs(dc) {
@@ -455,11 +455,11 @@ func validateCELSelectorsAgainstDevices(
 				collectedSlices = append(collectedSlices, slices...)
 			}
 			for _, capCfg := range mapper.getCapacityConfigs(dc) {
-				if seenDrivers.Has(capCfg.driver) {
+				if seenDrivers.Has(DriverReference(capCfg.driver)) {
 					continue
 				}
-				seenDrivers.Insert(capCfg.driver)
-				slices, err := sliceCache.ListByDriver(ctx, capCfg.driver)
+				seenDrivers.Insert(DriverReference(capCfg.driver))
+				slices, err := sliceCache.ListByDriver(ctx, DriverReference(capCfg.driver))
 				if err != nil {
 					return field.ErrorList{field.InternalError(basePath, fmt.Errorf("failed to list ResourceSlices for driver %s: %w", capCfg.driver, err))}
 				}

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -138,7 +138,7 @@ func prepareCounterCharge(
 func matchDevicesForSource(
 	ctx context.Context,
 	sliceCache *ResourceSliceCache,
-	driver string,
+	driver DriverReference,
 	deviceSelector resourcev1.DeviceSelector,
 	classSelectors []dracel.CompilationResult,
 	requestSelectors []dracel.CompilationResult,
@@ -158,10 +158,10 @@ func matchDevicesForSource(
 	if err != nil {
 		return nil, field.ErrorList{field.InternalError(reqPath, fmt.Errorf("failed to list ResourceSlices: %w", err))}
 	}
-	pools := groupSlicesByPool(sliceList, driver)
+	pools := groupSlicesByPool(sliceList, string(driver))
 	log.V(4).Info("Listed ResourceSlices for device matching", "driver", driver, "pools", len(pools), "slices", len(sliceList))
 
-	return matchDevicesWithSelectors(ctx, pools, driver, selectorSelectors, classSelectors, requestSelectors, reqPath)
+	return matchDevicesWithSelectors(ctx, pools, string(driver), selectorSelectors, classSelectors, requestSelectors, reqPath)
 }
 
 // safeChargeValue converts a driver-published resource.Quantity to a safe int64
@@ -351,6 +351,6 @@ func computeCounterCharges(
 		return nil
 	}
 
-	intVal := safeChargeValue(log, maxValue, counterConfig.driver, counterConfig.counterName, count)
+	intVal := safeChargeValue(log, maxValue, string(counterConfig.driver), counterConfig.counterName, count)
 	return corev1.ResourceList{quotaResource: *resource.NewQuantity(intVal, maxValue.Format)}
 }

--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -29,7 +29,7 @@ import (
 // deviceClassCounterConfig holds counter configuration for a specific DeviceClass.
 type deviceClassCounterConfig struct {
 	quotaResource  corev1.ResourceName
-	driver         string
+	driver         DriverReference
 	counterName    string
 	deviceSelector resourcev1.DeviceSelector
 }
@@ -132,7 +132,7 @@ func (m *ResourceMapper) PopulateFromConfiguration(mappings []configapi.DeviceCl
 				if source.Counter != nil {
 					dcCounters[deviceClassName] = append(dcCounters[deviceClassName], deviceClassCounterConfig{
 						quotaResource:  mapping.Name,
-						driver:         source.Counter.Driver,
+						driver:         DriverReference(source.Counter.Driver),
 						counterName:    source.Counter.Name,
 						deviceSelector: source.Counter.DeviceSelector,
 					})

--- a/pkg/dra/mapper_test.go
+++ b/pkg/dra/mapper_test.go
@@ -275,7 +275,7 @@ func TestCreateMapperFromConfiguration(t *testing.T) {
 	type wantCounterConfig struct {
 		quotaResource corev1.ResourceName
 		counterName   string
-		driver        string
+		driver        DriverReference
 	}
 	tests := []struct {
 		name                   string

--- a/pkg/dra/resourceslice_cache.go
+++ b/pkg/dra/resourceslice_cache.go
@@ -23,36 +23,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const allDriversKey = ""
+// DriverReference is the name of a DRA driver as it appears in
+// ResourceSlice.Spec.Driver (e.g., "gpu.nvidia.com").
+type DriverReference string
+
+const allDriversKey DriverReference = ""
 
 // ResourceSliceCache is a request-scoped cache for ResourceSlice listings.
 // It is created once per workload reconciliation and passed to both the CEL
 // validation and counter processing paths to avoid duplicate API calls and
 // ensure a consistent snapshot of ResourceSlices within a single reconciliation.
 type ResourceSliceCache struct {
-	client       client.Client
-	cachedSlices map[string][]resourcev1.ResourceSlice
+	client client.Client
+	// cachedSlices maps a DriverReference to its cached ResourceSlice listing.
+	// The sentinel key allDriversKey ("") stores the result of an unfiltered
+	// listing used as a fallback for DeviceClasses without counter sources.
+	cachedSlices map[DriverReference][]resourcev1.ResourceSlice
 }
 
 // NewResourceSliceCache creates a new ResourceSliceCache.
 func NewResourceSliceCache(cl client.Client) *ResourceSliceCache {
 	return &ResourceSliceCache{
 		client:       cl,
-		cachedSlices: make(map[string][]resourcev1.ResourceSlice),
+		cachedSlices: make(map[DriverReference][]resourcev1.ResourceSlice),
 	}
 }
 
 // ListByDriver returns ResourceSlices for the given driver, using the spec.driver
 // field index for efficient listing. Results are cached for subsequent calls with
 // the same driver within the same reconciliation.
-func (c *ResourceSliceCache) ListByDriver(ctx context.Context, driver string) ([]resourcev1.ResourceSlice, error) {
+func (c *ResourceSliceCache) ListByDriver(ctx context.Context, driver DriverReference) ([]resourcev1.ResourceSlice, error) {
 	if slices, ok := c.cachedSlices[driver]; ok {
 		return slices, nil
 	}
 	if allSlices, ok := c.cachedSlices[allDriversKey]; ok {
 		var filtered []resourcev1.ResourceSlice
 		for i := range allSlices {
-			if allSlices[i].Spec.Driver == driver {
+			if DriverReference(allSlices[i].Spec.Driver) == driver {
 				filtered = append(filtered, allSlices[i])
 			}
 		}
@@ -60,7 +67,7 @@ func (c *ResourceSliceCache) ListByDriver(ctx context.Context, driver string) ([
 		return filtered, nil
 	}
 	var sliceList resourcev1.ResourceSliceList
-	if err := c.client.List(ctx, &sliceList, client.MatchingFields{"spec.driver": driver}); err != nil {
+	if err := c.client.List(ctx, &sliceList, client.MatchingFields{"spec.driver": string(driver)}); err != nil {
 		return nil, err
 	}
 	c.cachedSlices[driver] = sliceList.Items

--- a/pkg/dra/resourceslice_cache_test.go
+++ b/pkg/dra/resourceslice_cache_test.go
@@ -60,7 +60,7 @@ func TestResourceSliceCache_ListByDriver(t *testing.T) {
 	cache := NewResourceSliceCache(cl)
 
 	t.Run("returns only requested driver slices", func(t *testing.T) {
-		got, err := cache.ListByDriver(ctx, "gpu.nvidia.com")
+		got, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -70,15 +70,21 @@ func TestResourceSliceCache_ListByDriver(t *testing.T) {
 	})
 
 	t.Run("second call returns cached result", func(t *testing.T) {
-		got1, _ := cache.ListByDriver(ctx, "gpu.nvidia.com")
-		got2, _ := cache.ListByDriver(ctx, "gpu.nvidia.com")
+		got1, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com"))
+		if err != nil {
+			t.Fatalf("unexpected error on first call: %v", err)
+		}
+		got2, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com"))
+		if err != nil {
+			t.Fatalf("unexpected error on second call: %v", err)
+		}
 		if diff := cmp.Diff(got1, got2, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
 			t.Errorf("cached result mismatch (-first +second):\n%s", diff)
 		}
 	})
 
 	t.Run("different driver returns different slices", func(t *testing.T) {
-		got, err := cache.ListByDriver(ctx, "nic.mellanox.com")
+		got, err := cache.ListByDriver(ctx, DriverReference("nic.mellanox.com"))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -110,8 +116,14 @@ func TestResourceSliceCache_ListAll(t *testing.T) {
 	})
 
 	t.Run("second call returns cached result", func(t *testing.T) {
-		got1, _ := cache.ListAll(ctx)
-		got2, _ := cache.ListAll(ctx)
+		got1, err := cache.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error on first call: %v", err)
+		}
+		got2, err := cache.ListAll(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error on second call: %v", err)
+		}
 		if diff := cmp.Diff(got1, got2, cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion")); diff != "" {
 			t.Errorf("cached result mismatch (-first +second):\n%s", diff)
 		}
@@ -153,7 +165,7 @@ func TestResourceSliceCache_ListAllThenListByDriver(t *testing.T) {
 	}
 
 	// Second call: ListByDriver filters from cached all-slices, no extra API call
-	gpuSlices, err := cache.ListByDriver(ctx, "gpu.nvidia.com")
+	gpuSlices, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com"))
 	if err != nil {
 		t.Fatalf("ListByDriver failed: %v", err)
 	}
@@ -186,18 +198,24 @@ func TestResourceSliceCache_ListByDriverThenListByDriverDifferent(t *testing.T) 
 	ctx := t.Context()
 	cache := NewResourceSliceCache(cl)
 
-	_, _ = cache.ListByDriver(ctx, "gpu.nvidia.com")
+	if _, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com")); err != nil {
+		t.Fatalf("unexpected error listing gpu driver: %v", err)
+	}
 	if listCallCount != 1 {
 		t.Errorf("expected 1 API call, got %d", listCallCount)
 	}
 
-	_, _ = cache.ListByDriver(ctx, "nic.mellanox.com")
+	if _, err := cache.ListByDriver(ctx, DriverReference("nic.mellanox.com")); err != nil {
+		t.Fatalf("unexpected error listing nic driver: %v", err)
+	}
 	if listCallCount != 2 {
 		t.Errorf("expected 2 API calls for different drivers, got %d", listCallCount)
 	}
 
 	// Same driver again — should be cached
-	_, _ = cache.ListByDriver(ctx, "gpu.nvidia.com")
+	if _, err := cache.ListByDriver(ctx, DriverReference("gpu.nvidia.com")); err != nil {
+		t.Fatalf("unexpected error listing cached gpu driver: %v", err)
+	}
 	if listCallCount != 2 {
 		t.Errorf("expected still 2 API calls (gpu cached), got %d", listCallCount)
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -633,6 +633,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	KueueDRAIntegrationPartitionableDevices: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 
 	KueueDRAIntegrationConsumableCapacity: {

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -121,17 +121,19 @@ cluster administrator.
 
 ## Counter-based quota for partitionable devices
 
-{{< feature-state state="alpha" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.19" >}}
 
 By default, Kueue tracks DRA quota by device count: each device request
 charges `count` units regardless of the device's capacity. This means a
 small GPU partition and a full GPU both count as "1 device", which does not
 reflect the actual resource consumption.
 
-With the `KueueDRAIntegrationPartitionableDevices` feature gate enabled,
 Kueue can track quota using **counter values** published by DRA drivers
 in `ResourceSlice` objects. This allows quota to reflect actual device
 capacity (e.g., GPU memory) rather than device count.
+
+This behavior is controlled by the `KueueDRAIntegrationPartitionableDevices`
+feature gate, which is enabled by default since v0.19.
 
 A `DeviceClass` uses either device-count quota (no `sources` configured) or
 counter-based quota (with `sources`), not both. Kueue rejects configurations
@@ -161,7 +163,6 @@ that map the same `DeviceClass` to multiple resource names.
   enabled (beta in Kubernetes 1.36).
 - A DRA driver that publishes `consumesCounters` on devices in
   `ResourceSlice` objects.
-- The `KueueDRAIntegrationPartitionableDevices` Kueue feature gate enabled.
 
 For setup instructions, see
 [Set Up Dynamic Resource Allocation](/docs/tasks/manage/setup_dra/#set-up-counter-based-quota-partitionable-devices).

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -709,8 +709,8 @@ compiler.</p>
 </td>
 <td>
    <p>Name is the counter name within the device's consumesCounters
-entries to track for quota. Must match a counter name published by
-the driver in ResourceSlice devices' consumesCounters field.
+entries to track for quota. Must be a DNS label and match a counter
+name published by the driver in ResourceSlice devices' consumesCounters field.
 Counter set names are per-device identifiers (e.g., gpu-0-counter-set,
 gpu-1-counter-set), so name matches across all counter sets
 for a given driver without requiring one mapping per device.
@@ -722,7 +722,7 @@ The total length must not exceed 63 characters.</p>
 </td>
 <td>
    <p>Driver is the DRA driver name used to filter relevant ResourceSlices.
-Must match the spec.driver field on ResourceSlice objects.
+Must be a lowercase DNS subdomain and match the spec.driver field on ResourceSlice objects.
 The total length must not exceed 63 characters.</p>
 </td>
 </tr>
@@ -793,7 +793,7 @@ The total length of each name must not exceed 253 characters.</p>
 Each source defines how quota is tracked for this DeviceClass.
 Extended resource requests that resolve to a DeviceClass with sources
 configured are marked inadmissible.
-Counter sources require KueueDRAIntegrationPartitionableDevices.
+Counter sources require KueueDRAIntegrationPartitionableDevices (enabled by default since v0.19).
 Capacity sources require KueueDRAIntegrationConsumableCapacity.</p>
 </td>
 </tr>

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -176,24 +176,23 @@ counting of both the `resources.requests` entry and the auto-created claim.
 
 ## Set up counter-based quota (partitionable devices)
 
-{{< feature-state state="alpha" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.19" >}}
 
 Use this when your cluster has partitionable devices and you want quota to
 reflect actual device capacity rather than device count. This requires
 Kubernetes 1.35+ with the `DRAPartitionableDevices` feature gate enabled
 and a DRA driver that publishes `consumesCounters` in `ResourceSlice` objects.
+Both `KueueDRAIntegration` and `KueueDRAIntegrationPartitionableDevices`
+feature gates are enabled by default since v0.19.
 
-### 1. Enable the feature gate and configure counter sources
+### 1. Configure counter sources
 
-Install or reconfigure Kueue with the `KueueDRAIntegrationPartitionableDevices`
-feature gate enabled and a `sources` entry in `deviceClassMappings`. Follow the
+Configure a `sources` entry in `deviceClassMappings`. Follow the
 [custom configuration installation instructions](/docs/installation/#install-a-custom-configured-released-version).
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
-featureGates:
-  KueueDRAIntegrationPartitionableDevices: true
 resources:
   deviceClassMappings:
   - name: gpu.memory

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -147,6 +147,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: KueueDRARejectWorkloadsWhenDRADisabled
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -147,6 +147,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: KueueDRARejectWorkloadsWhenDRADisabled
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

Graduates `KueueDRAIntegrationPartitionableDevices` from Alpha to Beta (default enabled) in v0.19. Addresses nits from #13018.

#### Which issue(s) this PR fixes:

Partially Fixes #11903

#### Special notes for your reviewer:

Follow-up to #13018.

#### Does this PR introduce a user-facing change?

```release-note
Graduate KueueDRAIntegrationPartitionableDevices to Beta (enabled by default)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Promoted partitionable-device counter/quota support to **Beta** in **v0.19** and made it **enabled by default** starting with **v0.19**.
- **Documentation**
  - Updated DRA setup guides, feature-state notes, configuration reference, and KEP history to match the **v0.19 beta/default** behavior and simplify setup.
- **Bug Fixes**
  - Improved driver-aware device selection/deduplication and tightened DRA configuration validation, including stricter **counter name/driver** formatting and a **63-character** driver name limit.
- **Tests**
  - Expanded validation and caching-related test coverage for the updated feature-gate and formatting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->