### PR TITLE
[release-0.17] MultiKueue: cover eventual retry after a manager restart during a worker disconnect (#13188)

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -432,6 +432,7 @@ func (rc *remoteClient) setClient(c client.WithWatch) {
 func (rc *remoteClient) StopWatchers() {
 	if rc.watchCancel != nil {
 		rc.watchCancel()
+		rc.watchCancel = nil
 	}
 }
 
@@ -683,6 +684,7 @@ func (c *clustersReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 	if retryAfter, err := c.setRemoteClientConfig(ctx, cluster.Name, clientConfig, c.origin); err != nil {
 		log.Error(err, "setting client config", "retryAfter", retryAfter)
+		c.disconnectCluster(req.Name)
 		if err := c.updateStatus(ctx, cluster, false, "ClientConnectionFailed", err.Error()); err != nil {
 			return reconcile.Result{}, err
 		} else {

--- a/test/integration/multikueue/external_job_test.go
+++ b/test/integration/multikueue/external_job_test.go
@@ -389,7 +389,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 
 			ginkgo.By("setting workload reservation in worker1, the raycluster is created in worker1", func() {
 				admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1)
+			restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, managersConfigNamespace.Name)
 
 			ginkgo.By("removing the managers raycluster and workload", func() {
 				gomega.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, raycluster)).Should(gomega.Succeed())

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1478,7 +1478,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("setting workload reservation in worker1, the job is created in worker1", func() {
 			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).Obj()
@@ -1489,7 +1489,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1)
+		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, managersConfigNamespace.Name)
 
 		ginkgo.By("removing the managers job and workload", func() {
 			gomega.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, job)).Should(gomega.Succeed())
@@ -1562,7 +1562,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1)
+		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, managersConfigNamespace.Name)
 
 		ginkgo.By("setting workload reservation in worker2, the workload is admitted and job is created in worker2", func() {
 			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, wlLookupKey, admission)
@@ -1653,7 +1653,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
 
-		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("waiting for the local workload admission check state to be set to pending and quotaReservatio removed", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1680,7 +1680,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	ginkgo.It("Should not evict admitted workloads when the connection to the reserving worker is briefly lost", framework.SlowSpec, func() {
 		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
 
-		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 		restoreConnection()
 
 		ginkgo.By("no admitted workload is evicted after the brief connection loss", func() {
@@ -1688,10 +1688,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
-	ginkgo.It("Should not immediately evict admitted workloads after a manager restart while the reserving worker is unreachable", framework.SlowSpec, func() {
+	ginkgo.It("Should not immediately evict but eventually retry admitted workloads after a manager restart while the reserving worker is unreachable", framework.SlowSpec, func() {
 		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
 
-		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("restarting the manager while worker2 is unreachable", func() {
 			managerTestCluster.fwk.StopManager(managerTestCluster.ctx)
@@ -1702,6 +1702,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		ginkgo.By("the restarted manager re-anchors the grace and does not immediately evict", func() {
 			expectNoEviction(keys, multiKueueAC.Name, testingWorkerLostTimeout*2/3)
+		})
+
+		ginkgo.By("the re-anchored grace is finite, so the workloads are eventually retried", func() {
+			expectEventuallyRetried(keys, multiKueueAC.Name, testingWorkerLostTimeout*4)
 		})
 
 		restoreConnection()
@@ -2369,7 +2373,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 			admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
 
-			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
+			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
 
 			ginkgo.By("waiting for quotaReservation to be removed", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -2513,6 +2517,29 @@ func expectNoEviction(keys []types.NamespacedName, acName string, within time.Du
 			g.Expect(acs).NotTo(gomega.BeNil())
 			g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
 			g.Expect(ptr.Deref(acs.RetryCount, 0)).To(gomega.BeZero())
+		}
+	}, within, util.Interval).Should(gomega.Succeed())
+}
+
+func expectEventuallyRetried(keys []types.NamespacedName, acName string, within time.Duration) {
+	ginkgo.GinkgoHelper()
+
+	baseRetryCount := make(map[types.NamespacedName]int32, len(keys))
+	for _, key := range keys {
+		wl := &kueue.Workload{}
+		gomega.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, key, wl)).To(gomega.Succeed())
+		acs := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName))
+		gomega.Expect(acs).NotTo(gomega.BeNil())
+		baseRetryCount[key] = ptr.Deref(acs.RetryCount, 0)
+	}
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		for _, key := range keys {
+			wl := &kueue.Workload{}
+			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, key, wl)).To(gomega.Succeed())
+			acs := admissioncheck.FindAdmissionCheck(wl.Status.AdmissionChecks, kueue.AdmissionCheckReference(acName))
+			g.Expect(acs).NotTo(gomega.BeNil())
+			g.Expect(ptr.Deref(acs.RetryCount, 0)).To(gomega.BeNumerically(">=", baseRetryCount[key]+1))
 		}
 	}, within, util.Interval).Should(gomega.Succeed())
 }

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -61,6 +61,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/klog/v2"
 	testingclock "k8s.io/utils/clock/testing"
@@ -1512,64 +1513,72 @@ func IsLoggedEntryAConcurrentModification(le observer.LoggedEntry) bool {
 	return errLog != nil && utillogging.IsWriteConflictError(errLog.(string))
 }
 
-// BreakConnection breaks connection to the cluster.
-// Returns a callback to restore the connection.
-func BreakConnection(ctx context.Context, cli client.Client, cluster *kueue.MultiKueueCluster) (restoreConnection func()) {
+// BreakConnection simulates a network loss to cluster's worker by rewriting the API server in its
+// kubeconfig secret to an unreachable address (connection refused).
+// The cluster stores the kubeconfig secret's name (Location) but not its namespace, so the caller
+// supplies secretNamespace. Returns a callback that restores the original kubeconfig.
+func BreakConnection(ctx context.Context, cli client.Client, cluster *kueue.MultiKueueCluster, secretNamespace string) (restoreConnection func()) {
 	ginkgo.GinkgoHelper()
 
-	var trueLocation string
 	clusterKey := client.ObjectKeyFromObject(cluster)
+	secretKey := client.ObjectKey{Namespace: secretNamespace, Name: cluster.Spec.ClusterSource.KubeConfig.Location}
+
+	originalSecret := &corev1.Secret{}
+	gomega.Expect(cli.Get(ctx, secretKey, originalSecret)).To(gomega.Succeed())
+	originalKubeConfig := originalSecret.Data[kueue.MultiKueueConfigSecretKey]
+	gomega.Expect(originalKubeConfig).NotTo(gomega.BeEmpty())
 
 	ginkgo.By(fmt.Sprintf("breaking the connection to %s", clusterKey), func() {
-		gomega.Eventually(func(g gomega.Gomega) {
-			createdCluster := &kueue.MultiKueueCluster{}
-			g.Expect(cli.Get(ctx, clusterKey, createdCluster)).To(gomega.Succeed())
-			trueLocation = createdCluster.Spec.ClusterSource.KubeConfig.Location
-			createdCluster.Spec.ClusterSource.KubeConfig.Location = "bad-secret"
-			g.Expect(cli.Update(ctx, createdCluster)).To(gomega.Succeed())
-		}, Timeout, Interval).Should(gomega.Succeed())
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			createdCluster := &kueue.MultiKueueCluster{}
-			g.Expect(cli.Get(ctx, clusterKey, createdCluster)).To(gomega.Succeed())
-			activeCondition := apimeta.FindStatusCondition(createdCluster.Status.Conditions, kueue.MultiKueueClusterActive)
-			g.Expect(activeCondition).To(gomega.BeComparableTo(&metav1.Condition{
-				Type:   kueue.MultiKueueClusterActive,
-				Status: metav1.ConditionFalse,
-				Reason: "BadKubeConfig",
-			}, IgnoreConditionMessage, IgnoreConditionTimestampsAndObservedGeneration))
-		}, Timeout, Interval).Should(gomega.Succeed())
+		setSecretKubeConfig(ctx, cli, secretKey, unreachableKubeConfig(originalKubeConfig))
+		expectClusterActive(ctx, cli, clusterKey, metav1.ConditionFalse, "ClientConnectionFailed")
 	})
 
-	return createConnectionRestoringCallback(ctx, cli, cluster, trueLocation)
-}
-
-func createConnectionRestoringCallback(ctx context.Context, cli client.Client, cluster *kueue.MultiKueueCluster, location string) func() {
 	return func() {
 		ginkgo.GinkgoHelper()
-
-		clusterKey := client.ObjectKeyFromObject(cluster)
-
 		ginkgo.By(fmt.Sprintf("restoring the connection to %s", clusterKey), func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdCluster := &kueue.MultiKueueCluster{}
-				g.Expect(cli.Get(ctx, clusterKey, createdCluster)).To(gomega.Succeed())
-				createdCluster.Spec.ClusterSource.KubeConfig.Location = location
-				g.Expect(cli.Update(ctx, createdCluster)).To(gomega.Succeed())
-			}, Timeout, Interval).Should(gomega.Succeed())
-
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdCluster := &kueue.MultiKueueCluster{}
-				g.Expect(cli.Get(ctx, clusterKey, createdCluster)).To(gomega.Succeed())
-				activeCondition := apimeta.FindStatusCondition(createdCluster.Status.Conditions, kueue.MultiKueueClusterActive)
-				g.Expect(activeCondition).To(gomega.BeComparableTo(&metav1.Condition{
-					Type:   kueue.MultiKueueClusterActive,
-					Status: metav1.ConditionTrue,
-					Reason: "Active",
-				}, IgnoreConditionMessage, IgnoreConditionTimestampsAndObservedGeneration))
-			}, Timeout, Interval).Should(gomega.Succeed())
+			setSecretKubeConfig(ctx, cli, secretKey, originalKubeConfig)
+			expectClusterActive(ctx, cli, clusterKey, metav1.ConditionTrue, "Active")
 		})
 	}
