### PR TITLE
Add Consumable Capacity e2e tests and address feedback from the implementation PR

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -560,6 +560,23 @@ run-test-e2e-dra-counter-%:
 		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
 		./hack/testing/e2e-test.sh
 
+.PHONY: test-e2e-dra-capacity
+test-e2e-dra-capacity: setup-e2e-env run-test-e2e-dra-capacity-$(E2E_KIND_VERSION:kindest/node:v%=%)
+
+run-test-e2e-dra-capacity-%: K8S_VERSION = $(@:run-test-e2e-dra-capacity-%=%)
+run-test-e2e-dra-capacity-%:
+	@echo Running DRA Consumable Capacity e2e for k8s ${K8S_VERSION}
+	E2E_KIND_VERSION="kindest/node:v$(K8S_VERSION)" KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) \
+		ARTIFACTS="$(ARTIFACTS)/$@" IMAGE_TAG=$(IMAGE_TAG) GINKGO_ARGS="$(E2E_GINKGO_ARGS)" \
+		E2E_MODE=$(E2E_MODE) \
+		E2E_SKIP_REINSTALL=$(E2E_SKIP_REINSTALL) \
+		E2E_ENFORCE_OPERATOR_UPDATE=$(E2E_ENFORCE_OPERATOR_UPDATE) \
+		KIND_CLUSTER_FILE="kind-cluster.yaml" E2E_TARGET_FOLDER="dra/capacity" \
+		DRA_EXAMPLE_DRIVER_VERSION=$(DRA_EXAMPLE_DRIVER_VERSION) \
+		DRA_GPU_ALLOW_MULTIPLE_ALLOCATIONS=true \
+		TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) \
+		./hack/testing/e2e-test.sh
+
 run-test-e2e-multikueue-sequential-%: K8S_VERSION = $(@:run-test-e2e-multikueue-sequential-%=%)
 run-test-e2e-multikueue-sequential-%:
 	@echo Running multikueue sequential suite of e2e tests for k8s ${K8S_VERSION}

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -442,6 +442,7 @@ function patch_kind_config_for_dra {
     # Enable Extended Resources (alpha feature in k8s 1.35)
     $YQ -i '.featureGates.DRAExtendedResource = true' "$patched_config"
     $YQ -i '.featureGates.DRAPartitionableDevices = true' "$patched_config"
+    $YQ -i '.featureGates.DRAConsumableCapacity = true' "$patched_config"
     $YQ -i '.containerdConfigPatches += ["[plugins.\"io.containerd.grpc.v1.cri\"]\n  enable_cdi = true"]' "$patched_config"
     $YQ -i '(.nodes[] | select(.role == "control-plane")).kubeadmConfigPatches[0] = "kind: ClusterConfiguration
 apiVersion: kubeadm.k8s.io/v1beta4
@@ -885,6 +886,8 @@ function cluster_kueue_deploy {
     elif [[ -n ${DRA_EXAMPLE_DRIVER_VERSION:-} ]]; then
         if [[ ${E2E_TARGET_FOLDER:-} == "dra/counter" ]]; then
             build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/dra/counter"
+        elif [[ ${E2E_TARGET_FOLDER:-} == "dra/capacity" ]]; then
+            build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/dra/capacity"
         else
             build_and_apply_kueue_manifests "$1" "${ROOT_DIR}/test/e2e/config/dra/whole-device"
         fi
@@ -1427,6 +1430,9 @@ function install_dra_example_driver {
     local -a extra_helm_args=()
     if [[ -n ${DRA_GPU_PARTITIONS:-} ]]; then
         extra_helm_args+=(--set "kubeletPlugin.gpuPartitions=${DRA_GPU_PARTITIONS}")
+    fi
+    if [[ "${DRA_GPU_ALLOW_MULTIPLE_ALLOCATIONS:-}" == "true" ]]; then
+        extra_helm_args+=(--set "gpuAllowMultipleAllocations=true")
     fi
 
     $HELM upgrade -i \

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -897,7 +897,7 @@ func validateDeviceClassSource(name, driver string, selector *resourcev1.DeviceS
 	}
 	if driver == "" {
 		allErrs = append(allErrs, field.Required(path.Child("driver"), ""))
-	} else if errs := apimachineryutilvalidation.IsDNS1123Subdomain(strings.ToLower(driver)); len(errs) != 0 {
+	} else if errs := apimachineryutilvalidation.IsDNS1123Subdomain(driver); len(errs) != 0 {
 		allErrs = append(allErrs, field.Invalid(path.Child("driver"), driver, strings.Join(errs, "; ")))
 	}
 	selectorPath := path.Child("deviceSelector", "cel", "expression")

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1699,6 +1699,35 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"capacity source with mixed-case driver rejected": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationConsumableCapacity: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "memory",
+									Driver: "Gpu.Example.Com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.driver",
+				},
+			},
+		},
 		"CC gate requires DRA base gate": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:                   false,

