### PR TITLE
Fix /tag-release ChatOps command.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -85,10 +85,11 @@ jobs:
           echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
           
           CHANGELOG="$(echo "$ISSUE_BODY" | sed -n '/^```markdown$/,/^```$/p' | sed '/^```markdown$/d;/^```$/d')"
+          EOF_DELIM="$(openssl rand -hex 16)"
           {
-            echo "changelog<<EOF"
+            echo "changelog<<${EOF_DELIM}"
             printf '%s\n' "$CHANGELOG"
-            echo "EOF"
+            echo "${EOF_DELIM}"
           } >> "$GITHUB_OUTPUT"
 
   sync-notes:

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -84,8 +84,12 @@ jobs:
           fi
           echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
           
-          CHANGELOG=$(echo "ISSUE_BODY" | sed -n '/^```markdown$/,/^```$/p' | sed '/^```markdown$/d;/^```$/d')
-          echo "changelog=$CHANGELOG" >> "$GITHUB_OUTPUT"
+          CHANGELOG="$(echo "$ISSUE_BODY" | sed -n '/^```markdown$/,/^```$/p' | sed '/^```markdown$/d;/^```$/d')"
+          {
+            echo "changelog<<EOF"
+            printf '%s\n' "$CHANGELOG"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
   sync-notes:
     name: Sync Release Notes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This issue fixing a bug 

```
❌ Failed to create release tag v0.19.0-rc.0: No changelog found in the issue description. Make sure the issue has the Markdown block under ## Changelog.
```

(https://github.com/mbobrovskyi/kueue/issues/316#issuecomment-4991452252) which happens on runngin /tag-release ChatOps command in release issue.

This happens because CHANGELOG is a multiline variable. When we add it to the $GITHUB_OUTPUT, GitHub Actions may interpret each line as a separate entry. To avoid this, we should explicitly use the multiline output syntax so GitHub Actions knows that it is a single multiline value.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation to correctly extract changelogs from issue content.
  * Changelogs are now reliably preserved as multiline values when passed between workflow steps, preventing truncated or malformed release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->