### PR TITLE
test/e2e: harden ConcurrentAdmission

### DIFF
--- a/test/e2e/singlecluster/baseline/concurrent_admission_test.go
+++ b/test/e2e/singlecluster/baseline/concurrent_admission_test.go
@@ -108,9 +108,6 @@ var _ = ginkgo.Describe("ConcurrentAdmission", ginkgo.Label("area:singlecluster"
 			}
 
 			ginkgo.By("Verifying the Parent Workload is labeled correctly", func() {
-				// Use LongTimeout as a safety margin: the ConcurrentAdmission parent flow only proceeds
-				// once a gate-enabled controller is the active leader, so a controller restart or
-				// leader-election handoff during this spec must not flake it.
 				gomega.Eventually(func(g gomega.Gomega) {
 					var parentWl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, parentWlKey, &parentWl)).To(gomega.Succeed())
@@ -172,9 +169,6 @@ var _ = ginkgo.Describe("ConcurrentAdmission", ginkgo.Label("area:singlecluster"
 			}
 
 			ginkgo.By("Verifying Parent Workload is admitted on spot flavor", func() {
-				// Use LongTimeout as a safety margin: the ConcurrentAdmission parent flow only proceeds
-				// once a gate-enabled controller is the active leader, so a controller restart or
-				// leader-election handoff during this spec must not flake it.
 				gomega.Eventually(func(g gomega.Gomega) {
 					var parentWl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, parentWlKey, &parentWl)).To(gomega.Succeed())

--- a/test/e2e/singlecluster/baseline/concurrent_admission_test.go
+++ b/test/e2e/singlecluster/baseline/concurrent_admission_test.go
@@ -108,11 +108,14 @@ var _ = ginkgo.Describe("ConcurrentAdmission", ginkgo.Label("area:singlecluster"
 			}
 
 			ginkgo.By("Verifying the Parent Workload is labeled correctly", func() {
+				// Use LongTimeout as a safety margin: the ConcurrentAdmission parent flow only proceeds
+				// once a gate-enabled controller is the active leader, so a controller restart or
+				// leader-election handoff during this spec must not flake it.
 				gomega.Eventually(func(g gomega.Gomega) {
 					var parentWl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, parentWlKey, &parentWl)).To(gomega.Succeed())
 					g.Expect(parentWl.Labels[controllerconstants.ConcurrentAdmissionParentLabelKey]).To(gomega.Equal("true"))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Verifying one Variant Workload is created per flavor (2 variants + 1 parent = 3 total)", func() {
@@ -169,6 +172,9 @@ var _ = ginkgo.Describe("ConcurrentAdmission", ginkgo.Label("area:singlecluster"
 			}
 
 			ginkgo.By("Verifying Parent Workload is admitted on spot flavor", func() {
+				// Use LongTimeout as a safety margin: the ConcurrentAdmission parent flow only proceeds
+				// once a gate-enabled controller is the active leader, so a controller restart or
+				// leader-election handoff during this spec must not flake it.
 				gomega.Eventually(func(g gomega.Gomega) {
 					var parentWl kueue.Workload
 					g.Expect(k8sClient.Get(ctx, parentWlKey, &parentWl)).To(gomega.Succeed())
@@ -177,7 +183,7 @@ var _ = ginkgo.Describe("ConcurrentAdmission", ginkgo.Label("area:singlecluster"
 					g.Expect(parentWl.Status.Admission.PodSetAssignments).ToNot(gomega.BeEmpty())
 					g.Expect(parentWl.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
 						gomega.Equal(kueue.ResourceFlavorReference(spotFlavor)))
-				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Verifying spot Variant is admitted and reservation Variant is pending", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/area testing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The `ConcurrentAdmission` specs in the parallel `singlecluster/baseline` e2e suite
wait for the parent Workload to be labeled/admitted with short timeouts
(`util.Timeout` = 10s and `util.MediumTimeout` = 45s). The parent flow only proceeds
once a `ConcurrentAdmission`-enabled controller is the active leader. If a controller
restart or leader-election handoff briefly leaves a `ConcurrentAdmission`-disabled
controller in charge, the parent Workload is admitted as an ordinary workload and
never receives the parent label, so these assertions time out. A 10s wait is also
shorter than the 15s leader-election lease, so it cannot absorb a single handoff.
This raises the first `ConcurrentAdmission`-dependent `Eventually` in each spec to
`util.LongTimeout` (90s).

Root-cause context: the specific trigger in #13292 was a custom-metric-labels
pod-group test that reconfigured and restarted kueue *inside the parallel suite*,
creating a ~40s window where `ConcurrentAdmission` was disabled cluster-wide. 

That test was already moved to the isolated `sequential` suite in #13294, which removes
the deterministic trigger. This PR is defense-in-depth so the specs stay green
against any future/unscheduled controller restart.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13292 

#### Special notes for your reviewer:
Evidence from the failing run (`pull-kueue-test-e2e-baseline-main-1-34`, build
`2079632436240584704`): parent Workload `job-job-68dcd` was created at 18:26:42 while
a `ConcurrentAdmission`-disabled (`CustomMetricLabels`) config held leadership
(18:26:09–18:26:50); the enabled leader returned only ~2s before the 10s deadline. In
a passing run the parent was created under a stable enabled leader and the label
appeared in 254ms.


This change was prepared with the assistance of an AI tool (Claude Code); all
conclusions were verified against the CI artifacts and source.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased wait times for concurrent admission end-to-end checks.
  * Improved test reliability by allowing more time for workload labeling and admission assertions to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->