### PR TITLE
fix: exclude terminal pods from the elastic ungating quota cap

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -546,6 +546,44 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"terminal pods do not consume the cap: replacements are ungated": {
+			// Regression for kueue#13121: Pods in a terminal phase (Succeeded,
+			// e.g. the first completion of a Job with completions > parallelism,
+			// or Failed with restartPolicy=Never) remain in the API without the
+			// gate but no longer occupy an admitted slot. They must not count
+			// against the granted cap, so the gated replacement pods can be
+			// ungated within the same admitted count.
+			workloads: []kueue.Workload{admittedElasticWorkload(2, now)},
+			pods: []corev1.Pod{
+				*chainPod("pod-succeeded").StatusPhase(corev1.PodSucceeded).Obj(),
+				*chainPod("pod-failed").StatusPhase(corev1.PodFailed).Obj(),
+				*chainPod("pod-replacement-0").Gate(kueue.ElasticJobSchedulingGate).Obj(),
+				*chainPod("pod-replacement-1").Gate(kueue.ElasticJobSchedulingGate).Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*chainPod("pod-failed").StatusPhase(corev1.PodFailed).Obj(),
+				*chainPod("pod-replacement-0").Obj(),
+				*chainPod("pod-replacement-1").Obj(),
+				*chainPod("pod-succeeded").StatusPhase(corev1.PodSucceeded).Obj(),
+			},
+		},
+		"running ungated pod still consumes the cap": {
+			// Boundary guard for the kueue#13121 fix: only terminal pods free
+			// their slot. A Running (non-terminal) ungated pod keeps consuming
+			// the cap, so the gated pod must stay gated at granted=1. This is
+			// also the only unit case where an already-ungated pod blocks a
+			// gated one at the cap (the kueue#12045 cases never modeled pod
+			// phases, and their ungated pods never exhausted the granted count).
+			workloads: []kueue.Workload{admittedElasticWorkload(1, now)},
+			pods: []corev1.Pod{
+				*chainPod("pod-running").StatusPhase(corev1.PodRunning).Obj(),
+				*chainPod("pod-waiting").Gate(kueue.ElasticJobSchedulingGate).Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*chainPod("pod-running").StatusPhase(corev1.PodRunning).Obj(),
+				*chainPod("pod-waiting").Gate(kueue.ElasticJobSchedulingGate).Obj(),
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -628,6 +666,26 @@ func TestReconcile(t *testing.T) {
 			}
 		})
 	}
+}
+
+// admittedElasticWorkload returns an admitted elastic workload "wl" in "ns"
+// with a single default PodSet granted count replicas.
+func admittedElasticWorkload(count int, now time.Time) kueue.Workload {
+	return *utiltestingapi.MakeWorkload("wl", "ns").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+		ControllerReference(rayClusterGVK, "ray", "ray-uid").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, count).Request(corev1.ResourceCPU, "1").Obj()).
+		SimpleReserveQuota("cq", "flavor", now).
+		AdmittedAt(true, now).
+		Obj()
+}
+
+// chainPod returns a pod of the "wl" slice chain in "ns".
+func chainPod(name string) *testingpod.PodWrapper {
+	return testingpod.MakePod(name, "ns").
+		Annotation(kueue.WorkloadAnnotation, "wl").
+		Annotation(kueue.WorkloadSliceNameAnnotation, "wl")
 }
 
 // ensureDefaultPodSetLabel sets the default PodSet label on the pod unless it

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4755,6 +4755,70 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should ungate a replacement pod once its predecessor reaches a terminal phase", framework.SlowSpec, func() {
+		// Regression for kueue#13121: a terminal (Succeeded/Failed) pod stays in
+		// the API without the elastic gate and was counted against the admitted
+		// cap, so the replacement pod of a Job with completions > parallelism
+		// stayed scheduling-gated forever. Mirrors the issue's repro:
+		// parallelism=1, completions=2.
+		testJob := testingjob.MakeJob("terminal-pod-repro", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Parallelism(1).
+			Completions(2).
+			Obj()
+
+		ginkgo.By("creating the job")
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		var (
+			jobWorkload *kueue.Workload
+			podSet      kueue.PodSetReference
+		)
+		ginkgo.By("admitting the job's workload at 1 pod")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			jobWorkload = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(jobWorkload)).Should(gomega.BeTrue())
+			g.Expect(jobWorkload.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(1)))
+			podSet = jobWorkload.Spec.PodSets[0].Name
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		mintPod := func(name string) *corev1.Pod {
+			return testingpod.MakePod(name, ns.Name).
+				Annotation(kueue.WorkloadAnnotation, jobWorkload.Name).
+				Annotation(kueue.WorkloadSliceNameAnnotation, jobWorkload.Name).
+				Label(pkgconstants.PodSetLabel, string(podSet)).
+				Gate(kueue.ElasticJobSchedulingGate).
+				Obj()
+		}
+
+		firstPod := mintPod("first-pod")
+		ginkgo.By("minting the first gated pod and waiting for it to be ungated")
+		util.MustCreate(ctx, k8sClient, firstPod)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(firstPod), firstPod)).Should(gomega.Succeed())
+			g.Expect(utilpod.HasGate(firstPod, kueue.ElasticJobSchedulingGate)).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("marking the first pod Succeeded, emulating its completion")
+		util.SetPodsPhase(ctx, k8sClient, corev1.PodSucceeded, firstPod)
+
+		replacementPod := mintPod("replacement-pod")
+		ginkgo.By("minting the gated replacement pod for the second completion")
+		util.MustCreate(ctx, k8sClient, replacementPod)
+
+		ginkgo.By("the ungater ungates the replacement: the terminal pod freed its slot")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(replacementPod), replacementPod)).Should(gomega.Succeed())
+			g.Expect(utilpod.HasGate(replacementPod, kueue.ElasticJobSchedulingGate)).Should(gomega.BeFalse(),
+				"replacement pod must be ungated once its predecessor is terminal, but it stayed scheduling-gated")
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should support scheduling pending workload after freeing capacity on scale-down", func() {
 		var (
 			testJobAWorkload *kueue.Workload


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area elastic-jobs

#### What this PR does / why we need it:

With `ElasticJobsViaWorkloadSlices` enabled, the `ElasticJobUngater` counts
every ungated pod against the admitted PodSet cap, including `Succeeded`/
`Failed` pods that remain in the API but no longer occupy an admitted slot.
A Job with `completions > parallelism` therefore never gets its replacement
pod ungated: the completed pod uses up the cap and the replacement stays
`SchedulingGated` forever.

This PR lands in two steps:
1. Regression tests first (current state, expected to fail in CI): a unit
   case where terminal pods must free their slots for gated replacements, a
   boundary guard pinning that a `Running` pod still consumes the cap, and a
   batch Job integration spec mirroring the issue's repro
   (`parallelism: 1, completions: 2`) that also covers the event trigger path.
2. The fix in a follow-up commit: exclude terminal pods from the cap
   accounting in `podsToUngate`, flipping the new tests green.

#### Which issue(s) this PR fixes:

Fixes #13121

#### Special notes for your reviewer:

* The first commit is deliberately tests-only so CI documents the bug; the
  PR stays draft until the fix commit lands.
* AI disclosure: prepared with the assistance of an AI coding tool, in line
  with the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where, with the ElasticJobsViaWorkloadSlices feature gate enabled, pods of an elastic job in a terminal phase (Succeeded or Failed) kept counting against the admitted quota, leaving replacement pods (e.g. for Jobs with completions > parallelism) SchedulingGated indefinitely.
```