### PR TITLE
MultiKueue: reject in-tree autoscaling for elastic RayClusters until worker-driven resizes are supported

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/ray"
 	"sigs.k8s.io/kueue/pkg/util/api"
-	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(
@@ -41,14 +40,6 @@ func copyJobSpec(dst, src *rayv1.RayCluster) {
 	*dst = rayv1.RayCluster{
 		ObjectMeta: api.CloneObjectMetaForCreation(&src.ObjectMeta),
 		Spec:       *src.Spec.DeepCopy(),
-	}
-	// An elastic RayCluster over MultiKueue is scaled by the manager: the
-	// manager's worker replica counts are the source of truth and are propagated
-	// to this remote copy on each sync. The remote must therefore not run the
-	// in-tree Ray autoscaler, which would otherwise fight the manager by editing
-	// worker replicas on the worker cluster.
-	if workloadslicing.Enabled(src) {
-		dst.Spec.EnableInTreeAutoscaling = nil
 	}
 }
 
@@ -89,14 +80,6 @@ func syncWorkerReplicas(dst, src *rayv1.RayCluster) bool {
 		srcSizes[wgs.GroupName] = groupSize{replicas: wgs.Replicas, numOfHosts: wgs.NumOfHosts}
 	}
 	changed := false
-	// Re-assert that the remote autoscaler stays off. copyJobSpec clears this
-	// at create time; re-asserting here keeps the "manager owns replicas"
-	// invariant reconciled, since the elastic sync path patches the remote in
-	// place rather than re-copying the full spec.
-	if dst.Spec.EnableInTreeAutoscaling != nil {
-		dst.Spec.EnableInTreeAutoscaling = nil
-		changed = true
-	}
 	for i := range dst.Spec.WorkerGroupSpecs {
 		wgs := &dst.Spec.WorkerGroupSpecs[i]
 		want, ok := srcSizes[wgs.GroupName]

--- a/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_multikueue_adapter_test.go
@@ -352,38 +352,6 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
-		// The elastic sync path must keep the remote autoscaler off, not just
-		// at create time. Here the worker copy has EnableInTreeAutoscaling set
-		// (e.g. re-enabled out-of-band); a scale-down sync should clear it so the
-		// manager stays the sole replica driver.
-		"elastic sync re-asserts that the remote autoscaler stays off": {
-			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
-			managersRayClusters: []rayv1.RayCluster{
-				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
-			},
-			workerRayClusters: []rayv1.RayCluster{
-				*elasticBuilder.Clone().
-					PrebuiltWorkloadLabel("wl1").
-					Label(kueue.MultiKueueOriginLabel, "origin1").
-					ScaleFirstWorkerGroup(3).
-					WithEnableAutoscaling(new(true)).
-					Obj(),
-			},
-			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
-				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "raycluster1", Namespace: TestNamespace}, "wl1", "origin1")
-				return err
-			},
-			wantManagersRayClusters: []rayv1.RayCluster{
-				*elasticBuilder.Clone().ScaleFirstWorkerGroup(1).Obj(),
-			},
-			wantWorkerRayClusters: []rayv1.RayCluster{
-				*elasticBuilder.Clone().
-					PrebuiltWorkloadLabel("wl1").
-					Label(kueue.MultiKueueOriginLabel, "origin1").
-					ScaleFirstWorkerGroup(1).
-					Obj(),
-			},
-		},
 		"non-elastic raycluster does not sync worker replicas even with the feature enabled": {
 			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true, features.WorkloadIdentifierAnnotations: false},
 			managersRayClusters: []rayv1.RayCluster{

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -210,6 +210,18 @@ func validateElasticJob(job *rayv1.RayCluster) field.ErrorList {
 		)
 	}
 
+	// MultiKueue does not support Ray autoscaling yet.
+	if ptr.Deref(job.Spec.EnableInTreeAutoscaling, false) &&
+		ptr.Deref(job.Spec.ManagedBy, "") == kueue.MultiKueueControllerName {
+		allErrors = append(
+			allErrors,
+			field.Forbidden(
+				specPath.Child("enableInTreeAutoscaling"),
+				"in-tree autoscaling is not supported for a MultiKueue-managed elastic RayCluster",
+			),
+		)
+	}
+
 	return allErrors
 }
 

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -37,6 +37,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestValidateDefault(t *testing.T) {
@@ -152,6 +153,30 @@ func TestValidateCreate(t *testing.T) {
 					"a kueue managed job can use autoscaling only when the ElasticJobsViaWorkloadSlices feature gate is on and the job is an elastic job",
 				),
 			}.ToAggregate(),
