### PR TITLE
fix(multikueue): fix unauthorized remote job deletion via spoofed workload owner annotations

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter.go
@@ -249,7 +249,7 @@ func (a *Adapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, err
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(unstructuredObj)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(unstructuredObj))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(unstructuredObj.GetName(), unstructuredObj.GetUID(), a.gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: unstructuredObj.GetNamespace()}}, nil

--- a/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
+++ b/pkg/controller/admissionchecks/multikueue/externalframeworks/adapter_test.go
@@ -499,8 +499,11 @@ func TestAdapter_WorkloadKeysFor(t *testing.T) {
 					},
 				},
 			},
-			want:       nil,
-			wantErrMsg: "no prebuilt workload found for TestJob: test-ns/test-job",
+			want: []types.NamespacedName{{
+				Name:      "testjob-test-job-6ed1d",
+				Namespace: "test-ns",
+			}},
+			wantErrMsg: "",
 		},
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -268,6 +268,7 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		if !ok {
 			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
 		}
+		jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
 
 		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
 		if err != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -245,6 +246,34 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 		if !managed {
 			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
+		}
+
+		// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+		if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
+			emptyList := watcher.GetEmptyList()
+			t := reflect.TypeOf(emptyList)
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+			if itemsField, found := t.FieldByName("Items"); found {
+				itemType := itemsField.Type.Elem()
+				if jobObj, ok := reflect.New(itemType).Interface().(client.Object); ok {
+					if err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj); err == nil {
+						if keys, err := watcher.WorkloadKeysFor(jobObj); err == nil {
+							ownsWorkload := false
+							for _, k := range keys {
+								if k.Name == wl.Name && k.Namespace == wl.Namespace {
+									ownsWorkload = true
+									break
+								}
+							}
+							if !ownsWorkload {
+								return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -236,7 +236,67 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, rejectionMessage)
 	}
 
-	// If the workload is deleted there is a chance that it's owner is also deleted. In that case
+	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
+	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
+		emptyList := watcher.GetEmptyList()
+		t := reflect.TypeOf(emptyList)
+		if t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		itemsField, found := t.FieldByName("Items")
+		if !found || itemsField.Type.Kind() != reflect.Slice {
+			return reconcile.Result{}, fmt.Errorf("items slice not found in list type %T", emptyList)
+		}
+		itemType := itemsField.Type.Elem()
+		jobObj, ok := reflect.New(itemType).Interface().(client.Object)
+		if !ok {
+			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
+		}
+
+		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
+		if err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				// Fail closed on transient errors.
+				return reconcile.Result{}, err
+			}
+			// Job not found. If the workload is not being deleted, requeue to
+			// wait for the Job to appear or be garbage collected.
+			if !isDeleted {
+				return reconcile.Result{}, err
+			}
+			// If the workload is being deleted and the Job is already gone,
+			// it is safe to proceed with remote object cleanup.
+		} else {
+			keys, err := watcher.WorkloadKeysFor(jobObj)
+			if err != nil {
+				// If the adapter cannot compute keys (e.g. job type doesn't support
+				// prebuilt workload labels), skip the ownership check and allow the
+				// reconcile to continue. This is not a security concern because the
+				// job exists and the adapter simply doesn't implement key derivation.
+				log.V(2).Info("Skipping ownership check: WorkloadKeysFor not supported", "workload", req.NamespacedName, "error", err)
+			} else {
+				ownsWorkload := false
+				for _, k := range keys {
+					if k.Name == wl.Name && k.Namespace == wl.Namespace {
+						ownsWorkload = true
+						break
+					}
+				}
+				if !ownsWorkload {
+					if !isDeleted {
+						return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+					}
+					// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+					log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+					w.deletedWlCache.Delete(req.String())
+					return reconcile.Result{}, nil
+				}
+			}
+		}
+	}
+
+	// If the workload is deleted there is a chance that its owner is also deleted. In that case
 	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
 	if !isDeleted {
 		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
@@ -247,36 +307,7 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		if !managed {
 			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
 		}
-
-		// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
-		if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
-			emptyList := watcher.GetEmptyList()
-			t := reflect.TypeOf(emptyList)
-			if t.Kind() == reflect.Ptr {
-				t = t.Elem()
-			}
-			if itemsField, found := t.FieldByName("Items"); found {
-				itemType := itemsField.Type.Elem()
-				if jobObj, ok := reflect.New(itemType).Interface().(client.Object); ok {
-					if err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj); err == nil {
-						if keys, err := watcher.WorkloadKeysFor(jobObj); err == nil {
-							ownsWorkload := false
-							for _, k := range keys {
-								if k.Name == wl.Name && k.Namespace == wl.Namespace {
-									ownsWorkload = true
-									break
-								}
-							}
-							if !ownsWorkload {
-								return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-							}
-						}
-					}
-				}
-			}
-		}
 	}
-
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -236,6 +236,21 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, rejectionMessage)
 	}
 
+	// If the workload is deleted there is a chance that its owner is also deleted. In that case
+	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
+	// For active workloads, check management first to give more informative rejection messages
+	// (e.g. "not managed by Kueue" takes priority over "cannot verify ownership").
+	if !isDeleted {
+		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if !managed {
+			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
+		}
+	}
+
 	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
 	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
 	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
@@ -270,44 +285,35 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		} else {
 			keys, err := watcher.WorkloadKeysFor(jobObj)
 			if err != nil {
-				// If the adapter cannot compute keys (e.g. job type doesn't support
-				// prebuilt workload labels), skip the ownership check and allow the
-				// reconcile to continue. This is not a security concern because the
-				// job exists and the adapter simply doesn't implement key derivation.
-				log.V(2).Info("Skipping ownership check: WorkloadKeysFor not supported", "workload", req.NamespacedName, "error", err)
-			} else {
-				ownsWorkload := false
-				for _, k := range keys {
-					if k.Name == wl.Name && k.Namespace == wl.Namespace {
-						ownsWorkload = true
-						break
-					}
+				// If the adapter cannot compute keys, we cannot verify ownership.
+				// We must fail closed to prevent Confused Deputy attacks.
+				if !isDeleted {
+					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
 				}
-				if !ownsWorkload {
-					if !isDeleted {
-						return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-					}
-					// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
-					log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
-					w.deletedWlCache.Delete(req.String())
-					return reconcile.Result{}, nil
+				log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
+				w.deletedWlCache.Delete(req.String())
+				return reconcile.Result{}, nil
+			}
+
+			ownsWorkload := false
+			for _, k := range keys {
+				if k.Name == wl.Name && k.Namespace == wl.Namespace {
+					ownsWorkload = true
+					break
 				}
+			}
+			if !ownsWorkload {
+				if !isDeleted {
+					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+				}
+				// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+				log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+				w.deletedWlCache.Delete(req.String())
+				return reconcile.Result{}, nil
 			}
 		}
 	}
 
-	// If the workload is deleted there is a chance that its owner is also deleted. In that case
-	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
-	if !isDeleted {
-		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if !managed {
-			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
-		}
-	}
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -252,82 +252,8 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		}
 	}
 
-	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
-	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
-	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
-		emptyList := watcher.GetEmptyList()
-		t := reflect.TypeOf(emptyList)
-		if t.Kind() == reflect.Pointer {
-			t = t.Elem()
-		}
-		itemsField, found := t.FieldByName("Items")
-		if !found || itemsField.Type.Kind() != reflect.Slice {
-			return reconcile.Result{}, fmt.Errorf("items slice not found in list type %T", emptyList)
-		}
-		itemType := itemsField.Type.Elem()
-		jobObj, ok := reflect.New(itemType).Interface().(client.Object)
-		if !ok {
-			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
-		}
-		jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
-
-		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
-		if err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				// Fail closed on transient errors.
-				return reconcile.Result{}, err
-			}
-			// Job not found. If the workload is not being deleted, requeue to
-			// wait for the Job to appear or be garbage collected.
-			if !isDeleted {
-				return reconcile.Result{}, err
-			}
-			// If the workload is being deleted and the Job is already gone,
-			// it is safe to proceed with remote object cleanup.
-		} else {
-			keys, err := watcher.WorkloadKeysFor(jobObj)
-			if err != nil {
-				// If the adapter cannot compute keys, we cannot verify ownership.
-				// We must fail closed to prevent Confused Deputy attacks.
-				if !isDeleted {
-					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
-				}
-				log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
-				w.deletedWlCache.Delete(req.String())
-				return reconcile.Result{}, nil
-			}
-
-			ownsWorkload := false
-			for _, k := range keys {
-				if k.Namespace != wl.Namespace {
-					continue
-				}
-
-				if k.Name == wl.Name {
-					ownsWorkload = true
-					break
-				}
-
-				prefix := k.Name
-				if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
-					prefix = prefix[:dashIdx+1]
-				}
-
-				if strings.HasPrefix(wl.Name, prefix) {
-					ownsWorkload = true
-					break
-				}
-			}
-			if !ownsWorkload {
-				if !isDeleted {
-					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-				}
-				// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
-				log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
-				w.deletedWlCache.Delete(req.String())
-				return reconcile.Result{}, nil
-			}
-		}
+	if result, done, err := w.verifyWorkloadOwnership(ctx, req, wl, owner, adapter, mkAc, isDeleted); done {
+		return result, err
 	}
 
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
@@ -349,6 +275,97 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	}
 
 	return w.reconcileGroup(ctx, grp)
