### PR TITLE
Fix reclaimable pods over-reservation after scale-down

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -80,6 +80,10 @@ type JobWithPodLabelSelector interface {
 // when reclaimable pod information is needed.
 type JobWithReclaimablePods interface {
 	// ReclaimablePods returns the list of reclaimable pods.
+	//
+	// Note: for Jobs with ordered Pods that support elastic scaling, implementations
+	// must account for which ranks remain after scaling down to prevent quota leaks.
+	// See the batch Job implementation and kueue#12958, kueue#13117.
 	ReclaimablePods(ctx context.Context, c client.Client) ([]kueue.ReclaimablePod, error)
 }
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -497,10 +497,6 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			log.Error(err, "Getting reclaimable pods")
 			return ctrl.Result{}, err
 		}
-		if WorkloadSliceEnabled(job) {
-			// Elastic jobs may have scaled down since admission (kueue#12958).
-			reclPods = workload.ReduceReclaimablePodsByScaleDown(log, wl, reclPods)
-		}
 		reclPods = workload.LimitReclaimablePodsToPodSetSizes(wl, reclPods)
 
 		if !workload.ReclaimablePodsAreEqual(reclPods, wl.Status.ReclaimablePods) {

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -212,11 +213,26 @@ func (j *Job) PodLabelSelector() string {
 
 func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.ReclaimablePod, error) {
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
-	if parallelism == 1 || j.Status.Succeeded == 0 {
+	completions := ptr.Deref(j.Spec.Completions, parallelism)
+
+	// For an Indexed Job derive the number of completed pods from
+	// completedIndexes rather than Status.Succeeded. After an elastic scale-down
+	// that shrinks completions, Status.Succeeded briefly keeps counting the
+	// removed high indexes until the Job controller recounts it; releasing quota
+	// based on that stale value would let the surviving pods run outside quota
+	// (kueue#13117). Counting only the completed indexes below the current
+	// completions yields the post-recount value immediately and can never
+	// over-credit, since completedIndexes lists real successes.
+	succeeded := j.Status.Succeeded
+	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
+		succeeded = completedIndexesCount(j.Status.CompletedIndexes, completions)
+	}
+
+	if parallelism == 1 || succeeded == 0 {
 		return nil, nil
 	}
 
-	remaining := ptr.Deref(j.Spec.Completions, parallelism) - j.Status.Succeeded
+	remaining := completions - succeeded
 	if remaining >= parallelism {
 		return nil, nil
 	}
@@ -225,6 +241,44 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 		Name:  kueue.DefaultPodSetName,
 		Count: parallelism - remaining,
 	}}, nil
+}
+
+// completedIndexesCount returns the number of indexes listed in an Indexed Job's
+// status.completedIndexes that are below completions. completedIndexes uses the
+// Kubernetes format: an ascending, comma-separated list of intervals where each
+// interval is a single index ("3") or an inclusive range ("3-5"), e.g. "1,3-5,7".
+// Capping the intervals at completions gives the number of completed pods within
+// the current pod set even while status.Succeeded is briefly stale after a
+// scale-down (kueue#13117).
+func completedIndexesCount(completedIndexes string, completions int32) int32 {
+	if completedIndexes == "" || completions <= 0 {
+		return 0
+	}
+	limit := int(completions)
+	count := 0
+	for interval := range strings.SplitSeq(completedIndexes, ",") {
+		firstStr, lastStr, isRange := strings.Cut(interval, "-")
+		first, err := strconv.Atoi(firstStr)
+		if err != nil {
+			continue
+		}
+		last := first
+		if isRange {
+			if last, err = strconv.Atoi(lastStr); err != nil {
+				continue
+			}
+		}
+		if first < 0 || last < first {
+			continue
+		}
+		if last >= limit {
+			last = limit - 1
+		}
+		if first <= last {
+			count += last - first + 1
+		}
+	}
+	return int32(count)
 }
 
 // The following labels are managed internally by batch/job controller, we should not

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -235,29 +235,24 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 			"statusSucceeded", j.Status.Succeeded)
 	}
 
