### PR TITLE
MultiKueue: skip workers with conflicting job names

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -182,6 +182,69 @@ func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error
 	return nil
 }
 
+func (g *wlGroup) hasJobNameConflict(ctx context.Context, cluster string) (bool, error) {
+	remote := g.remoteClients[cluster]
+	_, err := jobframework.ValidateRemoteObjectOwnership(ctx, remote.getClient(), g.controllerKey, g.jobAdapter.GVK(), remote.origin)
+	if errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (w *wlReconciler) reportJobNameConflict(ctx context.Context, group *wlGroup, cluster string) {
+	message := fmt.Sprintf(
+		"Worker cluster %q contains a conflicting %s %q not owned by this MultiKueue manager; skipping the cluster",
+		cluster, group.jobAdapter.GVK().Kind, group.controllerKey.String(),
+	)
+	ctrl.LoggerFrom(ctx).V(2).Info(message)
+	w.recorder.Eventf(group.local, nil, corev1.EventTypeWarning, "MultiKueueJobNameConflict", "SkipWorkerCluster", api.TruncateEventMessage(message))
+}
+
+func jobNameConflictError(clusters []string) error {
+	return fmt.Errorf("job name conflict on worker clusters %q: %w", clusters, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+}
+
+func (w *wlReconciler) removeConflictingRemote(ctx context.Context, group *wlGroup, cluster string) (reconcile.Result, error) {
+	w.reportJobNameConflict(ctx, group, cluster)
+	if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, cluster)); err != nil {
+		return reconcile.Result{}, fmt.Errorf("removing remote workload from worker cluster %q after a job name conflict: %w", cluster, err)
+	}
+	return reconcile.Result{}, jobNameConflictError([]string{cluster})
+}
+
+func (w *wlReconciler) syncJob(ctx context.Context, remoteClient client.Client, group *wlGroup) (bool, error) {
+	if features.Enabled(features.MultiKueueJobNameConflictCheck) {
+		return jobframework.SyncJobWithRemoteObjectOwnership(ctx, w.client, remoteClient, group.jobAdapter, group.controllerKey, group.local.Name, w.origin)
+	}
+	return group.jobAdapter.SyncJob(ctx, w.client, remoteClient, group.controllerKey, group.local.Name, w.origin)
+}
+
+func (w *wlReconciler) filterWorkersWithJobNameConflicts(ctx context.Context, group *wlGroup, workers []string) ([]string, []string, error) {
+	if !features.Enabled(features.MultiKueueJobNameConflictCheck) {
+		return workers, nil, nil
+	}
+
+	eligible := make([]string, 0, len(workers))
+	var conflicts []string
+	for _, cluster := range workers {
+		if group.remotes[cluster] != nil || group.remoteClients[cluster] == nil {
+			eligible = append(eligible, cluster)
+			continue
+		}
+		conflict, err := group.hasJobNameConflict(ctx, cluster)
+		if err != nil {
+			return nil, nil, fmt.Errorf("checking worker cluster %q for a job name conflict: %w", cluster, err)
+		}
+		if conflict {
+			conflicts = append(conflicts, cluster)
+			w.reportJobNameConflict(ctx, group, cluster)
+			continue
+		}
+		eligible = append(eligible, cluster)
+	}
+	return eligible, conflicts, nil
+}
+
 func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile Workload")
@@ -424,7 +487,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 			// The deferred flag is irrelevant here: the remote workload is
 			// Finished, so determineStatusUpdate always syncs (never defers).
-			if _, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+			if _, err := w.syncJob(ctx, remoteCl, group); err != nil {
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -453,7 +516,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				return reconcile.Result{}, err
 			}
 
