### PR TITLE
Validate Ray and Spark jobs on queue-name removal

### DIFF
--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -92,6 +92,17 @@ func ValidateJobOnCreate(job GenericJob) field.ErrorList {
 	return allErrs
 }
 
+// ShouldValidateRayOrSparkJobOnUpdate reports whether an update must be validated.
+// Jobs that Kueue does not manage are never validated on update.
+// With ValidateRayAndSparkJobUpdates enabled a job that was managed before the update is
+// also validated, so removing its queue-name label cannot leave it running unmanaged.
+func ShouldValidateRayOrSparkJobOnUpdate(oldJob, newJob GenericJob, manageJobsWithoutQueueName bool) bool {
+	if manageJobsWithoutQueueName || QueueName(newJob) != "" {
+		return true
+	}
+	return features.Enabled(features.ValidateRayAndSparkJobUpdates) && QueueName(oldJob) != ""
+}
+
 // ValidateJobOnUpdate encapsulates all GenericJob validations that must be performed on a Update operation
 func ValidateJobOnUpdate(oldJob, newJob GenericJob, defaultQueueExist func(string) bool) field.ErrorList {
 	allErrs := validateUpdateForQueueName(oldJob, newJob, defaultQueueExist)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -262,18 +262,18 @@ func (w *RayClusterWebhook) validateTopologyRequest(ctx context.Context, rayJob 
 func (w *RayClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayCluster) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !jobframework.ShouldValidateRayOrSparkJobOnUpdate(oldJob, newJob, w.manageJobsWithoutQueueName) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -256,22 +256,32 @@ func (w *RayClusterWebhook) validateTopologyRequest(ctx context.Context, rayJob 
 	return nil, podSetsErr
 }
 
+// shouldValidateUpdate reports whether the update must be validated. The gate keeps the
+// old behavior, which let a running job bypass validation by dropping its queue-name
+// label, available as a mitigation.
+func (w *RayClusterWebhook) shouldValidateUpdate(newJob *RayCluster) bool {
+	if features.Enabled(features.ValidateRayAndSparkJobUpdates) {
+		return true
+	}
+	return w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != ""
+}
+
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayClusterWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayCluster) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !w.shouldValidateUpdate(newJob) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -605,15 +605,28 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayv1.RayCluster
-		newJob    *rayv1.RayCluster
-		manageAll bool
-		wantErr   error
+		oldJob       *rayv1.RayCluster
+		newJob       *rayv1.RayCluster
+		manageAll    bool
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
 	}{
 		"invalid unmanaged": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
 				Obj(),
 			newJob: testingrayutil.MakeCluster("job", "ns").
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name unchanged while unsuspended": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Label("dummy-label", "dummy-value").
 				Obj(),
 			wantErr: nil,
 		},
@@ -641,6 +654,29 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"invalid managed - queue name should not be removed while unsuspended": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can be removed while unsuspended when ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
 		"priorityClassName is mutable": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
 				Queue("queue").
@@ -655,10 +691,16 @@ func TestValidateUpdate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
+				queues:                     queueManager,
+				cache:                      cqCache,
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -607,15 +607,29 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayv1.RayCluster
-		newJob    *rayv1.RayCluster
-		manageAll bool
-		wantErr   error
+		oldJob         *rayv1.RayCluster
+		newJob         *rayv1.RayCluster
+		manageAll      bool
+		defaultLqExist bool
+		featureGates   map[featuregate.Feature]bool
+		wantErr        error
 	}{
 		"invalid unmanaged": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
 				Obj(),
 			newJob: testingrayutil.MakeCluster("job", "ns").
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name unchanged while unsuspended": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Label("test-label", "test-value").
 				Obj(),
 			wantErr: nil,
 		},
@@ -643,6 +657,79 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"queue name removal is rejected when the job is unsuspended and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is unsuspended and ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
+		"queue name removal is rejected when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "", "queue-name must not be empty in namespace with default queue"),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:        nil,
+		},
+		"queue name removal is allowed when the job is suspended in a namespace without a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
+		"prebuilt workload name change is not validated when the job is unmanaged and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl1").
+				Obj(),
+			newJob: testingrayutil.MakeCluster("job", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl2").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
 		"priorityClassName is mutable": {
 			oldJob: testingrayutil.MakeCluster("job", "ns").
 				Queue("queue").
@@ -657,10 +744,22 @@ func TestValidateUpdate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			if tc.defaultLqExist {
+				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue(
+					string(constants.DefaultLocalQueueName), "ns").ClusterQueue("cluster-queue").Obj()); err != nil {
+					t.Fatalf("Failed to add the default LocalQueue: %v", err)
+				}
+			}
 			wh := &RayClusterWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
+				queues:                     queueManager,
+				cache:                      cqCache,
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -168,18 +168,18 @@ func (w *RayJobWebhook) validateTopologyRequest(ctx context.Context, rayJob *ray
 func (w *RayJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayJob) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !jobframework.ShouldValidateRayOrSparkJobOnUpdate(oldJob, newJob, w.manageJobsWithoutQueueName) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -164,22 +164,32 @@ func (w *RayJobWebhook) validateTopologyRequest(ctx context.Context, rayJob *ray
 	return raycluster.ValidateTopologyRequest(ctx, w.client, job, rayJob.Spec.RayClusterSpec, headGroupMetaPath, workerGroupSpecsPath)
 }
 
+// shouldValidateUpdate reports whether the update must be validated. The gate keeps the
+// old behavior, which let a running job bypass validation by dropping its queue-name
+// label, available as a mitigation.
+func (w *RayJobWebhook) shouldValidateUpdate(newJob *RayJob) bool {
+	if features.Enabled(features.ValidateRayAndSparkJobUpdates) {
+		return true
+	}
+	return w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != ""
+}
+
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayJob) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !w.shouldValidateUpdate(newJob) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -632,10 +632,12 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayv1.RayJob
-		newJob    *rayv1.RayJob
-		manageAll bool
-		wantErr   error
+		oldJob         *rayv1.RayJob
+		newJob         *rayv1.RayJob
+		manageAll      bool
+		defaultLqExist bool
+		featureGates   map[featuregate.Feature]bool
+		wantErr        error
 	}{
 		"invalid unmanaged": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
@@ -671,6 +673,20 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "shutdownAfterJobFinishes"), false, "a kueue managed job should delete the cluster after finishing"),
 			}.ToAggregate(),
 		},