-	if parallelism == 1 || succeeded == 0 {
-		log.V(3).Info("No reclaimable pods: single-pod Job or nothing completed",
-			"parallelism", parallelism,
-			"succeeded", succeeded)
-		return nil, nil
+	// A single-pod Job or one with no completed pods has nothing to reclaim; so
+	// does one whose remaining work still fills every parallel slot.
+	reclaimable := int32(0)
+	if parallelism > 1 && succeeded > 0 {
+		if remaining := completions - succeeded; remaining < parallelism {
+			reclaimable = parallelism - remaining
+		}
 	}
 
-	remaining := completions - succeeded
-	if remaining >= parallelism {
-		log.V(3).Info("No reclaimable pods: remaining work still fills the pod set",
-			"parallelism", parallelism,
-			"completions", completions,
-			"succeeded", succeeded,
-			"remaining", remaining)
-		return nil, nil
-	}
-
-	reclaimable := parallelism - remaining
 	log.V(3).Info("Computed reclaimable pods for Job",
 		"parallelism", parallelism,
 		"completions", completions,
 		"succeeded", succeeded,
 		"reclaimable", reclaimable)
+
+	if reclaimable == 0 {
+		return nil, nil
+	}
 	return []kueue.ReclaimablePod{{
 		Name:  kueue.DefaultPodSetName,
 		Count: reclaimable,

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,7 +227,7 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	// over-credit, since completedIndexes lists real successes.
 	succeeded := j.Status.Succeeded
 	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
-		succeeded = completedIndexesCount(j.Status.CompletedIndexes, completions)
+		succeeded = completedIndexesCount(log, j.Status.CompletedIndexes, completions)
 		log.V(3).Info("Derived completed pods from completedIndexes for Indexed Job",
 			"completedIndexes", j.Status.CompletedIndexes,
 			"completions", completions,
@@ -270,25 +271,15 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 // Capping the intervals at completions gives the number of completed pods within
 // the current pod set even while status.Succeeded is briefly stale after a
 // scale-down (kueue#13117).
-func completedIndexesCount(completedIndexes string, completions int32) int32 {
+func completedIndexesCount(log logr.Logger, completedIndexes string, completions int32) int32 {
 	if completedIndexes == "" || completions <= 0 {
 		return 0
 	}
 	limit := int(completions)
 	count := 0
 	for interval := range strings.SplitSeq(completedIndexes, ",") {
-		firstStr, lastStr, isRange := strings.Cut(interval, "-")
-		first, err := strconv.Atoi(firstStr)
-		if err != nil {
-			continue
-		}
-		last := first
-		if isRange {
-			if last, err = strconv.Atoi(lastStr); err != nil {
-				continue
-			}
-		}
-		if first < 0 || last < first {
+		first, last, ok := parseIndexRange(log, interval)
+		if !ok {
 			continue
 		}
 		last = min(last, limit-1)
@@ -297,6 +288,33 @@ func completedIndexesCount(completedIndexes string, completions int32) int32 {
 		}
 	}
 	return int32(count)
+}
+
+// parseIndexRange parses a single completedIndexes interval ("3" or "3-5") into
+// its inclusive [first, last] bounds. It returns ok=false and logs when the
+// interval is malformed or descending; the Job controller always writes
+// well-formed, ascending indexes, so a failure here signals unexpected status
+// content worth surfacing rather than silently skipping.
+func parseIndexRange(log logr.Logger, interval string) (first, last int, ok bool) {
+	firstStr, lastStr, isRange := strings.Cut(interval, "-")
+	first, err := strconv.Atoi(firstStr)
+	if err != nil {
+		log.V(3).Info("Ignoring malformed completedIndexes interval", "interval", interval, "error", err)
+		return 0, 0, false
+	}
+	last = first
+	if isRange {
+		if last, err = strconv.Atoi(lastStr); err != nil {
+			log.V(3).Info("Ignoring malformed completedIndexes interval", "interval", interval, "error", err)
+			return 0, 0, false
+		}
+	}
+	// first is never negative, so only a descending range like "5-3" is invalid.
+	if last < first {
+		log.V(3).Info("Ignoring descending completedIndexes interval", "interval", interval)
+		return 0, 0, false
+	}
+	return first, last, true
 }
 
 // The following labels are managed internally by batch/job controller, we should not

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -217,14 +217,9 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
 	completions := ptr.Deref(j.Spec.Completions, parallelism)
 
-	// For an Indexed Job derive the number of completed pods from
-	// completedIndexes rather than Status.Succeeded. After an elastic scale-down
-	// that shrinks completions, Status.Succeeded briefly keeps counting the
-	// removed high indexes until the Job controller recounts it; releasing quota
-	// based on that stale value would let the surviving pods run outside quota
-	// (kueue#13117). Counting only the completed indexes below the current
-	// completions yields the post-recount value immediately and can never
-	// over-credit, since completedIndexes lists real successes.
+	// Indexed Job: derive the succeeded count from completedIndexes, ignoring
+	// indexes >= completions. After an elastic scale-down, Status.Succeeded may
+	// still include the removed indexes (kueue#13117).
 	succeeded := j.Status.Succeeded
 	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
 		succeeded = completedIndexesCount(log, j.Status.CompletedIndexes, completions)
@@ -239,7 +234,7 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	// does one whose remaining work still fills every parallel slot.
 	reclaimable := int32(0)
 	if parallelism > 1 && succeeded > 0 {
-		if remaining := completions - succeeded; remaining < parallelism {
+		if remaining := max(completions-succeeded, 0); remaining < parallelism {
 			reclaimable = parallelism - remaining
 		}
 	}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -212,6 +212,7 @@ func (j *Job) PodLabelSelector() string {
 }
 
 func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.ReclaimablePod, error) {
+	log := ctrl.LoggerFrom(ctx)
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
 	completions := ptr.Deref(j.Spec.Completions, parallelism)
 
@@ -226,20 +227,39 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	succeeded := j.Status.Succeeded
 	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
 		succeeded = completedIndexesCount(j.Status.CompletedIndexes, completions)
+		log.V(3).Info("Derived completed pods from completedIndexes for Indexed Job",
+			"completedIndexes", j.Status.CompletedIndexes,
+			"completions", completions,
+			"derivedSucceeded", succeeded,
+			"statusSucceeded", j.Status.Succeeded)
 	}
 
 	if parallelism == 1 || succeeded == 0 {
+		log.V(3).Info("No reclaimable pods: single-pod Job or nothing completed",
+			"parallelism", parallelism,
+			"succeeded", succeeded)
 		return nil, nil
 	}
 
 	remaining := completions - succeeded
 	if remaining >= parallelism {
+		log.V(3).Info("No reclaimable pods: remaining work still fills the pod set",
+			"parallelism", parallelism,
+			"completions", completions,
+			"succeeded", succeeded,
+			"remaining", remaining)
 		return nil, nil
 	}
 
+	reclaimable := parallelism - remaining
+	log.V(3).Info("Computed reclaimable pods for Job",
+		"parallelism", parallelism,
+		"completions", completions,
+		"succeeded", succeeded,
+		"reclaimable", reclaimable)
 	return []kueue.ReclaimablePod{{
 		Name:  kueue.DefaultPodSetName,
-		Count: parallelism - remaining,
+		Count: reclaimable,
 	}}, nil
 }
 
@@ -271,9 +291,7 @@ func completedIndexesCount(completedIndexes string, completions int32) int32 {
 		if first < 0 || last < first {
 			continue
 		}
-		if last >= limit {
-			last = limit - 1
-		}
+		last = min(last, limit-1)
 		if first <= last {
 			count += last - first + 1
 		}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	batchv1 "k8s.io/api/batch/v1"
@@ -4562,7 +4563,7 @@ func TestCompletedIndexesCount(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := completedIndexesCount(tc.completedIndexes, tc.completions); got != tc.want {
+			if got := completedIndexesCount(logr.Discard(), tc.completedIndexes, tc.completions); got != tc.want {
 				t.Errorf("completedIndexesCount(%q, %d) = %d, want %d", tc.completedIndexes, tc.completions, got, tc.want)
 			}
 		})

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4569,3 +4569,45 @@ func TestCompletedIndexesCount(t *testing.T) {
 		})
 	}
 }
+
+func TestReclaimablePods(t *testing.T) {
+	indexedJob := func(succeeded int32, completedIndexes string) *Job {
+		j := utiltestingjob.MakeJob("job", "ns").
+			Indexed(true).
+			Parallelism(8).
+			Completions(8).
+			Obj()
+		j.Status.Succeeded = succeeded
+		j.Status.CompletedIndexes = completedIndexes
+		return (*Job)(j)
+	}
+	cases := map[string]struct {
+		job  *Job
+		want []kueue.ReclaimablePod
+	}{
+		// An ordinary (non-elastic) Indexed Job must reclaim its completed indexes
+		// exactly as before, now that the count is derived from completedIndexes.
+		"indexed Job reclaims its completed indexes": {
+			job:  indexedJob(4, "0-3"),
+			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 4}},
+		},
+		// Succeeded set without completedIndexes should not happen with the native
+		// Job controller (both are written in one update), but can with a custom
+		// spec.managedBy controller. We trust completedIndexes and hold the quota.
+		"indexed Job with empty completedIndexes holds quota": {
+			job:  indexedJob(4, ""),
+			want: nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := tc.job.ReclaimablePods(t.Context(), nil)
+			if err != nil {
+				t.Fatalf("ReclaimablePods() returned error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ReclaimablePods() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4538,3 +4538,33 @@ func TestCleanLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestCompletedIndexesCount(t *testing.T) {
+	cases := map[string]struct {
+		completedIndexes string
+		completions      int32
+		want             int32
+	}{
+		"empty":                         {completedIndexes: "", completions: 10, want: 0},
+		"zero completions":              {completedIndexes: "0-9", completions: 0, want: 0},
+		"single index":                  {completedIndexes: "0", completions: 10, want: 1},
+		"single range":                  {completedIndexes: "0-4", completions: 10, want: 5},
+		"mixed intervals":               {completedIndexes: "0-4,7,9-11", completions: 10, want: 7},
+		"surviving low indexes":         {completedIndexes: "0-8", completions: 10, want: 9},
+		"all completed within range":    {completedIndexes: "0-14", completions: 10, want: 10},
+		"range straddling the cap":      {completedIndexes: "5-19", completions: 10, want: 5},
+		"all removed (above the cap)":   {completedIndexes: "10-19", completions: 10, want: 0},
+		"range capped tighter":          {completedIndexes: "0-4", completions: 3, want: 3},
+		"discrete indexes":              {completedIndexes: "3,5,7", completions: 10, want: 3},
+		"discrete indexes partly above": {completedIndexes: "3,5,12", completions: 10, want: 2},
+		"malformed interval skipped":    {completedIndexes: "abc,0-2", completions: 10, want: 3},
+		"malformed range end skipped":   {completedIndexes: "0-x,4", completions: 10, want: 1},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := completedIndexesCount(tc.completedIndexes, tc.completions); got != tc.want {
+				t.Errorf("completedIndexesCount(%q, %d) = %d, want %d", tc.completedIndexes, tc.completions, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -1163,45 +1163,6 @@ func LimitReclaimablePodsToPodSetSizes(wl *kueue.Workload, reclaimablePods []kue
 	return limited
 }
 
-// ReduceReclaimablePodsByScaleDown returns a copy of reclaimablePods with every
-// count reduced, bounded at zero, by the pods removed from its PodSet since
-// admission (the admission's granted count minus the current PodSet count).
-//
-// Without this, a job's reclaimable count derived from monotonic state (e.g. a
-// batch/Job's Status.Succeeded) would release quota for pods already removed by
-// an elastic scale-down (kueue#12958).
-func ReduceReclaimablePodsByScaleDown(log logr.Logger, wl *kueue.Workload, reclaimablePods []kueue.ReclaimablePod) []kueue.ReclaimablePod {
-	if wl.Status.Admission == nil {
-		return reclaimablePods
-	}
-	admittedSizes := make(map[kueue.PodSetReference]int32, len(wl.Status.Admission.PodSetAssignments))
-	for i := range wl.Status.Admission.PodSetAssignments {
-		psa := &wl.Status.Admission.PodSetAssignments[i]
-		if psa.Count != nil {
-			admittedSizes[psa.Name] = *psa.Count
-		}
-	}
-	currentSizes := ExtractPodSetCountsFromWorkload(wl)
-	reduced := slices.Clone(reclaimablePods)
-	for i := range reduced {
-		admitted, found := admittedSizes[reduced[i].Name]
-		if !found {
-			continue
-		}
-		if scaledDown := admitted - currentSizes[reduced[i].Name]; scaledDown > 0 {
-			newCount := max(0, reduced[i].Count-scaledDown)
-			log.V(3).Info("Reducing reclaimable pods for scaled-down podSet",
-				"podSet", reduced[i].Name,
-				"admittedCount", admitted,
-				"currentCount", currentSizes[reduced[i].Name],
-				"reclaimableFrom", reduced[i].Count,
-				"reclaimableTo", newCount)
-			reduced[i].Count = newCount
-		}
-	}
-	return reduced
-}
-
 // ReclaimablePodsAreEqual checks if two Reclaimable pods are semantically equal
 // having the same length and all keys have the same value.
 func ReclaimablePodsAreEqual(a, b []kueue.ReclaimablePod) bool {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1182,59 +1182,6 @@ func TestLimitReclaimablePodsToPodSetSizes(t *testing.T) {
 	}
 }
 
-func TestReduceReclaimablePodsByScaleDown(t *testing.T) {
-	// makeWorkload builds a workload whose PodSet has been scaled down to
-	// currentSize while its admission still records the originally granted
-	// admittedSize.
-	makeWorkload := func(admittedSize, currentSize int32) *kueue.Workload {
-		return utiltestingapi.MakeWorkload("wl", "ns").
-			PodSets(*utiltestingapi.MakePodSet("main", int(currentSize)).Obj()).
-			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
-				PodSets(utiltestingapi.MakePodSetAssignment("main").Count(admittedSize).Obj()).
-				Obj(), time.Now()).
-			Obj()
-	}
-	cases := map[string]struct {
-		wl              *kueue.Workload
-		reclaimablePods []kueue.ReclaimablePod
-		want            []kueue.ReclaimablePod
-	}{
-		"no admission is a no-op": {
-			wl:              utiltestingapi.MakeWorkload("wl", "ns").PodSets(*utiltestingapi.MakePodSet("main", 10).Obj()).Obj(),
-			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 9}},
-			want:            []kueue.ReclaimablePod{{Name: "main", Count: 9}},
-		},
-		"no scale-down leaves the count unchanged": {
-			wl:              makeWorkload(10, 10),
-			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 5}},
-			want:            []kueue.ReclaimablePod{{Name: "main", Count: 5}},
-		},
-		"scale-down larger than the count clamps to zero": {
-			wl:              makeWorkload(20, 10),
-			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 9}},
-			want:            []kueue.ReclaimablePod{{Name: "main", Count: 0}},
-		},
-		"scale-down smaller than the count reduces by the delta": {
-			wl:              makeWorkload(20, 10),
-			reclaimablePods: []kueue.ReclaimablePod{{Name: "main", Count: 15}},
-			want:            []kueue.ReclaimablePod{{Name: "main", Count: 5}},
-		},
-		"podSet without an admission entry is left as is": {
-			wl:              makeWorkload(20, 10),
-			reclaimablePods: []kueue.ReclaimablePod{{Name: "other", Count: 4}},
-			want:            []kueue.ReclaimablePod{{Name: "other", Count: 4}},
-		},
-	}
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := ReduceReclaimablePodsByScaleDown(logr.Discard(), tc.wl, tc.reclaimablePods)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("Unexpected reclaimable pods (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
 func TestAssignmentClusterQueueState(t *testing.T) {
 	cases := map[string]struct {
 		state              *AssignmentClusterQueueState

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -993,19 +993,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 		// (overbooking) nor dropping below it (pods leak). Each pod requests 200m,
 		// so the ClusterQueue's reserved CPU must always equal running pods * 200m.
 		ginkgo.It("keeps the reserved quota equal to the running pods", func() {
-			reservedMilliCPU := func(g gomega.Gomega) int64 {
-				cq := &kueue.ClusterQueue{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
-				var total int64
-				for _, fu := range cq.Status.FlavorsUsage {
-					for _, r := range fu.Resources {
-						if r.Name == corev1.ResourceCPU {
-							total += r.Total.MilliValue()
-						}
-					}
-				}
-				return total
-			}
+			cqKey := client.ObjectKeyFromObject(clusterQueue)
 
 			elasticJob := testingjob.MakeJob("elastic-indexed-scale-down", ns.Name).
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
@@ -1022,7 +1010,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			ginkgo.By("admitting the job: 4 pods running, quota reserved for 4 (800m)", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(4))
-					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(800)))
+					g.Expect(clusterQueueReservedMilliCPU(g, cqKey)).Should(gomega.BeEquivalentTo(int64(800)))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -1036,7 +1024,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 				}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(2))
-					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(400)))
+					g.Expect(clusterQueueReservedMilliCPU(g, cqKey)).Should(gomega.BeEquivalentTo(int64(400)))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -1049,12 +1037,28 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(1))
-					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(200)))
+					g.Expect(clusterQueueReservedMilliCPU(g, cqKey)).Should(gomega.BeEquivalentTo(int64(200)))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
 })
