### PR TITLE
Drop duplicated replaced-slice target from preemption targets

### DIFF
--- a/pkg/scheduler/preemption/preemption_targets.go
+++ b/pkg/scheduler/preemption/preemption_targets.go
@@ -1,0 +1,55 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// PreemptionTargets holds the workloads a single preemptor evicts, in the order
+// they were selected, with at most one target per workload.
+//
+// The same workload can be selected from more than one source: a replaced
+// workload slice is seeded as a target up front and, because it stays in the
+// snapshot as an admitted workload, the preemptor can select it again. A
+// duplicate would subtract the workload's usage twice when simulating whether
+// the preemptor fits, and would leave a second target behind that is evicted
+// through preemption rather than replaced.
+type PreemptionTargets []*Target
+
+// Insert appends the targets whose workload is not in p yet, preserving the
+// order in which targets were added and keeping the target already present.
+func (p *PreemptionTargets) Insert(targets ...*Target) {
+	for _, target := range targets {
+		if !p.has(target) {
+			*p = append(*p, target)
+		}
+	}
+}
+
+// has reports whether p already targets target's workload. Preemptors evict a
+// handful of workloads at most, so a linear scan is cheaper than maintaining a
+// key set alongside the slice.
+func (p *PreemptionTargets) has(target *Target) bool {
+	key := workload.Key(target.WorkloadInfo.Obj)
+	for _, present := range *p {
+		if workload.Key(present.WorkloadInfo.Obj) == key {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/scheduler/preemption/preemption_targets_test.go
+++ b/pkg/scheduler/preemption/preemption_targets_test.go
@@ -14,20 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package scheduler
+package preemption
 
 import (
 	"slices"
 	"testing"
 
-	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-func TestMergeWithReplacedSliceTargets(t *testing.T) {
-	targetFor := func(name string) *preemption.Target {
-		return &preemption.Target{
+func TestPreemptionTargetsInsert(t *testing.T) {
+	targetFor := func(name string) *Target {
+		return &Target{
 			WorkloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload(name, "ns").Obj()),
 		}
 	}
@@ -38,32 +37,37 @@ func TestMergeWithReplacedSliceTargets(t *testing.T) {
 	other := targetFor("other")
 
 	cases := map[string]struct {
-		sliceTargets     []*preemption.Target
-		preemptorTargets []*preemption.Target
-		want             []*preemption.Target
+		inserts [][]*Target
+		want    PreemptionTargets
 	}{
-		"no slice targets": {
-			preemptorTargets: []*preemption.Target{other},
-			want:             []*preemption.Target{other},
+		"nothing inserted": {},
+		"only preemptor targets": {
+			inserts: [][]*Target{nil, {other}},
+			want:    PreemptionTargets{other},
 		},
 		"no overlap": {
-			sliceTargets:     []*preemption.Target{oldSlice},
-			preemptorTargets: []*preemption.Target{other},
-			want:             []*preemption.Target{oldSlice, other},
+			inserts: [][]*Target{{oldSlice}, {other}},
+			want:    PreemptionTargets{oldSlice, other},
 		},
 		"preemptor selected the replaced slice again": {
-			sliceTargets:     []*preemption.Target{oldSlice},
-			preemptorTargets: []*preemption.Target{oldSliceFromPreemptor, other},
-			want:             []*preemption.Target{oldSlice, other},
+			inserts: [][]*Target{{oldSlice}, {oldSliceFromPreemptor, other}},
+			want:    PreemptionTargets{oldSlice, other},
+		},
+		"duplicates within a single insert": {
+			inserts: [][]*Target{{oldSlice, oldSliceFromPreemptor}},
+			want:    PreemptionTargets{oldSlice},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := mergeWithReplacedSliceTargets(tc.sliceTargets, tc.preemptorTargets)
-			// Compare by identity: the slice-target instance must win over
-			// the preemptor's duplicate.
+			var got PreemptionTargets
+			for _, targets := range tc.inserts {
+				got.Insert(targets...)
+			}
+			// Compare by identity: the target inserted first must win over
+			// any later duplicate.
 			if !slices.Equal(tc.want, got) {
-				t.Errorf("unexpected merged targets: want %v, got %v", tc.want, got)
+				t.Errorf("unexpected targets: want %v, got %v", tc.want, got)
 			}
 		})
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -774,7 +774,7 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 	if arm == flavorassigner.Preempt {
 		faPreemptionTargets := s.preemptor.GetTargets(log, *wl, fullAssignment, snap)
 		if len(faPreemptionTargets) > 0 {
-			return fullAssignment, append(preemptionTargets, faPreemptionTargets...)
+			return fullAssignment, mergeWithReplacedSliceTargets(preemptionTargets, faPreemptionTargets)
 		}
 	}
 
@@ -795,10 +795,35 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 			return nil, false
 		})
 		if pa, found := reducer.Search(); found {
-			return pa.assignment, append(preemptionTargets, pa.preemptionTargets...)
+			return pa.assignment, mergeWithReplacedSliceTargets(preemptionTargets, pa.preemptionTargets)
 		}
 	}
 	return fullAssignment, nil
+}
+
+// mergeWithReplacedSliceTargets appends the targets selected by the
+// preemptor to the replaced-workload-slice targets, dropping preemptor
+// duplicates of the replaced slice. The old slice remains in the
+// snapshot as an admitted workload, so the preemptor can select it
+// again; keeping both copies would subtract the slice's usage twice in
+// fit simulations, and FindReplacedSliceTarget removes only one
+// occurrence, so the duplicate would be evicted via preemption instead
+// of replaced.
+func mergeWithReplacedSliceTargets(sliceTargets, preemptorTargets []*preemption.Target) []*preemption.Target {
+	if len(sliceTargets) == 0 {
+		return preemptorTargets
+	}
+	sliceKeys := sets.New[workload.Reference]()
+	for _, target := range sliceTargets {
+		sliceKeys.Insert(workload.Key(target.WorkloadInfo.Obj))
+	}
+	merged := slices.Clone(sliceTargets)
+	for _, target := range preemptorTargets {
+		if !sliceKeys.Has(workload.Key(target.WorkloadInfo.Obj)) {
+			merged = append(merged, target)
+		}
+	}
+	return merged
 }
 
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -256,7 +256,7 @@ func (e *entry) markAssumed() {
 // recordAssignment stores a flavor assignment and its preemption
 // targets from nominate. LastAssignment aliases the stored
 // assignment's LastState so it tracks any later mutation.
-func (e *entry) recordAssignment(a flavorassigner.Assignment, targets []*preemption.Target) {
+func (e *entry) recordAssignment(a flavorassigner.Assignment, targets preemption.PreemptionTargets) {
 	e.assignment = a
 	e.preemptionTargets = targets
 	e.inadmissibleMsg = e.assignment.Message()
@@ -587,7 +587,7 @@ type entry struct {
 	status               entryStatus
 	inadmissibleMsg      string
 	requeueReason        qcache.RequeueReason
-	preemptionTargets    []*preemption.Target
+	preemptionTargets    preemption.PreemptionTargets
 	clusterQueueSnapshot *schdcache.ClusterQueueSnapshot
 	quotaReservedReason  string
 	skipStatusUpdate     bool
@@ -730,7 +730,7 @@ type partialAssignment struct {
 	preemptionTargets []*preemption.Target
 }
 
-func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
+func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, preemption.PreemptionTargets) {
 	assignment, targets := s.getInitialAssignments(log, wl, snap)
 	cq := snap.ClusterQueue(wl.ClusterQueue)
 	updateAssignmentForTAS(log, snap, cq, wl, &assignment, targets)
@@ -759,10 +759,12 @@ func (s *Scheduler) getAssignments(log logr.Logger, wl *workload.Info, snap *sch
 //     identified during scheduling.
 //
 // If no valid assignment can be made, returns the original full assignment with no preemption targets.
-func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
+func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, preemption.PreemptionTargets) {
 	cq := snap.ClusterQueue(wl.ClusterQueue)
 
-	preemptionTargets, replaceableWorkloadSlice := workloadslicing.ReplacedWorkloadSlice(wl, snap)
+	replacedSliceTargets, replaceableWorkloadSlice := workloadslicing.ReplacedWorkloadSlice(wl, snap)
+	var preemptionTargets preemption.PreemptionTargets
+	preemptionTargets.Insert(replacedSliceTargets...)
 	flvAssigner := flavorassigner.New(wl, cq, snap.ResourceFlavors, fairsharing.Enabled(s.fairSharing), preemption.NewOracle(s.preemptor, snap), replaceableWorkloadSlice, s.quotaCheckStrategy)
 	fullAssignment := flvAssigner.Assign(log, nil)
 
@@ -774,7 +776,8 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 	if arm == flavorassigner.Preempt {
 		faPreemptionTargets := s.preemptor.GetTargets(log, *wl, fullAssignment, snap)
 		if len(faPreemptionTargets) > 0 {
-			return fullAssignment, mergeWithReplacedSliceTargets(preemptionTargets, faPreemptionTargets)
+			preemptionTargets.Insert(faPreemptionTargets...)
+			return fullAssignment, preemptionTargets
 		}
 	}
 
@@ -795,35 +798,11 @@ func (s *Scheduler) getInitialAssignments(log logr.Logger, wl *workload.Info, sn
 			return nil, false
 		})
 		if pa, found := reducer.Search(); found {
-			return pa.assignment, mergeWithReplacedSliceTargets(preemptionTargets, pa.preemptionTargets)
+			preemptionTargets.Insert(pa.preemptionTargets...)
+			return pa.assignment, preemptionTargets
 		}
 	}
 	return fullAssignment, nil
-}
-
-// mergeWithReplacedSliceTargets appends the targets selected by the
-// preemptor to the replaced-workload-slice targets, dropping preemptor
-// duplicates of the replaced slice. The old slice remains in the
-// snapshot as an admitted workload, so the preemptor can select it
-// again; keeping both copies would subtract the slice's usage twice in
-// fit simulations, and FindReplacedSliceTarget removes only one
-// occurrence, so the duplicate would be evicted via preemption instead
-// of replaced.
-func mergeWithReplacedSliceTargets(sliceTargets, preemptorTargets []*preemption.Target) []*preemption.Target {
-	if len(sliceTargets) == 0 {
-		return preemptorTargets
-	}
-	sliceKeys := sets.New[workload.Reference]()
-	for _, target := range sliceTargets {
-		sliceKeys.Insert(workload.Key(target.WorkloadInfo.Obj))
-	}
-	merged := slices.Clone(sliceTargets)
-	for _, target := range preemptorTargets {
-		if !sliceKeys.Has(workload.Key(target.WorkloadInfo.Obj)) {
-			merged = append(merged, target)
-		}
-	}
-	return merged
 }
 
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -896,7 +896,7 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 	if arm == flavorassigner.Preempt {
 		faPreemptionTargets := s.preemptor.GetTargets(ctx, *wl, fullAssignment, snap)
 		if len(faPreemptionTargets) > 0 {
-			return fullAssignment, append(preemptionTargets, faPreemptionTargets...)
+			return fullAssignment, mergeWithReplacedSliceTargets(preemptionTargets, faPreemptionTargets)
 		}
 	}
 
@@ -917,10 +917,35 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 			return nil, false
 		})
 		if pa, found := reducer.Search(); found {
-			return pa.assignment, append(preemptionTargets, pa.preemptionTargets...)
+			return pa.assignment, mergeWithReplacedSliceTargets(preemptionTargets, pa.preemptionTargets)
 		}
 	}
 	return fullAssignment, nil
+}
+
+// mergeWithReplacedSliceTargets appends the targets selected by the
+// preemptor to the replaced-workload-slice targets, dropping preemptor
+// duplicates of the replaced slice. The old slice remains in the
+// snapshot as an admitted workload, so the preemptor can select it
+// again; keeping both copies would subtract the slice's usage twice in
+// fit simulations, and FindReplacedSliceTarget removes only one
+// occurrence, so the duplicate would be evicted via preemption instead
+// of replaced.
+func mergeWithReplacedSliceTargets(sliceTargets, preemptorTargets []*preemption.Target) []*preemption.Target {
+	if len(sliceTargets) == 0 {
+		return preemptorTargets
+	}
+	sliceKeys := sets.New[workload.Reference]()
+	for _, target := range sliceTargets {
+		sliceKeys.Insert(workload.Key(target.WorkloadInfo.Obj))
+	}
+	merged := slices.Clone(sliceTargets)
+	for _, target := range preemptorTargets {
+		if !sliceKeys.Has(workload.Key(target.WorkloadInfo.Obj)) {
+			merged = append(merged, target)
+		}
+	}
+	return merged
 }
 
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -278,7 +278,7 @@ func (e *entry) markAssumed() {
 // recordAssignment stores a flavor assignment and its preemption
 // targets from nominate. LastAssignment aliases the stored
 // assignment's LastState so it tracks any later mutation.
-func (e *entry) recordAssignment(a flavorassigner.Assignment, targets []*preemption.Target) {
+func (e *entry) recordAssignment(a flavorassigner.Assignment, targets preemption.PreemptionTargets) {
 	e.assignment = a
 	e.preemptionTargets = targets
 	e.inadmissibleMsg = e.assignment.Message()
@@ -638,7 +638,7 @@ type entry struct {
 	status               entryStatus
 	inadmissibleMsg      string
 	requeueReason        qcache.RequeueReason
-	preemptionTargets    []*preemption.Target
+	preemptionTargets    preemption.PreemptionTargets
 	clusterQueueSnapshot *schdcache.ClusterQueueSnapshot
 	quotaReservedReason  string
 	skipStatusUpdate     bool
@@ -818,7 +818,7 @@ type partialAssignment struct {
 	preemptionTargets []*preemption.Target
 }
 
-func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
+func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, preemption.PreemptionTargets) {
 	cq := snap.ClusterQueue(wl.ClusterQueue)
 	// The flavor scan resumes from the progress recorded in LastAssignment, so it has to be
 	// dropped once it no longer describes the current state. Deciding that here rather than
@@ -877,10 +877,12 @@ func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentC
 //     identified during scheduling.
 //
 // If no valid assignment can be made, returns the original full assignment with no preemption targets.
-func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
+func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, preemption.PreemptionTargets) {
 	cq := snap.ClusterQueue(wl.ClusterQueue)
 
-	preemptionTargets, replaceableWorkloadSlice := workloadslicing.ReplacedWorkloadSlice(wl, snap)
+	replacedSliceTargets, replaceableWorkloadSlice := workloadslicing.ReplacedWorkloadSlice(wl, snap)
+	var preemptionTargets preemption.PreemptionTargets
+	preemptionTargets.Insert(replacedSliceTargets...)
 	flvAssigner := flavorassigner.New(
 		wl, cq, snap.ResourceFlavors, fairsharing.Enabled(s.fairSharing),
 		preemption.NewOracle(s.preemptor, snap), replaceableWorkloadSlice,
@@ -896,7 +898,8 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 	if arm == flavorassigner.Preempt {
 		faPreemptionTargets := s.preemptor.GetTargets(ctx, *wl, fullAssignment, snap)
 		if len(faPreemptionTargets) > 0 {
-			return fullAssignment, mergeWithReplacedSliceTargets(preemptionTargets, faPreemptionTargets)
+			preemptionTargets.Insert(faPreemptionTargets...)
+			return fullAssignment, preemptionTargets
 		}
 	}
 
@@ -917,35 +920,11 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 			return nil, false
 		})
 		if pa, found := reducer.Search(); found {
-			return pa.assignment, mergeWithReplacedSliceTargets(preemptionTargets, pa.preemptionTargets)
+			preemptionTargets.Insert(pa.preemptionTargets...)
+			return pa.assignment, preemptionTargets
 		}
 	}
 	return fullAssignment, nil
-}
-
-// mergeWithReplacedSliceTargets appends the targets selected by the
-// preemptor to the replaced-workload-slice targets, dropping preemptor
-// duplicates of the replaced slice. The old slice remains in the
-// snapshot as an admitted workload, so the preemptor can select it
-// again; keeping both copies would subtract the slice's usage twice in
-// fit simulations, and FindReplacedSliceTarget removes only one
-// occurrence, so the duplicate would be evicted via preemption instead
-// of replaced.
-func mergeWithReplacedSliceTargets(sliceTargets, preemptorTargets []*preemption.Target) []*preemption.Target {
-	if len(sliceTargets) == 0 {
-		return preemptorTargets
-	}
-	sliceKeys := sets.New[workload.Reference]()
-	for _, target := range sliceTargets {
-		sliceKeys.Insert(workload.Key(target.WorkloadInfo.Obj))
-	}
-	merged := slices.Clone(sliceTargets)
-	for _, target := range preemptorTargets {
-		if !sliceKeys.Has(workload.Key(target.WorkloadInfo.Obj)) {
-			merged = append(merged, target)
-		}
-	}
-	return merged
 }
 
 func (s *Scheduler) evictWorkloadAfterFailedTASReplacement(ctx context.Context, log logr.Logger, wl *kueue.Workload) error {

--- a/pkg/scheduler/scheduler_workloadslicing_test.go
+++ b/pkg/scheduler/scheduler_workloadslicing_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+	"testing"
+
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestMergeWithReplacedSliceTargets(t *testing.T) {
+	targetFor := func(name string) *preemption.Target {
+		return &preemption.Target{
+			WorkloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload(name, "ns").Obj()),
+		}
+	}
+	oldSlice := targetFor("old-slice")
+	// The preemptor works on the same snapshot, so a duplicate selection
+	// refers to the same workload key.
+	oldSliceFromPreemptor := targetFor("old-slice")
+	other := targetFor("other")
+
+	cases := map[string]struct {
+		sliceTargets     []*preemption.Target
+		preemptorTargets []*preemption.Target
+		want             []*preemption.Target
+	}{
+		"no slice targets": {
+			preemptorTargets: []*preemption.Target{other},
+			want:             []*preemption.Target{other},
+		},
+		"no overlap": {
+			sliceTargets:     []*preemption.Target{oldSlice},
+			preemptorTargets: []*preemption.Target{other},
+			want:             []*preemption.Target{oldSlice, other},
+		},
+		"preemptor selected the replaced slice again": {
+			sliceTargets:     []*preemption.Target{oldSlice},
+			preemptorTargets: []*preemption.Target{oldSliceFromPreemptor, other},
+			want:             []*preemption.Target{oldSlice, other},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := mergeWithReplacedSliceTargets(tc.sliceTargets, tc.preemptorTargets)
+			// Compare by identity: the slice-target instance must win over
+			// the preemptor's duplicate.
+			if !slices.Equal(tc.want, got) {
+				t.Errorf("unexpected merged targets: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area elastic-jobs

#### What this PR does / why we need it:

With `ElasticJobsViaWorkloadSlices` enabled, `getInitialAssignments` seeds the preemption targets with the replaced (old) workload slice via `workloadslicing.ReplacedWorkloadSlice`, which leaves the old slice in the snapshot as an admitted workload. In `Preempt` mode, `GetTargets` iterates the snapshot's workloads and can therefore select the old slice **again** — unconditionally under the `Any` preemption policy, or under `LowerPriority` when the new slice has a higher priority. The two lists were appended without deduplication.

Consequences of the duplicated target:

- `fits()` → `SimulateWorkloadRemoval` subtracts the old slice's usage twice, artificially inflating the capacity freed by preemption, so the capacity check can pass when it shouldn't and preempt more workloads than the delta requires.
- `FindReplacedSliceTarget` removes only the first occurrence of the old slice from the targets, so the remaining duplicate is issued as a real preemption: the old slice gets evicted with a `Preempted` condition/event instead of being finished as replaced.

This PR introduces a `preemption.PreemptionTargets` type whose `Insert` deduplicates by workload key, and uses it for the targets built in `getInitialAssignments`. The replaced slice is seeded first, so a preemptor that selects the same slice no longer adds a second entry; this applies to both the full-assignment and partial-admission paths. A table-driven unit test covers `Insert`, including which target instance survives a duplicate.

Note: the old slice must remain selectable by the preemptor for the fit simulation to free its usage — the bug is only that it appeared twice. The fix deliberately dedups rather than excluding the slice from candidate selection.

#### Which issue(s) this PR fixes:

Fixes #12538

#### Special notes for your reviewer:

- Verified with the new `TestPreemptionTargetsInsert` and the full `go test ./pkg/scheduler/... -count=1` suite.
- Rebased onto current main. `getAssignments`/`getInitialAssignments` moved from `logr.Logger` to `context.Context` and gained `resourceFormatter`/`schedulingCycle` arguments upstream; those are preserved, with only the target type and seeding changed.
- The encapsulation into a named type is @mimowo's suggestion from review, replacing the earlier free-standing `mergeWithReplacedSliceTargets` helper.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where the replaced workload slice could appear twice in the preemption targets when the preemptor selected it as a candidate. The duplicate caused its usage to be counted twice in preemption capacity checks, potentially evicting more workloads than needed, and could evict the old slice via preemption instead of finishing it as replaced.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate preemption targets from appearing in scheduling results.
  * Preserved the first selected target when duplicates are encountered, whether duplicates occur within one operation or across multiple operations.
  * Maintained consistent target ordering across scheduling operations.
  * Applied duplicate prevention consistently when targets are replaced, assigned to flavors, or generated during partial admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
