### PR TITLE
Automated cherry pick of #12838: Reject negative resource requests and limits in Workloads

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -499,6 +499,11 @@ const (
 	// VectorizedResourceRequests enables slice-based indexing for resource requests in TAS snapshots,
 	// replacing map lookups for higher performance during scheduling and preemption.
 	VectorizedResourceRequests featuregate.Feature = "VectorizedResourceRequests"
+
+	// owner: @vladikkuzn
+	//
+	// Rejects Workloads with negative container or pod-level resource requests/limits.
+	WorkloadValidateResourcesAreNonNegative featuregate.Feature = "WorkloadValidateResourcesAreNonNegative"
 )
 
 func init() {
@@ -770,6 +775,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 	VectorizedResourceRequests: {
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	WorkloadValidateResourcesAreNonNegative: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -32,4 +32,6 @@ type Requests interface {
 	ForEach(fn func(name corev1.ResourceName, val int64))
 	Len() int
 	IsEmpty() bool
+	// FloorToZero replaces negative resource values with zero.
+	FloorToZero()
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -116,6 +116,16 @@ func (r MapRequests) IsEmpty() bool {
 	return len(r) == 0
 }
 
+// FloorToZero replaces negative resource values with zero.
+// Defense-in-depth for pre-existing negative Workloads while
+// WorkloadValidateResourcesAreNonNegative rolls out.
+// TODO: remove ~2 releases after WorkloadValidateResourcesAreNonNegative locks to GA.
+func (r MapRequests) FloorToZero() {
+	for k, v := range r {
+		r[k] = max(v, 0)
+	}
+}
+
 func (r MapRequests) Add(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
 		r[k] += v

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -541,6 +541,46 @@ func TestLazyRequests(t *testing.T) {
 	}
 }
 
+func TestFloorToZero(t *testing.T) {
+	cases := map[string]struct {
+		requests MapRequests
+		want     MapRequests
+	}{
+		"empty": {
+			requests: MapRequests{},
+			want:     MapRequests{},
+		},
+		"negative floored to zero": {
+			requests: MapRequests{
+				corev1.ResourceCPU:    -100,
+				corev1.ResourceMemory: 1024,
+			},
+			want: MapRequests{
+				corev1.ResourceCPU:    0,
+				corev1.ResourceMemory: 1024,
+			},
+		},
+		"zero and positive unchanged": {
+			requests: MapRequests{
+				corev1.ResourceCPU:    0,
+				corev1.ResourceMemory: 1024,
+			},
+			want: MapRequests{
+				corev1.ResourceCPU:    0,
+				corev1.ResourceMemory: 1024,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.requests.FloorToZero()
+			if diff := cmp.Diff(tc.want, tc.requests); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestMapRequestsLen(t *testing.T) {
 	cases := map[string]struct {
 		req  MapRequests

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -573,7 +573,8 @@ func TestFloorToZero(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			tc.requests.FloorToZero()
+			var r Requests = tc.requests
+			r.FloorToZero()
 			if diff := cmp.Diff(tc.want, tc.requests); diff != "" {
 				t.Errorf("unexpected result (-want +got):\n%s", diff)
 			}

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -319,3 +319,12 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 func (sr *SliceRequests) IsEmpty() bool {
 	return sr == nil || len(*sr) == 0
 }
+
+func (sr *SliceRequests) FloorToZero() {
+	if sr == nil {
+		return
+	}
+	for i := range *sr {
+		(*sr)[i].value = max((*sr)[i].value, 0)
+	}
+}

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -165,16 +165,31 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	for ci := range ps.Template.Spec.Containers {
 		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], cPath.Index(ci))...)
 	}
+	// validate pod-level resources
+	if ps.Template.Spec.Resources != nil {
+		resPath := path.Child("template", "spec", "resources")
+		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Requests, resPath.Child("requests"))...)
+		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Resources.Limits, resPath.Child("limits"))...)
+	}
 
 	return allErrs
 }
 
 func validateContainer(c *corev1.Container, path *field.Path) field.ErrorList {
+	requestErrors := validateResourceList(c.Resources.Requests, path.Child("resources", "requests"))
+	limitErrors := validateResourceList(c.Resources.Limits, path.Child("resources", "limits"))
+	return append(requestErrors, limitErrors...)
+}
+
+// validateResourceList rejects the reserved pods key and, when enabled, negative quantities.
+func validateResourceList(resources corev1.ResourceList, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-	rPath := path.Child("resources", "requests")
-	for name := range c.Resources.Requests {
+	for name, quantity := range resources {
 		if name == corev1.ResourcePods {
-			allErrs = append(allErrs, field.Invalid(rPath.Key(string(name)), corev1.ResourcePods, "the key is reserved for internal kueue use"))
+			allErrs = append(allErrs, field.Invalid(path.Key(string(name)), corev1.ResourcePods, "the key is reserved for internal kueue use"))
+		}
+		if features.Enabled(features.WorkloadValidateResourcesAreNonNegative) {
+			allErrs = append(allErrs, validateResourceQuantity(quantity, path.Key(string(name)))...)
 		}
 	}
 	return allErrs

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
@@ -104,6 +105,153 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(firstPodSetSpecPath.Child("initContainers").Index(0).Child("resources", "requests").Key(string(corev1.ResourcePods)), nil, ""),
 				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourcePods)), nil, ""),
 			},
