### PR TITLE
disable was job tests for now

### DIFF
--- a/test/e2e/singlecluster/was/job_test.go
+++ b/test/e2e/singlecluster/was/job_test.go
@@ -53,7 +53,6 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
 		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 	})
-
 	ginkgo.When("A Job is admitted by Kueue with the GenericWorkload feature gate enabled", func() {
 		var (
 			onDemandRF       *kueue.ResourceFlavor
@@ -90,18 +89,14 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 			util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
 		})
 
-		ginkgo.It("Should create a Workload with PodSet count matching Job parallelism", func() {
+		ginkgo.XIt("Should create a Workload with PodSet count matching Job parallelism", func() {
 			const parallelism int32 = 3
 
-			// The upstream Job controller only creates PodGroups for Jobs that
-			// qualify for gang scheduling: parallelism > 1, Indexed completion
-			// mode, and completions == parallelism.
-			// TODO: KEP-5547 (Integrate Workload with Job) plans to add a
-			// dedicated API for opting a Job into gang scheduling, instead of
-			// inferring it from parallelism/completions/completion-mode. Once
-			// that API graduates to beta, these implicit qualification rules
-			// will no longer hold and this test will need to be updated to use
-			// the new API.
+			// This job is being skipped because in 1.37 the job controller has an
+			// api to control gang scheduling.
+			// The default behavior is not have gang scheduling so PodSet will not match podgroup mincount
+			// unless we bring in 1.37 apis to create the right job.
+			// Skipping for now but will reenable once we have 1.37 apis.
 			job := testingjob.MakeJob("was-test-job", ns.Name).
 				Queue("main").
 				Parallelism(parallelism).
@@ -152,35 +147,6 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 						gomega.Equal(int64(createdWorkload.Spec.PodSets[0].Count)),
 						"PodGroup gang minCount should match the Kueue Workload pod count",
 					)
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-		})
-
-		ginkgo.It("Should have consistent pod counts between Kueue Workload and Job with completions", func() {
-			const (
-				parallelism int32 = 2
-				completions int32 = 3
-			)
-
-			job := testingjob.MakeJob("was-completion-job", ns.Name).
-				Queue("main").
-				Parallelism(parallelism).
-				Completions(completions).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				RequestAndLimit(corev1.ResourceCPU, "200m").
-				RequestAndLimit(corev1.ResourceMemory, "40Mi").
-				TerminationGracePeriod(1).
-				Obj()
-			jobKey := client.ObjectKeyFromObject(job)
-			util.MustCreate(ctx, k8sClient, job)
-
-			ginkgo.By("verifying the Workload PodSet count matches the Job parallelism (not completions)", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					createdWorkload := workloadForJob(g, jobKey)
-					g.Expect(createdWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
-					// Kueue uses min(parallelism, completions) as the pod count.
-					// Since parallelism=2 < completions=3, the count should be 2.
-					g.Expect(createdWorkload.Spec.PodSets[0].Count).Should(gomega.Equal(parallelism))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

WAS jobs now no longer gang by default. We need to use `scheduling` field on Job to enforce gang scheduling but that would require importing unreleased APIs. Skipping until Kueue imports 1.37 apis (k8s releases 1.37).

I also removed a test that wasn't actually testing anything around WAS. hence why it was passing.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13245 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Temporarily skipped an e2e assertion that Workload PodSet counts match Job parallelism, due to Kubernetes v1.37 scheduling behavior not aligning under default controller conditions.
  * Removed an obsolete e2e test that validated PodSet count consistency when a Job’s completions differs from its parallelism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->