### PR TITLE
Use `E2E_KIND_VERSION` in populator tests

### DIFF
--- a/Makefile-kueue-populator.mk
+++ b/Makefile-kueue-populator.mk
@@ -24,7 +24,7 @@ kueue-populator-test-integration: ## Run integration tests for kueue-populator.
 
 .PHONY: kueue-populator-test-e2e
 kueue-populator-test-e2e: ## Run e2e tests for kueue-populator.
-	$(MAKE) -C cmd/experimental/kueue-populator test-e2e
+	$(MAKE) -C cmd/experimental/kueue-populator test-e2e E2E_KIND_VERSION=$(E2E_KIND_VERSION)
 
 .PHONY: kueue-populator-verify
 kueue-populator-verify: ## Run all verification tests for kueue-populator.

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -170,4 +170,4 @@ helm-chart-push: helm-chart-package
 
 .PHONY: helm-verify-lifecycle
 helm-verify-lifecycle: ## Run Helm install/uninstall lifecycle verification script.
-	./test/verify-helm-lifecycle.sh
+	E2E_KIND_VERSION=$(E2E_KIND_VERSION) ./test/verify-helm-lifecycle.sh

--- a/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
+++ b/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
@@ -43,7 +43,11 @@ trap cleanup EXIT
 echo "Creating Kind cluster..."
 # Delete existing cluster if any
 "$KIND" delete cluster --name "$KIND_CLUSTER_NAME" 2>/dev/null || true
-"$KIND" create cluster --name "$KIND_CLUSTER_NAME"
+if [[ -n "${E2E_KIND_VERSION:-}" ]]; then
+  "$KIND" create cluster --name "$KIND_CLUSTER_NAME" --image "$E2E_KIND_VERSION"
+else
+  "$KIND" create cluster --name "$KIND_CLUSTER_NAME"
+fi
 
 echo "Building and loading kueue-populator image..."
 make kind-image-build

--- a/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
+++ b/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
@@ -31,7 +31,7 @@ HELM="$ROOT_DIR/bin/helm"
 echo "Ensuring tools are available..."
 cd "$ROOT_DIR"
 # Pass explicit versions to bypass broken 'go list' in hack/tools
-make kind helm KIND_VERSION=v0.24.0 HELM_VERSION=v4.2.0
+make kind helm KIND_VERSION=v0.32.0 HELM_VERSION=v4.2.0
 cd "$SCRIPT_DIR/.."
 
 function cleanup {


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #13291

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * End-to-end Helm lifecycle tests now consistently use the configured Kind version.
  * Added fallback behavior to use Kind’s default image when no version is specified.
  * Improved reliability and reproducibility of Kubernetes cluster setup during testing by updating pinned Kind versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->