+}
+
+// verifyWorkloadOwnership checks if the workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
+// It returns a boolean indicating whether the reconciliation should stop, along with the result and error.
+func (w *wlReconciler) verifyWorkloadOwnership(ctx context.Context, req reconcile.Request, wl *kueue.Workload, owner *metav1.OwnerReference, adapter jobframework.MultiKueueAdapter, mkAc *kueue.AdmissionCheckState, isDeleted bool) (reconcile.Result, bool, error) {
+	watcher, implements := adapter.(jobframework.MultiKueueWatcher)
+	if !implements {
+		return reconcile.Result{}, false, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	emptyList := watcher.GetEmptyList()
+	t := reflect.TypeOf(emptyList)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	itemsField, found := t.FieldByName("Items")
+	if !found || itemsField.Type.Kind() != reflect.Slice {
+		return reconcile.Result{}, true, fmt.Errorf("items slice not found in list type %T", emptyList)
+	}
+	itemType := itemsField.Type.Elem()
+	jobObj, ok := reflect.New(itemType).Interface().(client.Object)
+	if !ok {
+		return reconcile.Result{}, true, errors.New("instantiated item type does not implement client.Object")
+	}
+	jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
+
+	err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			// Fail closed on transient errors.
+			return reconcile.Result{}, true, err
+		}
+		// Job not found. If the workload is not being deleted, requeue to
+		// wait for the Job to appear or be garbage collected.
+		if !isDeleted {
+			log.V(3).Info("Owner Job not found, requeuing", "job", owner.Name)
+			return reconcile.Result{}, true, err
+		}
+		// If the workload is being deleted and the Job is already gone,
+		// it is safe to proceed with remote object cleanup.
+	} else {
+		keys, err := watcher.WorkloadKeysFor(jobObj)
+		if err != nil {
+			// If the adapter cannot compute keys, we cannot verify ownership.
+			// We must fail closed to prevent Confused Deputy attacks.
+			if !isDeleted {
+				log.V(2).Info("Cannot verify ownership due to key derivation error", "workload", req.NamespacedName, "error", err)
+				return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
+			}
+			log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
+			w.deletedWlCache.Delete(req.String())
+			return reconcile.Result{}, true, nil
+		}
+
+		ownsWorkload := false
+		for _, k := range keys {
+			if k.Namespace != wl.Namespace {
+				continue
+			}
+
+			if k.Name == wl.Name {
+				ownsWorkload = true
+				break
+			}
+
+			prefix := k.Name
+			if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
+				prefix = prefix[:dashIdx+1]
+			}
+
+			if strings.HasPrefix(wl.Name, prefix) {
+				ownsWorkload = true
+				break
+			}
+		}
+		if !ownsWorkload {
+			if !isDeleted {
+				log.V(2).Info("Workload is not owned by the referenced Job", "workload", req.NamespacedName)
+				return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+			}
+			// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+			log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+			w.deletedWlCache.Delete(req.String())
+			return reconcile.Result{}, true, nil
+		}
+	}
+
+	return reconcile.Result{}, false, nil
 }
 
 func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *kueue.AdmissionCheckState, status kueue.CheckState, message string) error {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -299,7 +300,21 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 			ownsWorkload := false
 			for _, k := range keys {
-				if k.Name == wl.Name && k.Namespace == wl.Namespace {
+				if k.Namespace != wl.Namespace {
+					continue
+				}
+
+				if k.Name == wl.Name {
+					ownsWorkload = true
+					break
+				}
+
+				prefix := k.Name
+				if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
+					prefix = prefix[:dashIdx+1]
+				}
+
+				if strings.HasPrefix(wl.Name, prefix) {
 					ownsWorkload = true
 					break
 				}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -253,82 +253,8 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		}
 	}
 
-	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
-	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
-	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
-		emptyList := watcher.GetEmptyList()
-		t := reflect.TypeOf(emptyList)
-		if t.Kind() == reflect.Pointer {
-			t = t.Elem()
-		}
-		itemsField, found := t.FieldByName("Items")
-		if !found || itemsField.Type.Kind() != reflect.Slice {
-			return reconcile.Result{}, fmt.Errorf("items slice not found in list type %T", emptyList)
-		}
-		itemType := itemsField.Type.Elem()
-		jobObj, ok := reflect.New(itemType).Interface().(client.Object)
-		if !ok {
-			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
-		}
-		jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
-
-		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
-		if err != nil {
-			if client.IgnoreNotFound(err) != nil {
-				// Fail closed on transient errors.
-				return reconcile.Result{}, err
-			}
-			// Job not found. If the workload is not being deleted, requeue to
-			// wait for the Job to appear or be garbage collected.
-			if !isDeleted {
-				return reconcile.Result{}, err
-			}
-			// If the workload is being deleted and the Job is already gone,
-			// it is safe to proceed with remote object cleanup.
-		} else {
-			keys, err := watcher.WorkloadKeysFor(jobObj)
-			if err != nil {
-				// If the adapter cannot compute keys, we cannot verify ownership.
-				// We must fail closed to prevent Confused Deputy attacks.
-				if !isDeleted {
-					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
-				}
-				log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
-				w.deletedWlCache.Delete(req.String())
-				return reconcile.Result{}, nil
-			}
-
-			ownsWorkload := false
-			for _, k := range keys {
-				if k.Namespace != wl.Namespace {
-					continue
-				}
-
-				if k.Name == wl.Name {
-					ownsWorkload = true
-					break
-				}
-
-				prefix := k.Name
-				if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
-					prefix = prefix[:dashIdx+1]
-				}
-
-				if strings.HasPrefix(wl.Name, prefix) {
-					ownsWorkload = true
-					break
-				}
-			}
-			if !ownsWorkload {
-				if !isDeleted {
-					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-				}
-				// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
-				log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
-				w.deletedWlCache.Delete(req.String())
-				return reconcile.Result{}, nil
-			}
-		}
+	if result, done, err := w.verifyWorkloadOwnership(ctx, req, wl, owner, adapter, mkAc, isDeleted); done {
+		return result, err
 	}
 
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
@@ -350,6 +276,97 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 	}
 
 	return w.reconcileGroup(ctx, grp)
+}
+
+// verifyWorkloadOwnership checks if the workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
+// It returns a boolean indicating whether the reconciliation should stop, along with the result and error.
+func (w *wlReconciler) verifyWorkloadOwnership(ctx context.Context, req reconcile.Request, wl *kueue.Workload, owner *metav1.OwnerReference, adapter jobframework.MultiKueueAdapter, mkAc *kueue.AdmissionCheckState, isDeleted bool) (reconcile.Result, bool, error) {
+	watcher, implements := adapter.(jobframework.MultiKueueWatcher)
+	if !implements {
+		return reconcile.Result{}, false, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+
+	emptyList := watcher.GetEmptyList()
+	t := reflect.TypeOf(emptyList)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	itemsField, found := t.FieldByName("Items")
+	if !found || itemsField.Type.Kind() != reflect.Slice {
+		return reconcile.Result{}, true, fmt.Errorf("items slice not found in list type %T", emptyList)
+	}
+	itemType := itemsField.Type.Elem()
+	jobObj, ok := reflect.New(itemType).Interface().(client.Object)
+	if !ok {
+		return reconcile.Result{}, true, errors.New("instantiated item type does not implement client.Object")
+	}
+	jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
+
+	err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
+	if err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			// Fail closed on transient errors.
+			return reconcile.Result{}, true, err
+		}
+		// Job not found. If the workload is not being deleted, requeue to
+		// wait for the Job to appear or be garbage collected.
+		if !isDeleted {
+			log.V(3).Info("Owner Job not found, requeuing", "job", owner.Name)
+			return reconcile.Result{}, true, err
+		}
+		// If the workload is being deleted and the Job is already gone,
+		// it is safe to proceed with remote object cleanup.
+	} else {
+		keys, err := watcher.WorkloadKeysFor(jobObj)
+		if err != nil {
+			// If the adapter cannot compute keys, we cannot verify ownership.
+			// We must fail closed to prevent Confused Deputy attacks.
+			if !isDeleted {
+				log.V(2).Info("Cannot verify ownership due to key derivation error", "workload", req.NamespacedName, "error", err)
+				return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
+			}
+			log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
+			w.deletedWlCache.Delete(req.String())
+			return reconcile.Result{}, true, nil
+		}
+
+		ownsWorkload := false
+		for _, k := range keys {
+			if k.Namespace != wl.Namespace {
+				continue
+			}
+
+			if k.Name == wl.Name {
+				ownsWorkload = true
+				break
+			}
+
+			prefix := k.Name
+			if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
+				prefix = prefix[:dashIdx+1]
+			}
+
+			if strings.HasPrefix(wl.Name, prefix) {
+				ownsWorkload = true
+				break
+			}
+		}
+		if !ownsWorkload {
+			if !isDeleted {
+				log.V(2).Info("Workload is not owned by the referenced Job", "workload", req.NamespacedName)
+				return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+			}
+			// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+			log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+			w.deletedWlCache.Delete(req.String())
+			return reconcile.Result{}, true, nil
+		}
+	}
+
+	return reconcile.Result{}, false, nil
 }
 
 func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *kueue.AdmissionCheckState, status kueue.CheckState, message string) error {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -237,7 +237,67 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, rejectionMessage)
 	}
 