+		},
+		"invalid managed - elastic MultiKueue job with auto scaler": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				ManagedBy(kueue.MultiKueueControllerName).
+				SchedulingGate(kueue.ElasticJobSchedulingGate).
+				WithEnableAutoscaling(new(true)).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "enableInTreeAutoscaling"),
+					"in-tree autoscaling is not supported for a MultiKueue-managed elastic RayCluster",
+				),
+			}.ToAggregate(),
+		},
+		"valid managed - elastic MultiKueue job without auto scaler": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				ManagedBy(kueue.MultiKueueControllerName).
+				SchedulingGate(kueue.ElasticJobSchedulingGate).
+				Obj(),
+			wantErr: nil,
 		},
 		"invalid managed - too many worker groups": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -173,6 +173,17 @@ func (j *ClusterWrapper) WithEnableAutoscaling(value *bool) *ClusterWrapper {
 	return j
 }
 
+// SchedulingGate adds a scheduling gate to the head group and every worker group template.
+func (j *ClusterWrapper) SchedulingGate(name string) *ClusterWrapper {
+	gate := corev1.PodSchedulingGate{Name: name}
+	j.Spec.HeadGroupSpec.Template.Spec.SchedulingGates = append(j.Spec.HeadGroupSpec.Template.Spec.SchedulingGates, gate)
+	for i := range j.Spec.WorkerGroupSpecs {
+		wgs := &j.Spec.WorkerGroupSpecs[i]
+		wgs.Template.Spec.SchedulingGates = append(wgs.Template.Spec.SchedulingGates, gate)
+	}
+	return j
+}
+
 func (j *ClusterWrapper) ScaleFirstWorkerGroup(replicas int32) *ClusterWrapper {
 	j.Spec.WorkerGroupSpecs[0].Replicas = &replicas
 	return j


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue
/area integrations

#### What this PR does / why we need it:

Rejects `enableInTreeAutoscaling` for a MultiKueue-managed elastic (`ElasticJobsViaWorkloadSlices`) RayCluster at admission, since MultiKueue does not support Ray autoscaling yet. This also removes a self-inflicted teardown that exists on main today.

**Problem on main.** #12885 clears `enableInTreeAutoscaling` on the remote copy of an elastic RayCluster (scaling is manager-driven, the remote must not run the autoscaler). But `BuildPodSets` still accounts an autoscaler sidecar in the head PodSet whenever the flag is set on the manager object. The worker then derives pod sets **without** the sidecar, judges the prebuilt workload `OutOfSync`, and finishes it right after admission — before any resize. That finish propagates to the manager, which creates a replacement slice, deletes the remote workload, and leaves the worker RayCluster pointing at a missing prebuilt workload, ending in its deletion and continuous slice churn.

**This PR.** The inconsistency has two consistent resolutions: make the sidecar real on the worker, or keep the combination out of the system entirely. This PR does the latter — the autoscaler cannot do anything useful under MultiKueue for now (the manager owns worker replicas), so accepting the flag only buys a pinned sidecar that consumes head-pod resources without being able to act:

- The webhook rejects a MultiKueue-managed elastic RayCluster with `enableInTreeAutoscaling` set (`validateElasticJob`).
- `copyJobSpec` no longer strips `enableInTreeAutoscaling` from the remote copy and `BuildPodSets` needs no MultiKueue special case: the flag can never be set on a MultiKueue-managed elastic RayCluster, and for every object that can exist the sidecar accounting matches reality.
- `syncWorkerReplicas` keeps syncing only `Replicas` and `NumOfHosts`; the "re-assert the remote autoscaler off" logic from #12885 is removed along with the create-time strip.

Once autoscaler-driven resizes are reflected back into the manager's Workload, lifting the restriction is a pure validation removal (backwards compatible), at which point the worker becomes the source of truth for worker-group replicas.

#### Which issue(s) this PR fixes:

Related: #12885

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: an elastic RayCluster (ElasticJobsViaWorkloadSlices) managed by MultiKueue is now rejected at admission if `enableInTreeAutoscaling` is set, as MultiKueue does not support Ray autoscaling yet. Previously such a RayCluster was accepted but deleted right after admission due to inconsistent autoscaler-sidecar accounting between the manager and the worker.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MultiKueue-managed elastic RayClusters now reject configurations that enable in-tree autoscaling.
  * Replica synchronization no longer overrides the autoscaling setting during updates.

* **Tests**
  * Added validation coverage for supported and unsupported autoscaling configurations.
  * Added a helper for applying scheduling gates in RayCluster test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->