### PR TITLE
Replace explicit MapRequests with Requests interface

### DIFF
--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -197,8 +197,10 @@ func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq 
 			},
 		}
 		flv := cq.Spec.ResourceGroups[0].Flavors[0].Name
-		for r := range info.TotalRequests[0].Requests {
-			admission.PodSetAssignments[0].Flavors[r] = flv
+		if info.TotalRequests[0].Requests != nil {
+			info.TotalRequests[0].Requests.ForEach(func(name corev1.ResourceName, val int64) {
+				admission.PodSetAssignments[0].Flavors[name] = flv
+			})
 		}
 
 		wl.Status.Admission = &admission

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -445,7 +445,7 @@ func draRequestsChanged(oldInfo, newInfo *workload.Info) bool {
 	if !features.Enabled(features.KueueDRAIntegration) {
 		return false
 	}
-	return !equality.Semantic.DeepEqual(oldInfo.TotalRequests, newInfo.TotalRequests)
+	return !workload.Semantic.DeepEqual(oldInfo.TotalRequests, newInfo.TotalRequests)
 }
 
 func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
@@ -486,16 +486,20 @@ func (c *ClusterQueue) backoffWaitingTimeExpired(wInfo *workload.Info) bool {
 
 func (c *ClusterQueue) addPendingResources(wInfo *workload.Info) {
 	for _, ps := range wInfo.TotalRequests {
-		for name, q := range ps.Requests {
-			c.pendingResourcesTotal[name] += q
+		if ps.Requests != nil {
+			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+				c.pendingResourcesTotal[name] += q
+			})
 		}
 	}
 }
 
 func (c *ClusterQueue) subtractPendingResources(wInfo *workload.Info) {
 	for _, ps := range wInfo.TotalRequests {
-		for name, q := range ps.Requests {
-			c.pendingResourcesTotal[name] -= q
+		if ps.Requests != nil {
+			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+				c.pendingResourcesTotal[name] -= q
+			})
 		}
 	}
 }
@@ -670,8 +674,10 @@ func (c *ClusterQueue) pendingResources() map[corev1.ResourceName]int64 {
 	result := maps.Clone(c.pendingResourcesTotal)
 	if c.inflight != nil {
 		for _, ps := range c.inflight.TotalRequests {
-			for name, q := range ps.Requests {
-				result[name] += q
+			if ps.Requests != nil {
+				ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+					result[name] += q
+				})
 			}
 		}
 	}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -670,12 +670,12 @@ func TestPendingResources(t *testing.T) {
 	}
 
 	// Sum should equal wl1 + wl2 + wl3: CPU = 2+1+3 = 6000m, Memory = 1Gi+512Mi+2Gi.
-	wantCPU := wl1.TotalRequests[0].Requests[corev1.ResourceCPU] +
-		wl2.TotalRequests[0].Requests[corev1.ResourceCPU] +
-		wl3.TotalRequests[0].Requests[corev1.ResourceCPU]
-	wantMemory := wl1.TotalRequests[0].Requests[corev1.ResourceMemory] +
-		wl2.TotalRequests[0].Requests[corev1.ResourceMemory] +
-		wl3.TotalRequests[0].Requests[corev1.ResourceMemory]
+	wantCPU := wl1.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU) +
+		wl2.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU) +
+		wl3.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU)
+	wantMemory := wl1.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory) +
+		wl2.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory) +
+		wl3.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory)
 	if got[corev1.ResourceCPU] != wantCPU {
 		t.Errorf("CPU mismatch: want %d, got %d", wantCPU, got[corev1.ResourceCPU])
 	}

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -476,7 +476,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.MapRequests{corev1.ResourceCPU: 5000},
+									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 5000}),
 									Count:    1,
 									Flavors:  map[corev1.ResourceName]kueue.ResourceFlavorReference{corev1.ResourceCPU: "default"},
 								},
@@ -920,7 +920,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.MapRequests{corev1.ResourceCPU: 1000},
+									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -933,7 +933,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.MapRequests{corev1.ResourceCPU: 1000},
+									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -1068,6 +1068,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 				cmpopts.IgnoreFields(clusterQueue{}, "ResourceGroups"),
 				cmpopts.IgnoreFields(workload.Info{}, "Obj", "LastAssignment", "SchedulingHash"),
 				cmpopts.IgnoreUnexported(clusterQueue{}, hierarchy.ClusterQueue[*cohort]{}),
+				cmp.Comparer(resources.Equal),
 				cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("Unexpected clusterQueues (-want,+got):\n%s", diff)
 			}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -195,14 +195,22 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 		domainID := utiltas.DomainID(tr.Values)
 		_, found := c.usage[domainID]
 		if !found {
-			c.usage[domainID] = resources.MapRequests{}
+			c.usage[domainID] = resources.CreateEmpty()
 		}
 		if op == subtract {
 			c.usage[domainID].Sub(tr.TotalRequests())
-			c.usage[domainID].Sub(resources.MapRequests{corev1.ResourcePods: int64(tr.Count)})
+			c.usage[domainID].Sub(
+				resources.NewRequestsFromMap(
+					resources.MapRequests{corev1.ResourcePods: int64(tr.Count)},
+				),
+			)
 		} else {
 			c.usage[domainID].Add(tr.TotalRequests())
-			c.usage[domainID].Add(resources.MapRequests{corev1.ResourcePods: int64(tr.Count)})
+			c.usage[domainID].Add(
+				resources.NewRequestsFromMap(
+					resources.MapRequests{corev1.ResourcePods: int64(tr.Count)},
+				),
+			)
 		}
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -39,26 +39,26 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 	snapshot := &TASFlavorSnapshot{
 		leaves: leafDomainByID{
 			"domain2": &leafDomain{
-				freeCapacity: resources.MapRequests{
+				freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
-				},
-				tasUsage: resources.MapRequests{
+				}),
+				tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
 					corev1.ResourceCPU:    500,
-				},
+				}),
 			},
 			"domain1": &leafDomain{
-				freeCapacity: resources.MapRequests{
+				freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
 					corev1.ResourceCPU:    2000,
 					"nvidia.com/gpu":      1,
-				},
-				tasUsage: resources.MapRequests{
+				}),
+				tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    500,
 					"nvidia.com/gpu":      1,
 					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
-				},
+				}),
 			},
 		},
 	}
@@ -751,10 +751,10 @@ func TestCountPodsInAssignment(t *testing.T) {
 }
 
 func TestComputeAssumedUsageFromAssignment(t *testing.T) {
-	singlePodRequests := resources.MapRequests{
+	singlePodRequests := resources.NewRequestsFromMap(resources.MapRequests{
 		corev1.ResourceCPU:    1000,
 		corev1.ResourceMemory: 1024,
-	}
+	})
 
 	cases := map[string]struct {
 		assignment *tas.TopologyAssignment
@@ -775,11 +775,11 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 				},
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 1024,
 					corev1.ResourcePods:   1,
-				},
+				}),
 			},
 		},
 		"multiple domains": {
@@ -791,16 +791,16 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 				},
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    2000,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
-				},
-				"node-b": resources.MapRequests{
+				}),
+				"node-b": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    3000,
 					corev1.ResourceMemory: 3072,
 					corev1.ResourcePods:   3,
-				},
+				}),
 			},
 		},
 	}
@@ -808,7 +808,7 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tas.ComputeUsagePerDomain(tc.assignment, singlePodRequests)
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("ComputeUsagePerDomain() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -824,10 +824,10 @@ func TestAddAssumedUsage(t *testing.T) {
 	}{
 		"includes pod count for existing and new domains": {
 			assumedUsage: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:  1000,
 					corev1.ResourcePods: 1,
-				},
+				}),
 			},
 			assignment: &tas.TopologyAssignment{
 				Levels: []string{"hostname"},
@@ -837,22 +837,22 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.MapRequests{
+				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    500,
 					corev1.ResourceMemory: 2048,
-				},
+				}),
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    1500,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
-				},
-				"node-b": resources.MapRequests{
+				}),
+				"node-b": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 4096,
 					corev1.ResourcePods:   2,
-				},
+				}),
 			},
 		},
 		"includes pod count starting from empty assumed usage": {
@@ -864,36 +864,25 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.MapRequests{
+				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    250,
 					corev1.ResourceMemory: 512,
-				},
+				}),
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:    750,
 					corev1.ResourceMemory: 1536,
 					corev1.ResourcePods:   3,
-				},
+				}),
 			},
 		},
 	}
 
-	equateRequests := cmp.Transformer("Requests", func(r resources.Requests) map[corev1.ResourceName]int64 {
-		if r == nil {
-			return nil
-		}
-		m := make(map[corev1.ResourceName]int64)
-		r.ForEach(func(name corev1.ResourceName, val int64) {
-			m[name] = val
-		})
-		return m
-	})
-
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			addAssumedUsage(tc.assumedUsage, tc.assignment, tc.tasRequests)
-			if diff := cmp.Diff(tc.want, tc.assumedUsage, equateRequests); diff != "" {
+			if diff := cmp.Diff(tc.want, tc.assumedUsage, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -1037,9 +1026,9 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			flavorUsage := workload.TASFlavorUsage{
 				{
 					Values: []string{"node-a"},
-					SinglePodRequests: resources.MapRequests{
+					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU: 5000,
-					},
+					}),
 					Count: 1,
 				},
 			}
@@ -1048,9 +1037,9 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
 
 			// Add TAS usage of 4 CPU (4000m), leaving 4 CPU (8000m - 4000m = 4000m) remaining
-			usage := resources.MapRequests{
+			usage := resources.NewRequestsFromMap(resources.MapRequests{
 				corev1.ResourceCPU: 4000,
-			}
+			})
 			snapshot.updateTASUsage(domainID, usage, add, 1)
 
 			// Fits should now return false because 5 CPU > 4 CPU remaining

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -45,17 +45,17 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  2,
-						SinglePodRequests: resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 2,
-						},
+						}),
 					},
 				})
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:  4,
 					corev1.ResourcePods: 2,
-				},
+				}),
 			},
 		},
 		{
@@ -66,9 +66,9 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 1,
-						},
+						}),
 					},
 				})
 				// Self-healing add (replaces existing usage)