-			deferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+			deferred, err := w.syncJob(ctx, remoteCl, group)
 			if err != nil {
 				log.Error(err, "Syncing remote controller object")
 				// We'll retry this in the next reconciling.
@@ -569,6 +632,16 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 	// 6b. An admitting remote is visible: converge onto it.
 	if remoteCond != nil {
+		if features.Enabled(features.MultiKueueJobNameConflictCheck) {
+			conflict, err := group.hasJobNameConflict(ctx, admittingRemote)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("checking admitting worker cluster %q for a job name conflict: %w", admittingRemote, err)
+			}
+			if conflict {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
+		}
+
 		// remove the non-selected worker workloads
 		for rem, remWl := range group.remotes {
 			if remWl != nil && rem != admittingRemote {
@@ -602,12 +675,18 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 
 		if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
+			if features.Enabled(features.MultiKueueJobNameConflictCheck) && errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
 			log.Error(err, "validating remote controller object", "cluster", admittingRemote)
 			return reconcile.Result{}, err
 		}
 
-		syncDeferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+		syncDeferred, err := w.syncJob(ctx, remoteCl, group)
 		if err != nil {
+			if features.Enabled(features.MultiKueueJobNameConflictCheck) && errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
 			log.Error(err, "Syncing remote controller object")
 			// We'll retry this in the next reconciling.
 			return reconcile.Result{}, err
@@ -657,7 +736,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	}
 
 	res, err := w.nominateAndSynchronizeWorkers(ctx, group)
-	if err == nil && (res.RequeueAfter == 0 || requeueAfterSynchronize < res.RequeueAfter) {
+	if err == nil && requeueAfterSynchronize > 0 && (res.RequeueAfter == 0 || requeueAfterSynchronize < res.RequeueAfter) {
 		res.RequeueAfter = requeueAfterSynchronize
 	}
 	return res, err
@@ -809,6 +888,14 @@ func admittedClusterQueue(wl *kueue.Workload) kueue.ClusterQueueReference {
 }
 
 func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger, group *wlGroup, targetCluster string) (reconcile.Result, error) {
+	eligible, conflicts, err := w.filterWorkersWithJobNameConflicts(ctx, group, []string{targetCluster})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(conflicts) > 0 && len(eligible) == 0 {
+		return reconcile.Result{}, jobNameConflictError(conflicts)
+	}
+
 	var errs []error
 
 	for clusterName, remoteWl := range group.remotes {
@@ -901,6 +988,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 	}
 
 	var nominatedWorkers []string
+	patchNominatedWorkers := false
 
 	// For elastic workloads, retrieve the remote cluster where the original workload was scheduled.
 	// For now, new workload slices will continue to be assigned to the same cluster.
@@ -912,19 +1000,25 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		for workerName := range group.remotes {
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
-
-		if !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
-			if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
-				wl.Status.NominatedClusterNames = nominatedWorkers
-				return true, nil
-			}); err != nil {
-				log.V(2).Error(err, "Failed to patch nominated clusters", "workload", klog.KObj(group.local))
-				return reconcile.Result{}, err
-			}
-		}
+		patchNominatedWorkers = true
 	} else {
 		// Incremental dispatcher and External dispatcher path
 		nominatedWorkers = group.local.Status.NominatedClusterNames
+	}
+
+	nominatedWorkers, conflicts, err := w.filterWorkersWithJobNameConflicts(ctx, group, nominatedWorkers)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if patchNominatedWorkers && !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
+		if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
+			wl.Status.NominatedClusterNames = nominatedWorkers
+			return true, nil
+		}); err != nil {
+			log.V(2).Error(err, "Failed to patch nominated clusters", "workload", klog.KObj(group.local))
+			return reconcile.Result{}, err
+		}
 	}
 
 	var errs []error
@@ -956,7 +1050,13 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 			group.remotes[rem] = nil
 		}
 	}
-	return reconcile.Result{}, errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(conflicts) > 0 {
+		return reconcile.Result{}, jobNameConflictError(conflicts)
+	}
+	return reconcile.Result{}, nil
 }
 
 func (w *wlReconciler) Create(_ event.CreateEvent) bool {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -184,6 +184,69 @@ func (g *wlGroup) RemoveRemoteObjects(ctx context.Context, cluster string) error
 	return nil
 }
 