+		"queue name unchanged while unsuspended": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Label("test-label", "test-value").
+				Obj(),
+			wantErr: nil,
+		},
 		"invalid managed - queue name should not change while unsuspended": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
 				Queue("queue").
@@ -699,6 +715,89 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"queue name removal is rejected when the job is unsuspended and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is unsuspended and ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
+		"queue name removal is rejected when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "", "queue-name must not be empty in namespace with default queue"),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:        nil,
+		},
+		"queue name removal is allowed when the job is suspended in a namespace without a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(true).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
+		"prebuilt workload name change is not validated when the job is unmanaged and ValidateRayAndSparkJobUpdates is enabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl1").
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl2").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
 		"priorityClassName is immutable": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
 				Queue("queue").
@@ -713,10 +812,22 @@ func TestValidateUpdate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			if tc.defaultLqExist {
+				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue(
+					string(constants.DefaultLocalQueueName), "ns").ClusterQueue("cluster-queue").Obj()); err != nil {
+					t.Fatalf("Failed to add the default LocalQueue: %v", err)
+				}
+			}
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
+				queues:                     queueManager,
+				cache:                      cqCache,
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -632,10 +632,11 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testcases := map[string]struct {
-		oldJob    *rayv1.RayJob
-		newJob    *rayv1.RayJob
-		manageAll bool
-		wantErr   error
+		oldJob       *rayv1.RayJob
+		newJob       *rayv1.RayJob
+		manageAll    bool
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
 	}{
 		"invalid unmanaged": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
@@ -671,6 +672,20 @@ func TestValidateUpdate(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "shutdownAfterJobFinishes"), false, "a kueue managed job should delete the cluster after finishing"),
 			}.ToAggregate(),
 		},
+		"queue name unchanged while unsuspended": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Label("dummy-label", "dummy-value").
+				Obj(),
+			wantErr: nil,
+		},
 		"invalid managed - queue name should not change while unsuspended": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
 				Queue("queue").