@@ -76,21 +76,21 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain2"},
 						Count:  2,
-						SinglePodRequests: resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 3,
-						},
+						}),
 					},
 				})
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
-				},
-				"domain2": resources.MapRequests{
+				}),
+				"domain2": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:  6,
 					corev1.ResourcePods: 2,
-				},
+				}),
 			},
 		},
 		{
@@ -100,18 +100,18 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 1,
-						},
+						}),
 					},
 				})
 				cache.removeUsage(logr, wlKey)
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
-				},
+				}),
 			},
 		},
 		{
@@ -132,7 +132,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 
 			tc.operations(cache)
 
-			if diff := cmp.Diff(tc.wantUsage, cache.usage, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantUsage, cache.usage, cmpopts.EquateEmpty(), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected usage (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -97,7 +97,7 @@ func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources
 // Must be called under write lock.
 func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 	if _, found := n.nodeUsage[node]; !found {
-		n.nodeUsage[node] = resources.MapRequests{}
+		n.nodeUsage[node] = resources.CreateEmpty()
 	}
 	n.nodeUsage[node].Add(usage)
 	n.nodeUsage[node].Add(resources.OnePodRequest)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -36,13 +36,13 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	expected := make(map[string]resources.Requests)
 	for _, pv := range cache.podUsage {
 		if _, found := expected[pv.node]; !found {
-			expected[pv.node] = resources.MapRequests{}
+			expected[pv.node] = resources.CreateEmpty()
 		}
 		expected[pv.node].Add(pv.usage)
 		expected[pv.node].Add(resources.OnePodRequest)
 	}
 	got := collectNodeUsage(cache)
-	if diff := cmp.Diff(expected, got); diff != "" {
+	if diff := cmp.Diff(expected, got, cmp.Comparer(resources.Equal)); diff != "" {
 		t.Errorf("nodeUsage inconsistent with podUsage (-recomputed +nodeUsage):\n%s", diff)
 	}
 }
@@ -94,7 +94,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod2", "ns", "node-a", "2"),
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.MapRequests{corev1.ResourceCPU: 3000, corev1.ResourcePods: 2},
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 3000, corev1.ResourcePods: 2}),
 			},
 		},
 		"pod moves between nodes cleans up source node": {
@@ -103,7 +103,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.NodeName = "node-b"
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-b": resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+				"node-b": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
 			},
 		},
 		"pod resize on same node updates usage to new requests": {
@@ -112,7 +112,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1},
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
 			},
 		},
 		"resize one of two pods on same node updates only that pod's contribution": {
@@ -124,7 +124,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("3")
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.MapRequests{corev1.ResourceCPU: 5000, corev1.ResourcePods: 2},
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 5000, corev1.ResourcePods: 2}),
 			},
 		},
 		"terminated pod removes usage": {
@@ -143,7 +143,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			},
 			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.MapRequests{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1},
