### PR TITLE
use strings.Compare on hostname level

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1662,7 +1662,7 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 
 func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
-	slices.SortFunc(domains, compareDomainLevelValues)
+	slices.SortFunc(domains, s.compareDomainLevelValues)
 	levelIdx := 0
 	// assign only hostname values if topology defines it
 	if s.isLowestLevelNode {
@@ -1679,8 +1679,15 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 	return result
 }
 
+func (s *TASFlavorSnapshot) compareDomainLevelValues(a, b *domain) int {
+	if s.isLowestLevelNode && a.parent == b.parent {
+		return strings.Compare(a.levelValues[len(a.levelValues)-1], b.levelValues[len(b.levelValues)-1])
+	}
+	return compareDomainLevelValues(a, b)
+}
+
 func compareDomainLevelValues(a, b *domain) int {
-	return slices.Compare(a.levelValues, b.levelValues)
+	return slices.CompareFunc(a.levelValues, b.levelValues, strings.Compare)
 }
 
 func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstrained bool) []*domain {
@@ -1709,7 +1716,7 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 			return cmp.Compare(a.stateWithLeader, b.stateWithLeader)
 		}
 
-		return compareDomainLevelValues(a, b)
+		return s.compareDomainLevelValues(a, b)
 	})
 	return result
 }
@@ -1743,7 +1750,7 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 			return cmp.Compare(a.state, b.state)
 		}
 
-		return compareDomainLevelValues(a, b)
+		return s.compareDomainLevelValues(a, b)
 	})
 	return result
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -649,6 +649,63 @@ func TestSortedDomains(t *testing.T) {
 	}
 }
 
+func TestCompareDomainLevelValues(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	hostnameLevels := []string{"block", "rack", corev1.LabelHostname}
+	nonHostnameLevels := []string{"block", "rack"}
+
+	parent1 := &domain{id: "b1-r1", levelValues: []string{"b1", "r1"}}
+	parent2 := &domain{id: "b1-r2", levelValues: []string{"b1", "r2"}}
+
+	testCases := map[string]struct {
+		levels []string
+		a      *domain
+		b      *domain
+		want   int
+	}{
+		"isLowestLevelNode with same-parent sibling domains: ascending by hostname": {
+			levels: hostnameLevels,
+			a:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
+			b:      &domain{id: "node-b", parent: parent1, levelValues: []string{"b1", "r1", "node-b"}},
+			want:   -1,
+		},
+		"isLowestLevelNode with same-parent sibling domains: descending by hostname": {
+			levels: hostnameLevels,
+			a:      &domain{id: "node-b", parent: parent1, levelValues: []string{"b1", "r1", "node-b"}},
+			b:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
+			want:   1,
+		},
+		"isLowestLevelNode with same-parent sibling domains: equal hostname": {
+			levels: hostnameLevels,
+			a:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
+			b:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
+			want:   0,
+		},
+		"fallback comparator: multi-level inputs with different parents sorted lexicographically across levels": {
+			levels: hostnameLevels,
+			a:      &domain{id: "node-z", parent: parent1, levelValues: []string{"b1", "r1", "node-z"}},
+			b:      &domain{id: "node-a", parent: parent2, levelValues: []string{"b1", "r2", "node-a"}},
+			want:   -1,
+		},
+		"fallback comparator: non-hostname levels sorted lexicographically across levels": {
+			levels: nonHostnameLevels,
+			a:      &domain{id: "b1-r1", levelValues: []string{"b1", "r1"}},
+			b:      &domain{id: "b1-r2", levelValues: []string{"b1", "r2"}},
+			want:   -1,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			s := newTASFlavorSnapshot(log, "test", tc.levels, nil, &defaultChecker{})
+			got := s.compareDomainLevelValues(tc.a, tc.b)
+			if (got < 0 && tc.want >= 0) || (got > 0 && tc.want <= 0) || (got == 0 && tc.want != 0) {
+				t.Errorf("compareDomainLevelValues() = %d, want sign matching %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCountPodsInAssignment(t *testing.T) {
 	cases := map[string]struct {
 		assignment *tas.TopologyAssignment


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area tas

#### What this PR does / why we need it:
When `kubernetes.io/hostname` is configured as the lowest topology level, sibling domains sharing the same parent domain have identical parent level values. 

This change optimizes domain tie-breaking comparisons by:
1. Checking if `s.isLowestLevelNode && a.parent == b.parent` in `compareDomainLevelValues` to directly compare the leaf `nodeName` via `strings.Compare`.
2. Standardizing domain level value slice comparisons to use `slices.CompareFunc(a.levelValues, b.levelValues, strings.Compare)`.

#### Which issue(s) this PR fixes:
Part of: #13148

#### Special notes for your reviewer:

With the patch:
```bash
$ go test -v ./pkg/scheduler/ -bench=BenchmarkSchedulerTAS -run=^$ -cpuprofile=cpu.prof -benchtime=10s -count=5 | awk '/ns\/op/ {iters+=$2; ns+=$3; print "Run " ++n ": " $2 "iterations, " $3 " ns/op (" $3/1e6 " ms/op)"} END {if (n>0) printf "\nAverage (%d runs): %.2f iterations, %.2f ns/op (%.2f ms/op)\n", n, iters/n, ns/n, (ns/n)/1e6}'
Run 1: 60iterations, 203302221 ns/op (203.302 ms/op)
Run 2: 55iterations, 209770259 ns/op (209.77 ms/op)
Run 3: 58iterations, 206569969 ns/op (206.57 ms/op)
Run 4: 57iterations, 207157932 ns/op (207.158 ms/op)
Run 5: 52iterations, 205873147 ns/op (205.873 ms/op)

Average (5 runs): 56.40 iterations, 206534705.60 ns/op (206.53 ms/op)
```

Main:
```bash
$ go test -v ./pkg/scheduler/ -bench=BenchmarkSchedulerTAS -run=^$ -cpuprofile=cpu.prof -benchtime=10s -count=5 | awk '/ns\/op/ {iters+=$2; ns+=$3; print "Run " ++n ": " $2 "iterations, " $3 " ns/op (" $3/1e6 " ms/op)"} END {if (n>0) printf "\nAverage (%d runs): %.2f iterations, %.2f ns/op (%.2f ms/op)\n", n, iters/n, ns/n, (ns/n)/1e6}'
Run 1: 57iterations, 211963030 ns/op (211.963 ms/op)
Run 2: 55iterations, 215461624 ns/op (215.462 ms/op)
Run 3: 55iterations, 216954178 ns/op (216.954 ms/op)
Run 4: 52iterations, 219137813 ns/op (219.138 ms/op)
Run 5: 51iterations, 216095221 ns/op (216.095 ms/op)

Average (5 runs): 54.00 iterations, 215922373.20 ns/op (215.92 ms/op)
```

#### Does this PR introduce a user-facing change?
```release-note
TAS: improved workload evaluation performance by optimizing domain-ordering tie-breaks for sibling node domains with equal available capacity.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain ordering during placement calculations for hostname-based topologies.
  * Ensured consistent sorting behavior across leader-aware and standard placement scenarios.
  * Added/validated refined comparison logic so domains with the same parent follow the expected sibling order and fallback rules when parents differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->