### PR TITLE
Allow running only one ChatOps command at a time.

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -2,10 +2,15 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: release-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   authorize:
     name: Authorize and Parse Command
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: |
       github.event.issue.pull_request == null &&
       (contains(github.event.comment.body, '/sync-release-notes') ||
@@ -109,6 +114,7 @@ jobs:
     name: Sync Release Notes
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 30
     if: ${{ needs.authorize.outputs.command == 'sync-notes' }}
     permissions:
       contents: read
@@ -146,6 +152,7 @@ jobs:
     name: Create Release Branch
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 10
     if: ${{ needs.authorize.outputs.command == 'create-release-branch' }}
     permissions:
       contents: write
@@ -212,6 +219,7 @@ jobs:
     name: Wait for Images
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 60
     if: | 
       needs.authorize.outputs.command == 'wait-for-images' ||
       needs.authorize.outputs.command == 'wait-for-prod-images'
@@ -281,6 +289,7 @@ jobs:
     name: Tag Release
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 10
     if: ${{ needs.authorize.outputs.command == 'tag-release' }}
     permissions:
       contents: write
@@ -361,6 +370,7 @@ jobs:
     name: Create Draft Release
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 30
     if: ${{ needs.authorize.outputs.command == 'create-draft-release' }}
     permissions:
       contents: write
@@ -443,6 +453,7 @@ jobs:
     name: Prepare Pull
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 30
     if: ${{ needs.authorize.outputs.command == 'prepare-pull' }}
     permissions:
       contents: write
@@ -504,6 +515,7 @@ jobs:
     name: Publish Release
     runs-on: ubuntu-latest
     needs: authorize
+    timeout-minutes: 10
     if: ${{ needs.authorize.outputs.command == 'publish-release' }}
     permissions:
       contents: write


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Allow running only one ChatOps command at a time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12763

#### Special notes for your reviewer:
Address https://github.com/kubernetes-sigs/kueue/pull/13275#discussion_r3623919490.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow handling to prevent overlapping runs for the same release request.
  * In-progress release operations will now complete without being automatically canceled.
  * Added explicit time limits to key release workflow steps to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->