### PR TITLE
Reject leaderWorkerTemplate.size updates on managed LeaderWorkerSets

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -41,6 +41,10 @@ const (
 	// defaultLeaderWorkerSetReplicas mirrors the LeaderWorkerSet API default for
 	// spec.replicas (+kubebuilder:default=1), and is used when the field is unset.
 	defaultLeaderWorkerSetReplicas = 1
+	// defaultLeaderWorkerSetSize mirrors the LeaderWorkerSet API default for
+	// spec.leaderWorkerTemplate.size (+kubebuilder:default=1), and is used when the
+	// field is unset.
+	defaultLeaderWorkerSetSize = 1
 	// maxLeaderWorkerSetReplicas is a sanity upper bound on spec.replicas that guards
 	// against unbounded per-replica Workload creation from an unreasonably large value.
 	maxLeaderWorkerSetReplicas = 1_000_000

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -133,6 +133,7 @@ var (
 	specPath                      = field.NewPath("spec")
 	replicasPath                  = specPath.Child("replicas")
 	leaderWorkerTemplatePath      = specPath.Child("leaderWorkerTemplate")
+	leaderWorkerTemplateSizePath  = leaderWorkerTemplatePath.Child("size")
 	leaderTemplatePath            = leaderWorkerTemplatePath.Child("leaderTemplate")
 	leaderTemplateMetaPath        = leaderTemplatePath.Child("metadata")
 	workerTemplatePath            = leaderWorkerTemplatePath.Child("workerTemplate")
@@ -207,6 +208,15 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj *leaderwor
 			&oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.WorkerTemplate,
 			workerTemplatePath,
 		)...)