+
+// clusterQueueReservedMilliCPU returns the CPU currently reserved by the
+// ClusterQueue across all flavors, in milliCPU.
+func clusterQueueReservedMilliCPU(g gomega.Gomega, cqKey client.ObjectKey) int64 {
+	cq := &kueue.ClusterQueue{}
+	g.Expect(k8sClient.Get(ctx, cqKey, cq)).Should(gomega.Succeed())
+	var total int64
+	for _, fu := range cq.Status.FlavorsUsage {
+		for _, r := range fu.Resources {
+			if r.Name == corev1.ResourceCPU {
+				total += r.Total.MilliValue()
+			}
+		}
+	}
+	return total
+}
 
 func findRunningPods(g gomega.Gomega, namespace, jobName string) []corev1.Pod {
 	podList := &corev1.PodList{}

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -952,6 +952,108 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			})
 		})
 	})
+
+	ginkgo.When("Scaling down an elastic Indexed Job with completed indexes", func() {
+		var (
+			defaultRF    *kueue.ResourceFlavor
+			localQueue   *kueue.LocalQueue
+			clusterQueue *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			defaultRF = utiltestingapi.MakeResourceFlavor("default-" + ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, defaultRF)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cq-" + ns.Name).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultRF.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Obj(),
+				).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("main", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteAllJobsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteAllPodsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, defaultRF, true)
+			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+		})
+
+		// kueue#13117: after successes on surviving indexes and an elastic
+		// scale-down, the quota reserved for the Job must converge to the number
+		// of pods still running - neither staying inflated at the pre-scale podSet
+		// (overbooking) nor dropping below it (pods leak). Each pod requests 200m,
+		// so the ClusterQueue's reserved CPU must always equal running pods * 200m.
+		ginkgo.It("keeps the reserved quota equal to the running pods", func() {
+			reservedMilliCPU := func(g gomega.Gomega) int64 {
+				cq := &kueue.ClusterQueue{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+				var total int64
+				for _, fu := range cq.Status.FlavorsUsage {
+					for _, r := range fu.Resources {
+						if r.Name == corev1.ResourceCPU {
+							total += r.Total.MilliValue()
+						}
+					}
+				}
+				return total
+			}
+
+			elasticJob := testingjob.MakeJob("elastic-indexed-scale-down", ns.Name).
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				Queue("main").
+				Indexed(true).
+				Parallelism(4).
+				Completions(4).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				TerminationGracePeriod(1).
+				Obj()
+			util.MustCreate(ctx, k8sClient, elasticJob)
+
+			ginkgo.By("admitting the job: 4 pods running, quota reserved for 4 (800m)", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(4))
+					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(800)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("completing indexes 0 and 1: 2 pods running, quota converges to 2 (400m), not over-reserved", func() {
+				for _, idx := range []string{"0", "1"} {
+					util.WaitForActivePodsAndTerminate(ctx, k8sClient, restClient, cfg, ns.Name, 1, 0,
+						client.MatchingLabels{
+							"batch.kubernetes.io/job-name":             elasticJob.Name,
+							"batch.kubernetes.io/job-completion-index": idx,
+						})
+				}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(2))
+					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(400)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("scaling parallelism 4 -> 1: quota converges to the single running pod (200m)", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
+					elasticJob.Spec.Parallelism = ptr.To[int32](1)
+					g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(findRunningPods(g, ns.Name, elasticJob.Name)).Should(gomega.HaveLen(1))
+					g.Expect(reservedMilliCPU(g)).Should(gomega.BeEquivalentTo(int64(200)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
 })
 
 func findRunningPods(g gomega.Gomega, namespace, jobName string) []corev1.Pod {

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -1050,7 +1050,7 @@ func clusterQueueReservedMilliCPU(g gomega.Gomega, cqKey client.ObjectKey) int64
 	cq := &kueue.ClusterQueue{}
 	g.Expect(k8sClient.Get(ctx, cqKey, cq)).Should(gomega.Succeed())
 	var total int64
-	for _, fu := range cq.Status.FlavorsUsage {
+	for _, fu := range cq.Status.FlavorsReservation {
 		for _, r := range fu.Resources {
 			if r.Name == corev1.ResourceCPU {
 				total += r.Total.MilliValue()

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4394,10 +4394,11 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 			g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(8)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("marking part of the job's pods as succeeded")
+		ginkgo.By("marking indexes 0-3 as succeeded")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
 			testJob.Status.Succeeded = 4
+			testJob.Status.CompletedIndexes = "0-3"
 			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -4414,36 +4415,96 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling the job down below the succeeded count")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = new(int32(3))
-			testJob.Spec.Completions = new(int32(3))
+			testJob.Spec.Parallelism = ptr.To[int32](3)
+			testJob.Spec.Completions = ptr.To[int32](3)
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("the workload converges instead of wedging: podSet shrinks and the scaled-down reclaimable count is corrected to 0")
+		ginkgo.By("the workload converges instead of wedging: podSet shrinks to 3 and the surviving completed indexes (0-2) are reclaimable")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			wl := &workloads.Items[0]
 			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(3)))
-			// Scaling 8->3 removes 5 pods; max(0, 4-5)=0 reclaimable remain, so
-			// quota is charged for the full shrunk podSet rather than leaked
-			// (kueue#12958).
+			// Of the completed indexes 0-3, only 0-2 survive the scale-down to
+			// completions=3, so 3 pods are reclaimable and none are still running
+			// (kueue#13117).
 			g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
-				{Name: kueue.DefaultPodSetName, Count: 0},
+				{Name: kueue.DefaultPodSetName, Count: 3},
 			}))
 			g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
-	ginkgo.It("Should not release quota for reclaimable pods removed by a scale-down", framework.SlowSpec, func() {
-		// Regression for kueue#12958: scaling a Job down did not lower the
-		// workload's reclaimablePods count by the number of removed pods, so
-		// Kueue kept releasing quota for pods that no longer existed. The Job's
-		// reclaimable count is re-derived from Status.Succeeded on every reconcile,
-		// so the correction must survive that recompute — this reproduces the
-		// exact scenario from the issue (podSet 20, reclaimable 9, scale to 10).
-		testJob := testingjob.MakeJob("scale-down-reclaimable-leak", ns.Name).
+	ginkgo.It("Should not over-reserve quota for a non-indexed Job after a scale-down", framework.SlowSpec, func() {
+		// kueue#13117: for a non-indexed Job status.Succeeded stays accurate across
+		// a scale-down (completed pods are never deleted), so the reclaimable count
+		// must track the pods still running and not over-reserve.
+		testJob := testingjob.MakeJob("scale-down-nonindexed", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(20).
+			Completions(20).
+			Obj()
+
+		ginkgo.By("creating and admitting the job")
+		util.MustCreate(ctx, k8sClient, testJob)
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+			g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(20)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("15 pods succeed -> 5 running, reclaimable 15, quota for 5 pods (500m)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Status.Succeeded = 15
+			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 15},
+			}))
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(500)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("scaling parallelism 20 -> 10; the 5 still-running pods keep exactly their quota (500m), not the full podSet")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = ptr.To[int32](10)
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			wl := &workloads.Items[0]
+			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(10)))
+			g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 5},
+			}))
+			g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(500)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should derive reclaimable pods from completedIndexes while status.Succeeded is stale after scale-down", framework.SlowSpec, func() {
+		// kueue#13117: shrinking completions makes status.Succeeded briefly
+		// over-count the removed high indexes until the Job controller recounts
+		// it. Deriving the reclaimable count from completedIndexes capped at the
+		// current completions gives the correct value immediately, avoiding a
+		// quota leak for the surviving running pods.
+		testJob := testingjob.MakeJob("scale-down-stale-succeeded", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			SetAnnotation(workloadjob.JobCompletionsEqualParallelismAnnotation, "true").
 			Queue(kueue.LocalQueueName(localQueue.Name)).
@@ -4453,44 +4514,33 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 			Completions(20).
 			Obj()
 
-		ginkgo.By("creating a job")
+		ginkgo.By("creating and admitting the job")
 		util.MustCreate(ctx, k8sClient, testJob)
-
-		ginkgo.By("admitting the job's workload")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
-			g.Expect(workloads.Items[0].Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(20)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("9 pods succeed -> reclaimable 9, quota released for those 9 (11 pods charged)")
+		ginkgo.By("scaling down to 10; completedIndexes is pruned to 5-9 but status.Succeeded stays stale at 15")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Status.Succeeded = 9
-			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
-			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
-				{Name: kueue.DefaultPodSetName, Count: 9},
-			}))
-			cq := &kueue.ClusterQueue{}
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1100)))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("scaling the job down 20 -> 10 (removing 10 pods)")
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = new(int32(10))
-			testJob.Spec.Completions = new(int32(10))
+			testJob.Spec.Parallelism = ptr.To[int32](10)
+			testJob.Spec.Completions = ptr.To[int32](10)
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			// The Kubernetes API keeps completedIndexes within completions, so the
+			// removed indexes 10-19 are pruned to leave 5-9; status.Succeeded is
+			// deliberately left stale at 15 (the pre-recount over-count).
+			testJob.Status.Succeeded = 15
+			testJob.Status.CompletedIndexes = "5-9"
+			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("reclaimable drops to max(0, 9-10)=0 and stays there; full 10 pods are charged")
+		ginkgo.By("reclaimable is 5 (from completedIndexes 5-9), not derived from the stale Succeeded=15; the 5 running pods (0-4) keep quota (500m)")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
 			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
