### PR TITLE
fix(scheduler): respect cohort nominal quota in fair preemption

### DIFF
--- a/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
+++ b/pkg/scheduler/preemption/fairsharing/least_common_ancestor.go
@@ -14,13 +14,17 @@
 
 package fairsharing
 
-import schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+import (
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/resources"
+)
 
 // almostLCA is defined on two ClusterQueues, as the two nodes before
 // the lowest shared node - the LeastCommonAncestor (LCA). While LCA
 // is always a Cohort, almostLCA may be a ClusterQueue or a Cohort.
 type almostLCA interface {
 	DominantResourceShare() schdcache.DRS
+	BorrowingWith(resources.FlavorResource, resources.Amount) bool
 }
 
 // getAlmostLCAs returns almostLCAs of (preemptor, target).

--- a/pkg/scheduler/preemption/fairsharing/target.go
+++ b/pkg/scheduler/preemption/fairsharing/target.go
@@ -15,7 +15,10 @@
 package fairsharing
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -53,6 +56,20 @@ func (t *TargetClusterQueue) HasWorkload() bool {
 func (t *TargetClusterQueue) ComputeShares() (PreemptorNewShare, TargetOldShare) {
 	preemptorAlmostLCA, targetAlmostLCA := getAlmostLCAs(t)
 	return PreemptorNewShare(preemptorAlmostLCA.DominantResourceShare()), TargetOldShare(targetAlmostLCA.DominantResourceShare())
+}
+
+// PreemptorWithinNominal reports whether the preemptor's subtree at the
+// candidate target's least-common-ancestor boundary stays within nominal
+// quota for every contested flavor-resource. The incoming workload must
+// already be simulated before calling this method.
+func (t *TargetClusterQueue) PreemptorWithinNominal(frs sets.Set[resources.FlavorResource]) bool {
+	preemptorAlmostLCA, _ := getAlmostLCAs(t)
+	for fr := range frs {
+		if preemptorAlmostLCA.BorrowingWith(fr, resources.NewAmount(0)) {
+			return false
+		}
+	}
+	return true
 }
 
 // ComputeTargetShareAfterRemoval returns DominantResourceShare of the

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -384,14 +384,6 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 	var targets []*Target
 	var retryCandidates []*workload.Info
 
-	// If the preemptor CQ stays within nominal quota for the contested
-	// resources (including the incoming workload, already simulated),
-	// preemption is allowed regardless of DRS (nominal entitlement).
-	// When true, all cross-CQ candidates are preempted unconditionally
-	// (bypassing the strategy check), so no retryCandidates are produced
-	// and runSecondFsStrategy has nothing to do.
-	preemptorWithinNominal := features.Enabled(features.FairSharingPreemptWithinNominal) &&
-		queueWithinNominalInResourcesNeedingPreemption(preemptionCtx)
 	for candCQ := range ordering.Iter() {
 		if candCQ.InClusterQueuePreemption() {
 			candWl := candCQ.PopWorkload()
@@ -407,7 +399,14 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 			continue
 		}
 
-		if preemptorWithinNominal {
+		// If the preemptor subtree stays within nominal quota at the
+		// candidate target's least-common-ancestor boundary for the
+		// contested resources (including the incoming workload, already
+		// simulated), preemption is allowed regardless of DRS. This gives
+		// descendants access to their ancestor cohort's nominal quota even
+		// when their own ClusterQueue is borrowing.
+		if features.Enabled(features.FairSharingPreemptWithinNominal) &&
+			candCQ.PreemptorWithinNominal(preemptionCtx.frsNeedPreemption) {
 			candWl := candCQ.PopWorkload()
 			preemptionCtx.snapshot.RemoveWorkload(candWl)
 			targets = append(targets, &Target{
@@ -659,20 +658,6 @@ func workloadFitsForFairSharing(preemptionCtx *preemptionCtx) bool {
 func queueUnderNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx) bool {
 	for fr := range preemptionCtx.frsNeedPreemption {
 		if preemptionCtx.preemptorCQ.QuotaFor(fr).Nominal.Cmp(preemptionCtx.preemptorCQ.ResourceNode.Usage[fr]) <= 0 {
-			return false
-		}
-	}
-	return true
-}
-
-// queueWithinNominalInResourcesNeedingPreemption checks whether the
-// preemptor CQ's usage is at or below nominal quota (usage <= nominal)
-// for all flavor-resources needing preemption.
-// The difference from queueUnderNominalInResourcesNeedingPreemption is
-// that this treats usage exactly equal to nominal as "within nominal."
-func queueWithinNominalInResourcesNeedingPreemption(preemptionCtx *preemptionCtx) bool {
-	for fr := range preemptionCtx.frsNeedPreemption {
-		if preemptionCtx.preemptorCQ.Borrowing(fr) {
 			return false
 		}
 	}

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -885,7 +885,7 @@ func TestFairPreemptions(t *testing.T) {
 			incoming: unitWl.Clone().Name("a1").Obj(),
 			targetCQ: "a",
 			wantPreempted: sets.New(
-				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b1", kueue.InCohortReclamationReason),
 			),
 		},
 		// CQ "a": 3 CPU nominal on premium, 0 on cheap.

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -941,6 +941,73 @@ func TestFairPreemptions(t *testing.T) {
 			targetCQ:      "a",
 			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
 		},
+		//                 ROOT
+		//             /          \
+		//  cohort-a (3 premium)   b (0 premium, 6 cheap)
+		//           |
+		//           a (0 premium, 0 cheap)
+		//
+		// Admitted state:
+		//   a: 2 premium + 5 cheap (a borrows both flavors; cohort-a only
+		//      borrows cheap)
+		//   b: 1 premium (borrowed from cohort-a's lendable premium quota)
+		//
+		// Incoming: a wants 1 premium CPU. Although a itself borrows premium,
+		// cohort-a remains within its 3 premium CPUs. It can therefore reclaim
+		// that premium CPU from b regardless of cohort-a's cheap-resource DRS.
+		"nominal first: cohort nominal quota can preempt despite high aggregate DRS": {
+			flavors: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("premium").Obj(),
+				utiltestingapi.MakeResourceFlavor("cheap").Obj(),
+			},
+			assignmentFlavor: "premium",
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("a").
+					Cohort("cohort-a").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "0").Obj(),
+					).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.MayStopSearch,
+						WhenCanPreempt: kueue.MayStopSearch,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "6").Obj(),
+					).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").Obj(),
+				utiltestingapi.MakeCohort("cohort-a").
+					Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("premium").Resource(corev1.ResourceCPU, "3").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("cheap").Resource(corev1.ResourceCPU, "0").Obj(),
+					).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a_prem1").SimpleReserveQuota("a", "premium", now).Obj(),
+				*unitWl.Clone().Name("a_prem2").SimpleReserveQuota("a", "premium", now).Obj(),
+				*unitWl.Clone().Name("a_cheap1").SimpleReserveQuota("a", "cheap", now).Obj(),
+				*unitWl.Clone().Name("a_cheap2").SimpleReserveQuota("a", "cheap", now).Obj(),
+				*unitWl.Clone().Name("a_cheap3").SimpleReserveQuota("a", "cheap", now).Obj(),
+				*unitWl.Clone().Name("a_cheap4").SimpleReserveQuota("a", "cheap", now).Obj(),
+				*unitWl.Clone().Name("a_cheap5").SimpleReserveQuota("a", "cheap", now).Obj(),
+				*unitWl.Clone().Name("b_prem1").SimpleReserveQuota("b", "premium", now).Obj(),
+			},
+			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it?

Fair sharing already lets a ClusterQueue that stays within its own nominal quota preempt regardless of DominantResourceShare (DRS). That entitlement stopped at the ClusterQueue level, so in hierarchical setups a Cohort's own nominal quota gave its descendants no such preference: a workload could be blocked from reclaiming quota belonging to its parent Cohort purely because the Cohort's aggregate DRS was inflated by borrowing on an unrelated flavor.

This PR evaluates the nominal claim **per preemption candidate**, over the path from the preemptor ClusterQueue up to its *almostLCA* with that candidate's target. The claim holds when **any** node on that path is within nominal quota for every contested flavor-resource — either the ClusterQueue reclaiming its own quota (existing behavior), or an ancestor Cohort giving its descendants preferential access to the Cohort's own quota (new).

This replaces the single pre-loop check on the preemptor ClusterQueue, which could not see ancestor quota at all.

Fixes #9466

#### Useful notes for your reviewer

**AI usage disclosure:** per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance), this PR was developed with AI assistance (Claude Code) for analysis, implementation, and test authoring.