+func (g *wlGroup) hasJobNameConflict(ctx context.Context, cluster string) (bool, error) {
+	remote := g.remoteClients[cluster]
+	_, err := jobframework.ValidateRemoteObjectOwnership(ctx, remote.getClient(), g.controllerKey, g.jobAdapter.GVK(), remote.origin)
+	if errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+		return true, nil
+	}
+	return false, err
+}
+
+func (w *wlReconciler) reportJobNameConflict(ctx context.Context, group *wlGroup, cluster string) {
+	message := fmt.Sprintf(
+		"Worker cluster %q contains a conflicting %s %q not owned by this MultiKueue manager; skipping the cluster",
+		cluster, group.jobAdapter.GVK().Kind, group.controllerKey.String(),
+	)
+	ctrl.LoggerFrom(ctx).V(2).Info(message)
+	w.recorder.Eventf(group.local, nil, corev1.EventTypeWarning, "MultiKueueJobNameConflict", "SkipWorkerCluster", api.TruncateEventMessage(message))
+}
+
+func jobNameConflictError(clusters []string) error {
+	return fmt.Errorf("job name conflict on worker clusters %q: %w", clusters, jobframework.ErrRemoteObjectNotOwnedByMultiKueue)
+}
+
+func (w *wlReconciler) removeConflictingRemote(ctx context.Context, group *wlGroup, cluster string) (reconcile.Result, error) {
+	w.reportJobNameConflict(ctx, group, cluster)
+	if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, cluster)); err != nil {
+		return reconcile.Result{}, fmt.Errorf("removing remote workload from worker cluster %q after a job name conflict: %w", cluster, err)
+	}
+	return reconcile.Result{}, jobNameConflictError([]string{cluster})
+}
+
+func (w *wlReconciler) syncJob(ctx context.Context, remoteClient client.Client, group *wlGroup) (bool, error) {
+	if features.Enabled(features.MultiKueueJobNameConflictCheck) {
+		return jobframework.SyncJobWithRemoteObjectOwnership(ctx, w.client, remoteClient, group.jobAdapter, group.controllerKey, group.local.Name, w.origin)
+	}
+	return group.jobAdapter.SyncJob(ctx, w.client, remoteClient, group.controllerKey, group.local.Name, w.origin)
+}
+
+func (w *wlReconciler) filterWorkersWithJobNameConflicts(ctx context.Context, group *wlGroup, workers []string) ([]string, []string, error) {
+	if !features.Enabled(features.MultiKueueJobNameConflictCheck) {
+		return workers, nil, nil
+	}
+
+	eligible := make([]string, 0, len(workers))
+	var conflicts []string
+	for _, cluster := range workers {
+		if group.remotes[cluster] != nil || group.remoteClients[cluster] == nil {
+			eligible = append(eligible, cluster)
+			continue
+		}
+		conflict, err := group.hasJobNameConflict(ctx, cluster)
+		if err != nil {
+			return nil, nil, fmt.Errorf("checking worker cluster %q for a job name conflict: %w", cluster, err)
+		}
+		if conflict {
+			conflicts = append(conflicts, cluster)
+			w.reportJobNameConflict(ctx, group, cluster)
+			continue
+		}
+		eligible = append(eligible, cluster)
+	}
+	return eligible, conflicts, nil
+}
+
 func (w *wlReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile Workload")
@@ -429,7 +492,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 			// The deferred flag is irrelevant here: the remote workload is
 			// Finished, so determineStatusUpdate always syncs (never defers).
-			if _, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin); err != nil {
+			if _, err := w.syncJob(ctx, remoteCl, group); err != nil {
 				log.V(2).Error(err, "copying remote controller status", "workerCluster", remote)
 				// we should retry this
 				return reconcile.Result{}, err
@@ -458,7 +521,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 				return reconcile.Result{}, err
 			}
 
-			deferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+			deferred, err := w.syncJob(ctx, remoteCl, group)
 			if err != nil {
 				log.Error(err, "Syncing remote controller object")
 				// We'll retry this in the next reconciling.
@@ -574,6 +637,16 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 	// 6b. An admitting remote is visible: converge onto it.
 	if remoteCond != nil {
+		if features.Enabled(features.MultiKueueJobNameConflictCheck) {
+			conflict, err := group.hasJobNameConflict(ctx, admittingRemote)
+			if err != nil {
+				return reconcile.Result{}, fmt.Errorf("checking admitting worker cluster %q for a job name conflict: %w", admittingRemote, err)
+			}
+			if conflict {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
+		}
+
 		// remove the non-selected worker workloads
 		for rem, remWl := range group.remotes {
 			if remWl != nil && rem != admittingRemote {
@@ -607,12 +680,18 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 
 		if _, err := jobframework.ValidateRemoteObjectOwnership(ctx, remoteCl, group.controllerKey, group.jobAdapter.GVK(), w.origin); err != nil {
+			if features.Enabled(features.MultiKueueJobNameConflictCheck) && errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
 			log.Error(err, "validating remote controller object", "cluster", admittingRemote)
 			return reconcile.Result{}, err
 		}
 
-		syncDeferred, err := group.jobAdapter.SyncJob(ctx, w.client, remoteCl, group.controllerKey, group.local.Name, w.origin)
+		syncDeferred, err := w.syncJob(ctx, remoteCl, group)
 		if err != nil {
+			if features.Enabled(features.MultiKueueJobNameConflictCheck) && errors.Is(err, jobframework.ErrRemoteObjectNotOwnedByMultiKueue) {
+				return w.removeConflictingRemote(ctx, group, admittingRemote)
+			}
 			log.Error(err, "Syncing remote controller object")
 			// We'll retry this in the next reconciling.
 			return reconcile.Result{}, err
@@ -662,7 +741,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 	}
 
 	res, err := w.nominateAndSynchronizeWorkers(ctx, group)
-	if err == nil && (res.RequeueAfter == 0 || requeueAfterSynchronize < res.RequeueAfter) {
+	if err == nil && requeueAfterSynchronize > 0 && (res.RequeueAfter == 0 || requeueAfterSynchronize < res.RequeueAfter) {
 		res.RequeueAfter = requeueAfterSynchronize
 	}
 	return res, err
@@ -814,6 +893,14 @@ func admittedClusterQueue(wl *kueue.Workload) kueue.ClusterQueueReference {
 }
 
 func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger, group *wlGroup, targetCluster string) (reconcile.Result, error) {
+	eligible, conflicts, err := w.filterWorkersWithJobNameConflicts(ctx, group, []string{targetCluster})
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(conflicts) > 0 && len(eligible) == 0 {
+		return reconcile.Result{}, jobNameConflictError(conflicts)
+	}
+
 	var errs []error
 
 	for clusterName, remoteWl := range group.remotes {
@@ -898,6 +985,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 	}
 
 	var nominatedWorkers []string
+	patchNominatedWorkers := false
 
 	// For elastic workloads, retrieve the remote cluster where the original workload was scheduled.
 	// For now, new workload slices will continue to be assigned to the same cluster.
@@ -909,23 +997,31 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		for workerName := range group.remotes {
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
+		patchNominatedWorkers = true
+	} else {
+		// Incremental dispatcher and External dispatcher path
+		nominatedWorkers = group.local.Status.NominatedClusterNames
+	}
 
-		// group.remotes is a map, so iteration order is non-deterministic; sort only
-		// when we are about to persist, for a stable stored nomination.
-		slices.Sort(nominatedWorkers)
+	nominatedWorkers, conflicts, err := w.filterWorkersWithJobNameConflicts(ctx, group, nominatedWorkers)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if patchNominatedWorkers {
 		if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 			if sets.New(wl.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
 				return false, nil
 			}
+			// group.remotes is a map, so iteration order is non-deterministic; sort only
+			// when we are about to persist, for a stable stored nomination.
+			slices.Sort(nominatedWorkers)
 			wl.Status.NominatedClusterNames = nominatedWorkers
 			return true, nil
 		}); err != nil {
 			log.V(2).Error(err, "Failed to patch nominated clusters", "workload", klog.KObj(group.local))
 			return reconcile.Result{}, err
 		}
-	} else {
-		// Incremental dispatcher and External dispatcher path
-		nominatedWorkers = group.local.Status.NominatedClusterNames
 	}
 
 	var errs []error
@@ -957,7 +1053,13 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 			group.remotes[rem] = nil
 		}
 	}
-	return reconcile.Result{}, errors.Join(errs...)
+	if err := errors.Join(errs...); err != nil {
+		return reconcile.Result{}, err
+	}
+	if len(conflicts) > 0 {
+		return reconcile.Result{}, jobNameConflictError(conflicts)
+	}
+	return reconcile.Result{}, nil
 }
 
 func (w *wlReconciler) Create(_ event.CreateEvent) bool {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -453,6 +453,165 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"job name conflict check disabled preserves dispatch to conflicting worker": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: false,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+		},
+		"job name conflict check skips conflicting worker": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker2").
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
+		"job name conflict check returns error when every worker conflicts": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
+		"incremental dispatcher skips conflicting nominated worker without changing nominations": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			dispatcherName: ptr.To(config.MultiKueueDispatcherModeIncremental),
+			reconcileFor:   "wl1",
+			managersJobs:   []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
 		"remote wl with reservation but not admitted - other workers not deleted": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
@@ -569,6 +728,63 @@ func TestWlReconcile(t *testing.T) {
 					EventType: "Normal",
 					Reason:    "MultiKueue",
 					Message:   `The workload was admitted on "worker1"`,
+				},
+			},
+		},
+		"admitting remote with job name conflict is removed without deleting alternatives": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantWorker1Jobs:  []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
 				},
 			},
 		},

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -452,6 +452,165 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"job name conflict check disabled preserves dispatch to conflicting worker": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: false,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+		},
+		"job name conflict check skips conflicting worker": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker2").
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
+		"job name conflict check returns error when every worker conflicts": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			worker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
+		"incremental dispatcher skips conflicting nominated worker without changing nominations": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			dispatcherName: ptr.To(config.MultiKueueDispatcherModeIncremental),
+			reconcileFor:   "wl1",
+			managersJobs:   []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+
+			wantError:        jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1", "worker2").
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
+				},
+			},
+		},
 		"remote wl with reservation but not admitted - other workers not deleted": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
