### PR TITLE
test: move WAS e2e to the scheduling.k8s.io/v1beta1 PodGroup API

### DIFF
--- a/cmd/experimental/skills/was-cluster/SKILL.md
+++ b/cmd/experimental/skills/was-cluster/SKILL.md
@@ -49,7 +49,7 @@ Note: only `singlecluster/was` (Job integration) exists today. The former `was/e
 (JobSet) suite asserted against the upstream `scheduling.k8s.io/v1alpha3` Go types
 directly, which would have required vendoring that alpha API into Kueue, so it was
 removed. Re-add JobSet coverage once there's a way to verify it without vendoring
-`v1alpha3`.
+the upstream types.
 
 The `singlecluster/was` package lives under `test/e2e/singlecluster/` (rather than a
 top-level `test/e2e/was/`) so that `make test-e2e-k8s-main-was` — which targets the
@@ -57,7 +57,7 @@ whole `singlecluster` tree with `WAS_ENABLED=true` — actually runs it. Regular
 non-WAS runs (`make test-e2e-baseline`, `make test-e2e-extended`) target only the
 `singlecluster/baseline` and `singlecluster/extended` subfolders respectively, so
 they never pick up `singlecluster/was`, which requires feature gates
-(`GenericWorkload`, `WorkloadWithJob`) and the `scheduling.k8s.io/v1alpha3` API that
+(`GenericWorkload`, `WorkloadWithJob`) and the `scheduling.k8s.io/v1beta1` API that
 only a WAS-patched cluster provides.
 
 ### WAS-specific environment variables
@@ -67,7 +67,7 @@ These are specific to WAS; see the guideline link above for the rest.
 | Variable | Value | Why |
 |----------|-------|-----|
 | `E2E_KIND_VERSION` | `kindest/node:was-main` | Uses pre-built node image; skips `build_kind_node_image` (non-standard name) |
-| `WAS_ENABLED` | `1` | Triggers `patch_kind_config_for_was` adding the `GenericWorkload`/`WorkloadWithJob` feature gates and `scheduling.k8s.io/v1alpha3` runtime-config |
+| `WAS_ENABLED` | `1` | Triggers `patch_kind_config_for_was` adding the `GenericWorkload`/`WorkloadWithJob` feature gates and `scheduling.k8s.io/v1beta1` runtime-config |
 | `KIND_CLUSTER_NAME` | `was-test` | Cluster name |
 | `KIND_CLUSTER_FILE` | `kind-cluster.yaml` | Base kind config that gets patched by `patch_kind_config_for_was` |
 | `E2E_TARGET_FOLDER` | `singlecluster/was` | Points at the WAS test folder |
@@ -100,6 +100,6 @@ kind delete cluster --name was-test
 ## Troubleshooting
 
 - **`kind create` fails with kubeadm v1beta3 error**: You need `kind` >= v0.32.0. Check with `kind version`.
-- **`scheduling.k8s.io/v1alpha3` not in `kubectl api-resources`**: The k8s checkout must be at `main` (post v1alpha2→v1alpha3 rename). Rebuild the node image.
+- **`scheduling.k8s.io/v1beta1` not in `kubectl api-resources`**: The k8s checkout must be at `main` (post WAS beta graduation). Rebuild the node image.
 - **No PodGroups created for Jobs**: Jobs must qualify for gang scheduling: `parallelism > 1`, `completionMode: Indexed`, `completions == parallelism`. This is the `WorkloadWithJob` feature gate behavior (KEP-5547). Verify both gates landed on the controller-manager: `kubectl -n kube-system get pod -l component=kube-controller-manager -o jsonpath='{.items[0].spec.containers[0].command}' | tr ' ' '\n' | grep feature-gates` should show `GenericWorkload=true,WorkloadWithJob=true`.
 - **`ARTIFACTS: unbound variable` / `IMAGE_TAG: unbound variable` / `E2E_USE_HELM: unbound variable` / `GINKGO_ARGS: unbound variable`**: `e2e-test.sh` has `set -o nounset` and relies on `make` to default these. Set them explicitly when invoking the script directly (see Step 2 above).

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -505,7 +505,7 @@ apiServer:
   - name: enable-aggregator-routing
     value: \"true\"
   - name: runtime-config
-    value: \"scheduling.k8s.io/v1alpha3=true\"
+    value: \"scheduling.k8s.io/v1beta1=true\"
   - name: v
     value: \"3\"
 "' "$patched_config"
@@ -521,7 +521,7 @@ controllerManager:
 apiServer:
   extraArgs:
     enable-aggregator-routing: \"true\"
-    runtime-config: \"scheduling.k8s.io/v1alpha3=true\"
+    runtime-config: \"scheduling.k8s.io/v1beta1=true\"
     v: \"3\"
 "]' "$patched_config"
 

--- a/test/e2e/singlecluster/was/job_test.go
+++ b/test/e2e/singlecluster/was/job_test.go
@@ -41,7 +41,7 @@ import (
 // The tests require:
 // - A kind cluster built from Kubernetes main (not a release)
 // - The GenericWorkload and WorkloadWithJob feature gates enabled
-// - The scheduling.k8s.io/v1alpha3 API enabled via runtime-config
+// - The scheduling.k8s.io/v1beta1 API enabled via runtime-config
 // See hack/testing/kind-cluster-was.yaml.
 var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", "feature:was", "feature:was-job"), func() {
 	var ns *corev1.Namespace
@@ -135,7 +135,7 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 				// The Job qualifies for gang scheduling (parallelism > 1, Indexed,
 				// completions == parallelism), so the upstream Job controller creates
 				// a PodGroup owned by the Job. We read it as unstructured data to
-				// avoid vendoring k8s.io/api/scheduling/v1alpha3 into Kueue.
+				// avoid vendoring k8s.io/api/scheduling/v1beta1 into Kueue.
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdWorkload := workloadForJob(g, jobKey)
 					g.Expect(createdWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
@@ -153,16 +153,16 @@ var _ = ginkgo.Describe("WorkloadAwareScheduling Job", ginkgo.Label("area:was", 
 	})
 })
 
-// podGroupListGVK identifies the upstream scheduling.k8s.io/v1alpha3 PodGroup
+// podGroupListGVK identifies the upstream scheduling.k8s.io/v1beta1 PodGroup
 // list kind. We deliberately query it as unstructured data (instead of
-// importing k8s.io/api/scheduling/v1alpha3) so that Kueue does not need to
-// vendor that alpha API just to observe it in this e2e test.
-// TODO: once these APIs graduate (targeting Kubernetes 1.37) and Kueue can
-// depend on a k8s.io/api release that vendors them cleanly, switch this back
-// to a structured client using the typed PodGroup/PodGroupList types.
+// importing k8s.io/api/scheduling/v1beta1) so that Kueue does not need to
+// vendor that API just to observe it in this e2e test.
+// TODO: once Kueue can depend on a k8s.io/api release that vendors the beta
+// types (Kubernetes 1.37), switch this back to a structured client using the
+// typed PodGroup/PodGroupList types.
 var podGroupListGVK = schema.GroupVersionKind{
 	Group:   "scheduling.k8s.io",
-	Version: "v1alpha3",
+	Version: "v1beta1",
 	Kind:    "PodGroupList",
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?


/kind failing-test
/area was
/area testing

#### What this PR does / why we need it:

The k8s-main scheduler now watches `scheduling.k8s.io/v1beta1` PodGroups, while the WAS kind config serves only `v1alpha3`. The scheduler therefore never becomes ready, leaving the cluster unable to schedule pods and causing the WAS periodics to time out downstream.

This PR moves the WAS e2e setup to `v1beta1` by updating the API server runtime config, the unstructured PodGroup GVK used by the Job test, and the was-cluster documentation.

The existing `GenericWorkload` and `WorkloadWithJob` feature-gate configuration remains unchanged.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13311

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Workload Aware Scheduling guide to reference the Kubernetes `scheduling.k8s.io/v1beta1` API and revised setup and troubleshooting guidance.

* **Bug Fixes**
  * Updated test cluster configuration and end-to-end validation to use the current `v1beta1` PodGroup API, improving compatibility with newer Kubernetes environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->