### PR TITLE
Add /create-release-candidate ChatOps command.

### DIFF
--- a/.github/actions/create-draft-release/action.yml
+++ b/.github/actions/create-draft-release/action.yml
@@ -11,6 +11,9 @@ inputs:
   repo:
     description: Target repository in owner/name format
     required: true
+  prerelease:
+    description: Mark the release as a pre-release
+    required: true
 
 outputs:
   outcome:
@@ -29,6 +32,7 @@ runs:
         CHANGELOG: ${{ inputs.changelog }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         TARGET_REPO: ${{ inputs.repo }}
+        PRERELEASE: ${{ inputs.prerelease }}
       run: |
         RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
             --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
@@ -70,12 +74,18 @@ runs:
         set +e
         echo "Creating \`$VERSION\` release."
         
+        PRERELEASE_FLAG=""
+        if [ "$PRERELEASE" = "true" ]; then
+          PRERELEASE_FLAG="--prerelease"
+        fi
+
         gh release create "$VERSION" \
           --verify-tag \
           --repo "$TARGET_REPO" \
           --title "$VERSION" \
           --notes "$CHANGELOG" \
           --draft \
+          $PRERELEASE_FLAG \
           release-artifacts/*
         RELEASE_EXIT=$?
         set -e

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -14,6 +14,7 @@ jobs:
     if: |
       github.event.issue.pull_request == null &&
       (contains(github.event.comment.body, '/sync-release-notes') ||
+       contains(github.event.comment.body, '/create-release-candidate') ||
        contains(github.event.comment.body, '/create-release-branch') ||
        contains(github.event.comment.body, '/tag-release') ||
        contains(github.event.comment.body, '/create-draft-release') ||
@@ -76,6 +77,8 @@ jobs:
           COMMAND=""
           if printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/sync-release-notes[[:space:]]*$'; then
             COMMAND="sync-notes"
+          elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/create-release-candidate[[:space:]]*$'; then
+            COMMAND="create-release-candidate"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/create-release-branch[[:space:]]*$'; then
             COMMAND="create-release-branch"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/tag-release[[:space:]]*$'; then
@@ -147,6 +150,91 @@ jobs:
           git config --global user.email "kueue-release-bot@kubernetes.io"
           yes y | ./hack/releasing/sync-notes.sh "$VERSION"
           gh issue comment "$ISSUE_NUMBER" --body "✅ Release notes for version $VERSION have been synced."
+
+  create-release-candidate:
+    name: Create Release Candidate
+    runs-on: ubuntu-latest
+    needs: authorize
+    timeout-minutes: 30
+    if: ${{ needs.authorize.outputs.command == 'create-release-candidate' }}
+    env:
+      VERSION: ${{ needs.authorize.outputs.version }}
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check if Release is Already Published
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
+
+          if [ "$RELEASE_STATE" = "published" ]; then
+            BODY="❌ Release \`$VERSION\` has already been published. Skipping release candidate creation."
+            echo "$BODY"
+            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+            exit 1
+          fi
+
+      - name: Calculate Release Candidate Version
+        id: rc-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST_RC=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts=true --limit 1000 --json tagName --jq '.[].tagName' \
+            | grep -oP "(?<=${VERSION}-rc\.)\d+" | sort -n | tail -1)
+          if [ -z "$LAST_RC" ]; then
+            NEXT_RC=0
+          else
+            NEXT_RC=$((LAST_RC + 1))
+          fi
+          echo "version=${VERSION}-rc.${NEXT_RC}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and Push Tag
+        uses: ./.github/actions/create-release-tag
+        with:
+          version: ${{ steps.rc-version.outputs.version }}
+          changelog: ${{ needs.authorize.outputs.changelog }}
+          repo: ${{ github.repository }}
+
+      - name: Create Draft Release
+        uses: ./.github/actions/create-draft-release
+        with:
+          version: ${{ steps.rc-version.outputs.version }}
+          changelog: ${{ needs.authorize.outputs.changelog }}
+          repo: ${{ github.repository }}
+          prerelease: true
+
+      - name: Publish Release
+        uses: ./.github/actions/publish-release
+        with:
+          version: ${{ steps.rc-version.outputs.version }}
+          repo: ${{ github.repository }}
+
+      - name: Post Success Comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.rc-version.outputs.version }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          BODY="✅ Release candidate \`$VERSION\` has been created."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
 
   create-release-branch:
     name: Create Release Branch
@@ -311,6 +399,11 @@ jobs:
         with:
           version: ${{ needs.authorize.outputs.version }}
           changelog: ${{ needs.authorize.outputs.changelog }}
+<<<<<<< HEAD
+=======
+          issue-number: ${{ github.event.issue.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+>>>>>>> 4848f7b58 (Add /create-release-candidate ChatOps command.)
           repo: ${{ github.repository }}
 
       - name: Post Success Comment
@@ -361,15 +454,28 @@ jobs:
         with:
           version: ${{ needs.authorize.outputs.version }}
           changelog: ${{ needs.authorize.outputs.changelog }}
+<<<<<<< HEAD
           repo: ${{ github.repository }}
+=======
+          issue-number: ${{ github.event.issue.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
+          prerelease: false
+>>>>>>> 4848f7b58 (Add /create-release-candidate ChatOps command.)
 
       - name: Post Success Comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+<<<<<<< HEAD
           OUTPUT: ${{ steps.draft.outputs.outcome }}
         run: |
           BODY="✅ Draft release has been successfully ${OUTPUT}."
+=======
+          ACTION: ${{ steps.draft.outputs.action }}
+        run: |
+          BODY="✅ Draft release has been successfully ${ACTION}."
+>>>>>>> 4848f7b58 (Add /create-release-candidate ChatOps command.)
           echo "$BODY"
           gh issue comment "$ISSUE_NUMBER" --body "$BODY"
 
@@ -446,6 +552,11 @@ jobs:
         uses: ./.github/actions/publish-release
         with:
           version: ${{ needs.authorize.outputs.version }}
+<<<<<<< HEAD
+=======
+          issue-number: ${{ github.event.issue.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+>>>>>>> 4848f7b58 (Add /create-release-candidate ChatOps command.)
           repo: ${{ github.repository }}
 
       - name: Post Success Comment


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Add /create-release-candidate ChatOps command.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13109

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added release-candidate creation via an authorized `/create-release-candidate` command, including automatic `-rc.N` numbering.
  - Introduced reusable automation to create/update annotated tags, manage draft (and prerelease) releases, and publish them.

- **Bug Fixes**
  - Prevents duplicate/conflicting operations by detecting whether a release is already published, a draft already exists, or the release is missing.
  - Posts detailed captured error output back to the referenced issue when failures occur.

- **Refactor**
  - Refactored release workflows to delegate tag, draft/prerelease creation, and publishing to the new composite actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->