@@ -568,6 +727,63 @@ func TestWlReconcile(t *testing.T) {
 					EventType: "Normal",
 					Reason:    "MultiKueue",
 					Message:   `The workload was admitted on "worker1"`,
+				},
+			},
+		},
+		"admitting remote with job name conflict is removed without deleting alternatives": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations:  false,
+				features.MultiKueueJobNameConflictCheck: true,
+			},
+			reconcileFor: "wl1",
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+						Reason: "Admitted",
+					}).
+					Obj(),
+			},
+			worker1Jobs:     []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			useSecondWorker: true,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+
+			wantError: jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{Name: "ac1", State: kueue.CheckStatePending}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{*baseJobManagedByKueueBuilder.DeepCopy()},
+			wantWorker1Jobs:  []batchv1.Job{*baseJobBuilder.DeepCopy()},
+			wantWorker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
+					EventType: "Warning",
+					Reason:    "MultiKueueJobNameConflict",
+					Message:   `Worker cluster "worker1" contains a conflicting Job "ns/job1" not owned by this MultiKueue manager; skipping the cluster`,
 				},
 			},
 		},

--- a/pkg/controller/jobframework/multikueue_test.go
+++ b/pkg/controller/jobframework/multikueue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -109,6 +110,137 @@ func TestValidateRemoteObjectOwnership(t *testing.T) {
 				t.Fatalf("ValidateRemoteObjectOwnership() found = %v, wantFound %v", found, tc.wantFound)
 			}
 		})