@@ -4498,25 +4548,13 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 			wl := &workloads.Items[0]
 			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(10)))
 			g.Expect(wl.Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
-				{Name: kueue.DefaultPodSetName, Count: 0},
+				{Name: kueue.DefaultPodSetName, Count: 5},
 			}))
 			g.Expect(workload.IsAdmitted(wl)).Should(gomega.BeTrue())
 			cq := &kueue.ClusterQueue{}
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1000)))
+			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(500)))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		ginkgo.By("the corrected reclaimable count is stable (not re-inflated by the recompute)")
-		gomega.Consistently(func(g gomega.Gomega) {
-			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
-			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
-			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
-				{Name: kueue.DefaultPodSetName, Count: 0},
-			}))
-			cq := &kueue.ClusterQueue{}
-			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), cq)).Should(gomega.Succeed())
-			g.Expect(cq.Status.FlavorsUsage[0].Resources[0].Total.MilliValue()).Should(gomega.BeEquivalentTo(int64(1000)))
-		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should cap elastic pod ungating to the granted quota", framework.SlowSpec, func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area elastic-jobs

#### What this PR does / why we need it:

Follow-up to #13044. Using the accounting states from that thread (correct: quota = running, overbooking: quota > running, pods leak: quota < running), #13044 fixed the #12958 pods leak but its `ReduceReclaimablePodsByScaleDown` step causes overbooking that lasts until the Job finishes.