+		if features.Enabled(features.LWSImmutableGroupSize) {
+			// Immutable while managed: Workload updates never recompute PodSets,
+			// so growing Size would ungate extra pods without accounting for quota.
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+				ptr.Deref(newLeaderWorkerSet.Spec.LeaderWorkerTemplate.Size, defaultLeaderWorkerSetSize),
+				ptr.Deref(oldLeaderWorkerSet.Spec.LeaderWorkerTemplate.Size, defaultLeaderWorkerSetSize),
+				leaderWorkerTemplateSizePath,
+			)...)
+		}
 	}
 
 	return warnings, allErrs.ToAggregate()

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -960,6 +960,61 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
+		"change size when managed": {
+			featureGates: map[featuregate.Feature]bool{features.LWSImmutableGroupSize: true},
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(2).
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(10).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: leaderWorkerTemplateSizePath.String(),
+				},
+			}.ToAggregate(),
+		},
+		"change size when managed and the feature gate is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.LWSImmutableGroupSize: false},
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(2).
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(10).
+				Obj(),
+		},
+		"same size when managed": {
+			featureGates: map[featuregate.Feature]bool{features.LWSImmutableGroupSize: true},
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(2).
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Queue("test-queue").
+				Size(2).
+				Obj(),
+		},
+		"change size when unmanaged": {
+			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Size(2).
+				Obj(),
+			newObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				LeaderTemplate(corev1.PodTemplateSpec{}).
+				Size(10).
+				Obj(),
+		},
 		"change queue name when replicas ready": {
 			oldObj: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				LeaderTemplate(corev1.PodTemplateSpec{}).

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -526,6 +526,15 @@ const (
 	// WorkloadValidationForPodSetMetadata enables validation of labels and annotations
 	// in PodSet template metadata during Workload creation and update.
 	WorkloadValidationForPodSetMetadata featuregate.Feature = "WorkloadValidationForPodSetMetadata"
+
+	// owner: @ivnovakov
+	//
+	// pr: https://github.com/kubernetes-sigs/kueue/pull/13279#discussion_r3655384989
+	// Keeps spec.leaderWorkerTemplate.size immutable while a LeaderWorkerSet is managed by
+	// Kueue. Workload updates never recompute PodSets, so growing size would ungate extra
+	// pods per group without accounting for quota. Recreate the LeaderWorkerSet to change
+	// the size, or disable this gate to accept the previous behavior.
+	LWSImmutableGroupSize featuregate.Feature = "LWSImmutableGroupSize"
 )
 
 func init() {
@@ -808,6 +817,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	WorkloadValidationForPodSetMetadata: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	LWSImmutableGroupSize: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -157,6 +157,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: LWSImmutableGroupSize
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: ManagedJobsNamespaceSelectorAlwaysRespected
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -157,6 +157,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: LWSImmutableGroupSize
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: ManagedJobsNamespaceSelectorAlwaysRespected
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingleaderworkerset "sigs.k8s.io/kueue/pkg/util/testingjobs/leaderworkerset"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.BeforeEach(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(
+			leaderworkerset.SetupWebhook,
+			jobframework.WithManageJobsWithoutQueueName(false),
+		))
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "lws-webhook-")
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.When("the LeaderWorkerSet is managed by Kueue", func() {
+		ginkgo.It("should reject increasing the leaderWorkerTemplate size", func() {
+			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+				Queue("user-queue").
+				Size(2).
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, lws)
+
+			createdLws := &leaderworkersetv1.LeaderWorkerSet{}
+			ginkgo.By("Increasing the size is rejected by the webhook", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
+					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.SatisfyAll(
+						utiltesting.BeForbiddenError(),
+						gomega.MatchError(gomega.ContainSubstring("spec.leaderWorkerTemplate.size")),
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should reject decreasing the leaderWorkerTemplate size", func() {
+			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+				Queue("user-queue").
+				Size(2).
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, lws)
+
+			createdLws := &leaderworkersetv1.LeaderWorkerSet{}
+			ginkgo.By("Decreasing the size is rejected by the webhook", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
+					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](1)
+					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.SatisfyAll(
+						utiltesting.BeForbiddenError(),
+						gomega.MatchError(gomega.ContainSubstring("spec.leaderWorkerTemplate.size")),
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should allow changing replicas", func() {
+			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+				Queue("user-queue").
+				Replicas(1).
+				Size(2).
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, lws)
+
+			createdLws := &leaderworkersetv1.LeaderWorkerSet{}
+			ginkgo.By("Increasing replicas is accepted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
+					createdLws.Spec.Replicas = ptr.To[int32](3)
+					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("the LWSImmutableGroupSize feature gate is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LWSImmutableGroupSize, false)
+			})
+
+			ginkgo.It("should allow increasing the leaderWorkerTemplate size", func() {
+				lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+					Queue("user-queue").
+					Size(2).
+					RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+					Obj()
+				util.MustCreate(ctx, k8sClient, lws)
+
+				createdLws := &leaderworkersetv1.LeaderWorkerSet{}
+				ginkgo.By("Increasing the size is accepted", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
+						createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+						g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+		})
+	})
+
+	ginkgo.When("the LeaderWorkerSet is not managed by Kueue", func() {
+		ginkgo.It("should allow increasing the leaderWorkerTemplate size", func() {
+			lws := testingleaderworkerset.MakeLeaderWorkerSet("lws", ns.Name).
+				Size(2).
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, lws)
+
+			createdLws := &leaderworkersetv1.LeaderWorkerSet{}
+			ginkgo.By("Increasing the size is accepted", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
+					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -54,6 +54,7 @@ var _ = ginkgo.BeforeSuite(func() {
 		DepCRDPaths: []string{
 			util.MpiOperatorCrds,
 			util.JobsetCrds,
+			util.LeaderWorkerSetCrds,
 			util.RayOperatorCrds,
 			util.TrainingOperatorCrds,
 			util.AppWrapperCrds,

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -64,6 +64,7 @@ var (
 	ArtifactsDir             = filepath.Join(ProjectBaseDir, "artifacts")
 	AutoscalerCrds           = filepath.Join(ProjectBaseDir, "dep-crds", "cluster-autoscaler")
 	JobsetCrds               = filepath.Join(ProjectBaseDir, "dep-crds", "jobset-operator")
+	LeaderWorkerSetCrds      = filepath.Join(ProjectBaseDir, "dep-crds", "leaderworkerset-operator")
 	TrainingOperatorCrds     = filepath.Join(ProjectBaseDir, "dep-crds", "training-operator-crds")
 	KfTrainerCrds            = filepath.Join(ProjectBaseDir, "dep-crds", "kf-trainer-crds")
 	KfTrainerClusterRuntimes = filepath.Join(ProjectBaseDir, "dep-crds", "kf-trainer-runtimes")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

When a LeaderWorkerSet is managed by Kueue, its validating webhook keeps the leader and worker pod templates immutable on update, but `spec.leaderWorkerTemplate.size` is not covered, since it sits outside the PodTemplateSpec. A group's admitted quota is the PodSet `Count`, which `podSets()` derives from `size`. Existing groups' Workloads go to `toUpdate` in `filterWorkloads`, and `updateWorkload` never recomputes their PodSets, so raising `size` on an admitted LeaderWorkerSet grows the pods per group without accounting for the added quota. The upstream controller creates the extra pods and the pod controller ungates them, so a tenant can create a small LeaderWorkerSet, let it get admitted, then raise `size` to run more pods than the ClusterQueue allows.

This PR makes `spec.leaderWorkerTemplate.size` immutable while the LeaderWorkerSet is managed by Kueue, with `apivalidation.ValidateImmutableField` in the same block that already validates the pod templates as immutable. `replicas` stays mutable, since each replica is a separate Workload that re-admits through quota.

Verified with new unit cases in `TestValidateUpdate` and an integration webhook test. Both reproduce the bypass first: they fail before the change, where the size update is accepted, and pass after.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Adds `util.LeaderWorkerSetCrds` and wires it into the webhook integration suite's `DepCRDPaths`, since there was no LeaderWorkerSet integration coverage before.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
LeaderWorkerSet: Fixed a quota bypass where raising `spec.leaderWorkerTemplate.size` on an already-admitted, Kueue-managed LeaderWorkerSet ran more pods per group than the reserved quota covered. `spec.leaderWorkerTemplate.size` is now immutable while the LeaderWorkerSet is managed by Kueue, behind the new `LWSImmutableGroupSize` feature gate (Beta, enabled by default). `spec.replicas` stays mutable.

ACTION REQUIRED: If you change `spec.leaderWorkerTemplate.size` on a Kueue-managed LeaderWorkerSet, recreate it at the new size instead, or disable the `LWSImmutableGroupSize` feature gate to keep the previous behavior, which also restores the quota bypass.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `LWSImmutableGroupSize` feature gate, enabled by default in Beta starting with version 0.20.
  * Managed LeaderWorkerSet workloads now preserve their group size during suspended updates by default.

* **Bug Fixes**
  * Preserved default behavior when the group size is unset.
  * Size changes remain allowed for unmanaged workloads, and replica updates remain allowed for managed workloads.

* **Tests**
  * Added unit and integration coverage for managed and unmanaged update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->