+	}
+}
+
+func TestSyncJobWithRemoteObjectOwnership(t *testing.T) {
+	key := types.NamespacedName{Name: "test", Namespace: "default"}
+	secondaryKey := types.NamespacedName{Name: "secondary", Namespace: "default"}
+	const origin = "origin-1"
+
+	makeJob := func(key types.NamespacedName, labels map[string]string) *batchv1.Job {
+		return &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace, Labels: labels}}
+	}
+
+	tests := map[string]struct {
+		remoteJobs []client.Object
+		getKeys    []types.NamespacedName
+		origin     string
+		callSync   bool
+		wantErr    error
+	}{
+		"empty origin is rejected before sync": {
+			wantErr: jobframework.ErrMultiKueueOriginEmpty,
+		},
+		"missing remote object allows sync": {
+			origin:   origin,
+			callSync: true,
+		},
+		"owned remote object allows sync": {
+			remoteJobs: []client.Object{makeJob(key, map[string]string{kueue.MultiKueueOriginLabel: origin})},
+			origin:     origin,
+			callSync:   true,
+		},
+		"unowned remote object blocks sync": {
+			remoteJobs: []client.Object{makeJob(key, nil)},
+			origin:     origin,
+			callSync:   true,
+			wantErr:    jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+		"remote object from another origin blocks sync": {
+			remoteJobs: []client.Object{makeJob(key, map[string]string{kueue.MultiKueueOriginLabel: "origin-2"})},
+			origin:     origin,
+			callSync:   true,
+			wantErr:    jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+		"unowned secondary object blocks sync": {
+			remoteJobs: []client.Object{
+				makeJob(key, map[string]string{kueue.MultiKueueOriginLabel: origin}),
+				makeJob(secondaryKey, nil),
+			},
+			getKeys:  []types.NamespacedName{key, secondaryKey},
+			origin:   origin,
+			callSync: true,
+			wantErr:  jobframework.ErrRemoteObjectNotOwnedByMultiKueue,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			if err := batchv1.AddToScheme(scheme); err != nil {
+				t.Fatalf("adding batch scheme: %v", err)
+			}
+
+			remoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tc.remoteJobs...).Build()
+			localClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			adapter := mocks.NewMockMultiKueueAdapter(gomock.NewController(t))
+			if tc.callSync {
+				adapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job"))
+				adapter.EXPECT().SyncJob(gomock.Any(), localClient, gomock.Any(), key, "workload", tc.origin).
+					DoAndReturn(func(ctx context.Context, _ client.Client, validatingClient client.Client, key types.NamespacedName, _, _ string) (bool, error) {
+						getKeys := tc.getKeys
+						if len(getKeys) == 0 {
+							getKeys = []types.NamespacedName{key}
+						}
+						for _, getKey := range getKeys {
+							if err := validatingClient.Get(ctx, getKey, &batchv1.Job{}); client.IgnoreNotFound(err) != nil {
+								return false, err
+							}
+						}
+						return false, nil
+					})
+			}
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			_, err := jobframework.SyncJobWithRemoteObjectOwnership(ctx, localClient, remoteClient, adapter, key, "workload", tc.origin)
+			if diff := cmp.Diff(err, tc.wantErr, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("SyncJobWithRemoteObjectOwnership() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeleteRemoteObjectIfOwnedSkipsUnownedAdapterObjects(t *testing.T) {
+	const origin = "origin-1"
+	ownedKey := types.NamespacedName{Name: "owned", Namespace: "default"}
+	foreignKey := types.NamespacedName{Name: "foreign", Namespace: "default"}
+
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("adding batch scheme: %v", err)
+	}
+	ownedJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: ownedKey.Name, Namespace: ownedKey.Namespace,
+		Labels: map[string]string{kueue.MultiKueueOriginLabel: origin},
+	}}
+	foreignJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: foreignKey.Name, Namespace: foreignKey.Namespace}}
+	remoteClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ownedJob, foreignJob).Build()
+	localClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	adapter := mocks.NewMockMultiKueueAdapter(gomock.NewController(t))
+	adapter.EXPECT().GVK().Return(batchv1.SchemeGroupVersion.WithKind("Job")).AnyTimes()
+	adapter.EXPECT().DeleteRemoteObject(gomock.Any(), localClient, gomock.Any(), ownedKey).
+		DoAndReturn(func(ctx context.Context, _ client.Client, validatingClient client.Client, _ types.NamespacedName) error {
+			for _, key := range []types.NamespacedName{ownedKey, foreignKey} {
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}
+				if err := validatingClient.Delete(ctx, job); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	if err := jobframework.DeleteRemoteObjectIfOwned(ctx, localClient, remoteClient, adapter, ownedKey, origin); err != nil {
+		t.Fatalf("DeleteRemoteObjectIfOwned() error = %v", err)
+	}
+	if err := remoteClient.Get(ctx, ownedKey, &batchv1.Job{}); !apierrors.IsNotFound(err) {
+		t.Fatalf("owned object Get() error = %v, want NotFound", err)
+	}
+	if err := remoteClient.Get(ctx, foreignKey, &batchv1.Job{}); err != nil {
+		t.Fatalf("foreign object Get() error = %v, want object preserved", err)
 	}
 }
 

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
@@ -243,6 +244,13 @@ func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKe
 var ErrRemoteObjectNotOwnedByMultiKueue = errors.New("remote object is not owned by MultiKueue")
 var ErrMultiKueueOriginEmpty = errors.New("multikueue origin is empty")
 
+func validateRemoteObjectOrigin(remoteObject client.Object, key types.NamespacedName, origin string) error {
+	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
+		return fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, key)
+	}
+	return nil
+}
+
 // ValidateRemoteObjectOwnership retrieves the remote object and validates it is owned by this MultiKueue origin.
 // Returns (false, ErrMultiKueueOriginEmpty) if origin is empty.
 // Returns (true, nil) if the object exists and is owned by this MultiKueue origin.