-	// If the workload is deleted there is a chance that it's owner is also deleted. In that case
+	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
+	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
+		emptyList := watcher.GetEmptyList()
+		t := reflect.TypeOf(emptyList)
+		if t.Kind() == reflect.Pointer {
+			t = t.Elem()
+		}
+		itemsField, found := t.FieldByName("Items")
+		if !found || itemsField.Type.Kind() != reflect.Slice {
+			return reconcile.Result{}, fmt.Errorf("items slice not found in list type %T", emptyList)
+		}
+		itemType := itemsField.Type.Elem()
+		jobObj, ok := reflect.New(itemType).Interface().(client.Object)
+		if !ok {
+			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
+		}
+
+		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
+		if err != nil {
+			if client.IgnoreNotFound(err) != nil {
+				// Fail closed on transient errors.
+				return reconcile.Result{}, err
+			}
+			// Job not found. If the workload is not being deleted, requeue to
+			// wait for the Job to appear or be garbage collected.
+			if !isDeleted {
+				return reconcile.Result{}, err
+			}
+			// If the workload is being deleted and the Job is already gone,
+			// it is safe to proceed with remote object cleanup.
+		} else {
+			keys, err := watcher.WorkloadKeysFor(jobObj)
+			if err != nil {
+				// If the adapter cannot compute keys (e.g. job type doesn't support
+				// prebuilt workload labels), skip the ownership check and allow the
+				// reconcile to continue. This is not a security concern because the
+				// job exists and the adapter simply doesn't implement key derivation.
+				log.V(2).Info("Skipping ownership check: WorkloadKeysFor not supported", "workload", req.NamespacedName, "error", err)
+			} else {
+				ownsWorkload := false
+				for _, k := range keys {
+					if k.Name == wl.Name && k.Namespace == wl.Namespace {
+						ownsWorkload = true
+						break
+					}
+				}
+				if !ownsWorkload {
+					if !isDeleted {
+						return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+					}
+					// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+					log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+					w.deletedWlCache.Delete(req.String())
+					return reconcile.Result{}, nil
+				}
+			}
+		}
+	}
+
+	// If the workload is deleted there is a chance that its owner is also deleted. In that case
 	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
 	if !isDeleted {
 		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
@@ -248,36 +308,7 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		if !managed {
 			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
 		}
-
-		// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
-		if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
-			emptyList := watcher.GetEmptyList()
-			t := reflect.TypeOf(emptyList)
-			if t.Kind() == reflect.Ptr {
-				t = t.Elem()
-			}
-			if itemsField, found := t.FieldByName("Items"); found {
-				itemType := itemsField.Type.Elem()
-				if jobObj, ok := reflect.New(itemType).Interface().(client.Object); ok {
-					if err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj); err == nil {
-						if keys, err := watcher.WorkloadKeysFor(jobObj); err == nil {
-							ownsWorkload := false
-							for _, k := range keys {
-								if k.Name == wl.Name && k.Namespace == wl.Namespace {
-									ownsWorkload = true
-									break
-								}
-							}
-							if !ownsWorkload {
-								return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-							}
-						}
-					}
-				}
-			}
-		}
 	}
-
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -280,7 +280,15 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 // verifyWorkloadOwnership checks if the workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
 // This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
 // It returns a boolean indicating whether the reconciliation should stop, along with the result and error.
-func (w *wlReconciler) verifyWorkloadOwnership(ctx context.Context, req reconcile.Request, wl *kueue.Workload, owner *metav1.OwnerReference, adapter jobframework.MultiKueueAdapter, mkAc *kueue.AdmissionCheckState, isDeleted bool) (reconcile.Result, bool, error) {
+func (w *wlReconciler) verifyWorkloadOwnership(
+	ctx context.Context,
+	req reconcile.Request,
+	wl *kueue.Workload,
+	owner *metav1.OwnerReference,
+	adapter jobframework.MultiKueueAdapter,
+	mkAc *kueue.AdmissionCheckState,
+	isDeleted bool,
+) (reconcile.Result, bool, error) {
 	watcher, implements := adapter.(jobframework.MultiKueueWatcher)
 	if !implements {
 		return reconcile.Result{}, false, nil

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -237,6 +237,21 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, rejectionMessage)
 	}
 
+	// If the workload is deleted there is a chance that its owner is also deleted. In that case
+	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
+	// For active workloads, check management first to give more informative rejection messages
+	// (e.g. "not managed by Kueue" takes priority over "cannot verify ownership").
+	if !isDeleted {
+		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if !managed {
+			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
+		}
+	}
+
 	// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
 	// This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
 	if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
@@ -271,44 +286,35 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		} else {
 			keys, err := watcher.WorkloadKeysFor(jobObj)
 			if err != nil {
-				// If the adapter cannot compute keys (e.g. job type doesn't support
-				// prebuilt workload labels), skip the ownership check and allow the
-				// reconcile to continue. This is not a security concern because the
-				// job exists and the adapter simply doesn't implement key derivation.
-				log.V(2).Info("Skipping ownership check: WorkloadKeysFor not supported", "workload", req.NamespacedName, "error", err)
-			} else {
-				ownsWorkload := false
-				for _, k := range keys {
-					if k.Name == wl.Name && k.Namespace == wl.Namespace {
-						ownsWorkload = true
-						break
-					}
+				// If the adapter cannot compute keys, we cannot verify ownership.
+				// We must fail closed to prevent Confused Deputy attacks.
+				if !isDeleted {
+					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("cannot verify ownership: %v", err))
 				}
-				if !ownsWorkload {
-					if !isDeleted {
-						return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
-					}
-					// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
-					log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
-					w.deletedWlCache.Delete(req.String())
-					return reconcile.Result{}, nil
+				log.V(2).Info("Spoofed Workload deletion ignored due to key derivation error", "workload", req.NamespacedName, "error", err)
+				w.deletedWlCache.Delete(req.String())
+				return reconcile.Result{}, nil
+			}
+
+			ownsWorkload := false
+			for _, k := range keys {
+				if k.Name == wl.Name && k.Namespace == wl.Namespace {
+					ownsWorkload = true
+					break
 				}
+			}
+			if !ownsWorkload {
+				if !isDeleted {
+					return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+				}
+				// If deleted and not owned, ignore the deletion to prevent remote Confused Deputy attacks.
+				log.V(2).Info("Spoofed Workload deletion ignored", "workload", req.NamespacedName)
+				w.deletedWlCache.Delete(req.String())
+				return reconcile.Result{}, nil
 			}
 		}
 	}
 
-	// If the workload is deleted there is a chance that its owner is also deleted. In that case
-	// we skip calling `IsJobManagedByKueue` as its output would not be reliable.
-	if !isDeleted {
-		managed, unmanagedReason, err := adapter.IsJobManagedByKueue(ctx, w.client, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace})
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-
-		if !managed {
-			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
-		}
-	}
 	grp, err := w.readGroup(ctx, wl, mkAc.Name, adapter, owner.Name)
 	if err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -269,6 +269,7 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 		if !ok {
 			return reconcile.Result{}, errors.New("instantiated item type does not implement client.Object")
 		}
