### PR TITLE
Centralized TAS in MultiKueue

### DIFF
--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -370,21 +370,6 @@ type MultiKueue struct {
 	// Note: This field is going to be ignored when the MultiKueueIncrementalDispatcherConfig feature gate is disabled.
 	// +optional
 	IncrementalDispatcherConfig *IncrementalDispatcherConfig `json:"incrementalDispatcherConfig,omitempty"`
-
-	// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
-	// This field is ignored when the MultiKueueCentralizedTAS feature gate is
-	// disabled.
-	// +optional
-	CentralizedTAS *CentralizedTAS `json:"centralizedTAS,omitempty"`
-}
-
-// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
-type CentralizedTAS struct {
-	// Enable controls whether a MultiKueue manager watches the required
-	// resources in each worker cluster. It must be true to allow a ClusterQueue
-	// to be configured to use centralized TAS.
-	// +optional
-	Enable *bool `json:"enable,omitempty"`
 }
 
 // IncrementalDispatcherConfig holds configuration for the MultiKueue Incremental Dispatcher.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -370,6 +370,21 @@ type MultiKueue struct {
 	// Note: This field is going to be ignored when the MultiKueueIncrementalDispatcherConfig feature gate is disabled.
 	// +optional
 	IncrementalDispatcherConfig *IncrementalDispatcherConfig `json:"incrementalDispatcherConfig,omitempty"`
+
+	// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
+	// This field is ignored when the MultiKueueCentralizedTAS feature gate is
+	// disabled.
+	// +optional
+	CentralizedTAS *CentralizedTAS `json:"centralizedTAS,omitempty"`
+}
+
+// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
+type CentralizedTAS struct {
+	// Enable controls whether a MultiKueue manager watches the required
+	// resources in each worker cluster. It must be true to allow a ClusterQueue
+	// to be configured to use centralized TAS.
+	// +optional
+	Enable *bool `json:"enable,omitempty"`
 }
 
 // IncrementalDispatcherConfig holds configuration for the MultiKueue Incremental Dispatcher.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -1,7 +1,5 @@
 # KEP-13345: Support centralized scheduling and quota management in MultiKueue
 