@@ -265,16 +273,75 @@ func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Clie
 		return false, err
 	}
 
-	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
-		return false, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
+	if err := validateRemoteObjectOrigin(remoteObject, key, origin); err != nil {
+		return false, err
 	}
 
 	return true, nil
 }
 
+type remoteObjectOwnershipClient struct {
+	client.Client
+	gvk    schema.GroupVersionKind
+	origin string
+}
+
+func (c *remoteObjectOwnershipClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk != c.gvk {
+		return nil
+	}
+	return validateRemoteObjectOrigin(obj, key, c.origin)
+}
+
+func (c *remoteObjectOwnershipClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk != c.gvk {
+		return c.Client.Delete(ctx, obj, opts...)
+	}
+
+	found, err := ValidateRemoteObjectOwnership(ctx, c.Client, client.ObjectKeyFromObject(obj), c.gvk, c.origin)
+	if err != nil {
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			return nil
+		}
+		return err
+	}
+	if !found {
+		return nil
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+// SyncJobWithRemoteObjectOwnership prevents an adapter from reading status from
+// remote objects of its GVK that are not owned by this MultiKueue origin. The
+// validation happens on each object returned to the adapter, closing the gap
+// between a separate ownership check and the adapter's Get calls.
+func SyncJobWithRemoteObjectOwnership(ctx context.Context, localClient, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, workloadName, origin string) (bool, error) {
+	if origin == "" {
+		return false, ErrMultiKueueOriginEmpty
+	}
+	validatingClient := &remoteObjectOwnershipClient{
+		Client: remoteClient,
+		gvk:    adapter.GVK(),
+		origin: origin,
+	}
+	return adapter.SyncJob(ctx, localClient, validatingClient, key, workloadName, origin)
+}
+
 // DeleteRemoteObjectIfOwned fetches the remote object for the given adapter's GVK and key,
 // skips deletion if the object does not exist or is not owned by this MultiKueue origin,
-// and otherwise delegates to adapter.DeleteRemoteObject.
+// and otherwise delegates to adapter.DeleteRemoteObject through a client that
+// also preserves any additional objects not owned by this MultiKueue origin.
 // Returns ErrMultiKueueOriginEmpty if origin is empty.
 func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, origin string) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", origin)
@@ -297,5 +364,15 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 		return nil
 	}
 
-	return adapter.DeleteRemoteObject(ctx, localClient, remoteClient, key)
+	validatingClient := &remoteObjectOwnershipClient{
+		Client: remoteClient,
+		gvk:    adapter.GVK(),
+		origin: origin,
+	}
+	if err := adapter.DeleteRemoteObject(ctx, localClient, validatingClient, key); errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+		log.V(2).Info("Skipping remote object deletion because object ownership changed")
+		return nil
+	} else {
+		return err
+	}
 }

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
@@ -284,6 +285,13 @@ func NewWorkload(name string, obj client.Object, podSets []kueue.PodSet, labelKe
 var ErrRemoteObjectNotOwnedByMultiKueue = errors.New("remote object is not owned by MultiKueue")
 var ErrMultiKueueOriginEmpty = errors.New("multikueue origin is empty")
 
+func validateRemoteObjectOrigin(remoteObject client.Object, key types.NamespacedName, origin string) error {
+	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
+		return fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, key)
+	}
+	return nil
+}
+
 // ValidateRemoteObjectOwnership retrieves the remote object and validates it is owned by this MultiKueue origin.
 // Returns (false, ErrMultiKueueOriginEmpty) if origin is empty.
 // Returns (true, nil) if the object exists and is owned by this MultiKueue origin.
