### PR TITLE
Avoid in-place status mutation of the queued workload when admitting a workload slice

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -463,6 +463,9 @@ func (s *Scheduler) processEntry(
 
 	// Copy ClusterName from old slice before admission (needed for MultiKueue).
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
+		// e.Obj is shared with the queue manager's in-memory state and
+		// must not be modified in place; work on a copy.
+		e.Obj = e.Obj.DeepCopy()
 		e.Obj.Status.ClusterName = oldWorkloadSlice.WorkloadInfo.Obj.Status.ClusterName
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -501,6 +501,9 @@ func (s *Scheduler) processEntry(
 
 	// Copy ClusterName from old slice before admission (needed for MultiKueue).
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
+		// e.Obj is shared with the queue manager's in-memory state and
+		// must not be modified in place; work on a copy.
+		e.Obj = e.Obj.DeepCopy()
 		e.Obj.Status.ClusterName = oldWorkloadSlice.WorkloadInfo.Obj.Status.ClusterName
 	}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9857,3 +9857,91 @@ func TestFitsDedupsOverlappingVictims(t *testing.T) {
 		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
 	}
 }
+
+// TestProcessEntryKeepsQueuedWorkloadSliceUnmutated asserts that adopting the
+// ClusterName of the replaced workload slice does not write through to the Workload
+// object the entry was built from. That object is shared with the queue manager, and
+// processEntry can still bail out after the copy - for instance when a
+// ConcurrentAdmission migration is denied - so a workload that was never admitted
+// must not be left holding the ClusterName of the slice it would have replaced.
+func TestProcessEntryKeepsQueuedWorkloadSliceUnmutated(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
+	rf := utiltestingapi.MakeResourceFlavor("rf").Obj()
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas(rf.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj(),
+		).Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
+	oldSlice := utiltestingapi.MakeWorkload("old-slice", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		Request(corev1.ResourceCPU, "1").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+				Obj()).
+			Obj(), now).
+		AdmittedAt(true, now).
+		ClusterName("worker-cluster").
+		Obj()
+	newSlice := utiltestingapi.MakeWorkload("new-slice", metav1.NamespaceDefault).
+		Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(oldSlice))).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		Request(corev1.ResourceCPU, "1").
+		Obj()
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(ns, rf, cq, lq, oldSlice, newSlice).
+		WithStatusSubresource(&kueue.Workload{}).
+		Build()
+
+	cqCache := schdcache.New(cl)
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+
+	scheduler := New(qManager, cqCache, cl, &utiltesting.EventRecorder{}, WithClock(t, testingclock.NewFakeClock(now)), WithPreemptionExpectations(preemptexpectations.New()))
+	wg := sync.WaitGroup{}
+	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+		func() { wg.Add(1) },
+		func() { wg.Done() },
+	))
+
+	snapshot, err := cqCache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Building snapshot: %v", err)
+	}
+
+	// The entry holds the very same Workload pointer the queue manager handed out,
+	// which is what makes an in-place status write observable outside the cycle.
+	info := workload.NewInfo(newSlice)
+	info.ClusterQueue = kueue.ClusterQueueReference(cq.Name)
+	entries, inadmissibleEntries := scheduler.nominate(ctx, []qcache.Head{{Info: *info}}, snapshot)
+	if len(entries) != 1 {
+		t.Fatalf("Expected the replacing slice to be nominated, got %d entries and %d inadmissible entries", len(entries), len(inadmissibleEntries))
+	}
+	if entries[0].Obj != newSlice {
+		t.Fatalf("Expected the entry to reference the queued Workload object")
+	}
+
+	scheduler.processEntry(ctx, &entries[0], snapshot, make(preemption.PreemptedWorkloads), make(map[kueue.ClusterQueueReference]int))
+	wg.Wait()
+
+	if newSlice.Status.ClusterName != nil {
+		t.Errorf("Queued Workload was mutated in place: got ClusterName %q, want unset", *newSlice.Status.ClusterName)
+	}
+}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -49,6 +49,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -8759,5 +8760,93 @@ func (r *workloadUpdateWatcherRecorder) NotifyWorkloadUpdate(oldWl, newWl *kueue
 	}
 	if newWl != nil {
 		r.newWl = newWl.DeepCopy()
+	}
+}
+
+// TestProcessEntryKeepsQueuedWorkloadSliceUnmutated asserts that adopting the
+// ClusterName of the replaced workload slice does not write through to the Workload
+// object the entry was built from. That object is shared with the queue manager, and
+// processEntry can still bail out after the copy - for instance when a
+// ConcurrentAdmission migration is denied - so a workload that was never admitted
+// must not be left holding the ClusterName of the slice it would have replaced.
+func TestProcessEntryKeepsQueuedWorkloadSliceUnmutated(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+
+	now := time.Now().Truncate(time.Second)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
+	rf := utiltestingapi.MakeResourceFlavor("rf").Obj()
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas(rf.Name).
+				Resource(corev1.ResourceCPU, "1").
+				Obj(),
+		).Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", metav1.NamespaceDefault).ClusterQueue(cq.Name).Obj()
+	oldSlice := utiltestingapi.MakeWorkload("old-slice", metav1.NamespaceDefault).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		Request(corev1.ResourceCPU, "1").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "1").
+				Obj()).
+			Obj(), now).
+		AdmittedAt(true, now).
+		ClusterName("worker-cluster").
+		Obj()
+	newSlice := utiltestingapi.MakeWorkload("new-slice", metav1.NamespaceDefault).
+		Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(oldSlice))).
+		Queue(kueue.LocalQueueName(lq.Name)).
+		Request(corev1.ResourceCPU, "1").
+		Obj()
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(ns, rf, cq, lq, oldSlice, newSlice).
+		WithStatusSubresource(&kueue.Workload{}).
+		Build()
+
+	cqCache := schdcache.New(cl)
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache)
+	cqCache.AddOrUpdateResourceFlavor(log, rf)
+	if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+
+	scheduler := New(qManager, cqCache, cl, &utiltesting.EventRecorder{}, WithClock(t, testingclock.NewFakeClock(now)), WithPreemptionExpectations(preemptexpectations.New()))
+	wg := sync.WaitGroup{}
+	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+		func() { wg.Add(1) },
+		func() { wg.Done() },
+	))
+
+	snapshot, err := cqCache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Building snapshot: %v", err)
+	}
+
+	// The entry holds the very same Workload pointer the queue manager handed out,
+	// which is what makes an in-place status write observable outside the cycle.
+	info := workload.NewInfo(newSlice)
+	info.ClusterQueue = kueue.ClusterQueueReference(cq.Name)
+	entries, inadmissibleEntries := scheduler.nominate(ctx, []workload.Info{*info}, snapshot)
+	if len(entries) != 1 {
+		t.Fatalf("Expected the replacing slice to be nominated, got %d entries and %d inadmissible entries", len(entries), len(inadmissibleEntries))
+	}
+	if entries[0].Obj != newSlice {
+		t.Fatalf("Expected the entry to reference the queued Workload object")
+	}
+
+	scheduler.processEntry(ctx, &entries[0], snapshot, make(preemption.PreemptedWorkloads), make(map[kueue.ClusterQueueReference]int))
+	wg.Wait()
+
+	if newSlice.Status.ClusterName != nil {
+		t.Errorf("Queued Workload was mutated in place: got ClusterName %q, want unset", *newSlice.Status.ClusterName)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When admitting a workload slice that replaces an old slice (ElasticJobsViaWorkloadSlices), the scheduler copied the old slice's `Status.ClusterName` by writing directly through `e.Obj`.

`e.Obj` is not scheduler-owned: `Manager.heads()` copies the `workload.Info` struct only shallowly, so the underlying `*kueue.Workload` is the same object held by the queue manager's in-memory state (and the object can also be shared with the scheduler cache, since the workload controller passes the same pointer to both). Writing `Status.ClusterName` in place therefore modifies shared in-memory state without a corresponding API update — and if admission subsequently fails and the entry is requeued, the stale value persists in the queued copy.

This PR sets the field on a deep copy of the workload (`e.Obj = e.Obj.DeepCopy()`) before mutating, matching how the rest of the admission path (`admit`, `waitForPodsReadyIfBlocked`, eviction paths) handles workload mutations. `admit()` deep-copies `e.Obj` afterwards, so the value still reaches the admission patch and the cache exactly as before.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- No behavior change intended on the success path; the fix only prevents the in-place mutation of the shared object on the failure/requeue path.
- Verified with `go test ./pkg/scheduler/ -count=1` (full package, includes the workload-slice scheduling tests).
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented workload-slice replacement processing from unintentionally changing queued workload cluster information.
  * Ensured queued workload data remains unchanged when admission processing exits.
  * Improved reliability when replacing workload slices during scheduler processing.

* **Tests**
  * Added regression coverage to verify workload state is preserved during replacement processing.
  * Confirmed queued workload information remains intact across admission-processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->