### PR TITLE
Add version check to promote pull and wait for images.

### DIFF
--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -339,6 +339,11 @@ function prepare_local_branch() {
   clean_branches+=("$2")
 
   while IFS= read -r name; do
+    if should_skip_image "${name}" "${RELEASE_VERSION}" "${IMAGES_FILE}"; then
+      echo "+++ Skipping ${name} on historical branch release v0.${MINOR}"
+      continue
+    fi
+
     version="$RELEASE_VERSION"
     if [[ "${name}" == "charts/kueue" || "${name}" == "charts/kueue-populator" || "${name}" == "charts/kueue-priority-booster" ]]; then
       version="${version#v}"

--- a/hack/releasing/wait_for_images.sh
+++ b/hack/releasing/wait_for_images.sh
@@ -82,6 +82,24 @@ if ! command -v crane >/dev/null 2>&1; then
   exit 1
 fi
 
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck source=hack/utils.sh
+source "${SCRIPT_DIR}/../utils.sh"
+
+IMAGES_YAML_URL="https://raw.githubusercontent.com/kubernetes/k8s.io/main/registry.k8s.io/images/k8s-staging-kueue/images.yaml"
+TMP_IMAGES_FILE=$(mktemp)
+declare -r TMP_IMAGES_FILE
+
+function cleanup {
+  rm -f "${TMP_IMAGES_FILE}"
+}
+trap cleanup EXIT
+
+if ! curl -sSLo "${TMP_IMAGES_FILE}" "${IMAGES_YAML_URL}"; then
+  echo "!!! Warning: Failed to download images.yaml from github. Version checks may be skipped."
+  rm -f "${TMP_IMAGES_FILE}"
+fi
+
 # $1 - image name
 # $2 - version
 function check_image() {
@@ -118,6 +136,10 @@ function check_images() {
 
   echo "Images:"
   for image in "${images[@]}"; do
+    if should_skip_image "${image}" "${RELEASE_VERSION}" "${TMP_IMAGES_FILE}"; then
+      echo "  Skipping \"${image}\" check (introduced in later version)."
+      continue
+    fi
     echo ""
     if ! check_image "${image}" "${RELEASE_VERSION}"; then
       return 1
@@ -127,6 +149,10 @@ function check_images() {
   echo ""
   echo "Charts:"
   for chart in "${charts[@]}"; do
+    if should_skip_image "charts/${chart}" "${RELEASE_VERSION}" "${TMP_IMAGES_FILE}"; then
+      echo "  Skipping \"charts/${chart}\" check (introduced in later version)."
+      continue
+    fi
     echo ""
     if ! check_image "charts/${chart}" "${RELEASE_VERSION#v}"; then
       return 1

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -49,3 +49,61 @@ resolve_path() {
   local resolved="/${stack[*]}"
   echo "${resolved// /\/}"
 }
+
+# Returns 0 if version $1 is strictly less than version $2, else 1
+function version_less_than() {
+  local v1="${1#v}"; v1="${v1%-*}"
+  local v2="${2#v}"; v2="${v2%-*}"
+
+  local major1 minor1 patch1
+  IFS='.' read -r major1 minor1 patch1 <<< "${v1}"
+
+  local major2 minor2 patch2
+  IFS='.' read -r major2 minor2 patch2 <<< "${v2}"
+
+  if (( ${major1:-0} == ${major2:-0} && ${minor1:-0} == ${minor2:-0} )); then
+    (( ${patch1:-0} < ${patch2:-0} ))
+    return
+  fi
+  if (( ${major1:-0} == ${major2:-0} )); then
+    (( ${minor1:-0} < ${minor2:-0} ))
+    return
+  fi
+  (( ${major1:-0} < ${major2:-0} ))
+}
+
+# Returns 0 if the image should be skipped, else 1
+# $1 - image name
+# $2 - release version
+# $3 - images file path
+function should_skip_image() {
+  local name="$1"
+  local release_version="$2"
+  local images_file_path="$3"
+
+  if [[ ! -f "${images_file_path}" ]]; then
+    return 1 # Do not skip if file is missing (failsafe)
+  fi
+
+  local min_version
+  min_version=$(awk -v name="${name}" '
+    $0 ~ "^-[[:space:]]*name:[[:space:]]*" {
+      current_name = $3
+    }
+    current_name == name && $0 ~ /\["[^"]+"\]/ {
+      match($0, /\["[^"]+"\]/)
+      print substr($0, RSTART+2, RLENGTH-4)
+    }
+  ' "${images_file_path}" | sed 's/^v//' | sort -t. -k 1,1n -k 2,2n -k 3,3n | head -n 1)
+
+  if [[ -z "${min_version}" ]]; then
+    return 1 # Do not skip if no historical promotions exist (e.g. brand new image)
+  fi
+
+  if version_less_than "${release_version}" "${min_version}"; then
+    return 0 # Skip
+  fi
+
+  return 1 # Do not skip
+}
+

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -73,6 +73,11 @@ function version_less_than() {
 }
 
 # Returns 0 if the image should be skipped, else 1
+# Skips the image if the release version is older than
+# the image's initial release version.
+# E.g. skip 0.17.7 (< 0.18.0) for kueue-priority-booster.
+# If the image is new (does not have a minimum version defined)
+# it will not be skipped.
 # $1 - image name
 # $2 - release version
 # $3 - images file path

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -95,9 +95,14 @@ function should_skip_image() {
     $0 ~ "^-[[:space:]]*name:[[:space:]]*" {
       current_name = $3
     }
-    current_name == name && $0 ~ /\["[^"]+"\]/ {
-      match($0, /\["[^"]+"\]/)
-      print substr($0, RSTART+2, RLENGTH-4)
+    current_name == name && match($0, /\[[^\]]*\]/) {
+      arr = substr($0, RSTART+1, RLENGTH-2)
+      n = split(arr, versions, /,[[:space:]]*/)
+      for (i = 1; i <= n; i++) {
+        v = versions[i]
+        gsub(/^[[:space:]]*"|"[[:space:]]*$/, "", v)
+        if (v != "") print v
+      }
     }
   ' "${images_file_path}" | sed 's/^v//' | sort -t. -k 1,1n -k 2,2n -k 3,3n | head -n 1)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Updates promote_pull and wait_for_image to skip images when releasing for a version older than the version when the image was introduced in.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12976

#### Special notes for your reviewer:
Created with the help of AI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical release handling by skipping images and charts introduced after the requested release version.
  * Updated release preparation and image/chart availability checks to apply consistent skip decisions across workflows.
  * Added safe fallback behavior when image-history data is missing or incomplete to avoid unnecessary blocking.
  * Improved robustness when fetching the `images.yaml` snapshot by warning and continuing when the download fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->