@@ -699,6 +714,33 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"invalid managed - queue name should not be removed while unsuspended": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can be removed while unsuspended when ValidateRayAndSparkJobUpdates is disabled": {
+			oldJob: testingrayutil.MakeJob("job", "ns").
+				Queue("queue").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			newJob: testingrayutil.MakeJob("job", "ns").
+				Suspend(false).
+				ShutdownAfterJobFinishes(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
 		"priorityClassName is immutable": {
 			oldJob: testingrayutil.MakeJob("job", "ns").
 				Queue("queue").
@@ -713,10 +755,16 @@ func TestValidateUpdate(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
 			wh := &RayJobWebhook{
 				manageJobsWithoutQueueName: tc.manageAll,
+				queues:                     queueManager,
+				cache:                      cqCache,
 			}
-			ctx, _ := utiltesting.ContextWithLog(t)
 			_, result := wh.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
 			if diff := cmp.Diff(tc.wantErr, result); diff != "" {
 				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -169,18 +169,18 @@ func (w *RayServiceWebhook) validateTopologyRequest(ctx context.Context, rayServ
 func (w *RayServiceWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayService) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !jobframework.ShouldValidateRayOrSparkJobOnUpdate(oldJob, newJob, w.manageJobsWithoutQueueName) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -165,22 +165,32 @@ func (w *RayServiceWebhook) validateTopologyRequest(ctx context.Context, rayServ
 	return raycluster.ValidateTopologyRequest(ctx, w.client, job, &rayService.Spec.RayClusterSpec, headGroupMetaPath, workerGroupSpecsPath)
 }
 
+// shouldValidateUpdate reports whether the update must be validated. The gate keeps the
+// old behavior, which let a running job bypass validation by dropping its queue-name
+// label, available as a mitigation.
+func (w *RayServiceWebhook) shouldValidateUpdate(newJob *RayService) bool {
+	if features.Enabled(features.ValidateRayAndSparkJobUpdates) {
+		return true
+	}
+	return w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != ""
+}
+
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *RayServiceWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *rayv1.RayService) (admission.Warnings, error) {
 	oldJob := fromObject(oldObj)
 	newJob := fromObject(newObj)
-	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(newJob) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newObj)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !w.shouldValidateUpdate(newJob) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(oldJob, newJob, w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newObj)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
@@ -19,13 +19,23 @@ package rayservice
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 )
 
 func TestValidateCreate(t *testing.T) {
@@ -137,63 +147,106 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		oldService *rayv1.RayService
-		newService *rayv1.RayService
-		wantErr    bool
+		oldService   *rayv1.RayService
+		newService   *rayv1.RayService
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
 	}{
+		"unmanaged": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			wantErr: nil,
+		},
 		"valid update": {
-			oldService: &rayv1.RayService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayservice",
-					Namespace: "ns",
-					Labels: map[string]string{
-						constants.QueueLabel: "queue",
-					},
-				},
-				Spec: rayv1.RayServiceSpec{
-					RayClusterSpec: rayv1.RayClusterSpec{
-						Suspend: new(true),
-						HeadGroupSpec: rayv1.HeadGroupSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{Name: "head"}},
-								},
-							},
-						},
-					},
-				},
-			},
-			newService: &rayv1.RayService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayservice",
-					Namespace: "ns",
-					Labels: map[string]string{
-						constants.QueueLabel: "queue",
-					},
-				},
-				Spec: rayv1.RayServiceSpec{
-					RayClusterSpec: rayv1.RayClusterSpec{
-						Suspend: new(false),
-						HeadGroupSpec: rayv1.HeadGroupSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{Name: "head"}},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: false,
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name unchanged while unsuspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Label("dummy-label", "dummy-value").
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name should not change while unsuspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue2").
+				Suspend(false).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName("queue2"), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name should not be removed while unsuspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can change while suspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue2").
+				Suspend(true).
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name can be removed while unsuspended when ValidateRayAndSparkJobUpdates is disabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			webhook := &RayServiceWebhook{}
-			_, err := webhook.ValidateUpdate(t.Context(), tc.oldService, tc.newService)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tc.wantErr)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			webhook := &RayServiceWebhook{
+				queues: queueManager,
+				cache:  cqCache,
+			}
+			_, err := webhook.ValidateUpdate(ctx, tc.oldService, tc.newService)
+			if diff := cmp.Diff(tc.wantErr, err); diff != "" {
+				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook_test.go
@@ -19,13 +19,24 @@ package rayservice
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/component-base/featuregate"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 )
 
 func TestValidateCreate(t *testing.T) {
@@ -137,63 +148,154 @@ func TestValidateCreate(t *testing.T) {
 
 func TestValidateUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		oldService *rayv1.RayService
-		newService *rayv1.RayService
-		wantErr    bool
+		oldService     *rayv1.RayService
+		newService     *rayv1.RayService
+		defaultLqExist bool
+		featureGates   map[featuregate.Feature]bool
+		wantErr        error
 	}{
 		"valid update": {
-			oldService: &rayv1.RayService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayservice",
-					Namespace: "ns",
-					Labels: map[string]string{
-						constants.QueueLabel: "queue",
-					},
-				},
-				Spec: rayv1.RayServiceSpec{
-					RayClusterSpec: rayv1.RayClusterSpec{
-						Suspend: new(true),
-						HeadGroupSpec: rayv1.HeadGroupSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{Name: "head"}},
-								},
-							},
-						},
-					},
-				},
-			},
-			newService: &rayv1.RayService{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "rayservice",
-					Namespace: "ns",
-					Labels: map[string]string{
-						constants.QueueLabel: "queue",
-					},
-				},
-				Spec: rayv1.RayServiceSpec{
-					RayClusterSpec: rayv1.RayClusterSpec{
-						Suspend: new(false),
-						HeadGroupSpec: rayv1.HeadGroupSpec{
-							Template: corev1.PodTemplateSpec{
-								Spec: corev1.PodSpec{
-									Containers: []corev1.Container{{Name: "head"}},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantErr: false,
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name unchanged while unsuspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Label("test-label", "test-value").
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name should not change while unsuspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue2").
+				Suspend(false).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName("queue2"), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can change while suspended": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue2").
+				Suspend(true).
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name removal is rejected when the job is unsuspended and ValidateRayAndSparkJobUpdates is enabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is unsuspended and ValidateRayAndSparkJobUpdates is disabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(false).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
+		"queue name removal is rejected when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(constants.QueueLabel), "", "queue-name must not be empty in namespace with default queue"),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is disabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue(string(constants.DefaultLocalQueueName)).
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(true).
+				Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:        nil,
+		},
+		"queue name removal is allowed when the job is suspended in a namespace without a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Queue("queue").
+				Suspend(true).
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(true).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
+		"prebuilt workload name change is not validated when the job is unmanaged and ValidateRayAndSparkJobUpdates is enabled": {
+			oldService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl1").
+				Obj(),
+			newService: testingrayservice.MakeService("rayservice", "ns").
+				Suspend(false).
+				PrebuiltWorkloadLabel("wl2").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			webhook := &RayServiceWebhook{}
-			_, err := webhook.ValidateUpdate(t.Context(), tc.oldService, tc.newService)
-			if (err != nil) != tc.wantErr {
-				t.Errorf("ValidateUpdate() error = %v, wantErr %v", err, tc.wantErr)
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			if tc.defaultLqExist {
+				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue(
+					string(constants.DefaultLocalQueueName), "ns").ClusterQueue("cluster-queue").Obj()); err != nil {
+					t.Fatalf("Failed to add the default LocalQueue: %v", err)
+				}
+			}
+			webhook := &RayServiceWebhook{
+				queues: queueManager,
+				cache:  cqCache,
+			}
+			_, err := webhook.ValidateUpdate(ctx, tc.oldService, tc.newService)
+			if diff := cmp.Diff(tc.wantErr, err); diff != "" {
+				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -172,18 +172,18 @@ func (w *SparkApplicationWebhook) validateTopologyRequest(ctx context.Context, s
 
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *SparkApplicationWebhook) ValidateUpdate(ctx context.Context, oldSparkApp, newSparkApp *sparkv1beta2.SparkApplication) (admission.Warnings, error) {
-	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(fromObject(newSparkApp)) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(fromObject(oldSparkApp), fromObject(newSparkApp), w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newSparkApp)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !jobframework.ShouldValidateRayOrSparkJobOnUpdate(fromObject(oldSparkApp), fromObject(newSparkApp), w.manageJobsWithoutQueueName) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(fromObject(oldSparkApp), fromObject(newSparkApp), w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newSparkApp)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -170,20 +170,30 @@ func (w *SparkApplicationWebhook) validateTopologyRequest(ctx context.Context, s
 	return nil, podSetsErr
 }
 
+// shouldValidateUpdate reports whether the update must be validated. The gate keeps the
+// old behavior, which let a running job bypass validation by dropping its queue-name
+// label, available as a mitigation.
+func (w *SparkApplicationWebhook) shouldValidateUpdate(newSparkApp *SparkApplication) bool {
+	if features.Enabled(features.ValidateRayAndSparkJobUpdates) {
+		return true
+	}
+	return w.manageJobsWithoutQueueName || jobframework.QueueName(newSparkApp) != ""
+}
+
 // ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type
 func (w *SparkApplicationWebhook) ValidateUpdate(ctx context.Context, oldSparkApp, newSparkApp *sparkv1beta2.SparkApplication) (admission.Warnings, error) {
-	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
-	if w.manageJobsWithoutQueueName || jobframework.QueueName(fromObject(newSparkApp)) != "" {
-		log.Info("Validating update")
-		allErrors := jobframework.ValidateJobOnUpdate(fromObject(oldSparkApp), fromObject(newSparkApp), w.queues.DefaultLocalQueueExist)
-		validationErrs, err := w.validateCreate(ctx, newSparkApp)
-		if err != nil {
-			return nil, err
-		}
-		allErrors = append(allErrors, validationErrs...)
-		return nil, allErrors.ToAggregate()
+	if !w.shouldValidateUpdate(fromObject(newSparkApp)) {
+		return nil, nil
 	}
-	return nil, nil
+	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
+	log.V(5).Info("Validating update")
+	allErrors := jobframework.ValidateJobOnUpdate(fromObject(oldSparkApp), fromObject(newSparkApp), w.queues.DefaultLocalQueueExist)
+	validationErrs, err := w.validateCreate(ctx, newSparkApp)
+	if err != nil {
+		return nil, err
+	}
+	allErrors = append(allErrors, validationErrs...)
+	return nil, allErrors.ToAggregate()
 }
 
 // ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	sparkappv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
@@ -110,6 +111,105 @@ func TestValidateCreate(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	testSparkApp := sparkapplicationtesting.MakeSparkApplication("test-sparkapp", "test").Suspend(false)
+	testcases := map[string]struct {
+		oldSparkApp    *sparkappv1beta2.SparkApplication
+		newSparkApp    *sparkappv1beta2.SparkApplication
+		defaultLqExist bool
+		featureGates   map[featuregate.Feature]bool
+		wantErr        error
+	}{
+		"queue name unchanged while unsuspended": {
+			oldSparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Queue("local-queue").Label("test-label", "test-value").Obj(),
+			wantErr:     nil,
+		},
+		"queue name should not change while unsuspended": {
+			oldSparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Queue("local-queue-2").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(controllerconstants.QueueLabel), kueue.LocalQueueName("local-queue-2"), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can change while suspended": {
+			oldSparkApp: testSparkApp.Clone().Suspend(true).Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Suspend(true).Queue("local-queue-2").Obj(),
+			wantErr:     nil,
+		},
+		"queue name removal is rejected when the job is unsuspended and ValidateRayAndSparkJobUpdates is enabled": {
+			oldSparkApp:  testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp:  testSparkApp.Clone().Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(controllerconstants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is unsuspended and ValidateRayAndSparkJobUpdates is disabled": {
+			oldSparkApp:  testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp:  testSparkApp.Clone().Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
+		"queue name removal is rejected when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldSparkApp:    testSparkApp.Clone().Suspend(true).Queue(string(controllerconstants.DefaultLocalQueueName)).Obj(),
+			newSparkApp:    testSparkApp.Clone().Suspend(true).Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(controllerconstants.QueueLabel), "", "queue-name must not be empty in namespace with default queue"),
+			}.ToAggregate(),
+		},
+		"queue name removal is allowed when the job is suspended in a namespace with a default queue and ValidateRayAndSparkJobUpdates is disabled": {
+			oldSparkApp:    testSparkApp.Clone().Suspend(true).Queue(string(controllerconstants.DefaultLocalQueueName)).Obj(),
+			newSparkApp:    testSparkApp.Clone().Suspend(true).Obj(),
+			defaultLqExist: true,
+			featureGates:   map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:        nil,
+		},
+		"queue name removal is allowed when the job is suspended in a namespace without a default queue and ValidateRayAndSparkJobUpdates is enabled": {
+			oldSparkApp:  testSparkApp.Clone().Suspend(true).Queue("local-queue").Obj(),
+			newSparkApp:  testSparkApp.Clone().Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
+		"prebuilt workload name change is not validated when the job is unmanaged and ValidateRayAndSparkJobUpdates is enabled": {
+			oldSparkApp: testSparkApp.Clone().
+				Label(controllerconstants.PrebuiltWorkloadLabel, "wl1").
+				Obj(),
+			newSparkApp: testSparkApp.Clone().
+				Label(controllerconstants.PrebuiltWorkloadLabel, "wl2").
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: true},
+			wantErr:      nil,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			if tc.defaultLqExist {
+				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue(
+					string(controllerconstants.DefaultLocalQueueName), "test").ClusterQueue("cluster-queue").Obj()); err != nil {
+					t.Fatalf("Failed to add the default LocalQueue: %v", err)
+				}
+			}
+			webhook := &SparkApplicationWebhook{
+				queues: queueManager,
+				cache:  cqCache,
+			}
+			_, gotErr := webhook.ValidateUpdate(ctx, tc.oldSparkApp, tc.newSparkApp)
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	sparkappv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
@@ -110,6 +111,74 @@ func TestValidateCreate(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	testSparkApp := sparkapplicationtesting.MakeSparkApplication("test-sparkapp", "test").Suspend(false)
+	testcases := map[string]struct {
+		oldSparkApp  *sparkappv1beta2.SparkApplication
+		newSparkApp  *sparkappv1beta2.SparkApplication
+		featureGates map[featuregate.Feature]bool
+		wantErr      error
+	}{
+		"unmanaged": {
+			oldSparkApp: sparkapplicationtesting.MakeSparkApplication("test-sparkapp", "test").
+				Suspend(false).
+				Obj(),
+			newSparkApp: sparkapplicationtesting.MakeSparkApplication("test-sparkapp", "test").
+				Suspend(false).
+				Obj(),
+			wantErr: nil,
+		},
+		"queue name unchanged while unsuspended": {
+			oldSparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Queue("local-queue").Label("dummy-label", "dummy-value").Obj(),
+			wantErr:     nil,
+		},
+		"queue name should not change while unsuspended": {
+			oldSparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Queue("local-queue-2").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(controllerconstants.QueueLabel), kueue.LocalQueueName("local-queue-2"), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name should not be removed while unsuspended": {
+			oldSparkApp: testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(field.NewPath("metadata", "labels").Key(controllerconstants.QueueLabel), kueue.LocalQueueName(""), apivalidation.FieldImmutableErrorMsg),
+			}.ToAggregate(),
+		},
+		"queue name can change while suspended": {
+			oldSparkApp: testSparkApp.Clone().Suspend(true).Queue("local-queue").Obj(),
+			newSparkApp: testSparkApp.Clone().Suspend(true).Queue("local-queue-2").Obj(),
+			wantErr:     nil,
+		},
+		"queue name can be removed while unsuspended when ValidateRayAndSparkJobUpdates is disabled": {
+			oldSparkApp:  testSparkApp.Clone().Queue("local-queue").Obj(),
+			newSparkApp:  testSparkApp.Clone().Obj(),
+			featureGates: map[featuregate.Feature]bool{features.ValidateRayAndSparkJobUpdates: false},
+			wantErr:      nil,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cli := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cli)
+			queueManager := qcache.NewManagerForUnitTests(cli, cqCache)
+			webhook := &SparkApplicationWebhook{
+				queues: queueManager,
+				cache:  cqCache,
+			}
+			_, gotErr := webhook.ValidateUpdate(ctx, tc.oldSparkApp, tc.newSparkApp)
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -534,6 +534,15 @@ const (
 	// begun, and suspend defaulting only ever adds suspend, so no path exists to
 	// unsuspend an object or bypass quota via create-then-delete.
 	SkipAncestorCheckForDeletedWorkloads featuregate.Feature = "SkipAncestorCheckForDeletedWorkloads"
+
+	// owner: @ivnovakov
+	//
+	// Runs update validation in the RayCluster, RayJob, RayService and SparkApplication
+	// webhooks regardless of whether the updated object still looks managed by Kueue.
+	// When disabled, those webhooks only validate an update if manageJobsWithoutQueueName
+	// is set or the new object still carries a queue-name label, which lets a running job
+	// bypass the queue-name immutability check by dropping that label.
+	ValidateRayAndSparkJobUpdates featuregate.Feature = "ValidateRayAndSparkJobUpdates"
 )
 
 func init() {
@@ -834,6 +843,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	SkipAncestorCheckForDeletedWorkloads: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	ValidateRayAndSparkJobUpdates: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -554,6 +554,16 @@ const (
 	// Refuse to adopt an existing Workload by pod-group name when it was not created
 	// by the pod-group framework (missing is-group-workload annotation).
 	PodIntegrationValidateGroupOwner featuregate.Feature = "PodIntegrationValidateGroupOwner"
+
+	// owner: @ivnovakov
+	//
+	// Validates an update in the RayCluster, RayJob, RayService and SparkApplication
+	// webhooks when the object carried a queue-name label before the update, so removing
+	// that label cannot leave a job running unmanaged. Jobs that Kueue manages neither
+	// before nor after the update are never validated. When disabled, those webhooks only
+	// validate an update if manageJobsWithoutQueueName is set or the new object carries a
+	// queue-name label.
+	ValidateRayAndSparkJobUpdates featuregate.Feature = "ValidateRayAndSparkJobUpdates"
 )
 
 func init() {
@@ -862,6 +872,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	PodIntegrationValidateGroupOwner: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	ValidateRayAndSparkJobUpdates: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -507,6 +507,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: ValidateRayAndSparkJobUpdates
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -509,6 +509,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: ValidateRayAndSparkJobUpdates
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -507,6 +507,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: ValidateRayAndSparkJobUpdates
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -509,6 +509,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: ValidateRayAndSparkJobUpdates
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: VectorizedResourceRequests
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
@@ -27,10 +27,12 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
@@ -59,6 +61,56 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 			err := k8sClient.Create(ctx, job)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, true)
+			})
+
+			ginkgo.It("should reject removing the queue name from an unsuspended RayCluster", func() {
+				cluster := testingraycluster.MakeCluster("raycluster", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, cluster)
+
+				lookupKey := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+				createdCluster := &rayv1.RayCluster{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended cluster updating other fields while retaining the queue name.
+				createdCluster.Spec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdCluster)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended cluster dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+				delete(createdCluster.Labels, controllerconstants.QueueLabel)
+				err := k8sClient.Update(ctx, createdCluster)
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+			})
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, false)
+			})
+
+			ginkgo.It("should allow removing the queue name from an unsuspended RayCluster", func() {
+				cluster := testingraycluster.MakeCluster("raycluster", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, cluster)
+
+				lookupKey := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+				createdCluster := &rayv1.RayCluster{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended cluster updating other fields while retaining the queue name.
+				createdCluster.Spec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdCluster)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended cluster dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+				delete(createdCluster.Labels, controllerconstants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdCluster)).Should(gomega.Succeed())
+			})
 		})
 	})
 