Two design points worth a close look:

1. **The path stops at the almostLCA, not the LCA.** `computeDRS` (`pkg/scheduler/fair_sharing_iterator.go`) stores, for the tournament key `parentCohort=X`, the DRS of the node *below* X. A tournament at a cohort level therefore compares that cohort's *children* — the almostLCA — never the cohort itself. Including the LCA makes the preemptor look like it is borrowing whenever total cohort usage exceeds the cohort's subtree quota, which is the normal state once the incoming workload is simulated; that regresses plain nominal reclamation and mislabels `InCohortReclamation` as `InCohortFairSharing`.

2. **The check is a disjunction, not a conjunction.** The entitlement is a *claim*, so it is enough for one node on the path to hold it. Requiring every node to be within nominal would revoke the existing ClusterQueue-level behavior whenever an intermediate Cohort happened to be borrowing.

The behavior is gated by `FairSharingPreemptWithinNominal` (Beta, on by default since 0.17).

Verification run locally:
- `make ci-lint` — 0 issues
- `go test ./pkg/... ./cmd/...` and `go test ./pkg/scheduler/... -race -count=3` (matching CI flags) — pass
- All 8 `test/integration/singlecluster/scheduler` suites — pass, including 48/48 fairsharing specs
- `make verify` — passes except `verify-e2e-common-test`, which cannot run on macOS without GNU `timeout`

The new integration test was confirmed to fail against the previous ClusterQueue-only check and to pass with this change.

#### Release note

```release-note
FairSharing: Fixed a bug where a workload could be blocked from reclaiming its parent Cohort's nominal quota when that Cohort's DominantResourceShare was inflated by borrowing on an unrelated flavor. Descendants of a Cohort now get preferential access to the Cohort's own nominal quota, matching the behavior that already applied to a ClusterQueue's own nominal quota.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

- Fixed FairSharing admission ordering and preemption for hierarchical cohorts.
- Workloads within an ancestor cohort’s nominal quota can receive priority even when the cohort borrows other resource flavors.
- Added unit and integration tests for multi-flavor cohort preemption, including quota-boundary cases.

### Suggested release note

FairSharing: Fixed a bug that could delay admission or preemption of workloads within a cohort’s nominal quota when the cohort borrowed other resource flavors. This preemption behavior is gated by `FairSharingPreemptWithinNominal`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