This PR drops that reduction and computes the reclaimable count correctly at the source:

* Non-indexed: `status.succeeded` never over-counts (completions is immutable, scale-down only deletes running pods), so dropping the reduction is safe with no leak.
* Indexed: derive the count from `status.completedIndexes` capped at the current `completions` instead of `status.succeeded`. The cap is the recount the Job controller performs, so the value is correct even while `succeeded` is briefly stale, and it can never over-credit.

The #13044 webhook change (allowing the reclaimable decrease for a scaled-down podSet) is kept, since that is what actually resolves #12958. Batch Job is the only integration that is both elastic-capable and implements `ReclaimablePods`, so it is the only one affected.

#### Which issue(s) this PR fixes:

Fixes #13117

#### Special notes for your reviewer:

Completion requirements, each covered by a test:

* Integration: non-indexed, 20 pods, 15 succeeded, scale to 10, reservation 5.
* Integration: Indexed stale-window (new completions, stale succeeded), capped derivation returns the post-recount value.
* e2e: Indexed scale-down with successes on surviving indexes, reservation converges to running pods. 

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where reclaimable Pod accounting after scaling down an elastic Job could reserve quota for Pods that were no longer running. Reserved quota now tracks the remaining running Pods for indexed and non-indexed Jobs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reclaimable-capacity calculation for elastic **Indexed Jobs** during scale-down by deriving reclaimable pods from **completed indexes** (with correct capping), avoiding quota leaks when completion signals lag.
  * Prevented unintended extra reclaimable-pod reductions for elastic/workload-slicing when jobs scale down after admission.
* **Tests**
  * Added unit coverage for parsing `completedIndexes` interval strings (including malformed segments and cap handling).
  * Expanded unit/integration/e2e scale-down scenarios to validate reserved-capacity convergence after parallelism changes.
* **Documentation**
  * Clarified expected behavior in job reclaimability interface comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->