### PR TITLE
Sync release-utils.yml comment messages.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -55,7 +55,7 @@ jobs:
           ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           if [[ ! "$TITLE" =~ ^Release\ (v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
-            gh issue comment "$ISSUE_NUMBER" --body "Invalid issue title: \`$TITLE\`. Expected format: \`Release vX.Y.Z\`."
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Invalid issue title: \`$TITLE\`. Expected format: \`Release vX.Y.Z\`."
             exit 0
           fi
           VERSION="${BASH_REMATCH[1]}"
@@ -79,7 +79,7 @@ jobs:
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/wait-for-prod-images[[:space:]]*$'; then
             COMMAND="wait-for-prod-images"
           else
-            gh issue comment "$ISSUE_NUMBER" --body "Invalid command format."
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Invalid command format."
             exit 0
           fi
           echo "command=$COMMAND" >> "$GITHUB_OUTPUT"
@@ -122,7 +122,7 @@ jobs:
           git config --global user.name "kueue-release-bot"
           git config --global user.email "kueue-release-bot@kubernetes.io"
           yes y | ./hack/releasing/sync-notes.sh "$VERSION"
-          gh issue comment "$ISSUE_NUMBER" --body "Release notes for version $VERSION have been synced."
+          gh issue comment "$ISSUE_NUMBER" --body "✅ Release notes for version $VERSION have been synced."
 
   create-release-branch:
     name: Create Release Branch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Sync release-utils.yml comment messages.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved release workflow feedback messages with clearer success and failure indicators.
  * Added consistent formatting to command validation error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->