-
-
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
@@ -18,8 +16,6 @@
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
 - [Alternatives](#alternatives)
-
-
 
 ## Summary
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -1,0 +1,120 @@
+# KEP-13345: Support centralized scheduling and quota management in MultiKueue
+
+
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories (Optional)](#user-stories-optional)
+    - [Story 1: Global Fair Sharing](#story-1-global-fair-sharing)
+    - [Story 2: Cross-Cluster Preemption](#story-2-cross-cluster-preemption)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Remote Inventory Sync](#remote-inventory-sync)
+  - [Manager-Authoritative Placement](#manager-authoritative-placement)
+  - [Worker Pass-Through](#worker-pass-through)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+- [Alternatives](#alternatives)
+
+
+
+## Summary
+
+This KEP proposes an option to use the MultiKueue manager as a central scheduler across all worker clusters, specifically leveraging Topology Aware Scheduling (TAS). In this model, worker clusters act simply as compute pools. The central manager handles all admission, preemption, and fair-sharing decisions, and all project or team-specific quotas are managed entirely on the manager cluster.
+
+## Motivation
+
+Currently, MultiKueue delegates final scheduling decisions to the worker clusters. While this works well for many setups, it makes it difficult to achieve strict global fair sharing and cross-cluster preemption across an entire fleet because the manager lacks visibility into the actual physical capacity and topology of the worker nodes.
+
+Allowing the central manager to make these decisions helps organizations that manage compute capacity across multiple regions or clouds to better optimize their resources. It also simplifies cluster administration by consolidating team quota management into a single control plane, rather than needing to manage and sync quotas across every worker cluster.
+
+### Goals
+
+- Enable the MultiKueue manager to act as a central scheduler across all worker clusters.
+- Support all workloads currently supported by MultiKueue.
+- Ensure global preemption and fair sharing work seamlessly across the fleet.
+- The manager computes the exact node-level placement (e.g., `kubernetes.io/hostname`) for workloads.
+- Workers execute the manager's placement verbatim without re-evaluating TAS.
+
+### Non-Goals
+
+- Supporting workloads that span multiple clusters (cross-cluster gangs). A single workload must still fit entirely within one worker cluster.
+- Supporting dynamic node provisioning (autoscaling) for TAS workloads in this iteration.
+
+## Proposal
+
+We propose extending MultiKueue to allow the manager to ingest physical node and pod inventory from worker clusters into its own scheduler TAS cache. When a workload is admitted, the manager will compute the full `TopologyAssignment` (treating the worker cluster as the top-level topology domain) and project a host-exact placement onto the remote workload. The worker cluster will then skip its own scheduling cycle and apply the manager's placement directly.
+
+This solution works because all workloads are already mirrored in the manager via MultiKueue. The reason global features like fair-sharing and cross-cluster preemption don't work correctly today is simply because the manager lacks information about the physical capacity of the clusters and the specific topology placement of the workloads. By centralizing the TAS cache across all clusters, we give the manager the missing physical context it needs, bringing all of these advanced scheduling features alive globally without having to rewrite them.
+
+Furthermore, this architectural shift eliminates the need for several complex workarounds currently required in MultiKueue:
+
+- It removes the need for `MultiKueueOrchestratedPreemption` and its associated complexities.
+- It eliminates the need to declare higher, inflated quotas in the manager compared to the workers.
+- It removes the need to maintain a multiplier in the manager quota to account for fleet-wide capacity.
+
+### User Stories (Optional)
+
+#### Story 1: Global Fair Sharing
+
+As a platform administrator managing a fleet of GPU clusters across multiple regions, I want to define team quotas centrally on the manager cluster. If Team A is under quota and Team B is over quota, I want the manager to ensure Team A can preempt Team B's workloads globally, regardless of which specific worker cluster Team B's workloads happen to be running on.
+
+#### Story 2: Cross-Cluster Preemption
+
+As a machine learning engineer, I submit a high-priority distributed training job that requires a specific network topology (e.g., all pods on the same rack). If the fleet is full, I want the central manager to find the optimal worker cluster and preempt exactly the right lower-priority workloads on that specific cluster to make room for my job's topology requirements.
+
+### Risks and Mitigations
+
+**Risk:** Scalability and performance bottlenecks on the manager cluster.
+**Mitigation:** The manager's TAS cache does not store full pod specs. It only caches a highly optimized, pre-aggregated counter of the resources used by non-TAS pods per node. This ensures the memory footprint and CPU overhead remain minimal even at large scale.
+
+**Risk:** Worker cluster disconnection.
+**Mitigation:** The system relies on MultiKueue's existing `workerLostTimeout` mechanism. If a worker disconnects, the manager waits for a grace period. If the worker does not reconnect, the manager evicts the workload and retries scheduling it on a healthy cluster. When a worker reconnects, the manager performs a fresh `List` to rebuild the TAS cache for that cluster.
+
+## Drawbacks
+
+- **Scalability Limits**: Centralizing all node and pod state into a single manager introduces a fundamental scalability limit. While the TAS cache is optimized (storing only aggregated resource counters rather than full pod specs), the manager must still process a high volume of watch events from every worker cluster. However, this architecture should comfortably support the currently documented limits for TAS (2,500 nodes) and MultiKueue (20 worker clusters).
+- **Distributed System Complexity**: The manager's view of worker capacity is eventually consistent. Network partitions, watch delays, or API server latency on worker clusters can cause the manager to make scheduling decisions based on stale physical capacity data, potentially leading to transient placement failures or race conditions.
+- **Single Point of Failure**: While MultiKueue already relies on the manager for admission, centralizing TAS makes the manager a harder dependency for actual node-level placement. If the manager's TAS cache is degraded, no topology-aware workloads can be scheduled anywhere in the fleet.
+
+## Design Details
+
+### Remote Inventory Sync
+
+The manager will watch `Node` and `Pod` objects from all connected worker clusters. These events are fed directly into the manager's scheduler TAS cache. 
+
+To differentiate nodes across clusters, a cluster label (e.g., `kueue.x-k8s.io/multikueue-cluster`) is injected into the remote Node objects as they are synced into the cache. This label serves as the top-level topology domain for the manager.
+
+The manager reuses the exact same `utiltas.BelongsToNonTASCache` logic as the single-cluster controller to track non-TAS usage on the remote nodes.
+
+### Manager-Authoritative Placement
+
+When scheduling a workload, the manager computes the `TopologyAssignment` using the worker cluster as the top level and hostname as the lowest level. 
+
+Before stamping the admission onto the remote workload, the manager projects this assignment: it strips the cluster level and collapses the assignment to a host-exact placement (`Levels: []string{corev1.LabelHostname}`).
+
+### Worker Pass-Through
+
+Workers are configured with a single, massive quota per resource flavor (effectively acting as infinite compute pools from a quota perspective). 
+
+When the worker receives the remote workload with the manager-stamped admission, it recognizes that the workload is already admitted. The worker skips its own scheduling cycle, and its TAS ungater translates the host-exact `TopologyAssignment` into standard `nodeSelectors` on the pods.
+
+### Test Plan
+
+- **Unit tests**: Cover the topology projection logic (`projectAdmissionForWorker`) and the remote inventory cache sync logic.
+- **e2e tests**: Implement a comprehensive e2e test suite covering:
+  - Cross-cluster topology-correct preemption.
+  - Global fair sharing across worker clusters.
+  - Physical capacity enforcement (ensuring the manager blocks admission if the fleet is physically full, even if central quota is available).
+
+### Graduation Criteria
+
+TBD
+
+## Alternatives
+
+**Distributed TAS**: Let workers compute TAS and report back to the manager. 
+*Drawback*: This cannot guarantee strict global fair sharing or accurate cross-cluster preemption without implementing complex two-phase commit protocols between the manager and workers. The manager would have to blindly guess which worker might be able to fit the topology, leading to high latency and scheduling churn.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -1,5 +1,6 @@
 # KEP-13345: Support centralized scheduling and quota management in MultiKueue
 
+<!-- toc -->
 - [Summary](#summary)
 - [Motivation](#motivation)
   - [Goals](#goals)
@@ -9,6 +10,7 @@
     - [Story 1: Global Fair Sharing](#story-1-global-fair-sharing)
     - [Story 2: Cross-Cluster Preemption](#story-2-cross-cluster-preemption)
   - [Risks and Mitigations](#risks-and-mitigations)
+- [Drawbacks](#drawbacks)
 - [Design Details](#design-details)
   - [Remote Inventory Sync](#remote-inventory-sync)
   - [Manager-Authoritative Placement](#manager-authoritative-placement)
@@ -16,6 +18,7 @@
   - [Test Plan](#test-plan)
   - [Graduation Criteria](#graduation-criteria)
 - [Alternatives](#alternatives)
+<!-- /toc -->
 
 ## Summary
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -28,6 +28,12 @@ across all worker clusters, specifically leveraging Topology Aware Scheduling
 manager handles all admission, preemption, and fair-sharing decisions, and all
 project or team-specific quotas are managed entirely on the manager cluster.
 
+This new centralized scheduling scheme is necessarily more computationally
+expensive than MultiKueue's current mode which primarily manages global quota
+and dispatch and relies on workers to make authoritative scheduling decisions.
+Users will be able to select which mode a MultiKueue instance uses for their
+scheduling and scaling requirements.
+
 ## Motivation
 
 Currently, MultiKueue delegates final scheduling decisions to the worker
@@ -55,6 +61,7 @@ sync quotas across every worker cluster.
 - Supporting workloads that span multiple clusters (cross-cluster gangs). A
   single workload must still fit entirely within one worker cluster.
 - Supporting dynamic node provisioning (autoscaling) for TAS workloads in this iteration.
+- Fundamentally change the existing MultiKueue design.
 
 ## Proposal
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -75,7 +75,7 @@ As a machine learning engineer, I submit a high-priority distributed training jo
 
 ## Drawbacks
 
-- **Scalability Limits**: Centralizing all node and pod state into a single manager introduces a fundamental scalability limit. While the TAS cache is optimized (storing only aggregated resource counters rather than full pod specs), the manager must still process a high volume of watch events from every worker cluster. However, this architecture should comfortably support the currently documented limits for TAS (2,500 nodes) and MultiKueue (20 worker clusters).
+- **Scalability Limits**: Centralizing all node and pod state into a single manager introduces a fundamental scalability limit. While the TAS cache is optimized (storing only aggregated resource counters rather than full pod specs), the manager must still process a high volume of watch events from every worker cluster. However, this architecture should comfortably support the currently documented limits for TAS (100k nodes) and MultiKueue (20 worker clusters).
 - **Distributed System Complexity**: The manager's view of worker capacity is eventually consistent. Network partitions, watch delays, or API server latency on worker clusters can cause the manager to make scheduling decisions based on stale physical capacity data, potentially leading to transient placement failures or race conditions.
 - **Single Point of Failure**: While MultiKueue already relies on the manager for admission, centralizing TAS makes the manager a harder dependency for actual node-level placement. If the manager's TAS cache is degraded, no topology-aware workloads can be scheduled anywhere in the fleet.
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -108,12 +108,14 @@ cluster to make room for my job's topology requirements.
 ### Risks and Mitigations
 
 **Risk:** Scalability and performance bottlenecks on the manager cluster.
+
 **Mitigation:** The manager's TAS cache does not store full pod specs. It only
 caches a highly optimized, pre-aggregated counter of the resources used by
 non-TAS pods per node. This ensures the memory footprint and CPU overhead remain
 minimal even at large scale.
 
 **Risk:** Worker cluster disconnection.
+
 **Mitigation:** The system relies on MultiKueue's existing `workerLostTimeout`
 mechanism. If a worker disconnects, the manager waits for a grace period. If the
 worker does not reconnect, the manager evicts the workload and retries
@@ -159,7 +161,7 @@ single-cluster controller to track non-TAS usage on the remote nodes.
 ### Manager-Authoritative Placement
 
 When scheduling a workload, the manager computes the `TopologyAssignment` using
-the worker cluster as the top level and hostname as the lowest level. 
+the worker cluster as the top level and hostname as the lowest level.
 
 Before stamping the admission onto the remote workload, the manager projects
 this assignment: it strips the cluster level and collapses the assignment to a
@@ -168,7 +170,7 @@ host-exact placement (`Levels: []string{corev1.LabelHostname}`).
 ### Worker Pass-Through
 
 Workers are configured with a single, massive quota per resource flavor
-(effectively acting as infinite compute pools from a quota perspective). 
+(effectively acting as infinite compute pools from a quota perspective).
 
 When the worker receives the remote workload with the manager-stamped admission,
 it recognizes that the workload is already admitted. The worker skips its own
@@ -191,7 +193,8 @@ TBD
 
 ## Alternatives
 
-**Distributed TAS**: Let workers compute TAS and report back to the manager. 
+**Distributed TAS**: Let workers compute TAS and report back to the manager.
+
 *Drawback*: This cannot guarantee strict global fair sharing or accurate
 cross-cluster preemption without implementing complex two-phase commit protocols
 between the manager and workers. The manager would have to blindly guess which
@@ -202,6 +205,7 @@ churn.
 based on aggregated capacity advertised by each worker cluster organized by
 resource and topological domain instead of watching all Nodes and Pods across
 all worker clusters.
+
 *Drawback*: Requires a new API resource definition, more likely to provide
 outdated information at less-than-extraordinary scale and load, overlaps less
 with how utilization is calculated in single-cluster scenarios.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -12,6 +12,7 @@
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Drawbacks](#drawbacks)
 - [Design Details](#design-details)
+  - [Configuration](#configuration)
   - [Remote Inventory Sync](#remote-inventory-sync)
   - [Manager-Authoritative Placement](#manager-authoritative-placement)
   - [Worker Pass-Through](#worker-pass-through)

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -142,6 +142,58 @@ performs a fresh `List` to rebuild the TAS cache for that cluster.
 
 ## Design Details
 
+### Configuration
+
+This KEP proposes adding a new mode for MultiKueue and preserving its current
+strategy as the default. The new "centralized" mode necessarily changes the
+scalability profile of the Kueue manager by requiring more data which comes from
+other clusters.
+
+To enable centralized TAS, users must first enable the
+`MultiKueueCentralizedTAS` feature gate in the Kueue manager on the manager
+cluster and each worker cluster. The feature gate allows a new
+`multikueue.centralizedTAS` field to be set in the Kueue Configuration API:
+
+```go
+type MultiKueue struct {
+	...
+
+	// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
+	// This field is ignored when the MultiKueueCentralizedTAS feature gate is
+	// disabled.
+	// +optional
+	CentralizedTAS *CentralizedTAS `json:"centralizedTAS,omitempty"`
+}
+
+// CentralizedTAS configures MultiKueue's "centralized" scheduling scheme.
+type CentralizedTAS struct {
+	// Enable controls whether a MultiKueue manager watches the required
+	// resources in each worker cluster. It must be true to allow a ClusterQueue
+	// to be configured to use centralized TAS.
+	// +optional
+	Enable *bool `json:"enable,omitempty"`
+}
+```
+
+The Configuration API changes are intended to allow this functionality to be
+disabled even if the feature gate is graduated to stable and removed.
+
+When the Configuration's `multikueue.centralizedTAS.enabled` is `true`, a
+ClusterQueue can be configured to use centralized TAS with the
+`kueue.x-k8s.io/multikueue-centralized-tas="true"` annotation in addition to a
+MultiKueue AdmissionCheck. ClusterQueues may be created with a MultiKueue
+AdmissionCheck without the annotation to use the existing MultiKueue scheduling
+behavior.
+
+In short, to enable centralized TAS for a Workload:
+
+1. Enable the `MultiKueueCentralizedTAS` feature gate in the Kueue managers for
+   the manager and worker clusters.
+1. Set the manager's Configuration object to include
+   `multikueue.centralizedTAS.enabled=true`.
+1. Annotate the appropriate ClusterQueues with
+   `kueue.x-k8s.io/multikueue-centralized-tas="true"`.
+
 ### Remote Inventory Sync
 
 The manager will watch Node and Pod objects from all connected worker

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -70,7 +70,7 @@ pod inventory from worker clusters into its own scheduler TAS cache. When a
 workload is admitted, the manager will compute the full `TopologyAssignment`
 (treating the worker cluster as the top-level topology domain) and project a
 host-exact placement onto the remote workload. The worker cluster will then skip
-its own scheduling cycle and apply the manager's placement directly.
+the workload during its own scheduling cycle and apply the manager's placement directly.
 
 This solution works because all workloads are already mirrored in the manager
 via MultiKueue. The reason global features like fair-sharing and cross-cluster
@@ -224,8 +224,8 @@ Workers are configured with a single, massive quota per resource flavor
 (effectively acting as infinite compute pools from a quota perspective).
 
 When the worker receives the remote workload with the manager-stamped admission,
-it recognizes that the workload is already admitted. The worker skips its own
-scheduling cycle, and its TAS ungater translates the host-exact
+it recognizes that the workload is already admitted. The worker skips the workload during its own
+scheduling cycle, and the TAS ungater translates the workload's host-exact
 `TopologyAssignment` into standard `nodeSelectors` on the pods.
 
 ### Test Plan

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -85,7 +85,6 @@ Furthermore, this architectural shift eliminates the need for several complex wo
 
 - It removes the need for `MultiKueueOrchestratedPreemption` and its associated complexities.
 - It eliminates the need to declare higher, inflated quotas in the manager compared to the workers.
-- It removes the need to maintain a multiplier in the manager quota to account for fleet-wide capacity.
 
 ### User Stories (Optional)
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -22,13 +22,25 @@
 
 ## Summary
 
-This KEP proposes an option to use the MultiKueue manager as a central scheduler across all worker clusters, specifically leveraging Topology Aware Scheduling (TAS). In this model, worker clusters act simply as compute pools. The central manager handles all admission, preemption, and fair-sharing decisions, and all project or team-specific quotas are managed entirely on the manager cluster.
+This KEP proposes an option to use the MultiKueue manager as a central scheduler
+across all worker clusters, specifically leveraging Topology Aware Scheduling
+(TAS). In this model, worker clusters act simply as compute pools. The central
+manager handles all admission, preemption, and fair-sharing decisions, and all
+project or team-specific quotas are managed entirely on the manager cluster.
 
 ## Motivation
 
-Currently, MultiKueue delegates final scheduling decisions to the worker clusters. While this works well for many setups, it makes it difficult to achieve strict global fair sharing and cross-cluster preemption across an entire fleet because the manager lacks visibility into the actual physical capacity and topology of the worker nodes.
+Currently, MultiKueue delegates final scheduling decisions to the worker
+clusters. While this works well for many setups, it makes it difficult to
+achieve strict global fair sharing and cross-cluster preemption across an entire
+fleet because the manager lacks visibility into the actual physical capacity and
+topology of the worker nodes.
 
-Allowing the central manager to make these decisions helps organizations that manage compute capacity across multiple regions or clouds to better optimize their resources. It also simplifies cluster administration by consolidating team quota management into a single control plane, rather than needing to manage and sync quotas across every worker cluster.
+Allowing the central manager to make these decisions helps organizations that
+manage compute capacity across multiple regions or clouds to better optimize
+their resources. It also simplifies cluster administration by consolidating team
+quota management into a single control plane, rather than needing to manage and
+sync quotas across every worker cluster.
 
 ### Goals
 
@@ -40,14 +52,27 @@ Allowing the central manager to make these decisions helps organizations that ma
 
 ### Non-Goals
 
-- Supporting workloads that span multiple clusters (cross-cluster gangs). A single workload must still fit entirely within one worker cluster.
+- Supporting workloads that span multiple clusters (cross-cluster gangs). A
+  single workload must still fit entirely within one worker cluster.
 - Supporting dynamic node provisioning (autoscaling) for TAS workloads in this iteration.
 
 ## Proposal
 
-We propose extending MultiKueue to allow the manager to ingest physical node and pod inventory from worker clusters into its own scheduler TAS cache. When a workload is admitted, the manager will compute the full `TopologyAssignment` (treating the worker cluster as the top-level topology domain) and project a host-exact placement onto the remote workload. The worker cluster will then skip its own scheduling cycle and apply the manager's placement directly.
+We propose extending MultiKueue to allow the manager to ingest physical node and
+pod inventory from worker clusters into its own scheduler TAS cache. When a
+workload is admitted, the manager will compute the full `TopologyAssignment`
+(treating the worker cluster as the top-level topology domain) and project a
+host-exact placement onto the remote workload. The worker cluster will then skip
+its own scheduling cycle and apply the manager's placement directly.
 
-This solution works because all workloads are already mirrored in the manager via MultiKueue. The reason global features like fair-sharing and cross-cluster preemption don't work correctly today is simply because the manager lacks information about the physical capacity of the clusters and the specific topology placement of the workloads. By centralizing the TAS cache across all clusters, we give the manager the missing physical context it needs, bringing all of these advanced scheduling features alive globally without having to rewrite them.
+This solution works because all workloads are already mirrored in the manager
+via MultiKueue. The reason global features like fair-sharing and cross-cluster
+preemption don't work correctly today is simply because the manager lacks
+information about the physical capacity of the clusters and the specific
+topology placement of the workloads. By centralizing the TAS cache across all
+clusters, we give the manager the missing physical context it needs, bringing
+all of these advanced scheduling features alive globally without having to
+rewrite them.
 
 Furthermore, this architectural shift eliminates the need for several complex workarounds currently required in MultiKueue:
 
@@ -59,55 +84,97 @@ Furthermore, this architectural shift eliminates the need for several complex wo
 
 #### Story 1: Global Fair Sharing
 
-As a platform administrator managing a fleet of GPU clusters across multiple regions, I want to define team quotas centrally on the manager cluster. If Team A is under quota and Team B is over quota, I want the manager to ensure Team A can preempt Team B's workloads globally, regardless of which specific worker cluster Team B's workloads happen to be running on.
+As a platform administrator managing a fleet of GPU clusters across multiple
+regions, I want to define team quotas centrally on the manager cluster. If Team
+A is under quota and Team B is over quota, I want the manager to ensure Team A
+can preempt Team B's workloads globally, regardless of which specific worker
+cluster Team B's workloads happen to be running on.
 
 #### Story 2: Cross-Cluster Preemption
 
-As a machine learning engineer, I submit a high-priority distributed training job that requires a specific network topology (e.g., all pods on the same rack). If the fleet is full, I want the central manager to find the optimal worker cluster and preempt exactly the right lower-priority workloads on that specific cluster to make room for my job's topology requirements.
+As a machine learning engineer, I submit a high-priority distributed training
+job that requires a specific network topology (e.g., all pods on the same rack).
+If the fleet is full, I want the central manager to find the optimal worker
+cluster and preempt exactly the right lower-priority workloads on that specific
+cluster to make room for my job's topology requirements.
 
 ### Risks and Mitigations
 
 **Risk:** Scalability and performance bottlenecks on the manager cluster.
-**Mitigation:** The manager's TAS cache does not store full pod specs. It only caches a highly optimized, pre-aggregated counter of the resources used by non-TAS pods per node. This ensures the memory footprint and CPU overhead remain minimal even at large scale.
+**Mitigation:** The manager's TAS cache does not store full pod specs. It only
+caches a highly optimized, pre-aggregated counter of the resources used by
+non-TAS pods per node. This ensures the memory footprint and CPU overhead remain
+minimal even at large scale.
 
 **Risk:** Worker cluster disconnection.
-**Mitigation:** The system relies on MultiKueue's existing `workerLostTimeout` mechanism. If a worker disconnects, the manager waits for a grace period. If the worker does not reconnect, the manager evicts the workload and retries scheduling it on a healthy cluster. When a worker reconnects, the manager performs a fresh `List` to rebuild the TAS cache for that cluster.
+**Mitigation:** The system relies on MultiKueue's existing `workerLostTimeout`
+mechanism. If a worker disconnects, the manager waits for a grace period. If the
+worker does not reconnect, the manager evicts the workload and retries
+scheduling it on a healthy cluster. When a worker reconnects, the manager
+performs a fresh `List` to rebuild the TAS cache for that cluster.
 
 ## Drawbacks
 
-- **Scalability Limits**: Centralizing all node and pod state into a single manager introduces a fundamental scalability limit. While the TAS cache is optimized (storing only aggregated resource counters rather than full pod specs), the manager must still process a high volume of watch events from every worker cluster. However, this architecture should comfortably support the currently documented limits for TAS (100k nodes) and MultiKueue (20 worker clusters).
-- **Distributed System Complexity**: The manager's view of worker capacity is eventually consistent. Network partitions, watch delays, or API server latency on worker clusters can cause the manager to make scheduling decisions based on stale physical capacity data, potentially leading to transient placement failures or race conditions.
-- **Single Point of Failure**: While MultiKueue already relies on the manager for admission, centralizing TAS makes the manager a harder dependency for actual node-level placement. If the manager's TAS cache is degraded, no topology-aware workloads can be scheduled anywhere in the fleet.
+- **Scalability Limits**: Centralizing all node and pod state into a single
+  manager introduces a fundamental scalability limit. While the TAS cache is
+  optimized (storing only aggregated resource counters rather than full pod
+  specs), the manager must still process a high volume of watch events from
+  every worker cluster. However, this architecture should comfortably support
+  the currently documented limits for TAS (100k nodes) and MultiKueue (20 worker
+  clusters).
+- **Distributed System Complexity**: The manager's view of worker capacity is
+  eventually consistent. Network partitions, watch delays, or API server latency
+  on worker clusters can cause the manager to make scheduling decisions based on
+  stale physical capacity data, potentially leading to transient placement
+  failures or race conditions.
+- **Single Point of Failure**: While MultiKueue already relies on the manager
+  for admission, centralizing TAS makes the manager a harder dependency for
+  actual node-level placement. If the manager's TAS cache is degraded, no
+  topology-aware workloads can be scheduled anywhere in the fleet.
 
 ## Design Details
 
 ### Remote Inventory Sync
 
-The manager will watch `Node` and `Pod` objects from all connected worker clusters. These events are fed directly into the manager's scheduler TAS cache. 
+The manager will watch `Node` and `Pod` objects from all connected worker
+clusters. These events are fed directly into the manager's scheduler TAS cache. 
 
-To differentiate nodes across clusters, a cluster label (e.g., `kueue.x-k8s.io/multikueue-cluster`) is injected into the remote Node objects as they are synced into the cache. This label serves as the top-level topology domain for the manager.
+To differentiate nodes across clusters, a cluster label (e.g.,
+`kueue.x-k8s.io/multikueue-cluster`) is injected into the remote Node objects as
+they are synced into the cache. This label serves as the top-level topology
+domain for the manager.
 
-The manager reuses the exact same `utiltas.BelongsToNonTASCache` logic as the single-cluster controller to track non-TAS usage on the remote nodes.
+The manager reuses the exact same `utiltas.BelongsToNonTASCache` logic as the
+single-cluster controller to track non-TAS usage on the remote nodes.
 
 ### Manager-Authoritative Placement
 
-When scheduling a workload, the manager computes the `TopologyAssignment` using the worker cluster as the top level and hostname as the lowest level. 
+When scheduling a workload, the manager computes the `TopologyAssignment` using
+the worker cluster as the top level and hostname as the lowest level. 
 
-Before stamping the admission onto the remote workload, the manager projects this assignment: it strips the cluster level and collapses the assignment to a host-exact placement (`Levels: []string{corev1.LabelHostname}`).
+Before stamping the admission onto the remote workload, the manager projects
+this assignment: it strips the cluster level and collapses the assignment to a
+host-exact placement (`Levels: []string{corev1.LabelHostname}`).
 
 ### Worker Pass-Through
 
-Workers are configured with a single, massive quota per resource flavor (effectively acting as infinite compute pools from a quota perspective). 
+Workers are configured with a single, massive quota per resource flavor
+(effectively acting as infinite compute pools from a quota perspective). 
 
-When the worker receives the remote workload with the manager-stamped admission, it recognizes that the workload is already admitted. The worker skips its own scheduling cycle, and its TAS ungater translates the host-exact `TopologyAssignment` into standard `nodeSelectors` on the pods.
+When the worker receives the remote workload with the manager-stamped admission,
+it recognizes that the workload is already admitted. The worker skips its own
+scheduling cycle, and its TAS ungater translates the host-exact
+`TopologyAssignment` into standard `nodeSelectors` on the pods.
 
 ### Test Plan
 
-- **Unit tests**: Cover the topology projection logic (`projectAdmissionForWorker`) and the remote inventory cache sync logic.
+- **Unit tests**: Cover the topology projection logic
+  (`projectAdmissionForWorker`) and the remote inventory cache sync logic.
 - **e2e tests**: Implement a comprehensive e2e test suite covering:
   - Cross-cluster topology-correct preemption.
   - Global fair sharing across worker clusters.
-  - Physical capacity enforcement (ensuring the manager blocks admission if the fleet is physically full, even if central quota is available).
+  - Physical capacity enforcement (ensuring the manager blocks admission if the
+    fleet is physically full, even if central quota is available).
 
 ### Graduation Criteria
 
@@ -116,4 +183,8 @@ TBD
 ## Alternatives
 
 **Distributed TAS**: Let workers compute TAS and report back to the manager. 
-*Drawback*: This cannot guarantee strict global fair sharing or accurate cross-cluster preemption without implementing complex two-phase commit protocols between the manager and workers. The manager would have to blindly guess which worker might be able to fit the topology, leading to high latency and scheduling churn.
+*Drawback*: This cannot guarantee strict global fair sharing or accurate
+cross-cluster preemption without implementing complex two-phase commit protocols
+between the manager and workers. The manager would have to blindly guess which
+worker might be able to fit the topology, leading to high latency and scheduling
+churn.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -143,8 +143,10 @@ performs a fresh `List` to rebuild the TAS cache for that cluster.
 
 ### Remote Inventory Sync
 
-The manager will watch `Node` and `Pod` objects from all connected worker
-clusters. These events are fed directly into the manager's scheduler TAS cache. 
+The manager will watch Node and Pod objects from all connected worker
+clusters. These events are fed directly into the manager's scheduler TAS cache,
+which will be extended to index Nodes by cluster name in addition to their own
+name.
 
 To differentiate nodes across clusters, a cluster label (e.g.,
 `kueue.x-k8s.io/multikueue-cluster`) is injected into the remote Node objects as

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -179,7 +179,7 @@ type CentralizedTAS struct {
 The Configuration API changes are intended to allow this functionality to be
 disabled even if the feature gate is graduated to stable and removed.
 
-When the Configuration's `multikueue.centralizedTAS.enabled` is `true`, a
+When the Configuration's `multikueue.centralizedTAS.enable` is `true`, a
 ClusterQueue can be configured to use centralized TAS with the
 `kueue.x-k8s.io/multikueue-centralized-tas="true"` annotation in addition to a
 MultiKueue AdmissionCheck. ClusterQueues may be created with a MultiKueue
@@ -191,7 +191,7 @@ In short, to enable centralized TAS for a Workload:
 1. Enable the `MultiKueueCentralizedTAS` feature gate in the Kueue managers for
    the manager and worker clusters.
 1. Set the manager's Configuration object to include
-   `multikueue.centralizedTAS.enabled=true`.
+   `multikueue.centralizedTAS.enable=true`.
 1. Annotate the appropriate ClusterQueues with
    `kueue.x-k8s.io/multikueue-centralized-tas="true"`.
 

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -196,7 +196,7 @@ between the manager and workers. The manager would have to blindly guess which
 worker might be able to fit the topology, leading to high latency and scheduling
 churn.
 
-**Aggregated TAS Capacity**: Management cluster calculates `ToplogyAssignment`s
+**Aggregated TAS Capacity**: Management cluster calculates `TopologyAssignment`s
 based on aggregated capacity advertised by each worker cluster organized by
 resource and topological domain instead of watching all Nodes and Pods across
 all worker clusters.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -188,3 +188,11 @@ cross-cluster preemption without implementing complex two-phase commit protocols
 between the manager and workers. The manager would have to blindly guess which
 worker might be able to fit the topology, leading to high latency and scheduling
 churn.
+
+**Aggregated TAS Capacity**: Management cluster calculates `ToplogyAssignment`s
+based on aggregated capacity advertised by each worker cluster organized by
+resource and topological domain instead of watching all Nodes and Pods across
+all worker clusters.
+*Drawback*: Requires a new API resource definition, more likely to provide
+outdated information at less-than-extraordinary scale and load, overlaps less
+with how utilization is calculated in single-cluster scenarios.

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -123,6 +123,15 @@ scheduling it on a healthy cluster. When a worker reconnects, the manager
 performs a fresh `List` to rebuild the TAS cache for that cluster and re-evicts
 workloads on the workload which were evicted while it was disconnected.
 
+**Risk:** Topology on selected worker cluster is incompatible with manager cluster.
+
+**Mitigation:** The manager cluster will watch Topology resources on the worker
+clusters and deactivate the manager ClusterQueue when any of the workers'
+Topologies are incompatible with any of the Topologies reachable from
+the ClusterQueue on the manager cluster. A worker's Topology is considered
+compatible with the manager's Topology when the worker's Topology defines at
+least the same levels as the manager's Topology in the same order.
+
 ## Drawbacks
 
 - **Scalability Limits**: Centralizing all node and pod state into a single

--- a/keps/13345-centralized-multikueue-tas/README.md
+++ b/keps/13345-centralized-multikueue-tas/README.md
@@ -120,7 +120,8 @@ minimal even at large scale.
 mechanism. If a worker disconnects, the manager waits for a grace period. If the
 worker does not reconnect, the manager evicts the workload and retries
 scheduling it on a healthy cluster. When a worker reconnects, the manager
-performs a fresh `List` to rebuild the TAS cache for that cluster.
+performs a fresh `List` to rebuild the TAS cache for that cluster and re-evicts
+workloads on the workload which were evicted while it was disconnected.
 
 ## Drawbacks
 

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -6,8 +6,8 @@ owning-sig: sig-scheduling
 status: provisional
 creation-date: "2026-07-22"
 reviewers:
-  - "@alculquicondor"
+  - "@amy"
   - "@mimowo"
 approvers:
-  - "@alculquicondor"
+  - "@amy"
   - "@mimowo"

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -17,8 +17,8 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.11"
+latest-milestone: "v0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v0.11"
+  alpha: "v0.20"

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -1,0 +1,13 @@
+title: Support centralized scheduling and quota management in MultiKueue
+kep-number: 13345
+authors:
+  - "@mukund-wayve"
+owning-sig: sig-scheduling
+status: provisional
+creation-date: "2026-07-22"
+reviewers:
+  - "@alculquicondor"
+  - "@mimowo"
+approvers:
+  - "@alculquicondor"
+  - "@mimowo"

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -2,12 +2,23 @@ title: Support centralized scheduling and quota management in MultiKueue
 kep-number: 13345
 authors:
   - "@mukund-wayve"
-owning-sig: sig-scheduling
 status: provisional
-creation-date: "2026-07-22"
+creation-date: 2026-07-22
 reviewers:
   - "@amy"
   - "@mimowo"
 approvers:
   - "@amy"
   - "@mimowo"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.11"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v0.11"

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -23,3 +23,7 @@ latest-milestone: "v0.20"
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.20"
+
+feature-gates:
+  - name: MultiKueueCentralizedTAS
+disable-supported: true

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -2,6 +2,7 @@ title: Support centralized scheduling and quota management in MultiKueue
 kep-number: 13345
 authors:
   - "@mukund-wayve"
+  - "@nojnhuh"
 status: provisional
 creation-date: 2026-07-22
 reviewers:

--- a/keps/13345-centralized-multikueue-tas/kep.yaml
+++ b/keps/13345-centralized-multikueue-tas/kep.yaml
@@ -8,6 +8,7 @@ creation-date: 2026-07-22
 reviewers:
   - "@amy"
   - "@mimowo"
+  - "@olekzabl"
 approvers:
   - "@amy"
   - "@mimowo"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:

/area was
/area integrations
/area dashboard
/area localization
/area testing
/area website
-->

/kind kep

/area tas
/area multikueue

#### What this PR does / why we need it:

Adds a KEP for #13345 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13345 

#### Special notes for your reviewer:

Prototype for this KEP is [implemented here](https://github.com/kubernetes-sigs/kueue/pull/13341). This prototype was largely AI-generated and serves to demonstrate that centralized TAS is feasible with a surprisingly minimal footprint, requiring very few changes to the existing MultiKueue and TAS controllers.

It has a e2e test that proves the solution works at a small scale.


<img width="3884" height="2764" alt="image" src="https://github.com/user-attachments/assets/33f33aaa-4815-40cc-9658-cca92788ffe4" />


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented the configuration contract for centralized MultiKueue topology-aware scheduling.
  * Added guidance for the required feature gate, configuration option, ClusterQueue annotation, default behavior, and enablement steps.
  * Corrected configuration field names and improved the table of contents and supporting wording.
  * Added release metadata covering alpha status, planned milestones, and feature-gate support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->