### PR TITLE
MultiKueue: surface a precise out-of-sync admission-check message

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -103,10 +103,22 @@ type wlReconciler struct {
 
 var _ reconcile.Reconciler = (*wlReconciler)(nil)
 
+// remoteWorkload is a worker cluster's view of the local workload: the remote copy
+// (nil when there is none on the worker) together with why it is absent. Keeping both
+// in one place lets step 6a report a precise message without a separate side map,
+// mirroring how connectionState keeps a remote client's connection facts together.
+type remoteWorkload struct {
+	// wl is the remote copy of the workload, or nil when the worker has none.
+	wl *kueue.Workload
+	// outOfSync records that step 5 deleted the remote copy because its spec had drifted
+	// from the manager's, so step 6a re-dispatches it rather than treating it as a lost worker.
+	outOfSync bool
+}
+
 type wlGroup struct {
 	local               *kueue.Workload
 	localClient         client.Client
-	remotes             map[string]*kueue.Workload
+	remotes             map[string]*remoteWorkload
 	remoteClients       map[string]*remoteClient
 	acName              kueue.AdmissionCheckReference
 	jobAdapter          jobframework.MultiKueueAdapter
@@ -141,9 +153,9 @@ func (g *wlGroup) bestMatchByCondition(conditionType string) (*metav1.Condition,
 		bestMatchCond   *metav1.Condition
 		bestMatchRemote string
 	)
-	for remote, wl := range g.remotes {
-		if wl != nil {
-			cond := apimeta.FindStatusCondition(wl.Status.Conditions, conditionType)
+	for remote, rw := range g.remotes {
+		if rw.wl != nil {
+			cond := apimeta.FindStatusCondition(rw.wl.Status.Conditions, conditionType)
 			if cond != nil && cond.Status == metav1.ConditionTrue && (bestMatchCond == nil || cond.LastTransitionTime.Before(&bestMatchCond.LastTransitionTime)) {
 				bestMatchCond = cond
 				bestMatchRemote = remote
@@ -163,10 +175,11 @@ func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error
 		return fmt.Errorf("deleting remote controller object: %w", err)
 	}
 
-	remWl := g.remotes[cluster]
-	if remWl == nil {
+	rw := g.remotes[cluster]
+	if rw == nil || rw.wl == nil {
 		return nil
 	}
+	remWl := rw.wl
 
 	if controllerutil.RemoveFinalizer(remWl, kueue.ResourceInUseFinalizerName) {
 		if err := remoteClient.Update(ctx, remWl); err != nil {
@@ -178,7 +191,7 @@ func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error
 	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("deleting remote workload: %w", err)
 	}
-	g.remotes[cluster] = nil
+	rw.wl = nil
 	return nil
 }
 
@@ -339,7 +352,7 @@ func (w *wlReconciler) readGroup(ctx context.Context, local *kueue.Workload, acN
 	grp := wlGroup{
 		local:               local,
 		localClient:         w.client,
-		remotes:             make(map[string]*kueue.Workload, len(rClients)),
+		remotes:             make(map[string]*remoteWorkload, len(rClients)),
 		remoteClients:       rClients,
 		acName:              acName,
 		jobAdapter:          adapter,
@@ -356,7 +369,7 @@ func (w *wlReconciler) readGroup(ctx context.Context, local *kueue.Workload, acN
 		if err != nil {
 			wl = nil
 		}
-		grp.remotes[remote] = wl
+		grp.remotes[remote] = &remoteWorkload{wl: wl}
 	}
 	return &grp, nil
 }
@@ -441,7 +454,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	remoteEvictCond, evictedRemote := group.bestMatchByCondition(kueue.WorkloadEvicted)
 	if remoteEvictCond != nil {
 		remoteCl := group.remoteClients[evictedRemote].getClient()
-		remoteWl := group.remotes[evictedRemote]
+		remoteWl := group.remotes[evictedRemote].wl
 
 		log = log.WithValues("remote", evictedRemote, "remoteWorkload", klog.KObj(remoteWl))
 		ctx = ctrl.LoggerInto(ctx, log)
@@ -490,7 +503,8 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	// except for two cases (in which we'll update the remote workload accorddingly):
 	// - elastic workloads which have been scaled down
 	// - workloads for which workload priority has changed
-	for rem, remWl := range group.remotes {
+	for rem, rw := range group.remotes {
+		remWl := rw.wl
 		if remWl != nil && isRemoteSpecOutOfSync(group.local.Spec, remWl.Spec) {
 			var remotePreemptionGates []kueue.PreemptionGate
 			if features.Enabled(features.MultiKueueOrchestratedPreemption) {
@@ -530,7 +544,9 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				log.V(2).Error(err, "Deleting out of sync remote objects", "remote", rem)
 				return reconcile.Result{}, err
 			}
-			group.remotes[rem] = nil
+			// RemoveRemoteObjects cleared rw.wl; record why so step 6a can report a
+			// precise re-dispatch message instead of a generic "no longer exists".
+			rw.outOfSync = true
 		}
 	}
 
@@ -564,24 +580,29 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry,
 				"Admission check is Ready but no admitting cluster is recorded; this is unexpected, please report it")
 		}
+		if rw := group.remotes[admitting]; rw != nil && rw.outOfSync {
+			// The admitting worker's remote was deleted in step 5 for drifting from the
+			// manager spec; surface that precise reason rather than a generic loss.
+			return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry,
+				fmt.Sprintf("Remote workload on worker cluster %q is out of sync with its user job, resetting for re-dispatch", admitting))
+		}
 		return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Admitting remote no longer exists")
 	}
 
 	// 6b. An admitting remote is visible: converge onto it.
 	if remoteCond != nil {
 		// remove the non-selected worker workloads
-		for rem, remWl := range group.remotes {
-			if remWl != nil && rem != admittingRemote {
+		for rem, rw := range group.remotes {
+			if rw.wl != nil && rem != admittingRemote {
 				if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, rem)); err != nil {
 					log.V(2).Error(err, "Deleting out of sync remote objects", "remote", rem)
 					return reconcile.Result{}, err
 				}
-				group.remotes[rem] = nil
 			}
 		}
 
 		remoteCl := group.remoteClients[admittingRemote].getClient()
-		remoteWl := group.remotes[admittingRemote]
+		remoteWl := group.remotes[admittingRemote].wl
 
 		log = log.WithValues("remote", admittingRemote, "remoteWorkload", klog.KObj(remoteWl))
 		ctx = ctrl.LoggerInto(ctx, log)
@@ -631,7 +652,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) {
 		remWlName, requeueIn := w.workloadToOpenPreemptionGate(ctx, group)
 		if remWlName != nil {
-			remWl := group.remotes[*remWlName]
+			remWl := group.remotes[*remWlName].wl
 			remClient := group.remoteClients[*remWlName]
 			workload.OpenPreemptionGate(remWl, constants.MultiKueuePreemptionGate, metav1.NewTime(w.clock.Now()))
 			if err := remClient.getClient().Status().Update(ctx, remWl); err != nil {
@@ -804,7 +825,8 @@ func admittedClusterQueue(wl *kueue.Workload) kueue.ClusterQueueReference {
 func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger, group *wlGroup, targetCluster string) (reconcile.Result, error) {
 	var errs []error
 
-	for clusterName, remoteWl := range group.remotes {
+	for clusterName, rw := range group.remotes {
+		remoteWl := rw.wl
 		if clusterName == targetCluster {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[clusterName].origin, false)
@@ -823,7 +845,6 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 				log.V(2).Error(err, "removing remote workload", "cluster", clusterName)
 				errs = append(errs, err)
 			}
-			group.remotes[clusterName] = nil
 		}
 	}
 
@@ -930,7 +951,8 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 
 	log.V(4).Info("Synchronize nominated worker clusters", "dispatcherName", w.dispatcherName, "nominatedWorkerClusterNames", nominatedWorkers)
 
-	for rem, remoteWl := range group.remotes {
+	for rem, rw := range group.remotes {
+		remoteWl := rw.wl
 		if slices.Contains(nominatedWorkers, rem) {
 			if remoteWl == nil {
 				clone := cloneForCreate(group.local, group.remoteClients[rem].origin, true)
@@ -946,7 +968,6 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 				log.V(2).Error(err, "removing non-nominated remote object", "remote", rem)
 				errs = append(errs, err)
 			}
-			group.remotes[rem] = nil
 		}
 	}
 	return reconcile.Result{}, errors.Join(errs...)
@@ -1116,7 +1137,7 @@ func needsDelayedTopologyUpdate(local, remote *kueue.Workload) bool {
 func (w *wlReconciler) syncAdmittingRemoteState(ctx context.Context, group *wlGroup, admittingRemote string, acs *kueue.AdmissionCheckState) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	needsTopologyUpdate := needsDelayedTopologyUpdate(group.local, group.remotes[admittingRemote])
+	needsTopologyUpdate := needsDelayedTopologyUpdate(group.local, group.remotes[admittingRemote].wl)
 	needsACUpdate := acs.State != kueue.CheckStateRetry && acs.State != kueue.CheckStateRejected
 
 	if !needsTopologyUpdate && !needsACUpdate {
@@ -1125,7 +1146,7 @@ func (w *wlReconciler) syncAdmittingRemoteState(ctx context.Context, group *wlGr
 
 	if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 		if needsTopologyUpdate {
-			updateDelayedTopologyRequest(wl, group.remotes[admittingRemote])
+			updateDelayedTopologyRequest(wl, group.remotes[admittingRemote].wl)
 		}
 
 		if needsACUpdate {
@@ -1190,7 +1211,8 @@ func (w *wlReconciler) workloadToOpenPreemptionGate(ctx context.Context, group *
 	var oldestPreemptionSignalTime *metav1.Time
 	var workloadToUngateClusterName *string
 
-	for clusterName, wl := range group.remotes {
+	for clusterName, rw := range group.remotes {
+		wl := rw.wl
 		remoteWlLog := log.WithValues("remoteCluster", clusterName, "remoteWorkload", klog.KObj(wl))
 		if wl == nil {
 			continue

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1373,6 +1373,54 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"the local workload reports out of sync when the admitting remote drifted from the manager spec": {
+			// The admitting worker is reachable, but step 5 deleted its remote for drifting from
+			// the manager spec. Step 6a must surface that precise reason instead of the generic
+			// "Admitting remote no longer exists" used when the remote is simply gone.
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					PodSets(*utiltestingapi.MakePodSet("different-name", 1).Obj()).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload was admitted on "worker1"`,
+					}).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					ClusterName("worker1").
+					Obj(),
+			},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			useSecondWorker:  true,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					PodSets(*utiltestingapi.MakePodSet("different-name", 1).Obj()).
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateRetry,
+						Message: `Remote workload on worker cluster "worker1" is out of sync with its user job, resetting for re-dispatch, Previously: "Ready"`,
+					}).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					ClusterName("worker1").
+					Obj(),
+			},
+		},
 		"the local workload is retried when the admission check is Ready but no admitting cluster is recorded": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
@@ -1677,7 +1725,7 @@ func TestWlReconcile(t *testing.T) {
 					AdmissionCheck(kueue.AdmissionCheckState{
 						Name:    "ac1",
 						State:   kueue.CheckStateRetry,
-						Message: `Admitting remote no longer exists, Previously: "Ready"`,
+						Message: `Remote workload on worker cluster "worker1" is out of sync with its user job, resetting for re-dispatch, Previously: "Ready"`,
 					}).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
 					ClusterName("worker1").
@@ -2374,6 +2422,16 @@ type createCall struct {
 	obj     *kueue.Workload
 }
 
+// newRemoteWorkloads wraps a cluster->workload map into the group's
+// cluster->*remoteWorkload map used by wlGroup.remotes.
+func newRemoteWorkloads(wls map[string]*kueue.Workload) map[string]*remoteWorkload {
+	remotes := make(map[string]*remoteWorkload, len(wls))
+	for name, wl := range wls {
+		remotes[name] = &remoteWorkload{wl: wl}
+	}
+	return remotes
+}
+
 func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 	const externalMultiKueueDispatcherController = "external.com/mk-dispatcher"
 
@@ -2510,7 +2568,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			}
 			group := &wlGroup{
 				local:         local,
-				remotes:       tt.remotes,
+				remotes:       newRemoteWorkloads(tt.remotes),
 				remoteClients: remoteClients,
 				acName:        "ac1",
 			}
@@ -2754,7 +2812,7 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 	group := &wlGroup{
 		local:       local,
 		localClient: managerClient,
-		remotes:     map[string]*kueue.Workload{workerName: remote},
+		remotes:     newRemoteWorkloads(map[string]*kueue.Workload{workerName: remote}),
 		remoteClients: map[string]*remoteClient{
 			workerName: {client: workerClient, origin: defaultOrigin},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

When step 5 in the MultiKueue admission-check controller deletes a worker's
remote workload because its spec drifted from the manager's, step 6a previously
reported the generic admission-check message `Admitting remote no longer exists`
once the admitting worker had no admitted remote left. That hides the actual
reason — a re-dispatch after an out-of-sync deletion — from operators.

As suggested in
https://github.com/kubernetes-sigs/kueue/pull/12999#discussion_r3589317420, this
encapsulates the per-remote state instead of tracking it across `group.remotes`
and an ad-hoc side map (the `outOfSyncDeleted` map dropped from #12999):

- `wlGroup.remotes` now maps each cluster to a `*remoteWorkload` holding the
  remote copy (`nil` when absent) together with an `outOfSync` flag, mirroring
  how `connectionState` keeps a remote client's connection facts in one place.
- `RemoveRemoteObjects` clears the workload as the single source of truth;
  step 5 records `outOfSync` on the entry it deleted, so the redundant
  `group.remotes[...] = nil` assignments at the call sites are removed.
- Step 6a reports, only when the admitting worker's own remote was the one
  deleted for drifting, `Remote workload on worker cluster %q is out of sync
  with its user job, resetting for re-dispatch` (matching the existing step-3
  out-of-sync wording), and keeps the generic message for a remote that is
  simply gone. The flag is keyed per cluster, so an unrelated cluster's
  out-of-sync deletion is not misreported against the admitting one.

#### Which issue(s) this PR fixes:

Addresses #13090. Deferred from #12999 to keep that bugfix focused.

#### Special notes for your reviewer:

Draft while I gather any further review feedback.

Tests:
- Updated the existing elastic out-of-sync case to expect the precise message.
- Added `the local workload reports out of sync when the admitting remote
  drifted from the manager spec`, contrasting with the adjacent
  "reachable but gone → generic message" case.

Validated locally: `go build ./...`, `gofmt -l` clean, `go vet` on the
controller and integration packages, and the MultiKueue unit tests all pass.

_(Drafted with AI assistance.)_

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: The admission check now reports a precise "Remote workload on worker cluster <name> is out of sync with its user job, resetting for re-dispatch" message when the admitting worker's remote workload is reset for drifting from the manager spec, instead of the generic "Admitting remote no longer exists".
```