+		jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
 
 		err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
 		if err != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -298,7 +299,21 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 			ownsWorkload := false
 			for _, k := range keys {
-				if k.Name == wl.Name && k.Namespace == wl.Namespace {
+				if k.Namespace != wl.Namespace {
+					continue
+				}
+
+				if k.Name == wl.Name {
+					ownsWorkload = true
+					break
+				}
+
+				prefix := k.Name
+				if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
+					prefix = prefix[:dashIdx+1]
+				}
+
+				if strings.HasPrefix(wl.Name, prefix) {
 					ownsWorkload = true
 					break
 				}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
@@ -290,30 +289,31 @@ func (w *wlReconciler) verifyWorkloadOwnership(
 	mkAc *kueue.AdmissionCheckState,
 	isDeleted bool,
 ) (reconcile.Result, bool, error) {
-	watcher, implements := adapter.(jobframework.MultiKueueWatcher)
-	if !implements {
+	if !features.Enabled(features.MultiKueueStrictValidation) {
 		return reconcile.Result{}, false, nil
+	}
+
+	watcher, ok := adapter.(jobframework.MultiKueueWatcher)
+	if !ok {
+		// If strict validation is enabled but the adapter doesn't support the required interface,
+		// we fail closed and reject the workload to prevent bypassing the check.
+		if !isDeleted {
+			log := ctrl.LoggerFrom(ctx)
+			log.V(2).Info("Cannot verify ownership due to missing MultiKueueWatcher interface", "workload", req.NamespacedName)
+			return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "adapter does not implement MultiKueueWatcher for strict validation")
+		}
+		return reconcile.Result{}, true, nil
 	}
 
 	log := ctrl.LoggerFrom(ctx)
 
-	emptyList := watcher.GetEmptyList()
-	t := reflect.TypeOf(emptyList)
-	if t.Kind() == reflect.Pointer {
-		t = t.Elem()
-	}
-	itemsField, found := t.FieldByName("Items")
-	if !found || itemsField.Type.Kind() != reflect.Slice {
-		return reconcile.Result{}, true, fmt.Errorf("items slice not found in list type %T", emptyList)
-	}
-	itemType := itemsField.Type.Elem()
-	jobObj, ok := reflect.New(itemType).Interface().(client.Object)
-	if !ok {
-		return reconcile.Result{}, true, errors.New("instantiated item type does not implement client.Object")
+	jobObj, err := newJobObject(watcher)
+	if err != nil {
+		return reconcile.Result{}, true, err
 	}
 	jobObj.GetObjectKind().SetGroupVersionKind(adapter.GVK())
 
-	err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
+	err = w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj)
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			// Fail closed on transient errors.
@@ -341,28 +341,7 @@ func (w *wlReconciler) verifyWorkloadOwnership(
 			return reconcile.Result{}, true, nil
 		}
 
-		ownsWorkload := false
-		for _, k := range keys {
-			if k.Namespace != wl.Namespace {
-				continue
-			}
-
-			if k.Name == wl.Name {
-				ownsWorkload = true
-				break
-			}
-
-			prefix := k.Name
-			if dashIdx := strings.LastIndex(prefix, "-"); dashIdx != -1 {
-				prefix = prefix[:dashIdx+1]
-			}
-
-			if strings.HasPrefix(wl.Name, prefix) {
-				ownsWorkload = true
-				break
-			}
-		}
-		if !ownsWorkload {
+		if !isWorkloadOwnedByKeys(wl.Name, wl.Namespace, keys) {
 			if !isDeleted {
 				log.V(2).Info("Workload is not owned by the referenced Job", "workload", req.NamespacedName)
 				return reconcile.Result{}, true, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
@@ -375,6 +354,45 @@ func (w *wlReconciler) verifyWorkloadOwnership(
 	}
 
 	return reconcile.Result{}, false, nil
+}
+
+// newJobObject uses reflection to dynamically instantiate an empty client.Object
+// of the correct Job type (e.g. batchv1.Job, rayv1.RayJob) managed by the given adapter.
+// This is necessary because MultiKueue adapters handle arbitrary Job frameworks, so we
+// cannot hardcode the concrete struct type. We fetch the list type, extract the item type,
+// and create a new instance of it to pass into the Kubernetes client for GET requests.
+func newJobObject(watcher jobframework.MultiKueueWatcher) (client.Object, error) {
+	emptyList := watcher.GetEmptyList()
+	t := reflect.TypeOf(emptyList)
+	if t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	itemsField, found := t.FieldByName("Items")
+	if !found || itemsField.Type.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("items slice not found in list type %T", emptyList)
+	}
+	itemType := itemsField.Type.Elem()
+	jobObj, ok := reflect.New(itemType).Interface().(client.Object)
+	if !ok {
+		return nil, errors.New("instantiated item type does not implement client.Object")
+	}
+	return jobObj, nil
+}
+
+// isWorkloadOwnedByKeys checks if the given workload is exactly represented by one of the generated keys.
+// Exact matching is used to ensure security, preventing attackers from spoofing workloads by
+// registering names that merely share a prefix. If a framework dynamically mutates workload names
+// (e.g. by appending generations), the framework adapter must explicitly return all valid keys.
+func isWorkloadOwnedByKeys(wlName, wlNamespace string, keys []types.NamespacedName) bool {
+	for _, k := range keys {
+		if k.Namespace != wlNamespace {
+			continue
+		}
+		if wlName == k.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func (w *wlReconciler) updateACS(ctx context.Context, wl *kueue.Workload, acs *kueue.AdmissionCheckState, status kueue.CheckState, message string) error {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -281,7 +281,15 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 // verifyWorkloadOwnership checks if the workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
 // This check runs for both active and deleted workloads to prevent the deletion bypass via spoofed finalizers.
 // It returns a boolean indicating whether the reconciliation should stop, along with the result and error.
-func (w *wlReconciler) verifyWorkloadOwnership(ctx context.Context, req reconcile.Request, wl *kueue.Workload, owner *metav1.OwnerReference, adapter jobframework.MultiKueueAdapter, mkAc *kueue.AdmissionCheckState, isDeleted bool) (reconcile.Result, bool, error) {
+func (w *wlReconciler) verifyWorkloadOwnership(
+	ctx context.Context,
+	req reconcile.Request,
+	wl *kueue.Workload,
+	owner *metav1.OwnerReference,
+	adapter jobframework.MultiKueueAdapter,
+	mkAc *kueue.AdmissionCheckState,
+	isDeleted bool,
+) (reconcile.Result, bool, error) {
 	watcher, implements := adapter.(jobframework.MultiKueueWatcher)
 	if !implements {
 		return reconcile.Result{}, false, nil

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"slices"
 	"testing"
 	"time"
@@ -246,6 +247,34 @@ func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (re
 
 		if !managed {
 			return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, fmt.Sprintf("The owner is not managed by Kueue: %s", unmanagedReason))
+		}
+
+		// Verify that this Workload is genuinely owned by the referenced Job to prevent Confused Deputy attacks.
+		if watcher, implements := adapter.(jobframework.MultiKueueWatcher); implements {
+			emptyList := watcher.GetEmptyList()
+			t := reflect.TypeOf(emptyList)
+			if t.Kind() == reflect.Ptr {
+				t = t.Elem()
+			}
+			if itemsField, found := t.FieldByName("Items"); found {
+				itemType := itemsField.Type.Elem()
+				if jobObj, ok := reflect.New(itemType).Interface().(client.Object); ok {
+					if err := w.client.Get(ctx, types.NamespacedName{Name: owner.Name, Namespace: wl.Namespace}, jobObj); err == nil {
+						if keys, err := watcher.WorkloadKeysFor(jobObj); err == nil {
+							ownsWorkload := false
+							for _, k := range keys {
+								if k.Name == wl.Name && k.Namespace == wl.Namespace {
+									ownsWorkload = true
+									break
+								}
+							}
+							if !ownsWorkload {
+								return reconcile.Result{}, w.updateACS(ctx, wl, mkAc, kueue.CheckStateRejected, "Workload is not owned by the referenced Job")
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2413,7 +2413,7 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 	fakeClock := testingclock.NewFakeClock(now)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	managerWl := *baseWorkloadBuilder.Clone().
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: acState}).

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -280,7 +280,10 @@ func TestWlReconcile(t *testing.T) {
 			},
 		},
 		"unmanaged wl (spoofed owner annotation) is rejected": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.MultiKueueStrictValidation:    true,
+			},
 			reconcileFor: "wl1",
 			managersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().PrebuiltWorkloadLabel("different-wl").Obj(),

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2412,7 +2412,7 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 	fakeClock := testingclock.NewFakeClock(now)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	managerWl := *baseWorkloadBuilder.Clone().
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: acState}).

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -77,7 +77,8 @@ func TestWlReconcile(t *testing.T) {
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
 	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false)
-	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName)
+	// PrebuiltWorkloadLabel is required for WorkloadKeysFor to succeed in ownership verification.
+	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	cases := map[string]struct {
 		featureGates map[featuregate.Feature]bool
@@ -2305,7 +2306,9 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	// PrebuiltWorkloadLabel is required so WorkloadKeysFor can derive the owning workload key.
+	// Without it the ownership check fails closed and the test would break.
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	managerWl := *baseWorkloadBuilder.Clone().
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -78,7 +78,8 @@ func TestWlReconcile(t *testing.T) {
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
 	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false)
-	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName)
+	// PrebuiltWorkloadLabel is required for WorkloadKeysFor to succeed in ownership verification.
+	baseJobManagedByKueueBuilder := baseJobBuilder.Clone().ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	cases := map[string]struct {
 		featureGates map[featuregate.Feature]bool
@@ -2306,7 +2307,9 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	baseWorkloadBuilder := utiltestingapi.MakeWorkload("wl1", TestNamespace)
-	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName)
+	// PrebuiltWorkloadLabel is required so WorkloadKeysFor can derive the owning workload key.
+	// Without it the ownership check fails closed and the test would break.
+	baseJobBuilder := testingjob.MakeJob("job1", TestNamespace).Suspend(false).ManagedBy(kueue.MultiKueueControllerName).PrebuiltWorkloadLabel("wl1")
 
 	managerWl := *baseWorkloadBuilder.Clone().
 		AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -279,6 +279,34 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"unmanaged wl (spoofed owner annotation) is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().PrebuiltWorkloadLabel("different-wl").Obj(),
+			},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Annotations(map[string]string{
+						constants.JobOwnerGVKAnnotation:  batchv1.SchemeGroupVersion.WithKind("Job").String(),
+						constants.JobOwnerNameAnnotation: "job1",
+					}).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().PrebuiltWorkloadLabel("different-wl").Obj(),
+			},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Annotations(map[string]string{
+						constants.JobOwnerGVKAnnotation:  batchv1.SchemeGroupVersion.WithKind("Job").String(),
+						constants.JobOwnerNameAnnotation: "job1",
+					}).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected, Message: `Workload is not owned by the referenced Job, Previously: "Pending"`}).
+					Obj(),
+			},
+		},
 		"failing to read from a worker": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -3253,3 +3253,52 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 			gotResult.RequeueAfter, syncDeferredRequeueAfter)
 	}
 }
