### PR TITLE
fix(kueueviz): handle missing event timestamps

### DIFF
--- a/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
+++ b/cmd/kueueviz/frontend/src/WorkloadDetail.jsx
@@ -21,6 +21,31 @@ import useWebSocket from './useWebSocket';
 import './App.css';
 import ErrorMessage from './ErrorMessage';
 
+export const formatEventTimestamp = (timestamp) => {
+  if (!timestamp) return 'N/A';
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return 'N/A';
+
+  return `${date.toISOString().replace('T', '@').slice(0, 19)} UTC`;
+};
+
+export const getEventTimestamp = (event) =>
+  event?.firstTimestamp || event?.eventTime || event?.lastTimestamp || '';
+
+export const compareEvents = (a, b) => {
+  const aTime = new Date(getEventTimestamp(a)).getTime();
+  const bTime = new Date(getEventTimestamp(b)).getTime();
+  const aHasValidTime = !Number.isNaN(aTime);
+  const bHasValidTime = !Number.isNaN(bTime);
+
+  if (aHasValidTime !== bHasValidTime) return aHasValidTime ? -1 : 1;
+  if (aHasValidTime && aTime !== bTime) return bTime - aTime;
+
+  return (a.reason || '').localeCompare(b.reason || '') ||
+    (a.metadata?.name || '').localeCompare(b.metadata?.name || '');
+};
+
 const WorkloadDetail = () => {
   const { namespace, workloadName } = useParams();
   const workloadUrl = `/ws/workload/${namespace}/${workloadName}`;
@@ -33,10 +58,7 @@ const WorkloadDetail = () => {
 
   useEffect(() => {
     if (eventData && Array.isArray(eventData)) {
-      const sortedEvents = [...eventData].sort((a, b) =>
-        new Date(b.firstTimestamp) - new Date(a.firstTimestamp) || (a.reason || '').localeCompare(b.reason || '') || (a.name || '').localeCompare(b.name || '')
-      );
-      setEvents(sortedEvents);
+      setEvents([...eventData].sort(compareEvents));
     }
   }, [eventData]);
 
@@ -90,7 +112,7 @@ const WorkloadDetail = () => {
               {events.map((event) => (
                 <TableRow key={event.name}>
                   <TableCell>
-                    {new Date(event.firstTimestamp).toISOString().replace('T', '@').slice(0, 19)} UTC
+                    {formatEventTimestamp(getEventTimestamp(event))}
                   </TableCell>
                   <TableCell>{event.type}</TableCell>
                   <TableCell>{event.reason}</TableCell>

--- a/cmd/kueueviz/frontend/src/WorkloadDetail.test.js
+++ b/cmd/kueueviz/frontend/src/WorkloadDetail.test.js
@@ -1,0 +1,97 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('./useWebSocket', () => ({
+  default: vi.fn(),
+}));
+
+import { compareEvents, formatEventTimestamp, getEventTimestamp } from './WorkloadDetail';
+
+describe('formatEventTimestamp', () => {
+  it('formats a valid timestamp in UTC', () => {
+    expect(formatEventTimestamp('2026-06-26T10:27:28Z')).toBe('2026-06-26@10:27:28 UTC');
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['an invalid date string', 'not-a-timestamp'],
+    ['an out-of-range date', '275760-09-13T00:00:00.001Z'],
+  ])('returns N/A for %s', (_description, timestamp) => {
+    expect(formatEventTimestamp(timestamp)).toBe('N/A');
+  });
+});
+
+describe('getEventTimestamp', () => {
+  it('prefers firstTimestamp for legacy events', () => {
+    expect(getEventTimestamp({
+      firstTimestamp: '2026-06-26T10:27:28Z',
+      eventTime: '2026-06-26T11:00:00.000000Z',
+      lastTimestamp: '2026-06-26T10:30:00Z',
+    })).toBe('2026-06-26T10:27:28Z');
+  });
+
+  it('falls back to eventTime for modern events', () => {
+    expect(getEventTimestamp({
+      eventTime: '2026-06-26T11:00:00.000000Z',
+    })).toBe('2026-06-26T11:00:00.000000Z');
+  });
+
+  it('falls back to lastTimestamp when earlier fields are absent', () => {
+    expect(getEventTimestamp({
+      lastTimestamp: '2026-06-26T10:30:00Z',
+    })).toBe('2026-06-26T10:30:00Z');
+  });
+
+  it.each([
+    ['undefined event', undefined],
+    ['empty event', {}],
+  ])('returns empty string for %s', (_description, event) => {
+    expect(getEventTimestamp(event)).toBe('');
+  });
+});
+
+describe('compareEvents', () => {
+  it('sorts valid timestamps newest first and invalid timestamps last', () => {
+    const events = [
+      { metadata: { name: 'invalid' }, reason: 'A', firstTimestamp: 'not-a-timestamp' },
+      { metadata: { name: 'older' }, reason: 'C', firstTimestamp: '2026-06-26T10:00:00Z' },
+      { metadata: { name: 'missing' }, reason: 'B' },
+      { metadata: { name: 'newer' }, reason: 'D', eventTime: '2026-06-26T11:00:00Z' },
+    ];
+
+    expect([...events].sort(compareEvents).map((event) => event.metadata.name)).toEqual([
+      'newer',
+      'older',
+      'invalid',
+      'missing',
+    ]);
+  });
+
+  it('uses reason and name to order events with equal timestamps', () => {
+    const timestamp = '2026-06-26T10:00:00Z';
+    const events = [
+      { metadata: { name: 'b' }, reason: 'Same', firstTimestamp: timestamp },
+      { metadata: { name: 'a' }, reason: 'Same', firstTimestamp: timestamp },
+      { metadata: { name: 'c' }, reason: 'Earlier', firstTimestamp: timestamp },
+    ];
+
+    expect([...events].sort(compareEvents).map((event) => event.metadata.name)).toEqual(['c', 'a', 'b']);
+  });
+});


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dashboard
/area testing

#### What this PR does / why we need it:

Prevents the KueueViz workload detail page from crashing when a Kubernetes Event omits `firstTimestamp` or contains an invalid timestamp.

The frontend now:
- falls back to `eventTime` or `lastTimestamp` when `firstTimestamp` is absent;
- validates timestamps before formatting them;
- renders `N/A` for missing or invalid timestamps; and
- keeps valid events ordered newest-first while placing invalid or missing timestamps last.

Adds focused regression coverage for timestamp selection, formatting, and ordering.

#### Which issue(s) this PR fixes:

Fixes #12550

#### Special notes for your reviewer:

Validated with:

```shell
cd cmd/kueueviz/frontend
npm test
npm run build
```

All 64 frontend tests pass, and the production Vite build succeeds.

This PR was prepared with assistance from generative AI. I reviewed the changes and validation results.

#### Does this PR introduce a user-facing change?

```release-note
KueueViz: Prevent workload detail pages from crashing when Kubernetes Events have missing or invalid timestamps.
```
