### PR TITLE
Add /publish-release ChatOps command.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -13,7 +13,8 @@ jobs:
        contains(github.event.comment.body, '/tag-release') ||
        contains(github.event.comment.body, '/create-draft-release') ||
        contains(github.event.comment.body, '/wait-for-images') ||
-       contains(github.event.comment.body, '/wait-for-prod-images'))
+       contains(github.event.comment.body, '/wait-for-prod-images') ||
+       contains(github.event.comment.body, '/publish-release'))
     outputs:
       command: ${{ steps.parse.outputs.command }}
       version: ${{ steps.parse.outputs.version }}
@@ -78,6 +79,8 @@ jobs:
             COMMAND="wait-for-images"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/wait-for-prod-images[[:space:]]*$'; then
             COMMAND="wait-for-prod-images"
+          elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/publish-release[[:space:]]*$'; then
+            COMMAND="publish-release"
           else
             gh issue comment "$ISSUE_NUMBER" --body "Invalid command format."
             exit 0
@@ -420,3 +423,66 @@ jobs:
           BODY="✅ Draft release has been successfully ${ACTION}."
           echo "$BODY"
           gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: authorize
+    if: ${{ needs.authorize.outputs.command == 'publish-release' }}
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Publish Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          COMMAND: ${{ needs.authorize.outputs.command }}
+        run: |
+          # Check the current state of the release.
+          RELEASE_STATE=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts=false --json tagName,isDraft 2>/dev/null | \
+            jq -r --arg ver "$VERSION" '.[] | select(.tagName == $ver) | if .isDraft then "draft" else "published" end')
+
+          if [ "$RELEASE_STATE" = "published" ]; then
+            BODY="⚠️ Release \`$VERSION\` is already published."
+            echo "$BODY"
+            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+            exit 0
+          elif [ -z "$RELEASE_STATE" ]; then
+            BODY="❌ Release \`$VERSION\` not found. Please create a draft release first using \`/create-draft-release\`."
+            echo "$BODY"
+            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+            exit 1
+          fi
+
+          # Publish the draft release.
+          set +e
+          gh release edit "$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false 2> err.log
+          EDIT_EXIT=$?
+          set -e
+
+          if [ $EDIT_EXIT -ne 0 ]; then
+            ERR_MSG="$(cat err.log)"
+            echo "$ERR_MSG"
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`.
+
+            **Error details:**
+            \`\`\`text
+            ${ERR_MSG}
+            \`\`\`"
+            exit 1
+          fi
+
+          if [ "$COMMAND" != "create-release-candidate" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "✅ Release \`$VERSION\` has been successfully published."
+          fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add /publish-release ChatOps command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12763

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the `/publish-release` slash command to publish existing draft releases.
  * Release publication now provides clear status comments for already-published releases and missing releases (with guidance to create a draft first).
  * Added success and failure notifications when publishing succeeds or cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->