+
+func TestIsWorkloadOwnedByKeys(t *testing.T) {
+	cases := map[string]struct {
+		wlName      string
+		wlNamespace string
+		keys        []types.NamespacedName
+		want        bool
+	}{
+		"exact match": {
+			wlName:      "wl1",
+			wlNamespace: "default",
+			keys:        []types.NamespacedName{{Name: "wl1", Namespace: "default"}},
+			want:        true,
+		},
+		"wrong namespace": {
+			wlName:      "wl1",
+			wlNamespace: "default",
+			keys:        []types.NamespacedName{{Name: "wl1", Namespace: "other"}},
+			want:        false,
+		},
+		"prefix match with dash": {
+			wlName:      "job1-a1b2c",
+			wlNamespace: "default",
+			keys:        []types.NamespacedName{{Name: "job1", Namespace: "default"}},
+			want:        false,
+		},
+		"prefix match for generated name": {
+			wlName:      "job-test-12345",
+			wlNamespace: "default",
+			keys:        []types.NamespacedName{{Name: "job-test", Namespace: "default"}},
+			want:        false,
+		},
+		"no match": {
+			wlName:      "spoofed-wl",
+			wlNamespace: "default",
+			keys:        []types.NamespacedName{{Name: "victim-wl", Namespace: "default"}},
+			want:        false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := isWorkloadOwnedByKeys(tc.wlName, tc.wlNamespace, tc.keys)
+			if got != tc.want {
+				t.Errorf("isWorkloadOwnedByKeys() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -278,6 +278,34 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"unmanaged wl (spoofed owner annotation) is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().PrebuiltWorkloadLabel("different-wl").Obj(),
+			},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Annotations(map[string]string{
+						constants.JobOwnerGVKAnnotation:  batchv1.SchemeGroupVersion.WithKind("Job").String(),
+						constants.JobOwnerNameAnnotation: "job1",
+					}).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().PrebuiltWorkloadLabel("different-wl").Obj(),
+			},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Annotations(map[string]string{
+						constants.JobOwnerGVKAnnotation:  batchv1.SchemeGroupVersion.WithKind("Job").String(),
+						constants.JobOwnerNameAnnotation: "job1",
+					}).
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStateRejected, Message: `Workload is not owned by the referenced Job, Previously: "Pending"`}).
+					Obj(),
+			},
+		},
 		"failing to read from a worker": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1265,7 +1265,11 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 // EquivalentToWorkload checks if the job corresponds to the workload
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	if owner.Name != job.Object().GetName() {
+	if owner == nil || owner.Name != job.Object().GetName() {
+		return false, nil
+	}
+
+	if prebuiltWl := PrebuiltWorkloadNameFor(job.Object()); prebuiltWl != "" && wl.Name != prebuiltWl {
 		return false, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1412,7 +1412,11 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 // EquivalentToWorkload checks if the job corresponds to the workload
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	if owner.Name != job.Object().GetName() {
+	if owner == nil || owner.Name != job.Object().GetName() {
+		return false, nil
+	}
+
+	if prebuiltWl := PrebuiltWorkloadNameFor(job.Object()); prebuiltWl != "" && wl.Name != prebuiltWl {
 		return false, nil
 	}
 

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -112,7 +112,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(aw)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(aw.GetName(), aw.GetUID(), gvk, aw.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(aw.GetName(), aw.GetUID(), gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: aw.Namespace}}, nil

--- a/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_multikueue_adapter.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -113,7 +112,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(aw)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for appwrapper: %s", klog.KObj(aw))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(aw.GetName(), aw.GetUID(), gvk, aw.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: aw.Namespace}}, nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -225,7 +224,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for job: %s", klog.KObj(job))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -224,7 +224,11 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
+		if workloadslicing.Enabled(job) {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
+		} else {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), gvk)
+		}
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -231,10 +231,20 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		{Name: jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), gvk), Namespace: job.Namespace},
 	}
 	if workloadslicing.Enabled(job) {
+		gen := job.GetGeneration()
 		keys = append(keys, types.NamespacedName{
-			Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration()),
+			Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, gen),
 			Namespace: job.Namespace,
 		})
+		// Scale-down does not create a new Workload slice: the Job's generation
+		// increments (N→N+1) while the Workload retains the gen-N name.
+		// Include the previous generation so the ownership check still passes.
+		if gen > 0 {
+			keys = append(keys, types.NamespacedName{
+				Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, gen-1),
+				Namespace: job.Namespace,
+			})
+		}
 	}
 	return keys, nil
 }

--- a/pkg/controller/jobs/job/job_multikueue_adapter.go
+++ b/pkg/controller/jobs/job/job_multikueue_adapter.go
@@ -223,15 +223,20 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 	}
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
-	if prebuiltWorkload == "" {
-		if workloadslicing.Enabled(job) {
-			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
-		} else {
-			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), gvk)
-		}
+	if prebuiltWorkload != "" {
+		return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil
+	keys := []types.NamespacedName{
+		{Name: jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), gvk), Namespace: job.Namespace},
+	}
+	if workloadslicing.Enabled(job) {
+		keys = append(keys, types.NamespacedName{
+			Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration()),
+			Namespace: job.Namespace,
+		})
+	}
+	return keys, nil
 }
 
 // needElasticJobSync determines if a remote Job requires synchronization due to elastic job features.

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -111,7 +111,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(jobSet)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(jobSet.GetName(), jobSet.GetUID(), gvk, jobSet.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(jobSet.GetName(), jobSet.GetUID(), gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: jobSet.Namespace}}, nil

--- a/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
+++ b/pkg/controller/jobs/jobset/jobset_multikueue_adapter.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -112,7 +111,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(jobSet)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for jobset: %s", klog.KObj(jobSet))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(jobSet.GetName(), jobSet.GetUID(), gvk, jobSet.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: jobSet.Namespace}}, nil

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -144,7 +144,7 @@ func (a adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), a.gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_multikueue_adapter.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -145,7 +144,7 @@ func (a adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_multikueue_adapter.go
@@ -19,13 +19,11 @@ package leaderworkerset
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -108,7 +106,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	originUID, hasOriginUID := lws.Annotations[kueue.MultiKueueOriginUIDAnnotation]
 	if !hasOriginUID {
-		return nil, fmt.Errorf("no origin UID annotation found for leaderworkerset: %s", klog.KObj(lws))
+		originUID = string(lws.UID)
 	}
 
 	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -112,7 +111,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for mpijob: %s", klog.KObj(job))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil

--- a/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
+++ b/pkg/controller/jobs/mpijob/mpijob_multikueue_adapter.go
@@ -111,7 +111,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), gvk, job.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.Namespace}}, nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -19,14 +19,12 @@ package pod
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -105,7 +103,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(pod)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for pod: %s", klog.KObj(pod))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(pod.GetName(), pod.GetUID(), gvk, pod.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: pod.Namespace}}, nil

