### PR TITLE
Prevent quota bypass via spoofed pod role-hash

### DIFF
--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -50,6 +50,7 @@ var (
 	groupNameAnnotationPath        = annotationsPath.Key(podconstants.GroupNameAnnotation)
 	groupTotalCountAnnotationPath  = annotationsPath.Key(podconstants.GroupTotalCountAnnotation)
 	retriableInGroupAnnotationPath = annotationsPath.Key(podconstants.RetriableInGroupAnnotationKey)
+	roleHashAnnotationPath         = annotationsPath.Key(podconstants.RoleHashAnnotation)
 )
 
 type PodWebhook struct {
@@ -86,13 +87,30 @@ func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 
 var _ admission.Defaulter[*corev1.Pod] = &PodWebhook{}
 
-// addRoleHash calculates the role hash and adds it to the pod's annotations
-func (p *Pod) addRoleHash() error {
+// addRoleHash sets the role-hash annotation used to group pods into PodSets.
+//
+// When trustExisting is false — the default for plain pods and pod groups Kueue
+// builds a Workload for — the hash is always recomputed from the pod spec, so a
+// user-supplied value cannot dictate how pods are grouped and therefore the quota
+// footprint of the workload. When trustExisting is true, an existing annotation
+// is kept: this covers pods managed by a Kueue-aware parent
+// (StatefulSet/LeaderWorkerSet/Deployment), whose trusted reconciler sets a
+// PodSet-reference name rather than a spec hash, and pods adopting a prebuilt
+// Workload, whose role-hash maps onto the PodSet names the user declared there.
+func (p *Pod) addRoleHash(trustExisting bool) error {
 	if p.pod.Annotations == nil {
 		p.pod.Annotations = make(map[string]string)
 	}
 
-	hash, err := getRoleHash(p.pod)
+	var (
+		hash string
+		err  error
+	)
+	if trustExisting {
+		hash, err = getRoleHash(p.pod)
+	} else {
+		hash, err = utilpod.GenerateRoleHash(&p.pod.Spec)
+	}
 	if err != nil {
 		return err
 	}
@@ -184,7 +202,11 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 			}
 			utilpod.Gate(&pod.pod, kueue.TopologySchedulingGate)
 		}
-		if err := pod.addRoleHash(); err != nil {
+		// Preserve the role-hash for pods whose grouping is owned by a trusted
+		// writer: a verified Kueue-aware parent or a user-declared prebuilt Workload.
+		// Otherwise recompute it from the spec.
+		trustRoleHash := (suspendByParent && jobframework.IsOwnerManagedByKueueForObject(pod.Object())) || jobframework.PrebuiltWorkloadNameFor(&pod.pod) != ""
+		if err := pod.addRoleHash(trustRoleHash); err != nil {
 			return err
 		}
 		// copy back changes to the object
@@ -207,6 +229,7 @@ func (w *PodWebhook) ValidateCreate(ctx context.Context, obj *corev1.Pod) (admis
 
 	allErrs := jobframework.ValidateJobOnCreate(pod)
 	allErrs = append(allErrs, validateCommon(pod)...)
+	allErrs = append(allErrs, validateRoleHashOnCreate(pod)...)
 
 	if warn := warningForPodManagedLabel(pod); warn != "" {
 		warnings = append(warnings, warn)
@@ -232,6 +255,8 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *corev1.
 		allErrs = append(allErrs, validation.ValidateImmutableField(newGroupName, oldGroupName, getGroupNamePath(&newPod.pod))...)
 	}
 
+	allErrs = append(allErrs, validateRoleHashOnUpdate(oldPod, newPod)...)
+
 	if _, suspendByParent := newPod.pod.Annotations[podconstants.SuspendedByParentAnnotation]; !suspendByParent {
 		if warn := warningForPodManagedLabel(newPod); warn != "" {
 			warnings = append(warnings, warn)
@@ -251,6 +276,63 @@ func validateCommon(pod *Pod) field.ErrorList {
 	allErrs = append(allErrs, validateTopologyRequest(pod)...)
 	allErrs = append(allErrs, validatePrebuiltWorkloadName(pod)...)
 	return allErrs
+}
+
+// roleHashExempt reports whether the role-hash annotation checks should be
+// skipped for this pod. Exempt pods are those whose grouping is not derived from
+// the pod spec by Kueue:
+//   - pods managed by a verified Kueue-aware parent (e.g. StatefulSet, LeaderWorkerSet)
+//     carry a PodSet-reference role-hash set by a trusted reconciler;
+//   - pods adopting a prebuilt Workload map their role-hash onto the PodSet names
+//     the user declared on that Workload;
+//   - pods Kueue does not manage are never grouped into PodSets by their role-hash.
+func roleHashExempt(pod *Pod) bool {
+	if _, suspendByParent := pod.pod.GetAnnotations()[podconstants.SuspendedByParentAnnotation]; suspendByParent && jobframework.IsOwnerManagedByKueueForObject(pod.Object()) {
+		return true
+	}
+	if jobframework.PrebuiltWorkloadNameFor(&pod.pod) != "" {
+		return true
+	}
+	return pod.pod.GetLabels()[constants.ManagedByKueueLabelKey] != constants.ManagedByKueueLabelValue
+}
+
+// validateRoleHashOnCreate rejects a role-hash annotation that does not match the
+// hash derived from the pod spec. The mutating webhook recomputes the annotation
+// on creation, so in the normal flow it already matches; this is a defense-in-depth
+// guard against a value that reaches the API server without being recomputed.
+func validateRoleHashOnCreate(pod *Pod) field.ErrorList {
+	if roleHashExempt(pod) {
+		return nil
+	}
+	roleHash, ok := pod.pod.GetAnnotations()[podconstants.RoleHashAnnotation]
+	if !ok {
+		return nil
+	}
+	wantRoleHash, err := utilpod.GenerateRoleHash(&pod.pod.Spec)
+	if err != nil {
+		return field.ErrorList{field.InternalError(roleHashAnnotationPath, err)}
+	}
+	if roleHash != wantRoleHash {
+		return field.ErrorList{field.Invalid(roleHashAnnotationPath, roleHash,
+			fmt.Sprintf("%s is managed by Kueue and must match the pod spec", podconstants.RoleHashAnnotation))}
+	}
+	return nil
+}
+
+// validateRoleHashOnUpdate keeps the Kueue-managed role-hash annotation immutable.
+// It is set once by the mutating webhook on creation and determines how pods are
+// grouped into PodSets, and therefore the quota footprint of the workload, so a
+// tenant must not be able to change it afterwards. Immutability is enforced rather
+// than re-deriving the hash from the spec because Kueue itself mutates the pod spec
+// at admission (e.g. injecting flavor node selectors) without touching the
+// annotation, which would make a spec-derived check reject Kueue's own updates.
+func validateRoleHashOnUpdate(oldPod, newPod *Pod) field.ErrorList {
+	if roleHashExempt(newPod) {
+		return nil
+	}
+	oldRoleHash := oldPod.pod.GetAnnotations()[podconstants.RoleHashAnnotation]
+	newRoleHash := newPod.pod.GetAnnotations()[podconstants.RoleHashAnnotation]
+	return validation.ValidateImmutableField(newRoleHash, oldRoleHash, roleHashAnnotationPath)
 }
 
 func validateManagedLabel(pod *Pod) field.ErrorList {

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -126,6 +126,63 @@ func TestDefault(t *testing.T) {
 				KueueFinalizer().
 				Obj(),
 		},
+		// A tenant must not be able to dictate the role hash (and therefore the
+		// quota footprint) by pre-setting the role-hash annotation: the webhook
+		// recomputes it from the pod spec for directly-created pods.
+		"managed pod with a spoofed role-hash gets it recomputed from the pod spec": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				RoleHash("spoofed").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
+		// Pods managed by a Kueue-aware parent carry a PodSet-reference role-hash
+		// set by a trusted reconciler; the webhook must preserve it verbatim.
+		"parent-managed pod keeps its PodSet-reference role-hash": {
+			featureGates:       map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			enableIntegrations: []string{"batch/job"},
+			initObjects:        []client.Object{defaultNamespace},
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				SuspendedByParent("statefulset").
+				Queue("test-queue").
+				RoleHash("main").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				SuspendedByParent("statefulset").
+				Queue("test-queue").
+				KueueSchedulingGate().
+				RoleHash("main").
+				Obj(),
+		},
+		// A pod adopting a prebuilt Workload maps its role-hash onto the PodSet
+		// names the user declared on that Workload, so the webhook must preserve it.
+		"pod adopting a prebuilt workload keeps its declared role-hash": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			initObjects:  []client.Object{defaultNamespace},
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				PrebuiltWorkloadLabel("prebuilt-wl").
+				RoleHash("leader").
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				PrebuiltWorkloadLabel("prebuilt-wl").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("leader").
+				KueueFinalizer().
+				Obj(),
+		},
 		"pod with queue matching ns selector": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:  []client.Object{defaultNamespace},
@@ -1022,6 +1079,19 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
+		"managed pod with a role-hash not matching the pod spec is rejected": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			pod: testingpod.MakePod("test-pod", "test-ns").
+				ManagedByKueueLabel().
+				RoleHash("spoofed").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/role-hash]",
+				},
+			}.ToAggregate(),
+		},
 	}
 
 	for name, tc := range testCases {
@@ -1337,6 +1407,57 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
+		},
+		// The mutating webhook only runs on CREATE, so a tenant could otherwise
+		// tamper with the role-hash on UPDATE; the validating webhook keeps the
+		// Kueue-managed annotation immutable.
+		"managed pod with a changed role-hash is rejected on update": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				ManagedByKueueLabel().
+				RoleHash("a9f06f3a").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				ManagedByKueueLabel().
+				RoleHash("spoofed").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/role-hash]",
+				},
+			}.ToAggregate(),
+		},
+		"parent-managed pod with PodSet-reference role-hash is not rejected on update": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				SuspendedByParent("statefulset").
+				RoleHash("main").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				SuspendedByParent("statefulset").
+				RoleHash("main").
+				Obj(),
+		},
+		"managed pod adding parent annotation while changing role-hash is rejected on update": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			oldPod: testingpod.MakePod("test-pod", "test-ns").
+				ManagedByKueueLabel().
+				RoleHash("a9f06f3a").
+				Obj(),
+			newPod: testingpod.MakePod("test-pod", "test-ns").
+				ManagedByKueueLabel().
+				SuspendedByParent("statefulset").
+				RoleHash("spoofed").
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "metadata.annotations[kueue.x-k8s.io/role-hash]",
+				},
+			}.ToAggregate(),
 		},
 	}
 

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -867,6 +867,44 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 				})
 			})
 