+				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1}),
 			},
 		},
 		"removing last pod cleans up node entry": {
@@ -185,7 +185,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			if wantUsage == nil {
 				wantUsage = map[string]resources.Requests{}
 			}
-			if diff := cmp.Diff(wantUsage, collectNodeUsage(cache)); diff != "" {
+			if diff := cmp.Diff(wantUsage, collectNodeUsage(cache), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("collectNodeUsage() mismatch (-want +got):\n%s", diff)
 			}
 

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1947,7 +1947,8 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 
 									if tc.wantDRAResourceTotal != nil {
 										if len(wlInfo.TotalRequests) > 0 && wlInfo.TotalRequests[0].Requests != nil {
-											if gpuVal, hasGPU := wlInfo.TotalRequests[0].Requests["gpu"]; hasGPU {
+											gpuVal := wlInfo.TotalRequests[0].Requests.GetValue("gpu")
+											if gpuVal > 0 {
 												if gpuVal != *tc.wantDRAResourceTotal {
 													t.Errorf("Expected gpu resource total to be %d, got %d", *tc.wantDRAResourceTotal, gpuVal)
 												}

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -55,8 +55,8 @@ type celDeviceRequest struct {
 // total number of devices requested for each DeviceClass inside the provided
 // ResourceClaimSpec. Returns field errors for unsupported request features
 // (FirstAvailable, AdminAccess, AllocationMode All).
-func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.MapRequests, field.ErrorList) {
-	out := resources.MapRequests{}
+func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, field.ErrorList) {
+	out := resources.CreateEmpty()
 	if claimSpec == nil {
 		return out, nil
 	}
@@ -119,7 +119,7 @@ func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Ma
 		// apiserver accepts up to MaxInt64), so accumulate with a saturating add
 		// (matching the scheduler's Amount arithmetic) rather than letting the
 		// sum wrap to a negative count.
-		out[dc] = utilmath.SaturatingAdd(out[dc], q)
+		out.Set(dc, utilmath.SaturatingAdd(out.GetValue(dc), q))
 	}
 	return out, nil
 }
@@ -209,7 +209,7 @@ func GetResourceRequestsForResourceClaimTemplates(
 				return nil, allErrs
 			}
 
-			for dc, qty := range deviceCounts {
+			for dc, qty := range resources.ToMapRequests(deviceCounts) {
 				logical, found := mapper.Lookup(dc)
 				if !found {
 					allErrs = append(allErrs, field.NotFound(

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -765,7 +765,7 @@ func Test_countDevicesPerClass_overflow(t *testing.T) {
 			if len(errs) != 0 {
 				t.Fatalf("unexpected errors: %v", errs)
 			}
-			if got := out["gpu"]; got != tc.wantCount {
+			if got := out.GetValue("gpu"); got != tc.wantCount {
 				t.Errorf("count = %d, want %d", got, tc.wantCount)
 			}
 		})

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -17,8 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"maps"
-
 	corev1 "k8s.io/api/core/v1"
 	resourcehelpers "k8s.io/component-helpers/resource"
 
@@ -27,7 +25,19 @@ import (
 
 // Equal reports whether two Requests objects are Equal.
 func Equal(a, b Requests) bool {
-	return maps.Equal(ToMapRequests(a), ToMapRequests(b))
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil || a.Len() != b.Len() {
+		return false
+	}
+	equal := true
+	a.ForEach(func(name corev1.ResourceName, val int64) {
+		if equal && b.GetValue(name) != val {
+			equal = false
+		}
+	})
+	return equal
 }
 
 // CreateEmpty creates an empty Requests instance based on feature gates.
@@ -62,7 +72,7 @@ func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 // NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
 func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
-		return nil
+		return CreateEmpty()
 	}
 	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
 	return NewRequestsFromResourceList(rl)

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -17,11 +17,18 @@ limitations under the License.
 package resources
 
 import (
+	"maps"
+
 	corev1 "k8s.io/api/core/v1"
 	resourcehelpers "k8s.io/component-helpers/resource"
 
 	"sigs.k8s.io/kueue/pkg/features"
 )
+
+// Equal reports whether two Requests objects are Equal.
+func Equal(a, b Requests) bool {
+	return maps.Equal(ToMapRequests(a), ToMapRequests(b))
+}
 
 // CreateEmpty creates an empty Requests instance based on feature gates.
 func CreateEmpty() Requests {
@@ -45,9 +52,6 @@ func NewRequestsFromMap(m MapRequests) Requests {
 
 // NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
 func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
-	if len(rl) == 0 {
-		return nil
-	}
 	if features.Enabled(features.VectorizedResourceRequests) {
 		sr := ResourceListToSliceRequests(rl)
 		return &sr
@@ -69,14 +73,9 @@ func ToMapRequests(r Requests) MapRequests {
 	if isEmpty(r) {
 		return nil
 	}
-	if mr, ok := r.(MapRequests); ok {
-		return mr
-	}
 	res := make(MapRequests, r.Len())
 	r.ForEach(func(name corev1.ResourceName, val int64) {
-		if val != 0 {
-			res[name] = val
-		}
+		res[name] = val
 	})
 	return res
 }

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -24,14 +24,21 @@ import (
 type Requests interface {
 	Clone() Requests
 	ScaledUp(f int64) Requests
+	ScaledDown(f int64) Requests
 	Add(other Requests)
 	Sub(other Requests)
+	Divide(f int64)
+	Mul(f int64)
 	CountIn(capacity Requests) int32
 	CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName)
 	GetValue(name corev1.ResourceName) int64
+	Set(name corev1.ResourceName, val int64)
 	ForEach(fn func(name corev1.ResourceName, val int64))
 	Len() int
 	IsEmpty() bool
 	// FloorToZero replaces negative resource values with zero.
 	FloorToZero()
+	ToResourceList(formatter *ResourceFormatter) corev1.ResourceList
+	GreaterKeys(other Requests) []corev1.ResourceName
+	GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -64,7 +64,7 @@ func (r MapRequests) ScaledUp(f int64) Requests {
 	return ret
 }
 
-func (r MapRequests) ScaledDown(f int64) MapRequests {
+func (r MapRequests) ScaledDown(f int64) Requests {
 	ret := maps.Clone(r)
 	ret.Divide(f)
 	return ret
@@ -90,6 +90,13 @@ func (r MapRequests) Mul(f int64) {
 
 func (r MapRequests) GetValue(name corev1.ResourceName) int64 {
 	return r[name]
+}
+
+func (r MapRequests) Set(name corev1.ResourceName, val int64) {
+	if r == nil {
+		return
+	}
+	r[name] = val
 }
 
 func (r MapRequests) Len() int {
@@ -123,6 +130,9 @@ func (r MapRequests) Sub(other Requests) {
 }
 
 func (r MapRequests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
+	if len(r) == 0 {
+		return nil
+	}
 	ret := make(corev1.ResourceList, len(r))
 	for k, v := range r {
 		ret[k] = formatter.ResourceQuantity(k, v)
@@ -140,13 +150,14 @@ func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 }
 
 // GreaterKeys returns keys where the receiver is greater than other.
-func (r MapRequests) GreaterKeys(other MapRequests) []corev1.ResourceName {
-	if len(r) == 0 || len(other) == 0 {
+func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
+	if len(r) == 0 || isEmpty(other) {
 		return nil
 	}
+	otherMap := ToMapRequests(other)
 	var result []corev1.ResourceName
 	for name, value := range r {
-		if otherValue, found := other[name]; found && value > otherValue {
+		if otherValue, found := otherMap[name]; found && value > otherValue {
 			result = append(result, name)
 		}
 	}
@@ -158,7 +169,7 @@ func (r MapRequests) GreaterKeys(other MapRequests) []corev1.ResourceName {
 
 // GreaterKeysRL compares against a ResourceList and returns larger keys.
 func (r MapRequests) GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName {
-	return r.GreaterKeys(NewMapRequests(rl))
+	return r.GreaterKeys(NewRequestsFromResourceList(rl))
 }
 
 func (r MapRequests) CountIn(capacity Requests) int32 {

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -93,9 +93,6 @@ func (r MapRequests) GetValue(name corev1.ResourceName) int64 {
 }
 
 func (r MapRequests) Set(name corev1.ResourceName, val int64) {
-	if r == nil {
-		return
-	}
 	r[name] = val
 }
 

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -583,15 +583,8 @@ func TestFloorToZero(t *testing.T) {
 				r = &SliceRequests{}
 			}
 			r.FloorToZero()
-			// SliceRequests omits zero values on conversion; compare non-zero
-			// entries and assert no negatives remain.
 			got := ToMapRequests(r)
-			want := MapRequests{}
-			for k, v := range tc.want {
-				if v != 0 {
-					want[k] = v
-				}
-			}
+			want := tc.want
 			if len(want) == 0 {
 				want = nil
 			}
@@ -701,6 +694,43 @@ func TestMapRequestsGetValue(t *testing.T) {
 	}
 }
 
+func TestMapRequestsSet(t *testing.T) {
+	cases := map[string]struct {
+		initial  MapRequests
+		setKey   corev1.ResourceName
+		setValue int64
+		want     MapRequests
+	}{
+		"nil map set": {
+			initial:  nil,
+			setKey:   corev1.ResourceCPU,
+			setValue: 1000,
+			want:     nil,
+		},
+		"update existing resource": {
+			initial:  MapRequests{corev1.ResourceCPU: 1000},
+			setKey:   corev1.ResourceCPU,
+			setValue: 2000,
+			want:     MapRequests{corev1.ResourceCPU: 2000},
+		},
+		"insert new resource": {
+			initial:  MapRequests{corev1.ResourceCPU: 1000},
+			setKey:   corev1.ResourceMemory,
+			setValue: 1024,
+			want:     MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 1024},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			m := maps.Clone(tc.initial)
+			m.Set(tc.setKey, tc.setValue)
+			if diff := cmp.Diff(tc.want, m); diff != "" {
+				t.Errorf("Set mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestMapRequestsClone(t *testing.T) {
 	t.Run("nil map clone", func(t *testing.T) {
 		var m MapRequests
@@ -729,4 +759,82 @@ func TestMapRequestsClone(t *testing.T) {
 			t.Errorf("original map was mutated after modifying clone")
 		}
 	})
+}
+
+func TestToMapRequests(t *testing.T) {
+	cases := map[string]struct {
+		req  Requests
+		want MapRequests
+	}{
+		"nil requests": {
+			req:  nil,
+			want: nil,
+		},
+		"empty MapRequests": {
+			req:  MapRequests{},
+			want: nil,
+		},
+		"non-empty MapRequests": {
+			req:  MapRequests{corev1.ResourceCPU: 1000},
+			want: MapRequests{corev1.ResourceCPU: 1000},
+		},
+		"SliceRequests with non-zero values": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+			want: MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+		},
+		"MapRequests with zero values": {
+			req:  MapRequests{corev1.ResourceCPU: 0},
+			want: MapRequests{corev1.ResourceCPU: 0},
+		},
+		"SliceRequests with zero values": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 0}),
+			want: MapRequests{corev1.ResourceCPU: 0},
+		},
+		"SliceRequests with mixed zero and non-zero values": {
+			req:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 0}),
+			want: MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 0},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := ToMapRequests(tc.req)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ToMapRequests mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRequestsEqual(t *testing.T) {
+	m1 := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
+	m2 := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
+	m3 := MapRequests{corev1.ResourceCPU: 1000}
+
+	s1 := NewSliceRequests(m1)
+	s2 := NewSliceRequests(m2)
+	s3 := NewSliceRequests(m3)
+
+	tests := map[string]struct {
+		a, b Requests
+		want bool
+	}{
+		"both nil":                {a: nil, b: nil, want: true},
+		"nil and empty Map":       {a: nil, b: MapRequests{}, want: true},
+		"nil and empty Slice":     {a: nil, b: NewSliceRequests(MapRequests{}), want: true},
+		"equal MapRequests":       {a: m1, b: m2, want: true},
+		"equal SliceRequests":     {a: s1, b: s2, want: true},
+		"equal Map and Slice":     {a: m1, b: s2, want: true},
+		"equal Slice and Map":     {a: s1, b: m2, want: true},
+		"different MapRequests":   {a: m1, b: m3, want: false},
+		"different SliceRequests": {a: s1, b: s3, want: false},
+		"different Map and Slice": {a: m1, b: s3, want: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := Equal(tc.a, tc.b); got != tc.want {
+				t.Errorf("Equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
 }

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -701,12 +701,6 @@ func TestMapRequestsSet(t *testing.T) {
 		setValue int64
 		want     MapRequests
 	}{
-		"nil map set": {
-			initial:  nil,
-			setKey:   corev1.ResourceCPU,
-			setValue: 1000,
-			want:     nil,
-		},
 		"update existing resource": {
 			initial:  MapRequests{corev1.ResourceCPU: 1000},
 			setKey:   corev1.ResourceCPU,
@@ -819,8 +813,8 @@ func TestRequestsEqual(t *testing.T) {
 		want bool
 	}{
 		"both nil":                {a: nil, b: nil, want: true},
-		"nil and empty Map":       {a: nil, b: MapRequests{}, want: true},
-		"nil and empty Slice":     {a: nil, b: NewSliceRequests(MapRequests{}), want: true},
+		"nil and empty Map":       {a: nil, b: MapRequests{}, want: false},
+		"nil and empty Slice":     {a: nil, b: NewSliceRequests(MapRequests{}), want: false},
 		"equal MapRequests":       {a: m1, b: m2, want: true},
 		"equal SliceRequests":     {a: s1, b: s2, want: true},
 		"equal Map and Slice":     {a: m1, b: s2, want: true},

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -77,13 +77,11 @@ func toSliceRequests(r Requests) SliceRequests {
 	}
 	res := make(SliceRequests, 0, r.Len())
 	r.ForEach(func(name corev1.ResourceName, val int64) {
-		if val != 0 {
-			res = append(res, resourceEntry{
-				name:  name,
-				hash:  hashResourceName(name),
-				value: val,
-			})
-		}
+		res = append(res, resourceEntry{
+			name:  name,
+			hash:  hashResourceName(name),
+			value: val,
+		})
 	})
 	res.sort()
 	return res
@@ -96,14 +94,11 @@ func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
 	}
 	sr := make(SliceRequests, 0, len(rl))
 	for name, q := range rl {
-		val := ResourceValue(name, q)
-		if val != 0 {
-			sr = append(sr, resourceEntry{
-				name:  name,
-				hash:  hashResourceName(name),
-				value: val,
-			})
-		}
+		sr = append(sr, resourceEntry{
+			name:  name,
+			hash:  hashResourceName(name),
+			value: ResourceValue(name, q),
+		})
 	}
 	sr.sort()
 	return sr
@@ -116,9 +111,7 @@ func (sr *SliceRequests) ToMapRequests() MapRequests {
 	}
 	req := make(MapRequests, len(*sr))
 	for _, entry := range *sr {
-		if entry.value != 0 {
-			req[entry.name] = entry.value
-		}
+		req[entry.name] = entry.value
 	}
 	return req
 }
@@ -142,6 +135,19 @@ func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
 		return (*sr)[idx].value
 	}
 	return 0
+}
+
+func (sr *SliceRequests) Set(name corev1.ResourceName, val int64) {
+	if sr == nil {
+		return
+	}
+	target := resourceEntry{name: name, hash: hashResourceName(name), value: val}
+	idx, found := slices.BinarySearchFunc(*sr, target, resourceEntry.cmp)
+	if found {
+		(*sr)[idx].value = val
+	} else {
+		*sr = slices.Insert(*sr, idx, target)
+	}
 }
 
 func (sr *SliceRequests) Len() int {
@@ -172,6 +178,71 @@ func (sr *SliceRequests) ScaledUp(f int64) Requests {
 		}
 	}
 	return &res
+}
+
+func (sr *SliceRequests) ScaledDown(f int64) Requests {
+	if sr == nil {
+		return (*SliceRequests)(nil)
+	}
+	clone := sr.Clone().(*SliceRequests)
+	clone.Divide(f)
+	return clone
+}
+
+func (sr *SliceRequests) Divide(f int64) {
+	if sr == nil {
+		return
+	}
+	for i := range *sr {
+		if (*sr)[i].value == 0 && f == 0 {
+			continue
+		}
+		(*sr)[i].value /= f
+	}
+}
+
+func (sr *SliceRequests) Mul(f int64) {
+	if sr == nil {
+		return
+	}
+	for i := range *sr {
+		(*sr)[i].value = utilmath.SaturatingMul((*sr)[i].value, f)
+	}
+}
+
+func (sr *SliceRequests) ToResourceList(formatter *ResourceFormatter) corev1.ResourceList {
+	if sr.IsEmpty() {
+		return nil
+	}
+	ret := make(corev1.ResourceList, len(*sr))
+	for _, entry := range *sr {
+		ret[entry.name] = formatter.ResourceQuantity(entry.name, entry.value)
+	}
+	return ret
+}
+
+// GreaterKeys returns keys where the receiver is greater than other.
+func (sr *SliceRequests) GreaterKeys(other Requests) []corev1.ResourceName {
+	if sr.IsEmpty() || isEmpty(other) {
+		return nil
+	}
+	otherSR := toSliceRequests(other)
+	var result []corev1.ResourceName
+	j := 0
+	for _, entry := range *sr {
+		for j < len(otherSR) && otherSR[j].cmp(entry) < 0 {
+			j++
+		}
+		if j < len(otherSR) && otherSR[j].cmp(entry) == 0 && entry.value > otherSR[j].value {
+			result = append(result, entry.name)
+		}
+	}
+	return result
+}
+
+// GreaterKeysRL compares against a ResourceList and returns keys where the receiver is greater than the ResourceList value.
+func (sr *SliceRequests) GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName {
+	return sr.GreaterKeys(NewRequestsFromResourceList(rl))
 }
 
 // Add performs an element-wise addition.
@@ -267,14 +338,11 @@ func mergeInto(dst, a, b SliceRequests, fn mergeFunc) SliceRequests {
 }
 
 func appendEntry(dst SliceRequests, entry resourceEntry, val int64) SliceRequests {
-	if val != 0 {
-		return append(dst, resourceEntry{
-			name:  entry.name,
-			hash:  entry.hash,
-			value: val,
-		})
-	}
-	return dst
+	return append(dst, resourceEntry{
+		name:  entry.name,
+		hash:  entry.hash,
+		value: val,
+	})
 }
 
 func (sr *SliceRequests) CountIn(capacity Requests) int32 {

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -136,7 +136,17 @@ const (
 	opAdd byte = iota
 	opSub
 	opScaledUp
+	opScaledDown
+	opDivide
+	opMul
 	opCountIn
+	opSet
+	opGetValue
+	opLenAndIsEmpty
+	opToResourceList
+	opGreaterKeysRL
+	opGreaterKeys
+	opNumOps
 )
 
 type fuzzSeed struct {
@@ -177,6 +187,21 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			m2:       MapRequests{corev1.ResourcePods: 20},
 		},
 		{
+			opChoice: opScaledDown,
+			m1:       MapRequests{corev1.ResourceCPU: 300, corev1.ResourceMemory: 600},
+			m2:       MapRequests{},
+		},
+		{
+			opChoice: opDivide,
+			m1:       MapRequests{corev1.ResourceCPU: 200, corev1.ResourceMemory: 400},
+			m2:       MapRequests{},
+		},
+		{
+			opChoice: opMul,
+			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
+			m2:       MapRequests{},
+		},
+		{
 			opChoice: opCountIn,
 			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
 			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
@@ -191,6 +216,26 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			m1:       MapRequests{},
 			m2:       MapRequests{corev1.ResourceCPU: 100},
 		},
+		{
+			opChoice: opSet,
+			m1:       MapRequests{corev1.ResourceCPU: 100},
+			m2:       MapRequests{corev1.ResourceMemory: 200},
+		},
+		{
+			opChoice: opGetValue,
+			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
+			m2:       MapRequests{},
+		},
+		{
+			opChoice: opLenAndIsEmpty,
+			m1:       MapRequests{corev1.ResourceCPU: 100},
+			m2:       MapRequests{},
+		},
+		{
+			opChoice: opToResourceList,
+			m1:       MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+			m2:       MapRequests{},
+		},
 	}
 
 	for _, s := range seeds {
@@ -203,41 +248,110 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 		s1 := NewSliceRequests(m1)
 		s2 := NewSliceRequests(m2)
 
-		switch opChoice % 4 {
+		switch opChoice % opNumOps {
 		case opAdd:
 			m1Copy := m1.Clone()
 			m1Copy.Add(m2)
-
 			s1Copy := s1.Clone()
 			s1Copy.Add(s2)
-
 			checkRequestsEquivalence(t, "Add", m1Copy, s1Copy)
-
 		case opSub:
 			m1Copy := m1.Clone()
 			m1Copy.Sub(m2)
-
 			s1Copy := s1.Clone()
 			s1Copy.Sub(s2)
-
 			checkRequestsEquivalence(t, "Sub", m1Copy, s1Copy)
-
 		case opScaledUp:
 			factor := int64(opChoice%5 + 1)
 			mScaled := m1.ScaledUp(factor)
 			sScaled := s1.ScaledUp(factor)
-
 			checkRequestsEquivalence(t, "ScaledUp", mScaled, sScaled)
-
+		case opScaledDown:
+			factor := int64(opChoice%5 + 1)
+			mScaled := m1.ScaledDown(factor)
+			sScaled := s1.ScaledDown(factor)
+			checkRequestsEquivalence(t, "ScaledDown", mScaled, sScaled)
+		case opDivide:
+			factor := int64(opChoice%5 + 1)
+			m1Copy := m1.Clone()
+			m1Copy.Divide(factor)
+			s1Copy := s1.Clone()
+			s1Copy.Divide(factor)
+			checkRequestsEquivalence(t, "Divide", m1Copy, s1Copy)
+		case opMul:
+			factor := int64(opChoice%5 + 1)
+			m1Copy := m1.Clone()
+			m1Copy.Mul(factor)
+			s1Copy := s1.Clone()
+			s1Copy.Mul(factor)
+			checkRequestsEquivalence(t, "Mul", m1Copy, s1Copy)
 		case opCountIn:
 			mCnt, mRes := m1.CountInWithLimitingResource(m2)
 			sCnt, sRes := s1.CountInWithLimitingResource(s2)
-
 			if mCnt != sCnt {
-				t.Errorf("CountIn count mismatch: Map got %d, Slice got %d", mCnt, sCnt)
+				t.Errorf("CountInWithLimitingResource count mismatch: Map got %d, Slice got %d", mCnt, sCnt)
 			}
 			if mRes != sRes {
-				t.Errorf("CountIn limiting resource mismatch: Map got %s, Slice got %s", mRes, sRes)
+				t.Errorf("CountInWithLimitingResource limiting resource mismatch: Map got %s, Slice got %s", mRes, sRes)
+			}
+			// Test direct CountIn calls
+			mDirectCnt := m1.CountIn(m2)
+			sDirectCnt := s1.CountIn(s2)
+			if mDirectCnt != sDirectCnt {
+				t.Errorf("CountIn count mismatch: Map got %d, Slice got %d", mDirectCnt, sDirectCnt)
+			}
+
+			// Test cross-type capacity calls (MapRequests with Slice capacity, SliceRequests with Map capacity)
+			mWithSliceCapCnt, mWithSliceCapRes := m1.CountInWithLimitingResource(s2)
+			sWithMapCapCnt, sWithMapCapRes := s1.CountInWithLimitingResource(m2)
+			if mWithSliceCapCnt != sWithMapCapCnt {
+				t.Errorf("Cross-type CountIn count mismatch: Map+SliceCap got %d, Slice+MapCap got %d", mWithSliceCapCnt, sWithMapCapCnt)
+			}
+			if mWithSliceCapRes != sWithMapCapRes {
+				t.Errorf("Cross-type CountIn limiting resource mismatch: Map+SliceCap got %s, Slice+MapCap got %s", mWithSliceCapRes, sWithMapCapRes)
+			}
+		case opSet:
+			res := fuzzResourceNames[int(opChoice)%len(fuzzResourceNames)]
+			val := int64(opChoice%100 + 1)
+			m1Copy := m1.Clone()
+			m1Copy.Set(res, val)
+			s1Copy := s1.Clone()
+			s1Copy.Set(res, val)
+			checkRequestsEquivalence(t, "Set", m1Copy, s1Copy)
+		case opGetValue:
+			res := fuzzResourceNames[int(opChoice)%len(fuzzResourceNames)]
+			mVal := m1.GetValue(res)
+			sVal := s1.GetValue(res)
+			if mVal != sVal {
+				t.Errorf("GetValue mismatch for %s: Map got %d, Slice got %d", res, mVal, sVal)
+			}
+		case opLenAndIsEmpty:
+			if m1.Len() != s1.Len() {
+				t.Errorf("Len mismatch: Map got %d, Slice got %d", m1.Len(), s1.Len())
+			}
+			if m1.IsEmpty() != s1.IsEmpty() {
+				t.Errorf("IsEmpty mismatch: Map got %t, Slice got %t", m1.IsEmpty(), s1.IsEmpty())
+			}
+		case opToResourceList:
+			formatter := NewResourceFormatter()
+			mRL := m1.ToResourceList(formatter)
+			sRL := s1.ToResourceList(formatter)
+			if diff := cmp.Diff(mRL, sRL); diff != "" {
+				t.Errorf("ToResourceList mismatch (-want Map +got Slice):\n%s", diff)
+			}
+		case opGreaterKeysRL:
+			formatter := NewResourceFormatter()
+			mRL := m2.ToResourceList(formatter)
+			mKeys := m1.GreaterKeysRL(mRL)
+			sKeys := s1.GreaterKeysRL(mRL)
+			if diff := cmp.Diff(mKeys, sKeys); diff != "" {
+				t.Errorf("GreaterKeysRL mismatch (-want Map +got Slice):\n%s", diff)
+			}
+		case opGreaterKeys:
+			mKeys := m1.GreaterKeys(m2)
+			sKeys := s1.GreaterKeys(s2)
+			if diff := cmp.Diff(mKeys, sKeys); diff != "" {
+				t.Errorf("GreaterKeys mismatch (-want Map +got Slice):\n%s", diff)
 			}
 		}
 	})

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -27,18 +27,13 @@ import (
 
 // NewSliceRequests constructs a SliceRequests pointer from a MapRequests map for testing.
 func NewSliceRequests(req MapRequests) *SliceRequests {
-	if len(req) == 0 {
-		return nil
-	}
 	sr := make(SliceRequests, 0, len(req))
 	for name, val := range req {
-		if val != 0 {
-			sr = append(sr, resourceEntry{
-				name:  name,
-				hash:  hashResourceName(name),
-				value: val,
-			})
-		}
+		sr = append(sr, resourceEntry{
+			name:  name,
+			hash:  hashResourceName(name),
+			value: val,
+		})
 	}
 	sr.sort()
 	return &sr
@@ -69,7 +64,9 @@ func TestSliceRequests_Conversion(t *testing.T) {
 			input: MapRequests{
 				corev1.ResourceCPU: 0,
 			},
-			want: nil,
+			want: MapRequests{
+				corev1.ResourceCPU: 0,
+			},
 		},
 		"nil_map": {
 			input: nil,
@@ -153,11 +150,11 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		}
 	})
 
-	t.Run("merge resulting in zeros dropped", func(t *testing.T) {
+	t.Run("merge resulting in zero value retained", func(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
 		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a - b })
-		want := MapRequests{corev1.ResourceMemory: 2048}
+		want := MapRequests{corev1.ResourceCPU: 0, corev1.ResourceMemory: 2048}
 		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
 			t.Errorf("mismatch on zero drop merge (-want +got):\n%s", diff)
 		}
@@ -232,7 +229,7 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 			base:    MapRequests{corev1.ResourceCPU: 1000},
 			op:      "sub",
 			operand: MapRequests{corev1.ResourceCPU: 1000},
-			want:    nil,
+			want:    MapRequests{corev1.ResourceCPU: 0},
 		},
 	}
 
@@ -469,6 +466,272 @@ func TestSliceRequests_CountIn(t *testing.T) {
 			cntOnly := tc.request.CountIn(tc.capacity)
 			if cntOnly != tc.wantCnt {
 				t.Errorf("CountIn count mismatch: got %d, want %d", cntOnly, tc.wantCnt)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_Set(t *testing.T) {
+	type setOp struct {
+		name corev1.ResourceName
+		val  int64
+	}
+	cases := map[string]struct {
+		req  *SliceRequests
+		sets []setOp
+		want MapRequests
+	}{
+		"nil receiver": {
+			req: nil,
+			sets: []setOp{
+				{name: corev1.ResourceCPU, val: 1000},
+			},
+			want: nil,
+		},
+		"insert into empty slice": {
+			req: &SliceRequests{},
+			sets: []setOp{
+				{name: corev1.ResourceCPU, val: 1000},
+			},
+			want: MapRequests{corev1.ResourceCPU: 1000},
+		},
+		"update existing resource": {
+			req: NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+			sets: []setOp{
+				{name: corev1.ResourceCPU, val: 4000},
+			},
+			want: MapRequests{corev1.ResourceCPU: 4000, corev1.ResourceMemory: 2048},
+		},
+		"insert new resource preserving sorted order": {
+			req: NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			sets: []setOp{
+				{name: "nvidia.com/gpu", val: 2},
+				{name: corev1.ResourceMemory, val: 2048},
+			},
+			want: MapRequests{
+				corev1.ResourceCPU:    1000,
+				corev1.ResourceMemory: 2048,
+				"nvidia.com/gpu":      2,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			for _, s := range tc.sets {
+				tc.req.Set(s.name, s.val)
+			}
+			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+				t.Errorf("Set mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_ScaledDown(t *testing.T) {
+	cases := map[string]struct {
+		req    *SliceRequests
+		factor int64
+		want   Requests
+	}{
+		"scale down non-empty": {
+			req:    NewSliceRequests(MapRequests{corev1.ResourceCPU: 3000, corev1.ResourceMemory: 6144}),
+			factor: 3,
+			want:   NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+		},
+		"scale down nil receiver": {
+			req:    nil,
+			factor: 2,
+			want:   (*SliceRequests)(nil),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.ScaledDown(tc.factor)
+			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
+				t.Errorf("ScaledDown mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_Divide(t *testing.T) {
+	cases := map[string]struct {
+		req     *SliceRequests
+		divisor int64
+		want    MapRequests
+	}{
+		"nil receiver": {
+			req:     nil,
+			divisor: 2,
+			want:    nil,
+		},
+		"divide by non-zero": {
+			req:     NewSliceRequests(MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 4096}),
+			divisor: 2,
+			want:    MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.req.Divide(tc.divisor)
+			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+				t.Errorf("Divide mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_Mul(t *testing.T) {
+	cases := map[string]struct {
+		req    *SliceRequests
+		factor int64
+		want   MapRequests
+	}{
+		"nil receiver": {
+			req:    nil,
+			factor: 2,
+			want:   nil,
+		},
+		"normal multiplication": {
+			req:    NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}),
+			factor: 3,
+			want:   MapRequests{corev1.ResourceCPU: 3000, corev1.ResourceMemory: 6144},
+		},
+		"saturating multiplication overflow": {
+			req:    NewSliceRequests(MapRequests{corev1.ResourceCPU: math.MaxInt64}),
+			factor: 2,
+			want:   MapRequests{corev1.ResourceCPU: math.MaxInt64},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			tc.req.Mul(tc.factor)
+			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+				t.Errorf("Mul mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_ToResourceList(t *testing.T) {
+	formatter := NewResourceFormatter()
+	cases := map[string]struct {
+		req  *SliceRequests
+		want corev1.ResourceList
+	}{
+		"nil receiver": {
+			req:  nil,
+			want: nil,
+		},
+		"empty slice": {
+			req:  &SliceRequests{},
+			want: nil,
+		},
+		"populated requests": {
+			req: NewSliceRequests(MapRequests{
+				corev1.ResourceCPU:    2000,
+				corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
+			}),
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			},
+		},
+		"zero value requests": {
+			req: &SliceRequests{
+				{name: corev1.ResourceCPU, value: 0},
+			},
+			want: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("0"),
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.ToResourceList(formatter)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("ToResourceList mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_GreaterKeysRL(t *testing.T) {
+	baseReq := NewSliceRequests(MapRequests{
+		corev1.ResourceCPU:    2000,
+		corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
+	})
+	cases := map[string]struct {
+		req  *SliceRequests
+		rl   corev1.ResourceList
+		want []corev1.ResourceName
+	}{
+		"greater keys found": {
+			req: baseReq,
+			rl: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			want: []corev1.ResourceName{corev1.ResourceCPU},
+		},
+		"no greater keys": {
+			req: baseReq,
+			rl: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("3"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
+			},
+			want: nil,
+		},
+		"nil receiver": {
+			req:  nil,
+			rl:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			want: nil,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.GreaterKeysRL(tc.rl)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GreaterKeysRL mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSliceRequests_GreaterKeys(t *testing.T) {
+	baseReq := NewSliceRequests(MapRequests{
+		corev1.ResourceCPU:    2000,
+		corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
+	})
+	cases := map[string]struct {
+		req   *SliceRequests
+		other Requests
+		want  []corev1.ResourceName
+	}{
+		"greater keys found with MapRequests": {
+			req: baseReq,
+			other: MapRequests{
+				corev1.ResourceCPU:    1000,
+				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
+			},
+			want: []corev1.ResourceName{corev1.ResourceCPU},
+		},
+		"greater keys found with SliceRequests": {
+			req: baseReq,
+			other: NewSliceRequests(MapRequests{
+				corev1.ResourceCPU:    1000,
+				corev1.ResourceMemory: 8 * 1024 * 1024 * 1024,
+			}),
+			want: []corev1.ResourceName{corev1.ResourceCPU},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := tc.req.GreaterKeys(tc.other)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("GreaterKeys mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -225,19 +225,22 @@ func (a *Assignment) TotalRequestsFor(log logr.Logger, wl *workload.Info) resour
 		}
 		ps = *ps.ScaledTo(newCount)
 
-		for res, q := range ps.Requests {
+		if ps.Requests == nil {
+			continue
+		}
+		ps.Requests.ForEach(func(res corev1.ResourceName, q int64) {
 			// zero-quantity request may have no flavor (#8079), and is irrelevant for
 			// later calculations
 			if q == 0 {
-				continue
+				return
 			}
 			if IgnoreUndeclaredResources(a.quotaCheckStrategy) && a.PodSets[i].Flavors[res] == nil {
 				log.V(3).Info("Skipping usage count for resource with undefined flavor", "res", res)
-				continue
+				return
 			}
 			flv := a.PodSets[i].Flavors[res].Name
 			usage[resources.FlavorResource{Flavor: flv, Resource: res}] = usage[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
-		}
+		})
 	}
 	return usage
 }
@@ -658,7 +661,9 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 	if len(counts) == 0 {
 		for i, ps := range a.wl.TotalRequests {
 			requests[i] = ps
-			requests[i].Requests = maps.Clone(ps.Requests)
+			if ps.Requests != nil {
+				requests[i].Requests = ps.Requests.Clone()
+			}
 		}
 	} else {
 		for i := range a.wl.TotalRequests {
@@ -682,13 +687,24 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 
 	for i, podSet := range requests {
 		if a.cq.RGByResource(corev1.ResourcePods) != nil {
-			podSet.Requests[corev1.ResourcePods] = int64(podSet.Count)
+			if podSet.Requests != nil {
+				podSet.Requests.Set(corev1.ResourcePods, int64(podSet.Count))
+			} else {
+				podSet.Requests = resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: int64(podSet.Count)})
+			}
+		}
+
+		flavorsLen := 0
+		var resList corev1.ResourceList
+		if podSet.Requests != nil {
+			flavorsLen = podSet.Requests.Len()
+			resList = podSet.Requests.ToResourceList(a.resourceFormatter)
 		}
 
 		psAssignment := PodSetAssignment{
 			Name:     podSet.Name,
-			Flavors:  make(ResourceAssignment, len(podSet.Requests)),
-			Requests: podSet.Requests.ToResourceList(a.resourceFormatter),
+			Flavors:  make(ResourceAssignment, flavorsLen),
+			Requests: resList,
 			Count:    podSet.Count,
 		}
 
@@ -718,7 +734,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 	}
 
 	for _, podSets := range groupedRequests.InOrder {
-		requests := make(resources.MapRequests)
+		requests := resources.CreateEmpty()
 		psIDs := make([]int, len(podSets))
 		for idx, podset := range podSets {
 			psIDs[idx] = podset.originalIndex
@@ -733,7 +749,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			maps.Copy(groupFlavors, ips.podSetAssignment.Flavors)
 		}
 		var groupStatus Status
-		for resName, quantity := range requests {
+		for resName, quantity := range resources.ToMapRequests(requests) {
 			// Skip zero-quantity requests for resources not defined in the ClusterQueue (#8079) or
 			// If quotaCheckStrategy is IgnoreUndeclared, skip resources not declared in the ClusterQueue.
 			if a.cq.RGByResource(resName) == nil {
@@ -754,7 +770,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 
 			flavors, status, considered := a.findFlavorForPodSets(ctx, log, psIDs, requests, resName, assignment.Usage.Quota)
 			mergeFlavorAttemptsForResource(consideredFlavors, considered, resName, a.cq)
-			if status.IsError() || (len(flavors) == 0 && len(requests) > 0) {
+			if status.IsError() || (len(flavors) == 0 && requests.Len() > 0) {
 				groupFlavors = nil
 				groupStatus = *status
 				break
@@ -768,14 +784,20 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		finalConsidered := finalizeFlavorAssignmentAttempts(consideredFlavors)
 		atLeastOnePodsAssignmentFailed := false
 		for _, podSet := range podSets {
-			podSetFlavors := utilmaps.FilterKeys(groupFlavors, slices.Collect(maps.Keys(podSet.podSet.Requests)))
+			var reqKeys []corev1.ResourceName
+			if podSet.podSet.Requests != nil {
+				podSet.podSet.Requests.ForEach(func(name corev1.ResourceName, _ int64) {
+					reqKeys = append(reqKeys, name)
+				})
+			}
+			podSetFlavors := utilmaps.FilterKeys(groupFlavors, reqKeys)
 
 			podSet.podSetAssignment.Flavors = podSetFlavors
 			podSet.podSetAssignment.Status = groupStatus
 			podSet.podSetAssignment.FlavorAssignmentAttempts = finalConsidered
 
 			assignment.append(podSet.podSet.Requests, podSet.podSetAssignment)
-			if podSet.podSetAssignment.Status.IsError() || (len(podSet.podSet.Requests) > 0 && len(podSet.podSetAssignment.Flavors) == 0) {
+			if podSet.podSetAssignment.Status.IsError() || (podSet.podSet.Requests != nil && podSet.podSet.Requests.Len() > 0 && len(podSet.podSetAssignment.Flavors) == 0) {
 				atLeastOnePodsAssignmentFailed = true
 			}
 		}
@@ -898,7 +920,7 @@ func findRGIndicesByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.Reso
 	return indices
 }
 
-func (a *Assignment) append(requests resources.MapRequests, psAssignment *PodSetAssignment) {
+func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAssignment) {
 	flavorIdx := make(map[corev1.ResourceName]int, len(psAssignment.Flavors))
 	a.PodSets = append(a.PodSets, *psAssignment)
 	for resource, flvAssignment := range psAssignment.Flavors {
@@ -909,7 +931,10 @@ func (a *Assignment) append(requests resources.MapRequests, psAssignment *PodSet
 
 		// For workload slicing, only add the delta (new - old) to avoid double-counting
 		// podSets that already have quota reserved in the old slice.
-		requestAmount := requests[resource]
+		var requestAmount int64
+		if requests != nil {
+			requestAmount = requests.GetValue(resource)
+		}
 		if features.Enabled(features.ElasticJobsViaWorkloadSlices) && a.replaceWorkloadSlice != nil {
 			oldRequest := a.findOldPodSetRequest(psAssignment.Name, resource)
 			requestAmount -= oldRequest
@@ -929,8 +954,8 @@ func (a *Assignment) findOldPodSetRequest(psName kueue.PodSetReference, resource
 	}
 
 	for _, oldPS := range a.replaceWorkloadSlice.TotalRequests {
-		if oldPS.Name == psName {
-			return oldPS.Requests[resource]
+		if oldPS.Name == psName && oldPS.Requests != nil {
+			return oldPS.Requests.GetValue(resource)
 		}
 	}
 
@@ -947,7 +972,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 	ctx context.Context,
 	log logr.Logger,
 	psIDs []int,
-	requests resources.MapRequests,
+	requests resources.Requests,
 	resName corev1.ResourceName,
 	assignmentUsage resources.FlavorResourceQuantities,
 ) (ResourceAssignment, *Status, FlavorAssignmentAttempts) {
@@ -994,14 +1019,14 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			continue
 		}
 
-		assignments := make(ResourceAssignment, len(requests))
+		assignments := make(ResourceAssignment, requests.Len())
 		// Calculate representativeMode for this assignment as the worst mode among all requests.
 		representativeMode := bestGranularMode()
 		maxBorrow := 0
 		var flavorQuotaReasons []string
 		var flavorNoFitReason string
 
-		for rName, val := range requests {
+		requests.ForEach(func(rName corev1.ResourceName, val int64) {
 			// Ensure the same resource flavor is used for the workload slice as in the original admitted slice.
 			if features.Enabled(features.ElasticJobsViaWorkloadSlices) && a.replaceWorkloadSlice != nil {
 				for _, psID := range psIDs {
@@ -1019,7 +1044,9 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 					}
 
 					// Subtract the resource usage of the preempted slice to request only the delta needed.
-					val -= preemptWorkloadRequests.Requests[rName]
+					if preemptWorkloadRequests.Requests != nil {
+						val -= preemptWorkloadRequests.Requests.GetValue(rName)
+					}
 				}
 			}
 
@@ -1040,7 +1067,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			}
 			if representativeMode.preemptionMode == noFit {
 				// The flavor doesn't fit, no need to check other resources.
-				break
+				return
 			}
 
 			assignments[rName] = &FlavorAssignment{
@@ -1048,7 +1075,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 				Mode:   preemptionMode.flavorAssignmentMode(),
 				borrow: borrow,
 			}
-		}
+		})
 
 		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode, maxBorrow, flavorQuotaReasons, flavorNoFitReason)
 
@@ -1267,13 +1294,13 @@ func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {
 		(a.enableFairSharing && a.cq.Preemption.ReclaimWithinCohort != kueue.PreemptionPolicyNever)
 }
 
-func filterRequestedResources(req resources.MapRequests, allowList sets.Set[corev1.ResourceName]) resources.MapRequests {
-	filtered := make(resources.MapRequests)
-	for n, v := range req {
-		if allowList.Has(n) {
-			filtered[n] = v
+func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.ResourceName]) resources.Requests {
+	filtered := resources.CreateEmpty()
+	req.ForEach(func(resName corev1.ResourceName, quantity int64) {
+		if allowList.Has(resName) {
+			filtered.Set(resName, quantity)
 		}
-	}
+	})
 	return filtered
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3328,10 +3328,10 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU:    "two",
 							corev1.ResourceMemory: "two",
@@ -3394,10 +3394,10 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU:    "one",
 							corev1.ResourceMemory: "one",
@@ -3416,6 +3416,7 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 					Status: *NewStatus(
 						"insufficient quota for cpu in flavor one, previously considered podsets requests (0) + current podset request (1) > maximum capacity (500m)",
+						"could not assign two flavor since the original workload is assigned: one",
 						"could not assign two flavor since the original workload is assigned: one",
 					),
 					FlavorAssignmentAttempts: []FlavorAssignmentAttempt{
@@ -4937,7 +4938,7 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got := tt.assignment.ComputeTASNetUsage(testr.New(t), tt.cq, tt.wl, tt.prevAdmission)
 
-			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.Transformer("requestsToMap", resources.ToMapRequests)); diff != "" {
+			if diff := cmp.Diff(tt.want, got, cmpopts.EquateEmpty(), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected TAS usage (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -18,7 +18,6 @@ package flavorassigner
 
 import (
 	"fmt"
-	"maps"
 	"slices"
 
 	"github.com/go-logr/logr"
@@ -204,8 +203,16 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 
 // hasOverlapWithPodRequestedResources checks if the PodSet's resource requests overlap with the specified flavor resources.
 func hasOverlapWithPodRequestedResources(ps *kueue.PodSet, flavorResources sets.Set[corev1.ResourceName]) bool {
-	requests := resources.NewMapRequestsFromPodSpec(&ps.Template.Spec)
-	return flavorResources.HasAny(slices.Collect(maps.Keys(requests))...)
+	requests := resources.NewRequestsFromPodSpec(&ps.Template.Spec)
+	has := false
+	if requests != nil {
+		requests.ForEach(func(name corev1.ResourceName, _ int64) {
+			if flavorResources.Has(name) {
+				has = true
+			}
+		})
+	}
+	return has
 }
 
 // isTASImplied returns true if TAS is requested implicitly.

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -205,13 +205,11 @@ func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kue
 func hasOverlapWithPodRequestedResources(ps *kueue.PodSet, flavorResources sets.Set[corev1.ResourceName]) bool {
 	requests := resources.NewRequestsFromPodSpec(&ps.Template.Spec)
 	has := false
-	if requests != nil {
-		requests.ForEach(func(name corev1.ResourceName, _ int64) {
-			if flavorResources.Has(name) {
-				has = true
-			}
-		})
-	}
+	requests.ForEach(func(name corev1.ResourceName, _ int64) {
+		if flavorResources.Has(name) {
+			has = true
+		}
+	})
 	return has
 }
 

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -60,6 +60,7 @@ var snapCmpOpts = cmp.Options{
 	cmpopts.IgnoreFields(schdcache.CohortSnapshot{}, "Cohort"),
 	cmp.AllowUnexported(schdcache.ClusterQueueSnapshot{}),
 	cmpopts.IgnoreFields(schdcache.ClusterQueueSnapshot{}, "ClusterQueue"),
+	cmp.Comparer(resources.Equal),
 }
 
 func TestPreemption(t *testing.T) {

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -67,10 +67,10 @@ func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *
 		res := &containers[i].Resources
 		cMin := resource.MergeResourceListKeepMin(res.Requests, res.Limits)
 		cMax := resource.MergeResourceListKeepMax(res.Requests, res.Limits)
-		if resNames := resources.NewMapRequests(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
+		if resNames := resources.NewRequestsFromResourceList(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewMapRequests(containerRange.Min).GreaterKeys(resources.NewMapRequests(cMin)); len(resNames) > 0 {
+		if resNames := resources.NewRequestsFromResourceList(containerRange.Min).GreaterKeys(resources.NewMapRequests(cMin)); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -561,7 +561,7 @@ func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.R
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
 		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
-		domainUsage.Add(resources.MapRequests{corev1.ResourcePods: int64(domain.Count)})
+		domainUsage.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: int64(domain.Count)}))
 		usage[domainID] = domainUsage
 	}
 	return usage

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -162,7 +162,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 		podSpecPath := PodSetsPath.Index(i).Child("template").Child("spec")
 		for i := range ps.Template.Spec.InitContainers {
 			c := ps.Template.Spec.InitContainers[i]
-			if resNames := resources.NewMapRequests(c.Resources.Requests).GreaterKeys(resources.NewMapRequests(c.Resources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewRequestsFromResourceList(c.Resources.Requests).GreaterKeysRL(c.Resources.Limits); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("initContainers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
@@ -172,7 +172,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 
 		for i := range ps.Template.Spec.Containers {
 			c := ps.Template.Spec.Containers[i]
-			if resNames := resources.NewMapRequests(c.Resources.Requests).GreaterKeys(resources.NewMapRequests(c.Resources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewRequestsFromResourceList(c.Resources.Requests).GreaterKeysRL(c.Resources.Limits); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("containers").Index(i), resNames, RequestsMustNotExceedLimitMessage),
@@ -183,7 +183,7 @@ func ValidateResources(wi *Info) field.ErrorList {
 		// Pod-level resources (KEP-2837) are an optional pointer, only set when the
 		// PodLevelResources feature is enabled and used.
 		if podResources := ps.Template.Spec.Resources; podResources != nil {
-			if resNames := resources.NewMapRequests(podResources.Requests).GreaterKeys(resources.NewMapRequests(podResources.Limits)); len(resNames) > 0 {
+			if resNames := resources.NewRequestsFromResourceList(podResources.Requests).GreaterKeysRL(podResources.Limits); len(resNames) > 0 {
 				allErrors = append(
 					allErrors,
 					field.Invalid(podSpecPath.Child("resources"), resNames, RequestsMustNotExceedLimitMessage),

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -34,6 +34,7 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/util/sets"
 	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
@@ -77,6 +78,8 @@ const (
 	// SchedulingHashUnknown indicates the scheduling hash could not be computed.
 	SchedulingHashUnknown EquivalenceHash = "unknown"
 )
+
+var Semantic = conversion.EqualitiesOrDie(resources.Equal)
 
 // Reference is the full reference to Workload formed as <namespace>/< kueue.WorkloadName >.
 type Reference string
@@ -248,7 +251,7 @@ type PodSetResources struct {
 	// Name is the name of the PodSet.
 	Name kueue.PodSetReference
 	// Requests incorporates the requests from all pods in the podset.
-	Requests resources.MapRequests
+	Requests resources.Requests
 	// Count indicates how many pods are in the podset.
 	Count int32
 
@@ -262,7 +265,10 @@ type PodSetResources struct {
 	Flavors map[corev1.ResourceName]kueue.ResourceFlavorReference
 }
 
-func (p *PodSetResources) SinglePodRequests() resources.MapRequests {
+func (p *PodSetResources) SinglePodRequests() resources.Requests {
+	if p.Requests == nil {
+		return nil
+	}
 	return p.Requests.ScaledDown(int64(p.Count))
 }
 
@@ -286,16 +292,22 @@ func (p *PodSetResources) ScaledTo(newCount int32) *PodSetResources {
 	if p.TopologyRequest != nil {
 		return p
 	}
+	var req resources.Requests
+	if p.Requests != nil {
+		req = p.Requests.Clone()
+	}
 	ret := &PodSetResources{
 		Name:     p.Name,
-		Requests: maps.Clone(p.Requests),
+		Requests: req,
 		Count:    p.Count,
 		Flavors:  maps.Clone(p.Flavors),
 	}
 
 	if p.Count != 0 && p.Count != newCount {
-		ret.Requests.Divide(int64(ret.Count))
-		ret.Requests.Mul(int64(newCount))
+		if ret.Requests != nil {
+			ret.Requests.Divide(int64(ret.Count))
+			ret.Requests.Mul(int64(newCount))
+		}
 		ret.Count = newCount
 	}
 	return ret
@@ -356,7 +368,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 	podSetShapes := make([]map[string]any, 0, len(wl.Spec.PodSets))
 	for i, ps := range wl.Spec.PodSets {
 		effectiveCount := ps.Count
-		var effectiveRequests resources.MapRequests
+		var effectiveRequests resources.Requests
 		if i < len(totalRequests) {
 			effectiveCount = totalRequests[i].Count
 			effectiveRequests = totalRequests[i].Requests
@@ -365,7 +377,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 			"name":            ps.Name,
 			"spec":            utilpod.SpecShape(&ps.Template.Spec),
 			"count":           effectiveCount,
-			"requests":        effectiveRequests,
+			"requests":        resources.ToMapRequests(effectiveRequests),
 			"minCount":        ps.MinCount,
 			"topologyRequest": ps.TopologyRequest,
 		})
@@ -412,9 +424,11 @@ func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantities {
 		return total
 	}
 	for _, psReqs := range i.TotalRequests {
-		for res, q := range psReqs.Requests {
-			flv := psReqs.Flavors[res]
-			total[resources.FlavorResource{Flavor: flv, Resource: res}] = total[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
+		if psReqs.Requests != nil {
+			psReqs.Requests.ForEach(func(res corev1.ResourceName, q int64) {
+				flv := psReqs.Flavors[res]
+				total[resources.FlavorResource{Flavor: flv, Resource: res}] = total[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
+			})
 		}
 	}
 	return total
@@ -511,9 +525,11 @@ func (i *Info) TASUsage() TASUsage {
 }
 
 func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.ResourceList {
-	reqs := make(resources.MapRequests)
+	reqs := resources.CreateEmpty()
 	for _, psReqs := range i.TotalRequests {
-		reqs.Add(psReqs.Requests)
+		if psReqs.Requests != nil {
+			reqs.Add(psReqs.Requests)
+		}
 	}
 	return reqs.ToResourceList(formatter)
 }
@@ -628,24 +644,23 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
-		setRes.Requests = resources.NewMapRequests(effectiveRequests)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
 			// First, remove extended resources that were converted to DRA logical resources
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {
 				for extRes := range replacedRes {
-					delete(setRes.Requests, extRes)
+					delete(effectiveRequests, extRes)
 				}
 			}
 			// Then, add the DRA logical resources
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
-					if setRes.Requests == nil {
-						setRes.Requests = make(resources.MapRequests)
-					}
-					setRes.Requests[resName] += resources.ResourceValue(resName, quantity)
+					q := effectiveRequests[resName]
+					q.Add(quantity)
+					effectiveRequests[resName] = q
 				}
 			}
 		}
+		setRes.Requests = resources.NewRequestsFromResourceList(effectiveRequests)
 		setRes.Requests.FloorToZero()
 		setRes.Requests.Mul(int64(count))
 		res = append(res, setRes)
@@ -666,13 +681,13 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 			Name:     psa.Name,
 			Flavors:  psa.Flavors,
 			Count:    ptr.Deref(psa.Count, totalCounts[psa.Name]),
-			Requests: resources.NewMapRequests(psa.ResourceUsage),
+			Requests: resources.NewRequestsFromResourceList(psa.ResourceUsage),
 		}
 		if features.Enabled(features.TopologyAwareScheduling) && psa.TopologyAssignment != nil {
 			setRes.TopologyRequest = &TopologyRequest{
 				Levels: psa.TopologyAssignment.Levels,
 			}
-			var singlePodRequests resources.Requests = setRes.SinglePodRequests()
+			singlePodRequests := setRes.SinglePodRequests()
 			if ps := podset.FindPodSetByName(wl.Spec.PodSets, psa.Name); ps != nil {
 				singlePodRequests = resources.NewRequestsFromPodSpec(&ps.Template.Spec)
 			}
@@ -691,8 +706,10 @@ func totalRequestsFromAdmission(wl *kueue.Workload) []PodSetResources {
 		// If countAfterReclaim is lower then the admission count indicates that
 		// additional pods are marked as reclaimable, and the consumption should be scaled down.
 		if countAfterReclaim := currentCounts[psa.Name]; countAfterReclaim < setRes.Count {
-			setRes.Requests.Divide(int64(setRes.Count))
-			setRes.Requests.Mul(int64(countAfterReclaim))
+			if setRes.Requests != nil {
+				setRes.Requests.Divide(int64(setRes.Count))
+				setRes.Requests.Mul(int64(countAfterReclaim))
+			}
 			setRes.Count = countAfterReclaim
 		}
 		// Otherwise if countAfterReclaim is higher it means that the podSet was partially admitted
@@ -1064,8 +1081,12 @@ func PropagateResourceRequests(w *kueue.Workload, info *Info, formatter *resourc
 	if len(w.Status.ResourceRequests) == len(info.TotalRequests) {
 		match := true
 		for idx := range w.Status.ResourceRequests {
+			var resList corev1.ResourceList
+			if info.TotalRequests[idx].Requests != nil {
+				resList = info.TotalRequests[idx].Requests.ToResourceList(formatter)
+			}
 			if w.Status.ResourceRequests[idx].Name != info.TotalRequests[idx].Name ||
-				!equality.Semantic.DeepEqual(w.Status.ResourceRequests[idx].Resources, info.TotalRequests[idx].Requests.ToResourceList(formatter)) {
+				!equality.Semantic.DeepEqual(w.Status.ResourceRequests[idx].Resources, resList) {
 				match = false
 				break
 			}
@@ -1078,7 +1099,9 @@ func PropagateResourceRequests(w *kueue.Workload, info *Info, formatter *resourc
 	res := make([]kueue.PodSetRequest, len(info.TotalRequests))
 	for idx := range info.TotalRequests {
 		res[idx].Name = info.TotalRequests[idx].Name
-		res[idx].Resources = info.TotalRequests[idx].Requests.ToResourceList(formatter)
+		if info.TotalRequests[idx].Requests != nil {
+			res[idx].Resources = info.TotalRequests[idx].Requests.ToResourceList(formatter)
+		}
 	}
 	w.Status.ResourceRequests = res
 	return true

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -152,10 +152,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
-						},
+						}),
 						Count: 1,
 					},
 				},
@@ -174,10 +174,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    0,
 							corev1.ResourceMemory: 2 * 512 * 1024,
-						},
+						}),
 						Count: 2,
 					},
 				},
@@ -202,10 +202,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 512 * 1024,
-						},
+						}),
 						Count: 3,
 					},
 				},
@@ -230,10 +230,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 512 * 1024,
-						},
+						}),
 						Count: 5,
 					},
 				},
@@ -253,9 +253,9 @@ func TestNewInfo(t *testing.T) {
 					{
 						Name:  kueue.DefaultPodSetName,
 						Count: 2147483647,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 9223372036854775807,
-						},
+						}),
 					},
 				},
 			},
@@ -303,10 +303,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "driver",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "on-demand",
 						},
@@ -314,11 +314,11 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "workers",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    15,
 							corev1.ResourceMemory: 3 * 1024 * 1024,
 							"ex.com/gpu":          3,
-						},
+						}),
 						Count: 3,
 					},
 				},
@@ -361,11 +361,11 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceMemory:     "tas",
 							"example.com/logical-gpu": "quota",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:        2000,
 							corev1.ResourceMemory:     2 * 1024 * 1024 * 1024,
 							"example.com/logical-gpu": 2,
-						},
+						}),
 						Count: 2,
 						TopologyRequest: &TopologyRequest{
 							Levels: []string{corev1.LabelHostname},
@@ -416,10 +416,10 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
-						},
+						}),
 						Count: 3,
 					},
 				},
@@ -457,10 +457,10 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 10 * 1024,
-						},
+						}),
 						Count: 5,
 					},
 				},
@@ -500,10 +500,10 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    2 * 10,
 							corev1.ResourceMemory: 2 * 10 * 1024,
-						},
+						}),
 						Count: 2,
 					},
 				},
@@ -541,10 +541,10 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    0,
 							corev1.ResourceMemory: 0,
-						},
+						}),
 						Count: 0,
 					},
 				},
@@ -576,10 +576,10 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
-						},
+						}),
 						Count: 3,
 					},
 				},
@@ -596,10 +596,10 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
-						},
+						}),
 						Count: 1,
 					},
 				},
@@ -675,39 +675,39 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "a",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 20 * 1024,
 							corev1.ResourceName("example.com/credits"):            35,
-						},
+						}),
 						Count: 1,
 					},
 					{
 						Name: "b",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 4 * 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 80 * 1024,
 							corev1.ResourceName("example.com/credits"):            200,
 							corev1.ResourceName("nvidia.com/gpu"):                 2,
-						},
+						}),
 						Count: 2,
 					},
 					{
 						Name: "c",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceName("nvidia.com/vgpu"):            2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 20,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 1024,
-						},
+						}),
 						Count: 1,
 					},
 					{
 						Name: "d",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceName("nvidia.com/vgpu"):            2 * 2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 2 * 30,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 2 * 2048,
-						},
+						}),
 						Count: 2,
 					},
 				},