@@ -306,16 +314,75 @@ func ValidateRemoteObjectOwnership(ctx context.Context, remoteClient client.Clie
 		return false, err
 	}
 
-	if objOrigin, owned := remoteObject.GetLabels()[kueue.MultiKueueOriginLabel]; !owned || objOrigin != origin {
-		return false, fmt.Errorf("%w: expected %q=%q on %T %q", ErrRemoteObjectNotOwnedByMultiKueue, kueue.MultiKueueOriginLabel, origin, remoteObject, client.ObjectKeyFromObject(remoteObject))
+	if err := validateRemoteObjectOrigin(remoteObject, key, origin); err != nil {
+		return false, err
 	}
 
 	return true, nil
 }
 
+type remoteObjectOwnershipClient struct {
+	client.Client
+	gvk    schema.GroupVersionKind
+	origin string
+}
+
+func (c *remoteObjectOwnershipClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if err := c.Client.Get(ctx, key, obj, opts...); err != nil {
+		return err
+	}
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk != c.gvk {
+		return nil
+	}
+	return validateRemoteObjectOrigin(obj, key, c.origin)
+}
+
+func (c *remoteObjectOwnershipClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme())
+	if err != nil {
+		return err
+	}
+	if gvk != c.gvk {
+		return c.Client.Delete(ctx, obj, opts...)
+	}
+
+	found, err := ValidateRemoteObjectOwnership(ctx, c.Client, client.ObjectKeyFromObject(obj), c.gvk, c.origin)
+	if err != nil {
+		if errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+			return nil
+		}
+		return err
+	}
+	if !found {
+		return nil
+	}
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+// SyncJobWithRemoteObjectOwnership prevents an adapter from reading status from
+// remote objects of its GVK that are not owned by this MultiKueue origin. The
+// validation happens on each object returned to the adapter, closing the gap
+// between a separate ownership check and the adapter's Get calls.
+func SyncJobWithRemoteObjectOwnership(ctx context.Context, localClient, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, workloadName, origin string) (bool, error) {
+	if origin == "" {
+		return false, ErrMultiKueueOriginEmpty
+	}
+	validatingClient := &remoteObjectOwnershipClient{
+		Client: remoteClient,
+		gvk:    adapter.GVK(),
+		origin: origin,
+	}
+	return adapter.SyncJob(ctx, localClient, validatingClient, key, workloadName, origin)
+}
+
 // DeleteRemoteObjectIfOwned fetches the remote object for the given adapter's GVK and key,
 // skips deletion if the object does not exist or is not owned by this MultiKueue origin,
