### PR TITLE
Make DropQueue effective for ClusterQueues without a Cohort

### DIFF
--- a/pkg/scheduler/preemption/fairsharing/ordering.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering.go
@@ -95,7 +95,9 @@ func (t *TargetClusterQueueOrdering) Iter() iter.Seq[*TargetClusterQueue] {
 				targetCq: t.preemptorCq,
 			}
 
-			for targetCq.HasWorkload() {
+			// Respect DropQueue: a caller may drop the queue without
+			// popping a workload, which would otherwise loop forever.
+			for !t.prunedClusterQueues.Has(t.preemptorCq) && targetCq.HasWorkload() {
 				if !yield(targetCq) {
 					return
 				}

--- a/pkg/scheduler/preemption/fairsharing/ordering_test.go
+++ b/pkg/scheduler/preemption/fairsharing/ordering_test.go
@@ -65,6 +65,24 @@ func TestMakeClusterQueueOrdering(t *testing.T) {
 			candidateCQs: []kueue.ClusterQueueReference{"preemptor"},
 			wantOrder:    []kueue.ClusterQueueReference{"preemptor"},
 		},
+		"no cohort: DropQueue ends the iteration with candidates remaining": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("preemptor").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "4").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl1", "ns").Request(corev1.ResourceCPU, "1").
+					SimpleReserveQuota("preemptor", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("wl2", "ns").Request(corev1.ResourceCPU, "1").
+					SimpleReserveQuota("preemptor", "default", now).Obj(),
+			},
+			preemptorCQ:  "preemptor",
+			candidateCQs: []kueue.ClusterQueueReference{"preemptor"},
+			actions:      []string{"drop"},
+			wantOrder:    []kueue.ClusterQueueReference{"preemptor"},
+		},
 		"non-borrowing CQ is pruned even with candidates": {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue("preemptor").Cohort("all").


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The no-cohort branch of `TargetClusterQueueOrdering.Iter()` never consulted `prunedClusterQueues`, so `DropQueue` was a silent no-op for standalone ClusterQueues.

As analyzed in #12541 (see the issue comments), the infinite loop described there is not reachable with the current callers: `runSecondFsStrategy` pops a workload unconditionally on each iteration, and standalone CQs never reach the second strategy because all their candidates take the in-CQ path in `runFirstFsStrategy`. However, the asymmetry with the cohort path (which respects the pruned set) is a real footgun: any future caller that drops the queue without popping a workload would spin forever, exactly as the report describes.

This PR makes the standalone branch respect the pruned set, and extends `TestMakeClusterQueueOrdering` with a case where `DropQueue` is called on a standalone CQ with candidates remaining — under the old code the iterator keeps yielding the dropped queue.

#### Which issue(s) this PR fixes:

Fixes #12541

#### Special notes for your reviewer:

- No behavior change for current callers; this closes the latent hazard and makes `DropQueue` semantics uniform across both branches of `Iter()`.
- Verified with `go test ./pkg/scheduler/preemption/... -count=1` and the full `go test ./pkg/scheduler/ -count=1` suite.
- AI disclosure: this change was prepared with AI assistance (Claude Code) and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
Fair Sharing: add a safeguard to prevent a potential infinite loop when `DropQueue` is called for a standalone ClusterQueue without also calling `PopWorkload`.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
