### PR TITLE
Count admission-cycle preemption skips only for entries in Preempt mode

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -432,7 +432,11 @@ func (s *Scheduler) processEntry(
 	if preemptedWorkloads.HasAny(e.preemptionTargets) {
 		e.markSkipped("Workload has overlapping preemption targets with another workload")
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-		skippedPreemptions[cq.Name]++
+		// Entries in Fit mode can carry targets too (a replaced workload
+		// slice); only count the skip as a preemption skip in Preempt mode.
+		if mode == flavorassigner.Preempt {
+			skippedPreemptions[cq.Name]++
+		}
 		return
 	}
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -470,7 +470,11 @@ func (s *Scheduler) processEntry(
 	if preemptedWorkloads.HasAny(e.preemptionTargets) {
 		e.markSkipped("Workload has overlapping preemption targets with another workload")
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-		skippedPreemptions[cq.Name]++
+		// Entries in Fit mode can carry targets too (a replaced workload
+		// slice); only count the skip as a preemption skip in Preempt mode.
+		if mode == flavorassigner.Preempt {
+			skippedPreemptions[cq.Name]++
+		}
 		return
 	}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5776,6 +5776,162 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("sales", "foo-1", kueue.WorkloadSliceReplaced, corev1.EventTypeNormal).Obj(),
 			},
 		},
+		// An entry in Fit mode still carries a preemption target when it replaces a
+		// workload slice. If that target was already claimed by an earlier preemption in
+		// the same cycle, the entry is skipped - but it never needed preemption, so the
+		// skip must not be counted in the admission_cycle_preemption_skips metric.
+		"workload-slice in fit mode with overlapping target is not counted as a preemption skip": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("elastic-a").
+					Cohort("elastic").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("elastic-b").
+					Cohort("elastic").
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("elastic-a", "eng-alpha").ClusterQueue("elastic-a").Obj(),
+				*utiltestingapi.MakeLocalQueue("elastic-b", "eng-beta").ClusterQueue("elastic-b").Obj(),
+			},
+			workloads: []kueue.Workload{
+				// slice-1 borrows the whole cohort quota.
+				*utiltestingapi.MakeWorkload("slice-1", "eng-alpha").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("elastic-a").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").
+							Obj()).
+						Obj(), now).
+					Obj(),
+				// slice-2 replaces slice-1, so slice-1's usage is discounted and slice-2
+				// fits, yet slice-1 is still carried as its preemption target.
+				*utiltestingapi.MakeWorkload("slice-2", "eng-alpha").
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "eng-alpha/slice-1").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					Obj(),
+				// preemptor sorts first and reclaims from slice-1, claiming the target
+				// that slice-2 also carries.
+				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
+					UID("wl-preemptor").
+					JobUID("job-preemptor").
+					Priority(100).
+					Queue("elastic-b").
+					Request(corev1.ResourceCPU, "5").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("slice-1", "eng-alpha").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("elastic-a").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").
+							Obj()).
+						Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor, JobUID: job-preemptor) due to reclamation within the cohort; preemptor path: /elastic/elastic-b; preemptee path: /elastic/elastic-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor, JobUID: job-preemptor) due to reclamation within the cohort; preemptor path: /elastic/elastic-b; preemptee path: /elastic/elastic-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("slice-2", "eng-alpha").
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "eng-alpha/slice-1").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "Workload has overlapping preemption targets with another workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
+					UID("wl-preemptor").
+					JobUID("job-preemptor").
+					Priority(100).
+					Queue("elastic-b").
+					Request(corev1.ResourceCPU, "5").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 5 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/slice-1": *utiltestingapi.MakeAdmission("elastic-a").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "10").
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"elastic-a": {"eng-alpha/slice-2"},
+				"elastic-b": {"eng-beta/preemptor"},
+			},
+			// slice-2 was skipped in Fit mode, so its skip is not a preemption skip.
+			wantSkippedPreemptions: map[string]int{
+				"elastic-a": 0,
+				"elastic-b": 0,
+			},
+		},
 		"pending admission check with nofit and fit flavors": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("pending-check", "eng-beta").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -5796,6 +5796,168 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("sales", "foo-1", kueue.WorkloadSliceReplaced, corev1.EventTypeNormal).Obj(),
 			},
 		},
