### PR TITLE
Use common hack helpers for populator cluster lifecycle

### DIFF
--- a/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
+++ b/cmd/experimental/kueue-populator/test/verify-helm-lifecycle.sh
@@ -23,31 +23,43 @@ ROOT_DIR=$(realpath "$SCRIPT_DIR/../../../..")
 KIND_CLUSTER_NAME="kueue-populator-verify-helm"
 GIT_TAG=$(git describe --tags --dirty --always)
 
-# Use tools from the root project
-KIND="$ROOT_DIR/bin/kind"
-HELM="$ROOT_DIR/bin/helm"
+# E2E_KIND_VERSION is the kind node image (e.g. kindest/node:v1.36.1) and selects
+# the Kubernetes version of the cluster. Like every other cluster-creating path in
+# the repo, it is provided by the build system (the Makefile derives it from the
+# K8s version). A fallback keeps direct execution working. See #13296 / #13291.
+export E2E_KIND_VERSION="${E2E_KIND_VERSION:-kindest/node:v1.36.1}"
+# ARTIFACTS is where the shared helpers write cluster logs.
+export ARTIFACTS="${ARTIFACTS:-$ROOT_DIR/artifacts}"
+mkdir -p "$ARTIFACTS"
 
-# Ensure tools are built
+# Build the tools the shared helpers need before sourcing them: e2e-common.sh
+# reads config/components/manager/kustomization.yaml with yq at source time, so
+# it must run from ROOT_DIR with yq and kustomize already present. Tool versions
+# are resolved via the root Makefile (go list), consistent with the rest of the repo.
 echo "Ensuring tools are available..."
 cd "$ROOT_DIR"
-# Pass explicit versions to bypass broken 'go list' in hack/tools
-make kind helm KIND_VERSION=v0.32.0 HELM_VERSION=v4.2.0
+make kind helm yq kustomize
+
+# Reuse the common cluster lifecycle helpers so tooling versions and cluster
+# creation stay consistent with the rest of the build system. e2e-common.sh
+# resolves some paths relative to SOURCE_DIR (its own directory) and the current
+# working directory (ROOT_DIR).
+SOURCE_DIR="$ROOT_DIR/hack/testing"
+# shellcheck source=/dev/null
+source "$SOURCE_DIR/e2e-common.sh"
+
+KIND_CONFIG="$SOURCE_DIR/kind-cluster.yaml"
+
 cd "$SCRIPT_DIR/.."
 
 function cleanup {
   echo "Cleaning up Kind cluster..."
-  "$KIND" delete cluster --name "$KIND_CLUSTER_NAME" 2>/dev/null || true
+  cluster_cleanup "$KIND_CLUSTER_NAME"
 }
 trap cleanup EXIT
 
-echo "Creating Kind cluster..."
-# Delete existing cluster if any
-"$KIND" delete cluster --name "$KIND_CLUSTER_NAME" 2>/dev/null || true
-if [[ -n "${E2E_KIND_VERSION:-}" ]]; then
-  "$KIND" create cluster --name "$KIND_CLUSTER_NAME" --image "$E2E_KIND_VERSION"
-else
-  "$KIND" create cluster --name "$KIND_CLUSTER_NAME"
-fi
+echo "Creating Kind cluster (node image: $E2E_KIND_VERSION)..."
+ensure_kind_cluster "$KIND_CLUSTER_NAME" "$KIND_CONFIG" ""
 
 echo "Building and loading kueue-populator image..."
 make kind-image-build


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

The kueue-populator Helm lifecycle test created its Kind cluster by hand (`kind create cluster`) and pinned tool versions manually. This meant it did not follow the same process as the rest of the repo, and it ignored the configured Kubernetes version.

This PR makes the script reuse the common helpers in `hack/testing/e2e-common.sh`:
- Creates the cluster with `ensure_kind_cluster` (using the pinned `E2E_KIND_VERSION` node image).
- Deletes the cluster with `cluster_cleanup`.
- Resolves the kind/helm/yq/kustomize tool versions via `go list` (the same way core does), instead of hardcoding them.

This keeps the populator tests consistent with the rest of the build system, so we only have one build process to maintain.

#### Which issue(s) this PR fixes:

Fixes #13296

#### Special notes for your reviewer: 

- Addresses @mimowo's review comment from [#13298](https://github.com/kubernetes-sigs/kueue/pull/13298#discussion_r3625157964), tool versions now resolve via `go list` (Makefile-deps.mk), the same way core does.
- Removing the version pins means helm now resolves to v3.21.0 (via `go list`) instead of the previously pinned v4.2.0. This is intentional and I verified the full install/test/uninstall lifecycle passes locally. 


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm lifecycle verification reliability by using shared end-to-end cluster setup and cleanup helpers.
  * Added configurable defaults for the Kind node image and the artifacts/output directory.
  * Ensured the required Helm and related tools are built and available consistently before verification runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->