@@ -742,12 +742,12 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							// 100m * 3000 = 300
 							corev1.ResourceName("example.com/cpu-credits"): 300,
 							// 100M * 3m = 300k
 							corev1.ResourceName("example.com/memory-credits"): 300 * 1000,
-						},
+						}),
 						Count: 1,
 					},
 				},
@@ -760,8 +760,7 @@ func TestNewInfo(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
 			info := NewInfo(&tc.workload, tc.infoOptions...)
-			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"),
-				cmp.Transformer("requestsToMap", resources.ToMapRequests)); diff != "" {
+			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}
 		})
@@ -784,7 +783,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request(corev1.ResourceCPU, "200m").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.MapRequests{corev1.ResourceCPU: 200},
+				Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 200}),
 				Count:    1,
 			}},
 		},
@@ -807,7 +806,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request("example.com/gpu", "1").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.MapRequests{"example.com/gpu": 1},
+				Requests: resources.NewRequestsFromMap(resources.MapRequests{"example.com/gpu": 1}),
 				Count:    1,
 			}},
 		},
@@ -825,7 +824,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.MapRequests{corev1.ResourceCPU: 200},
+				Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 200}),
 				Count:    1,
 			}},
 		},
@@ -847,7 +846,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 			updateOptions: []InfoOption{WithPreserveTotalRequests()},
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.MapRequests{"gpu": 1},
+				Requests: resources.NewRequestsFromMap(resources.MapRequests{"gpu": 1}),
 				Count:    1,
 			}},
 		},
