### PR TITLE
fix(scheduler): add V(3) log when falling back to default weight for missing localqueue

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -463,7 +463,7 @@ func (i *Info) CalcLocalQueueFSUsage(
 	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
 	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
 		if apierrors.IsNotFound(err) {
-			// If the LocalQueue is missing, gracefully fallback to the default weight (1.0).
+			log.FromContext(ctx).V(3).Info("LocalQueue is missing, gracefully falling back to the default weight (1.0)", "localQueue", klog.KRef(lqObjKey.Namespace, lqObjKey.Name))
 			return afs.CalculateUsage(consumed, penalty, 1.0, resWeights), nil
 		}
 		return 0, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This addresses maintainer feedback from the backport PR #13264 (and originally #13214). When `CalcLocalQueueFSUsage` gracefully falls back to the default weight (1.0) due to a missing LocalQueue, it now emits a `V(3)` log statement with the local queue reference instead of just relying on an inline comment. 
This improves observability when debugging missing queues during AFS calculations.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A (Follow-up to #13214 / #13264)

#### Special notes for your reviewer:
As requested in https://github.com/kubernetes-sigs/kueue/pull/13264#discussion_r3622292800, this updates `main`. Please follow up with a cherry-pick to `release-0.18` after this merges.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a verbose diagnostic message when a referenced local queue is unavailable and the default usage weight is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->