+		// An entry in Fit mode still carries a preemption target when it replaces a
+		// workload slice. If that target was already claimed by an earlier preemption in
+		// the same cycle, the entry is skipped - but it never needed preemption, so the
+		// skip must not be counted in the admission_cycle_preemption_skips metric.
+		"workload-slice in fit mode with overlapping target is not counted as a preemption skip": {
+			// With RecomputeAssignmentUponPreemptionTargetsOverlap enabled, a Fit-mode
+			// entry with overlapping targets is turned into DeferredFit and returns
+			// before the overlap skip. Disable it so the skip branch is reached.
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:                    true,
+				features.RecomputeAssignmentUponPreemptionTargetsOverlap: false,
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("elastic-a").
+					Cohort("elastic").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("elastic-b").
+					Cohort("elastic").
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("elastic-a", "eng-alpha").ClusterQueue("elastic-a").Obj(),
+				*utiltestingapi.MakeLocalQueue("elastic-b", "eng-beta").ClusterQueue("elastic-b").Obj(),
+			},
+			workloads: []kueue.Workload{
+				// slice-1 borrows the whole cohort quota.
+				*utiltestingapi.MakeWorkload("slice-1", "eng-alpha").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("elastic-a").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").
+							Obj()).
+						Obj(), now).
+					Obj(),
+				// slice-2 replaces slice-1, so slice-1's usage is discounted and slice-2
+				// fits, yet slice-1 is still carried as its preemption target.
+				*utiltestingapi.MakeWorkload("slice-2", "eng-alpha").
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "eng-alpha/slice-1").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					Obj(),
+				// preemptor sorts first and reclaims from slice-1, claiming the target
+				// that slice-2 also carries.
+				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
+					UID("wl-preemptor").
+					JobUID("job-preemptor").
+					Priority(100).
+					Queue("elastic-b").
+					Request(corev1.ResourceCPU, "5").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("slice-1", "eng-alpha").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("elastic-a").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").
+							Obj()).
+						Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor, JobUID: job-preemptor) due to reclamation within the cohort; preemptor path: /elastic/elastic-b; preemptee path: /elastic/elastic-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-preemptor, JobUID: job-preemptor) due to reclamation within the cohort; preemptor path: /elastic/elastic-b; preemptee path: /elastic/elastic-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("slice-2", "eng-alpha").
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "eng-alpha/slice-1").
+					Priority(0).
+					Queue("elastic-a").
+					Request(corev1.ResourceCPU, "10").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "Workload has overlapping preemption targets with another workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("preemptor", "eng-beta").
+					UID("wl-preemptor").
+					JobUID("job-preemptor").
+					Priority(100).
+					Queue("elastic-b").
+					Request(corev1.ResourceCPU, "5").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 5 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("5"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/slice-1": *utiltestingapi.MakeAdmission("elastic-a").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "default", "10").
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"elastic-a": {"eng-alpha/slice-2"},
+				"elastic-b": {"eng-beta/preemptor"},
+			},
+			// slice-2 was skipped in Fit mode, so its skip is not a preemption skip.
+			wantSkippedPreemptions: map[string]int{
+				"elastic-a": 0,
+				"elastic-b": 0,
+			},
+		},
 		"pending admission check with nofit and fit flavors": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("pending-check", "eng-beta").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `processEntry`, the overlapping-preemption-targets skip incremented `skippedPreemptions` (reported as the `kueue_admission_cycle_preemption_skips` gauge) unconditionally. However, entries in `Fit` mode can also carry preemption targets: a workload slice replacing its old slice gets the old slice as a target from `workloadslicing.ReplacedWorkloadSlice`, without requiring any preemption.

When such Fit-mode targets overlapped with an earlier admission in the same cycle, the metric counted a "preemption skip" for a workload that did not require preemption. The adjacent no-longer-fits skip path already gates its increment on `mode == flavorassigner.Preempt`; this PR applies the same gate to the overlap path, making the metric consistent with its help text ("Workloads ... that got preemption candidates but had to be skipped").

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- Only the metric accounting changes; the skip behavior itself is unchanged.
- Verified with `go test ./pkg/scheduler/ -count=1`.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
Observability: Fixed the `kueue_admission_cycle_preemption_skips` metric to no longer count workloads that did not require preemption (for example, elastic workload slices replacing their old slice) when their targets overlapped with an earlier admission in the same cycle.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preemption tracking so workloads that can fit without preemption are no longer counted as skipped preemptions.
  * Corrected scheduler metrics when preemption targets overlap across workloads.
  * Fixed workload-slice replacement behavior when preemption targets are already claimed, while preserving the correct scheduling outcome and workload status.
  * Ensured affected workloads remain pending with accurate quota conditions, queue state, assignments, and preemption-skip metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->