+}
+
+// unreachableKubeConfig returns kubeConfig with every cluster's server rewritten to an unreachable
+// address, so a client built from it fails to connect (connection refused) rather than reaching the
+// real API server.
+func unreachableKubeConfig(kubeConfig []byte) []byte {
+	ginkgo.GinkgoHelper()
+	cfg, err := clientcmd.Load(kubeConfig)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	for name := range cfg.Clusters {
+		cfg.Clusters[name].Server = "https://127.0.0.1:1"
+	}
+	out, err := clientcmd.Write(*cfg)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return out
+}
+
+func setSecretKubeConfig(ctx context.Context, cli client.Client, secretKey client.ObjectKey, kubeConfig []byte) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		secret := &corev1.Secret{}
+		g.Expect(cli.Get(ctx, secretKey, secret)).To(gomega.Succeed())
+		secret.Data[kueue.MultiKueueConfigSecretKey] = kubeConfig
+		g.Expect(cli.Update(ctx, secret)).To(gomega.Succeed())
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
+func expectClusterActive(ctx context.Context, cli client.Client, clusterKey client.ObjectKey, status metav1.ConditionStatus, reason string) {
+	ginkgo.GinkgoHelper()
+	gomega.Eventually(func(g gomega.Gomega) {
+		cluster := &kueue.MultiKueueCluster{}
+		g.Expect(cli.Get(ctx, clusterKey, cluster)).To(gomega.Succeed())
+		activeCondition := apimeta.FindStatusCondition(cluster.Status.Conditions, kueue.MultiKueueClusterActive)
+		g.Expect(activeCondition).To(gomega.BeComparableTo(&metav1.Condition{
+			Type:   kueue.MultiKueueClusterActive,
+			Status: status,
+			Reason: reason,
+		}, IgnoreConditionMessage, IgnoreConditionTimestampsAndObservedGeneration))
+	}, Timeout, Interval).Should(gomega.Succeed())
 }
 
 func ResourceQtyToFloat64(quantityStr string) float64 {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature
/area multikueue

#### What this PR does / why we need it:

Cherry-pick of #13188 to `release-0.17`.

- Makes `util.BreakConnection` simulate a real network loss (rewriting the API server in the
  cluster's kubeconfig secret to an unreachable address) instead of a configuration error, and
  folds the "eventually retried after a manager restart during a worker disconnect" assertion
  into the manager-restart integration test.
- Fixes the bug this simulation exposed: when reconfiguring the remote client fails, the
  cluster was reported inactive (`ClientConnectionFailed`) without marking the in-memory client
  disconnected, so the previous, still-working client stayed in use as connected and the
  worker-lost handling never ran. `Reconcile` now calls `disconnectCluster` before reporting
  the cluster inactive.

Branch-specific resolutions:

- Kept this branch's "reserving worker" wording in the merged restart-test name (the #13124
  rename is not on this branch), and applied the `BreakConnection` signature change to this
  branch's differently-formatted call sites in `external_job_test.go`.
- Made `remoteClient.StopWatchers` idempotent (clear `watchCancel` after cancelling) as on
  `main`; without it the new `disconnectCluster` call cancels the watch context a second time,
  which the `TestUpdateConfig` cancel-count assertions catch.

#### Which issue(s) this PR fixes:

Backport of #13188.

#### Special notes for your reviewer:

Validated locally: `go build`, `go vet`, MultiKueue unit tests, and the affected MultiKueue
integration specs (all `BreakConnection` users and the merged restart test, 6/6) pass.

_(Drafted with AI assistance.)_

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where admitted workloads could remain stuck instead of being evicted and retried after `workerLostTimeout` when reconnecting to a worker cluster failed after its connection configuration changed.
```
