### PR TITLE
Fix classicalIterator ordering comment

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -950,10 +950,14 @@ func makeIterator(ctx context.Context, entries []entry, workloadOrdering workloa
 }
 
 // classicalIterator returns entries ordered on:
-// 1. request under nominal quota before borrowing.
-// 2. Fair Sharing: lower DominantResourceShare first.
-// 3. higher priority first.
+// 1. entries with quota already reserved first, as such workloads may
+// be considered for a second pass.
+// 2. request under nominal quota before borrowing.
+// 3. higher priority first, when PrioritySortingWithinCohort is enabled.
 // 4. FIFO on eviction or creation timestamp.
+//
+// Ordering on DominantResourceShare when Fair Sharing is enabled is
+// implemented separately by fairSharingIterator.
 type classicalIterator struct {
 	entries []entry
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The doc comment on `classicalIterator` listed "Fair Sharing: lower DominantResourceShare first" as its second ordering step, but `makeClassicalIterator` has no DRS comparison — that ordering is implemented separately by `fairSharingIterator` when Fair Sharing is enabled. The comment also omitted the first ordering step the code does implement: entries with quota already reserved (second-pass workloads) are processed first.

This PR corrects the comment to match the implementation:

1. entries with quota already reserved first,
2. request under nominal quota before borrowing,
3. higher priority first (when `PrioritySortingWithinCohort` is enabled),
4. FIFO on eviction or creation timestamp,

and notes that DRS ordering lives in `fairSharingIterator`.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- Comment-only change; no code is modified.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workload ordering rules, including reserved quota prioritization and subsequent scheduling stages.
  * Documented how Fair Sharing uses separate ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->