### PR TITLE
Rename Requests -> MapRequests

### DIFF
--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -476,7 +476,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.Requests{corev1.ResourceCPU: 5000},
+									Requests: resources.MapRequests{corev1.ResourceCPU: 5000},
 									Count:    1,
 									Flavors:  map[corev1.ResourceName]kueue.ResourceFlavorReference{corev1.ResourceCPU: "default"},
 								},
@@ -920,7 +920,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.Requests{corev1.ResourceCPU: 1000},
+									Requests: resources.MapRequests{corev1.ResourceCPU: 1000},
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -933,7 +933,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.Requests{corev1.ResourceCPU: 1000},
+									Requests: resources.MapRequests{corev1.ResourceCPU: 1000},
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -215,9 +215,9 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		option(opts)
 	}
 
-	var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+	var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
 	if features.Enabled(features.TASHandleOverlappingFlavors) {
-		aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
+		aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.MapRequests)
 	}
 
 	result := make(TASAssignmentsResult)

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -194,11 +194,11 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	}
 	tasSnapshots := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
 	if features.Enabled(features.TopologyAwareScheduling) {
-		var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+		var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
 		flvTASCache := c.tasCache.Clone()
 
 		if features.Enabled(features.TASHandleOverlappingFlavors) {
-			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
+			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.MapRequests)
 			for _, cache := range flvTASCache {
 				c.snapshotTopologyDomainUsages(cache, aggregatedDomainUsages)
 			}
@@ -207,7 +207,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 		for flavor, cache := range flvTASCache {
 			// Only when this flavor is aggregation targets,
 			// we should propagate aggregated domain usages to snapshot constructions.
-			var aggregatedDomainUsagesForFlavor map[utiltas.TopologyDomainID]resources.Requests
+			var aggregatedDomainUsagesForFlavor map[utiltas.TopologyDomainID]resources.MapRequests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && utiltas.IsLowestLevelHostname(cache.topology.Levels) {
 				aggregatedDomainUsagesForFlavor = aggregatedDomainUsages
 			}
@@ -244,7 +244,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 }
 
 func (c *Cache) snapshotTopologyDomainUsages(
-	tasFlvCache *TASFlavorCache, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+	tasFlvCache *TASFlavorCache, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests,
 ) {
 	tasFlvCache.RLock()
 	defer tasFlvCache.RUnlock()

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -52,7 +52,7 @@ func NewTASCache(client client.Client, resourceFormatter *resources.ResourceForm
 		resourceFormatter: resourceFormatter,
 		nonTasUsageCache: &nonTasUsageCache{
 			podUsage:  make(map[types.NamespacedName]podUsageValue),
-			nodeUsage: make(map[string]resources.Requests),
+			nodeUsage: make(map[string]resources.MapRequests),
 			lock:      sync.RWMutex{},
 		},
 		nodesCache: newNodesCache(),

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -47,7 +47,7 @@ import (
 type PodSetTestCase struct {
 	podSetName         string
 	topologyRequest    *kueue.PodSetTopologyRequest
-	requests           resources.Requests
+	requests           resources.MapRequests
 	count              int32
 	tolerations        []corev1.Toleration
 	nodeSelector       map[string]string
@@ -392,7 +392,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		pods                   []corev1.Pod
 		levels                 []string
 		nodeLabels             map[string]string
-		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
 		priorFlavorUsage       []workload.TopologyDomainRequests
 		priorOwnUsage          []workload.TopologyDomainRequests
 		workload               *kueue.Workload
@@ -428,7 +428,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
-				requests:        resources.Requests{corev1.ResourceCPU: 1000},
+				requests:        resources.MapRequests{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
 					Levels:  []string{corev1.LabelHostname},
@@ -466,7 +466,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
-				requests:        resources.Requests{corev1.ResourceCPU: 1000},
+				requests:        resources.MapRequests{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
 					Levels:  []string{corev1.LabelHostname},
@@ -505,7 +505,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
-				requests:        resources.Requests{corev1.ResourceCPU: 1000},
+				requests:        resources.MapRequests{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
 					Levels:  []string{corev1.LabelHostname},
@@ -544,7 +544,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
-				requests:        resources.Requests{corev1.ResourceCPU: 1000},
+				requests:        resources.MapRequests{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
 					Levels:  []string{corev1.LabelHostname},
@@ -582,7 +582,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
-				requests:        resources.Requests{corev1.ResourceCPU: 1000},
+				requests:        resources.MapRequests{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
 					Levels:  []string{corev1.LabelHostname},
@@ -667,7 +667,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -745,7 +745,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 2,
@@ -766,7 +766,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			nodes:  scatteredNodes,
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -789,7 +789,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -812,7 +812,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -836,7 +836,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -861,7 +861,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -903,7 +903,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -927,7 +927,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -952,7 +952,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -977,7 +977,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -1002,7 +1002,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 3,
@@ -1052,7 +1052,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 5,
@@ -1082,7 +1082,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 2,
@@ -1107,7 +1107,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      4,
@@ -1121,7 +1121,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -1149,7 +1149,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -1184,7 +1184,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -1216,7 +1216,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 4000,
 				},
 				count:      1,
@@ -1230,7 +1230,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      5,
@@ -1244,7 +1244,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceMemory: 1024,
 				},
 				count: 4,
@@ -1269,7 +1269,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -1301,7 +1301,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -1340,7 +1340,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -1379,7 +1379,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasBlockLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      10,
@@ -1403,7 +1403,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -1431,7 +1431,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -1470,7 +1470,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -1500,7 +1500,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 600,
 				},
 				count: 1,
@@ -1544,7 +1544,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 600,
 				},
 				count: 1,
@@ -1585,7 +1585,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 600,
 				},
 				count:      1,
@@ -1616,7 +1616,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 600,
 				},
 				count:      1,
@@ -1648,7 +1648,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 0,
 				},
 				count:      9,
@@ -1688,7 +1688,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 600,
 				},
 				count: 1,
@@ -1727,7 +1727,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -1756,7 +1756,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -1792,7 +1792,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -1847,7 +1847,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				nodeSelector: map[string]string{
@@ -1874,7 +1874,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU:                     1000,
 					corev1.ResourceName("example.com/gpu"): 1,
 				},
@@ -1906,7 +1906,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -1960,7 +1960,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 300,
 				},
 				count:      1,
@@ -1985,7 +1985,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 1,
@@ -2004,7 +2004,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:      1,
@@ -2034,7 +2034,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 300,
 				},
 				count:      1,
@@ -2066,7 +2066,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 300,
 				},
 				count:      1,
@@ -2110,7 +2110,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -2176,7 +2176,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -2261,7 +2261,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 12,
@@ -2336,7 +2336,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -2445,7 +2445,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -2489,7 +2489,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -2564,7 +2564,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -2644,7 +2644,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(3)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 12,
@@ -2709,7 +2709,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 25,
@@ -2774,7 +2774,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 23,
@@ -2842,7 +2842,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(5)),
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 25,
@@ -2918,7 +2918,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Preferred:       ptr.To(tasRackLabel),
 					PodSetSliceSize: new(int32(1)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 22,
@@ -2994,7 +2994,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Preferred:       ptr.To(tasRackLabel),
 					PodSetSliceSize: new(int32(1)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 25,
@@ -3072,7 +3072,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(5)),
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 25,
@@ -3167,7 +3167,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(2)),
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 20,
@@ -3265,7 +3265,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(2)),
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 20,
@@ -3353,7 +3353,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(2)),
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 20,
@@ -3441,7 +3441,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceSize:             new(int32(2)),
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 22,
@@ -3526,7 +3526,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(string(corev1.LabelHostname)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 22,
@@ -3596,7 +3596,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Preferred:                   ptr.To(string(tasRackLabel)),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -3618,7 +3618,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						PodSetSliceSize:             new(int32(5)),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -3705,7 +3705,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(string(tasRackLabel)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 15,
@@ -3794,7 +3794,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(string(tasRackLabel)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 24,
@@ -3876,7 +3876,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(string(tasRackLabel)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 23,
@@ -4011,7 +4011,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred: ptr.To(tasRackLabel),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"example.com/gpu": 1,
 				},
 				count: 20,
@@ -4078,7 +4078,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Preferred:                   ptr.To(string(tasRackLabel)),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4098,7 +4098,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(string(tasRackLabel)),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4159,7 +4159,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Preferred:                   ptr.To(string(tasRackLabel)),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4179,7 +4179,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(string(tasRackLabel)),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4260,7 +4260,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Preferred:                   ptr.To(tasBlockLabel),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 5,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4280,7 +4280,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						"example.com/gpu": 1,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4351,7 +4351,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      6,
@@ -4414,7 +4414,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      6,
@@ -4487,7 +4487,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -4519,7 +4519,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasBlockLabel),
 					PodSetSliceSize:             new(int32(1)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -4534,7 +4534,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Required:                    ptr.To(tasBlockLabel),
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -4550,7 +4550,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: new("not-existing-topology-level"),
 					PodSetSliceSize:             new(int32(1)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      1,
@@ -4602,7 +4602,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -4639,7 +4639,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 6,
@@ -4670,7 +4670,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -4733,7 +4733,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 3,
@@ -4760,7 +4760,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 3,
@@ -4822,7 +4822,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4844,7 +4844,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -4901,7 +4901,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -4921,7 +4921,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  2,
 					},
@@ -4986,7 +4986,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2500,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5003,7 +5003,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2500,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5064,7 +5064,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2500,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5081,7 +5081,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 500,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5142,7 +5142,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5159,7 +5159,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5201,7 +5201,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5214,7 +5214,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5253,7 +5253,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5275,7 +5275,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5361,7 +5361,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Preferred: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5383,7 +5383,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						PodSetSliceSize:             new(int32(2)),
 						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5433,7 +5433,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 10000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5445,7 +5445,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5537,7 +5537,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2000,
 					},
 					podSetGroupName: new("sameGroup"),
@@ -5559,7 +5559,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5689,7 +5689,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5712,7 +5712,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 						"example.com/gpu":  1,
 					},
@@ -5747,7 +5747,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 2,
@@ -5766,7 +5766,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceMemory: 1024,
 					},
 					count: 1,
