### PR TITLE
TAS: Document assignment re-encoding on node replacement

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1363,6 +1363,10 @@ hostnames, and decoding preserves domain order and Pod counts. Disabling the fea
 single-slice encoder but does not affect reading existing multi-slice assignments. New assignments must then fit the
 single-slice representation and object-size limit; otherwise they can fail to persist.
 
+On upgrade, existing `TopologyAssignment`s remain unchanged. If the assignment of an admitted Workload is later
+recomputed, for example during node hot swap, Kueue re-encodes the entire assignment using the currently enabled
+algorithm.
+
 When the feature gate is enabled, Kueue builds the hostname-prefix encoding first. If it needs multiple slices but the
 assignment is within the per-slice domain limit, Kueue serializes both encodings and keeps the smaller one. Assignments
 that exceed the per-slice domain limit always use the hostname-prefix encoding. When the lowest topology level is

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -300,13 +300,13 @@ func compactTopologyAssignmentEncoding(log logr.Logger, ta *TopologyAssignment) 
 
 	singleEncoded := singleCompactTopologyAssignmentEncoding(ta)
 	prefixJSON, prefixErr := json.Marshal(prefixEncoded)
-	singleJSON, singleErr := json.Marshal(singleEncoded)
 	if prefixErr != nil {
 		log.Error(prefixErr, "Failed to marshal hostname-prefix topology assignment while comparing encodings",
 			"domainCount", len(ta.Domains),
 			"sliceCount", len(prefixEncoded.Slices),
 		)
 	}
+	singleJSON, singleErr := json.Marshal(singleEncoded)
 	if singleErr != nil {
 		log.Error(singleErr, "Failed to marshal single-slice topology assignment while comparing encodings",
 			"domainCount", len(ta.Domains),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Follow-up to #11579 documenting post-upgrade node hot swap behavior and a small cleanup.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified upgrade behavior for topology assignments: existing assignments remain unchanged until they are recomputed.
  - Documented that recomputed assignments use the currently enabled hostname-prefix encoding algorithm.

- **Bug Fixes**
  - Improved error handling when comparing topology assignment encoding formats, ensuring failures are handled consistently before selecting the most compact representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->