@@ -856,13 +855,16 @@ func TestUpdateWithRebuild(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			info := NewInfo(tc.initial, tc.initialOptions...)
 			if len(tc.updateOptions) == 0 {
-				if diff := cmp.Diff(tc.wantRequests, info.TotalRequests, cmpopts.IgnoreFields(PodSetResources{}, "Flavors")); diff == "" {
+				if diff := cmp.Diff(tc.wantRequests, info.TotalRequests,
+					cmpopts.IgnoreFields(PodSetResources{}, "Flavors"),
+					cmp.Comparer(resources.Equal)); diff == "" {
 					t.Fatal("precondition failed: initial TotalRequests should differ from expected post-rebuild state")
 				}
 			}
 			info.Update(logr.Discard(), tc.updated, tc.updateOptions...)
 			if diff := cmp.Diff(tc.wantRequests, info.TotalRequests,
-				cmpopts.IgnoreFields(PodSetResources{}, "Flavors")); diff != "" {
+				cmpopts.IgnoreFields(PodSetResources{}, "Flavors"),
+				cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("TotalRequests after Update (-want,+got):\n%s", diff)
 			}
 		})
@@ -1281,10 +1283,10 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
-					},
+					}),
 				}},
 			},
 			want: resources.FlavorResourceQuantities{
@@ -1295,10 +1297,10 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, multiple flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
-					},
+					}),
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 						corev1.ResourceCPU: "default",
 						"example.com/gpu":  "gpu",
