### PR TITLE
MultiKueue: centralize remote-client disconnect handling in the cluster reconciler

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -327,7 +327,6 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 
 	startWatcher, err := rc.establishWatcher(watchCtx, kueue.SchemeGroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
-		rc.disconnect()
 		return rc.increaseFailedConnAttempt(), err
 	}
 	startWatcherCallbacks = append(startWatcherCallbacks, startWatcher)
@@ -343,14 +342,12 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to establish the watcher", "kind", kind)
 			// however let's not accept this for now.
-			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 		startWatcherCallbacks = append(startWatcherCallbacks, startWatcher)
 	}
 	if features.Enabled(features.MultiKueueManagerQuotaAutomation) {
 		if err := rc.startQueueWatchers(watchCtx); err != nil {
-			rc.disconnect()
 			return rc.increaseFailedConnAttempt(), err
 		}
 	}
@@ -576,15 +573,6 @@ func (rc *remoteClient) StopWatchers() {
 	}
 }
 
-// disconnect stops the watchers and marks the client as disconnected without
-// removing it from the clustersReconciler's remoteClients map. This allows the
-// workload reconciler to detect that the cluster was previously available but
-// is now unreachable, and apply the workerLostTimeout delay before requeuing.
-func (rc *remoteClient) disconnect() {
-	rc.StopWatchers()
-	rc.connState.markDisconnected(rc.clock.Now())
-}
-
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
@@ -750,7 +738,8 @@ func (c *clustersReconciler) disconnectCluster(clusterName string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if rc, found := c.remoteClients[clusterName]; found {
-		rc.disconnect()
+		rc.StopWatchers()
+		rc.connState.markDisconnected(rc.clock.Now())
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

Marking the remote client disconnected was spread across two layers: `updateConfigAndRefreshWatchers` called `rc.disconnect()` on each of its internal failure paths, while `clustersReconciler.Reconcile` called `c.disconnectCluster(req.Name)` on its failure branches before reporting the cluster inactive. The split was error-prone: #13188 fixed a case where a failure path reported the cluster inactive without updating the in-memory connection state, leaving the previous, still-working client in use as connected.

This PR removes `rc.disconnect()` from the internal failure paths of `updateConfigAndRefreshWatchers` (failed workload-watch establishment, failed adapter watchers, failed queue watchers). Every error from these paths already propagates to `clustersReconciler.Reconcile`, which calls `disconnectCluster` before reporting the cluster inactive, so `Reconcile` becomes the single owner of the in-memory connection state on reconcile failures. With no callers left, `remoteClient.disconnect()` is removed entirely and its body inlined into `disconnectCluster`, so the method cannot be picked up again from another code path. The invariant is preserved: whenever the cluster is reported inactive, the in-memory state is disconnected.

The watch goroutine's event-driven `markDisconnected` on a dropped watch stays as-is: it is the detection path for a lost connection and queues the reconcile (via `queueWatchEndedEvent`) that lands back in `Reconcile`. Routing it through the reconciler would leave a window where a dead watch still reads as connected and would delay the recorded first-loss time used by the worker-lost grace.

_This PR was prepared with AI assistance (Claude Code)._

#### Which issue(s) this PR fixes:

Fixes #13239

#### Special notes for your reviewer:

- No behavior change intended: on every failure path the state transition now happens once in `Reconcile` (moments later in the same call stack) instead of inside `updateConfigAndRefreshWatchers`. `disconnectedSince` semantics are unchanged — `markDisconnected` preserves the first-loss timestamp across repeated drops.
- The watcher cancellation on failure also moves out of `updateConfigAndRefreshWatchers`: it now happens in `disconnectCluster` → `StopWatchers()`, still within the same `Reconcile` invocation.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection recovery when setting up workload, adapter, or queue watchers fails.
  * Existing watchers are now stopped and connection state is updated consistently before retrying.
  * Preserved retry backoff behavior to support more reliable reconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->