### PR TITLE
test: retry kind cluster bring-up on node readiness timeout

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -555,9 +555,13 @@ function cluster_create {
     fi
 
     local log_file="$ARTIFACTS/$cluster-create.log"
-    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 > \"$log_file\" 2>&1"
-    # Retry only known-transient failures so real bugs still fail fast (#11586, #12307, #12984).
-    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches"
+    # Include node readiness in each cluster bring-up attempt so transient
+    # readiness delays can reuse the existing cleanup and recreation path.
+    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 > \"$log_file\" 2>&1 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
+    # Retry recognized bring-up failures (#11586, #12307, #12984). Persistent
+    # failures producing a matching error will exhaust the configured retries
+    # before failing.
+    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches|timed out waiting for the condition on nodes/"
     local continue_if="grep -qE '${retriable_errors}' \"$log_file\""
     local cleanup_cmd="if [ -f \"$log_file\" ]; then mv \"$log_file\" \"${log_file}.failed-\$(date +%s)\"; fi; $KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
 
@@ -576,8 +580,6 @@ function cluster_create {
     fi
 
     kubectl config --kubeconfig="$kubeconfig" use-context "kind-$cluster"
-    # wait for nodes to become ready before loading images or deploying components
-    kubectl wait --kubeconfig="$kubeconfig" --for=condition=Ready node --all --timeout=5m
     kubectl get nodes --kubeconfig="$kubeconfig" > "$ARTIFACTS/$cluster-nodes.log" || true
     kubectl describe pods --kubeconfig="$kubeconfig" -n kube-system > "$ARTIFACTS/$cluster-system-pods.log" || true
 }

--- a/hack/testing/e2e-common_test.sh
+++ b/hack/testing/e2e-common_test.sh
@@ -72,12 +72,60 @@ case "$*" in
   *" create --dry-run=server -f "*)
     exit 0
     ;;
+  "wait --kubeconfig="*" --for=condition=Ready node --all"*)
+    attempts=$(cat "${NODE_WAIT_FAKE_STATE:?}")
+    attempts=$((attempts + 1))
+    printf '%s' "${attempts}" >"${NODE_WAIT_FAKE_STATE}"
+    if [[ "${attempts}" -lt "${NODE_WAIT_FAKE_READY_AFTER:-2}" ]]; then
+      printf 'timed out waiting for the condition on nodes/kind-control-plane\n'
+      exit 1
+    fi
+    printf 'node/kind-control-plane condition met\n'
+    exit 0
+    ;;
+  "config "*)
+    exit 0
+    ;;
+  "get nodes"*)
+    printf 'fake node list\n'
+    exit 0
+    ;;
+  "describe pods"*)
+    exit 0
+    ;;
 esac
 
 printf 'unexpected kubectl call: %s\n' "$*" >&2
 exit 1
 EOF
 chmod +x "${test_dir}/kubectl"
+
+cat >"${test_dir}/kind" <<'EOF'
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+printf '%s\n' "$*" >>"${KIND_FAKE_LOG:?}"
+
+case "$*" in
+  "create cluster "*)
+    if [[ -n "${KIND_FAKE_CREATE_ERROR:-}" ]]; then
+      printf '%s\n' "${KIND_FAKE_CREATE_ERROR}"
+      exit 1
+    fi
+    printf 'Creating cluster ...\n'
+    exit 0
+    ;;
+  "delete cluster "*)
+    exit 0
+    ;;
+esac
+
+printf 'unexpected kind call: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "${test_dir}/kind"
 
 # shellcheck source=hack/testing/e2e-common.sh
 source "${ROOT_DIR}/hack/testing/e2e-common.sh"
@@ -116,6 +164,83 @@ if [[ -z "${endpoint_line}" || -z "${probe_line}" ]]; then
 fi
 if [[ "${endpoint_line}" -ge "${probe_line}" ]]; then
   echo "expected Kueue EndpointSlice check to run before the dry-run webhook probe" >&2