--- a/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
@@ -27,6 +27,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
@@ -57,6 +58,26 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 		ginkgo.It("the creation doesn't succeed if the queue name is invalid", func() {
 			job := testingraycluster.MakeCluster("raycluster", ns.Name).Queue("indexed_job").Obj()
 			err := k8sClient.Create(ctx, job)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+		})
+
+		ginkgo.It("should reject removing the queue name from an active RayCluster", func() {
+			cluster := testingraycluster.MakeCluster("raycluster", ns.Name).Queue("queue-name").Obj()
+			util.MustCreate(ctx, k8sClient, cluster)
+
+			lookupKey := types.NamespacedName{Name: cluster.Name, Namespace: cluster.Namespace}
+			createdCluster := &rayv1.RayCluster{}
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+
+			// Simulate a running workload updating other fields while retaining the queue name.
+			createdCluster.Spec.Suspend = new(false)
+			gomega.Expect(k8sClient.Update(ctx, createdCluster)).Should(gomega.Succeed())
+
+			// Simulate a running workload dropping its queue name to escape Kueue.
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdCluster)).Should(gomega.Succeed())
+			delete(createdCluster.Labels, controllerconstants.QueueLabel)
+			err := k8sClient.Update(ctx, createdCluster)
 			gomega.Expect(err).Should(gomega.HaveOccurred())
 			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
 		})

