### PR TITLE
Abstract resource.MapRequests behind Requests interface

### DIFF
--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -215,9 +215,9 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		option(opts)
 	}
 
-	var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
+	var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
 	if features.Enabled(features.TASHandleOverlappingFlavors) {
-		aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.MapRequests)
+		aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
 	}
 
 	result := make(TASAssignmentsResult)

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -194,11 +194,11 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 	}
 	tasSnapshots := make(map[kueue.ResourceFlavorReference]*TASFlavorSnapshot)
 	if features.Enabled(features.TopologyAwareScheduling) {
-		var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
+		var aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
 		flvTASCache := c.tasCache.Clone()
 
 		if features.Enabled(features.TASHandleOverlappingFlavors) {
-			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.MapRequests)
+			aggregatedDomainUsages = make(map[utiltas.TopologyDomainID]resources.Requests)
 			for _, cache := range flvTASCache {
 				c.snapshotTopologyDomainUsages(cache, aggregatedDomainUsages)
 			}
@@ -207,7 +207,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 		for flavor, cache := range flvTASCache {
 			// Only when this flavor is aggregation targets,
 			// we should propagate aggregated domain usages to snapshot constructions.
-			var aggregatedDomainUsagesForFlavor map[utiltas.TopologyDomainID]resources.MapRequests
+			var aggregatedDomainUsagesForFlavor map[utiltas.TopologyDomainID]resources.Requests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && utiltas.IsLowestLevelHostname(cache.topology.Levels) {
 				aggregatedDomainUsagesForFlavor = aggregatedDomainUsages
 			}
@@ -248,7 +248,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 }
 
 func (c *Cache) snapshotTopologyDomainUsages(
-	tasFlvCache *TASFlavorCache, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests,
+	tasFlvCache *TASFlavorCache, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
 ) {
 	tasFlvCache.RLock()
 	defer tasFlvCache.RUnlock()

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -54,7 +54,7 @@ func NewTASCache(client client.Client, schedulingSimulator simulator.SchedulingS
 		resourceFormatter: resourceFormatter,
 		nonTasUsageCache: &nonTasUsageCache{
 			podUsage:  make(map[types.NamespacedName]podUsageValue),
-			nodeUsage: make(map[string]resources.MapRequests),
+			nodeUsage: make(map[string]resources.Requests),
 			lock:      sync.RWMutex{},
 		},
 		nodesCache:          newNodesCache(),

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -392,7 +392,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 		pods                   []corev1.Pod
 		levels                 []string
 		nodeLabels             map[string]string
-		aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
 		priorFlavorUsage       []workload.TopologyDomainRequests
 		priorOwnUsage          []workload.TopologyDomainRequests
 		workload               *kueue.Workload
@@ -7817,7 +7817,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				)
 			}
 
-			var aggregatedDomainUsage map[tas.TopologyDomainID]resources.MapRequests
+			var aggregatedDomainUsage map[tas.TopologyDomainID]resources.Requests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsage = tc.aggregatedDomainUsages
 			}
@@ -7901,7 +7901,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 		unhealthyNode          string
 		topologyRequest        *kueue.PodSetTopologyRequest
 		count                  int32
-		aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
+		aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
 		priorFlavorUsage       []workload.TopologyDomainRequests
 		wantAssignment         *tas.TopologyAssignment
 		wantReason             string
@@ -8292,7 +8292,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 				)
 			}
 
-			var aggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests
+			var aggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsages = tc.aggregatedDomainUsages
 			}
@@ -8335,8 +8335,8 @@ func aggregatedDomainUsagesForPriorFlavorUsage(
 	flvInfo flavorInformation,
 	priorFlavorUsage []workload.TopologyDomainRequests,
 	cache *tasCache,
-	initialAggregatedDomainUsages map[tas.TopologyDomainID]resources.MapRequests,
-) map[tas.TopologyDomainID]resources.MapRequests {
+	initialAggregatedDomainUsages map[tas.TopologyDomainID]resources.Requests,
+) map[tas.TopologyDomainID]resources.Requests {
 	siblingCache := cache.NewTASFlavorCache(topologyInfo, flvInfo)
 	if len(priorFlavorUsage) > 0 {
 		siblingCache.addUsage(log, "prior-wl", priorFlavorUsage)
@@ -8344,7 +8344,7 @@ func aggregatedDomainUsagesForPriorFlavorUsage(
 
 	aggregatedDomainUsages := maps.Clone(initialAggregatedDomainUsages)
 	if aggregatedDomainUsages == nil {
-		aggregatedDomainUsages = make(map[tas.TopologyDomainID]resources.MapRequests, len(siblingCache.usage))
+		aggregatedDomainUsages = make(map[tas.TopologyDomainID]resources.Requests, len(siblingCache.usage))
 	}
 	for domainID, usage := range siblingCache.usage {
 		aggregatedDomainUsages[domainID] = usage.Clone()

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -38,7 +38,7 @@ func (s *TASFlavorSnapshot) handleElasticWorkload(
 	ctx context.Context,
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	if workers.PreviousAssignment == nil {
@@ -73,7 +73,7 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
 	previousCount int32,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
@@ -111,7 +111,7 @@ func (s *TASFlavorSnapshot) handleScaleDown(
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 ) elasticPlacementResult {
 	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
 	return s.finalizeElasticAssignment(workers, truncatedAssignment, leader, assumedUsage)
@@ -124,7 +124,7 @@ func (s *TASFlavorSnapshot) finalizeElasticAssignment(
 	workers TASPodSetRequests,
 	workersAssignment *utiltas.TopologyAssignment,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: workersAssignment}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -81,7 +81,7 @@ type TASFlavorCache struct {
 	flavor flavorInformation
 
 	// usage maintains the usage per topology domain
-	usage map[utiltas.TopologyDomainID]resources.MapRequests
+	usage map[utiltas.TopologyDomainID]resources.Requests
 
 	// wlUsage tracks the usage coming from workloads, so that we can make the
 	// usage removal indempotent - skip if it was not added.
@@ -104,7 +104,7 @@ func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 		client:              t.client,
 		topology:            topologyInfo,
 		flavor:              flavorInfo,
-		usage:               make(map[utiltas.TopologyDomainID]resources.MapRequests),
+		usage:               make(map[utiltas.TopologyDomainID]resources.Requests),
 		wlUsage:             make(map[workload.Reference][]workload.TopologyDomainRequests),
 		nonTasUsageCache:    t.nonTasUsageCache,
 		schedulingSimulator: t.schedulingSimulator,
@@ -153,10 +153,7 @@ func (c *TASFlavorCache) snapshot(
 	}
 	snapshot.initialize()
 
-	tasDomainUsages := make(map[utiltas.TopologyDomainID]resources.Requests, len(c.usage))
-	for k, v := range c.usage {
-		tasDomainUsages[k] = v
-	}
+	tasDomainUsages := c.usage
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
 		tasDomainUsages = aggregatedDomainUsages
 	}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -125,7 +125,7 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 }
 
 func (c *TASFlavorCache) snapshot(
-	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests,
+	log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
 ) (*TASFlavorSnapshot, error) {
 	c.RLock()
 	defer c.RUnlock()
@@ -153,7 +153,10 @@ func (c *TASFlavorCache) snapshot(
 	}
 	snapshot.initialize()
 
-	tasDomainUsages := c.usage
+	tasDomainUsages := make(map[utiltas.TopologyDomainID]resources.Requests, len(c.usage))
+	for k, v := range c.usage {
+		tasDomainUsages[k] = v
+	}
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
 		tasDomainUsages = aggregatedDomainUsages
 	}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -160,7 +160,7 @@ func (c *TASFlavorCache) snapshot(
 	for domainID, usage := range tasDomainUsages {
 		snapshot.addTASUsage(domainID, usage)
 	}
-	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.MapRequests) {
+	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -340,7 +340,7 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
 	if !leaf.cachedRemainingCapacity.IsValid() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		if !resources.IsEmpty(leaf.tasUsage) {
+		if !leaf.tasUsage.IsEmpty() {
 			leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
 		}
 	}
@@ -370,6 +370,9 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
+	if s.leaves[domainID].tasUsage == nil {
+		s.leaves[domainID].tasUsage = usage.CreateEmpty()
+	}
 	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
@@ -378,7 +381,7 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if req := resources.Clone(leaf.freeCapacity); req != nil {
+		if req := leaf.freeCapacity.Clone(); req != nil {
 			freeCapacityPerDomain[domainID] = req
 		}
 	}
@@ -390,7 +393,7 @@ func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]res
 	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if req := resources.Clone(leaf.tasUsage); req != nil {
+		if req := leaf.tasUsage.Clone(); req != nil {
 			tasUsagePerDomain[domainID] = req
 		}
 	}
@@ -413,12 +416,12 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 		freeCapacity := freeCapacityPerDomain[domain]
 		tasUsage := tasUsagePerDomain[domain]
 
-		freeCapacityDetails := make(map[corev1.ResourceName]string)
+		freeCapacityDetails := make(map[corev1.ResourceName]string, freeCapacity.Len())
 		resources.ForEach(freeCapacity, func(resourceName corev1.ResourceName, value int64) {
 			freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
 		})
 
-		tasUsageDetails := make(map[corev1.ResourceName]string)
+		tasUsageDetails := make(map[corev1.ResourceName]string, freeCapacity.Len())
 		resources.ForEach(tasUsage, func(resourceName corev1.ResourceName, value int64) {
 			tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
 		})
@@ -956,14 +959,12 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		},
 		stats: &tasExclusionStats{},
 	}
-	podReq := workersTasPodSetRequests.SinglePodRequests.Clone()
-	podReq.Add(resources.MapRequests{corev1.ResourcePods: 1})
-	requirements.requests = podReq
+	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
+	requirements.requests.Add(resources.MapRequests{corev1.ResourcePods: 1})
 
 	if leaderTasPodSetRequests != nil {
-		leaderReq := leaderTasPodSetRequests.SinglePodRequests.Clone()
-		leaderReq.Add(resources.MapRequests{corev1.ResourcePods: 1})
-		requirements.leaderRequests = leaderReq
+		requirements.leaderRequests = leaderTasPodSetRequests.SinglePodRequests.Clone()
+		requirements.leaderRequests.Add(resources.MapRequests{corev1.ResourcePods: 1})
 		state.leaderCount = 1
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -101,10 +101,10 @@ type leafDomain struct {
 	// freeCapacity represents the total node capacity minus the non-TAS usage,
 	// coming from Pods which are not managed by workloads admitted by TAS
 	// (typically static Pods, DaemonSets, or Deployments).
-	freeCapacity resources.MapRequests
+	freeCapacity resources.Requests
 
 	// tasUsage represents the usage associated with TAS workloads.
-	tasUsage resources.MapRequests
+	tasUsage resources.Requests
 
 	// cachedRemainingCapacity stores the pre-computed remaining capacity (freeCapacity - tasUsage) for this leaf.
 	// It is lazily calculated using LazyRequests and updated incrementally during TAS usage changes, avoiding repeated
@@ -312,10 +312,11 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 }
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.MapRequests) {
+	req := resources.NewRequestsFromMap(capacity)
 	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = resources.MapRequests{}
+		s.leaves[domainID].freeCapacity = req.CreateEmpty()
 	}
-	s.leaves[domainID].freeCapacity.Add(capacity)
+	s.leaves[domainID].freeCapacity.Add(req)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -323,7 +324,7 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
-	s.leaves[domainID].freeCapacity.Sub(usage)
+	s.leaves[domainID].freeCapacity.Sub(resources.NewRequestsFromMap(usage))
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -337,10 +338,10 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 	}
 }
 
-func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.MapRequests {
+func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
 	if !leaf.cachedRemainingCapacity.IsValid() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		if len(leaf.tasUsage) > 0 {
+		if leaf.tasUsage != nil {
 			leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
 		}
 	}
@@ -355,10 +356,11 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
+	u := resources.NewRequestsFromMap(usage)
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.MapRequests{}
+		s.leaves[domainID].tasUsage = u.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Add(usage)
+	s.leaves[domainID].tasUsage.Add(u)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -370,10 +372,11 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
+	u := resources.NewRequestsFromMap(usage)
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.MapRequests{}
+		s.leaves[domainID].tasUsage = u.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Sub(usage)
+	s.leaves[domainID].tasUsage.Sub(u)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -381,7 +384,7 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		freeCapacityPerDomain[domainID] = leaf.freeCapacity.Clone()
+		freeCapacityPerDomain[domainID] = leaf.freeCapacity.ToMapRequests().Clone()
 	}
 
 	return freeCapacityPerDomain
@@ -391,7 +394,7 @@ func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]res
 	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		tasUsagePerDomain[domainID] = leaf.tasUsage.Clone()
+		tasUsagePerDomain[domainID] = leaf.tasUsage.ToMapRequests().Clone()
 	}
 
 	return tasUsagePerDomain