--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -204,7 +204,8 @@ func computeCapacityCharge(
 ) (*resource.Quantity, field.ErrorList) {
 	dimName := resourcev1.QualifiedName(capCfg.resourceName)
 	var maxRounded resource.Quantity
-	foundCapacity := false
+	hasDimension := false
+	hasValidCharge := false
 
 	for i := range matched {
 		dev := &matched[i]
@@ -214,6 +215,7 @@ func computeCapacityCharge(
 				"device", dev.Name, "dimension", capCfg.resourceName)
 			continue
 		}
+		hasDimension = true
 
 		rounded, err := chargeForDevice(capDim, explicitRequest)
 		if err != nil {
@@ -222,16 +224,22 @@ func computeCapacityCharge(
 			continue
 		}
 
-		if !foundCapacity || rounded.Cmp(maxRounded) > 0 {
+		if !hasValidCharge || rounded.Cmp(maxRounded) > 0 {
 			maxRounded = rounded
 		}
-		foundCapacity = true
+		hasValidCharge = true
 	}
 
-	if !foundCapacity {
+	if !hasDimension {
 		return nil, field.ErrorList{field.InternalError(
 			reqPath,
 			fmt.Errorf("matched devices have no capacity dimension %q", capCfg.resourceName),
+		)}
+	}
+	if !hasValidCharge {
+		return nil, field.ErrorList{field.Invalid(
+			reqPath, nil,
+			fmt.Sprintf("capacity request cannot be satisfied by any matched device's RequestPolicy for dimension %q", capCfg.resourceName),
 		)}
 	}
 

--- a/pkg/dra/capacity_test.go
+++ b/pkg/dra/capacity_test.go
@@ -21,6 +21,8 @@ import (
 
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2/ktesting"
 )
 
 func TestRoundToValidValues(t *testing.T) {
@@ -185,6 +187,122 @@ func TestRoundToValidRange(t *testing.T) {
 			}
 			if got.Cmp(resource.MustParse(tc.want)) != 0 {
 				t.Errorf("got %s, want %s", got.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeCapacityCharge(t *testing.T) {
+	log := ktesting.NewLogger(t, ktesting.NewConfig())
+	reqPath := field.NewPath("test")
+
+	makeDevice := func(name string, capValue string, policy *resourcev1.CapacityRequestPolicy) resourcev1.Device {
+		return resourcev1.Device{
+			Name: name,
+			Capacity: map[resourcev1.QualifiedName]resourcev1.DeviceCapacity{
+				"memory": {
+					Value:         resource.MustParse(capValue),
+					RequestPolicy: policy,
+				},
+			},
+		}
+	}
+	ptrQty := func(s string) *resource.Quantity {
+		q := resource.MustParse(s)
+		return &q
+	}
+
+	tests := []struct {
+		name            string
+		matched         []resourcev1.Device
+		count           int64
+		explicitRequest *resource.Quantity
+		wantCharge      string
+		wantErrType     field.ErrorType
+	}{
+		{
+			name:            "explicit request with single device",
+			matched:         []resourcev1.Device{makeDevice("gpu-0", "80Gi", nil)},
+			count:           1,
+			explicitRequest: ptrQty("20Gi"),
+			wantCharge:      "20Gi",
+		},
+		{
+			name: "no request uses device Default",
+			matched: []resourcev1.Device{
+				makeDevice("gpu-0", "80Gi", &resourcev1.CapacityRequestPolicy{Default: ptrQty("40Gi")}),
+			},
+			count:      1,
+			wantCharge: "40Gi",
+		},
+		{
+			name: "heterogeneous Defaults uses max",
+			matched: []resourcev1.Device{
+				makeDevice("gpu-0", "80Gi", &resourcev1.CapacityRequestPolicy{Default: ptrQty("40Gi")}),
+				makeDevice("gpu-1", "100Gi", &resourcev1.CapacityRequestPolicy{Default: ptrQty("10Gi")}),
+			},
+			count:      1,
+			wantCharge: "40Gi",
+		},
+		{
+			name:        "no capacity dimension returns InternalError",
+			matched:     []resourcev1.Device{{Name: "gpu-0"}},
+			count:       1,
+			wantErrType: field.ErrorTypeInternal,
+		},
+		{
+			name: "all policies reject returns Invalid not InternalError",
+			matched: []resourcev1.Device{
+				makeDevice("gpu-0", "80Gi", &resourcev1.CapacityRequestPolicy{
+					ValidValues: []resource.Quantity{resource.MustParse("10Gi"), resource.MustParse("20Gi")},
+				}),
+				makeDevice("gpu-1", "80Gi", &resourcev1.CapacityRequestPolicy{
+					ValidValues: []resource.Quantity{resource.MustParse("10Gi"), resource.MustParse("30Gi")},
+				}),
+			},
+			count:           1,
+			explicitRequest: ptrQty("50Gi"),
+			wantErrType:     field.ErrorTypeInvalid,
+		},
+		{
+			name: "mixed devices some without dimension all with-dimension reject",
+			matched: []resourcev1.Device{
+				makeDevice("gpu-0", "80Gi", &resourcev1.CapacityRequestPolicy{
+					ValidValues: []resource.Quantity{resource.MustParse("10Gi")},
+				}),
+				{Name: "gpu-1"},
+			},
+			count:           1,
+			explicitRequest: ptrQty("50Gi"),
+			wantErrType:     field.ErrorTypeInvalid,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &deviceClassCapacityConfig{
+				driver:       "gpu.example.com",
+				resourceName: "memory",
+			}
+			result, errs := computeCapacityCharge(log, cfg, tc.matched, tc.count, tc.explicitRequest, reqPath)
+			if tc.wantErrType != "" {
+				if len(errs) == 0 {
+					t.Fatalf("expected error type %s, got no error (result=%v)", tc.wantErrType, result)
+				}
+				if errs[0].Type != tc.wantErrType {
+					t.Errorf("expected error type %s, got %s: %s", tc.wantErrType, errs[0].Type, errs[0].Detail)
+				}
+				return
+			}
+			if len(errs) > 0 {
+				t.Fatalf("unexpected error: %v", errs)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			want := resource.MustParse(tc.wantCharge)
+			if result.Cmp(want) != 0 {
+				t.Errorf("got %s, want %s", result.String(), tc.wantCharge)
 			}
 		})
 	}

--- a/test/e2e/config/dra/capacity/controller_manager_config.yaml
+++ b/test/e2e/config/dra/capacity/controller_manager_config.yaml
@@ -1,0 +1,36 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+metrics:
+  enableClusterQueueResources: true
+leaderElection:
+  leaderElect: true
+controller:
+  groupKindConcurrency:
+    Job.batch: 5
+    Pod: 5
+    Workload.kueue.x-k8s.io: 10
+    LocalQueue.kueue.x-k8s.io: 5
+    ClusterQueue.kueue.x-k8s.io: 5
+    ResourceFlavor.kueue.x-k8s.io: 1
+clientConnection:
+  qps: 300
+  burst: 500
+integrations:
+  frameworks:
+  - "batch/job"
+  - "pod"
+featureGates:
+  KueueDRAIntegration: true
+  KueueDRAIntegrationConsumableCapacity: true
+resources:
+  deviceClassMappings:
+  - name: gpu.memory
+    deviceClassNames:
+    - gpu.example.com
+    sources:
+    - capacity:
+        name: memory
+        driver: gpu.example.com
+        deviceSelector:
+          cel:
+            expression: "device.driver == 'gpu.example.com'"

--- a/test/e2e/config/dra/capacity/kustomization.yaml
+++ b/test/e2e/config/dra/capacity/kustomization.yaml
@@ -1,0 +1,25 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../../../../config/dev
+
+replicas:
+- name: kueue-controller-manager
+  count: 2
+
+patches:
+- path: manager_e2e_patch.yaml
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: kueue-controller-manager
+    namespace: kueue-system
+
+configMapGenerator:
+- behavior: merge
+  files:
+  - controller_manager_config.yaml
+  name: kueue-manager-config
+  namespace: kueue-system

--- a/test/e2e/config/dra/capacity/manager_e2e_patch.yaml
+++ b/test/e2e/config/dra/capacity/manager_e2e_patch.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /spec/template/spec/containers/0/imagePullPolicy
+  value: IfNotPresent

--- a/test/e2e/dra/capacity/dra_test.go
+++ b/test/e2e/dra/capacity/dra_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacity
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("DRA Consumable Capacity", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "e2e-dra-cc-")
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.When("Creating Jobs with consumable capacity resources", func() {
+		var (
+			resourceFlavor *kueue.ResourceFlavor
+			clusterQueue   *kueue.ClusterQueue
+			localQueue     *kueue.LocalQueue
+		)
+		ginkgo.BeforeEach(func() {
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("dra-cc-flavor-" + ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, resourceFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("dra-cc-cq-" + ns.Name).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(corev1.ResourceCPU, "4").
+						Resource("gpu.memory", "320Gi").
+						Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("dra-cc-lq", ns.Name).
+				ClusterQueue(clusterQueue.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		ginkgo.It("Should admit workload with explicit capacity request", func() {
+			ginkgo.By("Creating ResourceClaimTemplate with capacity.requests")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-explicit-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 1).
+				WithCapacityRequests(map[string]string{"memory": "20Gi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job with capacity RCT")
+			job := testingjob.MakeJob("cc-explicit-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-explicit-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying workload is admitted with capacity charge of 20Gi")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "20Gi")
+
+			ginkgo.By("Verifying job completes successfully")
+			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+		})
+
+		ginkgo.It("Should default to full device capacity when no request specified", func() {
+			ginkgo.By("Creating ResourceClaimTemplate without capacity.requests")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-default-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 1).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job")
+			job := testingjob.MakeJob("cc-default-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-default-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying workload charges RequestPolicy.Default (80Gi)")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "80Gi")
+
+			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+		})
+
+		ginkgo.It("Should round up capacity request to ValidRange step", func() {
+			ginkgo.By("Creating ResourceClaimTemplate requesting 15500Mi (rounds up to 16Gi with step=1Gi)")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-round-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 1).
+				WithCapacityRequests(map[string]string{"memory": "15500Mi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job")
+			job := testingjob.MakeJob("cc-round-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-round-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying charge is 16Gi (15500Mi rounded up to next 1Gi step)")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "16Gi")
+
+			util.ExpectJobToBeCompleted(ctx, k8sClient, job)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+		})
+
+		ginkgo.It("Should multiply capacity charge by request count", func() {
+			ginkgo.By("Creating ResourceClaimTemplate for 2 devices with capacity.requests")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-count2-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 2).
+				WithCapacityRequests(map[string]string{"memory": "20Gi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job requesting 2 devices")
+			job := testingjob.MakeJob("cc-count2-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-count2-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying capacity charge is 40Gi (20Gi x 2)")
+			util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlLookupKey, "gpu.memory", "40Gi")
+
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey, util.LongTimeout)
+		})
+
+		ginkgo.It("Should not admit workload when capacity charge exceeds quota", func() {
+			ginkgo.By("Creating ResourceClaimTemplate requesting 5 devices at 80Gi each (400Gi > 320Gi quota)")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-exceed-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 5).
+				WithCapacityRequests(map[string]string{"memory": "80Gi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job with capacity charge exceeding quota")
+			job := testingjob.MakeJob("cc-exceed-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				ResourceClaimTemplate("gpu", "cc-exceed-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Waiting for workload to be created")
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is not admitted")
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(createdWorkload)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should admit multiple workloads sharing capacity quota", func() {
+			ginkgo.By("Creating ResourceClaimTemplate for capacity request")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-share-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 1).
+				WithCapacityRequests(map[string]string{"memory": "20Gi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating two jobs each requesting 20Gi from the same gpu.memory pool")
+			job1 := testingjob.MakeJob("cc-share-job-1", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-share-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job1)
+
+			job2 := testingjob.MakeJob("cc-share-job-2", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+				ResourceClaimTemplate("gpu", "cc-share-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job2)
+
+			ginkgo.By("Verifying both workloads are admitted with 20Gi each")
+			wlLookupKey1 := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job1.Name, job1.UID),
+				Namespace: ns.Name,
+			}
+			wlLookupKey2 := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job2.Name, job2.UID),
+				Namespace: ns.Name,
+			}
+
+			for _, wlKey := range []types.NamespacedName{wlLookupKey1, wlLookupKey2} {
+				util.ExpectWorkloadResourceUsage(ctx, k8sClient, wlKey, "gpu.memory", "20Gi")
+			}
+
+			ginkgo.By("Verifying both jobs complete")
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey1, util.LongTimeout)
+			util.ExpectWorkloadToFinishWithTimeout(ctx, k8sClient, wlLookupKey2, util.LongTimeout)
+		})
+
+		ginkgo.It("Should mark workload inadmissible when capacity dimension has no matching devices", func() {
+			ginkgo.By("Creating ResourceClaimTemplate with unmatchable CEL selector")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-nomatch-template", ns.Name).
+				DeviceRequest("gpu-request", util.DRAExampleDriverName, 1).
+				WithCELSelectors("device.capacity[\"gpu.example.com\"].memory.compareTo(quantity(\"999Gi\")) == 0").
+				WithCapacityRequests(map[string]string{"memory": "10Gi"}).
+				Obj()
+			util.MustCreate(ctx, k8sClient, rct)
+
+			ginkgo.By("Creating Job with unmatchable CEL selector")
+			job := testingjob.MakeJob("cc-nomatch-job", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "200m").
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				ResourceClaimTemplate("gpu", "cc-nomatch-template").
+				Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			wlLookupKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: ns.Name,
+			}
+
+			ginkgo.By("Verifying workload is marked inadmissible")
+			createdWorkload := &kueue.Workload{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(createdWorkload)).To(gomega.BeFalse())
+
+				g.Expect(createdWorkload.Status.Conditions).To(gomega.ContainElement(gomega.And(
+					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
+					gomega.HaveField("Status", metav1.ConditionFalse),
+					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
+				)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})

--- a/test/e2e/dra/capacity/suite_test.go
+++ b/test/e2e/dra/capacity/suite_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package capacity
+
+import (
+	"cmp"
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var (
+	k8sClient client.WithWatch
+	ctx       context.Context
+)
+
+func TestAPIs(t *testing.T) {
+	util.RunE2ESuite(t, "End To End DRA Consumable Capacity Suite")
+}
+
+var _ = ginkgo.BeforeSuite(func() {
+	util.SetupLogger()
+
+	var err error
+	k8sClient, _, err = util.CreateClientUsingCluster("")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ctx = ginkgo.GinkgoT().Context()
+
+	waitForAvailableStart := time.Now()
+	util.WaitForKueueAvailability(ctx, k8sClient)
+	clusterName := cmp.Or(os.Getenv("KIND_CLUSTER_NAME"), "kind")
+	util.WaitForDRAExampleDriverAvailability(ctx, k8sClient, clusterName)
+	ginkgo.GinkgoLogr.Info(
+		"Kueue and DRA example driver are available in the cluster",
+		"clusterName", clusterName,
+		"waitingTime", time.Since(waitForAvailableStart),
+	)
+})

--- a/test/integration/singlecluster/controller/dra/dra_cc_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_cc_test.go
@@ -592,6 +592,121 @@ var _ = ginkgo.Describe("DRA Consumable Capacity Integration", ginkgo.Ordered, g
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.It("Should use max Default across devices with heterogeneous Defaults", func() {
+			ginkgo.By("Creating ResourceSlice with two devices having different Defaults")
+			default40 := resource.MustParse("40Gi")
+			default10 := resource.MustParse("10Gi")
+			slice := utiltesting.MakeResourceSlice("cc-hetdefault-slice", "gpu.example.com").
+				Pool("node1-gpu0", 1, 1).
+				Device("gpu-0").
+				DeviceCapacity("memory", "80Gi", &resourcev1.CapacityRequestPolicy{
+					Default: &default40,
+				}).
+				AllowMultipleAllocations(true).
+				Device("gpu-1").
+				DeviceCapacity("memory", "100Gi", &resourcev1.CapacityRequestPolicy{
+					Default: &default10,
+				}).
+				AllowMultipleAllocations(true).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, slice)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(k8sClient.Delete(ctx, slice)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Creating RCT without explicit request (uses per-device Default)")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-hetdefault", ns.Name).
+				DeviceRequest("gpu", "vgpu.example.com", 1).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating workload")
+			wl := utiltestingapi.MakeWorkload("cc-hetdefault-wl", ns.Name).
+				Queue("cc-lq").
+				Obj()
+			wl.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: new("cc-hetdefault")},
+			}
+			wl.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+				{Name: "gpu"},
+			}
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying charge uses max(40Gi, 10Gi) = 40Gi (per-device Default)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				memUsage := assignment.ResourceUsage["gpu.memory"]
+				g.Expect(memUsage.Cmp(resource.MustParse("40Gi"))).To(gomega.Equal(0),
+					"should be 40Gi (max Default across devices), not 10Gi (max-capacity device's Default)")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("Should mark inadmissible without retry when all policies reject request", framework.SlowSpec, func() {
+			ginkgo.By("Creating ResourceSlice where all devices have ValidValues that reject 50Gi")
+			defaultQty := resource.MustParse("10Gi")
+			slice := utiltesting.MakeResourceSlice("cc-allreject-slice", "gpu.example.com").
+				Pool("node1-gpu0", 1, 1).
+				Device("gpu-0").
+				DeviceCapacity("memory", "80Gi", &resourcev1.CapacityRequestPolicy{
+					Default:     &defaultQty,
+					ValidValues: []resource.Quantity{resource.MustParse("10Gi"), resource.MustParse("20Gi")},
+				}).
+				AllowMultipleAllocations(true).
+				Device("gpu-1").
+				DeviceCapacity("memory", "80Gi", &resourcev1.CapacityRequestPolicy{
+					Default:     &defaultQty,
+					ValidValues: []resource.Quantity{resource.MustParse("10Gi"), resource.MustParse("30Gi")},
+				}).
+				AllowMultipleAllocations(true).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, slice)).To(gomega.Succeed())
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(k8sClient.Delete(ctx, slice)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Creating RCT requesting 50Gi (exceeds all devices' ValidValues)")
+			rct := utiltesting.MakeResourceClaimTemplate("cc-allreject", ns.Name).
+				DeviceRequest("gpu", "vgpu.example.com", 1).
+				WithCapacityRequests(map[string]string{"memory": "50Gi"}).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating workload")
+			wl := utiltestingapi.MakeWorkload("cc-allreject-wl", ns.Name).
+				Queue("cc-lq").
+				Obj()
+			wl.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{Name: "gpu", ResourceClaimTemplateName: new("cc-allreject")},
+			}
+			wl.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+				{Name: "gpu"},
+			}
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is marked inadmissible with deterministic error")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
+					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
+					gomega.HaveField("Status", metav1.ConditionFalse),
+					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
+				)))
+			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying workload stays inadmissible (deterministic, no requeue)")
+			gomega.Consistently(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.It("Should use max capacity across multiple devices", func() {
 			ginkgo.By("Creating ResourceSlice with two devices having different capacities")
 			slice := utiltesting.MakeResourceSlice("cc-maxcap-slice", "gpu.example.com").


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area dra

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes feedback received in https://github.com/kubernetes-sigs/kueue/pull/13152

#### Special notes for your reviewer:
e2e tests run: https://github.com/kubernetes-sigs/kueue/pull/13152#issuecomment-5025311663

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end coverage for DRA consumable capacity, including charging, rounding, quotas, sharing, and device matching.
  - Added dedicated test configuration and an E2E suite to exercise the consumable-capacity feature gates.

- **Bug Fixes**
  - Improved DRA device-class source validation to reject mixed-case driver values.
  - More accurate capacity-policy error handling, preventing unnecessary retry behavior when capacity requests can’t be satisfied.

- **Tests**
  - Added integration scenarios for heterogeneous per-device defaults and rejected capacity requests.
  - Added unit tests for capacity-charge computation and error classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->