--- a/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
@@ -19,9 +19,13 @@ package jobs
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/test/util"
@@ -105,6 +109,56 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 			// no clusterSelector + RayClusterSpec present -> valid, full validation runs
 			// MakeJob() creates a valid RayClusterSpec by default
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, true)
+			})
+
+			ginkgo.It("should reject removing the queue name from an unsuspended RayJob", func() {
+				job := testingjob.MakeJob("rayjob-queue-removal", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, job)
+
+				lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+				createdJob := &rayv1.RayJob{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended job updating other fields while retaining the queue name.
+				createdJob.Spec.Suspend = false
+				gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended job dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+				delete(createdJob.Labels, constants.QueueLabel)
+				err := k8sClient.Update(ctx, createdJob)
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+			})
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, false)
+			})
+
+			ginkgo.It("should allow removing the queue name from an unsuspended RayJob", func() {
+				job := testingjob.MakeJob("rayjob-queue-removal", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, job)
+
+				lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+				createdJob := &rayv1.RayJob{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended job updating other fields while retaining the queue name.
+				createdJob.Spec.Suspend = false
+				gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended job dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+				delete(createdJob.Labels, constants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+			})
 		})
 	})
 })

--- a/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/rayjob_webhook_test.go
@@ -19,8 +19,11 @@ package jobs
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
+	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
@@ -105,6 +108,26 @@ var _ = ginkgo.Describe("RayJob Webhook", func() {
 			// no clusterSelector + RayClusterSpec present -> valid, full validation runs
 			// MakeJob() creates a valid RayClusterSpec by default
 			gomega.Expect(k8sClient.Create(ctx, job)).Should(gomega.Succeed())
+		})
+
+		ginkgo.It("should reject removing the queue name from a running RayJob", func() {
+			job := testingjob.MakeJob("rayjob-queue-removal", ns.Name).Queue("queue-name").Obj()
+			util.MustCreate(ctx, k8sClient, job)
+
+			lookupKey := types.NamespacedName{Name: job.Name, Namespace: job.Namespace}
+			createdJob := &rayv1.RayJob{}
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+			// Simulate a running workload updating other fields while retaining the queue name.
+			createdJob.Spec.Suspend = false
+			gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+
+			// Simulate a running workload dropping its queue name to escape Kueue.
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			delete(createdJob.Labels, constants.QueueLabel)
+			err := k8sClient.Update(ctx, createdJob)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
 		})
 	})
 })