@@ -1314,29 +1316,29 @@ func TestFlavorResourceUsage(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{
 					{
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 1_000,
 							"example.com/gpu":  3,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 							"example.com/gpu":  "model_a",
 						},
 					},
 					{
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    2_000,
 							corev1.ResourceMemory: 2 * utiltesting.Gi,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU:    "default",
 							corev1.ResourceMemory: "default",
 						},
 					},
 					{
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							"example.com/gpu": 1,
-						},
+						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							"example.com/gpu": "model_b",
 						},
@@ -1555,11 +1557,11 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
-					},
+					}),
 				}},
 			},
 			want: false,
@@ -1582,10 +1584,10 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU: 5000,
 						"nvidia.com/gpu":   1,
-					},
+					}),
 				}},
 			},
 			want: true,
@@ -1608,11 +1610,11 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU:    5000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
-					},
+					}),
 				}},
 			},
 			want: true,
@@ -1635,11 +1637,11 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
-					},
+					}),
 				}},
 			},
 			want: true,
@@ -1662,11 +1664,11 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(resources.MapRequests{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      2,
-					},
+					}),
 				}},
 			},
 			want: true,
@@ -1698,19 +1700,19 @@ func TestPropagateResourceRequests(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "ps1",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    10000,
 							corev1.ResourceMemory: 10 * 1024 * 1024,
 							"nvidia.com/gpu":      1,
-						},
+						}),
 					},
 					{
 						Name: "ps2",
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU:    20000,
 							corev1.ResourceMemory: 20 * 1024 * 1024,
 							"nvidia.com/gpu":      2,
-						},
+						}),
 					},
 				},
 			},