@@ -5792,7 +5792,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasBlockLabel),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 8,
@@ -5808,7 +5808,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count: 2,
@@ -5849,7 +5849,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{
 				{
 					podSetName: "ps1",
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    1000,
 						corev1.ResourceMemory: 1000,
 					},
@@ -5864,7 +5864,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName:   "ps2",
 					nodeSelector: map[string]string{"never": "match"},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    1000,
 						corev1.ResourceMemory: 1000,
 					},
@@ -5905,7 +5905,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -5960,7 +5960,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -6009,7 +6009,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 3,
@@ -6056,7 +6056,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 3,
@@ -6106,7 +6106,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:           1,
@@ -6129,7 +6129,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:           3,
@@ -6180,7 +6180,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:           1,
@@ -6203,7 +6203,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:           3,
@@ -6290,7 +6290,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{Topology: corev1.LabelHostname, Size: 2},
 					},
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 8,
@@ -6366,7 +6366,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					// Without the feature gate, only two-level fields are used;
 					// PodsetSliceRequiredTopologyConstraints would not be populated by the parser.
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 8,
@@ -6435,7 +6435,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{Topology: tasRackLabel, Size: 16},
 					},
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					"nvidia.com/gpu": 2,
 				},
 				count: 96,
@@ -6507,7 +6507,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 							{Topology: corev1.LabelHostname, Size: 2},
 						},
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:      6,
@@ -6574,7 +6574,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{Topology: corev1.LabelHostname, Size: 4},
 					},
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      16,
@@ -6630,7 +6630,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						{Topology: corev1.LabelHostname, Size: 2},
 					},
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count:      12,
@@ -6756,7 +6756,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 							{Topology: corev1.LabelHostname, Size: 3},
 						},
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
 					},
 					count:      24,
@@ -6799,7 +6799,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Term(10, "region", corev1.NodeSelectorOpIn, "us-west").
 						Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -6857,7 +6857,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					},
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "region", corev1.NodeSelectorOpIn, "us-west").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -6912,7 +6912,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						Term(100, "cloud.com/topology-rack", corev1.NodeSelectorOpIn, "r1").
 						Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -6952,7 +6952,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "region", corev1.NodeSelectorOpIn, "us-west").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -7004,7 +7004,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "region", corev1.NodeSelectorOpIn, "us-west").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -7048,7 +7048,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "region", corev1.NodeSelectorOpIn, "us-west").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -7105,7 +7105,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "type", corev1.NodeSelectorOpIn, "preferred").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 5,
@@ -7174,7 +7174,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "type", corev1.NodeSelectorOpIn, "preferred").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 5,
@@ -7243,7 +7243,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "type", corev1.NodeSelectorOpIn, "preferred").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -7313,7 +7313,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				nodeAffinity: &corev1.NodeAffinity{
 					PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "type", corev1.NodeSelectorOpIn, "preferred").Obj(),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 4,
@@ -7372,7 +7372,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 						PodSetSliceSize:             new(int32(1)),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    16 * 1000,
 						corev1.ResourceMemory: 64 * 1024 * 1024 * 1024,
 					},
@@ -7392,7 +7392,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					nodeAffinity: &corev1.NodeAffinity{
 						PreferredDuringSchedulingIgnoredDuringExecution: utiltesting.MakePreferredSchedulingTerms().Term(10, "cloud.com/topology-zone", corev1.NodeSelectorOpIn, "us-west").Obj(),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    4 * 1000,
 						corev1.ResourceMemory: 32 * 1024 * 1024 * 1024,
 						"nvidia.com/gpu":      8,
@@ -7440,7 +7440,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						PodSetSliceRequiredTopology: new("cloud.com/topology-rack"),
 						PodSetSliceSize:             new(int32(1)),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    1000,
 						corev1.ResourceMemory: 1024 * 1024 * 1024,
 					},
@@ -7457,7 +7457,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 						PodSetSliceRequiredTopology: new("cloud.com/topology-rack"),
 						PodSetSliceSize:             new(int32(1)),
 					},
-					requests: resources.Requests{
+					requests: resources.MapRequests{
 						corev1.ResourceCPU:    1000,
 						corev1.ResourceMemory: 1024 * 1024 * 1024,
 					},
@@ -7488,7 +7488,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			priorFlavorUsage: []workload.TopologyDomainRequests{
 				{
 					Values:            []string{"x1"},
-					SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000},
+					SinglePodRequests: resources.MapRequests{corev1.ResourceCPU: 1000},
 					Count:             1,
 				},
 			},
@@ -7498,7 +7498,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: new(corev1.LabelHostname),
 					},
-					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					requests: resources.MapRequests{corev1.ResourceCPU: 1000},
 					count:    1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels:  []string{corev1.LabelHostname},
@@ -7522,7 +7522,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: ptr.To(tasRackLabel),
 					},
-					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					requests: resources.MapRequests{corev1.ResourceCPU: 1000},
 					count:    1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels:  []string{tasBlockLabel, tasRackLabel},
@@ -7566,8 +7566,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			},
 			nodeLabels: map[string]string{},
 			priorOwnUsage: []workload.TopologyDomainRequests{
-				{Values: []string{"b1", "r1"}, SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000}, Count: 1},
-				{Values: []string{"b1", "r2"}, SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000}, Count: 1},
+				{Values: []string{"b1", "r1"}, SinglePodRequests: resources.MapRequests{corev1.ResourceCPU: 1000}, Count: 1},
+				{Values: []string{"b1", "r2"}, SinglePodRequests: resources.MapRequests{corev1.ResourceCPU: 1000}, Count: 1},
 			},
 			podSets: []PodSetTestCase{
 				{
@@ -7575,7 +7575,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					topologyRequest: &kueue.PodSetTopologyRequest{
 						Required: new(tasRackLabel),
 					},
-					requests: resources.Requests{corev1.ResourceCPU: 1000},
+					requests: resources.MapRequests{corev1.ResourceCPU: 1000},
 					count:    1,
 					wantAssignment: &tas.TopologyAssignment{
 						Levels:  []string{tasBlockLabel, tasRackLabel},
@@ -7613,7 +7613,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -7659,7 +7659,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -7705,7 +7705,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -7751,7 +7751,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: ptr.To(corev1.LabelHostname),
 				},
-				requests: resources.Requests{
+				requests: resources.MapRequests{
 					corev1.ResourceCPU: 1000,
 				},
 				count: 1,
@@ -7817,7 +7817,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				)
 			}
 
-			var aggregatedDomainUsage map[tas.TopologyDomainID]resources.Requests
+			var aggregatedDomainUsage map[tas.TopologyDomainID]resources.MapRequests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsage = tc.aggregatedDomainUsages
 			}
@@ -7898,7 +7898,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 		unhealthyNode          string
 		topologyRequest        *kueue.PodSetTopologyRequest
 		count                  int32
-		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
 		priorFlavorUsage       []workload.TopologyDomainRequests
 		wantAssignment         *tas.TopologyAssignment
 		wantReason             string
@@ -8215,7 +8215,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			priorFlavorUsage: []workload.TopologyDomainRequests{
 				{
 					Values:            []string{"x4"},
-					SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000},
+					SinglePodRequests: resources.MapRequests{corev1.ResourceCPU: 1000},
 					Count:             1,
 				},
 			},
@@ -8245,7 +8245,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 					TopologyRequest: tc.topologyRequest,
 					Template:        corev1.PodTemplateSpec{Spec: corev1.PodSpec{}},
 				},
-				SinglePodRequests: resources.Requests{corev1.ResourceCPU: 1000},
+				SinglePodRequests: resources.MapRequests{corev1.ResourceCPU: 1000},
 				Count:             tc.count,
 			}}
 
@@ -8289,7 +8289,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 				)
 			}
 
-			var aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
+			var aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsages = tc.aggregatedDomainUsages
 			}