-// and otherwise delegates to adapter.DeleteRemoteObject.
+// and otherwise delegates to adapter.DeleteRemoteObject through a client that
+// also preserves any additional objects not owned by this MultiKueue origin.
 // Returns ErrMultiKueueOriginEmpty if origin is empty.
 func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, remoteClient client.Client, adapter MultiKueueAdapter, key types.NamespacedName, origin string) error {
 	log := ctrl.LoggerFrom(ctx).WithValues("remoteObject", key, "adapterGVK", adapter.GVK().String(), "origin", origin)
@@ -338,5 +405,15 @@ func DeleteRemoteObjectIfOwned(ctx context.Context, localClient client.Client, r
 		return nil
 	}
 
-	return adapter.DeleteRemoteObject(ctx, localClient, remoteClient, key)
+	validatingClient := &remoteObjectOwnershipClient{
+		Client: remoteClient,
+		gvk:    adapter.GVK(),
+		origin: origin,
+	}
+	if err := adapter.DeleteRemoteObject(ctx, localClient, validatingClient, key); errors.Is(err, ErrRemoteObjectNotOwnedByMultiKueue) {
+		log.V(2).Info("Skipping remote object deletion because object ownership changed")
+		return nil
+	} else {
+		return err
+	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -249,6 +249,13 @@ const (
 	// controller falls back to the legacy behavior of allowing any path.
 	MultiKueueKubeConfigPathValidation featuregate.Feature = "MultiKueueKubeConfigPathValidation"
 
+	// owner: @MatteoFari
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12404
+	//
+	// Skip worker clusters that contain a same-name Job object not owned by
+	// the current MultiKueue manager.
+	MultiKueueJobNameConflictCheck featuregate.Feature = "MultiKueueJobNameConflictCheck"
+
 	// owner: @pbundyra
 	//
 	// Enables reclaimable pods counting towards quota.
@@ -653,6 +660,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	MultiKueueKubeConfigPathValidation: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	MultiKueueJobNameConflictCheck: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ReclaimablePods: {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -248,6 +248,13 @@ const (
 	// controller falls back to the legacy behavior of allowing any path.
 	MultiKueueKubeConfigPathValidation featuregate.Feature = "MultiKueueKubeConfigPathValidation"
 
+	// owner: @MatteoFari
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12404
+	//
+	// Skip worker clusters that contain a same-name Job object not owned by
+	// the current MultiKueue manager.
+	MultiKueueJobNameConflictCheck featuregate.Feature = "MultiKueueJobNameConflictCheck"
+
 	// owner: @pbundyra
 	//
 	// Enables reclaimable pods counting towards quota.
@@ -779,6 +786,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	MultiKueueKubeConfigPathValidation: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+	MultiKueueJobNameConflictCheck: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -241,6 +241,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobNameConflictCheck
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -257,6 +257,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobNameConflictCheck
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -241,6 +241,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobNameConflictCheck
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -257,6 +257,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: MultiKueueJobNameConflictCheck
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.19"
 - name: MultiKueueKubeConfigPathValidation
   versionedSpecs:
   - default: false

--- a/test/integration/multikueue/cluster_role_sharing_test.go
+++ b/test/integration/multikueue/cluster_role_sharing_test.go
@@ -36,6 +36,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
@@ -616,6 +617,67 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 			)).To(gomega.Succeed())
 			gomega.Expect(workerJob.UID).To(gomega.Equal(preExistingUID),
 				"pre-existing worker-local Job must not be deleted and recreated by MultiKueue's DeleteRemoteObject")
+		})
+	})
+
+	ginkgo.It("Should skip a worker with a pre-existing Job with the same NamespacedName", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueJobNameConflictCheck, true)
+		const jobName = "conflicting-job"
+
+		var preExistingUID types.UID
+		ginkgo.By("creating a pre-existing Job on worker1 not managed by MultiKueue", func() {
+			preExistingJob := testingjob.MakeJob(jobName, worker1Ns.Name).Obj()
+			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, preExistingJob)
+			preExistingUID = preExistingJob.UID
+		})
+
+		managerJob := testingjob.MakeJob(jobName, managerNs.Name).
+			ManagedBy(kueue.MultiKueueControllerName).
+			Queue(kueue.LocalQueueName(managerMkLq.Name)).
+			Obj()
+		ginkgo.By("creating a MultiKueue Job on the manager cluster with the same NamespacedName", func() {
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, managerJob)
+		})
+
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(managerJob.Name, managerJob.UID), Namespace: managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerMkCq.Name)).
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj()
+
+		ginkgo.By("setting workload quota reservation in the management cluster", func() {
+			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
+		})
+
+		ginkgo.By("dispatching the workload only to worker2", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, remoteWl)).To(gomega.Succeed())
+				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, &kueue.Workload{})).To(utiltesting.BeNotFoundError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admitting the workload on worker2", func() {
+			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, wlLookupKey, admission)
+			util.ExpectAdmissionCheckStateWithMessage(
+				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
+				multiKueueAC.Name,
+				kueue.CheckStateReady,
+				`The workload was admitted on "worker2"`,
+			)
+		})
+
+		ginkgo.By("creating the remote Job only on worker2", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteJob := &batchv1.Job{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(managerJob), remoteJob)).To(gomega.Succeed())
+				g.Expect(remoteJob.Labels).To(gomega.HaveKey(kueue.MultiKueueOriginLabel))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("preserving the pre-existing worker1 Job", func() {
+			workerJob := &batchv1.Job{}
+			gomega.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, types.NamespacedName{Name: jobName, Namespace: worker1Ns.Name}, workerJob)).To(gomega.Succeed())
+			gomega.Expect(workerJob.UID).To(gomega.Equal(preExistingUID))
 		})
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area multikueue
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Prevents MultiKueue from selecting workers with conflicting same-name Jobs. When enabled, it filters these workers before dispatch, rechecks ownership after admission and during synchronization, and preserves foreign objects during cleanup.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12404

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Added the `MultiKueueJobNameConflictCheck` feature gate to skip workers containing conflicting same-name Job objects.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `MultiKueueJobNameConflictCheck` feature gate for detecting same-name Jobs not managed by MultiKueue.
  * When enabled, conflicting worker clusters are skipped, nominations are adjusted, and warning events are emitted.
  * Conflicting remote admission options and objects are removed while preserving alternatives.
* **Bug Fixes**
  * Remote Job synchronization and deletion now avoid modifying unowned objects.
* **Configuration**
  * `MultiKueueJobNameConflictCheck` is Alpha in version 0.19 and disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->