### PR TITLE
test: cover multi-PodSet elastic ungating

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -98,8 +98,7 @@ func TestReconcile(t *testing.T) {
 	testCases := map[string]struct {
 		workloads []kueue.Workload
 		pods      []corev1.Pod
-		// skipDefaultPodSetLabels prevents default PodSet labeling so tests can verify that unlabeled Pods remain gated
-		// verify that Pods without a PodSet label remain gated.
+		// skipDefaultPodSetLabels prevents default PodSet labeling so tests can verify that unlabeled Pods remain gated.
 		skipDefaultPodSetLabels bool
 		expectUIDs              []types.UID
 		wantPods                []corev1.Pod
@@ -277,6 +276,7 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"do not ungate pod without podset label": {
+			skipDefaultPodSetLabels: true,
 			workloads: []kueue.Workload{
 				*makeAdmittedTwoPodSetWorkload(now),
 			},
@@ -294,7 +294,6 @@ func TestReconcile(t *testing.T) {
 					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 			},
-			skipDefaultPodSetLabels: true,
 		},
 		"skip already ungated pods": {
 			workloads: []kueue.Workload{

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -96,12 +96,14 @@ func TestReconcile(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 
 	testCases := map[string]struct {
+		workloads []kueue.Workload
+		pods      []corev1.Pod
+		// skipDefaultPodSetLabels keeps the Pod fixtures unlabeled so a test can
+		// verify that Pods without a PodSet label remain gated.
+		skipDefaultPodSetLabels bool
 		expectUIDs              []types.UID
-		workloads               []kueue.Workload
-		pods                    []corev1.Pod
 		wantPods                []corev1.Pod
 		wantErr                 error
-		skipDefaultPodSetLabels bool
 	}{
 		"ungate single pod": {
 			workloads: []kueue.Workload{

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -54,16 +54,54 @@ var podCmpOpts = []gocmp.Option{
 
 var rayClusterGVK = schema.GroupVersionKind{Group: "ray.io", Version: "v1", Kind: "RayCluster"}
 
+const (
+	headPodSet    kueue.PodSetReference = "head"
+	workersPodSet kueue.PodSetReference = "workers"
+)
+
+func makeAdmittedTwoPodSetWorkload(now time.Time) *kueue.Workload {
+	return utiltestingapi.MakeWorkload("wl", "ns").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+		ControllerReference(rayClusterGVK, "ray", "ray-uid").
+		PodSets(
+			*utiltestingapi.MakePodSet(headPodSet, 1).Request(corev1.ResourceCPU, "1").Obj(),
+			*utiltestingapi.MakePodSet(workersPodSet, 2).Request(corev1.ResourceCPU, "1").Obj(),
+		).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(
+					utiltestingapi.MakePodSetAssignment(headPodSet).
+						Assignment(corev1.ResourceCPU, "flavor", "1").
+						Obj(),
+					utiltestingapi.MakePodSetAssignment(workersPodSet).
+						Assignment(corev1.ResourceCPU, "flavor", "2").
+						Obj(),
+				).
+				Obj(), now,
+		).
+		AdmittedAt(true, now).
+		Obj()
+}
+
+func makeElasticPodForPodSet(name string, podSet kueue.PodSetReference) *testingpod.PodWrapper {
+	return testingpod.MakePod(name, "ns").
+		Annotation(kueue.WorkloadAnnotation, "wl").
+		Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+		Label(constants.PodSetLabel, string(podSet))
+}
+
 func TestReconcile(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 	now := time.Now().Truncate(time.Second)
 
 	testCases := map[string]struct {
-		expectUIDs []types.UID
-		workloads  []kueue.Workload
-		pods       []corev1.Pod
-		wantPods   []corev1.Pod
-		wantErr    error
+		expectUIDs              []types.UID
+		workloads               []kueue.Workload
+		pods                    []corev1.Pod
+		wantPods                []corev1.Pod
+		wantErr                 error
+		skipDefaultPodSetLabels bool
 	}{
 		"ungate single pod": {
 			workloads: []kueue.Workload{
@@ -144,6 +182,117 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
 					Obj(),
 			},
+		},
+		"ungate pods independently per podset": {
+			workloads: []kueue.Workload{
+				*makeAdmittedTwoPodSetWorkload(now),
+			},
+			pods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-0", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("head-1", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-0", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-1", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-2", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-0", headPodSet).Obj(),
+				*makeElasticPodForPodSet("head-1", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-0", workersPodSet).Obj(),
+				*makeElasticPodForPodSet("worker-1", workersPodSet).Obj(),
+				*makeElasticPodForPodSet("worker-2", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+		},
+		"do not share spare capacity between podsets": {
+			workloads: []kueue.Workload{
+				*makeAdmittedTwoPodSetWorkload(now),
+			},
+			pods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-running", headPodSet).Obj(),
+				*makeElasticPodForPodSet("head-waiting", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-waiting", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-running", headPodSet).Obj(),
+				*makeElasticPodForPodSet("head-waiting", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-waiting", workersPodSet).Obj(),
+			},
+		},
+		"terminal pod frees capacity only in its podset": {
+			workloads: []kueue.Workload{
+				*makeAdmittedTwoPodSetWorkload(now),
+			},
+			pods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-succeeded", headPodSet).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*makeElasticPodForPodSet("head-waiting", headPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*makeElasticPodForPodSet("worker-running-0", workersPodSet).
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*makeElasticPodForPodSet("worker-running-1", workersPodSet).
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*makeElasticPodForPodSet("worker-waiting", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*makeElasticPodForPodSet("head-succeeded", headPodSet).
+					StatusPhase(corev1.PodSucceeded).
+					Obj(),
+				*makeElasticPodForPodSet("head-waiting", headPodSet).Obj(),
+				*makeElasticPodForPodSet("worker-running-0", workersPodSet).
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*makeElasticPodForPodSet("worker-running-1", workersPodSet).
+					StatusPhase(corev1.PodRunning).
+					Obj(),
+				*makeElasticPodForPodSet("worker-waiting", workersPodSet).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+		},
+		"do not ungate pod without podset label": {
+			workloads: []kueue.Workload{
+				*makeAdmittedTwoPodSetWorkload(now),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			skipDefaultPodSetLabels: true,
 		},
 		"skip already ungated pods": {
 			workloads: []kueue.Workload{
@@ -678,11 +827,13 @@ func TestReconcile(t *testing.T) {
 
 			// Real elastic pods always carry the PodSet label; default it here so the
 			// per-PodSet ungating cap has a key to match against.
-			for i := range tc.pods {
-				ensureDefaultPodSetLabel(&tc.pods[i])
-			}
-			for i := range tc.wantPods {
-				ensureDefaultPodSetLabel(&tc.wantPods[i])
+			if !tc.skipDefaultPodSetLabels {
+				for i := range tc.pods {
+					ensureDefaultPodSetLabel(&tc.pods[i])
+				}
+				for i := range tc.wantPods {
+					ensureDefaultPodSetLabel(&tc.wantPods[i])
+				}
 			}
 
 			clientBuilder := utiltesting.NewClientBuilder().

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 	testCases := map[string]struct {
 		workloads []kueue.Workload
 		pods      []corev1.Pod
-		// skipDefaultPodSetLabels keeps the Pod fixtures unlabeled so a test can
+		// skipDefaultPodSetLabels prevents default PodSet labeling so tests can verify that unlabeled Pods remain gated
 		// verify that Pods without a PodSet label remain gated.
 		skipDefaultPodSetLabels bool
 		expectUIDs              []types.UID


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area elastic-jobs
/area testing

#### What this PR does / why we need it:

Adds multi-PodSet coverage for elastic Job ungating so the tests verify that quota accounting remains isolated between RayCluster-style head and worker PodSets.

The new cases cover:
- ungating each PodSet up to its own granted count;
- preventing spare capacity from leaking across PodSets;
- releasing terminal-Pod capacity only within the matching PodSet; and
- keeping Pods without the `kueue.x-k8s.io/podset` label gated.

#### Which issue(s) this PR fixes:

Fixes #13189

#### Special notes for your reviewer:

Rebased onto `main` after #13126 merged. Validated with Go:

```shell
go test ./pkg/controller/elasticjobs -run TestReconcile -count=1
go test ./pkg/controller/elasticjobs -run TestReconcile -count=10
go test ./pkg/controller/elasticjobs -count=1
go vet ./pkg/controller/elasticjobs
```

This PR was prepared with the assistance of generative AI. I reviewed the diff and validated it with focused, repeated, package-level, and vet checks.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for ungating workloads independently per podset.
  * Verified spare capacity and capacity released by terminal pods are not shared across podsets.
  * Confirmed pods without a PodSet label remain gated when default labeling is skipped.
  * Expanded test scenarios to cover multi-podset workloads and podset-specific labeling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->