@@ -1966,10 +1968,10 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
-						},
+						}),
 					},
 				},
 			},
@@ -1998,18 +2000,18 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
-						},
+						}),
 					},
 					{
 						Name:  "worker",
 						Count: 2,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024,
 							"foo-accelerator":     2,
-						},
+						}),
 					},
 				},
 			},
@@ -2035,17 +2037,17 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpus":             1,
-						},
+						}),
 					},
 					{
 						Name:  "worker",
 						Count: 1,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceMemory: 512 * 1024 * 1024,
-						},
+						}),
 					},
 				},
 			},
@@ -2056,7 +2058,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			info := NewInfo(&tc.workload, WithPreprocessedDRAResources(tc.draResources, nil))
 
-			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests); diff != "" {
+			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected TotalRequests (-want,+got):\n%s", diff)
 			}
 		})
@@ -2092,10 +2094,10 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 100,
 							"gpu":              1,
-						},
+						}),
 					},
 				},
 			},
@@ -2122,11 +2124,11 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 2,
-						Requests: resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(resources.MapRequests{
 							corev1.ResourceCPU: 200,
 							"gpu":              4,
 							"tpu":              2,
-						},
+						}),
 					},
 				},
 			},
@@ -2137,7 +2139,7 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			info := NewInfo(&tc.workload, WithPreprocessedDRAResources(tc.draResources, tc.replacedExtendedResources))
 
