### PR TITLE
TAS: prevent tas-ungater out-of-range panic when the topology assignment is shorter than the PodSet count

### DIFF
--- a/keps/77-dynamically-sized-jobs/README.md
+++ b/keps/77-dynamically-sized-jobs/README.md
@@ -587,6 +587,7 @@ TAS integration is gated separately via `ElasticJobsViaWorkloadSlicesWithTAS`
 * [ ] Re-evaluate in production-like environments with scale-up/scale-down cycles.
 * [ ] Re-evaluate full integration with required/preferred topology modes.
 * [ ] Re-evaluate handling scale-ups and scale-downs during node repair.
+* [ ] Correct handling of rank-based ordering for scale-downs.
 
 ## Implementation History
 

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -467,6 +467,17 @@ func readRanksIfAvailable(log logr.Logger,
 	}
 
 	for rank, pod := range result {
+		if rank >= len(rankToDomainID) {
+			// The assignment can cover fewer pods than the PodSet count (e.g. a slice size
+			// that does not evenly divide it), so a valid rank may have no domain.
+			// Fall back to greedy assignment for the whole PodSet.
+			//
+			// TODO: this may require adjustments to support ElasticJobs with TAS,
+			// tracked by the ElasticJobsViaWorkloadSlicesWithTAS feature gate.
+			log.V(3).Info("pod rank is out of range for the assigned topology domains, falling back to greedy assignment",
+				"pod", klog.KObj(pod), "rank", rank, "assignedPodCount", len(rankToDomainID))
+			return nil, false
+		}
 		if utilpod.HasGate(pod, kueue.TopologySchedulingGate) {
 			continue
 		}

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -2156,6 +2156,170 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"ranks: out-of-range pod index falls back to greedy assignment": {
+			// A stray Pod whose pod-index label is out of range (completion index 3
+			// with offset 1) cannot be used for rank ordering, so the ungater uses
+			// greedy assignment. The already-placed Pods keep their domains and the
+			// stray Pod stays gated.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet("worker", 2).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+							Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("worker").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+									Count(2).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r2"}, 1).Obj(),
+										).
+										Obj()).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				// correctly placed, already ungated Pods (ranks 0 and 1)
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "2").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+				// stray Pod with an out-of-range completion index (would be rank 2)
+				*testingpod.MakePod("stray", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "3").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			nodeSelectorAssertMode: nodeSelectorAssertExact,
+			wantPods: []corev1.Pod{
+				// listed name-sorted to match the fake client's List ordering
+				*testingpod.MakePod("stray", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "3").
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r1").
+					Obj(),
+				*testingpod.MakePod("w2", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Annotation(kueue.PodIndexOffsetAnnotation, "1").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "2").
+					NodeSelector(tasBlockLabel, "b1").
+					NodeSelector(tasRackLabel, "r2").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 1,
+				},
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r2",
+					},
+					Count: 1,
+				},
+			},
+		},
+		"ranks: TopologyAssignment shorter than the PodSet count falls back to greedy assignment": {
+			// When the TopologyAssignment covers fewer pods than the PodSet Count
+			// (here Count 2 with a single-rank assignment), a Pod's rank can exceed
+			// len(rankToDomainID); the ungater uses greedy assignment for those Pods.
+			// The scheduler produces this state for a slice size that does not divide
+			// the count (see the integration test).
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet("worker", 2).
+							Request(corev1.ResourceCPU, "1").
+							PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+							Obj(),
+					).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("worker").
+									Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+									Count(2).
+									TopologyAssignment(utiltestingapi.MakeTopologyAssignment(defaultTestLevels).
+										Domains(
+											utiltestingapi.MakeTopologyDomainAssignment([]string{"b1", "r1"}, 1).Obj(),
+										).
+										Obj()).
+									Obj(),
+							).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				// gated Pod whose rank (1) exceeds len(rankToDomainID) (1)
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					TopologySchedulingGate().
+					Obj(),
+			},
+			nodeSelectorAssertMode: nodeSelectorAssertCountsOnly,
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("w1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, "worker").
+					Label(batchv1.JobCompletionIndexAnnotation, "1").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{
+						tasBlockLabel: "b1",
+						tasRackLabel:  "r1",
+					},
+					Count: 1,
+				},
+			},
+		},
 		"ranks: support rank-based ordering for kubeflow with invalid offset annotation - for all Pods": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("unit-test", "ns").

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -109,6 +110,28 @@ func forceDeleteNamespace(ctx context.Context, c client.Client, ns *corev1.Names
 	}
 	util.ExpectAllPodsInNamespaceDeleted(ctx, c, ns)
 	return nil
