### PR TITLE
Release reserved usage when ConcurrentAdmission migration is denied

### DIFF
--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -36,3 +36,9 @@ func (p PreemptedWorkloads) Insert(newTargets []*Target) {
 		p[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
 	}
 }
+
+func (p PreemptedWorkloads) Delete(targets []*Target) {
+	for _, target := range targets {
+		delete(p, workload.Key(target.WorkloadInfo.Obj))
+	}
+}

--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -55,3 +55,9 @@ func (p PreemptedWorkloads) MergeWithTargets(targets []*Target) PreemptedWorkloa
 func (p PreemptedWorkloads) Workloads() []*workload.Info {
 	return slices.Collect(maps.Values(p))
 }
+
+func (p PreemptedWorkloads) Delete(targets []*Target) {
+	for _, target := range targets {
+		delete(p, workload.Key(target.WorkloadInfo.Obj))
+	}
+}

--- a/pkg/scheduler/preemption/preempted_workloads_test.go
+++ b/pkg/scheduler/preemption/preempted_workloads_test.go
@@ -69,3 +69,71 @@ func TestWorkloadsToRemoveNilReceiver(t *testing.T) {
 func workloadInfoForTest(namespace, name string) *workload.Info {
 	return &workload.Info{Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}}
 }
+
+func TestPreemptedWorkloadsDelete(t *testing.T) {
+	victimA := workloadInfoForTest("ns", "victim-a")
+	victimB := workloadInfoForTest("ns", "victim-b")
+	keyA, keyB := workload.Key(victimA.Obj), workload.Key(victimB.Obj)
+
+	tests := map[string]struct {
+		preempted PreemptedWorkloads
+		remove    []*Target
+		want      []workload.Reference
+	}{
+		"removes the only target": {
+			preempted: PreemptedWorkloads{keyA: victimA},
+			remove:    []*Target{{WorkloadInfo: victimA}},
+			want:      nil,
+		},
+		"removes one target and keeps the other": {
+			preempted: PreemptedWorkloads{keyA: victimA, keyB: victimB},
+			remove:    []*Target{{WorkloadInfo: victimA}},
+			want:      []workload.Reference{keyB},
+		},
+		"target that was never inserted is a no-op": {
+			preempted: PreemptedWorkloads{keyB: victimB},
+			remove:    []*Target{{WorkloadInfo: victimA}},
+			want:      []workload.Reference{keyB},
+		},
+		"no targets is a no-op": {
+			preempted: PreemptedWorkloads{keyB: victimB},
+			remove:    nil,
+			want:      []workload.Reference{keyB},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tc.preempted.Delete(tc.remove)
+			if len(tc.preempted) != len(tc.want) {
+				t.Fatalf("after Delete: got %d workloads, want %d (%#v)", len(tc.preempted), len(tc.want), tc.preempted)
+			}
+			for _, key := range tc.want {
+				if _, found := tc.preempted[key]; !found {
+					t.Errorf("after Delete: %q was removed but should have been kept", key)
+				}
+			}
+		})
+	}
+}
+
+// TestPreemptedWorkloadsInsertDeleteRoundTrip asserts Delete undoes Insert, which is
+// what lets processEntry release the targets it reserved when a migration is denied.
+func TestPreemptedWorkloadsInsertDeleteRoundTrip(t *testing.T) {
+	existing := workloadInfoForTest("ns", "already-preempted")
+	reserved := workloadInfoForTest("ns", "reserved-then-released")
+	preempted := PreemptedWorkloads{workload.Key(existing.Obj): existing}
+
+	targets := []*Target{{WorkloadInfo: reserved}}
+	preempted.Insert(targets)
+	if !preempted.HasAny(targets) {
+		t.Fatalf("Insert did not record the target")
+	}
+	preempted.Delete(targets)
+	if preempted.HasAny(targets) {
+		t.Errorf("Delete did not release the target, so it would still block later entries in the cycle")
+	}
+	if _, found := preempted[workload.Key(existing.Obj)]; !found {
+		t.Errorf("Delete removed an unrelated workload preempted by an earlier entry")
+	}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -470,6 +470,12 @@ func (s *Scheduler) processEntry(
 		if lessFavorableSibling := s.findAdmittedLessFavorableSibling(&e.Info, snapshot); lessFavorableSibling != nil {
 			if !s.isMigrationAllowed(cq, e, log) {
 				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+				// The entry is not admitted in this cycle, and nothing in
+				// this cycle can lift the migration constraint; release
+				// the usage and preemption targets reserved above so they
+				// don't block other entries in this cycle.
+				preemptedWorkloads.Delete(e.preemptionTargets)
+				cq.RemoveUsage(usage)
 				return
 			}
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -508,6 +508,12 @@ func (s *Scheduler) processEntry(
 		if lessFavorableSibling := s.findAdmittedLessFavorableSibling(&e.Info, snapshot); lessFavorableSibling != nil {
 			if !s.isMigrationAllowed(cq, e, log) {
 				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonPendingEvaluation
+				// The entry is not admitted in this cycle, and nothing in
+				// this cycle can lift the migration constraint; release
+				// the usage and preemption targets reserved above so they
+				// don't block other entries in this cycle.
+				preemptedWorkloads.Delete(e.preemptionTargets)
+				cq.RemoveUsage(usage)
 				return
 			}
 			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads

--- a/pkg/scheduler/scheduler_concurrent_admission_test.go
+++ b/pkg/scheduler/scheduler_concurrent_admission_test.go
@@ -325,6 +325,170 @@ func TestScheduleConcurrentAdmission(t *testing.T) {
 			},
 			featureGates: map[featuregate.Feature]bool{features.ConcurrentAdmission: true},
 		},
+		// The variant reserves its usage in the cycle snapshot as soon as it fits, but a
+		// denied migration means it is not admitted and nothing later in the cycle can
+		// lift the constraint. The reservation must be released so a workload borrowing
+		// from the same cohort is not blocked by quota nobody ends up using.
+		"concurrent admission: usage reserved for a denied migration is released within the cycle": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("sibling-less-favorable", "eng-alpha").
+					UID("sibling-uid").
+					Queue("migration-queue").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("migration-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "10").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("spot").
+					Obj(),
+				*utiltestingapi.MakeWorkload("candidate-more-favorable", "eng-alpha").
+					UID("candidate-uid").
+					Queue("migration-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("on-demand").
+					Obj(),
+				// Borrows the whole on-demand quota from the cohort, so it is only
+				// admissible once the denied candidate gives its reservation back.
+				*utiltestingapi.MakeWorkload("borrower", "eng-beta").
+					UID("borrower-uid").
+					Queue("borrower-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "borrower-parent-workload", "borrower-parent-uid").
+					AllowedFlavors("on-demand").
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("migration-queue", "eng-alpha").ClusterQueue("migration-cq").Obj(),
+				*utiltestingapi.MakeLocalQueue("borrower-queue", "eng-beta").ClusterQueue("borrower-cq").Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("migration-cq").
+					Cohort("migration-cohort").
+					NamespaceSelector(&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "dep",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"eng"},
+						}},
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("reservation").
+							Resource(corev1.ResourceCPU, "10").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "10").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "10").Obj(),
+					).
+					LastAcceptableFlavorName("reservation").
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("borrower-cq").
+					Cohort("migration-cohort").
+					NamespaceSelector(&metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "dep",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"eng"},
+						}},
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("reservation").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+					).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("sibling-less-favorable", "eng-alpha").
+					UID("sibling-uid").
+					Queue("migration-queue").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("migration-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "spot", "10").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("spot").
+					Obj(),
+				*utiltestingapi.MakeWorkload("candidate-more-favorable", "eng-alpha").
+					UID("candidate-uid").
+					Queue("migration-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "parent-workload", "parent-uid").
+					AllowedFlavors("on-demand").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+						Message:            "Target flavor is below LastAcceptableFlavorName",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("borrower", "eng-beta").
+					UID("borrower-uid").
+					Queue("borrower-queue").
+					Request(corev1.ResourceCPU, "10").
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "borrower-parent-workload", "borrower-parent-uid").
+					AllowedFlavors("on-demand").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue borrower-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(utiltestingapi.MakeAdmission("borrower-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10").
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"migration-cq": {"eng-alpha/candidate-more-favorable"},
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/sibling-less-favorable": *utiltestingapi.MakeAdmission("migration-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "10").
+						Obj()).
+					Obj(),
+				"eng-beta/borrower": *utiltestingapi.MakeAdmission("borrower-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "10").
+						Obj()).
+					Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{features.ConcurrentAdmission: true},
+		},
 	}
 
 	runScheduleTestCases(t, scheduleTestConfig{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

In `processEntry`, a workload's usage and preemption targets are recorded in the cycle snapshot (`preemptedWorkloads.Insert` + `cq.AddUsage`) once the fits check passes, before the ConcurrentAdmission migration check runs.

When a workload variant finds an admitted less-favorable sibling but `isMigrationAllowed` denies the migration (the target flavor is below `lastAcceptableFlavorName`), the entry returns without admitting anything — yet its usage and targets stay recorded for the rest of the cycle. Later entries in the same cycle can then be skipped with "Workload no longer fits after processing another workload" or "overlapping preemption targets" against capacity that nothing will consume. Because the denial is stable (it depends only on the constraint and the sibling's current flavor), this repeats every cycle while the denied variant exists, persistently under-utilizing the ClusterQueue.

This PR releases the reserved usage and preemption targets on the denied path. The allowed-migration path intentionally keeps its reservation, since the migration is issued and the variant is expected to be admitted in a subsequent cycle (analogous to the pending-preemption reservation).

It also adds a `PreemptedWorkloads.Delete` helper mirroring `Insert`. Removing this entry's targets is safe: if any of them had been inserted by an earlier entry, the overlap check would have skipped this entry before `Insert` ran, so the targets are uniquely owned by this entry.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

- I'd particularly appreciate a check of the intended semantics from the ConcurrentAdmission authors: should a migration-denied variant reserve capacity for the cycle? My reading is no — unlike `reserveCapacityForUnreclaimablePreempt`, nothing in the current cycle (or any subsequent one, while the constraint holds) converts this reservation into an admission.
- Verified with `go test ./pkg/scheduler/ -count=1` (includes the ConcurrentAdmission scheduler tests).
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
ConcurrentAdmission: Fixed a bug where a workload variant denied migration by the `lastAcceptableFlavorName` constraint kept its capacity reserved for the remainder of the scheduling cycle, which could unnecessarily delay admission of other workloads in the same cycle.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler resource handling when migration constraints prevent admission.
  * Prevented stale preemption and resource reservations from affecting subsequent scheduling decisions.
  * Ensured eligible workloads can be admitted after a denied migration releases its unused quota reservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->