### PR TITLE
fix(importer): Fix TOCTOU nil pointer dereference during ClusterQueue cache lookup

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -84,14 +84,15 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			wl.Spec.Priority = &pc.Value
 		}
 
+		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
+		if !ok {
+			return false, fmt.Errorf("cluster queue not found in cache: %s: %w", lq.Spec.ClusterQueue, cache.ErrCQNotFound)
+		}
+
 		if err := createWorkload(ctx, c, wl); err != nil {
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
-		if !ok {
-			return false, fmt.Errorf("cluster queue not found in cache: %s", lq.Spec.ClusterQueue)
-		}
 		if err := admitWorkload(ctx, c, wl, cq); err != nil {
 			return false, err
 		}

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -88,7 +88,11 @@ func Import(ctx context.Context, c client.Client, importCache *cache.ImportCache
 			return false, fmt.Errorf("creating workload: %w", err)
 		}
 
-		if err := admitWorkload(ctx, c, wl, importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]); err != nil {
+		cq, ok := importCache.ClusterQueues[string(lq.Spec.ClusterQueue)]
+		if !ok {
+			return false, fmt.Errorf("cluster queue not found in cache: %s", lq.Spec.ClusterQueue)
+		}
+		if err := admitWorkload(ctx, c, wl, cq); err != nil {
 			return false, err
 		}
 		log.V(2).Info("Successfully imported", "pod", klog.KObj(p), "workload", klog.KObj(wl))

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -172,6 +172,34 @@ func TestImportNamespace(t *testing.T) {
 					Obj(),
 			},
 		},
+		"missing cluster queue": {
+			pods: []corev1.Pod{
+				*basePodWrapper.DeepCopy(),
+			},
+			mapping: mapping.Rules{
+				mapping.Rule{
+					Match: mapping.Match{
+						PriorityClassName: "",
+						Labels: map[string]string{
+							testingQueueLabel: "q1",
+						},
+					},
+					ToLocalQueue: "lq1",
+				},
+			},
+			localQueues: []kueue.LocalQueue{
+				*baseLocalQueue.Obj(),
+			},
+			clusterQueues: nil, // intentionally omit cluster queues to trigger ErrCQNotFound
+
+			wantPods: []corev1.Pod{
+				*basePodWrapper.Clone().
+					Label(controllerconstants.QueueLabel, "lq1").
+					ManagedByKueueLabel().
+					Obj(),
+			},
+			wantError: cache.ErrCQNotFound,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fixes a Time-of-Check to Time-of-Use (TOCTOU) race condition in the Pod Importer tool. 
Previously, if a pod was created between the `Check` phase and the `Import` phase targeting a non-existent `ClusterQueue`, the `Import` phase would blindly look it up in the `importCache.ClusterQueues` map without checking if it actually existed. This returned `nil`, which was then passed to `admitWorkload`, causing a panic and crashing the importer tool upon dereferencing `cq.Name`.

This PR adds a safe map lookup check (`cq, ok := ...`) before passing the queue to `admitWorkload`, ensuring the importer handles this edge case gracefully without crashing.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12568

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pod import validation by detecting when the referenced ClusterQueue is missing from the cache.
  * Imports now fail early with a clear “cluster queue not found” error instead of continuing with incomplete information.
* **Tests**
  * Added coverage for the “missing cluster queue” scenario to ensure correct error handling and label updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->