### PR TITLE
fix(importer): fix denial of service via nil map panic on pods without labels

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -140,6 +140,9 @@ func addLabels(ctx context.Context, c client.Client, p *corev1.Pod, queue string
 				retry, reload, timeout = checkError(err)
 				continue
 			}
+			if p.Labels == nil {
+				p.Labels = make(map[string]string)
+			}
 			p.Labels[controllerconstants.QueueLabel] = queue
 			p.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
 			maps.Copy(p.Labels, addLabels)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fixes a Go panic in the `cmd/importer` tool that occurs when attempting to import a Pod that has no existing labels (`metadata.labels` is `nil`). 

While there was a nil-check at the beginning of the `addLabels` function, the retry loop (which executes if there is an API conflict on `Update`) calls `c.Get` to fetch the latest Pod state. If the freshly fetched Pod also lacks labels, `p.Labels` becomes `nil` again, causing the subsequent label assignments to panic and crash the importer tool entirely. 

This PR ensures the nil-check is also present inside the retry loop before assigning the `kueue.x-k8s.io/queue-name` label, preventing the DoS crash.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12559

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
