### PR TITLE
Implement VectorizedResourceRequests using SliceRequests

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -822,10 +822,21 @@ func TestAddAssumedUsage(t *testing.T) {
 		},
 	}
 
+	equateRequests := cmp.Transformer("Requests", func(r resources.Requests) map[corev1.ResourceName]int64 {
+		if r == nil {
+			return nil
+		}
+		m := make(map[corev1.ResourceName]int64)
+		r.ForEach(func(name corev1.ResourceName, val int64) {
+			m[name] = val
+		})
+		return m
+	})
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			addAssumedUsage(tc.assumedUsage, tc.assignment, tc.tasRequests)
-			if diff := cmp.Diff(tc.want, tc.assumedUsage); diff != "" {
+			if diff := cmp.Diff(tc.want, tc.assumedUsage, equateRequests); diff != "" {
 				t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -523,6 +523,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/8871
 	// Enable integration of the https://github.com/kubernetes-sigs/scheduler-library.
 	SchedulerLibraryIntegration featuregate.Feature = "SchedulerLibraryIntegration"
+
+	// owner: @j-skiba
+	//
+	// VectorizedResourceRequests enables slice-based indexing for resource requests in TAS snapshots,
+	// replacing map lookups for higher performance during scheduling and preemption.
+	VectorizedResourceRequests featuregate.Feature = "VectorizedResourceRequests"
 )
 
 func init() {
@@ -805,6 +811,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	SchedulerLibraryIntegration: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+	},
+	VectorizedResourceRequests: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -19,6 +19,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 	resourcehelpers "k8s.io/component-helpers/resource"
+
 	"sigs.k8s.io/kueue/pkg/features"
 )
 

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -72,9 +72,6 @@ func ToMapRequests(r Requests) MapRequests {
 	if mr, ok := r.(MapRequests); ok {
 		return mr
 	}
-	if sr, ok := r.(*SliceRequests); ok {
-		return sr.ToMapRequests()
-	}
 	res := make(MapRequests, r.Len())
 	r.ForEach(func(name corev1.ResourceName, val int64) {
 		if val != 0 {

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -1,0 +1,64 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	resourcehelpers "k8s.io/component-helpers/resource"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+// CreateEmpty creates an empty Requests instance based on feature gates.
+func CreateEmpty() Requests {
+	if features.Enabled(features.VectorizedResourceRequests) {
+		return &SliceRequests{}
+	}
+	return MapRequests{}
+}
+
+// NewRequestsFromMap creates a Requests instance from a MapRequests map based on feature gates.
+func NewRequestsFromMap(m MapRequests) Requests {
+	if len(m) == 0 {
+		return nil
+	}
+	if features.Enabled(features.VectorizedResourceRequests) {
+		sr := toSliceRequests(m)
+		return &sr
+	}
+	return m
+}
+
+// NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
+func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
+	if len(rl) == 0 {
+		return nil
+	}
+	if features.Enabled(features.VectorizedResourceRequests) {
+		sr := ResourceListToSliceRequests(rl)
+		return &sr
+	}
+	return NewMapRequests(rl)
+}
+
+// NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
+func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
+	if podSpec == nil {
+		return nil
+	}
+	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
+	return NewRequestsFromResourceList(rl)
+}

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -63,3 +63,23 @@ func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
 	return NewRequestsFromResourceList(rl)
 }
+
+// ToMapRequests converts any Requests instance into a MapRequests map.
+func ToMapRequests(r Requests) MapRequests {
+	if isEmpty(r) {
+		return nil
+	}
+	if mr, ok := r.(MapRequests); ok {
+		return mr
+	}
+	if sr, ok := r.(*SliceRequests); ok {
+		return sr.ToMapRequests()
+	}
+	res := make(MapRequests, r.Len())
+	r.ForEach(func(name corev1.ResourceName, val int64) {
+		if val != 0 {
+			res[name] = val
+		}
+	})
+	return res
+}

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -47,7 +47,7 @@ func CreateEmpty() Requests {
 
 // NewRequestsFromMap creates a Requests instance from a MapRequests map based on feature gates.
 func NewRequestsFromMap(m MapRequests) Requests {
-	if m == nil {
+	if len(m) == 0 {
 		return nil
 	}
 	if features.Enabled(features.VectorizedResourceRequests) {

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -18,9 +18,6 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	resourcehelpers "k8s.io/component-helpers/resource"
-
-	"sigs.k8s.io/kueue/pkg/features"
 )
 
 // Requests represents an abstract collection of resource requests.
@@ -35,45 +32,4 @@ type Requests interface {
 	ForEach(fn func(name corev1.ResourceName, val int64))
 	Len() int
 	IsEmpty() bool
-}
-
-// CreateEmpty creates an empty Requests instance based on feature gates.
-func CreateEmpty() Requests {
-	if features.Enabled(features.VectorizedResourceRequests) {
-		return &SliceRequests{}
-	}
-	return MapRequests{}
-}
-
-// NewRequestsFromMap creates a Requests instance from a MapRequests map based on feature gates.
-func NewRequestsFromMap(m MapRequests) Requests {
-	if len(m) == 0 {
-		return nil
-	}
-	if features.Enabled(features.VectorizedResourceRequests) {
-		sr := toSliceRequests(m)
-		return &sr
-	}
-	return m
-}
-
-// NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
-func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
-	if len(rl) == 0 {
-		return nil
-	}
-	if features.Enabled(features.VectorizedResourceRequests) {
-		sr := ResourceListToSliceRequests(rl)
-		return &sr
-	}
-	return NewMapRequests(rl)
-}
-
-// NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
-func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
-	if podSpec == nil {
-		return nil
-	}
-	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
-	return NewRequestsFromResourceList(rl)
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -18,6 +18,9 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	resourcehelpers "k8s.io/component-helpers/resource"
+
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 // Requests represents an abstract collection of resource requests.
@@ -34,17 +37,43 @@ type Requests interface {
 	IsEmpty() bool
 }
 
-// NewRequestsFromMap creates a Requests instance from a MapRequests map.
+// CreateEmpty creates an empty Requests instance based on feature gates.
+func CreateEmpty() Requests {
+	if features.Enabled(features.VectorizedResourceRequests) {
+		return &SliceRequests{}
+	}
+	return MapRequests{}
+}
+
+// NewRequestsFromMap creates a Requests instance from a MapRequests map based on feature gates.
 func NewRequestsFromMap(m MapRequests) Requests {
+	if m == nil {
+		return nil
+	}
+	if features.Enabled(features.VectorizedResourceRequests) {
+		sr := toSliceRequests(m)
+		return &sr
+	}
 	return m
 }
 
-// NewRequestsFromResourceList creates a Requests instance from a ResourceList.
+// NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
 func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
+	if len(rl) == 0 {
+		return nil
+	}
+	if features.Enabled(features.VectorizedResourceRequests) {
+		sr := ResourceListToSliceRequests(rl)
+		return &sr
+	}
 	return NewMapRequests(rl)
 }
 
-// NewRequestsFromPodSpec creates a Requests instance from a PodSpec.
+// NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
 func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
-	return NewMapRequestsFromPodSpec(podSpec)
+	if podSpec == nil {
+		return nil
+	}
+	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
+	return NewRequestsFromResourceList(rl)
 }

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -27,10 +27,6 @@ func isEmpty(requests Requests) bool {
 	return requests == nil || requests.IsEmpty()
 }
 
-func CreateEmpty() Requests {
-	return MapRequests{}
-}
-
 func NewLazyRequests(base Requests) LazyRequests {
 	return LazyRequests{base: base}
 }

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -498,12 +498,16 @@ func TestLazyRequests(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			var originalBase Requests
+			var base Requests
 			if tc.base != nil {
-				originalBase = tc.base.Clone()
+				base = NewRequestsFromMap(tc.base)
+			}
+			var originalBase Requests
+			if base != nil {
+				originalBase = base.Clone()
 			}
 
-			lazy := NewLazyRequests(tc.base)
+			lazy := NewLazyRequests(base)
 
 			if tc.op != nil {
 				tc.op(&lazy)
@@ -517,13 +521,18 @@ func TestLazyRequests(t *testing.T) {
 				t.Errorf("expected cachedCreated=%t, got cached=%v", tc.wantCachedCreated, lazy.cached)
 			}
 
-			gotResult := lazy.Get()
-			if !cmp.Equal(gotResult, tc.wantResult) {
-				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", cmp.Diff(gotResult, tc.wantResult))
+			var wantResult Requests
+			if tc.wantResult != nil {
+				wantResult = NewRequestsFromMap(tc.wantResult)
 			}
 
-			if tc.base != nil && !cmp.Equal(tc.base, originalBase) {
-				t.Errorf("base map was mutated! diff (-got +want):\n%s", cmp.Diff(tc.base, originalBase))
+			gotResult := lazy.Get()
+			if !cmp.Equal(gotResult, wantResult) {
+				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", cmp.Diff(gotResult, wantResult))
+			}
+
+			if base != nil && !cmp.Equal(base, originalBase) {
+				t.Errorf("base map was mutated! diff (-got +want):\n%s", cmp.Diff(base, originalBase))
 			}
 		})
 	}

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -521,19 +521,15 @@ func TestLazyRequests(t *testing.T) {
 				t.Errorf("expected cachedCreated=%t, got cached=%v", tc.wantCachedCreated, lazy.cached)
 			}
 
-			var wantResult Requests
-			if tc.wantResult != nil {
-				wantResult = NewRequestsFromMap(tc.wantResult)
-			}
-
-			gotResult := lazy.Get()
-			if diff := cmp.Diff(gotResult, wantResult, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
-				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", diff)
+			gotResult := ToMapRequests(lazy.Get())
+			wantResult := tc.wantResult
+			if diff := cmp.Diff(wantResult, gotResult); diff != "" {
+				t.Errorf("unexpected Get() result, diff (-want +got):\n%s", diff)
 			}
 
 			if base != nil {
-				if diff := cmp.Diff(base, originalBase, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
-					t.Errorf("base map was mutated! diff (-got +want):\n%s", diff)
+				if diff := cmp.Diff(ToMapRequests(originalBase), ToMapRequests(base)); diff != "" {
+					t.Errorf("base map was mutated! diff (-want +got):\n%s", diff)
 				}
 			}
 		})

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -527,12 +527,14 @@ func TestLazyRequests(t *testing.T) {
 			}
 
 			gotResult := lazy.Get()
-			if !cmp.Equal(gotResult, wantResult) {
-				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", cmp.Diff(gotResult, wantResult))
+			if diff := cmp.Diff(gotResult, wantResult, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
+				t.Errorf("unexpected Get() result, diff (-got +want):\n%s", diff)
 			}
 
-			if base != nil && !cmp.Equal(base, originalBase) {
-				t.Errorf("base map was mutated! diff (-got +want):\n%s", cmp.Diff(base, originalBase))
+			if base != nil {
+				if diff := cmp.Diff(base, originalBase, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
+					t.Errorf("base map was mutated! diff (-got +want):\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -1,0 +1,284 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"cmp"
+	"hash/fnv"
+	"math"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+
+	utilmath "sigs.k8s.io/kueue/pkg/util/math"
+)
+
+// HashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
+func HashResourceName(name corev1.ResourceName) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(name))
+	return h.Sum64()
+}
+
+// ResourceEntry encapsulates a single resource name, its pre-computed 64-bit hash, and its value.
+type ResourceEntry struct {
+	Name  corev1.ResourceName
+	Hash  uint64
+	Value int64
+}
+
+// Cmp compares two ResourceEntry structs by Hash, then Name.
+// Returns 0 if both Hash and Name match.
+func (e ResourceEntry) Cmp(other ResourceEntry) int {
+	if c := cmp.Compare(e.Hash, other.Hash); c != 0 {
+		return c
+	}
+	return cmp.Compare(e.Name, other.Name)
+}
+
+// SliceRequests represents resource requests as a single sorted slice of ResourceEntry structs.
+// Sorted by uint64 Hash to enable fast O(M+N) two-pointer merge operations.
+type SliceRequests []ResourceEntry
+
+func (sr SliceRequests) sort() {
+	slices.SortFunc(sr, ResourceEntry.Cmp)
+}
+
+func toSliceRequests(r Requests) SliceRequests {
+	if isEmpty(r) {
+		return nil
+	}
+	if sr, ok := r.(*SliceRequests); ok {
+		if sr == nil {
+			return nil
+		}
+		return *sr
+	}
+	res := make(SliceRequests, 0, r.Len())
+	r.ForEach(func(name corev1.ResourceName, val int64) {
+		if val != 0 {
+			res = append(res, ResourceEntry{
+				Name:  name,
+				Hash:  HashResourceName(name),
+				Value: val,
+			})
+		}
+	})
+	res.sort()
+	return res
+}
+
+// ResourceListToSliceRequests constructs a SliceRequests from a corev1.ResourceList.
+func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
+	if len(rl) == 0 {
+		return nil
+	}
+	sr := make(SliceRequests, 0, len(rl))
+	for name, q := range rl {
+		val := ResourceValue(name, q)
+		if val != 0 {
+			sr = append(sr, ResourceEntry{
+				Name:  name,
+				Hash:  HashResourceName(name),
+				Value: val,
+			})
+		}
+	}
+	sr.sort()
+	return sr
+}
+
+// ToMapRequests converts a SliceRequests back to a MapRequests map.
+func (sr *SliceRequests) ToMapRequests() MapRequests {
+	if sr.IsEmpty() {
+		return nil
+	}
+	req := make(MapRequests, len(*sr))
+	for _, entry := range *sr {
+		if entry.Value != 0 {
+			req[entry.Name] = entry.Value
+		}
+	}
+	return req
+}
+
+func (sr *SliceRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
+	if sr == nil {
+		return
+	}
+	for _, entry := range *sr {
+		fn(entry.Name, entry.Value)
+	}
+}
+
+func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
+	if sr == nil {
+		return 0
+	}
+	target := ResourceEntry{Name: name, Hash: HashResourceName(name)}
+	idx, found := slices.BinarySearchFunc(*sr, target, ResourceEntry.Cmp)
+	if found {
+		return (*sr)[idx].Value
+	}
+	return 0
+}
+
+func (sr *SliceRequests) Len() int {
+	if sr == nil {
+		return 0
+	}
+	return len(*sr)
+}
+
+func (sr *SliceRequests) Clone() Requests {
+	if sr == nil {
+		return (*SliceRequests)(nil)
+	}
+	res := slices.Clone(*sr)
+	return &res
+}
+
+func (sr *SliceRequests) ScaledUp(f int64) Requests {
+	if sr == nil {
+		return (*SliceRequests)(nil)
+	}
+	res := make(SliceRequests, len(*sr))
+	for i, entry := range *sr {
+		res[i] = ResourceEntry{
+			Name:  entry.Name,
+			Hash:  entry.Hash,
+			Value: utilmath.SaturatingMul(entry.Value, f),
+		}
+	}
+	return &res
+}
+
+// Add performs an element-wise addition.
+func (sr *SliceRequests) Add(other Requests) {
+	if isEmpty(other) || sr == nil {
+		return
+	}
+	*sr = sr.MergeWith(toSliceRequests(other), func(a, b int64) int64 {
+		return a + b
+	})
+}
+
+// Sub performs an element-wise subtraction.
+func (sr *SliceRequests) Sub(other Requests) {
+	if isEmpty(other) || sr == nil {
+		return
+	}
+	*sr = sr.MergeWith(toSliceRequests(other), func(a, b int64) int64 {
+		return a - b
+	})
+}
+
+// MergeFunc defines a computation lambda between matching or missing values in two SliceRequests.
+type MergeFunc func(valA, valB int64) int64
+
+// MergeWith performs a linear O(N+M) out-of-place merge into a fresh SliceRequests.
+func (sr SliceRequests) MergeWith(other SliceRequests, fn MergeFunc) SliceRequests {
+	if len(sr) == 0 && len(other) == 0 {
+		return nil
+	}
+	result := make(SliceRequests, 0, max(len(sr), len(other)))
+	i, j := 0, 0
+
+	for i < len(sr) && j < len(other) {
+		c := sr[i].Cmp(other[j])
+		switch {
+		case c == 0:
+			appendEntry(&result, sr[i], fn(sr[i].Value, other[j].Value))
+			i++
+			j++
+		case c < 0:
+			appendEntry(&result, sr[i], fn(sr[i].Value, 0))
+			i++
+		default:
+			appendEntry(&result, other[j], fn(0, other[j].Value))
+			j++
+		}
+	}
+
+	for i < len(sr) {
+		appendEntry(&result, sr[i], fn(sr[i].Value, 0))
+		i++
+	}
+
+	for j < len(other) {
+		appendEntry(&result, other[j], fn(0, other[j].Value))
+		j++
+	}
+
+	return result
+}
+
+func appendEntry(result *SliceRequests, entry ResourceEntry, val int64) {
+	if val != 0 {
+		*result = append(*result, ResourceEntry{
+			Name:  entry.Name,
+			Hash:  entry.Hash,
+			Value: val,
+		})
+	}
+}
+
+func (sr *SliceRequests) CountIn(capacity Requests) int32 {
+	count, _ := sr.CountInWithLimitingResource(capacity)
+	return count
+}
+
+func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
+	if sr.IsEmpty() || isEmpty(capacity) {
+		return 0, ""
+	}
+
+	capSR, isSlice := capacity.(*SliceRequests)
+	minCount, limitingRes, j := int32(math.MaxInt32), corev1.ResourceName(""), 0
+
+	for _, entry := range *sr {
+		var capVal int64
+		if isSlice && capSR != nil {
+			for j < len(*capSR) && (*capSR)[j].Cmp(entry) < 0 {
+				j++
+			}
+			if j < len(*capSR) && (*capSR)[j].Cmp(entry) == 0 {
+				capVal = (*capSR)[j].Value
+			}
+		} else {
+			capVal = capacity.GetValue(entry.Name)
+		}
+
+		count := int32(math.MaxInt32)
+		if entry.Value != 0 {
+			count = max(int32(capVal/entry.Value), 0)
+		}
+		if count < minCount || (count == minCount && (limitingRes == "" || entry.Name < limitingRes)) {
+			minCount = count
+			limitingRes = entry.Name
+		}
+	}
+
+	if minCount == math.MaxInt32 {
+		return 0, ""
+	}
+	return minCount, limitingRes
+}
+
+func (sr *SliceRequests) IsEmpty() bool {
+	return sr == nil || len(*sr) == 0
+}

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -232,6 +232,9 @@ func (sr *SliceRequests) mergeWithInPlace(other SliceRequests, fn mergeFunc) {
 	}
 
 	// Fallback: allocate a new backing slice when *sr has insufficient capacity.
+	// Note that in the common case of both slices having the same size this will
+	// pre-allocate 2x capacity, so that the following merges will skip allocations
+	// and fall in the fast in-place branch.
 	*sr = mergeInto(make(SliceRequests, 0, totalLen), *sr, other, fn)
 }
 

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -179,7 +179,7 @@ func (sr *SliceRequests) Add(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.MergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
+	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
 		return a + b
 	})
 }
