### PR TITLE
Fix flaky admission check strategies test

### DIFF
--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -113,10 +113,10 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 					*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).Resource(resourceGPU, "5", "5").Obj()).
 				Cohort("cohort").
 				Obj()
-			util.MustCreate(ctx, k8sClient, clusterQueue)
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
 
 			localQueue = utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
-			util.MustCreate(ctx, k8sClient, localQueue)
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
 		})
 
 		ginkgo.AfterEach(func() {


### PR DESCRIPTION


#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:
Workload step starts before the queues are ready:

```
  2026-07-07T13:28:25.96422051Z LEVEL(-2) localqueue-reconciler core/localqueue_controller.go:238 LocalQueue create
  event {"replica-role": "standalone", "localQueue": {"name":"queue","namespace":"core-workload-jvv5j"}}
  STEP: creating and waiting for workload to have a quota reservation @ 07/07/26 13:28:25.964
  [FAILED] Timed out after 10.001s.
  The function passed to Eventually failed at /home/prow/go/src/sigs.k8s.io/kueue/test/integration/singlecluster/
  scheduler/workload_controller_test.go:143 with:
  should have quota reservation
  Expected
      <bool>: false
  to be true
```
Added a wait for both queues to become active before such step.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12863

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test setup by waiting for scheduling queues to become active before proceeding.
  * Increased test reliability for admission check strategy scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->