-			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests); diff != "" {
+			if diff := cmp.Diff(tc.wantInfo.TotalRequests, info.TotalRequests, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("Unexpected TotalRequests (-want,+got):\n%s", diff)
 			}
 		})
@@ -2865,7 +2867,7 @@ func TestSchedulingHash(t *testing.T) {
 		))
 		after.UpdateSchedulingHash(logr.Discard())
 
-		if diff := cmp.Diff(before.TotalRequests, after.TotalRequests); diff == "" {
+		if diff := cmp.Diff(before.TotalRequests, after.TotalRequests, cmp.Comparer(resources.Equal)); diff == "" {
 			t.Fatal("precondition failed: TotalRequests should differ after DRA translation")
 		}
 		if before.SchedulingHash == after.SchedulingHash {


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Replace usage of MapRequests with Requests interface

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed inconsistent use of the vectorized `SliceRequests` implementation introduced in #2953 to 
optimize TAS hot paths. The remaining direct uses of `MapRequests` in non-hot paths are now replaced
with the `Requests` abstraction, with the implementation selected by factory functions based on the
`VectorizedResourceRequests` feature gate. The previous `MapRequests` implementation remains available
when the feature gate is disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nil/empty handling for resource requests to avoid missing or incorrect totals across scheduling, queue accounting, flavor assignment, and DRA/device resource aggregation.
  * Corrected GPU “total request” checks to use actual requested quantity.
  * Hardened semantic comparisons so request-change detection behaves consistently.
* **Improvements**
  * Enhanced resource-request operations (set, scaling/divide/mul, conversions, and key comparisons) with clearer empty/nil behavior and preservation of zero-valued entries.
  * Updated request propagation and scheduling hash generation to use the refined request handling.
* **Tests**
  * Expanded and updated unit and fuzz coverage for conversions, arithmetic, equality, and nil/empty edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->