+}
+
+// assignedPodCount returns the number of pods covered by the TopologyAssignment,
+// summed the same way the ungater builds rankToDomainID, so it measures exactly
+// the slice length that pod ranks index into.
+func assignedPodCount(ta *kueue.TopologyAssignment) int32 {
+	var total int32
+	for count := range utiltas.PodCounts(ta) {
+		total += count
+	}
+	return total
+}
+
+// countUngatedPods returns how many of the given pods have no scheduling gates left.
+func countUngatedPods(pods []corev1.Pod) int {
+	ungated := 0
+	for i := range pods {
+		if len(pods[i].Spec.SchedulingGates) == 0 {
+			ungated++
+		}
+	}
+	return ungated
 }
 
 // _ is an unused variable placeholder, commonly used to ignore returned values or satisfy unused variable constraints.
@@ -3441,6 +3464,156 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 							},
 						}),
 					))
+				})
+			})
+		})
+		ginkgo.When("PodSet slice size does not divide the PodSet count", func() {
+			// When a slice-topology PodSet's slice size does not evenly divide its
+			// count, the scheduler places floor(count/sliceSize)*sliceSize pods but
+			// keeps the full Count, so the TopologyAssignment covers fewer pods than
+			// Count. The first spec asserts the scheduler produces that state; the
+			// second checks the ungater handles it with greedy assignment.
+			var (
+				nodes []corev1.Node
+			)
+			ginkgo.BeforeEach(func() {
+				nodes = []corev1.Node{
+					*testingnode.MakeNode("x1").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						Label(corev1.LabelHostname, "x1").
+						StatusAllocatable(corev1.ResourceList{
+							"nvidia.com/gpu":      resource.MustParse("12"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("x2").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						Label(corev1.LabelHostname, "x2").
+						StatusAllocatable(corev1.ResourceList{
+							"nvidia.com/gpu":      resource.MustParse("12"),
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourcePods:   resource.MustParse("20"),
+						}).
+						Ready().
+						Obj(),
+				}
+				util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+				topology = utiltestingapi.MakeDefaultThreeLevelTopology("default")
+				util.MustCreate(ctx, k8sClient, topology)
+
+				tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavor)
+
+				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource("nvidia.com/gpu", "40").Obj()).
+					Obj()
+				util.MustCreate(ctx, k8sClient, clusterQueue)
+				util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.MustCreate(ctx, k8sClient, localQueue)
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				for _, node := range nodes {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+				}
+			})
+
+			ginkgo.It("scheduler persists Count greater than the sum of TopologyAssignment domains", func() {
+				var wl *kueue.Workload
+
+				ginkgo.By("creating a slice-topology workload whose count (3) is not divisible by the slice size (2)", func() {
+					wl = utiltestingapi.MakeWorkload("wl-short-assignment", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 3).
+							PreferredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+							SliceRequiredTopologyRequest(corev1.LabelHostname).
+							SliceSizeTopologyRequest(2).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						Request("nvidia.com/gpu", "1").
+						Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("verifying it is admitted but the assignment covers only floor(3/2)*2=2 pods while Count stays 3", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+					gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+
+					psa := wl.Status.Admission.PodSetAssignments[0]
+					gomega.Expect(psa.Count).ShouldNot(gomega.BeNil())
+					gomega.Expect(psa.TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					domainSum := assignedPodCount(psa.TopologyAssignment)
+
+					gomega.Expect(*psa.Count).To(gomega.Equal(int32(3)))
+					gomega.Expect(domainSum).To(gomega.Equal(int32(2)),
+						"scheduler floors slice placement to floor(3/2)*2=2 pods")
+					gomega.Expect(domainSum).To(gomega.BeNumerically("<", *psa.Count),
+						"TopologyAssignment covers fewer pods than the PodSet count")
+				})
+			})
+
+			ginkgo.It("ungater falls back to greedy assignment when a rank is out of range", func() {
+				// The scheduler admits count 3 with an assignment covering only 2 pods
+				// (see the sibling spec), so the gated Pod at completion index 2 has a
+				// rank beyond rankToDomainID. The ungater falls back to greedy assignment
+				// and ungates the two Pods that fit onto the domain, leaving the extra
+				// Pod gated.
+				var wl *kueue.Workload
+
+				ginkgo.By("creating and admitting a rank-ordered slice-topology workload (count 3, slice size 2)", func() {
+					wl = utiltestingapi.MakeWorkload("wl-ungater-oob", ns.Name).
+						PodSets(*utiltestingapi.MakePodSet("worker", 3).
+							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							PreferredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+							SliceRequiredTopologyRequest(corev1.LabelHostname).
+							SliceSizeTopologyRequest(2).
+							Obj()).
+						Queue(kueue.LocalQueueName(localQueue.Name)).
+						Request("nvidia.com/gpu", "1").
+						Obj()
+					util.MustCreate(ctx, k8sClient, wl)
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				})
+
+				ginkgo.By("creating 3 gated pods, including the out-of-range completion index 2", func() {
+					for i := range 3 {
+						pod := testingpod.MakePod(fmt.Sprintf("worker-%d", i), ns.Name).
+							Annotation(kueue.WorkloadAnnotation, wl.Name).
+							Annotation(kueue.PodSetRequiredTopologyAnnotation, utiltesting.DefaultBlockTopologyLevel).
+							Label(batchv1.JobCompletionIndexAnnotation, strconv.Itoa(i)).
+							Label(constants.PodSetLabel, "worker").
+							TopologySchedulingGate().
+							Obj()
+						util.MustCreate(ctx, k8sClient, pod)
+					}
+				})
+
+				ginkgo.By("verifying the ungater ungates the 2 pods that fit", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var pods corev1.PodList
+						g.Expect(k8sClient.List(ctx, &pods, client.InNamespace(ns.Name),
+							client.MatchingLabels{constants.PodSetLabel: "worker"})).To(gomega.Succeed())
+						g.Expect(countUngatedPods(pods.Items)).To(gomega.Equal(2),
+							"the assignment spans 2 ranks, so greedy assignment ungates exactly 2 of the 3 pods")
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The tas-ungater builds `rankToDomainID` with one entry per pod covered by the
`TopologyAssignment`, but `readRanksForLabels` bounds pod ranks by the PodSet
`Count`. When the assignment covers fewer pods than `Count`, a pod whose rank
falls in that gap indexes `rankToDomainID` out of range in
`assignGatedPodsToDomainsByRanks` and panics the ungater. controller-runtime
recovers and requeues the reconcile, so the ungater keeps panicking on retry and
the workload's pods stay gated.

This is reachable for a slice-required-topology PodSet whose slice size does not
evenly divide its count: the scheduler places `floor(count/sliceSize)*sliceSize`
pods but keeps `Count` at the full value, so the persisted assignment is shorter
than `Count`.

This PR bounds-checks the rank against `len(rankToDomainID)` in
`readRanksIfAvailable` and falls back to greedy assignment when a rank is out of
range. The pods that fit are ungated onto the assigned domains.

Added a unit test and an integration test that drives the real scheduler and
ungater.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed a bug where a PodSet slice size that did not evenly divide its count could make the topology ungater panic repeatedly, so the workload's Pods stayed stuck gated. The ungater no longer panics and ungates the Pods that fit the topology assignment.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology-based pod placement when topology assignments don’t cover all expected pods.
  * Pods with invalid or out-of-range rank information now safely fall back to greedy domain assignment.
  * Extra pods beyond the available rank/domain range remain gated until placement is valid.
* **Tests**
  * Added integration and controller test coverage for uneven slice sizes/counts, completion/rank index offsets, and partial topology assignments.
* **Documentation**
  * Updated KEP guidance for correct rank-based ordering behavior during scale-downs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->