--- a/pkg/controller/jobs/pod/pod_multikueue_adapter.go
+++ b/pkg/controller/jobs/pod/pod_multikueue_adapter.go
@@ -103,7 +103,11 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(pod)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(pod.GetName(), pod.GetUID(), gvk, pod.GetGeneration())
+		if utilpod.IsPodGroup(pod) {
+			prebuiltWorkload = utilpod.GetPodGroupName(pod)
+		} else {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(pod.GetName(), pod.GetUID(), gvk)
+		}
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: pod.Namespace}}, nil

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -265,7 +265,11 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
+		if workloadslicing.Enabled(job) {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
+		} else {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), a.gvk)
+		}
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -266,7 +265,7 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -319,13 +319,32 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 	}
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
-	if prebuiltWorkload == "" {
-		if workloadslicing.Enabled(job) {
-			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
-		} else {
-			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), a.gvk)
-		}
+	if prebuiltWorkload != "" {
+		return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil
+	if !workloadslicing.Enabled(job) {
+		return []types.NamespacedName{{
+			Name:      jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), a.gvk),
+			Namespace: job.GetNamespace(),
+		}}, nil
+	}
+
+	gen := job.GetGeneration()
+	keys := []types.NamespacedName{
+		{
+			Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, gen),
+			Namespace: job.GetNamespace(),
+		},
+	}
+	// Scale-down does not create a new Workload slice: the job's generation
+	// increments (N→N+1) while the Workload retains the gen-N name.
+	// Include the previous generation so the ownership check still passes.
+	if gen > 0 {
+		keys = append(keys, types.NamespacedName{
+			Name:      jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, gen-1),
+			Namespace: job.GetNamespace(),
+		})
+	}
+	return keys, nil
 }

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -321,7 +320,7 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for %s: %s", a.gvk.Kind, klog.KObj(job))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -320,7 +320,11 @@ func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.Namespaced
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(job)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
+		if workloadslicing.Enabled(job) {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.GetName(), job.GetUID(), a.gvk, job.GetGeneration())
+		} else {
+			prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(job.GetName(), job.GetUID(), a.gvk)
+		}
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: job.GetNamespace()}}, nil

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -100,7 +100,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(statefulSet)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(statefulSet.GetName(), statefulSet.GetUID(), gvk, statefulSet.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(statefulSet.GetName(), statefulSet.GetUID(), gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -19,13 +19,11 @@ package statefulset
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -102,7 +100,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(statefulSet)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for statefulset: %s", klog.KObj(statefulSet))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(statefulSet.GetName(), statefulSet.GetUID(), gvk, statefulSet.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -99,9 +99,13 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 	}
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(statefulSet)
-	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(statefulSet.GetName(), statefulSet.GetUID(), gvk)
+	if prebuiltWorkload != "" {
+		return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil
 	}
 
-	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil
+	return []types.NamespacedName{
+		{Name: jobframework.GetWorkloadNameForOwnerWithGVK(statefulSet.GetName(), statefulSet.GetUID(), gvk), Namespace: statefulSet.Namespace},
+		// TODO(#9497, v0.20): Remove legacy fallback.
+		{Name: GetWorkloadName("", statefulSet.Name), Namespace: statefulSet.Namespace},
+	}, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter.go
@@ -103,9 +103,14 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 		return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: statefulSet.Namespace}}, nil
 	}
 
+	// Use GetOwnerUID so that on a worker cluster the key is computed from the
+	// origin UID (stamped in MultiKueueOriginUIDAnnotation), which is exactly
+	// what the StatefulSet reconciler uses when naming the Workload.  On the
+	// manager cluster GetOwnerUID falls back to statefulSet.UID, so both sides
+	// produce consistent names.
 	return []types.NamespacedName{
-		{Name: jobframework.GetWorkloadNameForOwnerWithGVK(statefulSet.GetName(), statefulSet.GetUID(), gvk), Namespace: statefulSet.Namespace},
-		// TODO(#9497, v0.20): Remove legacy fallback.
+		{Name: GetWorkloadName(GetOwnerUID(statefulSet), statefulSet.Name), Namespace: statefulSet.Namespace},
+		// TODO(#9497, v0.20): Remove legacy fallback (empty UID).
 		{Name: GetWorkloadName("", statefulSet.Name), Namespace: statefulSet.Namespace},
 	}, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_multikueue_adapter_test.go
@@ -207,3 +207,65 @@ func TestMultiKueueAdapter(t *testing.T) {
 		})
 	}
 }