+		},
+		"should reject reserved pods resource key in limits": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						InitContainers(corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourcePods: resource.MustParse("1"),
+								},
+							},
+						}).
+						Containers(corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourcePods: resource.MustParse("1"),
+								},
+							},
+						}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("initContainers").Index(0).Child("resources", "limits").Key(string(corev1.ResourcePods)), nil, ""),
+				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "limits").Key(string(corev1.ResourcePods)), nil, ""),
+			},
+		},
+		"should reject negative container resource request": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						Containers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "-1",
+						})...).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceCPU)), nil, ""),
+			},
+		},
+		"should reject negative initContainer resource request": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						InitContainers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "-1",
+						})...).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("initContainers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceCPU)), nil, ""),
+			},
+		},
+		"should reject negative container resource limit": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						Containers(corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("-1"),
+								},
+							},
+						}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "limits").Key(string(corev1.ResourceCPU)), nil, ""),
+			},
+		},
+		"should reject negative resource among multiple valid requests and limits": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						Containers(corev1.Container{
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("-1Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("-2Gi"),
+								},
+							},
+						}).
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceMemory)), nil, ""),
+				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "limits").Key(string(corev1.ResourceMemory)), nil, ""),
+			},
+		},
+		"should reject negative pod-level resource request": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						PodLevelRequest(corev1.ResourceCPU, "-1").
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("resources", "requests").Key(string(corev1.ResourceCPU)), nil, ""),
+			},
+		},
+		"should reject negative pod-level resource limit": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("bad", 1).
+						PodLevelLimit(corev1.ResourceMemory, "-1Gi").
+						Obj(),
+				).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("resources", "limits").Key(string(corev1.ResourceMemory)), nil, ""),
+			},
+		},
+		"should accept negative container resource request when WorkloadValidateResourcesAreNonNegative is disabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadValidateResourcesAreNonNegative: false,
+			},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ok", 1).
+						Containers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "-1",
+						})...).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should accept zero container resource request": {
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ok", 1).
+						Containers(utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+							corev1.ResourceCPU: "0",
+						})...).
+						Obj(),
+				).
+				Obj(),
+			wantErr: nil,
 		},
 		"empty podSetUpdates": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).AdmissionChecks(kueue.AdmissionCheckState{}).Obj(),

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -651,6 +651,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 				}
 			}
 		}
+		setRes.Requests.FloorToZero()
 		setRes.Requests.Mul(int64(count))
 		res = append(res, setRes)
 	}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -171,6 +171,28 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		"negative request floored to zero in total requests": {
+			workload: *utiltestingapi.MakeWorkload("", "").
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+						Request(corev1.ResourceCPU, "-10m").
+						Request(corev1.ResourceMemory, "512Ki").
+						Obj(),
+				).
+				Obj(),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: kueue.DefaultPodSetName,
+						Requests: resources.MapRequests{
+							corev1.ResourceCPU:    0,
+							corev1.ResourceMemory: 2 * 512 * 1024,
+						},
+						Count: 2,
+					},
+				},
+			},
+		},
 		"pending with reclaim; reclaimablePods on": {
 			workload: *utiltestingapi.MakeWorkload("", "").
 				PodSets(

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -569,3 +569,9 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.14"
+- name: WorkloadValidateResourcesAreNonNegative
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -569,3 +569,9 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.14"
+- name: WorkloadValidateResourcesAreNonNegative
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -25,6 +25,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -245,6 +246,49 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 										corev1.ResourcePods: "1",
 									})...,
 								).
+								Obj(),
+						).
+						Obj()
+				},
+				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("should not limit num-pods resource",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("bad", 1).
+								Containers(corev1.Container{
+									Resources: corev1.ResourceRequirements{
+										Limits: corev1.ResourceList{
+											corev1.ResourcePods: resource.MustParse("1"),
+										},
+									},
+								}).
+								Obj(),
+						).
+						Obj()
+				},
+				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("should not allow negative resource requests",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("bad", 1).
+								Containers(
+									utiltesting.SingleContainerForRequest(map[corev1.ResourceName]string{
+										corev1.ResourceCPU: "-1",
+									})...,
+								).
+								Obj(),
+						).
+						Obj()
+				},
+				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("should not allow negative pod-level resource requests",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("bad", 1).
+								PodLevelRequest(corev1.ResourceCPU, "-1").
 								Obj(),
 						).
 						Obj()


### PR DESCRIPTION
Cherry pick of #12838 on release-0.18.

#12838: Reject negative resource requests and limits in Workloads

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup

Release-branch adaptations:
- Feature gate versioned as `0.18` (source PR ends at `0.20` on main)
- Webhook unit tests keep `field.ErrorList` `wantErr` (no `.ToAggregate()`)

Applied via `git am` of https://github.com/kubernetes-sigs/kueue/pull/12838.patch (same as `hack/cherry_pick_pull.sh`).

AI usage: this PR was prepared with assistance from Cursor.

```release-note
Scheduling: Fixed a bug where negative container resource requests or limits
could create artificial ClusterQueue quota credit, allowing Workloads to bypass
configured quota limits. Kueue now floors negative values to zero during quota
accounting and rejects them during Workload validation by default. The
validation is controlled by the Beta
`WorkloadValidateResourcesAreNonNegative` feature gate.
```