### PR TITLE
[release-0.18] MultiKueue: remove markConnecting for a clean connectionState invariant (#13169)

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -76,7 +76,7 @@ const (
 	retryIncrement = 5 * time.Second
 	retryMaxSteps  = 7
 
-	// Bounds how long startWatcher waits for client.Watch(). The schedule
+	// Bounds how long establishWatch waits for client.Watch(). The schedule
 	// (1m, 2m, 4m, 8m, 10m, ...) catches hung remotes quickly while the cap
 	// covers the apiserver cold cache + conversion warmup path documented in
 	// kubernetes/kubernetes#136950 (~8 min at 50k Workloads). v1beta2 does
@@ -153,9 +153,8 @@ type connectionState struct {
 	connected bool
 	// disconnectedSince is when the client last became disconnected: the watch dropping, or the
 	// client's creation for one that has never connected. It becomes nil only when a fully
-	// established connection (markConnected) clears it; the optimistic markConnecting does not, and
-	// it is preserved across failed reconnect attempts, so the worker-lost grace measures from the
-	// first loss, not the latest failed retry.
+	// established connection (markConnected) clears it, and is preserved across failed reconnect
+	// attempts, so the worker-lost grace measures from the first loss, not the latest failed retry.
 	disconnectedSince *time.Time
 }
 
@@ -169,14 +168,6 @@ func (c *connectionState) lostSince() *time.Time {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.disconnectedSince
-}
-
-// markConnecting optimistically marks the client connected before the watchers are started,
-// preserving any recorded disconnectedSince until the connection is fully established.
-func (c *connectionState) markConnecting() {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.connected = true
 }
 
 // markConnected records a fully established connection, clearing the recorded loss time.
@@ -326,16 +317,18 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 
 	rc.setClient(remoteClient)
 
-	// Mark as connected before starting watchers to avoid a race condition.
-	// If a watcher queues an event and wlReconciler processes it before connected=true,
-	// the workload will be treated as unavailable and requeued after 15m.
-	rc.connState.markConnecting()
+	// Establish every watch before marking the client connected: each establishWatcher call
+	// only opens the watch and returns a func that begins consuming it. We invoke those funcs
+	// only after markConnected, so connected flips exactly once all watches are up and no watch
+	// goroutine delivers an event while the client still looks disconnected.
+	var startWatcherCallbacks []func()
 
-	err = rc.startWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
+	startWatcher, err := rc.establishWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
 		rc.disconnect()
 		return rc.increaseFailedConnAttempt(), err
 	}
+	startWatcherCallbacks = append(startWatcherCallbacks, startWatcher)
 
 	// add a watch for all the adapters implementing multiKueueWatcher
 	for kind, adapter := range rc.adapters {
@@ -343,24 +336,28 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		if !implementsWatcher {
 			continue
 		}
-		err := rc.startWatcher(watchCtx, kind, watcher)
+		startWatcher, err := rc.establishWatcher(watchCtx, kind, watcher)
 		if err != nil {
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
-			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to start the watcher", "kind", kind)
+			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to establish the watcher", "kind", kind)
 			// however let's not accept this for now.
 			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
+		startWatcherCallbacks = append(startWatcherCallbacks, startWatcher)
 	}
 	if features.Enabled(features.MultiKueueManagerQuotaAutomation) {
-		err = rc.startQueueWatchers(watchCtx)
-		if err != nil {
+		if err := rc.startQueueWatchers(watchCtx); err != nil {
 			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 	}
 
 	rc.connState.markConnected()
+	for _, startWatcher := range startWatcherCallbacks {
+		startWatcher()
+	}
+
 	rc.resetFailedConnAttempt()
 	return nil, nil
 }
@@ -414,51 +411,52 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 	}
 }
 
-func (rc *remoteClient) startWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) error {
+func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) (func(), error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("watchKind", kind)
 	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishBackoff.WaitTime(int(rc.failedConnAttempts)+1))
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	go func() {
-		log.V(2).Info("Starting watch")
-		for r := range newWatcher.ResultChan() {
-			switch r.Type {
-			case watch.Bookmark:
-				// Bookmark events are periodic signals from the API server to
-				// keep the connection alive. They carry no meaningful payload
-				// and can be safely ignored.
-				log.V(5).Info("Watch bookmark received")
-			case watch.Error:
-				switch s := r.Object.(type) {
-				case *metav1.Status:
-					log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+	return func() {
+		go func() {
+			log.V(2).Info("Starting watch")
+			for r := range newWatcher.ResultChan() {
+				switch r.Type {
+				case watch.Bookmark:
+					// Bookmark events are periodic signals from the API server to
+					// keep the connection alive. They carry no meaningful payload
+					// and can be safely ignored.
+					log.V(5).Info("Watch bookmark received")
+				case watch.Error:
+					switch s := r.Object.(type) {
+					case *metav1.Status:
+						log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+					default:
+						log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
+					}
 				default:
-					log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
-				}
-			default:
-				wlKeys, err := w.WorkloadKeysFor(r.Object)
-				if err != nil {
-					log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
-				} else {
-					for _, wlKey := range wlKeys {
-						rc.queueWorkloadEvent(ctx, wlKey)
+					wlKeys, err := w.WorkloadKeysFor(r.Object)
+					if err != nil {
+						log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
+					} else {
+						for _, wlKey := range wlKeys {
+							rc.queueWorkloadEvent(ctx, wlKey)
+						}
 					}
 				}
 			}
-		}
-		log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
-		// If the context is not yet Done , queue a reconcile to attempt reconnection
-		if ctx.Err() == nil {
-			// reconnect if this is the first watch failing.
-			if wasConnected := rc.connState.markDisconnected(rc.clock.Now()); wasConnected {
-				log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
-				rc.queueWatchEndedEvent(ctx)
+			log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
+			// If the context is not yet Done , queue a reconcile to attempt reconnection
+			if ctx.Err() == nil {
+				// reconnect if this is the first watch failing.
+				if wasConnected := rc.connState.markDisconnected(rc.clock.Now()); wasConnected {
+					log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
+					rc.queueWatchEndedEvent(ctx)
+				}
 			}
-		}
-	}()
-	return nil
+		}()
+	}, nil
 }
 
 func (rc *remoteClient) startQueueWatchers(ctx context.Context) error {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -940,25 +940,6 @@ func TestConnectionStateTransitions(t *testing.T) {
 		t.Fatalf("drop from connected must record now (%v), got %v", now, s)
 	}
 
-	// Optimistic reconnect (before watchers) preserves the first-drop time.
-	fakeClock.Step(time.Minute)
-	cs.markConnecting()
-	if !cs.isConnected() {
-		t.Fatal("want connected after markConnecting")
-	}
-	if s := cs.lostSince(); s == nil || !s.Equal(now) {
-		t.Fatalf("markConnecting must preserve the first-drop time (%v), got %v", now, s)
-	}
-
-	// A failed reconnect (disconnect after the optimistic connect) must NOT reset the loss time.
-	fakeClock.Step(time.Minute)
-	if was := cs.markDisconnected(fakeClock.Now()); !was {
-		t.Fatal("want wasConnected=true (was optimistically connected)")
-	}
-	if s := cs.lostSince(); s == nil || !s.Equal(now) {
-		t.Fatalf("markDisconnected must preserve the first-drop time across a failed reconnect (%v), got %v", now, s)
-	}
-
 	// A repeated drop while already disconnected reports no transition and preserves the time.
 	fakeClock.Step(time.Minute)
 	if was := cs.markDisconnected(fakeClock.Now()); was {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

Cherry-pick of #13169 to `release-0.18`.

Removes `markConnecting` so `connected` is true only when the cluster is actually
connected: every watch is established first, `markConnected` flips the state once,
and only then the watcher goroutines start consuming, so no watch event is
delivered while the client still looks disconnected.

Applies cleanly on top of the #12999 backport already on this branch; the only
manual resolution kept this branch's `kueue.GroupVersion` (no `SchemeGroupVersion` rename on this branch).

#### Which issue(s) this PR fixes:

Backport of #13169 (fixes #13092 on this branch).

#### Special notes for your reviewer:

Validated locally: `go build`, `go vet`, and the MultiKueue unit tests pass.

_(Drafted with AI assistance.)_

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
