### PR TITLE
Fix FairSharing iterator dropping entries when a ClusterQueue has multiple heads

### DIFF
--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -37,9 +37,13 @@ import (
 // consideration by scheduling when FairSharing is enabled. See
 // runTournament for description of algorithm.
 type fairSharingIterator struct {
-	// cqToEntry tracks ClusterQueues which still have workloads
-	// to schedule, and the corresponding workload entry.
-	cqToEntry     map[*schdcache.ClusterQueueSnapshot]*entry
+	// cqToEntries tracks ClusterQueues which still have workloads to
+	// schedule, and the corresponding workload entries. A ClusterQueue
+	// may have several entries in a cycle (e.g. second-pass workloads
+	// in addition to the queue head); the slices are never empty and
+	// are ordered by compareEntries, so the first element is the
+	// ClusterQueue's current nominee.
+	cqToEntries   map[*schdcache.ClusterQueueSnapshot][]*entry
 	entryComparer entryComparer
 	log           logr.Logger
 }
@@ -47,7 +51,7 @@ type fairSharingIterator struct {
 func makeFairSharingIterator(ctx context.Context, entries []entry, workloadOrdering workload.Ordering) *fairSharingIterator {
 	log := ctrl.LoggerFrom(ctx)
 	f := fairSharingIterator{
-		cqToEntry: make(map[*schdcache.ClusterQueueSnapshot]*entry, len(entries)),
+		cqToEntries: make(map[*schdcache.ClusterQueueSnapshot][]*entry, len(entries)),
 		entryComparer: entryComparer{
 			log:              log,
 			workloadOrdering: workloadOrdering,
@@ -55,25 +59,44 @@ func makeFairSharingIterator(ctx context.Context, entries []entry, workloadOrder
 		log: log,
 	}
 	for i := range entries {
-		f.cqToEntry[entries[i].clusterQueueSnapshot] = &entries[i]
+		cq := entries[i].clusterQueueSnapshot
+		f.cqToEntries[cq] = append(f.cqToEntries[cq], &entries[i])
+	}
+	for _, cqEntries := range f.cqToEntries {
+		slices.SortFunc(cqEntries, func(a, b *entry) int {
+			return compareEntries(log, workloadOrdering, a, b)
+		})
 	}
 	return &f
 }
 
 func (f *fairSharingIterator) hasNext() bool {
-	return len(f.cqToEntry) > 0
+	return len(f.cqToEntries) > 0
+}
+
+// popEntryForCq removes and returns the first pending entry of the
+// ClusterQueue, dropping the ClusterQueue from the iterator once it has
+// no entries left.
+func (f *fairSharingIterator) popEntryForCq(cq *schdcache.ClusterQueueSnapshot) *entry {
+	cqEntries := f.cqToEntries[cq]
+	head := cqEntries[0]
+	if len(cqEntries) == 1 {
+		delete(f.cqToEntries, cq)
+	} else {
+		f.cqToEntries[cq] = cqEntries[1:]
+	}
+	return head
 }
 
 func (f *fairSharingIterator) pop() *entry {
 	cq := f.getCq()
 
-	// CQ has no Cohort. We simply return its workload.
+	// CQ has no Cohort. We simply return its nominated workload.
 	if !cq.HasParent() {
-		entry := f.cqToEntry[cq]
+		entry := f.popEntryForCq(cq)
 		f.log.V(3).Info("Returning workload from ClusterQueue without Cohort",
 			"clusterQueue", klog.KRef("", string(cq.GetName())),
 			"workload", klog.KObj(entry.Obj))
-		delete(f.cqToEntry, cq)
 		return entry
 	}
 
@@ -83,10 +106,10 @@ func (f *fairSharingIterator) pop() *entry {
 	log := f.log.WithValues("rootCohort", klog.KRef("", string(root.GetName())))
 
 	log.V(5).Info("Computing DominantResourceShare for tournament")
-	f.entryComparer.computeDRS(root, f.cqToEntry)
+	f.entryComparer.computeDRS(root, f.cqToEntries)
 
 	log.V(3).Info("Running tournament to decide next workload to consider in scheduling cycle")
-	entry := runTournament(root, f.entryComparer, f.cqToEntry)
+	entry := runTournament(root, f.entryComparer, f.cqToEntries)
 
 	log = log.WithValues(
 		"cohort", klog.KRef("", string(entry.clusterQueueSnapshot.Parent().GetName())),
@@ -96,7 +119,9 @@ func (f *fairSharingIterator) pop() *entry {
 	log.V(3).Info("Determined tournament winner")
 	f.entryComparer.logDrsValuesWhenVerbose(log)
 
-	delete(f.cqToEntry, entry.clusterQueueSnapshot)
+	// The winner is always the first entry of its ClusterQueue, as only
+	// the first entry of each ClusterQueue takes part in the tournament.
+	f.popEntryForCq(entry.clusterQueueSnapshot)
 	return entry
 }
 
@@ -106,7 +131,7 @@ func (f *fairSharingIterator) pop() *entry {
 // consideration is nearly deterministic within Cohort (only when DRS,
 // Priority, and time are equal it is non-deterministic).
 func (f *fairSharingIterator) getCq() *schdcache.ClusterQueueSnapshot {
-	for cq := range f.cqToEntry {
+	for cq := range f.cqToEntries {
 		return cq
 	}
 	return nil
@@ -122,7 +147,7 @@ func (f *fairSharingIterator) getCq() *schdcache.ClusterQueueSnapshot {
 // This process results in one workload (or zero if Cohort has no
 // remaining workloads to schedule this cycle) being bubbled up per
 // node, until exactly one workload remains at the root.
-func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntry map[*schdcache.ClusterQueueSnapshot]*entry) *entry {
+func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntries map[*schdcache.ClusterQueueSnapshot][]*entry) *entry {
 	candidates := make([]*entry, 0, cohort.ChildCount())
 
 	// Run algorithm recursively for each of the child Cohorts.
@@ -130,16 +155,17 @@ func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntry
 		// The tournament returns 0 nodes, when the child
 		// Cohort has no workloads left to be scheduled this
 		// cycle.
-		if candidate := runTournament(childCohort, ec, cqToEntry); candidate != nil {
+		if candidate := runTournament(childCohort, ec, cqToEntries); candidate != nil {
 			candidates = append(candidates, candidate)
 		}
 	}
 
-	// Collect entries from CQ. If an entry was returned during a
-	// previous call to pop, it will not be in the cqToEntry map.
+	// Collect the first entry of each CQ. Once all of a CQ's entries
+	// were returned during previous calls to pop, the CQ is no longer
+	// in the cqToEntries map.
 	for _, childCq := range cohort.ChildCQs() {
-		if candidate, ok := cqToEntry[childCq]; ok {
-			candidates = append(candidates, candidate)
+		if cqEntries, ok := cqToEntries[childCq]; ok {
+			candidates = append(candidates, cqEntries[0])
 		}
 	}
 
@@ -217,16 +243,18 @@ func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bo
 // root-1.  During the tournament, these values are used to compare
 // all children the parentCohort, to select the child with the lowest
 // DRS after admission of its nominated workload.
-func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEntry map[*schdcache.ClusterQueueSnapshot]*entry) {
+func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEntries map[*schdcache.ClusterQueueSnapshot][]*entry) {
 	e.drsValues = make(map[drsKey]schdcache.DRS)
 	if features.Enabled(features.FairSharingPrioritizeNonBorrowing) {
 		e.requestedFRs = make(map[workload.Reference]resources.FlavorResourceQuantities)
 	}
 	for _, cq := range rootCohort.SubtreeClusterQueues() {
-		entry, ok := cqToEntry[cq]
+		cqEntries, ok := cqToEntries[cq]
 		if !ok {
 			continue
 		}
+		// Only the first entry of each CQ takes part in the tournament.
+		entry := cqEntries[0]
 		log := e.log.WithValues(
 			"workload", klog.KObj(entry.Obj),
 			"clusterQueue", klog.KRef("", string(cq.Name)),

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -37,9 +37,13 @@ import (
 // consideration by scheduling when FairSharing is enabled. See
 // runTournament for description of algorithm.
 type fairSharingIterator struct {
-	// cqToEntry tracks ClusterQueues which still have workloads
-	// to schedule, and the corresponding workload entry.
-	cqToEntry     map[*schdcache.ClusterQueueSnapshot]*entry
+	// cqToEntries tracks ClusterQueues which still have workloads to
+	// schedule, and the corresponding workload entries. A ClusterQueue
+	// may have several entries in a cycle (e.g. second-pass workloads
+	// in addition to the queue head); the slices are never empty and
+	// are ordered by compareEntries, so the first element is the
+	// ClusterQueue's current nominee.
+	cqToEntries   map[*schdcache.ClusterQueueSnapshot][]*entry
 	entryComparer entryComparer
 	log           logr.Logger
 }
@@ -47,7 +51,7 @@ type fairSharingIterator struct {
 func makeFairSharingIterator(ctx context.Context, entries []entry, workloadOrdering workload.Ordering) *fairSharingIterator {
 	log := ctrl.LoggerFrom(ctx)
 	f := fairSharingIterator{
-		cqToEntry: make(map[*schdcache.ClusterQueueSnapshot]*entry, len(entries)),
+		cqToEntries: make(map[*schdcache.ClusterQueueSnapshot][]*entry, len(entries)),
 		entryComparer: entryComparer{
 			log:              log,
 			workloadOrdering: workloadOrdering,
@@ -55,25 +59,44 @@ func makeFairSharingIterator(ctx context.Context, entries []entry, workloadOrder
 		log: log,
 	}
 	for i := range entries {
-		f.cqToEntry[entries[i].clusterQueueSnapshot] = &entries[i]
+		cq := entries[i].clusterQueueSnapshot
+		f.cqToEntries[cq] = append(f.cqToEntries[cq], &entries[i])
+	}
+	for _, cqEntries := range f.cqToEntries {
+		slices.SortFunc(cqEntries, func(a, b *entry) int {
+			return compareEntries(log, workloadOrdering, a, b)
+		})
 	}
 	return &f
 }
 
 func (f *fairSharingIterator) hasNext() bool {
-	return len(f.cqToEntry) > 0
+	return len(f.cqToEntries) > 0
+}
+
+// popEntryForCq removes and returns the first pending entry of the
+// ClusterQueue, dropping the ClusterQueue from the iterator once it has
+// no entries left.
+func (f *fairSharingIterator) popEntryForCq(cq *schdcache.ClusterQueueSnapshot) *entry {
+	cqEntries := f.cqToEntries[cq]
+	head := cqEntries[0]
+	if len(cqEntries) == 1 {
+		delete(f.cqToEntries, cq)
+	} else {
+		f.cqToEntries[cq] = cqEntries[1:]
+	}
+	return head
 }
 
 func (f *fairSharingIterator) pop() *entry {
 	cq := f.getCq()
 
-	// CQ has no Cohort. We simply return its workload.
+	// CQ has no Cohort. We simply return its nominated workload.
 	if !cq.HasParent() {
-		entry := f.cqToEntry[cq]
+		entry := f.popEntryForCq(cq)
 		f.log.V(3).Info("Returning workload from ClusterQueue without Cohort",
 			"clusterQueue", klog.KRef("", string(cq.GetName())),
 			"workload", klog.KObj(entry.Obj))
-		delete(f.cqToEntry, cq)
 		return entry
 	}
 
@@ -83,10 +106,10 @@ func (f *fairSharingIterator) pop() *entry {
 	log := f.log.WithValues("rootCohort", klog.KRef("", string(root.GetName())))
 
 	log.V(5).Info("Computing DominantResourceShare for tournament")
-	f.entryComparer.computeDRS(root, f.cqToEntry)
+	f.entryComparer.computeDRS(root, f.cqToEntries)
 
 	log.V(3).Info("Running tournament to decide next workload to consider in scheduling cycle")
-	entry := runTournament(root, f.entryComparer, f.cqToEntry)
+	entry := runTournament(root, f.entryComparer, f.cqToEntries)
 
 	log = log.WithValues(
 		"cohort", klog.KRef("", string(entry.clusterQueueSnapshot.Parent().GetName())),
@@ -96,7 +119,9 @@ func (f *fairSharingIterator) pop() *entry {
 	log.V(3).Info("Determined tournament winner")
 	f.entryComparer.logDrsValuesWhenVerbose(log)
 
-	delete(f.cqToEntry, entry.clusterQueueSnapshot)
+	// The winner is always the first entry of its ClusterQueue, as only
+	// the first entry of each ClusterQueue takes part in the tournament.
+	f.popEntryForCq(entry.clusterQueueSnapshot)
 	return entry
 }
 
@@ -106,7 +131,7 @@ func (f *fairSharingIterator) pop() *entry {
 // consideration is nearly deterministic within Cohort (only when DRS,
 // Priority, and time are equal it is non-deterministic).
 func (f *fairSharingIterator) getCq() *schdcache.ClusterQueueSnapshot {
-	for cq := range f.cqToEntry {
+	for cq := range f.cqToEntries {
 		return cq
 	}
 	return nil
@@ -122,7 +147,7 @@ func (f *fairSharingIterator) getCq() *schdcache.ClusterQueueSnapshot {
 // This process results in one workload (or zero if Cohort has no
 // remaining workloads to schedule this cycle) being bubbled up per
 // node, until exactly one workload remains at the root.
-func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntry map[*schdcache.ClusterQueueSnapshot]*entry) *entry {
+func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntries map[*schdcache.ClusterQueueSnapshot][]*entry) *entry {
 	candidates := make([]*entry, 0, cohort.ChildCount())
 
 	// Run algorithm recursively for each of the child Cohorts.
@@ -130,16 +155,17 @@ func runTournament(cohort *schdcache.CohortSnapshot, ec entryComparer, cqToEntry
 		// The tournament returns 0 nodes, when the child
 		// Cohort has no workloads left to be scheduled this
 		// cycle.
-		if candidate := runTournament(childCohort, ec, cqToEntry); candidate != nil {
+		if candidate := runTournament(childCohort, ec, cqToEntries); candidate != nil {
 			candidates = append(candidates, candidate)
 		}
 	}
 
-	// Collect entries from CQ. If an entry was returned during a
-	// previous call to pop, it will not be in the cqToEntry map.
+	// Collect the first entry of each CQ. Once all of a CQ's entries
+	// were returned during previous calls to pop, the CQ is no longer
+	// in the cqToEntries map.
 	for _, childCq := range cohort.ChildCQs() {
-		if candidate, ok := cqToEntry[childCq]; ok {
-			candidates = append(candidates, candidate)
+		if cqEntries, ok := cqToEntries[childCq]; ok {
+			candidates = append(candidates, cqEntries[0])
 		}
 	}
 
@@ -224,16 +250,18 @@ func (e *entryComparer) less(a, b *entry, parentCohort kueue.CohortReference) bo
 // root-1.  During the tournament, these values are used to compare
 // all children the parentCohort, to select the child with the lowest
 // DRS after admission of its nominated workload.
-func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEntry map[*schdcache.ClusterQueueSnapshot]*entry) {
+func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEntries map[*schdcache.ClusterQueueSnapshot][]*entry) {
 	e.drsValues = make(map[drsKey]schdcache.DRS)
 	if features.Enabled(features.FairSharingPrioritizeNonBorrowing) {
 		e.requestedFRs = make(map[workload.Reference]resources.FlavorResourceQuantities)
 	}
 	for _, cq := range rootCohort.SubtreeClusterQueues() {
-		entry, ok := cqToEntry[cq]
+		cqEntries, ok := cqToEntries[cq]
 		if !ok {
 			continue
 		}
+		// Only the first entry of each CQ takes part in the tournament.
+		entry := cqEntries[0]
 		log := e.log.WithValues(
 			"workload", klog.KObj(entry.Obj),
 			"clusterQueue", klog.KRef("", string(cq.Name)),

--- a/pkg/scheduler/fair_sharing_iterator_test.go
+++ b/pkg/scheduler/fair_sharing_iterator_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// TestFairSharingIteratorReturnsAllEntriesOfClusterQueue verifies that the
+// iterator considers every entry of a ClusterQueue within a cycle, in
+// compareEntries order. A ClusterQueue can have several entries in one cycle:
+// workloads queued for a second pass of scheduling in addition to the queue
+// head.
+func TestFairSharingIteratorReturnsAllEntriesOfClusterQueue(t *testing.T) {
+	now := time.Now()
+	cq := &schdcache.ClusterQueueSnapshot{Name: "cq"}
+
+	secondPass := utiltestingapi.MakeWorkload("second-pass", "ns").
+		Creation(now.Add(2*time.Minute)).
+		SimpleReserveQuota("cq", "default", now).
+		Obj()
+	headOld := utiltestingapi.MakeWorkload("head-old", "ns").
+		Creation(now).
+		Obj()
+	headNew := utiltestingapi.MakeWorkload("head-new", "ns").
+		Creation(now.Add(time.Minute)).
+		Obj()
+
+	entries := make([]entry, 0, 3)
+	for _, wl := range []*kueue.Workload{headNew, headOld, secondPass} {
+		entries = append(entries, entry{
+			Info:                 *workload.NewInfo(wl),
+			clusterQueueSnapshot: cq,
+		})
+	}
+
+	iterator := makeFairSharingIterator(context.Background(), entries, workload.Ordering{})
+	var got []string
+	for iterator.hasNext() {
+		got = append(got, iterator.pop().Obj.Name)
+	}
+	// The entry with quota already reserved goes first, the remaining ones
+	// follow in FIFO order.
+	want := []string{"second-pass", "head-old", "head-new"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected pop order (-want,+got):\n%s", diff)
+	}
+}

--- a/pkg/scheduler/fair_sharing_iterator_test.go
+++ b/pkg/scheduler/fair_sharing_iterator_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -57,7 +56,7 @@ func TestFairSharingIteratorReturnsAllEntriesOfClusterQueue(t *testing.T) {
 		})
 	}
 
-	iterator := makeFairSharingIterator(context.Background(), entries, workload.Ordering{})
+	iterator := makeFairSharingIterator(t.Context(), entries, workload.Ordering{})
 	var got []string
 	for iterator.hasNext() {
 		got = append(got, iterator.pop().Obj.Name)

--- a/pkg/scheduler/fair_sharing_iterator_test.go
+++ b/pkg/scheduler/fair_sharing_iterator_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package scheduler
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -52,12 +52,12 @@ func TestFairSharingIteratorReturnsAllEntriesOfClusterQueue(t *testing.T) {
 	entries := make([]entry, 0, 3)
 	for _, wl := range []*kueue.Workload{headNew, headOld, secondPass} {
 		entries = append(entries, entry{
-			Info:                 *workload.NewInfo(wl),
+			Head:                 qcache.Head{Info: *workload.NewInfo(wl)},
 			clusterQueueSnapshot: cq,
 		})
 	}
 
-	iterator := makeFairSharingIterator(context.Background(), entries, workload.Ordering{})
+	iterator := makeFairSharingIterator(t.Context(), entries, workload.Ordering{})
 	var got []string
 	for iterator.hasNext() {
 		got = append(got, iterator.pop().Obj.Name)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -968,45 +968,54 @@ func (co *classicalIterator) pop() *entry {
 	return head
 }
 
-func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
-	slices.SortFunc(entries, func(a, b entry) int {
-		// First process workloads which already have quota reserved. Such workload
-		// may be considered if this is their second pass.
-		aHasQuota := workload.HasQuotaReservation(a.Obj)
-		bHasQuota := workload.HasQuotaReservation(b.Obj)
-		if aHasQuota != bHasQuota {
-			if aHasQuota {
-				return -1
-			}
-			return 1
-		}
-
-		// 1. Request under nominal quota.
-		aBorrows := a.assignment.Borrows()
-		bBorrows := b.assignment.Borrows()
-		if aBorrows != bBorrows {
-			return cmp.Compare(aBorrows, bBorrows)
-		}
-
-		// 2. Higher priority first if not disabled.
-		if features.Enabled(features.PrioritySortingWithinCohort) {
-			p1 := priority.EffectivePriority(log, a.Obj)
-			p2 := priority.EffectivePriority(log, b.Obj)
-			if p1 != p2 {
-				return cmp.Compare(p2, p1)
-			}
-		}
-
-		// 3. FIFO.
-		aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
-		bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
-		if aComparisonTimestamp.Before(bComparisonTimestamp) {
+// compareEntries defines the classical (non-FairSharing) admission
+// order between two entries. It is also used to order the entries of a
+// single ClusterQueue in the fairSharingIterator, when a ClusterQueue
+// has more than one entry in a cycle (e.g. second-pass workloads in
+// addition to the queue head).
+func compareEntries(log logr.Logger, workloadOrdering workload.Ordering, a, b *entry) int {
+	// First process workloads which already have quota reserved. Such workload
+	// may be considered if this is their second pass.
+	aHasQuota := workload.HasQuotaReservation(a.Obj)
+	bHasQuota := workload.HasQuotaReservation(b.Obj)
+	if aHasQuota != bHasQuota {
+		if aHasQuota {
 			return -1
 		}
-		if bComparisonTimestamp.Before(aComparisonTimestamp) {
-			return 1
+		return 1
+	}
+
+	// 1. Request under nominal quota.
+	aBorrows := a.assignment.Borrows()
+	bBorrows := b.assignment.Borrows()
+	if aBorrows != bBorrows {
+		return cmp.Compare(aBorrows, bBorrows)
+	}
+
+	// 2. Higher priority first if not disabled.
+	if features.Enabled(features.PrioritySortingWithinCohort) {
+		p1 := priority.EffectivePriority(log, a.Obj)
+		p2 := priority.EffectivePriority(log, b.Obj)
+		if p1 != p2 {
+			return cmp.Compare(p2, p1)
 		}
-		return 0
+	}
+
+	// 3. FIFO.
+	aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
+	bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
+	if aComparisonTimestamp.Before(bComparisonTimestamp) {
+		return -1
+	}
+	if bComparisonTimestamp.Before(aComparisonTimestamp) {
+		return 1
+	}
+	return 0
+}
+
+func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
+	slices.SortFunc(entries, func(a, b entry) int {
+		return compareEntries(log, workloadOrdering, &a, &b)
 	})
 	return &classicalIterator{
 		entries: entries,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1107,55 +1107,64 @@ func (co *classicalIterator) pop() *entry {
 	return head
 }
 
-func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
-	slices.SortFunc(entries, func(a, b entry) int {
-		// First process workloads which already have quota reserved. Such workload
-		// may be considered if this is their second pass.
-		aHasQuota := workload.HasQuotaReservation(a.Obj)
-		bHasQuota := workload.HasQuotaReservation(b.Obj)
-		if aHasQuota != bHasQuota {
-			if aHasQuota {
+// compareEntries defines the classical (non-FairSharing) admission
+// order between two entries. It is also used to order the entries of a
+// single ClusterQueue in the fairSharingIterator, when a ClusterQueue
+// has more than one entry in a cycle (e.g. second-pass workloads in
+// addition to the queue head).
+func compareEntries(log logr.Logger, workloadOrdering workload.Ordering, a, b *entry) int {
+	// First process workloads which already have quota reserved. Such workload
+	// may be considered if this is their second pass.
+	aHasQuota := workload.HasQuotaReservation(a.Obj)
+	bHasQuota := workload.HasQuotaReservation(b.Obj)
+	if aHasQuota != bHasQuota {
+		if aHasQuota {
+			return -1
+		}
+		return 1
+	}
+
+	// 1. Process workloads pending preemption if the feature is enabled.
+	if features.Enabled(features.PrioritizePreemptorWorkloads) {
+		if a.IsPreemptor != b.IsPreemptor {
+			if a.IsPreemptor {
 				return -1
 			}
 			return 1
 		}
+	}
 
-		// 1. Process workloads pending preemption if the feature is enabled.
-		if features.Enabled(features.PrioritizePreemptorWorkloads) {
-			if a.IsPreemptor != b.IsPreemptor {
-				if a.IsPreemptor {
-					return -1
-				}
-				return 1
-			}
-		}
+	// 2. Request under nominal quota.
+	aBorrows := a.assignment.Borrows()
+	bBorrows := b.assignment.Borrows()
+	if aBorrows != bBorrows {
+		return cmp.Compare(aBorrows, bBorrows)
+	}
 
-		// 2. Request under nominal quota.
-		aBorrows := a.assignment.Borrows()
-		bBorrows := b.assignment.Borrows()
-		if aBorrows != bBorrows {
-			return cmp.Compare(aBorrows, bBorrows)
+	// 3. Higher priority first if not disabled.
+	if features.Enabled(features.PrioritySortingWithinCohort) {
+		p1 := priority.EffectivePriority(log, a.Obj)
+		p2 := priority.EffectivePriority(log, b.Obj)
+		if p1 != p2 {
+			return cmp.Compare(p2, p1)
 		}
+	}
 
-		// 3. Higher priority first if not disabled.
-		if features.Enabled(features.PrioritySortingWithinCohort) {
-			p1 := priority.EffectivePriority(log, a.Obj)
-			p2 := priority.EffectivePriority(log, b.Obj)
-			if p1 != p2 {
-				return cmp.Compare(p2, p1)
-			}
-		}
+	// 4. FIFO.
+	aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
+	bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
+	if aComparisonTimestamp.Before(bComparisonTimestamp) {
+		return -1
+	}
+	if bComparisonTimestamp.Before(aComparisonTimestamp) {
+		return 1
+	}
+	return 0
+}
 
-		// 4. FIFO.
-		aComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(a.Obj)
-		bComparisonTimestamp := workloadOrdering.GetQueueOrderTimestamp(b.Obj)
-		if aComparisonTimestamp.Before(bComparisonTimestamp) {
-			return -1
-		}
-		if bComparisonTimestamp.Before(aComparisonTimestamp) {
-			return 1
-		}
-		return 0
+func makeClassicalIterator(log logr.Logger, entries []entry, workloadOrdering workload.Ordering) *classicalIterator {
+	slices.SortFunc(entries, func(a, b entry) int {
+		return compareEntries(log, workloadOrdering, &a, &b)
 	})
 	return &classicalIterator{
 		entries: entries,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Manager.heads()` can return more than one workload for the same ClusterQueue in a single scheduling cycle: every workload ready in the second-pass queue (`secondPassQueue.takeAllReady()`) plus the popped ClusterQueue head. The `fairSharingIterator` stored entries in a `map[*ClusterQueueSnapshot]*entry`, so when a ClusterQueue had several entries, all but one were silently overwritten and never considered in that cycle.

The dropped entry fell through to `requeueAndUpdate` with status `notNominated` and an empty `inadmissibleMsg`, resulting in a Pending/QuotaReserved condition patch with an empty message and a delayed admission (for second-pass workloads, another backoff round). The classical iterator handles multiple entries per CQ correctly — it even sorts quota-reserved (second-pass) entries first.

This PR:
- tracks a list of entries per ClusterQueue (`map[*ClusterQueueSnapshot][]*entry`), ordered so the first element is the CQ's current nominee; the tournament still sees exactly one entry per CQ (the head of the list);
- extracts the classical iterator's ordering into `compareEntries` and reuses it to order a ClusterQueue's entries (quota-reserved first, fewer borrows, priority, FIFO), so both iterators share one definition of intra-CQ order;
- adds a regression test: with the old code, only one of a ClusterQueue's entries was returned by the iterator.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- The bug is reachable whenever FairSharing is enabled and a ClusterQueue has a second-pass workload (e.g. TAS delayed topology assignment) in the same cycle as a regular head, or several second-pass workloads at once.
- Verified with `go test ./pkg/scheduler/ -count=1` (full package) plus the new `TestFairSharingIteratorReturnsAllEntriesOfClusterQueue`.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
FairSharing: Fixed a bug where only one workload per ClusterQueue was considered in each scheduling cycle. Workloads awaiting a second scheduling pass (for example, TAS workloads with a delayed topology assignment) could be repeatedly delayed when another workload from the same ClusterQueue was considered in the same cycle.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fair-sharing scheduling to process multiple pending workloads per ClusterQueue.
  * Ensured workloads are returned in the expected order, with quota-reserved workloads first and remaining workloads handled FIFO.

* **Refactor**
  * Unified workload ordering logic while preserving existing scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->