### PR TITLE
[release-0.17] Fix local queue custom metric label race(manual CP)

### DIFF
--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -37,8 +37,11 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -3981,4 +3984,64 @@ func TestAncestors(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	defer metrics.InitMetricVectors(nil)
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team"}})
+	cache := New(
+		utiltesting.NewFakeClient(),
+		WithCustomLabels(customLabels),
+		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{
+			Enabled:       true,
+			QueueSelector: labels.Everything(),
+		}),
+	)
+
+	if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").Obj()); err != nil {
+		t.Fatalf("Failed to add cluster queue: %v", err)
+	}
+
+	oldLQ := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Label("team", "alpha").Obj()
+	if err := cache.AddLocalQueue(oldLQ); err != nil {
+		t.Fatalf("Failed to add local queue: %v", err)
+	}
+
+	lqRef := queue.NewLocalQueueReference("ns", kueue.LocalQueueName("lq"))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		prev := oldLQ
+		for i := 0; i < 10000; i++ {
+			next := prev.DeepCopy()
+			next.Labels = map[string]string{"team": "alpha"}
+			if i%2 == 0 {
+				next.Labels["team"] = "beta"
+			}
+			if err := cache.UpdateLocalQueue(prev, next); err != nil {
+				t.Errorf("Failed to update local queue: %v", err)
+				return
+			}
+			prev = next
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 10000; i++ {
+			cache.ResyncLocalQueueGaugeMetrics(kueue.ClusterQueueReference("cq"), lqRef)
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -4011,7 +4011,6 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 		t.Fatalf("Failed to add local queue: %v", err)
 	}
 
-	lqRef := queue.NewLocalQueueReference("ns", kueue.LocalQueueName("lq"))
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 
@@ -4035,7 +4034,7 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 	wg.Go(func() {
 		<-start
 		for range 10000 {
-			cache.ResyncLocalQueueGaugeMetrics(kueue.ClusterQueueReference("cq"), lqRef)
+			cache.ResyncGaugeMetrics()
 		}
 	})
 

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -4014,13 +4014,11 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 	lqRef := queue.NewLocalQueueReference("ns", kueue.LocalQueueName("lq"))
 	start := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(2)
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		prev := oldLQ
-		for i := 0; i < 10000; i++ {
+		for i := range 10000 {
 			next := prev.DeepCopy()
 			next.Labels = map[string]string{"team": "alpha"}
 			if i%2 == 0 {
@@ -4032,15 +4030,14 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 			}
 			prev = next
 		}
-	}()
+	})
 
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
-		for i := 0; i < 10000; i++ {
+		for range 10000 {
 			cache.ResyncLocalQueueGaugeMetrics(kueue.ClusterQueueReference("cq"), lqRef)
 		}
-	}()
+	})
 
 	close(start)
 	wg.Wait()

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -67,6 +67,9 @@ func (q *LocalQueue) updateAdmittedUsage(usage resources.FlavorResourceQuantitie
 }
 
 func (q *LocalQueue) reportActiveWorkloads(tracker *roletracker.RoleTracker) {
+	q.RLock()
+	defer q.RUnlock()
+
 	namespace, name := queue.MustParseLocalQueueReference(q.key)
 	lqRef := metrics.LocalQueueReference{
 		Name:      name,
@@ -77,6 +80,9 @@ func (q *LocalQueue) reportActiveWorkloads(tracker *roletracker.RoleTracker) {
 }
 
 func (q *LocalQueue) reportResourceMetrics(cqQuotas map[resources.FlavorResource]ResourceQuota, tracker *roletracker.RoleTracker) {
+	q.RLock()
+	defer q.RUnlock()
+
 	namespace, name := queue.MustParseLocalQueueReference(q.key)
 	lqRef := metrics.LocalQueueReference{Name: name, Namespace: namespace}
 	for fr := range cqQuotas {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Ref: https://github.com/kubernetes-sigs/kueue/pull/12881#issuecomment-5019799114, #13161 

Cherry-pick the LocalQueue custom metric race fix to release 0.17 through a small adaption. The test now uses the `Cache.ResyncGaugeMetrics`, which exercises the same LocalQueue metric report path on this patch.
<img width="400" height="250" alt="patch1" src="https://github.com/user-attachments/assets/b3a795d1-e260-4fe9-9107-c955f97ae5ff" />

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
