### PR TITLE
Avoid mutating cache-owned workload Infos in AdmissionFairSharing snapshot

### DIFF
--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -316,12 +316,17 @@ func (c *Cache) snapshotClusterQueue(
 		if !afsEnabled {
 			return cc, nil
 		}
-		for _, wl := range cc.Workloads {
+		for key, wl := range cc.Workloads {
 			usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights, afsEntryPenalties, afsConsumedResources)
 			if err != nil {
 				return nil, fmt.Errorf("failed to calculate LocalQueue FS usage for LocalQueue %v", client.ObjectKey{Namespace: wl.Obj.Namespace, Name: string(wl.Obj.Spec.QueueName)})
 			}
-			wl.LocalQueueFSUsage = &usage
+			// The Infos in cc.Workloads are shared with the live cache,
+			// which must not be modified while holding only the read
+			// lock; store the usage on a snapshot-owned copy instead.
+			wlCopy := *wl
+			wlCopy.LocalQueueFSUsage = &usage
+			cc.Workloads[key] = &wlCopy
 			log.V(5).Info("Calculated LocalQueueFSUsage for workload", "workload", klog.KObj(wl.Obj), "queue", wl.Obj.Spec.QueueName, "usage", usage)
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`Cache.Snapshot` holds only the cache read lock, and `snapshotClusterQueue` clones the workloads map shallowly (`maps.Clone(cq.Workloads)`), so the `*workload.Info` values in the snapshot are shared with the live cache. The AdmissionFairSharing path then wrote `wl.LocalQueueFSUsage = &usage` through those shared pointers.

That is a write to cache-owned state under `RLock`, and it makes "taking a snapshot" mutate the live cache. It is currently benign only because the scheduler is the sole caller of `Snapshot` and (apparently) the only reader of `LocalQueueFSUsage`; any new concurrent reader of cache-owned Infos would turn this into a data race.

This PR stores the computed usage on a snapshot-owned shallow copy of the `Info` and replaces the map value in the snapshot's own map, leaving the cache untouched. Readers of the snapshot (e.g. AdmissionFairSharing candidate ordering in preemption) see the same values as before.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- No behavior change intended: `CalcLocalQueueFSUsage` is read-only on the Info, and everything that consumes `LocalQueueFSUsage` reads it from the snapshot's `Workloads` map, which still carries the value.
- Verified with `go test ./pkg/scheduler/ -run TestScheduleForAFS -count=1`, which drives `Cache.Snapshot` with the AFS options through the scheduler. (The `pkg/cache/scheduler` unit-test binary currently fails to link on my machine due to an unrelated Go 1.26.0 arm64 linker crash that also reproduces on an unmodified tree; CI should be authoritative.)
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
AFS: Fixed a bug that could modify cached Workload data while calculating LocalQueue fair-sharing usage, potentially producing inconsistent scheduling snapshots.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Admission Fair Sharing workload snapshots by preserving the original workload data while calculating LocalQueue filesystem usage.
  * Ensured usage updates are applied consistently to snapshot data without unintentionally modifying active workload information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->