### PR TITLE
DRA: Fix validations for capacity qualified names

### DIFF
--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -709,10 +709,10 @@ type DeviceClassCounterSource struct {
 // for devices that allow multiple allocations (KEP-5075).
 type DeviceClassCapacitySource struct {
 	// Name identifies the capacity dimension to track for quota
-	// (e.g., "gpu.memory").
-	// Must not exceed 63 characters.
+	// (e.g., "gpu.example.com/memory").
+	// Must be a valid DRA QualifiedName.
 	// +required
-	Name string `json:"name"`
+	Name resourcev1.QualifiedName `json:"name"`
 
 	// Driver is the DRA driver name used to filter relevant ResourceSlices.
 	// Must match the spec.driver field on ResourceSlice objects.

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1174,11 +1174,10 @@ type DeviceClassCounterSource struct {
 // for devices that allow multiple allocations (KEP-5075).
 type DeviceClassCapacitySource struct {
     // Name identifies the capacity dimension to track for quota
-    // (e.g., "gpu.memory").
-    // Must be a valid QualifiedName; the name part must not exceed
-    // 63 characters.
+    // (e.g., "gpu.example.com/memory").
+    // Must be a valid DRA QualifiedName.
     // +required
-    Name string `json:"name"`
+    Name resourcev1.QualifiedName `json:"name"`
 
     // Driver is the DRA driver name used to filter relevant ResourceSlices.
     // Must match the spec.driver field on ResourceSlice objects.

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -585,7 +585,13 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 							"counter sources require KueueDRAIntegrationPartitionableDevices to be enabled"))
 						continue
 					}
-					allErrs = append(allErrs, validateDeviceClassSource(source.Counter.Name, source.Counter.Driver, &source.Counter.DeviceSelector, sourcePath.Child("counter"), celCache)...)
+					counterPath := sourcePath.Child("counter")
+					if source.Counter.Name == "" {
+						allErrs = append(allErrs, field.Required(counterPath.Child("name"), ""))
+					} else if errs := apimachineryutilvalidation.IsDNS1123Label(source.Counter.Name); len(errs) != 0 {
+						allErrs = append(allErrs, field.Invalid(counterPath.Child("name"), source.Counter.Name, strings.Join(errs, ",")))
+					}
+					allErrs = append(allErrs, validateDeviceClassSource(source.Counter.Driver, &source.Counter.DeviceSelector, counterPath, celCache)...)
 				}
 				if source.Capacity != nil {
 					hasCapacity = true
@@ -594,7 +600,9 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 							"capacity sources require KueueDRAIntegrationConsumableCapacity to be enabled"))
 						continue
 					}
