### PR TITLE
docs: document custom metric labels for Workloads

### DIFF
--- a/site/content/en/docs/reference/metrics.md
+++ b/site/content/en/docs/reference/metrics.md
@@ -14,6 +14,14 @@ Kueue exposes [prometheus](https://prometheus.io) metrics to monitor the health
 of the system and the status of [ClusterQueues](/docs/concepts/cluster_queue)
 and [LocalQueues](/docs/concepts/local_queue).
 
+{{% alert title="Custom labels" color="primary" %}}
+The label sets below are the built-in defaults. With the `CustomMetricLabels`
+feature gate enabled, supported metrics can carry additional `custom_*` labels
+sourced from ClusterQueue, LocalQueue, Cohort, or Workload metadata. These are
+configured at runtime and are not shown in the generated tables. See
+[Configure Custom Metric Labels](/docs/tasks/manage/observability/configure_custom_metric_labels).
+{{% /alert %}}
+
 <!-- NOTE: Sections below contain tables generated from code. Do not edit content between BEGIN/END GENERATED TABLE markers. Use `make generate-metrics-tables` to update. -->
 
 ## Kueue health

--- a/site/content/en/docs/tasks/manage/observability/configure_custom_metric_labels.md
+++ b/site/content/en/docs/tasks/manage/observability/configure_custom_metric_labels.md
@@ -4,12 +4,12 @@ linkTitle: "Custom Metric Labels"
 date: 2026-03-10
 weight: 4
 description: >
-  Add custom Prometheus labels to Kueue ClusterQueue, LocalQueue, and Cohort metrics from Kubernetes metadata.
+  Add custom Prometheus labels to Kueue ClusterQueue, LocalQueue, Cohort, and Workload metrics from Kubernetes metadata.
 ---
 
 This page shows you how to configure custom metric labels that promote Kubernetes
-labels or annotations on ClusterQueues, LocalQueues, and Cohorts into additional
-Prometheus metric label dimensions.
+labels or annotations on ClusterQueues, LocalQueues, Cohorts, and Workloads into
+additional Prometheus metric label dimensions.
 
 The intended audience for this page are [batch administrators](/docs/tasks#batch-administrator).
 
@@ -30,8 +30,9 @@ alpha and disabled by default. See
 for details on how to enable feature gates.
 
 Add a `metrics.customLabels` section to the Kueue controller configuration.
-Each entry defines one extra Prometheus label dimension on ClusterQueue,
-LocalQueue, and Cohort metrics.
+Each entry defines one extra Prometheus label dimension. The `sourceKind` field
+selects the object the value is read from: `ClusterQueue` (the default),
+`LocalQueue`, `Cohort`, or `Workload`.
 
 ```yaml
 apiVersion: config.kueue.x-k8s.io/v1beta2
@@ -45,23 +46,42 @@ metrics:
       sourceLabelKey: "billing/cost-center"
     - name: budget
       sourceAnnotationKey: "billing.example.com/budget"
+    - name: workload_type
+      sourceKind: Workload
+      sourceLabelKey: "company.com/workload-type"
+      trackedValues: ["inference", "training"]
 ```
 
 ### Field reference
 
 | Field                | Description |
 |----------------------|-------------|
-| `name`               | Suffix for the Prometheus label. Kueue prepends `custom_` automatically (e.g. `name: team` → label `custom_team`). Must follow Prometheus label naming conventions: `[a-zA-Z_][a-zA-Z0-9_]*`. |
+| `name`               | Suffix for the Prometheus label. Kueue prepends `custom_` automatically (e.g. `name: team` → label `custom_team`). Must follow Prometheus label naming conventions: `[a-zA-Z][a-zA-Z0-9_]*`, and be unique across entries. |
+| `sourceKind`         | Object the value is read from: `ClusterQueue` (default), `LocalQueue`, `Cohort`, or `Workload`. |
 | `sourceLabelKey`     | Kubernetes label key to read the value from. Must be a valid Kubernetes qualified name. Mutually exclusive with `sourceAnnotationKey`. Defaults to `name` if neither is specified. |
 | `sourceAnnotationKey`| Kubernetes annotation key to read the value from. Must be a valid Kubernetes qualified name. Mutually exclusive with `sourceLabelKey`. |
+| `trackedValues`      | List of allowed values for the label. Required for `Workload` labels (1 to 12 values); optional for other kinds (up to 16), where an empty list allows any value. A value not in the list is reported as `kueue.x-k8s.io/_UNTRACKED_VALUE_`. |
 
-A maximum of **8** custom labels can be configured.
+The number of custom labels is limited to keep metric cardinality bounded: up to
+**2** labels with `sourceKind: Workload`, up to **6** for each other kind, and
+**20** in total. The configuration is validated at startup, so an invalid entry
+prevents the controller from starting.
 
 ### How values are resolved
 
-For each ClusterQueue, LocalQueue, or Cohort, Kueue reads the value of the
-specified Kubernetes label or annotation. If the object does not have the
-label/annotation, an empty string is used as the value.
+For each object, Kueue reads the value of the configured Kubernetes label or
+annotation. If the object does not have it, an empty string is used.
+
+For `ClusterQueue`, `LocalQueue`, and `Cohort` labels the value is read from the
+object itself. For `Workload` labels the value is read from the Workload; Kueue
+copies the configured source key from the underlying job (Job, JobSet, and other
+supported kinds) onto the Workload it creates, so you set the label or annotation
+on the job.
+
+A `Workload` label must declare its allowed values in `trackedValues`. Workloads
+are numerous and can carry arbitrary values, so any value outside the list is
+reported under `kueue.x-k8s.io/_UNTRACKED_VALUE_`. This keeps the number of time
+series bounded regardless of how many distinct values workloads use.
 
 ## Example: label by team
 
@@ -93,11 +113,40 @@ Using the configuration above with `name: team`:
     kueue_admitted_workloads_total{custom_team="platform"}
     ```
 
+## Example: break down workloads by type
+
+`Workload` labels split a workload count metric by a label or annotation carried
+by individual workloads instead of by a queue. Currently they apply to the
+`kueue_admitted_active_workloads` metric.
+
+Using the `workload_type` entry from the configuration above:
+
+1. Submit jobs carrying the `company.com/workload-type` label to a ClusterQueue
+   `cq-1` labeled `team=platform`.
+
+2. `kueue_admitted_active_workloads` carries both `custom_team` (from the
+   ClusterQueue) and `custom_workload_type` (from each workload). With 10 active
+   `inference` workloads, 20 `training`, and 3 with some other value:
+
+    ```
+    kueue_admitted_active_workloads{cluster_queue="cq-1", ..., custom_team="platform", custom_workload_type="inference"} 10
+    kueue_admitted_active_workloads{cluster_queue="cq-1", ..., custom_team="platform", custom_workload_type="training"} 20
+    kueue_admitted_active_workloads{cluster_queue="cq-1", ..., custom_team="platform", custom_workload_type="kueue.x-k8s.io/_UNTRACKED_VALUE_"} 3
+    ```
+
+3. Aggregate by workload type:
+
+    ```promql
+    sum by (custom_workload_type) (kueue_admitted_active_workloads)
+    ```
+
 {{% alert title="Cardinality considerations" color="warning" %}}
 Each unique combination of label values creates a separate time series in
 Prometheus. Keep the number of distinct values low (e.g. team names, cost
-centers) to avoid excessive cardinality. Avoid using high-cardinality values
-such as user IDs or timestamps.
+centers, a small set of workload types) to avoid excessive cardinality. Avoid
+using high-cardinality values such as user IDs or timestamps. For `Workload`
+labels, list only the values you need in `trackedValues`; everything else is
+grouped under `kueue.x-k8s.io/_UNTRACKED_VALUE_`.
 {{% /alert %}}
 
 ## What's next


### PR DESCRIPTION
Extend the Custom Metric Labels task page to cover the new Workload source kind (sourceKind and trackedValues): how workload label values are sourced from the underlying job, why tracked values are required and how out-of-list values map to the untracked-value sentinel, the per-source-kind limits, and an example breaking down kueue_admitted_active_workloads by workload type.

#### What type of PR is this?
/kind documentation
/area website


#### What this PR does / why we need it:
Documents the new `Workload` source kind for custom metric labels (`sourceKind`,
`trackedValues`, the untracked-value sentinel, per-source-kind limits, and a
`kueue_admitted_active_workloads` breakdown example), and notes on the Prometheus
Metrics reference page that supported metrics can gain `custom_*` labels when the
`CustomMetricLabels` gate is enabled.

#### Which issue(s) this PR fixes:

Fixes #13282 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented support for custom metric labels sourced from Workload metadata, alongside existing resource sources.
  * Added configuration guidance for selecting label sources and tracking specific values.
  * Clarified label resolution, missing values, untracked values, and cardinality limits.
  * Added an example for analyzing active workloads by a custom Workload-derived label.
  * Updated Prometheus metrics documentation to explain custom labels and runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->