--- a/test/integration/singlecluster/webhook/jobs/rayservice_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/rayservice_webhook_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("RayService Webhook", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.When("With manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
+			fwk.StartManager(ctx, cfg, managerSetup(rayservice.SetupRayServiceWebhook))
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rayservice-")
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			fwk.StopManager(ctx)
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, true)
+			})
+
+			ginkgo.It("should reject removing the queue name from an unsuspended RayService", func() {
+				service := testingrayservice.MakeService("rayservice", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, service)
+
+				lookupKey := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+				createdService := &rayv1.RayService{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended service updating other fields while retaining the queue name.
+				createdService.Spec.RayClusterSpec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdService)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended service dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+				delete(createdService.Labels, constants.QueueLabel)
+				err := k8sClient.Update(ctx, createdService)
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+			})
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, false)
+			})
+
+			ginkgo.It("should allow removing the queue name from an unsuspended RayService", func() {
+				service := testingrayservice.MakeService("rayservice", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, service)
+
+				lookupKey := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+				createdService := &rayv1.RayService{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended service updating other fields while retaining the queue name.
+				createdService.Spec.RayClusterSpec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdService)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended service dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+				delete(createdService.Labels, constants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdService)).Should(gomega.Succeed())
+			})
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/rayservice_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/rayservice_webhook_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("RayService Webhook", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.When("With manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
+			fwk.StartManager(ctx, cfg, managerSetup(rayservice.SetupRayServiceWebhook))
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rayservice-")
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			fwk.StopManager(ctx)
+		})
+
+		ginkgo.It("should reject removing the queue name from an active RayService", func() {
+			service := testingrayservice.MakeService("rayservice", ns.Name).Queue("queue-name").Obj()
+			util.MustCreate(ctx, k8sClient, service)
+
+			lookupKey := types.NamespacedName{Name: service.Name, Namespace: service.Namespace}
+			createdService := &rayv1.RayService{}
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+
+			// Simulate a running workload updating other fields while retaining the queue name.
+			createdService.Spec.RayClusterSpec.Suspend = new(false)
+			gomega.Expect(k8sClient.Update(ctx, createdService)).Should(gomega.Succeed())
+
+			// Simulate a running workload dropping its queue name to escape Kueue.
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdService)).Should(gomega.Succeed())
+			delete(createdService.Labels, constants.QueueLabel)
+			err := k8sClient.Update(ctx, createdService)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/sparkapplication_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/sparkapplication_webhook_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	sparkappv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/sparkapplication"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingspark "sigs.k8s.io/kueue/pkg/util/testingjobs/sparkapplication"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("SparkApplication Webhook", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.When("With manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
+			fwk.StartManager(ctx, cfg, managerSetup(sparkapplication.SetupWebhook))
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "sparkapplication-")
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			fwk.StopManager(ctx)
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is enabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, true)
+			})
+
+			ginkgo.It("should reject removing the queue name from an unsuspended SparkApplication", func() {
+				app := testingspark.MakeSparkApplication("sparkapp", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, app)
+
+				lookupKey := types.NamespacedName{Name: app.Name, Namespace: app.Namespace}
+				createdApp := &sparkappv1beta2.SparkApplication{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended application updating other fields while retaining the queue name.
+				createdApp.Spec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdApp)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended application dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+				delete(createdApp.Labels, controllerconstants.QueueLabel)
+				err := k8sClient.Update(ctx, createdApp)
+				gomega.Expect(err).Should(gomega.HaveOccurred())
+				gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+			})
+		})
+
+		ginkgo.When("ValidateRayAndSparkJobUpdates is disabled", func() {
+			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ValidateRayAndSparkJobUpdates, false)
+			})
+
+			ginkgo.It("should allow removing the queue name from an unsuspended SparkApplication", func() {
+				app := testingspark.MakeSparkApplication("sparkapp", ns.Name).Queue("queue-name").Obj()
+				util.MustCreate(ctx, k8sClient, app)
+
+				lookupKey := types.NamespacedName{Name: app.Name, Namespace: app.Namespace}
+				createdApp := &sparkappv1beta2.SparkApplication{}
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended application updating other fields while retaining the queue name.
+				createdApp.Spec.Suspend = new(false)
+				gomega.Expect(k8sClient.Update(ctx, createdApp)).Should(gomega.Succeed())
+
+				// Simulate an unsuspended application dropping its queue name to become unmanaged.
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+				delete(createdApp.Labels, controllerconstants.QueueLabel)
+				gomega.Expect(k8sClient.Update(ctx, createdApp)).Should(gomega.Succeed())
+			})
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/sparkapplication_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/sparkapplication_webhook_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	sparkappv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/sparkapplication"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingspark "sigs.k8s.io/kueue/pkg/util/testingjobs/sparkapplication"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("SparkApplication Webhook", func() {
+	var ns *corev1.Namespace
+
+	ginkgo.When("With manageJobsWithoutQueueName disabled", func() {
+		ginkgo.BeforeEach(func() {
+			fwk.StartManager(ctx, cfg, managerSetup(sparkapplication.SetupWebhook))
+			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "sparkapplication-")
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			fwk.StopManager(ctx)
+		})
+
+		ginkgo.It("should reject removing the queue name from an active SparkApplication", func() {
+			app := testingspark.MakeSparkApplication("sparkapp", ns.Name).Queue("queue-name").Obj()
+			util.MustCreate(ctx, k8sClient, app)
+
+			lookupKey := types.NamespacedName{Name: app.Name, Namespace: app.Namespace}
+			createdApp := &sparkappv1beta2.SparkApplication{}
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+
+			// Simulate a running workload updating other fields while retaining the queue name.
+			createdApp.Spec.Suspend = new(false)
+			gomega.Expect(k8sClient.Update(ctx, createdApp)).Should(gomega.Succeed())
+
+			// Simulate a running workload dropping its queue name to escape Kueue.
+			gomega.Expect(k8sClient.Get(ctx, lookupKey, createdApp)).Should(gomega.Succeed())
+			delete(createdApp.Labels, controllerconstants.QueueLabel)
+			err := k8sClient.Update(ctx, createdApp)
+			gomega.Expect(err).Should(gomega.HaveOccurred())
+			gomega.Expect(err).Should(utiltesting.BeForbiddenError())
+		})
+	})
+})

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -60,6 +60,7 @@ var _ = ginkgo.BeforeSuite(func() {
 			util.TrainingOperatorCrds,
 			util.AppWrapperCrds,
 			util.KfTrainerCrds,
+			util.SparkOperatorCrds,
 		},
 		WebhookPath: util.WebhookPath,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind bug
/area integrations

#### What this PR does / why we need it:

The `ValidateUpdate` webhooks for RayJob, RayCluster, RayService and SparkApplication ran
`jobframework.ValidateJobOnUpdate` only when the updated object still carried the
`kueue.x-k8s.io/queue-name` label, or when `manageJobsWithoutQueueName` was enabled.
Removing that label from an unsuspended job made the guard false, so the immutability
check in `validateUpdateForQueueName` was skipped. The job then stopped being managed by
Kueue while its pods kept running, and its resources were no longer counted against quota.

The four webhooks now share `jobframework.ShouldValidateJobOnUpdate`, which also validates
a job that carried the label before the update. A job that carries it neither before nor
after is still not validated. The `ValidateRayAndSparkJobUpdates` feature gate toggles that
added condition and nothing else, so with the gate disabled the guard is the one from
before this change. The gate is Beta and enabled by default in 0.20.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

- The unit tables cover every scenario in both gate states. The unmanaged cases change the
  prebuilt workload name on an unsuspended job with no queue-name label on either side.
  That change is invalid on its own, so a nil result with the gate enabled can only mean
  the job was never validated.
- The integration specs cover the fix in both gate states, two per integration. Nothing
  exercises `DefaultLocalQueueExist` through a live webhook. That wiring is shared with
  `BaseWebhook` and every other integration, and was already untested at integration level
  before this PR.
- `log.Info` becomes `log.V(5).Info` in the four webhooks, matching the job, pod,
  deployment, statefulset and leaderworkerset webhooks. Unrelated to the fix.
- This PR was written in part with the assistance of generative AI.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
RayJob, RayCluster, RayService, and SparkApplication: Fixed a bug where removing the `kueue.x-k8s.io/queue-name` label from an unsuspended job was accepted, so the job stopped being managed by Kueue while its pods kept running and its resources were no longer counted against quota. Removing the label is now rejected, both from an unsuspended job and from a suspended job in a namespace with a default LocalQueue. Controlled by the `ValidateRayAndSparkJobUpdates` feature gate, which is Beta and enabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `ValidateRayAndSparkJobUpdates` feature gate, enabled by default.
  - Update validation now consistently applies to RayCluster, RayJob, RayService, and SparkApplication resources.
  - Queue-label changes and removals are rejected when validation is enabled, including for suspended jobs where applicable.
  - Updates remain allowed when the feature gate is disabled or validation is not required.

- **Tests**
  - Added comprehensive unit and integration coverage for queue changes, default queues, suspension states, and feature-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->