### PR TITLE
KEP-2941: use per-device Default for capacity charge computation

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1591,23 +1591,23 @@ and each PodSet's charges are tracked separately in `resourceUsage`.
 5. Filters devices by `deviceSelector` to narrow the candidate pool
 6. From filtered devices, matches using DeviceClass selectors and the workload's
    ResourceClaimTemplate request selectors using the `dracel` compiler
-7. Resolves the effective charge:
-   - Base charge: `capacity.requests[<name>]` if specified, otherwise
-     `RequestPolicy.Default` if set (from the max-capacity device), otherwise the
-     maximum `Capacity.Value` across matched devices
-   - Rounds the base charge against each matched device's `RequestPolicy`
-     independently, then takes the maximum rounded value. This follows the same
-     conservative pattern as partitionable devices (which charge the max
-     `consumesCounters` value across matched devices). Even if the `deviceSelector`
-     matches heterogeneous devices with different policies, Kueue never under-charges
-   - Rounding per `RequestPolicy`: `ValidValues` rounds up to the smallest valid
-     value >= base; `ValidRange` rounds up to `Min` if below, aligns to
-     `Min + n*Step` if `Step` is set. If the rounded value exceeds `Max` or all
-     valid values for a given device, that device's policy is skipped (it cannot
-     satisfy the request). If no device's policy can satisfy the request, the
-     workload is marked inadmissible
-   - If no matched device has the configured capacity dimension, the workload is
-     marked inadmissible
+7. Resolves the effective charge per device independently, then takes the
+   maximum across all matched devices:
+   - For each matched device with the capacity dimension, determines the
+     base charge: `capacity.requests[<name>]` if specified, otherwise the
+     device's own `RequestPolicy.Default` if set, otherwise the device's
+     `Capacity.Value`
+   - Rounds the base charge against the device's own `RequestPolicy`.
+     If the device has no `RequestPolicy`, the base charge is used as-is.
+     `ValidValues` rounds up to the smallest valid value >= base;
+     `ValidRange` rounds up to `Min` if below, aligns to `Min + n*Step`
+     if `Step` is set. If the rounded value exceeds `Max` or all valid
+     values, the device is skipped (it cannot satisfy the request)
+   - Takes the maximum rounded charge across all devices. This ensures
+     Kueue never under-charges even if the `deviceSelector` matches
+     heterogeneous devices with different Defaults or policies
+   - If no matched device has the capacity dimension or can satisfy the
+     request, the workload is marked inadmissible
 8. For `count > 1`, multiplies per-device charge by count using saturating
    arithmetic (capped at `MaxInt64` rather than wrapping)
 
@@ -1661,8 +1661,10 @@ Capacity resources participate in Cohort borrowing and lending like any other re
 2. **RequestPolicy violation**: the workload requests more capacity than
    `ValidRange.Max` or exceeds all `ValidValues`. The workload is marked inadmissible.
 
-3. **Request omits capacity**: Kueue charges `RequestPolicy.Default` if set, or the
-   full device `Capacity.Value` if `Default` is unset or no `RequestPolicy` exists.
+3. **Request omits capacity**: For each matched device, Kueue charges the device's
+   own `RequestPolicy.Default` if set, or the device's full `Capacity.Value` if
+   `Default` is unset or no `RequestPolicy` exists. The maximum charge across all
+   devices is used.
 
 4. **AllowMultipleAllocations not set**: the apiserver enforces that `RequestPolicy`
    requires `AllowMultipleAllocations: true`. If the `deviceSelector` also matches


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind documentation
/area dra

#### What this PR does / why we need it:
Updates the CC processing flow to compute charges per device independently instead of picking one global Default from the max-capacity device.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
The previous design picked RequestPolicy.Default from the max-capacity device and used it as the base charge for all devices. When devices have different Defaults, this can under-charge:

  Device A: Capacity=80Gi, Default=40Gi, ValidValues=[20Gi, 40Gi, 80Gi]
  Device B: Capacity=100Gi, Default=10Gi, ValidValues=[10Gi, 50Gi, 100Gi]

  Previous: picks B's Default (10Gi) → rounds to max(20Gi, 10Gi) = 20Gi
  Correct:  per-device → A charges 40Gi, B charges 10Gi → max = 40Gi

  If the kube-scheduler allocates Device A, it consumes 40Gi but Kueue only reserved 20Gi.

The implementation in computeCapacityCharge (pkg/dra/capacity.go) now computes charges per device independently (each device uses its own Default and policy), then takes the max. Only affects the omitted-request fallback path — explicit capacity.requests is unchanged.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how Consumable Capacity charges are calculated per matched device.
  * Documented rounding behavior based on each device’s request policy.
  * Clarified that devices that can’t satisfy a request are skipped, and the highest applicable charge is used.
  * Added details for requests that omit capacity, including default and full-capacity behavior.
  * Clarified when a request is inadmissible due to unavailable capacity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->