### PR TITLE
docs: document the commit-message auto-close keyword rule in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Kueue follows the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/d
 - **Disclose AI usage** in the PR description.
 - **Disclose AI usage** when commenting or filing issues.
 - **No AI authorship markers.** Do not add AI co-author lines, `assisted-by`, `co-developed`, or similar commit trailers.
-- **No `#` in commit messages.** Prow flags commit messages containing `#` (for example `Fixes #123`) with the `do-not-merge/invalid-commit-message` label. Put issue references in the PR description instead.
+- **No auto-close keywords or `#` mentions in commit messages.** [Keywords which can automatically close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) (for example `Fixes #123`) and `#` mentions are not allowed in commit messages — Prow flags them with the `do-not-merge/invalid-commit-message` label. Put issue references in the PR description instead.
 - Always use `PULL_REQUEST_TEMPLATE.md` or `ISSUE_TEMPLATE`, in the .github directory, before creating pull requests or issues.
 
 ## Skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Kueue follows the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/d
 - **Disclose AI usage** in the PR description.
 - **Disclose AI usage** when commenting or filing issues.
 - **No AI authorship markers.** Do not add AI co-author lines, `assisted-by`, `co-developed`, or similar commit trailers.
+- **No `#` in commit messages.** Prow flags commit messages containing `#` (for example `Fixes #123`) with the `do-not-merge/invalid-commit-message` label. Put issue references in the PR description instead.
 - Always use `PULL_REQUEST_TEMPLATE.md` or `ISSUE_TEMPLATE`, in the .github directory, before creating pull requests or issues.
 
 ## Skills


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Adds a rule to the AI Contribution Policy in `AGENTS.md`: [keywords which can automatically close issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) (for example `Fixes #123`) and `#` mentions are not allowed in commit messages. Prow flags such commits with the `do-not-merge/invalid-commit-message` label, and AI tools commonly emit `Fixes #<n>` trailers in commit messages by default, so the label is easy to trip (see https://github.com/kubernetes-sigs/kueue/pull/13248#issuecomment-5031035225). Recording the rule where agents read their instructions prevents the round-trip of rewriting history and force-pushing after the label is applied.

_This PR was prepared with AI assistance (Claude Code)._

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

One-line addition to the AI Contribution Policy list; issue references belong in the PR description, where GitHub's auto-close linking works regardless.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