@@ -500,7 +503,8 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 			return false
 		}
 		remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
-		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
+		req := resources.NewRequestsFromMap(domainUsage.SinglePodRequests)
+		if req.CountIn(remainingCapacity.Get()) < domainUsage.Count {
 			return false
 		}
 	}
@@ -521,8 +525,8 @@ type tasExclusionStats struct {
 
 type topologyAssignmentPodRequirements struct {
 	podRequirements           simulator.PodRequirements
-	requests                  resources.MapRequests
-	leaderRequests            *resources.MapRequests
+	requests                  resources.Requests
+	leaderRequests            resources.Requests
 	assumedUsage              map[utiltas.TopologyDomainID]resources.MapRequests
 	requiredReplacementDomain utiltas.TopologyDomainID
 	simulateEmpty             bool
@@ -957,12 +961,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		},
 		stats: &tasExclusionStats{},
 	}
-	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
-	requirements.requests.Add(resources.MapRequests{corev1.ResourcePods: 1})
+	podReq := workersTasPodSetRequests.SinglePodRequests.Clone()
+	podReq.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: 1}))
+	requirements.requests = resources.NewRequestsFromMap(podReq)
 
 	if leaderTasPodSetRequests != nil {
-		requirements.leaderRequests = new(leaderTasPodSetRequests.SinglePodRequests.Clone())
-		requirements.leaderRequests.Add(resources.MapRequests{corev1.ResourcePods: 1})
+		leaderReq := leaderTasPodSetRequests.SinglePodRequests.Clone()
+		leaderReq.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: 1}))
+		requirements.leaderRequests = resources.NewRequestsFromMap(leaderReq)
 		state.leaderCount = 1
 	}
 
@@ -1861,7 +1867,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.simulateEmpty, cachingRemainingResourcesEnabled)
 
 	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
-		remainingCapacity.Sub(leafAssumedUsage)
+		remainingCapacity.Sub(resources.NewRequestsFromMap(leafAssumedUsage))
 	}
 	var limitingRes corev1.ResourceName
 	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
@@ -1875,7 +1881,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	leaf.leaderState = 0
 	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity.Get()) > 0 {
 		leaf.leaderState = 1
-		remainingCapacity.Sub(*requirements.leaderRequests)
+		remainingCapacity.Sub(requirements.leaderRequests)
 	}
 
 	leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -327,7 +327,7 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests, op usageOp, count int32) {
+func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
 	u := usage.Clone()
 	u.Add(resources.MapRequests{corev1.ResourcePods: int64(count)})
 	if op == add {
@@ -437,7 +437,7 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 type TASPodSetRequests struct {
 	PodSet            *kueue.PodSet
 	PodSetUpdates     []*kueue.PodSetUpdate
-	SinglePodRequests resources.MapRequests
+	SinglePodRequests resources.Requests
 	Count             int32
 	Flavor            kueue.ResourceFlavorReference
 	Implied           bool
@@ -447,7 +447,7 @@ type TASPodSetRequests struct {
 	PreviousAssignment *kueue.TopologyAssignment
 }
 
-func (t *TASPodSetRequests) TotalRequests() resources.MapRequests {
+func (t *TASPodSetRequests) TotalRequests() resources.Requests {
 	return t.SinglePodRequests.ScaledUp(int64(t.Count))
 }
 
@@ -788,10 +788,10 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 	addUsagePerDomain(assumedUsage, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
 }
 
-func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.MapRequests) {
+func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.MapRequests{}
+			assumedUsage[domainID] = resources.CreateEmpty()
 		}
 		assumedUsage[domainID].Add(usage)
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -312,11 +312,10 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 }
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.MapRequests) {
-	req := resources.NewRequestsFromMap(capacity)
 	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = req.CreateEmpty()
+		s.leaves[domainID].freeCapacity = capacity.CreateEmpty()
 	}
-	s.leaves[domainID].freeCapacity.Add(req)
+	s.leaves[domainID].freeCapacity.Add(capacity)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -324,7 +323,7 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
-	s.leaves[domainID].freeCapacity.Sub(resources.NewRequestsFromMap(usage))
+	s.leaves[domainID].freeCapacity.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -356,11 +355,10 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	u := resources.NewRequestsFromMap(usage)
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = u.CreateEmpty()
+		s.leaves[domainID].tasUsage = usage.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Add(u)
+	s.leaves[domainID].tasUsage.Add(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -372,11 +370,10 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	u := resources.NewRequestsFromMap(usage)
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = u.CreateEmpty()
+		s.leaves[domainID].tasUsage = usage.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Sub(u)
+	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
@@ -384,7 +381,9 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		freeCapacityPerDomain[domainID] = leaf.freeCapacity.ToMapRequests().Clone()
+		if m, ok := leaf.freeCapacity.(resources.MapRequests); ok {
+			freeCapacityPerDomain[domainID] = m.Clone()
+		}
 	}
 
 	return freeCapacityPerDomain
@@ -394,7 +393,9 @@ func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]res
 	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		tasUsagePerDomain[domainID] = leaf.tasUsage.ToMapRequests().Clone()
+		if m, ok := leaf.tasUsage.(resources.MapRequests); ok {
+			tasUsagePerDomain[domainID] = m.Clone()
+		}
 	}
 
 	return tasUsagePerDomain
@@ -503,8 +504,7 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 			return false
 		}
 		remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
-		req := resources.NewRequestsFromMap(domainUsage.SinglePodRequests)
-		if req.CountIn(remainingCapacity.Get()) < domainUsage.Count {
+		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
 			return false
 		}
 	}
@@ -962,13 +962,13 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		stats: &tasExclusionStats{},
 	}
 	podReq := workersTasPodSetRequests.SinglePodRequests.Clone()
-	podReq.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: 1}))
-	requirements.requests = resources.NewRequestsFromMap(podReq)
+	podReq.Add(resources.MapRequests{corev1.ResourcePods: 1})
+	requirements.requests = podReq
 
 	if leaderTasPodSetRequests != nil {
 		leaderReq := leaderTasPodSetRequests.SinglePodRequests.Clone()
-		leaderReq.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: 1}))
-		requirements.leaderRequests = resources.NewRequestsFromMap(leaderReq)
+		leaderReq.Add(resources.MapRequests{corev1.ResourcePods: 1})
+		requirements.leaderRequests = leaderReq
 		state.leaderCount = 1
 	}
 
@@ -1867,7 +1867,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.simulateEmpty, cachingRemainingResourcesEnabled)
 
 	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
-		remainingCapacity.Sub(resources.NewRequestsFromMap(leafAssumedUsage))
+		remainingCapacity.Sub(leafAssumedUsage)
 	}
 	var limitingRes corev1.ResourceName
 	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -954,11 +954,11 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		stats: &tasExclusionStats{},
 	}
 	requirements.requests = workersTasPodSetRequests.SinglePodRequests.Clone()
-	requirements.requests.Add(resources.MapRequests{corev1.ResourcePods: 1})
+	requirements.requests.Add(resources.OnePodRequest)
 
 	if leaderTasPodSetRequests != nil {
 		requirements.leaderRequests = leaderTasPodSetRequests.SinglePodRequests.Clone()
-		requirements.leaderRequests.Add(resources.MapRequests{corev1.ResourcePods: 1})
+		requirements.leaderRequests.Add(resources.OnePodRequest)
 		state.leaderCount = 1
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -313,7 +313,7 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
 	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = capacity.CreateEmpty()
+		s.leaves[domainID].freeCapacity = resources.CreateEmpty()
 	}
 	s.leaves[domainID].freeCapacity.Add(capacity)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -338,7 +338,7 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
-	if !leaf.cachedRemainingCapacity.IsValid() {
+	if leaf.cachedRemainingCapacity.IsEmpty() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
 		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
 	}
@@ -354,7 +354,7 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = usage.CreateEmpty()
+		s.leaves[domainID].tasUsage = resources.CreateEmpty()
 	}
 	s.leaves[domainID].tasUsage.Add(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -369,7 +369,7 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = usage.CreateEmpty()
+		s.leaves[domainID].tasUsage = resources.CreateEmpty()
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -311,7 +311,7 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 	parent.children = append(parent.children, dom)
 }
 
-func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.MapRequests) {
+func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
 	if s.leaves[domainID].freeCapacity == nil {
 		s.leaves[domainID].freeCapacity = capacity.CreateEmpty()
 	}
@@ -319,7 +319,7 @@ func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capac
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
+func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
 	// least one TAS pod, and so the addCapacity function to initialize
 	// freeCapacity is already called.
@@ -347,7 +347,7 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 	return leaf.cachedRemainingCapacity.Get()
 }
 
-func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
+func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
@@ -362,16 +362,13 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.MapRequests) {
+func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
 		// function was not called).
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
-	}
-	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = usage.CreateEmpty()
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -381,8 +378,8 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if !resources.IsEmpty(leaf.freeCapacity) {
-			freeCapacityPerDomain[domainID] = leaf.freeCapacity.CloneRequests()
+		if req := resources.Clone(leaf.freeCapacity); req != nil {
+			freeCapacityPerDomain[domainID] = req
 		}
 	}
 
@@ -393,8 +390,8 @@ func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]res
 	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if !resources.IsEmpty(leaf.tasUsage) {
-			tasUsagePerDomain[domainID] = leaf.tasUsage.CloneRequests()
+		if req := resources.Clone(leaf.tasUsage); req != nil {
+			tasUsagePerDomain[domainID] = req
 		}
 	}
 
