### PR TITLE
Requeue Topology pending deletion while referencing flavors remain

### DIFF
--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -18,6 +18,7 @@ package tas
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,6 +46,10 @@ import (
 
 const (
 	updateChBuffer = 10
+
+	// topologyInUseRequeueInterval is how often a Topology pending deletion
+	// re-verifies whether referencing ResourceFlavors are gone.
+	topologyInUseRequeueInterval = time.Minute
 )
 
 type topologyReconciler struct {
@@ -115,7 +120,13 @@ func (r *topologyReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			}
 			if len(flavors) != 0 {
 				log.V(3).Info("topology is still in use", "ResourceFlavors", flavors)
-				return ctrl.Result{}, nil
+				// The in-use check reads the TAS cache, which may not have
+				// observed the deletion of a referencing ResourceFlavor yet
+				// when that flavor's delete event enqueued this Topology.
+				// Since topologyName is immutable, no further ResourceFlavor
+				// event may re-enqueue the Topology, so requeue to re-verify
+				// instead of leaving the finalizer stuck until a restart.
+				return ctrl.Result{RequeueAfter: topologyInUseRequeueInterval}, nil
 			}
 			controllerutil.RemoveFinalizer(topology, kueue.ResourceInUseFinalizerName)
 			if err := r.client.Update(ctx, topology); err != nil {

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -18,6 +18,7 @@ package tas
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -46,6 +47,10 @@ import (
 
 const (
 	updateChBuffer = 10
+
+	// topologyInUseRequeueInterval is how often a Topology pending deletion
+	// re-verifies whether referencing ResourceFlavors are gone.
+	topologyInUseRequeueInterval = time.Minute
 )
 
 type topologyReconciler struct {
@@ -116,7 +121,13 @@ func (r *topologyReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 			}
 			if len(flavors) != 0 {
 				log.V(3).Info("topology is still in use", "ResourceFlavors", flavors)
-				return ctrl.Result{}, nil
+				// The in-use check reads the TAS cache, which may not have
+				// observed the deletion of a referencing ResourceFlavor yet
+				// when that flavor's delete event enqueued this Topology.
+				// Since topologyName is immutable, no further ResourceFlavor
+				// event may re-enqueue the Topology, so requeue to re-verify
+				// instead of leaving the finalizer stuck until a restart.
+				return ctrl.Result{RequeueAfter: topologyInUseRequeueInterval}, nil
 			}
 			controllerutil.RemoveFinalizer(topology, kueue.ResourceInUseFinalizerName)
 			if err := r.client.Update(ctx, topology); err != nil {

--- a/pkg/controller/tas/topology_controller_test.go
+++ b/pkg/controller/tas/topology_controller_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestTopologyReconcilerFinalizerRemovalOnDeletion(t *testing.T) {
+	cases := map[string]struct {
+		flavorInCache     bool
+		wantRequeueAfter  time.Duration
+		wantFinalizerGone bool
+	}{
+		"topology still referenced in the TAS cache is requeued": {
+			flavorInCache:    true,
+			wantRequeueAfter: topologyInUseRequeueInterval,
+		},
+		"topology with no referencing flavors gets the finalizer removed": {
+			wantFinalizerGone: true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			now := metav1.Now()
+			topology := utiltestingapi.MakeTopology("t1").Levels("kubernetes.io/hostname").Obj()
+			topology.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+			topology.DeletionTimestamp = &now
+
+			cl := utiltesting.NewFakeClient(topology)
+			cqCache := schdcache.New(cl)
+			cqCache.AddOrUpdateTopology(log, topology)
+			if tc.flavorInCache {
+				flavor := utiltestingapi.MakeResourceFlavor("rf").TopologyName("t1").Obj()
+				cqCache.AddOrUpdateResourceFlavor(log, flavor)
+			}
+
+			r := newTopologyReconciler(cl, nil, cqCache, nil)
+			got, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "t1"}})
+			if err != nil {
+				t.Fatalf("unexpected reconcile error: %v", err)
+			}
+			if got.RequeueAfter != tc.wantRequeueAfter {
+				t.Errorf("unexpected RequeueAfter: want %v, got %v", tc.wantRequeueAfter, got.RequeueAfter)
+			}
+
+			gotTopology := &kueue.Topology{}
+			getErr := cl.Get(ctx, types.NamespacedName{Name: "t1"}, gotTopology)
+			if tc.wantFinalizerGone {
+				// The fake client deletes the object once the last finalizer
+				// is removed from a terminating object.
+				if getErr == nil && len(gotTopology.Finalizers) != 0 {
+					t.Errorf("expected finalizer to be removed, still present: %v", gotTopology.Finalizers)
+				}
+				if getErr != nil && !apierrors.IsNotFound(getErr) {
+					t.Errorf("unexpected error getting topology: %v", getErr)
+				}
+			} else {
+				if getErr != nil {
+					t.Fatalf("unexpected error getting topology: %v", getErr)
+				}
+				if len(gotTopology.Finalizers) == 0 {
+					t.Error("expected finalizer to be kept while the topology is in use")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

A Topology pending deletion keeps its `kueue.x-k8s.io/resource-in-use` finalizer until no ResourceFlavor references it. That check reads the TAS cache, and the reconcile is triggered by the referencing flavor's **delete** event (delayed by `UpdatesBatchPeriod`). If the reconcile runs before the cache has observed the flavor deletion, it logs "topology is still in use" and returns **without requeue**.

Because `spec.topologyName` is immutable on ResourceFlavors (CEL validation on both v1beta1 and v1beta2), the flavor's delete event is the *last* event that can ever enqueue that Topology — losing the race leaves the Topology stuck in `Terminating` until a controller restart resyncs it, matching the symptom reported in #12572.

This PR requeues the Topology with a 1-minute interval while it is pending deletion and still referenced, so finalizer removal re-verifies periodically instead of depending on event/cache ordering. A table-driven reconciler test covers both the requeue-while-referenced and finalizer-removal paths.

#### Which issue(s) this PR fixes:

Fixes #12572

#### Special notes for your reviewer:

- The issue proposed handling ResourceFlavor `Update` events. During implementation I found that `topologyName` is immutable once set (CEL rule in both served API versions), so a flavor can never be *updated* to stop referencing a Topology — only deleted, which the handler already covers. The remaining reachable stuck-in-Terminating path is the event/cache race above, which this PR fixes; an `Update` handler would have no effect today. Detailed analysis is in the linked issue comment.
- Verified with the new `TestTopologyReconcilerFinalizerRemovalOnDeletion` and `go test ./pkg/controller/tas/ -count=1`.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where a deleted Topology could remain stuck in Terminating with the `kueue.x-k8s.io/resource-in-use` finalizer if the reconcile raced with the deletion of the last referencing ResourceFlavor. The Topology now periodically re-verifies whether referencing flavors remain.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology deletion handling when resources are still in use.
  * The system now periodically rechecks referenced resources instead of leaving deletion blocked until a restart.
  * Topology finalizers are removed promptly once no resources depend on the topology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->