+
+// TestWorkloadKeysFor verifies that WorkloadKeysFor returns the correct workload
+// keys for the three meaningful cases: prebuilt label, plain local StatefulSet,
+// and remote StatefulSet (MultiKueue worker) where the Workload is named from
+// the origin UID stored in the annotation rather than from the object's own UID.
+func TestWorkloadKeysFor(t *testing.T) {
+	adapter := &multiKueueAdapter{}
+
+	cases := map[string]struct {
+		statefulSet *appsv1.StatefulSet
+		wantKeys    []types.NamespacedName
+	}{
+		"prebuilt workload label returns that name directly": {
+			statefulSet: utiltestingstatefulset.MakeStatefulSet("sts", TestNamespace).
+				UID("local-uid").
+				PrebuiltWorkloadLabel("my-prebuilt-wl").
+				Obj(),
+			wantKeys: []types.NamespacedName{
+				{Name: "my-prebuilt-wl", Namespace: TestNamespace},
+			},
+		},
+		"plain local StatefulSet uses its own UID": {
+			statefulSet: utiltestingstatefulset.MakeStatefulSet("sts", TestNamespace).
+				UID("local-uid").
+				Obj(),
+			wantKeys: []types.NamespacedName{
+				{Name: GetWorkloadName("local-uid", "sts"), Namespace: TestNamespace},
+				// legacy fallback (empty UID)
+				{Name: GetWorkloadName("", "sts"), Namespace: TestNamespace},
+			},
+		},
+		"remote StatefulSet uses origin UID annotation, not object UID": {
+			// On a worker cluster MultiKueue stamps MultiKueueOriginLabel and
+			// writes the manager UID into MultiKueueOriginUIDAnnotation.
+			// The Workload is named from the origin UID, so the first key must
+			// also be built from the annotation rather than from .UID.
+			// Reverting to statefulSet.GetUID() must turn this case red.
+			statefulSet: utiltestingstatefulset.MakeStatefulSet("sts", TestNamespace).
+				UID("worker-local-uid").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				Annotation(kueue.MultiKueueOriginUIDAnnotation, "manager-origin-uid").
+				Obj(),
+			wantKeys: []types.NamespacedName{
+				{Name: GetWorkloadName("manager-origin-uid", "sts"), Namespace: TestNamespace},
+				// legacy fallback (empty UID)
+				{Name: GetWorkloadName("", "sts"), Namespace: TestNamespace},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := adapter.WorkloadKeysFor(tc.statefulSet)
+			if err != nil {
+				t.Fatalf("WorkloadKeysFor returned unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.wantKeys, got); diff != "" {
+				t.Errorf("WorkloadKeysFor keys mismatch (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -118,7 +117,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(trainJob)
 	if prebuiltWorkload == "" {
-		return nil, fmt.Errorf("no prebuilt workload found for trainjob: %s", klog.KObj(trainJob))
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(trainJob.GetName(), trainJob.GetUID(), gvk, trainJob.GetGeneration())
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: trainJob.Namespace}}, nil

--- a/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
+++ b/pkg/controller/jobs/trainjob/trainjob_multikueue_adapter.go
@@ -117,7 +117,7 @@ func (*multiKueueAdapter) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedN
 
 	prebuiltWorkload := jobframework.PrebuiltWorkloadNameFor(trainJob)
 	if prebuiltWorkload == "" {
-		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(trainJob.GetName(), trainJob.GetUID(), gvk, trainJob.GetGeneration())
+		prebuiltWorkload = jobframework.GetWorkloadNameForOwnerWithGVK(trainJob.GetName(), trainJob.GetUID(), gvk)
 	}
 
 	return []types.NamespacedName{{Name: prebuiltWorkload, Namespace: trainJob.Namespace}}, nil

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -76,6 +76,9 @@ const (
 	// Enables MultiKueue support.
 	MultiKueue featuregate.Feature = "MultiKueue"
 
+	// Enables strict validation for MultiKueue workload ownership to prevent spoofing.
+	MultiKueueStrictValidation featuregate.Feature = "MultiKueueStrictValidation"
+
 	// owner: @mimowo
 	//
 	// Enable Topology Aware Scheduling allowing to optimize placement of Pods
@@ -607,6 +610,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	MultiKueue: {
 		{Version: version.MustParse("0.6"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueStrictValidation: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -76,6 +76,8 @@ const (
 	// Enables MultiKueue support.
 	MultiKueue featuregate.Feature = "MultiKueue"
 
+	// owner: @Vaishnav88sk
+	//
 	// Enables strict validation for MultiKueue workload ownership to prevent spoofing.
 	MultiKueueStrictValidation featuregate.Feature = "MultiKueueStrictValidation"
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -612,7 +612,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.9"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MultiKueueStrictValidation: {
-		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TopologyAwareScheduling: {
 		{Version: version.MustParse("0.9"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -257,10 +257,16 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.20"
+- name: MultiKueueStrictValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: PartialAdmission
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -257,9 +257,9 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: MultiKueueStrictValidation
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -257,10 +257,16 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.20"
+- name: MultiKueueStrictValidation
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: PartialAdmission
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -257,9 +257,9 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: MultiKueueStrictValidation
   versionedSpecs:

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
+
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -305,6 +307,10 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
+				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
+					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
+					return true, nil
+				})).To(gomega.Succeed())
 				util.SetQuotaReservation(
 					managerTestCluster.ctx,
 					managerTestCluster.client,
@@ -375,6 +381,10 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
+				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
+					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
+					return true, nil
+				})).To(gomega.Succeed())
 
 				admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
 
@@ -407,6 +417,10 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
+				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
+					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
+					return true, nil
+				})).To(gomega.Succeed())
 				util.SetQuotaReservation(
 					managerTestCluster.ctx,
 					managerTestCluster.client,
@@ -462,12 +476,18 @@ var _ = ginkgo.Describe(
 					util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, raycluster)
 					rayclusterLookupKey := client.ObjectKeyFromObject(raycluster)
 					createdRayCluster := &rayv1.RayCluster{}
+					gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, rayclusterLookupKey, createdRayCluster)).To(gomega.Succeed())
 
-					createdWorkload := &kueue.Workload{}
 					wlLookupKey := types.NamespacedName{
 						Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 						Namespace: managerNs.Name,
 					}
+					gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
+						jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
+						return true, nil
+					})).To(gomega.Succeed())
+
+					createdWorkload := &kueue.Workload{}
 
 					ginkgo.By("setting workload reservation in the management cluster", func() {
 						admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -29,8 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
-
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -44,6 +42,7 @@ import (
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -301,6 +300,7 @@ var _ = ginkgo.Describe(
 				)
 				raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
 					Queue(managerLq.Name).
+					ManagedBy(kueue.MultiKueueControllerName).
 					Obj()
 				util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, raycluster)
 				wlLookupKey := types.NamespacedName{
@@ -368,6 +368,7 @@ var _ = ginkgo.Describe(
 				)
 				raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
 					Queue(managerLq.Name).
+					ManagedBy(kueue.MultiKueueControllerName).
 					Obj()
 				// The owner UID exists only on the manager, so a worker GC would delete a copy that kept it.
 				raycluster.OwnerReferences = []metav1.OwnerReference{{
@@ -472,6 +473,7 @@ var _ = ginkgo.Describe(
 				func() {
 					raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
 						Queue(managerLq.Name).
+						ManagedBy(kueue.MultiKueueControllerName).
 						Obj()
 					util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, raycluster)
 					rayclusterLookupKey := client.ObjectKeyFromObject(raycluster)

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -42,7 +42,6 @@ import (
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
-	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -307,10 +306,7 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
-				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
-					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
-					return true, nil
-				})).To(gomega.Succeed())
+
 				util.SetQuotaReservation(
 					managerTestCluster.ctx,
 					managerTestCluster.client,
@@ -382,10 +378,6 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
-				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
-					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
-					return true, nil
-				})).To(gomega.Succeed())
 
 				admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
 
@@ -418,10 +410,7 @@ var _ = ginkgo.Describe(
 					Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 					Namespace: managerNs.Name,
 				}
-				gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
-					jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
-					return true, nil
-				})).To(gomega.Succeed())
+
 				util.SetQuotaReservation(
 					managerTestCluster.ctx,
 					managerTestCluster.client,
@@ -484,10 +473,6 @@ var _ = ginkgo.Describe(
 						Name:      workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID),
 						Namespace: managerNs.Name,
 					}
-					gomega.Expect(clientutil.Patch(managerTestCluster.ctx, managerTestCluster.client, raycluster, func() (bool, error) {
-						jobframework.SetPrebuiltWorkloadName(raycluster, wlLookupKey.Name)
-						return true, nil
-					})).To(gomega.Succeed())
 
 					createdWorkload := &kueue.Workload{}
 

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1910,7 +1910,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			gomega.Eventually(func(g gomega.Gomega) {
 				getJob(worker1.ctx, worker1.client, remoteJob)
 				g.Expect(remoteJob.Spec.Parallelism).To(gomega.BeEquivalentTo(new(int32(1))))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 		ginkgo.By("observe: there are no new workloads created in response to scale-down even in the worker1 cluster", func() {
 			list := &kueue.WorkloadList{}
@@ -2236,7 +2236,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				remote := raycluster.DeepCopy()
 				getRayCluster(worker1.ctx, worker1.client, remote)
 				g.Expect(remote.Spec.WorkerGroupSpecs[0].Replicas).To(gomega.BeEquivalentTo(new(int32(1))))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("observe: there are still no workloads in the worker2 cluster", func() {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2729,12 +2729,21 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimJob)
 
+		// Fetch the job to get the defaulted PodSpec
+		createdVictimJob := &batchv1.Job{}
+		gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(victimJob), createdVictimJob)).To(gomega.Succeed())
+		podSets, err := jobframework.JobPodSets(managerTestCluster.ctx, (*workloadjob.Job)(createdVictimJob), managerTestCluster.client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: managerNs.Name}
 		victimWl := utiltestingapi.MakeWorkload("victim-wl", managerNs.Name).
 			Queue(kueue.LocalQueueName(managerLq.Name)).
 			ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+			Annotation("kueue.x-k8s.io/job-owner-gvk", "batch/v1, Kind=Job").
+			JobUID(string(victimJob.UID)).
 			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
 			Obj()
+		victimWl.Spec.PodSets = podSets
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimWl)
 
 		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
@@ -2763,14 +2772,19 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
 		})
 
-		ginkgo.By("verifying the spoofed workload is rejected", func() {
-			util.ExpectAdmissionCheckStateWithMessage(
-				managerTestCluster.ctx, managerTestCluster.client,
-				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name},
-				multiKueueAC.Name,
-				kueue.CheckStateRejected,
-				"Workload is not owned by the referenced Job",
-			)
+		ginkgo.By("verifying the spoofed workload is rejected or deleted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := &kueue.Workload{}
+				err := managerTestCluster.client.Get(managerTestCluster.ctx, types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, wl)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				g.Expect(err).To(gomega.Succeed())
+				ac := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				g.Expect(ac).NotTo(gomega.BeNil())
+				g.Expect(ac.State).To(gomega.Equal(kueue.CheckStateRejected))
+				g.Expect(ac.Message).To(gomega.ContainSubstring("Workload is not owned by the referenced Job"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("verifying the victim Job's remote workload on worker1 is NOT deleted", func() {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2716,6 +2716,70 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			})
 		})
 	})
+
+	// Regression test for the Confused Deputy vulnerability where a tenant
+	// crafts a Workload with owner annotations pointing to a different Job
+	// to trigger unauthorized deletion of that Job's remote workload.
+	ginkgo.It("Should reject a workload with spoofed owner annotations without deleting the victim Job's remote workload", func() {
+		// Step 1: Create the legitimate victim Job and let it get a remote workload.
+		victimJob := testingjob.MakeJob("victim-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			PrebuiltWorkloadLabel("victim-wl").
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimJob)
+
+		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: managerNs.Name}
+		victimWl := utiltestingapi.MakeWorkload("victim-wl", managerNs.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimWl)
+
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
+			Obj()
+
+		ginkgo.By("setting quota reservation on the victim workload so remote copies are created", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, victimWlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimWlKey, remoteWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Step 2: Craft the spoofed workload. The attacker references the victim
+		// Job by name in owner annotations, but the Job's prebuilt label points to
+		// a *different* workload ("victim-wl"), so the ownership check fails.
+		ginkgo.By("creating a spoofed workload whose owner annotations reference the victim Job", func() {
+			spoofedWl := utiltestingapi.MakeWorkload("spoofed-wl", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+				AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+				Obj()
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, spoofedWl)
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client,
+				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
+		})
+
+		ginkgo.By("verifying the spoofed workload is rejected", func() {
+			util.ExpectAdmissionCheckStateWithMessage(
+				managerTestCluster.ctx, managerTestCluster.client,
+				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name},
+				multiKueueAC.Name,
+				kueue.CheckStateRejected,
+				"Workload is not owned by the referenced Job",
+			)
+		})
+
+		ginkgo.By("verifying the victim Job's remote workload on worker1 is NOT deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimWlKey, remoteWl)).To(gomega.Succeed())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })
 
 func waitForRemoteWorkloadToBeDeleted(workerCtx context.Context, workerClient client.Client, wlLookupKey types.NamespacedName, workerName string, timeout time.Duration) {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2546,12 +2546,21 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimJob)
 
+		// Fetch the job to get the defaulted PodSpec
+		createdVictimJob := &batchv1.Job{}
+		gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(victimJob), createdVictimJob)).To(gomega.Succeed())
+		podSets, err := jobframework.JobPodSets(managerTestCluster.ctx, (*workloadjob.Job)(createdVictimJob), managerTestCluster.client)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: managerNs.Name}
 		victimWl := utiltestingapi.MakeWorkload("victim-wl", managerNs.Name).
 			Queue(kueue.LocalQueueName(managerLq.Name)).
 			ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+			Annotation("kueue.x-k8s.io/job-owner-gvk", "batch/v1, Kind=Job").
+			JobUID(string(victimJob.UID)).
 			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
 			Obj()
+		victimWl.Spec.PodSets = podSets
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimWl)
 
 		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
@@ -2580,14 +2589,19 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
 		})
 