-					allErrs = append(allErrs, validateDeviceClassSource(source.Capacity.Name, source.Capacity.Driver, &source.Capacity.DeviceSelector, sourcePath.Child("capacity"), celCache)...)
+					capacityPath := sourcePath.Child("capacity")
+					allErrs = append(allErrs, validateQualifiedName(source.Capacity.Name, capacityPath.Child("name"))...)
+					allErrs = append(allErrs, validateDeviceClassSource(source.Capacity.Driver, &source.Capacity.DeviceSelector, capacityPath, celCache)...)
 				}
 			}
 			if counterCount > 0 && hasCapacity {
@@ -828,11 +836,11 @@ func validateCustomLabels(c *configapi.Configuration) field.ErrorList {
 		}
 		switch {
 		case entry.SourceLabelKey != "":
-			allErrs = append(allErrs, validateQualifiedName(fldPath.Child("sourceLabelKey"), entry.SourceLabelKey)...)
+			allErrs = append(allErrs, validateLabelKey(fldPath.Child("sourceLabelKey"), entry.SourceLabelKey)...)
 		case entry.SourceAnnotationKey != "":
-			allErrs = append(allErrs, validateQualifiedName(fldPath.Child("sourceAnnotationKey"), entry.SourceAnnotationKey)...)
+			allErrs = append(allErrs, validateLabelKey(fldPath.Child("sourceAnnotationKey"), entry.SourceAnnotationKey)...)
 		default:
-			allErrs = append(allErrs, validateQualifiedName(fldPath.Child("name"), entry.Name)...)
+			allErrs = append(allErrs, validateLabelKey(fldPath.Child("name"), entry.Name)...)
 		}
 
 		sourceKind := ptr.Deref(entry.SourceKind, configapi.DefaultCustomMetricLabelSourceKind)
@@ -874,7 +882,7 @@ func validateCustomLabels(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
-func validateQualifiedName(fldPath *field.Path, value string) field.ErrorList {
+func validateLabelKey(fldPath *field.Path, value string) field.ErrorList {
 	if errs := content.IsLabelKey(value); len(errs) > 0 {
 		return field.ErrorList{field.Invalid(fldPath, value, strings.Join(errs, "; "))}
 	}
@@ -888,13 +896,8 @@ func counterNameForMapping(mapping configapi.DeviceClassMapping) string {
 	return ""
 }
 
-func validateDeviceClassSource(name, driver string, selector *resourcev1.DeviceSelector, path *field.Path, celCache *dracel.Cache) field.ErrorList {
+func validateDeviceClassSource(driver string, selector *resourcev1.DeviceSelector, path *field.Path, celCache *dracel.Cache) field.ErrorList {
 	var allErrs field.ErrorList
-	if name == "" {
-		allErrs = append(allErrs, field.Required(path.Child("name"), ""))
-	} else if errs := apimachineryutilvalidation.IsDNS1123Label(name); len(errs) != 0 {
-		allErrs = append(allErrs, field.Invalid(path.Child("name"), name, strings.Join(errs, ",")))
-	}
 	if driver == "" {
 		allErrs = append(allErrs, field.Required(path.Child("driver"), ""))
 	} else if len(driver) > resourcev1.DriverNameMaxLength {
@@ -911,6 +914,65 @@ func validateDeviceClassSource(name, driver string, selector *resourcev1.DeviceS
 			allErrs = append(allErrs, field.Invalid(selectorPath, selector.CEL.Expression,
 				fmt.Sprintf("CEL compilation failed: %v", result.Error)))
 		}
+	}
+	return allErrs
+}
+
+// validateQualifiedName is copied from:
+// https://github.com/kubernetes/kubernetes/blob/f5ab85e7c9d716e8bc5cf467ba931d8e8123764f/pkg/apis/resource/validation/validation.go#L1342-L1373
+func validateQualifiedName(name resourcev1.QualifiedName, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	parts := strings.Split(string(name), "/")
+	switch len(parts) {
+	case 1:
+		allErrs = append(allErrs, validateCIdentifier(parts[0], fldPath)...)
+	case 2:
+		if len(parts[0]) == 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath, "", "the domain must not be empty"))
+		} else {
+			allErrs = append(allErrs, validateDriverName(parts[0], fldPath)...)
+		}
+		if len(parts[1]) == 0 {
+			allErrs = append(allErrs, field.Invalid(fldPath, "", "the name must not be empty"))
+		} else {
+			allErrs = append(allErrs, validateCIdentifier(parts[1], fldPath)...)
+		}
+		// TODO: This validation is incomplete. It should reject qualified names
+		// that contain more than one slash. Currently, names like "a/b/c" are not
+		// handled and are implicitly accepted.
+		//
+		// This needs to be fixed in two places:
+		// 1. Here in this function.
+		// 2. In the corresponding declarative validation utility `resourcesQualifiedName`
+		//    in `staging/src/k8s.io/apimachinery/pkg/api/validate/strfmt.go`.
+		//
+		// The fix should be introduced carefully, possibly using ratcheting to avoid
+		// breaking existing, non-compliant objects.
+	}
+
+	return allErrs
+}
+
+func validateDriverName(name string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(name) > resourcev1.DeviceMaxDomainLength {
+		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, resourcev1.DeviceMaxDomainLength))
+	}
+	for _, msg := range apimachineryutilvalidation.IsDNS1123Subdomain(strings.ToLower(name)) {
+		allErrs = append(allErrs, field.Invalid(fldPath, name, msg))
+	}
+	return allErrs
+}
+
+// validateCIdentifier is copied from
+// https://github.com/kubernetes/kubernetes/blob/f5ab85e7c9d716e8bc5cf467ba931d8e8123764f/pkg/apis/resource/validation/validation.go#L1386-L1395
+func validateCIdentifier(id string, fldPath *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(id) > resourcev1.DeviceMaxIDLength {
+		allErrs = append(allErrs, field.TooLong(fldPath, "" /*unused*/, resourcev1.DeviceMaxIDLength))
+	}
+	for _, msg := range content.IsCIdentifier(id) {
+		allErrs = append(allErrs, field.Invalid(fldPath, id, msg))
 	}
 	return allErrs
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1668,7 +1668,7 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		"valid capacity source": {
+		"valid capacity source with qualified name": {
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationConsumableCapacity: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
@@ -1679,7 +1679,7 @@ func TestValidate(t *testing.T) {
 							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
 							Sources: []configapi.DeviceClassSourceConfig{
 								{Capacity: &configapi.DeviceClassCapacitySource{
-									Name:   "memory",
+									Name:   "gpu.example.com/memory",
 									Driver: "gpu.example.com",
 									DeviceSelector: resourcev1.DeviceSelector{
 										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
@@ -2434,6 +2434,8 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 }
 
 func TestValidateDeviceClassMappings(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationConsumableCapacity, true)
+
 	testCases := map[string]struct {
 		cfg     *configapi.Configuration
 		wantErr field.ErrorList
@@ -2462,6 +2464,198 @@ func TestValidateDeviceClassMappings(t *testing.T) {
 							DeviceClassNames: []corev1.ResourceName{"foo.com/device"},
 						},
 					},
+				},
+			},
+		},
+		"valid capacity unqualified name": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "memory",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"valid capacity qualified name": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "gpu.example.com/memory",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"valid capacity C identifier": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "gpu.example.com/Memory_Bytes",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"valid capacity name with uppercase domain": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "GPU.example.com/memory",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
+		"capacity name with empty domain": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "/memory",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.name",
+				},
+			},
+		},
+		"capacity name with invalid C identifier": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "gpu.example.com/memory-bytes",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.name",
+				},
+			},
+		},
+		"capacity name domain exceeds max length": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   resourcev1.QualifiedName(strings.Repeat("a", resourcev1.DeviceMaxDomainLength+1) + "/memory"),
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeTooLong,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.name",
+				},
+			},
+		},
+		"capacity name identifier exceeds max length": {
+			cfg: &configapi.Configuration{
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   resourcev1.QualifiedName("gpu.example.com/" + strings.Repeat("a", resourcev1.DeviceMaxIDLength+1)),
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeTooLong,
+					Field: "resources.deviceClassMappings[0].sources[0].capacity.name",
 				},
 			},
 		},

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1668,6 +1668,29 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"valid capacity source": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationConsumableCapacity: true},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "gpu.memory",
+							DeviceClassNames: []corev1.ResourceName{"vgpu.example.com"},
+							Sources: []configapi.DeviceClassSourceConfig{
+								{Capacity: &configapi.DeviceClassCapacitySource{
+									Name:   "memory",
+									Driver: "gpu.example.com",
+									DeviceSelector: resourcev1.DeviceSelector{
+										CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'gpu.example.com'"},
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+		},
 		"valid capacity source with qualified name": {
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationConsumableCapacity: true},
 			cfg: &configapi.Configuration{

--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -171,7 +171,7 @@ func processCapacityCharge(
 		// Resolve the explicit capacity request from the claim, if any.
 		var explicitRequest *resource.Quantity
 		if exactly.Capacity != nil {
-			if reqVal, ok := exactly.Capacity.Requests[resourcev1.QualifiedName(capCfg.resourceName)]; ok {
+			if reqVal, ok := exactly.Capacity.Requests[capCfg.resourceName]; ok {
 				explicitRequest = &reqVal
 			}
 		}
@@ -202,14 +202,13 @@ func computeCapacityCharge(
 	explicitRequest *resource.Quantity,
 	reqPath *field.Path,
 ) (*resource.Quantity, field.ErrorList) {
-	dimName := resourcev1.QualifiedName(capCfg.resourceName)
 	var maxRounded resource.Quantity
 	hasDimension := false
 	hasValidCharge := false
 
 	for i := range matched {
 		dev := &matched[i]
-		capDim, ok := dev.Capacity[dimName]
+		capDim, ok := dev.Capacity[capCfg.resourceName]
 		if !ok {
 			log.V(4).Info("Device has no capacity dimension, skipping",
 				"device", dev.Name, "dimension", capCfg.resourceName)
@@ -243,7 +242,7 @@ func computeCapacityCharge(
 		)}
 	}
 
-	chargeValue := safeChargeValue(log, maxRounded, capCfg.driver, capCfg.resourceName, count)
+	chargeValue := safeChargeValue(log, maxRounded, capCfg.driver, string(capCfg.resourceName), count)
 	result := resource.NewQuantity(chargeValue, maxRounded.Format)
 	return result, nil
 }

--- a/pkg/dra/mapper.go
+++ b/pkg/dra/mapper.go
@@ -37,7 +37,7 @@ type deviceClassCounterConfig struct {
 // deviceClassCapacityConfig holds capacity configuration for a specific DeviceClass.
 type deviceClassCapacityConfig struct {
 	driver         string
-	resourceName   string
+	resourceName   resourcev1.QualifiedName
 	deviceSelector resourcev1.DeviceSelector
 }
 

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -657,12 +657,12 @@ for devices that allow multiple allocations (KEP-5075).</p>
     
   
 <tr><td><code>name</code> <B>[Required]</B><br/>
-<code>string</code>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#qualifiedname-v1-resource"><code>k8s.io/api/resource/v1.QualifiedName</code></a>
 </td>
 <td>
    <p>Name identifies the capacity dimension to track for quota
-(e.g., &quot;gpu.memory&quot;).
-Must not exceed 63 characters.</p>
+(e.g., &quot;gpu.example.com/memory&quot;).
+Must be a valid DRA QualifiedName.</p>
 </td>
 </tr>
 <tr><td><code>driver</code> <B>[Required]</B><br/>


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
Allows DRA capacity sources to use `resourcev1.QualifiedName` values such as `gpu.example.com/memory`, and updates the related configuration API, validation, lookup, and documentation.

The upstream capacity API: https://github.com/kubernetes/kubernetes/blob/f5ab85e7c9d716e8bc5cf467ba931d8e8123764f/pkg/apis/resource/types.go#L1172-L1203

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DRA capacity dimensions for quota configuration now accept qualified names (for example, `gpu.example.com/memory`), alongside previously supported forms.
* **Bug Fixes**
  * Enhanced validation for DRA capacity sources and custom label keys, including clearer rejection of invalid capacity names.
  * Improved capacity charge computation and lookups to consistently resolve against the configured capacity dimension key.
* **Documentation**
  * Updated DRA configuration references, examples, and the API field description to reflect qualified-name requirements.
* **Tests**
  * Expanded validation coverage for qualified and unqualified capacity-name formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->