@@ -417,18 +414,14 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 		tasUsage := tasUsagePerDomain[domain]
 
 		freeCapacityDetails := make(map[corev1.ResourceName]string)
-		if freeCapacity != nil {
-			freeCapacity.ForEach(func(resourceName corev1.ResourceName, value int64) {
-				freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
-			})
-		}
+		resources.ForEach(freeCapacity, func(resourceName corev1.ResourceName, value int64) {
+			freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+		})
 
 		tasUsageDetails := make(map[corev1.ResourceName]string)
-		if tasUsage != nil {
-			tasUsage.ForEach(func(resourceName corev1.ResourceName, value int64) {
-				tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
-			})
-		}
+		resources.ForEach(tasUsage, func(resourceName corev1.ResourceName, value int64) {
+			tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+		})
 
 		details[domain] = domainCapacityDetails{
 			FreeCapacity: freeCapacityDetails,
@@ -516,7 +509,7 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 type findTopologyAssignmentsOption struct {
 	simulateEmpty          bool
 	workload               *kueue.Workload
-	aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.MapRequests
+	aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
 }
 
 type tasExclusionStats struct {
@@ -529,7 +522,7 @@ type topologyAssignmentPodRequirements struct {
 	podRequirements           simulator.PodRequirements
 	requests                  resources.Requests
 	leaderRequests            resources.Requests
-	assumedUsage              map[utiltas.TopologyDomainID]resources.MapRequests
+	assumedUsage              map[utiltas.TopologyDomainID]resources.Requests
 	requiredReplacementDomain utiltas.TopologyDomainID
 	simulateEmpty             bool
 	matchKey                  *podSetMatchKey
@@ -630,7 +623,7 @@ func WithWorkload(wl *kueue.Workload) FindTopologyAssignmentsOption {
 // WithAggregatedDomainUsages supplies a cross-flavor assumedUsage so that
 // per-PodSet TAS placements within a single workload account for reservations
 // already made in sibling flavors sharing the same Topology (hostname leaf).
-func WithAggregatedDomainUsages(m map[utiltas.TopologyDomainID]resources.MapRequests) FindTopologyAssignmentsOption {
+func WithAggregatedDomainUsages(m map[utiltas.TopologyDomainID]resources.Requests) FindTopologyAssignmentsOption {
 	return func(o *findTopologyAssignmentsOption) {
 		o.aggregatedDomainUsages = m
 	}
@@ -646,7 +639,7 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(ctx context.Context
 	}
 
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
-	assumedUsage := make(map[utiltas.TopologyDomainID]resources.MapRequests)
+	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
 	if features.Enabled(features.TASHandleOverlappingFlavors) && opts.aggregatedDomainUsages != nil {
 		assumedUsage = opts.aggregatedDomainUsages
 	}
@@ -751,7 +744,7 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	tr *TASPodSetRequests,
 	existingAssignment *utiltas.TopologyAssignment,
 	wl *kueue.Workload,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 ) (*utiltas.TopologyAssignment, *utiltas.TopologyAssignment, string) {
 	tr.Count = deleteDomain(existingAssignment, wl.Status.UnhealthyNodes[0].Name)
 	if isStale, staleDomain := s.IsTopologyAssignmentStale(existingAssignment); isStale {
@@ -794,11 +787,11 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	return newAssignment, replacementAssignment[tr.PodSet.Name], ""
 }
 
-func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
+func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
 	addUsagePerDomain(assumedUsage, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
 }
 
-func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests, usagePerDomain map[utiltas.TopologyDomainID]resources.MapRequests) {
+func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.MapRequests) {
 	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
 			assumedUsage[domainID] = resources.MapRequests{}
@@ -950,7 +943,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	ctx context.Context,
 	workersTasPodSetRequests TASPodSetRequests,
 	leaderTasPodSetRequests *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.MapRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
 	requirements := &topologyAssignmentPodRequirements{
 		assumedUsage:              assumedUsage,

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -340,9 +340,7 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
 	if !leaf.cachedRemainingCapacity.IsValid() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		if !leaf.tasUsage.IsEmpty() {
-			leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
-		}
+		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
 	}
 	return leaf.cachedRemainingCapacity.Get()
 }
@@ -381,9 +379,7 @@ func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID
 	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if req := leaf.freeCapacity.Clone(); req != nil {
-			freeCapacityPerDomain[domainID] = req
-		}
+		freeCapacityPerDomain[domainID] = leaf.freeCapacity.Clone()
 	}
 
 	return freeCapacityPerDomain
@@ -393,9 +389,7 @@ func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]res
 	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if req := leaf.tasUsage.Clone(); req != nil {
-			tasUsagePerDomain[domainID] = req
-		}
+		tasUsagePerDomain[domainID] = leaf.tasUsage.Clone()
 	}
 
 	return tasUsagePerDomain
@@ -412,17 +406,17 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
-	for _, domain := range slices.Sorted(maps.Keys(s.leaves)) {
+	for _, domain := range slices.Sorted(maps.Keys(freeCapacityPerDomain)) {
 		freeCapacity := freeCapacityPerDomain[domain]
 		tasUsage := tasUsagePerDomain[domain]
 
 		freeCapacityDetails := make(map[corev1.ResourceName]string, freeCapacity.Len())
-		resources.ForEach(freeCapacity, func(resourceName corev1.ResourceName, value int64) {
+		freeCapacity.ForEach(func(resourceName corev1.ResourceName, value int64) {
 			freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
 		})
 
-		tasUsageDetails := make(map[corev1.ResourceName]string, freeCapacity.Len())
-		resources.ForEach(tasUsage, func(resourceName corev1.ResourceName, value int64) {
+		tasUsageDetails := make(map[corev1.ResourceName]string, tasUsage.Len())
+		tasUsage.ForEach(func(resourceName corev1.ResourceName, value int64) {
 			tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
 		})
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -340,7 +340,7 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
 	if !leaf.cachedRemainingCapacity.IsValid() {
 		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		if leaf.tasUsage != nil {
+		if !resources.IsEmpty(leaf.tasUsage) {
 			leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
 		}
 	}
@@ -377,24 +377,24 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.MapRequests {
-	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
+func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.Requests {
+	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if m, ok := leaf.freeCapacity.(resources.MapRequests); ok {
-			freeCapacityPerDomain[domainID] = m.Clone()
+		if !resources.IsEmpty(leaf.freeCapacity) {
+			freeCapacityPerDomain[domainID] = leaf.freeCapacity.CloneRequests()
 		}
 	}
 
 	return freeCapacityPerDomain
 }
 
-func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]resources.MapRequests {
-	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.MapRequests, len(s.leaves))
+func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]resources.Requests {
+	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		if m, ok := leaf.tasUsage.(resources.MapRequests); ok {
-			tasUsagePerDomain[domainID] = m.Clone()
+		if !resources.IsEmpty(leaf.tasUsage) {
+			tasUsagePerDomain[domainID] = leaf.tasUsage.CloneRequests()
 		}
 	}
 
@@ -412,20 +412,22 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
-	for _, domain := range slices.Sorted(maps.Keys(freeCapacityPerDomain)) {
+	for _, domain := range slices.Sorted(maps.Keys(s.leaves)) {
 		freeCapacity := freeCapacityPerDomain[domain]
 		tasUsage := tasUsagePerDomain[domain]
 
-		freeCapacityDetails := make(map[corev1.ResourceName]string, len(freeCapacity))
-		for _, resourceName := range slices.Sorted(maps.Keys(freeCapacity)) {
-			value := freeCapacity[resourceName]
-			freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+		freeCapacityDetails := make(map[corev1.ResourceName]string)
+		if freeCapacity != nil {
+			freeCapacity.ForEach(func(resourceName corev1.ResourceName, value int64) {
+				freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+			})
 		}
 
-		tasUsageDetails := make(map[corev1.ResourceName]string, len(freeCapacity))
-		for _, resourceName := range slices.Sorted(maps.Keys(tasUsage)) {
-			value := tasUsage[resourceName]
-			tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+		tasUsageDetails := make(map[corev1.ResourceName]string)
+		if tasUsage != nil {
+			tasUsage.ForEach(func(resourceName corev1.ResourceName, value int64) {
+				tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+			})
 		}
 
 		details[domain] = domainCapacityDetails{

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -760,14 +760,14 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 
 func TestAddAssumedUsage(t *testing.T) {
 	cases := map[string]struct {
-		assumedUsage map[tas.TopologyDomainID]resources.MapRequests
+		assumedUsage map[tas.TopologyDomainID]resources.Requests
 		assignment   *tas.TopologyAssignment
 		tasRequests  *TASPodSetRequests
-		want         map[tas.TopologyDomainID]resources.MapRequests
+		want         map[tas.TopologyDomainID]resources.Requests
 	}{
 		"includes pod count for existing and new domains": {
-			assumedUsage: map[tas.TopologyDomainID]resources.MapRequests{
-				"node-a": {
+			assumedUsage: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": resources.MapRequests{
 					corev1.ResourceCPU:  1000,
 					corev1.ResourcePods: 1,
 				},
@@ -785,13 +785,13 @@ func TestAddAssumedUsage(t *testing.T) {
 					corev1.ResourceMemory: 2048,
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.MapRequests{
-				"node-a": {
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": resources.MapRequests{
 					corev1.ResourceCPU:    1500,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
 				},
-				"node-b": {
+				"node-b": resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 4096,
 					corev1.ResourcePods:   2,
@@ -799,7 +799,7 @@ func TestAddAssumedUsage(t *testing.T) {
 			},
 		},
 		"includes pod count starting from empty assumed usage": {
-			assumedUsage: map[tas.TopologyDomainID]resources.MapRequests{},
+			assumedUsage: map[tas.TopologyDomainID]resources.Requests{},
 			assignment: &tas.TopologyAssignment{
 				Levels: []string{"hostname"},
 				Domains: []tas.TopologyDomainAssignment{
@@ -812,8 +812,8 @@ func TestAddAssumedUsage(t *testing.T) {
 					corev1.ResourceMemory: 512,
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.MapRequests{
-				"node-a": {
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": resources.MapRequests{
 					corev1.ResourceCPU:    750,
 					corev1.ResourceMemory: 1536,
 					corev1.ResourcePods:   3,

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -701,14 +701,14 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 
 	cases := map[string]struct {
 		assignment *tas.TopologyAssignment
-		want       map[tas.TopologyDomainID]resources.MapRequests
+		want       map[tas.TopologyDomainID]resources.Requests
 	}{
 		"empty assignment": {
 			assignment: &tas.TopologyAssignment{
 				Levels:  []string{"hostname"},
 				Domains: nil,
 			},
-			want: map[tas.TopologyDomainID]resources.MapRequests{},
+			want: map[tas.TopologyDomainID]resources.Requests{},
 		},
 		"single domain with one pod": {
 			assignment: &tas.TopologyAssignment{
@@ -717,8 +717,8 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 					{Values: []string{"node-a"}, Count: 1},
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.MapRequests{
-				"node-a": {
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 1024,
 					corev1.ResourcePods:   1,
@@ -733,13 +733,13 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 					{Values: []string{"node-b"}, Count: 3},
 				},
 			},
-			want: map[tas.TopologyDomainID]resources.MapRequests{
-				"node-a": {
+			want: map[tas.TopologyDomainID]resources.Requests{
+				"node-a": resources.MapRequests{
 					corev1.ResourceCPU:    2000,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
 				},
-				"node-b": {
+				"node-b": resources.MapRequests{
 					corev1.ResourceCPU:    3000,
 					corev1.ResourceMemory: 3072,
 					corev1.ResourcePods:   3,

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -127,7 +127,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cache := &TASFlavorCache{
 				wlUsage: make(map[workload.Reference][]workload.TopologyDomainRequests),
-				usage:   make(map[utiltas.TopologyDomainID]resources.MapRequests),
+				usage:   make(map[utiltas.TopologyDomainID]resources.Requests),
 			}
 
 			tc.operations(cache)

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -36,7 +36,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 	testCases := []struct {
 		name       string
 		operations func(cache *TASFlavorCache)
-		wantUsage  map[utiltas.TopologyDomainID]resources.MapRequests
+		wantUsage  map[utiltas.TopologyDomainID]resources.Requests
 	}{
 		{
 			name: "add usage",
@@ -51,8 +51,8 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					},
 				})
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
-				"domain1": {
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": resources.MapRequests{
 					corev1.ResourceCPU:  4,
 					corev1.ResourcePods: 2,
 				},
@@ -82,12 +82,12 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					},
 				})
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
-				"domain1": {
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": resources.MapRequests{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
 				},
-				"domain2": {
+				"domain2": resources.MapRequests{
 					corev1.ResourceCPU:  6,
 					corev1.ResourcePods: 2,
 				},
@@ -107,8 +107,8 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 				})
 				cache.removeUsage(logr, wlKey)
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{
-				"domain1": {
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
+				"domain1": resources.MapRequests{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
 				},
@@ -119,7 +119,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 			operations: func(cache *TASFlavorCache) {
 				cache.removeUsage(logr, wlKey)
 			},
-			wantUsage: map[utiltas.TopologyDomainID]resources.MapRequests{},
+			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{},
 		},
 	}
 

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -32,13 +32,13 @@ import (
 // the hot path documented in kueue#8449.
 type nonTasUsageCache struct {
 	podUsage  map[types.NamespacedName]podUsageValue
-	nodeUsage map[string]resources.MapRequests // pre-aggregated per-node totals
+	nodeUsage map[string]resources.Requests // pre-aggregated per-node totals
 	lock      sync.RWMutex
 }
 
 type podUsageValue struct {
 	node  string
-	usage resources.MapRequests
+	usage resources.Requests
 }
 
 // update may add a pod to the cache, or
@@ -85,7 +85,7 @@ func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
 // forEachNodeUsage invokes fn for each node's usage while holding the read lock.
 // usage is the live cache entry, not a copy: fn must only read it, and must not
 // mutate or retain it beyond the call. Clone it if a longer-lived copy is needed.
-func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources.MapRequests)) {
+func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources.Requests)) {
 	n.lock.RLock()
 	defer n.lock.RUnlock()
 	for node, reqs := range n.nodeUsage {
@@ -95,24 +95,24 @@ func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources
 
 // addNodeUsage increments the pre-aggregated per-node usage.
 // Must be called under write lock.
-func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.MapRequests) {
+func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 	if _, found := n.nodeUsage[node]; !found {
 		n.nodeUsage[node] = resources.MapRequests{}
 	}
 	n.nodeUsage[node].Add(usage)
-	n.nodeUsage[node][corev1.ResourcePods]++
+	n.nodeUsage[node].Add(resources.MapRequests{corev1.ResourcePods: 1})
 }
 
 // removeNodeUsage decrements the pre-aggregated per-node usage.
 // Must be called under write lock.
-func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.MapRequests, log logr.Logger) {
+func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.Requests, log logr.Logger) {
 	existing, found := n.nodeUsage[node]
 	if !found {
 		return
 	}
 	existing.Sub(usage)
-	existing[corev1.ResourcePods]--
-	if pods := existing[corev1.ResourcePods]; pods <= 0 {
+	existing.Sub(resources.MapRequests{corev1.ResourcePods: 1})
+	if pods := existing.GetValue(corev1.ResourcePods); pods <= 0 {
 		if pods < 0 {
 			log.V(0).Info("Unexpected negative pod count in nodeUsage", "node", node, "podCount", pods)
 		}

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -65,7 +65,7 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
 	}
 
 	log.V(5).Info("Adding non-TAS pod to the cache")
-	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
+	requests := resources.NewMapRequestsFromPodSpec(&pod.Spec)
 	n.podUsage[key] = podUsageValue{
 		node:  pod.Spec.NodeName,
 		usage: requests,

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -100,7 +100,7 @@ func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 		n.nodeUsage[node] = resources.MapRequests{}
 	}
 	n.nodeUsage[node].Add(usage)
-	n.nodeUsage[node].Add(resources.MapRequests{corev1.ResourcePods: 1})
+	n.nodeUsage[node].Add(resources.OnePodRequest)
 }
 
 // removeNodeUsage decrements the pre-aggregated per-node usage.
@@ -111,7 +111,7 @@ func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.Requests
 		return
 	}
 	existing.Sub(usage)
-	existing.Sub(resources.MapRequests{corev1.ResourcePods: 1})
+	existing.Sub(resources.OnePodRequest)
 	if pods := existing.GetValue(corev1.ResourcePods); pods <= 0 {
 		if pods < 0 {
 			log.V(0).Info("Unexpected negative pod count in nodeUsage", "node", node, "podCount", pods)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/resources"
@@ -34,13 +33,13 @@ import (
 // and verifies it matches the incremental nodeUsage.
 func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	t.Helper()
-	expected := make(map[string]resources.MapRequests)
+	expected := make(map[string]resources.Requests)
 	for _, pv := range cache.podUsage {
 		if _, found := expected[pv.node]; !found {
 			expected[pv.node] = resources.MapRequests{}
 		}
 		expected[pv.node].Add(pv.usage)
-		expected[pv.node][corev1.ResourcePods]++
+		expected[pv.node].Add(resources.MapRequests{corev1.ResourcePods: 1})
 	}
 	got := collectNodeUsage(cache)
 	if diff := cmp.Diff(expected, got); diff != "" {
@@ -50,7 +49,7 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 
 func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.Requests {
 	usage := make(map[string]resources.Requests, len(cache.nodeUsage))
-	cache.forEachNodeUsage(func(node string, reqs resources.MapRequests) {
+	cache.forEachNodeUsage(func(node string, reqs resources.Requests) {
 		usage[node] = reqs.Clone()
 	})
 	return usage
@@ -83,7 +82,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 		// podsDelete is the set of pod keys to delete from the cache after
 		// initialPods are applied (and after podsUpdate, if any).
 		podsDelete    []client.ObjectKey
-		wantNodeUsage map[string]resources.MapRequests
+		wantNodeUsage map[string]resources.Requests
 	}{
 		"add then delete same pod": {
 			initialPods: []*corev1.Pod{makePod("pod1", "ns", "node-a", "2")},
@@ -94,8 +93,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod1", "ns", "node-a", "1"),
 				makePod("pod2", "ns", "node-a", "2"),
 			},
-			wantNodeUsage: map[string]resources.MapRequests{
-				"node-a": {corev1.ResourceCPU: 3000, corev1.ResourcePods: 2},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": resources.MapRequests{corev1.ResourceCPU: 3000, corev1.ResourcePods: 2},
 			},
 		},
 		"pod moves between nodes cleans up source node": {
@@ -103,8 +102,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.NodeName = "node-b"
 			},
-			wantNodeUsage: map[string]resources.MapRequests{
-				"node-b": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-b": resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
 			},
 		},
 		"pod resize on same node updates usage to new requests": {
@@ -112,8 +111,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
 			},
-			wantNodeUsage: map[string]resources.MapRequests{
-				"node-a": {corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
 			},
 		},
 		"resize one of two pods on same node updates only that pod's contribution": {
@@ -124,8 +123,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			podsUpdate: func(pods []*corev1.Pod) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("3")
 			},
-			wantNodeUsage: map[string]resources.MapRequests{
-				"node-a": {corev1.ResourceCPU: 5000, corev1.ResourcePods: 2},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": resources.MapRequests{corev1.ResourceCPU: 5000, corev1.ResourcePods: 2},
 			},
 		},
 		"terminated pod removes usage": {
@@ -143,8 +142,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod2", "ns", "node-a", "1"),
 			},
 			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
-			wantNodeUsage: map[string]resources.MapRequests{
-				"node-a": {corev1.ResourceCPU: 1000, corev1.ResourcePods: 1},
+			wantNodeUsage: map[string]resources.Requests{
+				"node-a": resources.MapRequests{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1},
 			},
 		},
 		"removing last pod cleans up node entry": {
@@ -163,8 +162,8 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			cache := &nonTasUsageCache{
-				podUsage:  make(map[types.NamespacedName]podUsageValue),
-				nodeUsage: make(map[string]resources.MapRequests),
+				podUsage:  make(map[client.ObjectKey]podUsageValue),
+				nodeUsage: make(map[string]resources.Requests),
 			}
 
 			for _, pod := range tc.initialPods {
@@ -184,7 +183,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 
 			wantUsage := tc.wantNodeUsage
 			if wantUsage == nil {
-				wantUsage = map[string]resources.MapRequests{}
+				wantUsage = map[string]resources.Requests{}
 			}
 			if diff := cmp.Diff(wantUsage, collectNodeUsage(cache)); diff != "" {
 				t.Errorf("collectNodeUsage() mismatch (-want +got):\n%s", diff)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -39,7 +39,7 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 			expected[pv.node] = resources.MapRequests{}
 		}
 		expected[pv.node].Add(pv.usage)
-		expected[pv.node].Add(resources.MapRequests{corev1.ResourcePods: 1})
+		expected[pv.node].Add(resources.OnePodRequest)
 	}
 	got := collectNodeUsage(cache)
 	if diff := cmp.Diff(expected, got); diff != "" {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -51,7 +51,7 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.MapRequests {
 	usage := map[string]resources.MapRequests{}
 	cache.forEachNodeUsage(func(node string, reqs resources.MapRequests) {
-		usage[node] = reqs.Clone()
+		usage[node] = reqs.Clone().(resources.MapRequests)
 	})
 	return usage
 }

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -48,10 +48,10 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	}
 }
 
-func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.MapRequests {
-	usage := map[string]resources.MapRequests{}
+func collectNodeUsage(cache *nonTasUsageCache) map[string]resources.Requests {
+	usage := make(map[string]resources.Requests, len(cache.nodeUsage))
 	cache.forEachNodeUsage(func(node string, reqs resources.MapRequests) {
-		usage[node] = reqs.Clone().(resources.MapRequests)
+		usage[node] = reqs.Clone()
 	})
 	return usage
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -23,6 +23,7 @@ import (
 // Requests represents an abstract collection of resource requests.
 type Requests interface {
 	Clone() Requests
+	ScaledUp(f int64) Requests
 	Add(other Requests)
 	Sub(other Requests)
 	CountIn(capacity Requests) int32

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -30,4 +30,5 @@ type Requests interface {
 	GetValue(name corev1.ResourceName) int64
 	ForEach(fn func(name corev1.ResourceName, val int64))
 	Len() int
+	IsEmpty() bool
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -28,23 +28,5 @@ type Requests interface {
 	Sub(other Requests)
 	CountIn(capacity Requests) int32
 	CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName)
-	ToMapRequests() MapRequests
-}
-
-// NewRequests creates a Requests interface from a Kubernetes ResourceList.
-func NewRequests(rl corev1.ResourceList) Requests {
-	return NewMapRequests(rl)
-}
-
-// NewRequestsFromMap creates a Requests interface wrapping the provided MapRequests map.
-func NewRequestsFromMap(m MapRequests) Requests {
-	if m == nil {
-		return nil
-	}
-	return m
-}
-
-// NewRequestsFromPodSpec creates a Requests interface from a PodSpec.
-func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
-	return NewMapRequestsFromPodSpec(podSpec)
+	GetValue(name corev1.ResourceName) int64
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -23,7 +23,6 @@ import (
 // Requests represents an abstract collection of resource requests.
 type Requests interface {
 	Clone() Requests
-	CreateEmpty() Requests
 	Add(other Requests)
 	Sub(other Requests)
 	CountIn(capacity Requests) int32

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -1,0 +1,50 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Requests represents an abstract collection of resource requests.
+type Requests interface {
+	CloneRequests() Requests
+	CreateEmpty() Requests
+	Add(other Requests)
+	Sub(other Requests)
+	CountIn(capacity Requests) int32
+	CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName)
+	ToMapRequests() MapRequests
+}
+
+// NewRequests creates a Requests interface from a Kubernetes ResourceList.
+func NewRequests(rl corev1.ResourceList) Requests {
+	return NewMapRequests(rl)
+}
+
+// NewRequestsFromMap creates a Requests interface wrapping the provided MapRequests map.
+func NewRequestsFromMap(m MapRequests) Requests {
+	if m == nil {
+		return nil
+	}
+	return m
+}
+
+// NewRequestsFromPodSpec creates a Requests interface from a PodSpec.
+func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
+	return NewMapRequestsFromPodSpec(podSpec)
+}

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -22,8 +22,6 @@ import (
 
 // Requests represents an abstract collection of resource requests.
 type Requests interface {
-	IsNil() bool
-	IsEmpty() bool
 	Clone() Requests
 	CreateEmpty() Requests
 	Add(other Requests)

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -29,4 +29,6 @@ type Requests interface {
 	CountIn(capacity Requests) int32
 	CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName)
 	GetValue(name corev1.ResourceName) int64
+	ForEach(fn func(name corev1.ResourceName, val int64))
+	Len() int
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -22,7 +22,8 @@ import (
 
 // Requests represents an abstract collection of resource requests.
 type Requests interface {
-	CloneRequests() Requests
+	IsNil() bool
+	Clone() Requests
 	CreateEmpty() Requests
 	Add(other Requests)
 	Sub(other Requests)

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -23,6 +23,7 @@ import (
 // Requests represents an abstract collection of resource requests.
 type Requests interface {
 	IsNil() bool
+	IsEmpty() bool
 	Clone() Requests
 	CreateEmpty() Requests
 	Add(other Requests)

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -1,0 +1,78 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+// LazyRequests wraps a base Requests interface and performs copy-on-write
+// (lazy cloning) when mutations occur.
+type LazyRequests struct {
+	base   Requests
+	cached Requests
+}
+
+// isNil safely checks if a Requests interface instance is nil or wraps a nil map.
+func isNil(r Requests) bool {
+	return r == nil || r.ToMapRequests() == nil
+}
+
+func NewLazyRequests(base Requests) LazyRequests {
+	return LazyRequests{base: base}
+}
+
+// IsValid returns true if either the base or cached Requests is initialized.
+func (l *LazyRequests) IsValid() bool {
+	return !isNil(l.base) || !isNil(l.cached)
+}
+
+// Get returns the underlying Requests (either the cached clone if mutated, or base).
+func (l *LazyRequests) Get() Requests {
+	if !isNil(l.cached) {
+		return l.cached
+	}
+	return l.base
+}
+
+// Sub subtracts subRequests from the underlying Requests interface,
+// cloning base on first write.
+func (l *LazyRequests) Sub(subRequests Requests) {
+	if isNil(subRequests) || len(subRequests.ToMapRequests()) == 0 {
+		return
+	}
+	if isNil(l.cached) {
+		if isNil(l.base) {
+			l.cached = MapRequests{}
+		} else {
+			l.cached = l.base.CloneRequests()
+		}
+	}
+	l.cached.Sub(subRequests)
+}
+
+// Add adds addRequests to the underlying Requests interface,
+// cloning base on first write.
+func (l *LazyRequests) Add(addRequests Requests) {
+	if isNil(addRequests) || len(addRequests.ToMapRequests()) == 0 {
+		return
+	}
+	if isNil(l.cached) {
+		if isNil(l.base) {
+			l.cached = MapRequests{}
+		} else {
+			l.cached = l.base.CloneRequests()
+		}
+	}
+	l.cached.Add(addRequests)
+}

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -42,11 +42,12 @@ func (l *LazyRequests) Get() Requests {
 
 func (l *LazyRequests) ensureWritable(other Requests) {
 	if IsNil(l.cached) {
-		if !IsNil(l.base) {
-			l.cached = l.base.CloneRequests()
-		} else if !IsNil(other) {
+		switch {
+		case !IsNil(l.base):
+			l.cached = l.base.Clone()
+		case !IsNil(other):
 			l.cached = other.CreateEmpty()
-		} else {
+		default:
 			l.cached = MapRequests{}
 		}
 	}

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -23,29 +23,33 @@ type LazyRequests struct {
 	cached Requests
 }
 
+func IsEmpty(requests Requests) bool {
+	return requests == nil || requests.Len() == 0
+}
+
 func NewLazyRequests(base Requests) LazyRequests {
 	return LazyRequests{base: base}
 }
 
 // IsValid returns true if either the base or cached Requests is initialized.
 func (l *LazyRequests) IsValid() bool {
-	return l.base.IsEmpty() || !l.cached.IsEmpty()
+	return !IsEmpty(l.base) || !IsEmpty(l.cached)
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
 func (l *LazyRequests) Get() Requests {
-	if !l.cached.IsEmpty() {
+	if !IsEmpty(l.cached) {
 		return l.cached
 	}
 	return l.base
 }
 
 func (l *LazyRequests) ensureWritable(other Requests) {
-	if l.cached.IsNil() {
+	if IsEmpty(l.cached) {
 		switch {
-		case l.base.IsNil():
+		case !IsEmpty(l.base):
 			l.cached = l.base.Clone()
-		case other.IsNil():
+		case !IsEmpty(other):
 			l.cached = other.CreateEmpty()
 		default:
 			l.cached = MapRequests{}
@@ -56,7 +60,7 @@ func (l *LazyRequests) ensureWritable(other Requests) {
 // Sub subtracts subRequests from the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Sub(subRequests Requests) {
-	if subRequests.IsEmpty() {
+	if IsEmpty(subRequests) {
 		return
 	}
 	l.ensureWritable(subRequests)
@@ -66,7 +70,7 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 // Add adds addRequests to the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Add(addRequests Requests) {
-	if addRequests.IsEmpty() {
+	if IsEmpty(addRequests) {
 		return
 	}
 	l.ensureWritable(addRequests)

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -25,7 +25,24 @@ type LazyRequests struct {
 
 // isNil safely checks if a Requests interface instance is nil or wraps a nil map.
 func isNil(r Requests) bool {
-	return r == nil || r.ToMapRequests() == nil
+	if r == nil {
+		return true
+	}
+	if m, ok := r.(MapRequests); ok {
+		return m == nil
+	}
+	return false
+}
+
+// isZero checks if a Requests interface instance is nil or has 0 resource entries.
+func isZero(r Requests) bool {
+	if isNil(r) {
+		return true
+	}
+	if m, ok := r.(MapRequests); ok {
+		return len(m) == 0
+	}
+	return false
 }
 
 func NewLazyRequests(base Requests) LazyRequests {
@@ -48,7 +65,7 @@ func (l *LazyRequests) Get() Requests {
 // Sub subtracts subRequests from the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Sub(subRequests Requests) {
-	if isNil(subRequests) || len(subRequests.ToMapRequests()) == 0 {
+	if isZero(subRequests) {
 		return
 	}
 	if isNil(l.cached) {
@@ -64,7 +81,7 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 // Add adds addRequests to the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Add(addRequests Requests) {
-	if isNil(addRequests) || len(addRequests.ToMapRequests()) == 0 {
+	if isZero(addRequests) {
 		return
 	}
 	if isNil(l.cached) {

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -24,7 +24,7 @@ type LazyRequests struct {
 }
 
 func isEmpty(requests Requests) bool {
-	return requests == nil || requests.Len() == 0
+	return requests == nil || requests.IsEmpty()
 }
 
 func CreateEmpty() Requests {

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -27,13 +27,17 @@ func IsEmpty(requests Requests) bool {
 	return requests == nil || requests.Len() == 0
 }
 
+func CreateEmpty() Requests {
+	return MapRequests{}
+}
+
 func NewLazyRequests(base Requests) LazyRequests {
 	return LazyRequests{base: base}
 }
 
-// IsValid returns true if either the base or cached Requests is initialized.
-func (l *LazyRequests) IsValid() bool {
-	return !IsEmpty(l.base) || !IsEmpty(l.cached)
+// IsEmpty returns true if both the base and cached Requests are empty.
+func (l *LazyRequests) IsEmpty() bool {
+	return IsEmpty(l.base) && IsEmpty(l.cached)
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
@@ -44,15 +48,13 @@ func (l *LazyRequests) Get() Requests {
 	return l.base
 }
 
-func (l *LazyRequests) ensureWritable(other Requests) {
+func (l *LazyRequests) ensureWritable() {
 	if IsEmpty(l.cached) {
 		switch {
 		case !IsEmpty(l.base):
 			l.cached = l.base.Clone()
-		case !IsEmpty(other):
-			l.cached = other.CreateEmpty()
 		default:
-			l.cached = MapRequests{}
+			l.cached = CreateEmpty()
 		}
 	}
 }
@@ -63,7 +65,7 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 	if IsEmpty(subRequests) {
 		return
 	}
-	l.ensureWritable(subRequests)
+	l.ensureWritable()
 	l.cached.Sub(subRequests)
 }
 
@@ -73,6 +75,6 @@ func (l *LazyRequests) Add(addRequests Requests) {
 	if IsEmpty(addRequests) {
 		return
 	}
-	l.ensureWritable(addRequests)
+	l.ensureWritable()
 	l.cached.Add(addRequests)
 }

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -23,73 +23,51 @@ type LazyRequests struct {
 	cached Requests
 }
 
-// isNil safely checks if a Requests interface instance is nil or wraps a nil map.
-func isNil(r Requests) bool {
-	if r == nil {
-		return true
-	}
-	if m, ok := r.(MapRequests); ok {
-		return m == nil
-	}
-	return false
-}
-
-// isZero checks if a Requests interface instance is nil or has 0 resource entries.
-func isZero(r Requests) bool {
-	if isNil(r) {
-		return true
-	}
-	if m, ok := r.(MapRequests); ok {
-		return len(m) == 0
-	}
-	return false
-}
-
 func NewLazyRequests(base Requests) LazyRequests {
 	return LazyRequests{base: base}
 }
 
 // IsValid returns true if either the base or cached Requests is initialized.
 func (l *LazyRequests) IsValid() bool {
-	return !isNil(l.base) || !isNil(l.cached)
+	return !IsNil(l.base) || !IsNil(l.cached)
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
 func (l *LazyRequests) Get() Requests {
-	if !isNil(l.cached) {
+	if !IsNil(l.cached) {
 		return l.cached
 	}
 	return l.base
 }
 
+func (l *LazyRequests) ensureWritable(other Requests) {
+	if IsNil(l.cached) {
+		if !IsNil(l.base) {
+			l.cached = l.base.CloneRequests()
+		} else if !IsNil(other) {
+			l.cached = other.CreateEmpty()
+		} else {
+			l.cached = MapRequests{}
+		}
+	}
+}
+
 // Sub subtracts subRequests from the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Sub(subRequests Requests) {
-	if isZero(subRequests) {
+	if IsEmpty(subRequests) {
 		return
 	}
-	if isNil(l.cached) {
-		if isNil(l.base) {
-			l.cached = MapRequests{}
-		} else {
-			l.cached = l.base.CloneRequests()
-		}
-	}
+	l.ensureWritable(subRequests)
 	l.cached.Sub(subRequests)
 }
 
 // Add adds addRequests to the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Add(addRequests Requests) {
-	if isZero(addRequests) {
+	if IsEmpty(addRequests) {
 		return
 	}
-	if isNil(l.cached) {
-		if isNil(l.base) {
-			l.cached = MapRequests{}
-		} else {
-			l.cached = l.base.CloneRequests()
-		}
-	}
+	l.ensureWritable(addRequests)
 	l.cached.Add(addRequests)
 }

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -23,7 +23,7 @@ type LazyRequests struct {
 	cached Requests
 }
 
-func IsEmpty(requests Requests) bool {
+func isEmpty(requests Requests) bool {
 	return requests == nil || requests.Len() == 0
 }
 
@@ -37,21 +37,21 @@ func NewLazyRequests(base Requests) LazyRequests {
 
 // IsEmpty returns true if both the base and cached Requests are empty.
 func (l *LazyRequests) IsEmpty() bool {
-	return IsEmpty(l.base) && IsEmpty(l.cached)
+	return isEmpty(l.base) && isEmpty(l.cached)
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
 func (l *LazyRequests) Get() Requests {
-	if !IsEmpty(l.cached) {
+	if !isEmpty(l.cached) {
 		return l.cached
 	}
 	return l.base
 }
 
 func (l *LazyRequests) ensureWritable() {
-	if IsEmpty(l.cached) {
+	if isEmpty(l.cached) {
 		switch {
-		case !IsEmpty(l.base):
+		case !isEmpty(l.base):
 			l.cached = l.base.Clone()
 		default:
 			l.cached = CreateEmpty()
@@ -62,7 +62,7 @@ func (l *LazyRequests) ensureWritable() {
 // Sub subtracts subRequests from the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Sub(subRequests Requests) {
-	if IsEmpty(subRequests) {
+	if isEmpty(subRequests) {
 		return
 	}
 	l.ensureWritable()
@@ -72,7 +72,7 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 // Add adds addRequests to the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Add(addRequests Requests) {
-	if IsEmpty(addRequests) {
+	if isEmpty(addRequests) {
 		return
 	}
 	l.ensureWritable()

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -29,23 +29,23 @@ func NewLazyRequests(base Requests) LazyRequests {
 
 // IsValid returns true if either the base or cached Requests is initialized.
 func (l *LazyRequests) IsValid() bool {
-	return !IsNil(l.base) || !IsNil(l.cached)
+	return l.base.IsEmpty() || !l.cached.IsEmpty()
 }
 
 // Get returns the underlying Requests (either the cached clone if mutated, or base).
 func (l *LazyRequests) Get() Requests {
-	if !IsNil(l.cached) {
+	if !l.cached.IsEmpty() {
 		return l.cached
 	}
 	return l.base
 }
 
 func (l *LazyRequests) ensureWritable(other Requests) {
-	if IsNil(l.cached) {
+	if l.cached.IsNil() {
 		switch {
-		case !IsNil(l.base):
+		case l.base.IsNil():
 			l.cached = l.base.Clone()
-		case !IsNil(other):
+		case other.IsNil():
 			l.cached = other.CreateEmpty()
 		default:
 			l.cached = MapRequests{}
@@ -56,7 +56,7 @@ func (l *LazyRequests) ensureWritable(other Requests) {
 // Sub subtracts subRequests from the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Sub(subRequests Requests) {
-	if IsEmpty(subRequests) {
+	if subRequests.IsEmpty() {
 		return
 	}
 	l.ensureWritable(subRequests)
@@ -66,7 +66,7 @@ func (l *LazyRequests) Sub(subRequests Requests) {
 // Add adds addRequests to the underlying Requests interface,
 // cloning base on first write.
 func (l *LazyRequests) Add(addRequests Requests) {
-	if IsEmpty(addRequests) {
+	if addRequests.IsEmpty() {
 		return
 	}
 	l.ensureWritable(addRequests)

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -31,6 +31,22 @@ import (
 // The following resources calculations are inspired on
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
 
+// IsNil safely checks if a Requests interface instance is nil or wraps a nil map.
+func IsNil(r Requests) bool {
+	if r == nil {
+		return true
+	}
+	if m, ok := r.(MapRequests); ok {
+		return m == nil
+	}
+	return false
+}
+
+// IsEmpty checks if a Requests interface instance is nil or has 0 resource entries.
+func IsEmpty(r Requests) bool {
+	return IsNil(r) || r.Len() == 0
+}
+
 // MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
 type MapRequests map[corev1.ResourceName]int64
 
@@ -88,26 +104,44 @@ func (r MapRequests) GetValue(name corev1.ResourceName) int64 {
 	return r[name]
 }
 
+func (r MapRequests) Len() int {
+	return len(r)
+}
+
+func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
+	for k, v := range r {
+		fn(k, v)
+	}
+}
+
 func (r MapRequests) Add(other Requests) {
-	if isNil(other) {
+	if IsNil(other) {
 		return
 	}
 	if m, ok := other.(MapRequests); ok {
 		for k, v := range m {
 			r[k] += v
 		}
+		return
 	}
+	other.ForEach(func(k corev1.ResourceName, v int64) {
+		r[k] += v
+	})
 }
 
 func (r MapRequests) Sub(other Requests) {
-	if isNil(other) {
+	if IsNil(other) {
 		return
 	}
 	if m, ok := other.(MapRequests); ok {
 		for k, v := range m {
 			r[k] -= v
 		}
+		return
 	}
+	other.ForEach(func(k corev1.ResourceName, v int64) {
+		r[k] -= v
+	})
 }
 
 func (r MapRequests) CreateEmpty() Requests {
@@ -163,7 +197,7 @@ func (r MapRequests) CountIn(capacity Requests) int32 {
 // When multiple resources have the same count, ties are broken alphabetically
 // by resource name for determinism.
 func (r MapRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
-	if isNil(capacity) {
+	if IsNil(capacity) {
 		return 0, ""
 	}
 	var (

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -31,15 +31,12 @@ import (
 // The following resources calculations are inspired on
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
 
-// IsNil safely checks if a Requests interface instance is nil or wraps a nil map.
+// IsNil safely checks if a Requests interface instance is nil or wraps a nil backend.
 func IsNil(r Requests) bool {
 	if r == nil {
 		return true
 	}
-	if m, ok := r.(MapRequests); ok {
-		return m == nil
-	}
-	return false
+	return r.IsNil()
 }
 
 // IsEmpty checks if a Requests interface instance is nil or has 0 resource entries.
@@ -49,6 +46,10 @@ func IsEmpty(r Requests) bool {
 
 // MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
 type MapRequests map[corev1.ResourceName]int64
+
+func (r MapRequests) IsNil() bool {
+	return r == nil
+}
 
 func NewMapRequests(rl corev1.ResourceList) MapRequests {
 	r := MapRequests{}
@@ -62,22 +63,29 @@ func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
 	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
 }
 
-func (r MapRequests) CloneRequests() Requests {
-	return r.Clone()
-}
-
-func (r MapRequests) Clone() MapRequests {
+func (r MapRequests) Clone() Requests {
+	if len(r) == 0 {
+		return nil
+	}
 	return maps.Clone(r)
 }
 
+// Clone safely clones r, returning nil if r is nil or empty.
+func Clone(r Requests) Requests {
+	if IsEmpty(r) {
+		return nil
+	}
+	return r.Clone()
+}
+
 func (r MapRequests) ScaledUp(f int64) MapRequests {
-	ret := r.Clone()
+	ret := maps.Clone(r)
 	ret.Mul(f)
 	return ret
 }
 
 func (r MapRequests) ScaledDown(f int64) MapRequests {
-	ret := r.Clone()
+	ret := maps.Clone(r)
 	ret.Divide(f)
 	return ret
 }
@@ -114,32 +122,22 @@ func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
 	}
 }
 
+// ForEach safely calls fn for each resource entry in r, no-opting if r is nil or empty.
+func ForEach(r Requests, fn func(name corev1.ResourceName, val int64)) {
+	if IsEmpty(r) || fn == nil {
+		return
+	}
+	r.ForEach(fn)
+}
+
 func (r MapRequests) Add(other Requests) {
-	if IsNil(other) {
-		return
-	}
-	if m, ok := other.(MapRequests); ok {
-		for k, v := range m {
-			r[k] += v
-		}
-		return
-	}
-	other.ForEach(func(k corev1.ResourceName, v int64) {
+	ForEach(other, func(k corev1.ResourceName, v int64) {
 		r[k] += v
 	})
 }
 
 func (r MapRequests) Sub(other Requests) {
-	if IsNil(other) {
-		return
-	}
-	if m, ok := other.(MapRequests); ok {
-		for k, v := range m {
-			r[k] -= v
-		}
-		return
-	}
-	other.ForEach(func(k corev1.ResourceName, v int64) {
+	ForEach(other, func(k corev1.ResourceName, v int64) {
 		r[k] -= v
 	})
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -53,13 +53,10 @@ func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
 }
 
 func (r MapRequests) Clone() Requests {
-	if len(r) == 0 {
-		return nil
-	}
 	return maps.Clone(r)
 }
 
-func (r MapRequests) ScaledUp(f int64) MapRequests {
+func (r MapRequests) ScaledUp(f int64) Requests {
 	ret := maps.Clone(r)
 	ret.Mul(f)
 	return ret

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -34,6 +34,8 @@ import (
 // MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
 type MapRequests map[corev1.ResourceName]int64
 
+var OnePodRequest = MapRequests{corev1.ResourcePods: 1}
+
 func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
 	for k, v := range r {
 		fn(k, v)

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -42,8 +42,12 @@ func NewMapRequests(rl corev1.ResourceList) MapRequests {
 	return r
 }
 
-func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
+func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
 	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+}
+
+func (r MapRequests) CloneRequests() Requests {
+	return r.Clone()
 }
 
 func (r MapRequests) Clone() MapRequests {
@@ -80,16 +84,30 @@ func (r MapRequests) Mul(f int64) {
 	}
 }
 
-func (r MapRequests) Add(addRequests MapRequests) {
-	for k, v := range addRequests {
+func (r MapRequests) Add(other Requests) {
+	if isNil(other) {
+		return
+	}
+	for k, v := range other.ToMapRequests() {
 		r[k] += v
 	}
 }
 
-func (r MapRequests) Sub(subRequests MapRequests) {
-	for k, v := range subRequests {
+func (r MapRequests) Sub(other Requests) {
+	if isNil(other) {
+		return
+	}
+	for k, v := range other.ToMapRequests() {
 		r[k] -= v
 	}
+}
+
+func (r MapRequests) ToMapRequests() MapRequests {
+	return r
+}
+
+func (r MapRequests) CreateEmpty() MapRequests {
+	return MapRequests{}
 }
 
 func (r MapRequests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
@@ -131,7 +149,7 @@ func (r MapRequests) GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName
 	return r.GreaterKeys(NewMapRequests(rl))
 }
 
-func (r MapRequests) CountIn(capacity MapRequests) int32 {
+func (r MapRequests) CountIn(capacity Requests) int32 {
 	count, _ := r.CountInWithLimitingResource(capacity)
 	return count
 }
@@ -140,13 +158,17 @@ func (r MapRequests) CountIn(capacity MapRequests) int32 {
 // and the resource that is most constraining (i.e., gave the minimum count).
 // When multiple resources have the same count, ties are broken alphabetically
 // by resource name for determinism.
-func (r MapRequests) CountInWithLimitingResource(capacity MapRequests) (int32, corev1.ResourceName) {
+func (r MapRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
+	if isNil(capacity) {
+		return 0, ""
+	}
+	capMap := capacity.ToMapRequests()
 	var (
 		result           *int32
 		limitingResource corev1.ResourceName
 	)
 	for rName, rValue := range r {
-		cap, found := capacity[rName]
+		cap, found := capMap[rName]
 		if !found && rValue != 0 {
 			return 0, rName
 		}
@@ -174,60 +196,4 @@ func (r MapRequests) CountInWithLimitingResource(capacity MapRequests) (int32, c
 		}
 	}
 	return ptr.Deref(result, 0), limitingResource
-}
-
-// LazyRequests wraps a base Requests map and performs copy-on-write
-// (lazy cloning) when mutations occur.
-type LazyRequests struct {
-	base   MapRequests
-	cached MapRequests
-}
-
-func NewLazyRequests(base MapRequests) LazyRequests {
-	return LazyRequests{base: base}
-}
-
-// IsValid returns true if either the base or cached map is initialized.
-func (l *LazyRequests) IsValid() bool {
-	return l.base != nil || l.cached != nil
-}
-
-// Get returns the underlying Requests (either the cached clone if mutated, or base).
-func (l *LazyRequests) Get() MapRequests {
-	if l.cached != nil {
-		return l.cached
-	}
-	return l.base
-}
-
-// Sub subtracts subRequests from the underlying Requests map,
-// cloning base on first write.
-func (l *LazyRequests) Sub(subRequests MapRequests) {
-	if len(subRequests) == 0 {
-		return
-	}
-	if l.cached == nil {
-		if l.base == nil {
-			l.cached = MapRequests{}
-		} else {
-			l.cached = l.base.Clone()
-		}
-	}
-	l.cached.Sub(subRequests)
-}
-
-// Add adds addRequests to the underlying Requests map,
-// cloning base on first write.
-func (l *LazyRequests) Add(addRequests MapRequests) {
-	if len(addRequests) == 0 {
-		return
-	}
-	if l.cached == nil {
-		if l.base == nil {
-			l.cached = MapRequests{}
-		} else {
-			l.cached = l.base.Clone()
-		}
-	}
-	l.cached.Add(addRequests)
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -109,10 +109,6 @@ func (r MapRequests) Sub(other Requests) {
 	})
 }
 
-func (r MapRequests) CreateEmpty() Requests {
-	return MapRequests{}
-}
-
 func (r MapRequests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
 	ret := make(corev1.ResourceList, len(r))
 	for k, v := range r {

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -34,14 +34,6 @@ import (
 // MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
 type MapRequests map[corev1.ResourceName]int64
 
-func (r MapRequests) IsNil() bool {
-	return r == nil
-}
-
-func (r MapRequests) IsEmpty() bool {
-	return len(r) == 0
-}
-
 func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
 	for k, v := range r {
 		fn(k, v)

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -31,24 +31,21 @@ import (
 // The following resources calculations are inspired on
 // https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/types.go
 
-// IsNil safely checks if a Requests interface instance is nil or wraps a nil backend.
-func IsNil(r Requests) bool {
-	if r == nil {
-		return true
-	}
-	return r.IsNil()
-}
-
-// IsEmpty checks if a Requests interface instance is nil or has 0 resource entries.
-func IsEmpty(r Requests) bool {
-	return IsNil(r) || r.Len() == 0
-}
-
 // MapRequests maps ResourceName to flavor to value; for CPU it is tracked in MilliCPU.
 type MapRequests map[corev1.ResourceName]int64
 
 func (r MapRequests) IsNil() bool {
 	return r == nil
+}
+
+func (r MapRequests) IsEmpty() bool {
+	return len(r) == 0
+}
+
+func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
+	for k, v := range r {
+		fn(k, v)
+	}
 }
 
 func NewMapRequests(rl corev1.ResourceList) MapRequests {
@@ -68,14 +65,6 @@ func (r MapRequests) Clone() Requests {
 		return nil
 	}
 	return maps.Clone(r)
-}
-
-// Clone safely clones r, returning nil if r is nil or empty.
-func Clone(r Requests) Requests {
-	if IsEmpty(r) {
-		return nil
-	}
-	return r.Clone()
 }
 
 func (r MapRequests) ScaledUp(f int64) MapRequests {
@@ -116,28 +105,14 @@ func (r MapRequests) Len() int {
 	return len(r)
 }
 
-func (r MapRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
-	for k, v := range r {
-		fn(k, v)
-	}
-}
-
-// ForEach safely calls fn for each resource entry in r, no-opting if r is nil or empty.
-func ForEach(r Requests, fn func(name corev1.ResourceName, val int64)) {
-	if IsEmpty(r) || fn == nil {
-		return
-	}
-	r.ForEach(fn)
-}
-
 func (r MapRequests) Add(other Requests) {
-	ForEach(other, func(k corev1.ResourceName, v int64) {
+	other.ForEach(func(k corev1.ResourceName, v int64) {
 		r[k] += v
 	})
 }
 
 func (r MapRequests) Sub(other Requests) {
-	ForEach(other, func(k corev1.ResourceName, v int64) {
+	other.ForEach(func(k corev1.ResourceName, v int64) {
 		r[k] -= v
 	})
 }
@@ -195,14 +170,19 @@ func (r MapRequests) CountIn(capacity Requests) int32 {
 // When multiple resources have the same count, ties are broken alphabetically
 // by resource name for determinism.
 func (r MapRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
-	if IsNil(capacity) {
-		return 0, ""
-	}
+	return CountInWithLimitingResource(r, capacity)
+}
+
+// CountInWithLimitingResource returns how many times requests fit into capacity
+// and the resource that is most constraining (i.e., gave the minimum count).
+// When multiple resources have the same count, ties are broken alphabetically
+// by resource name for determinism.
+func CountInWithLimitingResource(requests Requests, capacity Requests) (int32, corev1.ResourceName) {
 	var (
 		result           *int32
 		limitingResource corev1.ResourceName
 	)
-	for rName, rValue := range r {
+	requests.ForEach(func(rName corev1.ResourceName, rValue int64) {
 		cap := capacity.GetValue(rName)
 		// find the minimum count matching all the resource quota.
 		var count int32
@@ -226,6 +206,6 @@ func (r MapRequests) CountInWithLimitingResource(capacity Requests) (int32, core
 			result = new(count)
 			limitingResource = rName
 		}
-	}
+	})
 	return ptr.Deref(result, 0), limitingResource
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -97,6 +97,10 @@ func (r MapRequests) Len() int {
 	return len(r)
 }
 
+func (r MapRequests) IsEmpty() bool {
+	return len(r) == 0
+}
+
 func (r MapRequests) Add(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
 		r[k] += v

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -84,12 +84,18 @@ func (r MapRequests) Mul(f int64) {
 	}
 }
 
+func (r MapRequests) GetValue(name corev1.ResourceName) int64 {
+	return r[name]
+}
+
 func (r MapRequests) Add(other Requests) {
 	if isNil(other) {
 		return
 	}
-	for k, v := range other.ToMapRequests() {
-		r[k] += v
+	if m, ok := other.(MapRequests); ok {
+		for k, v := range m {
+			r[k] += v
+		}
 	}
 }
 
@@ -97,16 +103,14 @@ func (r MapRequests) Sub(other Requests) {
 	if isNil(other) {
 		return
 	}
-	for k, v := range other.ToMapRequests() {
-		r[k] -= v
+	if m, ok := other.(MapRequests); ok {
+		for k, v := range m {
+			r[k] -= v
+		}
 	}
 }
 
-func (r MapRequests) ToMapRequests() MapRequests {
-	return r
-}
-
-func (r MapRequests) CreateEmpty() MapRequests {
+func (r MapRequests) CreateEmpty() Requests {
 	return MapRequests{}
 }
 
@@ -162,16 +166,12 @@ func (r MapRequests) CountInWithLimitingResource(capacity Requests) (int32, core
 	if isNil(capacity) {
 		return 0, ""
 	}
-	capMap := capacity.ToMapRequests()
 	var (
 		result           *int32
 		limitingResource corev1.ResourceName
 	)
 	for rName, rValue := range r {
-		cap, found := capMap[rName]
-		if !found && rValue != 0 {
-			return 0, rName
-		}
+		cap := capacity.GetValue(rName)
 		// find the minimum count matching all the resource quota.
 		var count int32
 		if rValue == 0 {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -498,7 +498,7 @@ func TestLazyRequests(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			var originalBase MapRequests
+			var originalBase Requests
 			if tc.base != nil {
 				originalBase = tc.base.Clone()
 			}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -415,14 +415,14 @@ func TestLazyRequests(t *testing.T) {
 		op                func(*LazyRequests)
 		wantResult        MapRequests
 		wantCachedCreated bool
-		wantValid         bool
+		wantEmpty         bool
 	}{
 		"no operation preserves base": {
 			base:              MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			op:                nil,
 			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"subtraction creates clone and updates result": {
 			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -431,7 +431,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: 7, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"addition creates clone and updates result": {
 			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -440,7 +440,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: 15, corev1.ResourceMemory: 100},
 			wantCachedCreated: true,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"subtraction with empty map short circuits": {
 			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -449,7 +449,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"addition with empty map short circuits": {
 			base: MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
@@ -458,7 +458,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: 10, corev1.ResourceMemory: 100},
 			wantCachedCreated: false,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"nil base input with non-empty addition": {
 			base: nil,
@@ -467,7 +467,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: 5},
 			wantCachedCreated: true,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
 		"nil base input with empty addition short circuits": {
 			base: nil,
@@ -476,7 +476,7 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        nil,
 			wantCachedCreated: false,
-			wantValid:         false,
+			wantEmpty:         true,
 		},
 		"nil base input with non-empty subtraction": {
 			base: nil,
@@ -485,14 +485,14 @@ func TestLazyRequests(t *testing.T) {
 			},
 			wantResult:        MapRequests{corev1.ResourceCPU: -5},
 			wantCachedCreated: true,
-			wantValid:         true,
+			wantEmpty:         false,
 		},
-		"zero-value LazyRequests is not valid": {
+		"zero-value LazyRequests is empty": {
 			base:              nil,
 			op:                nil,
 			wantResult:        nil,
 			wantCachedCreated: false,
-			wantValid:         false,
+			wantEmpty:         true,
 		},
 	}
 
@@ -509,8 +509,8 @@ func TestLazyRequests(t *testing.T) {
 				tc.op(&lazy)
 			}
 
-			if gotValid := lazy.IsValid(); gotValid != tc.wantValid {
-				t.Errorf("unexpected IsValid() result, want=%t, got=%t", tc.wantValid, gotValid)
+			if gotEmpty := lazy.IsEmpty(); gotEmpty != tc.wantEmpty {
+				t.Errorf("unexpected IsEmpty() result, want=%t, got=%t", tc.wantEmpty, gotEmpty)
 			}
 
 			if (lazy.cached != nil) != tc.wantCachedCreated {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -528,3 +528,127 @@ func TestLazyRequests(t *testing.T) {
 		})
 	}
 }
+
+func TestMapRequestsLen(t *testing.T) {
+	cases := map[string]struct {
+		req  MapRequests
+		want int
+	}{
+		"nil map": {
+			req:  nil,
+			want: 0,
+		},
+		"empty map": {
+			req:  MapRequests{},
+			want: 0,
+		},
+		"single resource": {
+			req:  MapRequests{corev1.ResourceCPU: 1000},
+			want: 1,
+		},
+		"multiple resources": {
+			req:  MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 1024, corev1.ResourcePods: 1},
+			want: 3,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.req.Len(); got != tc.want {
+				t.Errorf("unexpected Len(), want=%d, got=%d", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMapRequestsIsEmpty(t *testing.T) {
+	cases := map[string]struct {
+		req  MapRequests
+		want bool
+	}{
+		"nil map": {
+			req:  nil,
+			want: true,
+		},
+		"empty map": {
+			req:  MapRequests{},
+			want: true,
+		},
+		"non-empty map": {
+			req:  MapRequests{corev1.ResourceCPU: 1000},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.req.IsEmpty(); got != tc.want {
+				t.Errorf("unexpected IsEmpty(), want=%t, got=%t", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMapRequestsGetValue(t *testing.T) {
+	cases := map[string]struct {
+		req      MapRequests
+		resource corev1.ResourceName
+		want     int64
+	}{
+		"nil map": {
+			req:      nil,
+			resource: corev1.ResourceCPU,
+			want:     0,
+		},
+		"empty map": {
+			req:      MapRequests{},
+			resource: corev1.ResourceCPU,
+			want:     0,
+		},
+		"missing resource": {
+			req:      MapRequests{corev1.ResourceMemory: 1024},
+			resource: corev1.ResourceCPU,
+			want:     0,
+		},
+		"existing resource": {
+			req:      MapRequests{corev1.ResourceCPU: 1000},
+			resource: corev1.ResourceCPU,
+			want:     1000,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.req.GetValue(tc.resource); got != tc.want {
+				t.Errorf("unexpected GetValue(), want=%d, got=%d", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMapRequestsClone(t *testing.T) {
+	t.Run("nil map clone", func(t *testing.T) {
+		var m MapRequests
+		cloned := m.Clone()
+		if cloned != nil && !cloned.IsEmpty() {
+			t.Errorf("expected empty clone for nil map, got %v", cloned)
+		}
+	})
+
+	t.Run("empty map clone", func(t *testing.T) {
+		m := MapRequests{}
+		cloned := m.Clone()
+		if cloned != nil && !cloned.IsEmpty() {
+			t.Errorf("expected empty clone, got %v", cloned)
+		}
+	})
+
+	t.Run("non-empty map clone", func(t *testing.T) {
+		m := MapRequests{corev1.ResourceCPU: 1000}
+		cloned := m.Clone()
+		if !cmp.Equal(m, cloned) {
+			t.Errorf("cloned map mismatch (-want +got):\n%s", cmp.Diff(m, cloned))
+		}
+		cloned.Add(MapRequests{corev1.ResourceMemory: 1024})
+		if m.GetValue(corev1.ResourceMemory) != 0 {
+			t.Errorf("original map was mutated after modifying clone")
+		}
+	})
+}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -120,7 +120,7 @@ func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQu
 			for _, domain := range psa.TopologyAssignment.Domains {
 				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
 					Values:            domain.Values,
-					SinglePodRequests: singlePodRequests.Clone().(resources.MapRequests),
+					SinglePodRequests: singlePodRequests.Clone(),
 					Count:             domain.Count,
 				})
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -120,7 +120,7 @@ func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQu
 			for _, domain := range psa.TopologyAssignment.Domains {
 				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
 					Values:            domain.Values,
-					SinglePodRequests: singlePodRequests.Clone(),
+					SinglePodRequests: singlePodRequests.ToMapRequests().Clone(),
 					Count:             domain.Count,
 				})
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -120,7 +120,7 @@ func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQu
 			for _, domain := range psa.TopologyAssignment.Domains {
 				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
 					Values:            domain.Values,
-					SinglePodRequests: singlePodRequests.Clone(),
+					SinglePodRequests: singlePodRequests.Clone().(resources.MapRequests),
 					Count:             domain.Count,
 				})
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -113,14 +113,14 @@ func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQu
 				log.Error(err, "Failed to find TAS flavor while computing TAS net usage", "podSet", psa.Name)
 				continue
 			}
-			singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
+			singlePodRequests := resources.NewMapRequestsFromPodSpec(&podSet.Template.Spec)
 			if _, ok := result[*tasFlavor]; !ok {
 				result[*tasFlavor] = make(workload.TASFlavorUsage, 0)
 			}
 			for _, domain := range psa.TopologyAssignment.Domains {
 				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
 					Values:            domain.Values,
-					SinglePodRequests: singlePodRequests.ToMapRequests().Clone(),
+					SinglePodRequests: singlePodRequests.Clone(),
 					Count:             domain.Count,
 				})
 			}

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -129,7 +129,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 
 	return &schdcache.TASPodSetRequests{
 		Count:              podCount,
-		SinglePodRequests:  singlePodRequests,
+		SinglePodRequests:  singlePodRequests.ToMapRequests(),
 		PodSet:             podSet,
 		PodSetUpdates:      podSetUpdates,
 		Flavor:             *tasFlvr,
@@ -204,7 +204,7 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 
 // hasOverlapWithPodRequestedResources checks if the PodSet's resource requests overlap with the specified flavor resources.
 func hasOverlapWithPodRequestedResources(ps *kueue.PodSet, flavorResources sets.Set[corev1.ResourceName]) bool {
-	requests := resources.NewRequestsFromPodSpec(&ps.Template.Spec)
+	requests := resources.NewMapRequestsFromPodSpec(&ps.Template.Spec)
 	return flavorResources.HasAny(slices.Collect(maps.Keys(requests))...)
 }
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -111,7 +111,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	}
 	podSet := &wl.Obj.Spec.PodSets[podSetIndex]
 	// Use PodSpec directly for TAS placement, not quota-filtered admission values.
-	singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
+	singlePodRequests := resources.NewMapRequestsFromPodSpec(&podSet.Template.Spec)
 	var podSetUpdates []*kueue.PodSetUpdate
 	for _, ac := range wl.Obj.Status.AdmissionChecks {
 		if ac.State == kueue.CheckStateReady {
@@ -129,7 +129,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 
 	return &schdcache.TASPodSetRequests{
 		Count:              podCount,
-		SinglePodRequests:  singlePodRequests.ToMapRequests(),
+		SinglePodRequests:  singlePodRequests,
 		PodSet:             podSet,
 		PodSetUpdates:      podSetUpdates,
 		Flavor:             *tasFlvr,

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -83,7 +83,7 @@ func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) field.Err
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.InitContainers, path.Child("initContainers"))...)
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.Containers, path.Child("containers"))...)
 	if podRange, found := s[corev1.LimitTypePod]; found {
-		total := resources.NewRequestsFromPodSpec(ps)
+		total := resources.NewMapRequestsFromPodSpec(ps)
 		if resNames := total.GreaterKeysRL(podRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -556,8 +556,8 @@ func TruncateAssignment(ta *TopologyAssignment, newCount int32) *TopologyAssignm
 }
 
 // ComputeUsagePerDomain calculates resource usage per topology domain from an assignment.
-func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.MapRequests) map[TopologyDomainID]resources.MapRequests {
-	usage := make(map[TopologyDomainID]resources.MapRequests)
+func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.Requests) map[TopologyDomainID]resources.Requests {
+	usage := make(map[TopologyDomainID]resources.Requests)
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
 		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -668,7 +668,7 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 			}
 			singlePodRequests := setRes.SinglePodRequests()
 			if ps := podset.FindPodSetByName(wl.Spec.PodSets, psa.Name); ps != nil {
-				singlePodRequests = resources.NewRequestsFromPodSpec(&ps.Template.Spec)
+				singlePodRequests = resources.NewMapRequestsFromPodSpec(&ps.Template.Spec)
 			}
 			for req := range tas.InternalSeqFrom(psa.TopologyAssignment) {
 				setRes.TopologyRequest.DomainRequests = append(setRes.TopologyRequest.DomainRequests, TopologyDomainRequests{

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -272,12 +272,12 @@ type TopologyRequest struct {
 
 type TopologyDomainRequests struct {
 	Values            []string
-	SinglePodRequests resources.MapRequests
+	SinglePodRequests resources.Requests
 	// Count indicates how many pods are requested in this TopologyDomain.
 	Count int32
 }
 
-func (t *TopologyDomainRequests) TotalRequests() resources.MapRequests {
+func (t *TopologyDomainRequests) TotalRequests() resources.Requests {
 	return t.SinglePodRequests.ScaledUp(int64(t.Count))
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

This PR abstracts `resources.Requests` behind a `Requests` interface to enable pluggable resource request storage backends for Topology-Aware Scheduling (TAS).

This refactoring paves the way for slice-based indexing for resource requests in follow-up work.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved resource capacity tracking for topology-aware scheduling, with more accurate TAS/non-TAS usage and correct handling of nil/empty request data.
  - Enhanced worker/leader placement requirements by standardizing the pod request inputs used across flavor and topology calculations.
  - Improved per-domain reporting of free capacity and TAS usage to ensure complete and consistent serialization.
  - Updated pod request aggregation used for TAS net usage, admission/topology requests, and LimitRange validation for more reliable min/max checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->