+			ginkgo.It("Should not let a spoofed role-hash collapse pods with different requests into one PodSet", func() {
+				ginkgo.By("Creating two pods with different CPU requests but the same, spoofed role-hash")
+				pod1 := testingpod.MakePod("test-pod1", ns.Name).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					RoleHash("spoofed").
+					Request(corev1.ResourceCPU, "1").
+					Obj()
+				pod2 := testingpod.MakePod("test-pod2", ns.Name).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					Queue("test-queue").
+					RoleHash("spoofed").
+					Request(corev1.ResourceCPU, "5").
+					Obj()
+
+				util.MustCreate(ctx, k8sClient, pod1)
+				util.MustCreate(ctx, k8sClient, pod2)
+
+				ginkgo.By("checking the workload keeps the two roles in separate PodSets, so both footprints are counted against quota")
+				wlLookupKey := types.NamespacedName{Namespace: pod1.Namespace, Name: "test-group"}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Spec.PodSets).To(gomega.HaveLen(2))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Expect(createdWorkload.Spec.PodSets[0].Count).To(gomega.Equal(int32(1)))
+				gomega.Expect(createdWorkload.Spec.PodSets[1].Count).To(gomega.Equal(int32(1)))
+				gotRequests := []resource.Quantity{
+					createdWorkload.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU],
+					createdWorkload.Spec.PodSets[1].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU],
+				}
+				gomega.Expect(gotRequests).To(gomega.ConsistOf(resource.MustParse("1"), resource.MustParse("5")),
+					"both the 1-CPU and 5-CPU roles must be accounted for, not collapsed onto the first pod's request")
+			})
+
 			ginkgo.It("Should ungate pods when admitted with fast admission", func() {
 				ginkgo.By("Creating pod1 and delaying creation of pod2")
 				pod1 := testingpod.MakePod("test-pod1", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

`getRoleHash` trusts the `kueue.x-k8s.io/role-hash` annotation when it is present, and the mutating webhook wrote it back unchanged on create. A tenant could set the same role-hash on Pods in a group that request different resources. Kueue groups pods by that hash into one PodSet and takes the footprint from the first pod, so the group was admitted against less quota than it consumes, bypassing the ClusterQueue and LocalQueue limits.

The mutating webhook now recomputes the role-hash from the pod spec, so a user-supplied value can no longer decide the grouping. An existing value is kept only when a trusted writer owns the grouping: a Kueue-aware parent (StatefulSet, LeaderWorkerSet, Deployment) that sets a PodSet-reference name, or a Pod adopting a prebuilt workload. The mutating webhook runs only on create, so the validating webhook keeps the annotation immutable on update.

Verified by unit tests in `pod_webhook_test.go` and an integration test that a two-pod group with different requests sharing one spoofed role-hash yields a Workload with two PodSets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Pods: Fixed a bug where a user-supplied `kueue.x-k8s.io/role-hash` annotation on a plain Pod or Pod group could group pods with different resource requests into a single PodSet, letting a workload be admitted against less quota than it consumes. Kueue now recomputes the role-hash from the pod spec and keeps the annotation immutable after creation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod `role-hash` annotations are now preserved or recomputed depending on trust: directly-managed pods recompute from the pod spec, while trusted parent-managed pods and pods adopting prebuilt workloads preserve the expected hash.
  * Creation admission now rejects managed pods when the provided `role-hash` does not match the pod spec.
  * Update admission now blocks `role-hash` changes for non-exempt managed pods.
  * Integration coverage ensures spoofed `role-hash` values don’t incorrectly merge pods with different CPU requests into a single PodSet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->