+  exit 1
+fi
+
+# cluster_create retries the bring-up when the node readiness wait times out.
+export KIND="${test_dir}/kind"
+KIND_FAKE_LOG="${test_dir}/kind.log"
+NODE_WAIT_FAKE_STATE="${test_dir}/node-wait-state"
+export KIND_FAKE_LOG NODE_WAIT_FAKE_STATE
+: >"${KIND_FAKE_LOG}"
+printf '0' >"${NODE_WAIT_FAKE_STATE}"
+export ARTIFACTS="${test_dir}/artifacts"
+mkdir -p "${ARTIFACTS}"
+
+cluster_create "flake-test" "unused-kind-config.yaml" ""
+
+create_attempts=$(grep -c "^create cluster" "${KIND_FAKE_LOG}" || true)
+if [[ "${create_attempts}" != "2" ]]; then
+  echo "expected cluster creation to be retried after a node readiness timeout; got ${create_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+node_wait_attempts=$(cat "${NODE_WAIT_FAKE_STATE}")
+if [[ "${node_wait_attempts}" != "2" ]]; then
+  echo "expected the node readiness wait to run once per bring-up attempt; got ${node_wait_attempts} run(s)" >&2
+  exit 1
+fi
+
+if ! ls "${ARTIFACTS}"/flake-test-create.log.failed-* >/dev/null 2>&1; then
+  echo "expected the failed bring-up log to be archived before the retry" >&2
+  exit 1
+fi
+
+# A bring-up failure matching no retriable error aborts after a single attempt.
+: >"${KIND_FAKE_LOG}"
+export KIND_FAKE_CREATE_ERROR="node(s) already exist for a cluster with the name"
+if cluster_create "failfast-test" "unused-kind-config.yaml" ""; then
+  echo "expected cluster_create to fail on a non-retriable error" >&2
+  exit 1
+fi
+unset KIND_FAKE_CREATE_ERROR
+
+create_attempts=$(grep -c "^create cluster" "${KIND_FAKE_LOG}" || true)
+if [[ "${create_attempts}" != "1" ]]; then
+  echo "expected a non-retriable failure to fail fast without retrying; got ${create_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+# A persistent node readiness timeout exhausts all bring-up attempts and fails.
+: >"${KIND_FAKE_LOG}"
+printf '0' >"${NODE_WAIT_FAKE_STATE}"
+export NODE_WAIT_FAKE_READY_AFTER=99
+if cluster_create "persistent-test" "unused-kind-config.yaml" ""; then
+  echo "expected cluster_create to fail when nodes never become ready" >&2
+  exit 1
+fi
+unset NODE_WAIT_FAKE_READY_AFTER
+
+create_attempts=$(grep -c "^create cluster" "${KIND_FAKE_LOG}" || true)
+if [[ "${create_attempts}" != "3" ]]; then
+  echo "expected a persistent readiness timeout to exhaust all attempts; got ${create_attempts} attempt(s)" >&2
+  exit 1
+fi
+
+node_wait_attempts=$(cat "${NODE_WAIT_FAKE_STATE}")
+if [[ "${node_wait_attempts}" != "3" ]]; then
+  echo "expected the node readiness wait to run once per bring-up attempt; got ${node_wait_attempts} run(s)" >&2
+  exit 1
+fi
+
+archived_count=$(find "${ARTIFACTS}" -name "persistent-test-create.log.failed-*" | wc -l | tr -d ' ')
+if [[ "${archived_count}" != "2" ]]; then
+  echo "expected the first two attempts' logs to be archived; got ${archived_count}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${ARTIFACTS}/persistent-test-create.log" ]]; then
+  echo "expected the final attempt's log to remain for failure reporting" >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind flake
/area testing

#### What this PR does / why we need it:

`cluster_create` retries known kind bring-up failures, but the node readiness wait currently runs after the retried operation. A transient readiness timeout can therefore leave setup continuing on an unusable cluster and surface later as an unrelated component timeout.

This PR moves the node readiness wait into each bring-up attempt, captures its output in the creation log, and reuses the existing cleanup and recreation path when the wait times out.

It also adds regression coverage for both the retry path and a non-retriable failure that should stop after one attempt.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #13311

The deterministic failure in #13311 is fixed separately by the PodGroup v1beta1 PR; this PR contains only the generic CI hardening discovered during that investigation.

#### Special notes for your reviewer:

A persistent failure producing the same node-readiness timeout will exhaust the configured retries before failing. Propagating the final background startup status in the singlecluster path is a separate follow-up.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster creation reliability by enforcing “node Ready” checks as part of the bring-up process.
  - Expanded retry handling to cover additional node readiness timeout failures.
  - Preserves failed bring-up logs across retries for easier troubleshooting.
  - Continues to fail fast for non-retriable cluster creation errors.
- **Tests**
  - Enhanced end-to-end fakes for node readiness waiting and `kind` invocation logging.
  - Added/extended coverage for retry behavior, log archival on failures, and exhausting retries when readiness never becomes Ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->