-		ginkgo.By("verifying the spoofed workload is rejected", func() {
-			util.ExpectAdmissionCheckStateWithMessage(
-				managerTestCluster.ctx, managerTestCluster.client,
-				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name},
-				multiKueueAC.Name,
-				kueue.CheckStateRejected,
-				"Workload is not owned by the referenced Job",
-			)
+		ginkgo.By("verifying the spoofed workload is rejected or deleted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := &kueue.Workload{}
+				err := managerTestCluster.client.Get(managerTestCluster.ctx, types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, wl)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				g.Expect(err).To(gomega.Succeed())
+				ac := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				g.Expect(ac).NotTo(gomega.BeNil())
+				g.Expect(ac.State).To(gomega.Equal(kueue.CheckStateRejected))
+				g.Expect(ac.Message).To(gomega.ContainSubstring("Workload is not owned by the referenced Job"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.By("verifying the victim Job's remote workload on worker1 is NOT deleted", func() {

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2540,9 +2540,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	ginkgo.It("Should reject a workload with spoofed owner annotations without deleting the victim Job's remote workload", func() {
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueStrictValidation, true)
 		// Step 1: Create the legitimate victim Job and let it get a remote workload.
-		victimJob := testingjob.MakeJob("victim-job", managerNs.Name).
+		victimJob := testingjob.MakeJob("victim-job", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			PrebuiltWorkloadLabel("victim-wl").
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimJob)
@@ -2553,18 +2553,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		podSets, err := jobframework.JobPodSets(managerTestCluster.ctx, (*workloadjob.Job)(createdVictimJob), managerTestCluster.client)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: managerNs.Name}
-		victimWl := utiltestingapi.MakeWorkload("victim-wl", managerNs.Name).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: f.managerNs.Name}
+		victimWl := utiltestingapi.MakeWorkload("victim-wl", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
 			Annotation("kueue.x-k8s.io/job-owner-gvk", "batch/v1, Kind=Job").
 			JobUID(string(victimJob.UID)).
-			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(f.multiKueueAC.Name), State: kueue.CheckStatePending}).
 			Obj()
 		victimWl.Spec.PodSets = podSets
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimWl)
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 			Obj()
 
@@ -2580,22 +2580,22 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		// Job (to avoid Kubernetes GC from deleting the Workload immediately), but the Job's
 		// prebuilt label points to a *different* workload, so the Kueue ownership check fails.
 		ginkgo.By("creating a spoofed workload whose owner annotations reference the victim Job", func() {
-			spoofedWl := utiltestingapi.MakeWorkload("spoofed-wl", managerNs.Name).
-				Queue(kueue.LocalQueueName(managerLq.Name)).
+			spoofedWl := utiltestingapi.MakeWorkload("spoofed-wl", f.managerNs.Name).
+				Queue(kueue.LocalQueueName(f.managerLq.Name)).
 				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
-				AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+				AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(f.multiKueueAC.Name), State: kueue.CheckStatePending}).
 				Obj()
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, spoofedWl)
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client,
-				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
+				types.NamespacedName{Name: "spoofed-wl", Namespace: f.managerNs.Name}, admission)
 		})
 
 		ginkgo.By("verifying the spoofed workload is rejected", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				wl := &kueue.Workload{}
-				err := managerTestCluster.client.Get(managerTestCluster.ctx, types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, wl)
+				err := managerTestCluster.client.Get(managerTestCluster.ctx, types.NamespacedName{Name: "spoofed-wl", Namespace: f.managerNs.Name}, wl)
 				g.Expect(err).To(gomega.Succeed())
-				ac := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				ac := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))
 				g.Expect(ac).NotTo(gomega.BeNil())
 				g.Expect(ac.State).To(gomega.Equal(kueue.CheckStateRejected))
 				g.Expect(ac.Message).To(gomega.ContainSubstring("Workload is not owned by the referenced Job"))

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2538,6 +2538,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	// crafts a Workload with owner annotations pointing to a different Job
 	// to trigger unauthorized deletion of that Job's remote workload.
 	ginkgo.It("Should reject a workload with spoofed owner annotations without deleting the victim Job's remote workload", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueStrictValidation, true)
 		// Step 1: Create the legitimate victim Job and let it get a remote workload.
 		victimJob := testingjob.MakeJob("victim-job", managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2533,4 +2533,68 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			})
 		})
 	})
+
+	// Regression test for the Confused Deputy vulnerability where a tenant
+	// crafts a Workload with owner annotations pointing to a different Job
+	// to trigger unauthorized deletion of that Job's remote workload.
+	ginkgo.It("Should reject a workload with spoofed owner annotations without deleting the victim Job's remote workload", func() {
+		// Step 1: Create the legitimate victim Job and let it get a remote workload.
+		victimJob := testingjob.MakeJob("victim-job", managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			PrebuiltWorkloadLabel("victim-wl").
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimJob)
+
+		victimWlKey := types.NamespacedName{Name: "victim-wl", Namespace: managerNs.Name}
+		victimWl := utiltestingapi.MakeWorkload("victim-wl", managerNs.Name).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+			AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, victimWl)
+
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
+			Obj()
+
+		ginkgo.By("setting quota reservation on the victim workload so remote copies are created", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, victimWlKey, admission)
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimWlKey, remoteWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Step 2: Craft the spoofed workload. The attacker references the victim
+		// Job by name in owner annotations, but the Job's prebuilt label points to
+		// a *different* workload ("victim-wl"), so the ownership check fails.
+		ginkgo.By("creating a spoofed workload whose owner annotations reference the victim Job", func() {
+			spoofedWl := utiltestingapi.MakeWorkload("spoofed-wl", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), victimJob.Name, string(victimJob.UID)).
+				AdmissionCheck(kueue.AdmissionCheckState{Name: kueue.AdmissionCheckReference(multiKueueAC.Name), State: kueue.CheckStatePending}).
+				Obj()
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, spoofedWl)
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client,
+				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
+		})
+
+		ginkgo.By("verifying the spoofed workload is rejected", func() {
+			util.ExpectAdmissionCheckStateWithMessage(
+				managerTestCluster.ctx, managerTestCluster.client,
+				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name},
+				multiKueueAC.Name,
+				kueue.CheckStateRejected,
+				"Workload is not owned by the referenced Job",
+			)
+		})
+
+		ginkgo.By("verifying the victim Job's remote workload on worker1 is NOT deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, victimWlKey, remoteWl)).To(gomega.Succeed())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
 })

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2575,9 +2575,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		// Step 2: Craft the spoofed workload. The attacker references the victim
-		// Job by name in owner annotations, but the Job's prebuilt label points to
-		// a *different* workload ("victim-wl"), so the ownership check fails.
+		// Step 2: Craft the spoofed workload. The attacker references another existing
+		// Job (to avoid Kubernetes GC from deleting the Workload immediately), but the Job's
+		// prebuilt label points to a *different* workload, so the Kueue ownership check fails.
 		ginkgo.By("creating a spoofed workload whose owner annotations reference the victim Job", func() {
 			spoofedWl := utiltestingapi.MakeWorkload("spoofed-wl", managerNs.Name).
 				Queue(kueue.LocalQueueName(managerLq.Name)).
@@ -2589,13 +2589,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, admission)
 		})
 
-		ginkgo.By("verifying the spoofed workload is rejected or deleted", func() {
+		ginkgo.By("verifying the spoofed workload is rejected", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				wl := &kueue.Workload{}
 				err := managerTestCluster.client.Get(managerTestCluster.ctx, types.NamespacedName{Name: "spoofed-wl", Namespace: managerNs.Name}, wl)
-				if apierrors.IsNotFound(err) {
-					return
-				}
 				g.Expect(err).To(gomega.Succeed())
 				ac := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
 				g.Expect(ac).NotTo(gomega.BeNil())

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -605,7 +605,8 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 					Message:            "admitted",
 					LastTransitionTime: metav1.NewTime(time.Now()),
 				})
-				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(utiltesting.BeForbiddenError())
+				err := k8sClient.Status().Update(ctx, wl)
+				g.Expect(err).Should(utiltesting.BeForbiddenError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fixes a Confused Deputy vulnerability where a malicious or misconfigured tenant could trigger the deletion of an arbitrary remote Job by creating a fake `Workload` and spoofing the `kueue.x-k8s.io/job-owner-name` annotation. Because the Workload had no quota, MultiKueue incorrectly assumed the Job needed to be stopped and triggered remote deletion. 

This PR hardens the reconciliation logic in `wlReconciler` to enforce bidirectional ownership verification. It dynamically fetches the actual Job object using reflection on the adapter's `GetEmptyList()`, queries the Job for its expected Workload keys via `WorkloadKeysFor()`, and rejects the Admission Check if the Workload is not genuinely owned by the referenced Job.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12548

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed an issue in MultiKueue where Workloads could bypass admission checks by spoofing owner references. This strict validation is enabled by default and controlled by the `MultiKueueStrictValidation` feature gate.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened MultiKueue workload admission checks to validate that an accepted workload is genuinely owned by the referenced job, preventing spoofed/inconsistent ownership.
  * Improved handling for deleted workloads so legitimate removals aren’t incorrectly rejected, while spoofed deletion attempts are still mitigated.

* **Tests**
  * Added unit tests covering spoofed owner annotation scenarios and expected rejection behavior.
  * Added an integration regression test simulating a “confused deputy” case, confirming the victim workload remains present on the worker cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->