@@ -189,38 +189,41 @@ func (sr *SliceRequests) Sub(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.MergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
+	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
 		return a - b
 	})
 }
 
-// MergeFunc defines a computation lambda between matching or missing values in two SliceRequests.
-type MergeFunc func(valA, valB int64) int64
+// mergeFunc defines a computation lambda between matching or missing values in two SliceRequests.
+type mergeFunc func(valA, valB int64) int64
 
-// MergeWithInPlace performs a linear O(N+M) in-place merge of other into *sr.
-func (sr *SliceRequests) MergeWithInPlace(other SliceRequests, fn MergeFunc) {
+// mergeWithInPlace performs a linear O(N+M) in-place merge of other into *sr.
+func (sr *SliceRequests) mergeWithInPlace(other SliceRequests, fn mergeFunc) {
 	if sr == nil {
 		return
 	}
-	s := *sr
-	n, m := len(s), len(other)
+	n, m := len(*sr), len(other)
 	if n == 0 && m == 0 {
 		return
 	}
 
-	// For self-merging (&s[0] == &other[0]), all keys match 1-to-1 and output size is at most n.
 	totalLen := n + m
-	if n > 0 && m > 0 && &s[0] == &other[0] {
-		totalLen = n
-	}
-
-	if cap(s) >= totalLen {
-		// When cap(s) >= totalLen, we merge in-place with 0 heap allocations.
-		// Shifting s to the right by m slots ensures the write pointer (starting at 0)
-		// never overtakes the read pointer of s (starting at offset m).
-		// Because each written entry consumes at least one input (i++ or j++),
-		// the invariant w <= m + i guarantees write safety.
+	if cap(*sr) >= totalLen {
+		// Capture the input slice header by value into s before right-shifting.
+		// This preserves the input read view and allows reslicing s to offset m independently
+		// while keeping the destination (*sr)[:0] anchored at offset 0.
+		s := *sr
 		if n > 0 && m > 0 && &s[0] != &other[0] {
+			// Why we shift 's' to the right by m slots:
+			// mergeInto writes results into (*sr)[:0] starting at index 0. If 'other' has elements
+			// that sort before s (e.g. other[0] < s[0]), writing other[0] to index 0 would overwrite
+			// s[0] before it has been read and compared.
+			//
+			// Shifting s to start at offset m (index range [m .. m+n-1]) creates m slots of head-room.
+			// Since each merged entry written advances the write pointer w by 1 while consuming at
+			// least one input from s (advancing read pointer i) or other (advancing j), the write
+			// pointer w is guaranteed to never overtake the read pointer of s (m + i). This allows
+			// merging directly into (*sr)[:0] in-place with 0 heap allocations without data corruption.
 			copy(s[:totalLen][m:], s)
 			s = s[:totalLen][m:]
 		}
@@ -228,11 +231,11 @@ func (sr *SliceRequests) MergeWithInPlace(other SliceRequests, fn MergeFunc) {
 		return
 	}
 
-	// Fallback: allocate the exact required capacity and merge in a single pass.
-	*sr = mergeInto(make(SliceRequests, 0, totalLen), s, other, fn)
+	// Fallback: allocate a new backing slice when *sr has insufficient capacity.
+	*sr = mergeInto(make(SliceRequests, 0, totalLen), *sr, other, fn)
 }
 
-func mergeInto(dst, a, b SliceRequests, fn MergeFunc) SliceRequests {
+func mergeInto(dst, a, b SliceRequests, fn mergeFunc) SliceRequests {
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
 		c := a[i].cmp(b[j])

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -278,14 +278,13 @@ func (sr *SliceRequests) CountIn(capacity Requests) int32 {
 
 func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
 	if sr.IsEmpty() || isEmpty(capacity) {
-		return 0, ""
+		return 0, emptyResourceName
 	}
 
 	capSR, isSlice := capacity.(*SliceRequests)
 	minCount, limitingRes, j := int32(math.MaxInt32), emptyResourceName, 0
-	found := false
 
-	for _, entry := range *sr {
+	for i, entry := range *sr {
 		var capVal int64
 		if isSlice && capSR != nil {
 			for j < len(*capSR) && (*capSR)[j].Cmp(entry) < 0 {
@@ -302,16 +301,12 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 		if entry.value != 0 {
 			count = int32(max(0, min(capVal/entry.value, math.MaxInt32)))
 		}
-		if !found || count < minCount || (count == minCount && (limitingRes == "" || entry.name < limitingRes)) {
+		if i == 0 || count < minCount || (count == minCount && entry.name < limitingRes) {
 			minCount = count
 			limitingRes = entry.name
-			found = true
 		}
 	}
 
-	if !found {
-		return 0, ""
-	}
 	return minCount, limitingRes
 }
 

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -29,6 +29,8 @@ import (
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
 
+const emptyResourceName = corev1.ResourceName("")
+
 // HashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
 func HashResourceName(name corev1.ResourceName) uint64 {
 	h := fnv.New64a()
@@ -177,7 +179,7 @@ func (sr *SliceRequests) Add(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	*sr = sr.MergeWith(toSliceRequests(other), func(a, b int64) int64 {
+	sr.MergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
 		return a + b
 	})
 }
@@ -187,7 +189,7 @@ func (sr *SliceRequests) Sub(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	*sr = sr.MergeWith(toSliceRequests(other), func(a, b int64) int64 {
+	sr.MergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
 		return a - b
 	})
 }
@@ -195,51 +197,78 @@ func (sr *SliceRequests) Sub(other Requests) {
 // MergeFunc defines a computation lambda between matching or missing values in two SliceRequests.
 type MergeFunc func(valA, valB int64) int64
 
-// MergeWith performs a linear O(N+M) out-of-place merge into a fresh SliceRequests.
-func (sr SliceRequests) MergeWith(other SliceRequests, fn MergeFunc) SliceRequests {
-	if len(sr) == 0 && len(other) == 0 {
-		return nil
+// MergeWithInPlace performs a linear O(N+M) in-place merge of other into *sr.
+func (sr *SliceRequests) MergeWithInPlace(other SliceRequests, fn MergeFunc) {
+	if sr == nil {
+		return
 	}
-	result := make(SliceRequests, 0, max(len(sr), len(other)))
-	i, j := 0, 0
+	s := *sr
+	n, m := len(s), len(other)
+	if n == 0 && m == 0 {
+		return
+	}
 
-	for i < len(sr) && j < len(other) {
-		c := sr[i].Cmp(other[j])
+	// For self-merging (&s[0] == &other[0]), all keys match 1-to-1 and output size is at most n.
+	totalLen := n + m
+	if n > 0 && m > 0 && &s[0] == &other[0] {
+		totalLen = n
+	}
+
+	if cap(s) >= totalLen {
+		// When cap(s) >= totalLen, we merge in-place with 0 heap allocations.
+		// Shifting s to the right by m slots ensures the write pointer (starting at 0)
+		// never overtakes the read pointer of s (starting at offset m).
+		// Because each written entry consumes at least one input (i++ or j++),
+		// the invariant w <= m + i guarantees write safety.
+		if n > 0 && m > 0 && &s[0] != &other[0] {
+			copy(s[:totalLen][m:], s)
+			s = s[:totalLen][m:]
+		}
+		*sr = mergeInto((*sr)[:0], s, other, fn)
+		return
+	}
+
+	// Fallback: allocate the exact required capacity and merge in a single pass.
+	*sr = mergeInto(make(SliceRequests, 0, totalLen), s, other, fn)
+}
+
+func mergeInto(dst, a, b SliceRequests, fn MergeFunc) SliceRequests {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		c := a[i].Cmp(b[j])
 		switch {
 		case c == 0:
-			appendEntry(&result, sr[i], fn(sr[i].value, other[j].value))
+			dst = appendEntry(dst, a[i], fn(a[i].value, b[j].value))
 			i++
 			j++
 		case c < 0:
-			appendEntry(&result, sr[i], fn(sr[i].value, 0))
+			dst = appendEntry(dst, a[i], fn(a[i].value, 0))
 			i++
 		default:
-			appendEntry(&result, other[j], fn(0, other[j].value))
+			dst = appendEntry(dst, b[j], fn(0, b[j].value))
 			j++
 		}
 	}
-
-	for i < len(sr) {
-		appendEntry(&result, sr[i], fn(sr[i].value, 0))
+	for i < len(a) {
+		dst = appendEntry(dst, a[i], fn(a[i].value, 0))
 		i++
 	}
-
-	for j < len(other) {
-		appendEntry(&result, other[j], fn(0, other[j].value))
+	for j < len(b) {
+		dst = appendEntry(dst, b[j], fn(0, b[j].value))
 		j++
 	}
-
-	return result
+	return dst
 }
 
-func appendEntry(result *SliceRequests, entry ResourceEntry, val int64) {
+func appendEntry(dst SliceRequests, entry ResourceEntry, val int64) SliceRequests {
 	if val != 0 {
-		*result = append(*result, ResourceEntry{
+		return append(dst, ResourceEntry{
 			name:  entry.name,
 			hash:  entry.hash,
 			value: val,
 		})
 	}
+	return dst
 }
 
 func (sr *SliceRequests) CountIn(capacity Requests) int32 {
@@ -253,7 +282,7 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 	}
 
 	capSR, isSlice := capacity.(*SliceRequests)
-	minCount, limitingRes, j := int32(math.MaxInt32), corev1.ResourceName(""), 0
+	minCount, limitingRes, j := int32(math.MaxInt32), emptyResourceName, 0
 	found := false
 
 	for _, entry := range *sr {

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -21,8 +21,10 @@ import (
 	"hash/fnv"
 	"math"
 	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
@@ -30,24 +32,27 @@ import (
 // HashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
 func HashResourceName(name corev1.ResourceName) uint64 {
 	h := fnv.New64a()
-	_, _ = h.Write([]byte(name))
+	if _, err := h.Write([]byte(name)); err != nil {
+		ctrl.Log.WithName("resources").Error(err, "Failed to write resource name hash", "resourceName", name)
+		return 0
+	}
 	return h.Sum64()
 }
 
 // ResourceEntry encapsulates a single resource name, its pre-computed 64-bit hash, and its value.
 type ResourceEntry struct {
-	Name  corev1.ResourceName
-	Hash  uint64
-	Value int64
+	name  corev1.ResourceName
+	hash  uint64
+	value int64
 }
 
 // Cmp compares two ResourceEntry structs by Hash, then Name.
 // Returns 0 if both Hash and Name match.
 func (e ResourceEntry) Cmp(other ResourceEntry) int {
-	if c := cmp.Compare(e.Hash, other.Hash); c != 0 {
+	if c := cmp.Compare(e.hash, other.hash); c != 0 {
 		return c
 	}
-	return cmp.Compare(e.Name, other.Name)
+	return strings.Compare(string(e.name), string(other.name))
 }
 
 // SliceRequests represents resource requests as a single sorted slice of ResourceEntry structs.
@@ -72,9 +77,9 @@ func toSliceRequests(r Requests) SliceRequests {
 	r.ForEach(func(name corev1.ResourceName, val int64) {
 		if val != 0 {
 			res = append(res, ResourceEntry{
-				Name:  name,
-				Hash:  HashResourceName(name),
-				Value: val,
+				name:  name,
+				hash:  HashResourceName(name),
+				value: val,
 			})
 		}
 	})
@@ -92,9 +97,9 @@ func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
 		val := ResourceValue(name, q)
 		if val != 0 {
 			sr = append(sr, ResourceEntry{
-				Name:  name,
-				Hash:  HashResourceName(name),
-				Value: val,
+				name:  name,
+				hash:  HashResourceName(name),
+				value: val,
 			})
 		}
 	}
@@ -109,8 +114,8 @@ func (sr *SliceRequests) ToMapRequests() MapRequests {
 	}
 	req := make(MapRequests, len(*sr))
 	for _, entry := range *sr {
-		if entry.Value != 0 {
-			req[entry.Name] = entry.Value
+		if entry.value != 0 {
+			req[entry.name] = entry.value
 		}
 	}
 	return req
@@ -121,7 +126,7 @@ func (sr *SliceRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
 		return
 	}
 	for _, entry := range *sr {
-		fn(entry.Name, entry.Value)
+		fn(entry.name, entry.value)
 	}
 }
 
@@ -129,10 +134,10 @@ func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
 	if sr == nil {
 		return 0
 	}
-	target := ResourceEntry{Name: name, Hash: HashResourceName(name)}
+	target := ResourceEntry{name: name, hash: HashResourceName(name)}
 	idx, found := slices.BinarySearchFunc(*sr, target, ResourceEntry.Cmp)
 	if found {
-		return (*sr)[idx].Value
+		return (*sr)[idx].value
 	}
 	return 0
 }
@@ -159,9 +164,9 @@ func (sr *SliceRequests) ScaledUp(f int64) Requests {
 	res := make(SliceRequests, len(*sr))
 	for i, entry := range *sr {
 		res[i] = ResourceEntry{
-			Name:  entry.Name,
-			Hash:  entry.Hash,
-			Value: utilmath.SaturatingMul(entry.Value, f),
+			name:  entry.name,
+			hash:  entry.hash,
+			value: utilmath.SaturatingMul(entry.value, f),
 		}
 	}
 	return &res
@@ -202,25 +207,25 @@ func (sr SliceRequests) MergeWith(other SliceRequests, fn MergeFunc) SliceReques
 		c := sr[i].Cmp(other[j])
 		switch {
 		case c == 0:
-			appendEntry(&result, sr[i], fn(sr[i].Value, other[j].Value))
+			appendEntry(&result, sr[i], fn(sr[i].value, other[j].value))
 			i++
 			j++
 		case c < 0:
-			appendEntry(&result, sr[i], fn(sr[i].Value, 0))
+			appendEntry(&result, sr[i], fn(sr[i].value, 0))
 			i++
 		default:
-			appendEntry(&result, other[j], fn(0, other[j].Value))
+			appendEntry(&result, other[j], fn(0, other[j].value))
 			j++
 		}
 	}
 
 	for i < len(sr) {
-		appendEntry(&result, sr[i], fn(sr[i].Value, 0))
+		appendEntry(&result, sr[i], fn(sr[i].value, 0))
 		i++
 	}
 
 	for j < len(other) {
-		appendEntry(&result, other[j], fn(0, other[j].Value))
+		appendEntry(&result, other[j], fn(0, other[j].value))
 		j++
 	}
 
@@ -230,9 +235,9 @@ func (sr SliceRequests) MergeWith(other SliceRequests, fn MergeFunc) SliceReques
 func appendEntry(result *SliceRequests, entry ResourceEntry, val int64) {
 	if val != 0 {
 		*result = append(*result, ResourceEntry{
-			Name:  entry.Name,
-			Hash:  entry.Hash,
-			Value: val,
+			name:  entry.name,
+			hash:  entry.hash,
+			value: val,
 		})
 	}
 }
@@ -249,6 +254,7 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 
 	capSR, isSlice := capacity.(*SliceRequests)
 	minCount, limitingRes, j := int32(math.MaxInt32), corev1.ResourceName(""), 0
+	found := false
 
 	for _, entry := range *sr {
 		var capVal int64
@@ -257,23 +263,24 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 				j++
 			}
 			if j < len(*capSR) && (*capSR)[j].Cmp(entry) == 0 {
-				capVal = (*capSR)[j].Value
+				capVal = (*capSR)[j].value
 			}
 		} else {
-			capVal = capacity.GetValue(entry.Name)
+			capVal = capacity.GetValue(entry.name)
 		}
 
 		count := int32(math.MaxInt32)
-		if entry.Value != 0 {
-			count = max(int32(capVal/entry.Value), 0)
+		if entry.value != 0 {
+			count = int32(max(0, min(capVal/entry.value, math.MaxInt32)))
 		}
-		if count < minCount || (count == minCount && (limitingRes == "" || entry.Name < limitingRes)) {
+		if !found || count < minCount || (count == minCount && (limitingRes == "" || entry.name < limitingRes)) {
 			minCount = count
-			limitingRes = entry.Name
+			limitingRes = entry.name
+			found = true
 		}
 	}
 
-	if minCount == math.MaxInt32 {
+	if !found {
 		return 0, ""
 	}
 	return minCount, limitingRes

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 )
@@ -34,35 +33,36 @@ const emptyResourceName = corev1.ResourceName("")
 // hashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
 func hashResourceName(name corev1.ResourceName) uint64 {
 	h := fnv.New64a()
-	if _, err := h.Write([]byte(name)); err != nil {
-		ctrl.Log.WithName("resources").Error(err, "Failed to write resource name hash", "resourceName", name)
-		return 0
-	}
+	// Write cannot fail: this is guaranteed by the hash.Hash interface contract:
+	// https://github.com/golang/go/blob/go1.26.5/src/hash/hash.go#L26-L29
+	// and by the fnv.New64a implementation, which always returns len(data), nil.
+	// https://github.com/golang/go/blob/go1.26.5/src/hash/fnv/fnv.go#L56-L115
+	_, _ = h.Write([]byte(name))
 	return h.Sum64()
 }
 
-// ResourceEntry encapsulates a single resource name, its pre-computed 64-bit hash, and its value.
-type ResourceEntry struct {
+// resourceEntry encapsulates a single resource name, its pre-computed 64-bit hash, and its value.
+type resourceEntry struct {
 	name  corev1.ResourceName
 	hash  uint64
 	value int64
 }
 
-// Cmp compares two ResourceEntry structs by Hash, then Name.
-// Returns 0 if both Hash and Name match.
-func (e ResourceEntry) Cmp(other ResourceEntry) int {
+// cmp compares two resourceEntry structs by hash, then name.
+// Returns 0 if both hash and name match.
+func (e resourceEntry) cmp(other resourceEntry) int {
 	if c := cmp.Compare(e.hash, other.hash); c != 0 {
 		return c
 	}
 	return strings.Compare(string(e.name), string(other.name))
 }
 
-// SliceRequests represents resource requests as a single sorted slice of ResourceEntry structs.
-// Sorted by uint64 Hash to enable fast O(M+N) two-pointer merge operations.
-type SliceRequests []ResourceEntry
+// SliceRequests represents resource requests as a single sorted slice of resourceEntry structs.
+// Sorted by uint64 hash to enable fast O(M+N) two-pointer merge operations.
+type SliceRequests []resourceEntry
 
 func (sr SliceRequests) sort() {
-	slices.SortFunc(sr, ResourceEntry.Cmp)
+	slices.SortFunc(sr, resourceEntry.cmp)
 }
 
 func toSliceRequests(r Requests) SliceRequests {
@@ -78,7 +78,7 @@ func toSliceRequests(r Requests) SliceRequests {
 	res := make(SliceRequests, 0, r.Len())
 	r.ForEach(func(name corev1.ResourceName, val int64) {
 		if val != 0 {
-			res = append(res, ResourceEntry{
+			res = append(res, resourceEntry{
 				name:  name,
 				hash:  hashResourceName(name),
 				value: val,
@@ -98,7 +98,7 @@ func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
 	for name, q := range rl {
 		val := ResourceValue(name, q)
 		if val != 0 {
-			sr = append(sr, ResourceEntry{
+			sr = append(sr, resourceEntry{
 				name:  name,
 				hash:  hashResourceName(name),
 				value: val,
@@ -136,8 +136,8 @@ func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
 	if sr == nil {
 		return 0
 	}
-	target := ResourceEntry{name: name, hash: hashResourceName(name)}
-	idx, found := slices.BinarySearchFunc(*sr, target, ResourceEntry.Cmp)
+	target := resourceEntry{name: name, hash: hashResourceName(name)}
+	idx, found := slices.BinarySearchFunc(*sr, target, resourceEntry.cmp)
 	if found {
 		return (*sr)[idx].value
 	}
@@ -165,7 +165,7 @@ func (sr *SliceRequests) ScaledUp(f int64) Requests {
 	}
 	res := make(SliceRequests, len(*sr))
 	for i, entry := range *sr {
-		res[i] = ResourceEntry{
+		res[i] = resourceEntry{
 			name:  entry.name,
 			hash:  entry.hash,
 			value: utilmath.SaturatingMul(entry.value, f),
@@ -235,7 +235,7 @@ func (sr *SliceRequests) MergeWithInPlace(other SliceRequests, fn MergeFunc) {
 func mergeInto(dst, a, b SliceRequests, fn MergeFunc) SliceRequests {
 	i, j := 0, 0
 	for i < len(a) && j < len(b) {
-		c := a[i].Cmp(b[j])
+		c := a[i].cmp(b[j])
 		switch {
 		case c == 0:
 			dst = appendEntry(dst, a[i], fn(a[i].value, b[j].value))
@@ -260,9 +260,9 @@ func mergeInto(dst, a, b SliceRequests, fn MergeFunc) SliceRequests {
 	return dst
 }
 
-func appendEntry(dst SliceRequests, entry ResourceEntry, val int64) SliceRequests {
+func appendEntry(dst SliceRequests, entry resourceEntry, val int64) SliceRequests {
 	if val != 0 {
-		return append(dst, ResourceEntry{
+		return append(dst, resourceEntry{
 			name:  entry.name,
 			hash:  entry.hash,
 			value: val,
@@ -287,10 +287,10 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 	for i, entry := range *sr {
 		var capVal int64
 		if isSlice && capSR != nil {
-			for j < len(*capSR) && (*capSR)[j].Cmp(entry) < 0 {
+			for j < len(*capSR) && (*capSR)[j].cmp(entry) < 0 {
 				j++
 			}
-			if j < len(*capSR) && (*capSR)[j].Cmp(entry) == 0 {
+			if j < len(*capSR) && (*capSR)[j].cmp(entry) == 0 {
 				capVal = (*capSR)[j].value
 			}
 		} else {

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -31,8 +31,8 @@ import (
 
 const emptyResourceName = corev1.ResourceName("")
 
-// HashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
-func HashResourceName(name corev1.ResourceName) uint64 {
+// hashResourceName computes a 64-bit FNV-1a hash of a ResourceName.
+func hashResourceName(name corev1.ResourceName) uint64 {
 	h := fnv.New64a()
 	if _, err := h.Write([]byte(name)); err != nil {
 		ctrl.Log.WithName("resources").Error(err, "Failed to write resource name hash", "resourceName", name)
@@ -80,7 +80,7 @@ func toSliceRequests(r Requests) SliceRequests {
 		if val != 0 {
 			res = append(res, ResourceEntry{
 				name:  name,
-				hash:  HashResourceName(name),
+				hash:  hashResourceName(name),
 				value: val,
 			})
 		}
@@ -100,7 +100,7 @@ func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
 		if val != 0 {
 			sr = append(sr, ResourceEntry{
 				name:  name,
-				hash:  HashResourceName(name),
+				hash:  hashResourceName(name),
 				value: val,
 			})
 		}
@@ -136,7 +136,7 @@ func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
 	if sr == nil {
 		return 0
 	}
-	target := ResourceEntry{name: name, hash: HashResourceName(name)}
+	target := ResourceEntry{name: name, hash: hashResourceName(name)}
 	idx, found := slices.BinarySearchFunc(*sr, target, ResourceEntry.Cmp)
 	if found {
 		return (*sr)[idx].value

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var fuzzResourceNames = []corev1.ResourceName{
+	corev1.ResourceCPU,
+	corev1.ResourceMemory,
+	corev1.ResourcePods,
+	corev1.ResourceEphemeralStorage,
+	"nvidia.com/gpu",
+	"example.com/tpu",
+	"hugepages-2Mi",
+	"example.com/rdma",
+}
+
+func parseFuzzData(data []byte) (MapRequests, MapRequests, byte) {
+	if len(data) < 4 {
+		return MapRequests{}, MapRequests{}, 0
+	}
+	opChoice := data[0]
+	data = data[1:]
+
+	m1 := make(MapRequests)
+	m2 := make(MapRequests)
+
+	len1 := int(data[0] % 5)
+	data = data[1:]
+	for i := 0; i < len1 && len(data) >= 5; i++ {
+		res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
+		val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
+		if val != 0 {
+			m1[res] = val
+		}
+		data = data[5:]
+	}
+
+	if len(data) > 0 {
+		len2 := int(data[0] % 5)
+		data = data[1:]
+		for i := 0; i < len2 && len(data) >= 5; i++ {
+			res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
+			val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
+			if val != 0 {
+				m2[res] = val
+			}
+			data = data[5:]
+		}
+	}
+
+	return m1, m2, opChoice
+}
+
+func normalizeMap(m MapRequests) MapRequests {
+	if len(m) == 0 {
+		return nil
+	}
+	res := make(MapRequests)
+	for k, v := range m {
+		if v != 0 {
+			res[k] = v
+		}
+	}
+	if len(res) == 0 {
+		return nil
+	}
+	return res
+}
+
+func checkRequestsEquivalence(t *testing.T, opName string, mapRes Requests, sliceRes Requests) {
+	var mapM, sliceM MapRequests
+	if mapRes != nil {
+		if m, ok := mapRes.(MapRequests); ok {
+			mapM = normalizeMap(m)
+		} else if s, ok := mapRes.(*SliceRequests); ok {
+			mapM = normalizeMap(s.ToMapRequests())
+		}
+	}
+	if sliceRes != nil {
+		if s, ok := sliceRes.(*SliceRequests); ok {
+			sliceM = normalizeMap(s.ToMapRequests())
+		} else if m, ok := sliceRes.(MapRequests); ok {
+			sliceM = normalizeMap(m)
+		}
+	}
+	if diff := cmp.Diff(mapM, sliceM); diff != "" {
+		t.Errorf("%s mismatch (-want Map +got Slice):\n%s", opName, diff)
+	}
+}
+
+func resourceIndex(res corev1.ResourceName) byte {
+	for i, r := range fuzzResourceNames {
+		if r == res {
+			return byte(i)
+		}
+	}
+	return 0
+}
+
+type fuzzSeed struct {
+	opChoice byte
+	m1       MapRequests
+	m2       MapRequests
+}
+
+func (s fuzzSeed) encode() []byte {
+	buf := []byte{s.opChoice, byte(len(s.m1))}
+	for res, val := range s.m1 {
+		idx := resourceIndex(res)
+		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+	}
+	buf = append(buf, byte(len(s.m2)))
+	for res, val := range s.m2 {
+		idx := resourceIndex(res)
+		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+	}
+	return buf
+}
+
+func FuzzSliceRequestsEquivalence(f *testing.F) {
+	seeds := []fuzzSeed{
+		{
+			opChoice: 0, // Add
+			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
+			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
+		},
+		{
+			opChoice: 1, // Sub
+			m1:       MapRequests{corev1.ResourceCPU: 200},
+			m2:       MapRequests{corev1.ResourceCPU: 100},
+		},
+		{
+			opChoice: 2, // ScaledUp
+			m1:       MapRequests{corev1.ResourcePods: 10},
+			m2:       MapRequests{corev1.ResourcePods: 20},
+		},
+		{
+			opChoice: 3, // CountIn
+			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
+			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
+		},
+	}
+
+	for _, s := range seeds {
+		f.Add(s.encode())
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		m1, m2, opChoice := parseFuzzData(data)
+
+		s1 := NewSliceRequests(m1)
+		s2 := NewSliceRequests(m2)
+
+		switch opChoice % 4 {
+		case 0: // Add
+			m1Copy := m1.Clone()
+			m1Copy.Add(m2)
+
+			s1Copy := s1.Clone()
+			s1Copy.Add(s2)
+
+			checkRequestsEquivalence(t, "Add", m1Copy, s1Copy)
+
+		case 1: // Sub
+			m1Copy := m1.Clone()
+			m1Copy.Sub(m2)
+
+			s1Copy := s1.Clone()
+			s1Copy.Sub(s2)
+
+			checkRequestsEquivalence(t, "Sub", m1Copy, s1Copy)
+
+		case 2: // ScaledUp
+			factor := int64(opChoice%5 + 1)
+			mScaled := m1.ScaledUp(factor)
+			sScaled := s1.ScaledUp(factor)
+
+			checkRequestsEquivalence(t, "ScaledUp", mScaled, sScaled)
+
+		case 3: // CountIn & CountInWithLimitingResource
+			mCnt, mRes := m1.CountInWithLimitingResource(m2)
+			sCnt, sRes := s1.CountInWithLimitingResource(s2)
+
+			if mCnt != sCnt {
+				t.Errorf("CountIn count mismatch: Map got %d, Slice got %d", mCnt, sCnt)
+			}
+			if mRes != sRes {
+				t.Errorf("CountIn limiting resource mismatch: Map got %s, Slice got %s", mRes, sRes)
+			}
+		}
+	})
+}

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -34,6 +34,27 @@ var fuzzResourceNames = []corev1.ResourceName{
 	"example.com/rdma",
 }
 
+// parseFuzzData decodes raw fuzz byte slices into two MapRequests maps (m1, m2) and an operation choice byte.
+//
+// Algorithm:
+//  1. Header (1 byte): data[0] is returned as opChoice to select the test operation (opAdd, opSub, opScaledUp, opCountIn).
+//  2. Map 1 parsing:
+//     - The next byte (data[0] % 5) defines len1, the number of resource entries to populate in m1 (0 to 4).
+//     - Each entry consumes 5 bytes:
+//     - Byte 0: Resource name index into fuzzResourceNames array (data[0] % len(fuzzResourceNames)).
+//     - Bytes 1..4: 32-bit unsigned little-endian integer value for the resource quantity.
+//  3. Map 2 parsing:
+//     - If bytes remain, the next byte (data[0] % 5) defines len2 (0 to 4).
+//     - Up to len2 entries are parsed using 5 bytes each, exactly as in m1.
+//
+// Example:
+//
+//	Input data: []byte{0, 2, 0, 100, 0, 0, 0, 1, 50, 0, 0, 0}
+//	- opChoice = 0 (opAdd)
+//	- m1 length = 2 % 5 = 2 entries
+//	  - Entry 1: index 0 -> fuzzResourceNames[0] ("cpu"), val = 100 -> m1["cpu"] = 100
+//	  - Entry 2: index 1 -> fuzzResourceNames[1] ("memory"), val = 50 -> m1["memory"] = 50
+//	- m2 = MapRequests{} (no remaining bytes)
 func parseFuzzData(data []byte) (MapRequests, MapRequests, byte) {
 	if len(data) < 4 {
 		return MapRequests{}, MapRequests{}, 0
@@ -41,34 +62,28 @@ func parseFuzzData(data []byte) (MapRequests, MapRequests, byte) {
 	opChoice := data[0]
 	data = data[1:]
 
-	m1 := make(MapRequests)
-	m2 := make(MapRequests)
+	m1, data := parseFuzzMap(data)
+	m2, _ := parseFuzzMap(data)
 
-	len1 := int(data[0] % 5)
+	return m1, m2, opChoice
+}
+
+func parseFuzzMap(data []byte) (MapRequests, []byte) {
+	if len(data) == 0 {
+		return make(MapRequests), data
+	}
+	m := make(MapRequests)
+	count := int(data[0] % 5)
 	data = data[1:]
-	for i := 0; i < len1 && len(data) >= 5; i++ {
+	for i := 0; i < count && len(data) >= 5; i++ {
 		res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
 		val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
 		if val != 0 {
-			m1[res] = val
+			m[res] = val
 		}
 		data = data[5:]
 	}
-
-	if len(data) > 0 {
-		len2 := int(data[0] % 5)
-		data = data[1:]
-		for i := 0; i < len2 && len(data) >= 5; i++ {
-			res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
-			val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
-			if val != 0 {
-				m2[res] = val
-			}
-			data = data[5:]
-		}
-	}
-
-	return m1, m2, opChoice
+	return m, data
 }
 
 func normalizeMap(m MapRequests) MapRequests {
@@ -117,6 +132,13 @@ func resourceIndex(res corev1.ResourceName) byte {
 	return 0
 }
 
+const (
+	opAdd byte = iota
+	opSub
+	opScaledUp
+	opCountIn
+)
+
 type fuzzSeed struct {
 	opChoice byte
 	m1       MapRequests
@@ -140,22 +162,22 @@ func (s fuzzSeed) encode() []byte {
 func FuzzSliceRequestsEquivalence(f *testing.F) {
 	seeds := []fuzzSeed{
 		{
-			opChoice: 0, // Add
+			opChoice: opAdd,
 			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
 			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
 		},
 		{
-			opChoice: 1, // Sub
+			opChoice: opSub,
 			m1:       MapRequests{corev1.ResourceCPU: 200},
 			m2:       MapRequests{corev1.ResourceCPU: 100},
 		},
 		{
-			opChoice: 2, // ScaledUp
+			opChoice: opScaledUp,
 			m1:       MapRequests{corev1.ResourcePods: 10},
 			m2:       MapRequests{corev1.ResourcePods: 20},
 		},
 		{
-			opChoice: 3, // CountIn
+			opChoice: opCountIn,
 			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
 			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
 		},
@@ -172,7 +194,7 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 		s2 := NewSliceRequests(m2)
 
 		switch opChoice % 4 {
-		case 0: // Add
+		case opAdd:
 			m1Copy := m1.Clone()
 			m1Copy.Add(m2)
 
@@ -181,7 +203,7 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 
 			checkRequestsEquivalence(t, "Add", m1Copy, s1Copy)
 
-		case 1: // Sub
+		case opSub:
 			m1Copy := m1.Clone()
 			m1Copy.Sub(m2)
 
@@ -190,14 +212,14 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 
 			checkRequestsEquivalence(t, "Sub", m1Copy, s1Copy)
 
-		case 2: // ScaledUp
+		case opScaledUp:
 			factor := int64(opChoice%5 + 1)
 			mScaled := m1.ScaledUp(factor)
 			sScaled := s1.ScaledUp(factor)
 
 			checkRequestsEquivalence(t, "ScaledUp", mScaled, sScaled)
 
-		case 3: // CountIn & CountInWithLimitingResource
+		case opCountIn:
 			mCnt, mRes := m1.CountInWithLimitingResource(m2)
 			sCnt, sRes := s1.CountInWithLimitingResource(s2)
 

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -56,7 +56,7 @@ var fuzzResourceNames = []corev1.ResourceName{
 //	  - Entry 2: index 1 -> fuzzResourceNames[1] ("memory"), val = 50 -> m1["memory"] = 50
 //	- m2 = MapRequests{} (no remaining bytes)
 func parseFuzzData(data []byte) (MapRequests, MapRequests, byte) {
-	if len(data) < 4 {
+	if len(data) == 0 {
 		return MapRequests{}, MapRequests{}, 0
 	}
 	opChoice := data[0]

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -35,7 +35,7 @@ func NewSliceRequests(req MapRequests) *SliceRequests {
 		if val != 0 {
 			sr = append(sr, ResourceEntry{
 				name:  name,
-				hash:  HashResourceName(name),
+				hash:  hashResourceName(name),
 				value: val,
 			})
 		}
@@ -123,8 +123,8 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 	t.Run("with sufficient capacity", func(t *testing.T) {
 		base := make(SliceRequests, 0, 4)
-		base = append(base, ResourceEntry{name: corev1.ResourceCPU, hash: HashResourceName(corev1.ResourceCPU), value: 1000})
-		other := SliceRequests{ResourceEntry{name: corev1.ResourceMemory, hash: HashResourceName(corev1.ResourceMemory), value: 2048}}
+		base = append(base, ResourceEntry{name: corev1.ResourceCPU, hash: hashResourceName(corev1.ResourceCPU), value: 1000})
+		other := SliceRequests{ResourceEntry{name: corev1.ResourceMemory, hash: hashResourceName(corev1.ResourceMemory), value: 2048}}
 
 		base.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -1,0 +1,363 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// NewSliceRequests constructs a SliceRequests pointer from a MapRequests map for testing.
+func NewSliceRequests(req MapRequests) *SliceRequests {
+	if len(req) == 0 {
+		return nil
+	}
+	sr := make(SliceRequests, 0, len(req))
+	for name, val := range req {
+		if val != 0 {
+			sr = append(sr, ResourceEntry{
+				Name:  name,
+				Hash:  HashResourceName(name),
+				Value: val,
+			})
+		}
+	}
+	sr.sort()
+	return &sr
+}
+
+func TestSliceRequests_Conversion(t *testing.T) {
+	cases := map[string]struct {
+		input MapRequests
+		want  MapRequests
+	}{
+		"multiple resources": {
+			input: MapRequests{
+				corev1.ResourceCPU:    1000,
+				corev1.ResourceMemory: 2048,
+				"nvidia.com/gpu":      2,
+			},
+			want: MapRequests{
+				corev1.ResourceCPU:    1000,
+				corev1.ResourceMemory: 2048,
+				"nvidia.com/gpu":      2,
+			},
+		},
+		"empty_map": {
+			input: MapRequests{},
+			want:  nil,
+		},
+		"map with zero values": {
+			input: MapRequests{
+				corev1.ResourceCPU: 0,
+			},
+			want: nil,
+		},
+		"nil_map": {
+			input: nil,
+			want:  nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sr := toSliceRequests(tc.input)
+			got := sr.ToMapRequests()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ToMapRequests mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("nil_receiver_ToMapRequests", func(t *testing.T) {
+		var nilSR *SliceRequests
+		if got := nilSR.ToMapRequests(); got != nil {
+			t.Errorf("expected nil for nil receiver ToMapRequests, got %v", got)
+		}
+	})
+}
+
+func TestSliceRequests_EdgeCases(t *testing.T) {
+	var nilSR *SliceRequests
+	called := false
+	nilSR.ForEach(func(name corev1.ResourceName, val int64) {
+		called = true
+	})
+	if called {
+		t.Errorf("expected ForEach on nilSR to not execute callback")
+	}
+
+	var emptySR SliceRequests
+	merged := emptySR.MergeWith(emptySR, func(a, b int64) int64 { return a + b })
+	if merged != nil {
+		t.Errorf("expected MergeWith on empty slices to return nil")
+	}
+
+	e1 := ResourceEntry{Name: "a", Hash: 100, Value: 1}
+	e2 := ResourceEntry{Name: "b", Hash: 100, Value: 1}
+	if e1.Cmp(e2) >= 0 {
+		t.Errorf("expected e1 < e2 for same hash but different name")
+	}
+}
+
+func TestSliceRequests_ResourceList(t *testing.T) {
+	rl := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("2"),
+		corev1.ResourceMemory: resource.MustParse("4Gi"),
+	}
+	sr := ResourceListToSliceRequests(rl)
+	wantMap := MapRequests{
+		corev1.ResourceCPU:    2000,
+		corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
+	}
+	if diff := cmp.Diff(wantMap, sr.ToMapRequests()); diff != "" {
+		t.Errorf("ResourceListToSliceRequests mismatch (-want +got):\n%s", diff)
+	}
+
+	if ResourceListToSliceRequests(nil) != nil {
+		t.Errorf("expected nil for nil resource list")
+	}
+}
+
+func TestSliceRequests_AddAndSub(t *testing.T) {
+	cases := map[string]struct {
+		base    MapRequests
+		op      string
+		operand MapRequests
+		want    MapRequests
+	}{
+		"add disjoint": {
+			base:    MapRequests{corev1.ResourceCPU: 1000},
+			op:      "add",
+			operand: MapRequests{corev1.ResourceMemory: 2048},
+			want:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+		},
+		"add overlapping": {
+			base:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+			op:      "add",
+			operand: MapRequests{corev1.ResourceMemory: 1024, "nvidia.com/gpu": 1},
+			want:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 3072, "nvidia.com/gpu": 1},
+		},
+		"sub exact": {
+			base:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+			op:      "sub",
+			operand: MapRequests{corev1.ResourceMemory: 1024},
+			want:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 1024},
+		},
+		"sub to zero": {
+			base:    MapRequests{corev1.ResourceCPU: 1000},
+			op:      "sub",
+			operand: MapRequests{corev1.ResourceCPU: 1000},
+			want:    nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sr := NewSliceRequests(tc.base)
+			opSr := NewSliceRequests(tc.operand)
+			if tc.op == "add" {
+				sr.Add(opSr)
+			} else {
+				sr.Sub(opSr)
+			}
+			if diff := cmp.Diff(tc.want, sr.ToMapRequests()); diff != "" {
+				t.Errorf("mismatch after %s (-want +got):\n%s", tc.op, diff)
+			}
+		})
+	}
+
+	t.Run("nil and empty operands", func(t *testing.T) {
+		var nilSR *SliceRequests
+		opSr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		nilSR.Add(opSr)
+		nilSR.Sub(opSr)
+		opSr.Add(nil)
+		opSr.Sub(nil)
+	})
+}
+
+func TestSliceRequests_GetValue(t *testing.T) {
+	cases := map[string]struct {
+		req  *SliceRequests
+		res  corev1.ResourceName
+		want int64
+	}{
+		"existing resource": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			res:  corev1.ResourceCPU,
+			want: 1000,
+		},
+		"missing resource": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			res:  corev1.ResourceMemory,
+			want: 0,
+		},
+		"nil receiver": {
+			req:  nil,
+			res:  corev1.ResourceCPU,
+			want: 0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.GetValue(tc.res)
+			if got != tc.want {
+				t.Errorf("GetValue(%s) = %d, want %d", tc.res, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_LenAndIsEmpty(t *testing.T) {
+	cases := map[string]struct {
+		req         *SliceRequests
+		wantLen     int
+		wantIsEmpty bool
+	}{
+		"populated requests": {
+			req:         NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+			wantLen:     2,
+			wantIsEmpty: false,
+		},
+		"empty slice": {
+			req:         &SliceRequests{},
+			wantLen:     0,
+			wantIsEmpty: true,
+		},
+		"nil receiver": {
+			req:         nil,
+			wantLen:     0,
+			wantIsEmpty: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if len := tc.req.Len(); len != tc.wantLen {
+				t.Errorf("Len() = %d, want %d", len, tc.wantLen)
+			}
+			if isEmpty := tc.req.IsEmpty(); isEmpty != tc.wantIsEmpty {
+				t.Errorf("IsEmpty() = %t, want %t", isEmpty, tc.wantIsEmpty)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_ScaledUp(t *testing.T) {
+	cases := map[string]struct {
+		req    *SliceRequests
+		factor int64
+		want   Requests
+	}{
+		"scale up non-empty": {
+			req:    NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+			factor: 3,
+			want:   NewSliceRequests(MapRequests{corev1.ResourceCPU: 3000, corev1.ResourceMemory: 6144}),
+		},
+		"scale up nil receiver": {
+			req:    nil,
+			factor: 2,
+			want:   (*SliceRequests)(nil),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.ScaledUp(tc.factor)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ScaledUp mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_Clone(t *testing.T) {
+	cases := map[string]struct {
+		req  *SliceRequests
+		want Requests
+	}{
+		"clone non-empty": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			want: NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+		},
+		"clone nil receiver": {
+			req:  nil,
+			want: (*SliceRequests)(nil),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.Clone()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("Clone mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_CountIn(t *testing.T) {
+	cases := map[string]struct {
+		capacity Requests
+		request  *SliceRequests
+		wantCnt  int32
+		wantRes  corev1.ResourceName
+	}{
+		"normal bottleneck": {
+			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000, corev1.ResourceMemory: 20480, corev1.ResourcePods: 100}),
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 2048, corev1.ResourcePods: 10}),
+			wantCnt:  5,
+			wantRes:  corev1.ResourceCPU,
+		},
+		"missing resource": {
+			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000}),
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, "nvidia.com/gpu": 1}),
+			wantCnt:  0,
+			wantRes:  "nvidia.com/gpu",
+		},
+		"nil capacity": {
+			capacity: nil,
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			wantCnt:  0,
+			wantRes:  "",
+		},
+		"nil receiver": {
+			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000}),
+			request:  nil,
+			wantCnt:  0,
+			wantRes:  "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cnt, res := tc.request.CountInWithLimitingResource(tc.capacity)
+			if cnt != tc.wantCnt || res != tc.wantRes {
+				t.Errorf("CountIn mismatch: got (%d, %s), want (%d, %s)", cnt, res, tc.wantCnt, tc.wantRes)
+			}
+			cntOnly := tc.request.CountIn(tc.capacity)
+			if cntOnly != tc.wantCnt {
+				t.Errorf("CountIn count mismatch: got %d, want %d", cntOnly, tc.wantCnt)
+			}
+		})
+	}
+}

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -193,6 +193,21 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 		opSr.Add(nil)
 		opSr.Sub(nil)
 	})
+
+	t.Run("add and sub with MapRequests operand", func(t *testing.T) {
+		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		sr.Add(MapRequests{corev1.ResourceMemory: 2048})
+		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("Add MapRequests mismatch (-want +got):\n%s", diff)
+		}
+
+		sr.Sub(MapRequests{corev1.ResourceCPU: 500})
+		wantSub := MapRequests{corev1.ResourceCPU: 500, corev1.ResourceMemory: 2048}
+		if diff := cmp.Diff(wantSub, sr.ToMapRequests()); diff != "" {
+			t.Errorf("Sub MapRequests mismatch (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestSliceRequests_GetValue(t *testing.T) {
@@ -330,8 +345,8 @@ func TestSliceRequests_CountIn(t *testing.T) {
 			wantRes:  corev1.ResourceCPU,
 		},
 		"missing resource": {
-			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000}),
-			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, "nvidia.com/gpu": 1}),
+			capacity: NewSliceRequests(MapRequests{corev1.ResourcePods: 500}),
+			request:  NewSliceRequests(MapRequests{corev1.ResourcePods: 1000, "nvidia.com/gpu": 1}),
 			wantCnt:  0,
 			wantRes:  "nvidia.com/gpu",
 		},
@@ -352,6 +367,24 @@ func TestSliceRequests_CountIn(t *testing.T) {
 			request:  NewSliceRequests(MapRequests{corev1.ResourceMemory: 1}),
 			wantCnt:  math.MaxInt32,
 			wantRes:  corev1.ResourceMemory,
+		},
+		"non-slice capacity (MapRequests)": {
+			capacity: MapRequests{corev1.ResourceCPU: 10000, corev1.ResourceMemory: 20480},
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 2048}),
+			wantCnt:  5,
+			wantRes:  corev1.ResourceCPU,
+		},
+		"non-slice capacity missing resource": {
+			capacity: MapRequests{corev1.ResourceCPU: 10000},
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 2048}),
+			wantCnt:  0,
+			wantRes:  corev1.ResourceMemory,
+		},
+		"empty request": {
+			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000}),
+			request:  &SliceRequests{},
+			wantCnt:  0,
+			wantRes:  "",
 		},
 	}
 

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -105,10 +105,10 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 		t.Errorf("expected ForEach on nilSR to not execute callback")
 	}
 
-	nilSR.MergeWithInPlace(nil, func(a, b int64) int64 { return a + b })
+	nilSR.mergeWithInPlace(nil, func(a, b int64) int64 { return a + b })
 
 	var emptySR SliceRequests
-	emptySR.MergeWithInPlace(emptySR, func(a, b int64) int64 { return a + b })
+	emptySR.mergeWithInPlace(emptySR, func(a, b int64) int64 { return a + b })
 	if emptySR != nil {
 		t.Errorf("expected MergeWithInPlace on empty slices to leave slice empty")
 	}
@@ -126,7 +126,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		base = append(base, resourceEntry{name: corev1.ResourceCPU, hash: hashResourceName(corev1.ResourceCPU), value: 1000})
 		other := SliceRequests{resourceEntry{name: corev1.ResourceMemory, hash: hashResourceName(corev1.ResourceMemory), value: 2048}}
 
-		base.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		base.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
 		if diff := cmp.Diff(want, base.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch with sufficient capacity (-want +got):\n%s", diff)
@@ -137,7 +137,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		other := *NewSliceRequests(MapRequests{corev1.ResourceMemory: 2048})
 
-		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch with insufficient capacity (-want +got):\n%s", diff)
@@ -146,7 +146,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 
 	t.Run("self merge", func(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
-		sr.MergeWithInPlace(*sr, func(a, b int64) int64 { return a + b })
+		sr.mergeWithInPlace(*sr, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 4096}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch on self merge (-want +got):\n%s", diff)
@@ -156,7 +156,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 	t.Run("merge resulting in zeros dropped", func(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
 		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
-		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a - b })
+		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a - b })
 		want := MapRequests{corev1.ResourceMemory: 2048}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch on zero drop merge (-want +got):\n%s", diff)
@@ -166,7 +166,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 	t.Run("empty receiver with non-empty operand", func(t *testing.T) {
 		var sr SliceRequests
 		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
-		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch on empty receiver merge (-want +got):\n%s", diff)
@@ -176,7 +176,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 	t.Run("non-empty receiver with empty operand", func(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		var other SliceRequests
-		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch on empty operand merge (-want +got):\n%s", diff)

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -33,9 +34,9 @@ func NewSliceRequests(req MapRequests) *SliceRequests {
 	for name, val := range req {
 		if val != 0 {
 			sr = append(sr, ResourceEntry{
-				Name:  name,
-				Hash:  HashResourceName(name),
-				Value: val,
+				name:  name,
+				hash:  HashResourceName(name),
+				value: val,
 			})
 		}
 	}
@@ -110,8 +111,8 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 		t.Errorf("expected MergeWith on empty slices to return nil")
 	}
 
-	e1 := ResourceEntry{Name: "a", Hash: 100, Value: 1}
-	e2 := ResourceEntry{Name: "b", Hash: 100, Value: 1}
+	e1 := ResourceEntry{name: "a", hash: 100, value: 1}
+	e2 := ResourceEntry{name: "b", hash: 100, value: 1}
 	if e1.Cmp(e2) >= 0 {
 		t.Errorf("expected e1 < e2 for same hash but different name")
 	}
@@ -283,7 +284,7 @@ func TestSliceRequests_ScaledUp(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.ScaledUp(tc.factor)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
 				t.Errorf("ScaledUp mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -308,7 +309,7 @@ func TestSliceRequests_Clone(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.Clone()
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
 				t.Errorf("Clone mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -345,6 +346,12 @@ func TestSliceRequests_CountIn(t *testing.T) {
 			request:  nil,
 			wantCnt:  0,
 			wantRes:  "",
+		},
+		"large ratio overflow clamped to MaxInt32": {
+			capacity: NewSliceRequests(MapRequests{corev1.ResourceMemory: 100_000_000_000}),
+			request:  NewSliceRequests(MapRequests{corev1.ResourceMemory: 1}),
+			wantCnt:  math.MaxInt32,
+			wantRes:  corev1.ResourceMemory,
 		},
 	}
 

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -33,7 +33,7 @@ func NewSliceRequests(req MapRequests) *SliceRequests {
 	sr := make(SliceRequests, 0, len(req))
 	for name, val := range req {
 		if val != 0 {
-			sr = append(sr, ResourceEntry{
+			sr = append(sr, resourceEntry{
 				name:  name,
 				hash:  hashResourceName(name),
 				value: val,
@@ -113,9 +113,9 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 		t.Errorf("expected MergeWithInPlace on empty slices to leave slice empty")
 	}
 
-	e1 := ResourceEntry{name: "a", hash: 100, value: 1}
-	e2 := ResourceEntry{name: "b", hash: 100, value: 1}
-	if e1.Cmp(e2) >= 0 {
+	e1 := resourceEntry{name: "a", hash: 100, value: 1}
+	e2 := resourceEntry{name: "b", hash: 100, value: 1}
+	if e1.cmp(e2) >= 0 {
 		t.Errorf("expected e1 < e2 for same hash but different name")
 	}
 }
@@ -123,8 +123,8 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 	t.Run("with sufficient capacity", func(t *testing.T) {
 		base := make(SliceRequests, 0, 4)
-		base = append(base, ResourceEntry{name: corev1.ResourceCPU, hash: hashResourceName(corev1.ResourceCPU), value: 1000})
-		other := SliceRequests{ResourceEntry{name: corev1.ResourceMemory, hash: hashResourceName(corev1.ResourceMemory), value: 2048}}
+		base = append(base, resourceEntry{name: corev1.ResourceCPU, hash: hashResourceName(corev1.ResourceCPU), value: 1000})
+		other := SliceRequests{resourceEntry{name: corev1.ResourceMemory, hash: hashResourceName(corev1.ResourceMemory), value: 2048}}
 
 		base.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
@@ -365,7 +365,7 @@ func TestSliceRequests_ScaledUp(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.ScaledUp(tc.factor)
-			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
+			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
 				t.Errorf("ScaledUp mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -390,7 +390,7 @@ func TestSliceRequests_Clone(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.Clone()
-			if diff := cmp.Diff(tc.want, got, cmp.AllowUnexported(ResourceEntry{})); diff != "" {
+			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
 				t.Errorf("Clone mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -105,10 +105,12 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 		t.Errorf("expected ForEach on nilSR to not execute callback")
 	}
 
+	nilSR.MergeWithInPlace(nil, func(a, b int64) int64 { return a + b })
+
 	var emptySR SliceRequests
-	merged := emptySR.MergeWith(emptySR, func(a, b int64) int64 { return a + b })
-	if merged != nil {
-		t.Errorf("expected MergeWith on empty slices to return nil")
+	emptySR.MergeWithInPlace(emptySR, func(a, b int64) int64 { return a + b })
+	if emptySR != nil {
+		t.Errorf("expected MergeWithInPlace on empty slices to leave slice empty")
 	}
 
 	e1 := ResourceEntry{name: "a", hash: 100, value: 1}
@@ -116,6 +118,70 @@ func TestSliceRequests_EdgeCases(t *testing.T) {
 	if e1.Cmp(e2) >= 0 {
 		t.Errorf("expected e1 < e2 for same hash but different name")
 	}
+}
+
+func TestSliceRequests_MergeWithInPlace(t *testing.T) {
+	t.Run("with sufficient capacity", func(t *testing.T) {
+		base := make(SliceRequests, 0, 4)
+		base = append(base, ResourceEntry{name: corev1.ResourceCPU, hash: HashResourceName(corev1.ResourceCPU), value: 1000})
+		other := SliceRequests{ResourceEntry{name: corev1.ResourceMemory, hash: HashResourceName(corev1.ResourceMemory), value: 2048}}
+
+		base.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
+		if diff := cmp.Diff(want, base.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch with sufficient capacity (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("with insufficient capacity", func(t *testing.T) {
+		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		other := *NewSliceRequests(MapRequests{corev1.ResourceMemory: 2048})
+
+		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch with insufficient capacity (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("self merge", func(t *testing.T) {
+		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
+		sr.MergeWithInPlace(*sr, func(a, b int64) int64 { return a + b })
+		want := MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 4096}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch on self merge (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("merge resulting in zeros dropped", func(t *testing.T) {
+		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
+		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a - b })
+		want := MapRequests{corev1.ResourceMemory: 2048}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch on zero drop merge (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("empty receiver with non-empty operand", func(t *testing.T) {
+		var sr SliceRequests
+		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		want := MapRequests{corev1.ResourceCPU: 1000}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch on empty receiver merge (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("non-empty receiver with empty operand", func(t *testing.T) {
+		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
+		var other SliceRequests
+		sr.MergeWithInPlace(other, func(a, b int64) int64 { return a + b })
+		want := MapRequests{corev1.ResourceCPU: 1000}
+		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+			t.Errorf("mismatch on empty operand merge (-want +got):\n%s", diff)
+		}
+	})
 }
 
 func TestSliceRequests_ResourceList(t *testing.T) {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4937,7 +4937,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := tt.assignment.ComputeTASNetUsage(testr.New(t), tt.cq, tt.wl, tt.prevAdmission)
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.AllowUnexported(resources.ResourceEntry{})); diff != "" {
 				t.Errorf("Unexpected TAS usage (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4937,7 +4937,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := tt.assignment.ComputeTASNetUsage(testr.New(t), tt.cq, tt.wl, tt.prevAdmission)
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.AllowUnexported(resources.ResourceEntry{})); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.Transformer("requestsToMap", resources.ToMapRequests)); diff != "" {
 				t.Errorf("Unexpected TAS usage (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4877,7 +4877,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 			want: workload.TASUsage{
 				"tas": []workload.TopologyDomainRequests{{
 					Values: []string{"node-a"},
-					SinglePodRequests: resources.NewMapRequests(corev1.ResourceList{
+					SinglePodRequests: resources.NewRequestsFromResourceList(corev1.ResourceList{
 						corev1.ResourceCPU:           resource.MustParse("1"),
 						corev1.ResourceMemory:        resource.MustParse("1Gi"),
 						"example.com/gpu":            resource.MustParse("1"),

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3566,42 +3566,55 @@ func runTASScheduleTestCases(t *testing.T, cfg tasScheduleTestConfig, cases map[
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
 			features.TASCachingRemainingResources:     true,
+			features.VectorizedResourceRequests:       false,
+		},
+		{
+			features.WorkloadRequestUseMergePatch:     false,
+			features.UnadmittedWorkloadsObservability: false,
+			features.TASCacheNodeMatchResults:         true,
+			features.TASCachingRemainingResources:     true,
+			features.VectorizedResourceRequests:       true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
 			features.TASCachingRemainingResources:     true,
+			features.VectorizedResourceRequests:       true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         true,
 			features.TASCachingRemainingResources:     true,
+			features.VectorizedResourceRequests:       true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     true,
 			features.UnadmittedWorkloadsObservability: true,
 			features.TASCacheNodeMatchResults:         true,
 			features.TASCachingRemainingResources:     true,
+			features.VectorizedResourceRequests:       true,
 		},
 		{
 			features.WorkloadRequestUseMergePatch:     false,
 			features.UnadmittedWorkloadsObservability: false,
 			features.TASCacheNodeMatchResults:         false,
 			features.TASCachingRemainingResources:     false,
+			features.VectorizedResourceRequests:       true,
 		},
 	}
 
 	for name, tc := range cases {
 		for _, scenario := range scenarios {
 			t.Run(
-				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t cachingRemainingResources:%t",
+				fmt.Sprintf("%s WorkloadRequestUseMergePatch:%t observability:%t cacheMatchResults:%t cachingRemainingResources:%t vectorizedRequests:%t",
 					name,
 					scenario[features.WorkloadRequestUseMergePatch],
 					scenario[features.UnadmittedWorkloadsObservability],
 					scenario[features.TASCacheNodeMatchResults],
 					scenario[features.TASCachingRemainingResources],
+					scenario[features.VectorizedResourceRequests],
 				),
 				func(t *testing.T) {
 					features.SetFeatureGatesDuringTest(t, scenario)

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -738,7 +738,7 @@ func TestNewInfo(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
 			info := NewInfo(&tc.workload, tc.infoOptions...)
-			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash")); diff != "" {
+			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"), cmp.AllowUnexported(resources.ResourceEntry{})); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -349,12 +349,12 @@ func TestNewInfo(t *testing.T) {
 							Levels: []string{corev1.LabelHostname},
 							DomainRequests: []TopologyDomainRequests{{
 								Values: []string{"node-a"},
-								SinglePodRequests: resources.MapRequests{
+								SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 									corev1.ResourceCPU:           1000,
 									corev1.ResourceMemory:        1024 * 1024 * 1024,
 									"example.com/gpu":            1,
 									"networking.example.com/vpc": 1,
-								},
+								}),
 								Count: 2,
 							}},
 						},

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -738,7 +738,8 @@ func TestNewInfo(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
 			info := NewInfo(&tc.workload, tc.infoOptions...)
-			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"), cmp.AllowUnexported(resources.ResourceEntry{})); diff != "" {
+			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"),
+				cmp.Transformer("requestsToMap", resources.ToMapRequests)); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}
 		})

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -549,6 +549,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: VectorizedResourceRequests
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: VisibilityOnDemand
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -549,6 +549,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: VectorizedResourceRequests
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: VisibilityOnDemand
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

`SliceRequests` stores resource requests as a `[]ResourceEntry` slice sorted by 64-bit FNV-1a resource name hash, enabling linear $O(N+M)$ two-pointer scans instead of hash map lookups.

This PR optimizes resource counting performance:

1. **`SliceRequests.CountInWithLimitingResource`**: Refactored to a zero-heap-allocation single-pass $O(N+M)$ two-pointer scan.
2. **`SliceRequests.CountIn`**: Added a dedicated fast path comparing primitive `uint64` hashes directly and bypassing limiting-resource string tracking overhead.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

FG on
```bash
go test -v ./pkg/scheduler/ -bench=BenchmarkSchedulerTAS -run=^$ -cpuprofile=cpu.prof -benchtime=10s -count=5 | awk '/ns\/op/ {iters+=$2; ns+=$3; print "Run " ++n ": " $2 "iterations, " $3 " ns/op (" $3/1e6 " ms/op)"} END {if (n>0) printf "\nAverage (%d runs): %.2f iterations, %.2f ns/op (%.2f ms/op)\n", n, iters/n, ns/n, (ns/n)/1e6}'
Run 1: 76iterations, 156909966 ns/op (156.91 ms/op)
Run 2: 75iterations, 158512278 ns/op (158.512 ms/op)
Run 3: 75iterations, 160795698 ns/op (160.796 ms/op)
Run 4: 73iterations, 161104366 ns/op (161.104 ms/op)
Run 5: 72iterations, 156936815 ns/op (156.937 ms/op)

Average (5 runs): 74.20 iterations, 158851824.60 ns/op (158.85 ms/op)
```
<img width="2056" height="794" alt="on" src="https://github.com/user-attachments/assets/86271b36-41af-420f-9c63-a3bf4a531b43" />


FG off
```bash
go test -v ./pkg/scheduler/ -bench=BenchmarkSchedulerTAS -run=^$ -cpuprofile=cpu.prof -benchtime=10s -count=5 | awk '/ns\/op/ {iters+=$2; ns+=$3; print "Run " ++n ": " $2 "iterations, " $3 " ns/op (" $3/1e6 " ms/op)"} END {if (n>0) printf "\nAverage (%d runs): %.2f iterations, %.2f ns/op (%.2f ms/op)\n", n, iters/n, ns/n, (ns/n)/1e6}'
Run 1: 50iterations, 221771410 ns/op (221.771 ms/op)
Run 2: 51iterations, 230333655 ns/op (230.334 ms/op)
Run 3: 50iterations, 223238689 ns/op (223.239 ms/op)
Run 4: 49iterations, 226791204 ns/op (226.791 ms/op)
Run 5: 52iterations, 221886056 ns/op (221.886 ms/op)

Average (5 runs): 50.40 iterations, 224804202.80 ns/op (224.80 ms/op)
```
<img width="2056" height="836" alt="off" src="https://github.com/user-attachments/assets/cc4d61c9-0928-42ce-b458-94b16dd6cbba" />


#### Does this PR introduce a user-facing change?

```release-note
TAS: Improved scheduling evaluation performance and reduced memory allocations for Topology-Aware Scheduling (TAS).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a beta feature gate for vectorized resource request handling, enabled by default in version 0.19.
  * Introduced a new slice-backed resource request representation to support faster/equivalent processing.

* **Improvements**
  * Enhanced resource request conversions and operations to handle empty/nil values consistently, including add/subtract, scaling, and capacity-based counting.

* **Tests**
  * Added fuzz and expanded unit coverage to confirm equivalence between request representations.
  * Updated scheduling and flavor/workload-related test expectations for vectorized request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->