@@ -8328,8 +8328,8 @@ func aggregatedDomainUsagesForPriorFlavorUsage(
 	flvInfo flavorInformation,
 	priorFlavorUsage []workload.TopologyDomainRequests,
 	cache *tasCache,
-	initialAggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests,
-) map[tas.TopologyDomainID]resources.Requests {
+	initialAggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests,
+) map[tas.TopologyDomainID]resources.MapRequests {
 	siblingCache := cache.NewTASFlavorCache(topologyInfo, flvInfo)
 	if len(priorFlavorUsage) > 0 {
 		siblingCache.addUsage(log, "prior-wl", priorFlavorUsage)
@@ -8337,7 +8337,7 @@ func aggregatedDomainUsagesForPriorFlavorUsage(
 
 	aggregatedDomainUsages := maps.Clone(initialAggregatedDomainUsages)
 	if aggregatedDomainUsages == nil {
-		aggregatedDomainUsages = make(map[tas.TopologyDomainID]resources.Requests, len(siblingCache.usage))
+		aggregatedDomainUsages = make(map[tas.TopologyDomainID]resources.MapRequests, len(siblingCache.usage))
 	}
 	for domainID, usage := range siblingCache.usage {
 		aggregatedDomainUsages[domainID] = usage.Clone()

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -35,7 +35,7 @@ type elasticPlacementResult struct {
 func (s *TASFlavorSnapshot) handleElasticWorkload(
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	if workers.PreviousAssignment == nil {
@@ -69,7 +69,7 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
 	previousCount int32,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
@@ -107,7 +107,7 @@ func (s *TASFlavorSnapshot) handleScaleDown(
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 ) elasticPlacementResult {
 	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
 	return s.finalizeElasticAssignment(workers, truncatedAssignment, leader, assumedUsage)
@@ -120,7 +120,7 @@ func (s *TASFlavorSnapshot) finalizeElasticAssignment(
 	workers TASPodSetRequests,
 	workersAssignment *utiltas.TopologyAssignment,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: workersAssignment}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -80,7 +80,7 @@ type TASFlavorCache struct {
 	flavor flavorInformation
 
 	// usage maintains the usage per topology domain
-	usage map[utiltas.TopologyDomainID]resources.Requests
+	usage map[utiltas.TopologyDomainID]resources.MapRequests
 
 	// wlUsage tracks the usage coming from workloads, so that we can make the
 	// usage removal indempotent - skip if it was not added.
@@ -95,13 +95,12 @@ type TASFlavorCache struct {
 func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 	flavorInfo flavorInformation) *TASFlavorCache {
 	return &TASFlavorCache{
-		client:            t.client,
-		topology:          topologyInfo,
-		flavor:            flavorInfo,
-		usage:             make(map[utiltas.TopologyDomainID]resources.Requests),
-		wlUsage:           make(map[workload.Reference][]workload.TopologyDomainRequests),
-		nonTasUsageCache:  t.nonTasUsageCache,
-		resourceFormatter: t.resourceFormatter,
+		client:           t.client,
+		topology:         topologyInfo,
+		flavor:           flavorInfo,
+		usage:            make(map[utiltas.TopologyDomainID]resources.MapRequests),
+		wlUsage:          make(map[workload.Reference][]workload.TopologyDomainRequests),
+		nonTasUsageCache: t.nonTasUsageCache,
 	}
 }
 
@@ -118,7 +117,7 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 }
 
 func (c *TASFlavorCache) snapshot(
-	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests,
 ) *TASFlavorSnapshot {
 	c.RLock()
 	defer c.RUnlock()
@@ -150,7 +149,7 @@ func (c *TASFlavorCache) snapshot(
 	for domainID, usage := range tasDomainUsages {
 		snapshot.addTASUsage(domainID, usage)
 	}
-	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
+	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.MapRequests) {
 		if domainID, ok := nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}
@@ -184,14 +183,14 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 		domainID := utiltas.DomainID(tr.Values)
 		_, found := c.usage[domainID]
 		if !found {
-			c.usage[domainID] = resources.Requests{}
+			c.usage[domainID] = resources.MapRequests{}
 		}
 		if op == subtract {
 			c.usage[domainID].Sub(tr.TotalRequests())
-			c.usage[domainID].Sub(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
+			c.usage[domainID].Sub(resources.MapRequests{corev1.ResourcePods: int64(tr.Count)})
 		} else {
 			c.usage[domainID].Add(tr.TotalRequests())
-			c.usage[domainID].Add(resources.Requests{corev1.ResourcePods: int64(tr.Count)})
+			c.usage[domainID].Add(resources.MapRequests{corev1.ResourcePods: int64(tr.Count)})
 		}
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -100,10 +100,10 @@ type leafDomain struct {
 	// freeCapacity represents the total node capacity minus the non-TAS usage,
 	// coming from Pods which are not managed by workloads admitted by TAS
 	// (typically static Pods, DaemonSets, or Deployments).
-	freeCapacity resources.Requests
+	freeCapacity resources.MapRequests
 
 	// tasUsage represents the usage associated with TAS workloads.
-	tasUsage resources.Requests
+	tasUsage resources.MapRequests
 
 	// cachedRemainingCapacity stores the pre-computed remaining capacity (freeCapacity - tasUsage) for this leaf.
 	// It is lazily calculated using LazyRequests and updated incrementally during TAS usage changes, avoiding repeated
@@ -267,7 +267,7 @@ func (s *TASFlavorSnapshot) addNode(node *corev1.Node) utiltas.TopologyDomainID 
 		}
 		s.leaves[domainID] = &leafDomain
 	}
-	capacity := resources.NewRequests(node.Status.Allocatable)
+	capacity := resources.NewMapRequests(node.Status.Allocatable)
 	s.addCapacity(domainID, capacity)
 	return domainID
 }
@@ -318,15 +318,15 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 	parent.children = append(parent.children, dom)
 }
 
-func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
+func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.MapRequests) {
 	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = resources.Requests{}
+		s.leaves[domainID].freeCapacity = resources.MapRequests{}
 	}
 	s.leaves[domainID].freeCapacity.Add(capacity)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
+func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
 	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
@@ -334,9 +334,9 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
+func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests, op usageOp, count int32) {
 	u := usage.Clone()
-	u.Add(resources.Requests{corev1.ResourcePods: int64(count)})
+	u.Add(resources.MapRequests{corev1.ResourcePods: int64(count)})
 	if op == add {
 		s.addTASUsage(domainID, u)
 	} else {
@@ -344,7 +344,7 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 	}
 }
 
-func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
+func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.MapRequests {
 	if !leaf.cachedRemainingCapacity.IsValid() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
 		if len(leaf.tasUsage) > 0 {
@@ -354,7 +354,7 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 	return leaf.cachedRemainingCapacity.Get()
 }
 
-func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
+func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
@@ -363,13 +363,13 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.Requests{}
+		s.leaves[domainID].tasUsage = resources.MapRequests{}
 	}
 	s.leaves[domainID].tasUsage.Add(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
+func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
@@ -378,14 +378,14 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.Requests{}
+		s.leaves[domainID].tasUsage = resources.MapRequests{}
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.Requests {
-	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
+func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.MapRequests {
+	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
 		freeCapacityPerDomain[domainID] = leaf.freeCapacity.Clone()
@@ -394,8 +394,8 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	return freeCapacityPerDomain
 }
 
-func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]resources.Requests {
-	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
+func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]resources.MapRequests {
+	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
 		tasUsagePerDomain[domainID] = leaf.tasUsage.Clone()
@@ -448,7 +448,7 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 type TASPodSetRequests struct {
 	PodSet            *kueue.PodSet
 	PodSetUpdates     []*kueue.PodSetUpdate
-	SinglePodRequests resources.Requests
+	SinglePodRequests resources.MapRequests
 	Count             int32
 	Flavor            kueue.ResourceFlavorReference
 	Implied           bool
@@ -458,7 +458,7 @@ type TASPodSetRequests struct {
 	PreviousAssignment *kueue.TopologyAssignment
 }
 
-func (t *TASPodSetRequests) TotalRequests() resources.Requests {
+func (t *TASPodSetRequests) TotalRequests() resources.MapRequests {
 	return t.SinglePodRequests.ScaledUp(int64(t.Count))
 }
 
@@ -517,7 +517,7 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 type findTopologyAssignmentsOption struct {
 	simulateEmpty          bool
 	workload               *kueue.Workload
-	aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+	aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
 }
 
 // ExclusionStats tracks why nodes were excluded during TAS scheduling.
@@ -533,9 +533,9 @@ type ExclusionStats struct {
 // topologyAssignmentPodRequirements stores pod-driven scheduling filters and
 // resource inputs that are only needed while filling per-domain counts.
 type topologyAssignmentPodRequirements struct {
-	requests                  resources.Requests
-	leaderRequests            *resources.Requests
-	assumedUsage              map[utiltas.TopologyDomainID]resources.Requests
+	requests                  resources.MapRequests
+	leaderRequests            *resources.MapRequests
+	assumedUsage              map[utiltas.TopologyDomainID]resources.MapRequests
 	tolerations               []corev1.Toleration
 	selector                  labels.Selector
 	affinitySelector          *nodeaffinity.NodeSelector
@@ -659,7 +659,7 @@ func WithWorkload(wl *kueue.Workload) FindTopologyAssignmentsOption {
 // WithAggregatedDomainUsages supplies a cross-flavor assumedUsage so that
 // per-PodSet TAS placements within a single workload account for reservations
 // already made in sibling flavors sharing the same Topology (hostname leaf).
-func WithAggregatedDomainUsages(m map[utiltas.TopologyDomainID]resources.Requests) FindTopologyAssignmentsOption {
+func WithAggregatedDomainUsages(m map[utiltas.TopologyDomainID]resources.MapRequests) FindTopologyAssignmentsOption {
 	return func(o *findTopologyAssignmentsOption) {
 		o.aggregatedDomainUsages = m
 	}
@@ -674,7 +674,7 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(log logr.Logger, fl
 	}
 
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
-	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+	assumedUsage := make(map[utiltas.TopologyDomainID]resources.MapRequests)
 	if features.Enabled(features.TASHandleOverlappingFlavors) && opts.aggregatedDomainUsages != nil {
 		assumedUsage = opts.aggregatedDomainUsages
 	}
@@ -779,7 +779,7 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	tr *TASPodSetRequests,
 	existingAssignment *utiltas.TopologyAssignment,
 	wl *kueue.Workload,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 ) (*utiltas.TopologyAssignment, *utiltas.TopologyAssignment, string) {
 	tr.Count = deleteDomain(existingAssignment, wl.Status.UnhealthyNodes[0].Name)
 	if isStale, staleDomain := s.IsTopologyAssignmentStale(existingAssignment); isStale {
@@ -822,14 +822,14 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	return newAssignment, replacementAssignment[tr.PodSet.Name], ""
 }
 
-func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
+func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
 	addUsagePerDomain(assumedUsage, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
 }
 
-func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests, usagePerDomain map[utiltas.TopologyDomainID]resources.MapRequests) {
 	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.Requests{}
+			assumedUsage[domainID] = resources.MapRequests{}
 		}
 		assumedUsage[domainID].Add(usage)
 	}
@@ -977,7 +977,7 @@ func (s *TASFlavorSnapshot) findIncompleteSliceDomain(tr *TASPodSetRequests, ta 
 func (s *TASFlavorSnapshot) findTopologyAssignment(
 	workersTasPodSetRequests TASPodSetRequests,
 	leaderTasPodSetRequests *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
 	requirements := &topologyAssignmentPodRequirements{
 		assumedUsage:              assumedUsage,
@@ -991,11 +991,11 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		stats: newExclusionStats(),
 	}
 	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
-	requirements.requests.Add(resources.Requests{corev1.ResourcePods: 1})
+	requirements.requests.Add(resources.MapRequests{corev1.ResourcePods: 1})
 
 	if leaderTasPodSetRequests != nil {
 		requirements.leaderRequests = new(leaderTasPodSetRequests.SinglePodRequests.Clone())
-		requirements.leaderRequests.Add(resources.Requests{corev1.ResourcePods: 1})
+		requirements.leaderRequests.Add(resources.MapRequests{corev1.ResourcePods: 1})
 		state.leaderCount = 1
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -39,22 +39,22 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 	snapshot := &TASFlavorSnapshot{
 		leaves: leafDomainByID{
 			"domain2": &leafDomain{
-				freeCapacity: resources.Requests{
+				freeCapacity: resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
 				},
-				tasUsage: resources.Requests{
+				tasUsage: resources.MapRequests{
 					corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
 					corev1.ResourceCPU:    500,
 				},
 			},
 			"domain1": &leafDomain{
-				freeCapacity: resources.Requests{
+				freeCapacity: resources.MapRequests{
 					corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
 					corev1.ResourceCPU:    2000,
 					"nvidia.com/gpu":      1,
 				},
-				tasUsage: resources.Requests{
+				tasUsage: resources.MapRequests{
 					corev1.ResourceCPU:    500,
 					"nvidia.com/gpu":      1,
 					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
@@ -694,21 +694,21 @@ func TestCountPodsInAssignment(t *testing.T) {
 }
 
 func TestComputeAssumedUsageFromAssignment(t *testing.T) {
-	singlePodRequests := resources.Requests{
+	singlePodRequests := resources.MapRequests{
 		corev1.ResourceCPU:    1000,
 		corev1.ResourceMemory: 1024,
 	}
 
 	cases := map[string]struct {
 		assignment *tas.TopologyAssignment
-		want       map[tas.TopologyDomainID]resources.Requests
+		want       map[tas.TopologyDomainID]resources.MapRequests
 	}{
 		"empty assignment": {
 			assignment: &tas.TopologyAssignment{
 				Levels:  []string{"hostname"},
 				Domains: nil,
 			},
-			want: map[tas.TopologyDomainID]resources.Requests{},
+			want: map[tas.TopologyDomainID]resources.MapRequests{},
 		},
 		"single domain with one pod": {
 			assignment: &tas.TopologyAssignment{
@@ -717,7 +717,7 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 					{Values: []string{"node-a"}, Count: 1},
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.Requests{
+			want: map[tas.TopologyDomainID]resources.MapRequests{
 				"node-a": {
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 1024,
@@ -733,7 +733,7 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 					{Values: []string{"node-b"}, Count: 3},
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.Requests{
+			want: map[tas.TopologyDomainID]resources.MapRequests{
 				"node-a": {
 					corev1.ResourceCPU:    2000,
 					corev1.ResourceMemory: 2048,
@@ -760,13 +760,13 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 
 func TestAddAssumedUsage(t *testing.T) {
 	cases := map[string]struct {
-		assumedUsage map[tas.TopologyDomainID]resources.Requests
+		assumedUsage map[tas.TopologyDomainID]resources.MapRequests
 		assignment   *tas.TopologyAssignment
 		tasRequests  *TASPodSetRequests
-		want         map[tas.TopologyDomainID]resources.Requests
+		want         map[tas.TopologyDomainID]resources.MapRequests
 	}{
 		"includes pod count for existing and new domains": {
-			assumedUsage: map[tas.TopologyDomainID]resources.Requests{
+			assumedUsage: map[tas.TopologyDomainID]resources.MapRequests{
 				"node-a": {
 					corev1.ResourceCPU:  1000,
 					corev1.ResourcePods: 1,
@@ -780,12 +780,12 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.Requests{
+				SinglePodRequests: resources.MapRequests{
 					corev1.ResourceCPU:    500,
 					corev1.ResourceMemory: 2048,
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.Requests{
+			want: map[tas.TopologyDomainID]resources.MapRequests{
 				"node-a": {
 					corev1.ResourceCPU:    1500,
 					corev1.ResourceMemory: 2048,
@@ -799,7 +799,7 @@ func TestAddAssumedUsage(t *testing.T) {
 			},
 		},
 		"includes pod count starting from empty assumed usage": {
-			assumedUsage: map[tas.TopologyDomainID]resources.Requests{},
+			assumedUsage: map[tas.TopologyDomainID]resources.MapRequests{},
 			assignment: &tas.TopologyAssignment{
 				Levels: []string{"hostname"},
 				Domains: []tas.TopologyDomainAssignment{
@@ -807,12 +807,12 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.Requests{
+				SinglePodRequests: resources.MapRequests{
 					corev1.ResourceCPU:    250,
 					corev1.ResourceMemory: 512,
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.Requests{
+			want: map[tas.TopologyDomainID]resources.MapRequests{
 				"node-a": {
 					corev1.ResourceCPU:    750,
 					corev1.ResourceMemory: 1536,
@@ -969,7 +969,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			flavorUsage := workload.TASFlavorUsage{
 				{
 					Values: []string{"node-a"},
-					SinglePodRequests: resources.Requests{
+					SinglePodRequests: resources.MapRequests{
 						corev1.ResourceCPU: 5000,
 					},
 					Count: 1,
@@ -980,7 +980,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
 
 			// Add TAS usage of 4 CPU (4000m), leaving 4 CPU (8000m - 4000m = 4000m) remaining
-			usage := resources.Requests{
+			usage := resources.MapRequests{
 				corev1.ResourceCPU: 4000,
 			}
 			snapshot.updateTASUsage(domainID, usage, add, 1)

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -36,7 +36,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 	testCases := []struct {
 		name       string
 		operations func(cache *TASFlavorCache)
-		wantUsage  map[utiltas.TopologyDomainID]resources.Requests
+		wantUsage  map[utiltas.TopologyDomainID]resources.MapRequests
 	}{
 		{
 			name: "add usage",
@@ -45,13 +45,13 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  2,
-						SinglePodRequests: resources.Requests{
+						SinglePodRequests: resources.MapRequests{
 							corev1.ResourceCPU: 2,
 						},
 					},
 				})
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
 				"domain1": {
 					corev1.ResourceCPU:  4,
 					corev1.ResourcePods: 2,
@@ -66,7 +66,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.Requests{
+						SinglePodRequests: resources.MapRequests{
 							corev1.ResourceCPU: 1,
 						},
 					},
@@ -76,13 +76,13 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain2"},
 						Count:  2,
-						SinglePodRequests: resources.Requests{
+						SinglePodRequests: resources.MapRequests{
 							corev1.ResourceCPU: 3,
 						},
 					},
 				})
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
 				"domain1": {
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
@@ -100,14 +100,14 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.Requests{
+						SinglePodRequests: resources.MapRequests{
 							corev1.ResourceCPU: 1,
 						},
 					},
 				})
 				cache.removeUsage(logr, wlKey)
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
 				"domain1": {
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
@@ -119,7 +119,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 			operations: func(cache *TASFlavorCache) {
 				cache.removeUsage(logr, wlKey)
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{},
+			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{},
 		},
 	}
 
@@ -127,7 +127,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := &TASFlavorCache{
 				wlUsage: make(map[workload.Reference][]workload.TopologyDomainRequests),
-				usage:   make(map[utiltas.TopologyDomainID]resources.Requests),
+				usage:   make(map[utiltas.TopologyDomainID]resources.MapRequests),
 			}
 
 			tc.operations(cache)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -32,13 +32,13 @@ import (
 // the hot path documented in kueue#8449.
 type nonTasUsageCache struct {
 	podUsage  map[types.NamespacedName]podUsageValue
-	nodeUsage map[string]resources.Requests // pre-aggregated per-node totals
+	nodeUsage map[string]resources.MapRequests // pre-aggregated per-node totals
 	lock      sync.RWMutex
 }
 
 type podUsageValue struct {
 	node  string
-	usage resources.Requests
+	usage resources.MapRequests
 }
 
 // update may add a pod to the cache, or
@@ -85,7 +85,7 @@ func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
 // forEachNodeUsage invokes fn for each node's usage while holding the read lock.
 // usage is the live cache entry, not a copy: fn must only read it, and must not
 // mutate or retain it beyond the call. Clone it if a longer-lived copy is needed.
-func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources.Requests)) {
+func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources.MapRequests)) {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 	for node, reqs := range n.nodeUsage {
@@ -95,9 +95,9 @@ func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources
 
 // addNodeUsage increments the pre-aggregated per-node usage.
 // Must be called under write lock.
-func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
+func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.MapRequests) {
 	if _, found := n.nodeUsage[node]; !found {
-		n.nodeUsage[node] = resources.Requests{}
+		n.nodeUsage[node] = resources.MapRequests{}
 	}
 	n.nodeUsage[node].Add(usage)
 	n.nodeUsage[node][corev1.ResourcePods]++
@@ -105,7 +105,7 @@ func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 
 // removeNodeUsage decrements the pre-aggregated per-node usage.
 // Must be called under write lock.
-func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.Requests, log logr.Logger) {
+func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.MapRequests, log logr.Logger) {
 	existing, found := n.nodeUsage[node]
 	if !found {
 		return

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -34,10 +34,10 @@ import (
 // and verifies it matches the incremental nodeUsage.
 func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	t.Helper()
-	expected := make(map[string]resources.Requests)
+	expected := make(map[string]resources.MapRequests)
 	for _, pv := range cache.podUsage {
 		if _, found := expected[pv.node]; !found {
-			expected[pv.node] = resources.Requests{}
+			expected[pv.node] = resources.MapRequests{}
 		}
 		expected[pv.node].Add(pv.usage)
 		expected[pv.node][corev1.ResourcePods]++
@@ -48,9 +48,9 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	}
 }
 
-func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.Requests {
-	usage := map[string]resources.Requests{}
-	cache.forEachNodeUsage(func(node string, reqs resources.Requests) {
+func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.MapRequests {
+	usage := map[string]resources.MapRequests{}
+	cache.forEachNodeUsage(func(node string, reqs resources.MapRequests) {
 		usage[node] = reqs.Clone()
 	})
 	return usage
@@ -83,7 +83,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 		// podsDelete is the set of pod keys to delete from the cache after
 		// initialPods are applied (and after podsUpdate, if any).
 		podsDelete    []client.ObjectKey
-		wantNodeUsage map[string]resources.Requests
+		wantNodeUsage map[string]resources.MapRequests
 	}{
 		"add then delete same pod": {
 			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "2")},
@@ -94,7 +94,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod1", "ns", "node-a", "1"),
 				makePod("pod2", "ns", "node-a", "2"),
 			},
-			wantNodeUsage: map[string]resources.Requests{
+			wantNodeUsage: map[string]resources.MapRequests{
 				"node-a": {corev1.ResourceCPU: 3000, corev1.ResourcePods: 2},
 			},
 		},
@@ -103,7 +103,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.NodeName = "node-b"
 			},
-			wantNodeUsage: map[string]resources.Requests{
+			wantNodeUsage: map[string]resources.MapRequests{
 				"node-b": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
 			},
 		},
@@ -112,7 +112,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
 			},
-			wantNodeUsage: map[string]resources.Requests{
+			wantNodeUsage: map[string]resources.MapRequests{
 				"node-a": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
 			},
 		},
@@ -124,7 +124,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("3")
 			},
-			wantNodeUsage: map[string]resources.Requests{
+			wantNodeUsage: map[string]resources.MapRequests{
 				"node-a": {corev1.ResourceCPU: 5000, corev1.ResourcePods: 2},
 			},
 		},
@@ -143,7 +143,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod2", "ns", "node-a", "1"),
 			},
 			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
-			wantNodeUsage: map[string]resources.Requests{
+			wantNodeUsage: map[string]resources.MapRequests{
 				"node-a": {corev1.ResourceCPU: 1000, corev1.ResourcePods: 1},
 			},
 		},
@@ -164,7 +164,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			cache := &nonTasUsageCache{
 				podUsage:  make(map[types.NamespacedName]podUsageValue),
-				nodeUsage: make(map[string]resources.Requests),
+				nodeUsage: make(map[string]resources.MapRequests),
 			}
 
 			for _, pod := range tc.initialPods {
@@ -184,7 +184,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 
 			wantUsage := tc.wantNodeUsage
 			if wantUsage == nil {
-				wantUsage = map[string]resources.Requests{}
+				wantUsage = map[string]resources.MapRequests{}
 			}
 			if diff := cmp.Diff(wantUsage, collectNodeUsage(cache)); diff != "" {
 				t.Errorf("collectNodeUsage() mismatch (-want +got):\n%s", diff)

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -55,8 +55,8 @@ type celDeviceRequest struct {
 // total number of devices requested for each DeviceClass inside the provided
 // ResourceClaimSpec. Returns field errors for unsupported request features
 // (FirstAvailable, AdminAccess, AllocationMode All).
-func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, field.ErrorList) {
-	out := resources.Requests{}
+func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.MapRequests, field.ErrorList) {
+	out := resources.MapRequests{}
 	if claimSpec == nil {
 		return out, nil
 	}

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -31,38 +31,38 @@ import (
 // The following resources calculations are inspired on
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
 
-// Requests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
-type Requests map[corev1.ResourceName]int64
+// MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
+type MapRequests map[corev1.ResourceName]int64
 
-func NewRequests(rl corev1.ResourceList) Requests {
-	r := Requests{}
+func NewMapRequests(rl corev1.ResourceList) MapRequests {
+	r := MapRequests{}
 	for name, quant := range rl {
 		r[name] = ResourceValue(name, quant)
 	}
 	return r
 }
 
-func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
-	return NewRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
+	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
 }
 
-func (r Requests) Clone() Requests {
+func (r MapRequests) Clone() MapRequests {
 	return maps.Clone(r)
 }
 
-func (r Requests) ScaledUp(f int64) Requests {
+func (r MapRequests) ScaledUp(f int64) MapRequests {
 	ret := r.Clone()
 	ret.Mul(f)
 	return ret
 }
 
-func (r Requests) ScaledDown(f int64) Requests {
+func (r MapRequests) ScaledDown(f int64) MapRequests {
 	ret := r.Clone()
 	ret.Divide(f)
 	return ret
 }
 
-func (r Requests) Divide(f int64) {
+func (r MapRequests) Divide(f int64) {
 	for k := range r {
 		if r[k] == 0 && f == 0 {
 			// Skip dividing by 0 when resources are 0.
@@ -74,25 +74,25 @@ func (r Requests) Divide(f int64) {
 	}
 }
 
-func (r Requests) Mul(f int64) {
+func (r MapRequests) Mul(f int64) {
 	for k := range r {
 		r[k] = utilmath.SaturatingMul(r[k], f)
 	}
 }
 
-func (r Requests) Add(addRequests Requests) {
+func (r MapRequests) Add(addRequests MapRequests) {
 	for k, v := range addRequests {
 		r[k] += v
 	}
 }
 
-func (r Requests) Sub(subRequests Requests) {
+func (r MapRequests) Sub(subRequests MapRequests) {
 	for k, v := range subRequests {
 		r[k] -= v
 	}
 }
 
-func (r Requests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
+func (r MapRequests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
 	ret := make(corev1.ResourceList, len(r))
 	for k, v := range r {
 		ret[k] = formatter.ResourceQuantity(k, v)
@@ -110,7 +110,7 @@ func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 }
 
 // GreaterKeys returns keys where the receiver is greater than other.
-func (r Requests) GreaterKeys(other Requests) []corev1.ResourceName {
+func (r MapRequests) GreaterKeys(other MapRequests) []corev1.ResourceName {
 	if len(r) == 0 || len(other) == 0 {
 		return nil
 	}
@@ -127,11 +127,11 @@ func (r Requests) GreaterKeys(other Requests) []corev1.ResourceName {
 }
 
 // GreaterKeysRL compares against a ResourceList and returns larger keys.
-func (r Requests) GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName {
-	return r.GreaterKeys(NewRequests(rl))
+func (r MapRequests) GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName {
+	return r.GreaterKeys(NewMapRequests(rl))
 }
 
-func (r Requests) CountIn(capacity Requests) int32 {
+func (r MapRequests) CountIn(capacity MapRequests) int32 {
 	count, _ := r.CountInWithLimitingResource(capacity)
 	return count
 }
@@ -140,7 +140,7 @@ func (r Requests) CountIn(capacity Requests) int32 {
 // and the resource that is most constraining (i.e., gave the minimum count).
 // When multiple resources have the same count, ties are broken alphabetically
 // by resource name for determinism.
-func (r Requests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
+func (r MapRequests) CountInWithLimitingResource(capacity MapRequests) (int32, corev1.ResourceName) {
 	var (
 		result           *int32
 		limitingResource corev1.ResourceName
@@ -179,11 +179,11 @@ func (r Requests) CountInWithLimitingResource(capacity Requests) (int32, corev1.
 // LazyRequests wraps a base Requests map and performs copy-on-write
 // (lazy cloning) when mutations occur.
 type LazyRequests struct {
-	base   Requests
-	cached Requests
+	base   MapRequests
+	cached MapRequests
 }
 
-func NewLazyRequests(base Requests) LazyRequests {
+func NewLazyRequests(base MapRequests) LazyRequests {
 	return LazyRequests{base: base}
 }
 
@@ -193,7 +193,7 @@ func (l *LazyRequests) IsValid() bool {
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
-func (l *LazyRequests) Get() Requests {
+func (l *LazyRequests) Get() MapRequests {
 	if l.cached != nil {
 		return l.cached
 	}
@@ -202,13 +202,13 @@ func (l *LazyRequests) Get() Requests {
 
 // Sub subtracts subRequests from the underlying Requests map,
 // cloning base on first write.
-func (l *LazyRequests) Sub(subRequests Requests) {
+func (l *LazyRequests) Sub(subRequests MapRequests) {
 	if len(subRequests) == 0 {
 		return
 	}
 	if l.cached == nil {
 		if l.base == nil {
-			l.cached = Requests{}
+			l.cached = MapRequests{}
 		} else {
 			l.cached = l.base.Clone()
 		}
@@ -218,13 +218,13 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 
 // Add adds addRequests to the underlying Requests map,
 // cloning base on first write.
-func (l *LazyRequests) Add(addRequests Requests) {
+func (l *LazyRequests) Add(addRequests MapRequests) {
 	if len(addRequests) == 0 {
 		return
 	}
 	if l.cached == nil {
 		if l.base == nil {
-			l.cached = Requests{}
+			l.cached = MapRequests{}
 		} else {
 			l.cached = l.base.Clone()
 		}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -28,88 +28,88 @@ import (
 
 func TestCountIn(t *testing.T) {
 	cases := map[string]struct {
-		requests   Requests
-		capacity   Requests
+		requests   MapRequests
+		capacity   MapRequests
 		wantResult int32
 	}{
 		"requests equal capacity": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1,
 				corev1.ResourceMemory: 1,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    1,
 				corev1.ResourceMemory: 1,
 			},
 			wantResult: 1,
 		},
 		"requests with extra resource": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1,
 				corev1.ResourceMemory: 1,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 1,
 			},
 			wantResult: 0,
 		},
 		"first resource is bottleneck": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    5,
 				corev1.ResourceMemory: 1,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    12,
 				corev1.ResourceMemory: 8,
 			},
 			wantResult: 2,
 		},
 		"second resource is bottleneck": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1,
 				corev1.ResourceMemory: 5,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    8,
 				corev1.ResourceMemory: 12,
 			},
 			wantResult: 2,
 		},
 		"capacity non divisible cleanly by requests": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU: 2,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 5,
 			},
 			wantResult: 2,
 		},
 		"requests amount of zero": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU: 0,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 5,
 			},
 			wantResult: int32(math.MaxInt32),
 		},
 		"has one resource with request amount of zero": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    0,
 				corev1.ResourceMemory: 1,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    5,
 				corev1.ResourceMemory: 5,
 			},
 			wantResult: 5,
 		},
 		"requests amount of zero for extra resource": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1,
 				corev1.ResourceMemory: 0,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 5,
 			},
 			wantResult: 5,
@@ -127,17 +127,17 @@ func TestCountIn(t *testing.T) {
 
 func TestCountInWithLimitingResource(t *testing.T) {
 	cases := map[string]struct {
-		requests             Requests
-		capacity             Requests
+		requests             MapRequests
+		capacity             MapRequests
 		wantCount            int32
 		wantLimitingResource corev1.ResourceName
 	}{
 		"CPU is limiting": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1000,
 				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    500,
 				corev1.ResourceMemory: 32 * 1024 * 1024 * 1024,
 			},
@@ -145,11 +145,11 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantLimitingResource: corev1.ResourceCPU,
 		},
 		"memory is limiting": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1000,
 				corev1.ResourceMemory: 16 * 1024 * 1024 * 1024,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    8000,
 				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
 			},
@@ -157,11 +157,11 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantLimitingResource: corev1.ResourceMemory,
 		},
 		"tie-breaker by resource name": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    1000,
 				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    500,
 				corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
 			},
@@ -169,11 +169,11 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantLimitingResource: corev1.ResourceCPU, // "cpu" < "memory"
 		},
 		"resource not in capacity": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU: 1000,
 				"nvidia.com/gpu":   2,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 8000,
 				// GPU not in capacity
 			},
@@ -181,21 +181,21 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantLimitingResource: "nvidia.com/gpu",
 		},
 		"capacity exhausted": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU: 1000,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: 0,
 			},
 			wantCount:            0,
 			wantLimitingResource: corev1.ResourceCPU,
 		},
 		"request zero is skipped": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    0,
 				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    8000,
 				corev1.ResourceMemory: 16 * 1024 * 1024 * 1024,
 			},
@@ -203,12 +203,12 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantLimitingResource: corev1.ResourceMemory, // CPU skipped because request is 0
 		},
 		"GPU exhausted on GPU node": {
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU:    2000,
 				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
 				"nvidia.com/gpu":      2,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU:    8000,
 				corev1.ResourceMemory: 32 * 1024 * 1024 * 1024,
 				"nvidia.com/gpu":      0,
@@ -222,10 +222,10 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			// CountInWithLimitingResource must report this as "fits 0 times",
 			// not a negative count, so downstream consumers don't propagate
 			// invalid values into apiserver-validated structures.
-			requests: Requests{
+			requests: MapRequests{
 				corev1.ResourceCPU: 1000,
 			},
-			capacity: Requests{
+			capacity: MapRequests{
 				corev1.ResourceCPU: -3000,
 			},
 			wantCount:            0,
@@ -247,44 +247,44 @@ func TestCountInWithLimitingResource(t *testing.T) {
 
 func TestGreaterKeys(t *testing.T) {
 	cases := map[string]struct {
-		a, b Requests
+		a, b MapRequests
 		want []corev1.ResourceName
 	}{
 		"empty_a": {
-			b:    Requests{corev1.ResourceCPU: 1},
+			b:    MapRequests{corev1.ResourceCPU: 1},
 			want: nil,
 		},
 		"empty_b": {
-			a:    Requests{corev1.ResourceCPU: 1},
+			a:    MapRequests{corev1.ResourceCPU: 1},
 			want: nil,
 		},
 		"less_one": {
-			a:    Requests{corev1.ResourceCPU: 500},
-			b:    Requests{corev1.ResourceCPU: 1000},
+			a:    MapRequests{corev1.ResourceCPU: 500},
+			b:    MapRequests{corev1.ResourceCPU: 1000},
 			want: nil,
 		},
 		"greater_one": {
-			a:    Requests{corev1.ResourceCPU: 1000},
-			b:    Requests{corev1.ResourceCPU: 500},
+			a:    MapRequests{corev1.ResourceCPU: 1000},
+			b:    MapRequests{corev1.ResourceCPU: 500},
 			want: []corev1.ResourceName{corev1.ResourceCPU},
 		},
 		"multiple": {
-			a: Requests{
+			a: MapRequests{
 				"r1": 2,
 				"r2": 1,
 			},
-			b: Requests{
+			b: MapRequests{
 				"r1": 1,
 				"r2": 2,
 			},
 			want: []corev1.ResourceName{"r1"},
 		},
 		"multiple_unrelated": {
-			a: Requests{
+			a: MapRequests{
 				"r1": 2,
 				"r2": 2,
 			},
-			b: Requests{
+			b: MapRequests{
 				"r3": 1,
 				"r4": 1,
 			},
@@ -302,7 +302,7 @@ func TestGreaterKeys(t *testing.T) {
 }
 
 func TestGreaterKeysRL(t *testing.T) {
-	reqs := Requests{
+	reqs := MapRequests{
 		corev1.ResourceCPU:    1000,
 		corev1.ResourceMemory: 1024,
 	}
@@ -411,68 +411,68 @@ func TestResourceQuantityRoundTrips(t *testing.T) {
 
 func TestLazyRequests(t *testing.T) {
 	cases := map[string]struct {
-		base              Requests
+		base              MapRequests
 		op                func(*LazyRequests)
-		wantResult        Requests
+		wantResult        MapRequests
 		wantCachedCreated bool
 		wantValid         bool
 	}{
 		"no operation preserves base": {
-			base:              Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			base:              MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op:                nil,
-			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
 			wantValid:         true,
 		},
 		"subtraction creates clone and updates result": {
-			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op: func(l *LazyRequests) {
-				l.Sub(Requests{corev1.ResourceCPU: 3})
+				l.Sub(MapRequests{corev1.ResourceCPU: 3})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: 7, corev1.ResourceMemory: 100},
+			wantResult:        MapRequests{corev1.ResourceCPU: 7, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
 			wantValid:         true,
 		},
 		"addition creates clone and updates result": {
-			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op: func(l *LazyRequests) {
-				l.Add(Requests{corev1.ResourceCPU: 5})
+				l.Add(MapRequests{corev1.ResourceCPU: 5})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: 15, corev1.ResourceMemory: 100},
+			wantResult:        MapRequests{corev1.ResourceCPU: 15, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
 			wantValid:         true,
 		},
 		"subtraction with empty map short circuits": {
-			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op: func(l *LazyRequests) {
-				l.Sub(Requests{})
+				l.Sub(MapRequests{})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
 			wantValid:         true,
 		},
 		"addition with empty map short circuits": {
-			base: Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op: func(l *LazyRequests) {
-				l.Add(Requests{})
+				l.Add(MapRequests{})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
+			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
 			wantValid:         true,
 		},
 		"nil base input with non-empty addition": {
 			base: nil,
 			op: func(l *LazyRequests) {
-				l.Add(Requests{corev1.ResourceCPU: 5})
+				l.Add(MapRequests{corev1.ResourceCPU: 5})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: 5},
+			wantResult:        MapRequests{corev1.ResourceCPU: 5},
 			wantCachedCreated: true,
 			wantValid:         true,
 		},
 		"nil base input with empty addition short circuits": {
 			base: nil,
 			op: func(l *LazyRequests) {
-				l.Add(Requests{})
+				l.Add(MapRequests{})
 			},
 			wantResult:        nil,
 			wantCachedCreated: false,
@@ -481,9 +481,9 @@ func TestLazyRequests(t *testing.T) {
 		"nil base input with non-empty subtraction": {
 			base: nil,
 			op: func(l *LazyRequests) {
-				l.Sub(Requests{corev1.ResourceCPU: 5})
+				l.Sub(MapRequests{corev1.ResourceCPU: 5})
 			},
-			wantResult:        Requests{corev1.ResourceCPU: -5},
+			wantResult:        MapRequests{corev1.ResourceCPU: -5},
 			wantCachedCreated: true,
 			wantValid:         true,
 		},
@@ -498,7 +498,7 @@ func TestLazyRequests(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			var originalBase Requests
+			var originalBase MapRequests
 			if tc.base != nil {
 				originalBase = tc.base.Clone()
 			}

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -45,8 +45,8 @@ func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 	return json.Marshal(temp)
 }
 
-func (frq FlavorResourceQuantities) FlattenFlavors() Requests {
-	result := Requests{}
+func (frq FlavorResourceQuantities) FlattenFlavors() MapRequests {
+	result := MapRequests{}
 	for key, val := range frq {
 		result[key.Resource] += val.Int64()
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -708,7 +708,7 @@ func (a *FlavorAssigner) assignFlavors(log logr.Logger, counts []int32) Assignme
 	}
 
 	for _, podSets := range groupedRequests.InOrder {
-		requests := make(resources.Requests)
+		requests := make(resources.MapRequests)
 		psIDs := make([]int, len(podSets))
 		for idx, podset := range podSets {
 			psIDs[idx] = podset.originalIndex
@@ -888,7 +888,7 @@ func findRGIndicesByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.Reso
 	return indices
 }
 
-func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {
+func (a *Assignment) append(requests resources.MapRequests, psAssignment *PodSetAssignment) {
 	flavorIdx := make(map[corev1.ResourceName]int, len(psAssignment.Flavors))
 	a.PodSets = append(a.PodSets, *psAssignment)
 	for resource, flvAssignment := range psAssignment.Flavors {
@@ -936,7 +936,7 @@ func (a *Assignment) findOldPodSetRequest(psName kueue.PodSetReference, resource
 func (a *FlavorAssigner) findFlavorForPodSets(
 	log logr.Logger,
 	psIDs []int,
-	requests resources.Requests,
+	requests resources.MapRequests,
 	resName corev1.ResourceName,
 	assignmentUsage resources.FlavorResourceQuantities,
 ) (ResourceAssignment, *Status, FlavorAssignmentAttempts) {
@@ -1255,8 +1255,8 @@ func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {
 		(a.enableFairSharing && a.cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever)
 }
 
-func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.ResourceName]) resources.Requests {
-	filtered := make(resources.Requests)
+func filterRequestedResources(req resources.MapRequests, allowList sets.Set[corev1.ResourceName]) resources.MapRequests {
+	filtered := make(resources.MapRequests)
 	for n, v := range req {
 		if allowList.Has(n) {
 			filtered[n] = v

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3327,7 +3327,7 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
 						},
@@ -3393,7 +3393,7 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
 						},
@@ -4876,7 +4876,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 			want: workload.TASUsage{
 				"tas": []workload.TopologyDomainRequests{{
 					Values: []string{"node-a"},
-					SinglePodRequests: resources.NewRequests(corev1.ResourceList{
+					SinglePodRequests: resources.NewMapRequests(corev1.ResourceList{
 						corev1.ResourceCPU:           resource.MustParse("1"),
 						corev1.ResourceMemory:        resource.MustParse("1Gi"),
 						"example.com/gpu":            resource.MustParse("1"),

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -67,10 +67,10 @@ func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *
 		res := &containers[i].Resources
 		cMin := resource.MergeResourceListKeepMin(res.Requests, res.Limits)
 		cMax := resource.MergeResourceListKeepMax(res.Requests, res.Limits)
-		if resNames := resources.NewRequests(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
+		if resNames := resources.NewMapRequests(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewRequests(containerRange.Min).GreaterKeys(resources.NewRequests(cMin)); len(resNames) > 0 {
+		if resNames := resources.NewMapRequests(containerRange.Min).GreaterKeys(resources.NewMapRequests(cMin)); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}
@@ -87,7 +87,7 @@ func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) field.Err
 		if resNames := total.GreaterKeysRL(podRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewRequests(podRange.Min).GreaterKeys(total); len(resNames) > 0 {
+		if resNames := resources.NewMapRequests(podRange.Min).GreaterKeys(total); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -556,12 +556,12 @@ func TruncateAssignment(ta *TopologyAssignment, newCount int32) *TopologyAssignm
 }
 
 // ComputeUsagePerDomain calculates resource usage per topology domain from an assignment.
-func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.Requests) map[TopologyDomainID]resources.Requests {
-	usage := make(map[TopologyDomainID]resources.Requests)
+func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.MapRequests) map[TopologyDomainID]resources.MapRequests {
+	usage := make(map[TopologyDomainID]resources.MapRequests)
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
 		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
-		domainUsage.Add(resources.Requests{corev1.ResourcePods: int64(domain.Count)})
+		domainUsage.Add(resources.MapRequests{corev1.ResourcePods: int64(domain.Count)})
 		usage[domainID] = domainUsage
 	}
 	return usage

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -162,7 +162,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 		podSpecPath := PodSetsPath.Index(i).Child("template").Child("spec")
 		for i := range ps.Template.Spec.InitContainers {
 			c := ps.Template.Spec.InitContainers[i]
-			if resNames := resources.NewRequests(c.Resources.Requests).GreaterKeys(resources.NewRequests(c.Resources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewMapRequests(c.Resources.Requests).GreaterKeys(resources.NewMapRequests(c.Resources.Limits)); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("initContainers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
@@ -172,7 +172,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 
 		for i := range ps.Template.Spec.Containers {
 			c := ps.Template.Spec.Containers[i]
-			if resNames := resources.NewRequests(c.Resources.Requests).GreaterKeys(resources.NewRequests(c.Resources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewMapRequests(c.Resources.Requests).GreaterKeys(resources.NewMapRequests(c.Resources.Limits)); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("containers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
@@ -183,7 +183,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
 		// PodLevelResources feature is enabled and used.
 		if podResources := ps.Template.Spec.Resources; podResources != nil {
-			if resNames := resources.NewRequests(podResources.Requests).GreaterKeys(resources.NewRequests(podResources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewMapRequests(podResources.Requests).GreaterKeys(resources.NewMapRequests(podResources.Limits)); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("resources"), resNames, RequestsMustNotExceedLimitMessage),

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -247,7 +247,7 @@ type PodSetResources struct {
 	// Name is the name of the PodSet.
 	Name kueue.PodSetReference
 	// Requests incorporates the requests from all pods in the podset.
-	Requests resources.Requests
+	Requests resources.MapRequests
 	// Count indicates how many pods are in the podset.
 	Count int32
 
@@ -261,7 +261,7 @@ type PodSetResources struct {
 	Flavors map[corev1.ResourceName]kueue.ResourceFlavorReference
 }
 
-func (p *PodSetResources) SinglePodRequests() resources.Requests {
+func (p *PodSetResources) SinglePodRequests() resources.MapRequests {
 	return p.Requests.ScaledDown(int64(p.Count))
 }
 
@@ -272,12 +272,12 @@ type TopologyRequest struct {
 
 type TopologyDomainRequests struct {
 	Values            []string
-	SinglePodRequests resources.Requests
+	SinglePodRequests resources.MapRequests
 	// Count indicates how many pods are requested in this TopologyDomain.
 	Count int32
 }
 
-func (t *TopologyDomainRequests) TotalRequests() resources.Requests {
+func (t *TopologyDomainRequests) TotalRequests() resources.MapRequests {
 	return t.SinglePodRequests.ScaledUp(int64(t.Count))
 }
 
@@ -355,7 +355,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 	podSetShapes := make([]map[string]any, 0, len(wl.Spec.PodSets))
 	for i, ps := range wl.Spec.PodSets {
 		effectiveCount := ps.Count
-		var effectiveRequests resources.Requests
+		var effectiveRequests resources.MapRequests
 		if i < len(totalRequests) {
 			effectiveCount = totalRequests[i].Count
 			effectiveRequests = totalRequests[i].Requests
@@ -506,7 +506,7 @@ func (i *Info) TASUsage() TASUsage {
 }
 
 func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.ResourceList {
-	reqs := make(resources.Requests)
+	reqs := make(resources.MapRequests)
 	for _, psReqs := range i.TotalRequests {
 		reqs.Add(psReqs.Requests)
 	}
@@ -623,7 +623,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
-		setRes.Requests = resources.NewRequests(effectiveRequests)
+		setRes.Requests = resources.NewMapRequests(effectiveRequests)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
 			// First, remove extended resources that were converted to DRA logical resources
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {
@@ -635,7 +635,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
 					if setRes.Requests == nil {
-						setRes.Requests = make(resources.Requests)
+						setRes.Requests = make(resources.MapRequests)
 					}
 					setRes.Requests[resName] += resources.ResourceValue(resName, quantity)
 				}
@@ -660,7 +660,7 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 			Name:     psa.Name,
 			Flavors:  psa.Flavors,
 			Count:    ptr.Deref(psa.Count, totalCounts[psa.Name]),
-			Requests: resources.NewRequests(psa.ResourceUsage),
+			Requests: resources.NewMapRequests(psa.ResourceUsage),
 		}
 		if features.Enabled(features.TopologyAwareScheduling) && psa.TopologyAssignment != nil {
 			setRes.TopologyRequest = &TopologyRequest{

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -148,7 +148,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -176,7 +176,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 512 * 1024,
 						},
@@ -204,7 +204,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 512 * 1024,
 						},
@@ -227,7 +227,7 @@ func TestNewInfo(t *testing.T) {
 					{
 						Name:  kueue.DefaultPodSetName,
 						Count: 2147483647,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 9223372036854775807,
 						},
 					},
@@ -277,7 +277,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "driver",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -288,7 +288,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "workers",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    15,
 							corev1.ResourceMemory: 3 * 1024 * 1024,
 							"ex.com/gpu":          3,
@@ -335,7 +335,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceMemory:     "tas",
 							"example.com/logical-gpu": "quota",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:        2000,
 							corev1.ResourceMemory:     2 * 1024 * 1024 * 1024,
 							"example.com/logical-gpu": 2,
@@ -345,7 +345,7 @@ func TestNewInfo(t *testing.T) {
 							Levels: []string{corev1.LabelHostname},
 							DomainRequests: []TopologyDomainRequests{{
 								Values: []string{"node-a"},
-								SinglePodRequests: resources.Requests{
+								SinglePodRequests: resources.MapRequests{
 									corev1.ResourceCPU:           1000,
 									corev1.ResourceMemory:        1024 * 1024 * 1024,
 									"example.com/gpu":            1,
@@ -390,7 +390,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
 						},
@@ -431,7 +431,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 10 * 1024,
 						},
@@ -474,7 +474,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    2 * 10,
 							corev1.ResourceMemory: 2 * 10 * 1024,
 						},
@@ -515,7 +515,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    0,
 							corev1.ResourceMemory: 0,
 						},
@@ -550,7 +550,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
 						},
@@ -570,7 +570,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						},
@@ -649,7 +649,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "a",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 20 * 1024,
 							corev1.ResourceName("example.com/credits"):            35,
@@ -658,7 +658,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "b",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 4 * 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 80 * 1024,
 							corev1.ResourceName("example.com/credits"):            200,
@@ -668,7 +668,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "c",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceName("nvidia.com/vgpu"):            2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 20,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 1024,
@@ -677,7 +677,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "d",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceName("nvidia.com/vgpu"):            2 * 2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 2 * 30,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 2 * 2048,
@@ -716,7 +716,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							// 100m * 3000 = 300
 							corev1.ResourceName("example.com/cpu-credits"): 300,
 							// 100M * 3m = 300k
@@ -757,7 +757,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request(corev1.ResourceCPU, "200m").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.Requests{corev1.ResourceCPU: 200},
+				Requests: resources.MapRequests{corev1.ResourceCPU: 200},
 				Count:    1,
 			}},
 		},
@@ -780,7 +780,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request("example.com/gpu", "1").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.Requests{"example.com/gpu": 1},
+				Requests: resources.MapRequests{"example.com/gpu": 1},
 				Count:    1,
 			}},
 		},
@@ -798,7 +798,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.Requests{corev1.ResourceCPU: 200},
+				Requests: resources.MapRequests{corev1.ResourceCPU: 200},
 				Count:    1,
 			}},
 		},
@@ -820,7 +820,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 			updateOptions: []InfoOption{WithPreserveTotalRequests()},
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.Requests{"gpu": 1},
+				Requests: resources.MapRequests{"gpu": 1},
 				Count:    1,
 			}},
 		},
@@ -1307,7 +1307,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					},
@@ -1321,7 +1321,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, multiple flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					},
@@ -1340,7 +1340,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{
 					{
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 1_000,
 							"example.com/gpu":  3,
 						},
@@ -1350,7 +1350,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    2_000,
 							corev1.ResourceMemory: 2 * utiltesting.Gi,
 						},
@@ -1360,7 +1360,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							"example.com/gpu": 1,
 						},
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -1581,7 +1581,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1608,7 +1608,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU: 5000,
 						"nvidia.com/gpu":   1,
 					},
@@ -1634,7 +1634,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU:    5000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1661,7 +1661,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1688,7 +1688,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.Requests{
+					Requests: resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      2,
@@ -1724,7 +1724,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "ps1",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    10000,
 							corev1.ResourceMemory: 10 * 1024 * 1024,
 							"nvidia.com/gpu":      1,
@@ -1732,7 +1732,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 					},
 					{
 						Name: "ps2",
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU:    20000,
 							corev1.ResourceMemory: 20 * 1024 * 1024,
 							"nvidia.com/gpu":      2,
@@ -1992,7 +1992,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
 						},
@@ -2024,7 +2024,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
 						},
@@ -2032,7 +2032,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "worker",
 						Count: 2,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024,
 							"foo-accelerator":     2,
 						},
@@ -2061,7 +2061,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             1,
 						},
@@ -2069,7 +2069,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "worker",
 						Count: 1,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceMemory: 512 * 1024 * 1024,
 						},
 					},
@@ -2118,7 +2118,7 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpu":              1,
 						},
@@ -2148,7 +2148,7 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 2,
-						Requests: resources.Requests{
+						Requests: resources.MapRequests{
 							corev1.ResourceCPU: 200,
 							"gpu":              4,
 							"tpu":              2,


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Renames `resources.Requests` -> `resources.MapRequests`

This is a preparatory PR. In the next PRs I plan to introduce `Requests` interface that will be used instead of specific `resources.MapRequests` type. In the second PR I will introduce the second implementation of `Requests` interface that will be based on slices instead of maps. Implementation based on maps adds significant performance impact in hot paths during scheduling that requires preemption

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated resource request tracking to use a consistent map-based representation across workload admission/validation, scheduling, topology-aware placement, flavor assignment, and device resource accounting.
  * Kept capacity calculations, validation behavior, and scheduling outcomes aligned while improving consistency for CPU, memory, pod counts, and related arithmetic.
* **Tests**
  * Updated unit tests and expected values for workload resource accounting, topology usage, caching, and flavor assignment to match the new request representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->