### PR TITLE
fix(performance): measure actual workload admission latency

### DIFF
--- a/test/performance/scheduler/runner/recorder/recorder.go
+++ b/test/performance/scheduler/runner/recorder/recorder.go
@@ -86,7 +86,9 @@ func (cqs *CQState) CsvRecord() []string {
 type CQStore map[string]*CQState
 
 type WLEvent struct {
-	Time time.Time
+	Time          time.Time
+	CreationTime  time.Time
+	AdmissionTime time.Time
 	types.NamespacedName
 	UID       types.UID
 	ClassName string
@@ -196,7 +198,15 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 	}
 
 	if ev.Admitted && !state.LastEvent.Admitted {
-		state.TimeToAdmitMs = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+		admissionStartTime := state.FirstEventTime
+		admissionTime := ev.Time
+		if !ev.CreationTime.IsZero() &&
+			!ev.AdmissionTime.IsZero() &&
+			!ev.AdmissionTime.Before(ev.CreationTime) {
+			admissionStartTime = ev.CreationTime
+			admissionTime = ev.AdmissionTime
+		}
+		state.TimeToAdmitMs = admissionTime.Sub(admissionStartTime).Milliseconds()
 	}
 
 	if ev.Evicted && !state.LastEvent.Evicted {
@@ -451,15 +461,24 @@ func (r *Recorder) RecordWorkloadState(wl *kueue.Workload) {
 	if !r.running.Load() {
 		return
 	}
+	admitted := workload.IsAdmitted(wl)
+	admissionTime := time.Time{}
+	if admitted {
+		if condition := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted); condition != nil {
+			admissionTime = condition.LastTransitionTime.Time
+		}
+	}
 	ev := &WLEvent{
-		Time: time.Now(),
+		Time:          time.Now(),
+		CreationTime:  wl.CreationTimestamp.Time,
+		AdmissionTime: admissionTime,
 		NamespacedName: types.NamespacedName{
 			Namespace: wl.Namespace,
 			Name:      wl.Name,
 		},
 		UID:       wl.UID,
 		ClassName: wl.Labels[generator.ClassLabel],
-		Admitted:  workload.IsAdmitted(wl),
+		Admitted:  admitted,
 		Evicted:   workloadevict.IsEvicted(wl),
 		Finished:  workloadfinish.IsFinished(wl),
 	}

--- a/test/performance/scheduler/runner/recorder/recorder_test.go
+++ b/test/performance/scheduler/runner/recorder/recorder_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+)
+
+func TestRecordWLEventAdmissionLatency(t *testing.T) {
+	creationTime := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	tests := map[string]struct {
+		events []WLEvent
+		wantMs int64
+	}{
+		"first observed event is admitted": {
+			events: []WLEvent{{
+				Time:          creationTime.Add(30 * time.Second),
+				CreationTime:  creationTime,
+				AdmissionTime: creationTime.Add(20 * time.Second),
+				Admitted:      true,
+			}},
+			wantMs: 20_000,
+		},
+		"pending event precedes admission": {
+			events: []WLEvent{
+				{
+					Time:         creationTime.Add(time.Second),
+					CreationTime: creationTime,
+				},
+				{
+					Time:          creationTime.Add(30 * time.Second),
+					CreationTime:  creationTime,
+					AdmissionTime: creationTime.Add(20 * time.Second),
+					Admitted:      true,
+				},
+			},
+			wantMs: 20_000,
+		},
+		"missing admission timestamp preserves observation times": {
+			events: []WLEvent{
+				{
+					Time:         creationTime.Add(time.Second),
+					CreationTime: creationTime,
+				},
+				{
+					Time:         creationTime.Add(30 * time.Second),
+					CreationTime: creationTime,
+					Admitted:     true,
+				},
+			},
+			wantMs: 29_000,
+		},
+		"missing creation timestamp preserves observation baseline": {
+			events: []WLEvent{
+				{
+					Time: creationTime.Add(time.Second),
+				},
+				{
+					Time:          creationTime.Add(30 * time.Second),
+					AdmissionTime: creationTime.Add(20 * time.Second),
+					Admitted:      true,
+				},
+			},
+			wantMs: 29_000,
+		},
+		"admission before creation preserves observation baseline": {
+			events: []WLEvent{
+				{
+					Time:         creationTime.Add(time.Second),
+					CreationTime: creationTime,
+				},
+				{
+					Time:          creationTime.Add(30 * time.Second),
+					CreationTime:  creationTime,
+					AdmissionTime: creationTime.Add(-time.Second),
+					Admitted:      true,
+				},
+			},
+			wantMs: 29_000,
+		},
+		"object timestamps do not depend on observation clock": {
+			events: []WLEvent{{
+				Time:          creationTime.Add(-time.Second),
+				CreationTime:  creationTime,
+				AdmissionTime: creationTime.Add(20 * time.Second),
+				Admitted:      true,
+			}},
+			wantMs: 20_000,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := New(time.Minute)
+			uid := types.UID("test-workload")
+			for i := range tc.events {
+				tc.events[i].UID = uid
+				r.recordWLEvent(&tc.events[i])
+			}
+
+			if got := r.Store.WL[uid].TimeToAdmitMs; got != tc.wantMs {
+				t.Errorf("TimeToAdmitMs = %d, want %d", got, tc.wantMs)
+			}
+		})
+	}
+}
+
+func TestRecordWLEventCreationTimeDoesNotAffectFinishLatency(t *testing.T) {
+	creationTime := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	uid := types.UID("test-workload")
+	r := New(time.Minute)
+	r.recordWLEvent(&WLEvent{
+		Time:          creationTime.Add(30 * time.Second),
+		CreationTime:  creationTime,
+		AdmissionTime: creationTime.Add(20 * time.Second),
+		UID:           uid,
+		Admitted:      true,
+		Finished:      true,
+	})
+
+	if got := r.Store.WL[uid].TimeToFinishedMs; got != 0 {
+		t.Errorf("TimeToFinishedMs = %d, want 0", got)
+	}
+}
+
+func TestRecordWorkloadStateCarriesObjectTimestamps(t *testing.T) {
+	creationTime := time.Date(2026, time.July, 1, 12, 0, 0, 0, time.UTC)
+	admissionTime := creationTime.Add(20 * time.Second)
+	uid := types.UID("test-workload")
+	wl := &kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-workload",
+			Namespace:         "default",
+			UID:               uid,
+			CreationTimestamp: metav1.NewTime(creationTime),
+		},
+		Status: kueue.WorkloadStatus{
+			Conditions: []metav1.Condition{{
+				Type:               kueue.WorkloadAdmitted,
+				Status:             metav1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(admissionTime),
+			}},
+		},
+	}
+
+	r := New(time.Minute)
+	r.running.Store(true)
+	r.RecordWorkloadState(wl)
+	var ev *WLEvent
+	select {
+	case ev = <-r.wlEvChan:
+	default:
+		t.Fatal("RecordWorkloadState() did not enqueue an event")
+	}
+
+	if !ev.CreationTime.Equal(creationTime) {
+		t.Errorf("CreationTime = %v, want %v", ev.CreationTime, creationTime)
+	}
+	if !ev.AdmissionTime.Equal(admissionTime) {
+		t.Errorf("AdmissionTime = %v, want %v", ev.AdmissionTime, admissionTime)
+	}
+	if !ev.Admitted {
+		t.Error("Admitted = false, want true")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area testing

#### What this PR does / why we need it:

The performance scheduler runner can first observe a Workload after it has already been admitted, causing admission latency to be recorded as zero or otherwise undercounted.

This change carries the Workload creation timestamp and the Admitted condition transition timestamp into recorder events. It calculates admission latency from those object timestamps when both are valid, while preserving the existing observation-time fallback for missing or contradictory timestamps. Finish-latency semantics remain unchanged.

Tests cover first-observed-admitted workloads, normal pending-to-admitted transitions, fallback cases, observation clock skew, unchanged finish latency, and timestamp extraction from Workload objects.

#### Which issue(s) this PR fixes:

Fixes #11870

#### Special notes for your reviewer:

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated with:

- `go test ./test/performance/scheduler/runner/recorder ./test/performance/scheduler/runner/controller`
- `go test -race -count=50 ./test/performance/scheduler/runner/recorder ./test/performance/scheduler/runner/controller`
- `go test -count=1 ./test/performance/scheduler/runner/...`
- `go vet ./test/performance/scheduler/runner/recorder ./test/performance/scheduler/runner/controller`

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Workload admission latency is now measured using creation and admission timestamps when available, providing more accurate timing results.
  * Recording preserves workload creation time, admission transition time, and admission status.
  * Existing latency calculations continue to work when timestamp information is incomplete.

* **Tests**
  * Added coverage for admission latency calculations, fallback behavior, finish latency, and timestamp recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->