### PR TITLE
Update main with the latest v0.17.8

### DIFF
--- a/CHANGELOG/CHANGELOG-0.17.md
+++ b/CHANGELOG/CHANGELOG-0.17.md
@@ -1,3 +1,62 @@
+## v0.17.8
+
+Changes since `v0.17.7`:
+
+## Actions Required Before Upgrading
+
+### (No, really, you MUST read this before you upgrade)
+
+- **Minor releases:** Review the `.0` release notes for each new minor version you cross; see: [`v0.16.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.16.0), [`v0.17.0`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.0).
+- **Patch releases:** Review the patch release notes leading up to this version, but *only* within this minor release line; see: [`v0.17.1`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.1), [`v0.17.2`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.2), [`v0.17.3`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.3), [`v0.17.4`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.4), [`v0.17.5`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.5), [`v0.17.6`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.6), [`v0.17.7`](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.17.7).
+
+## Changes by Kind
+
+### Feature
+
+- Helm: Added enableVisibilityAuthReaderRoleBinding Helm value (default: true) to make the visibility server's auth-reader RoleBinding in kube-system optional. Set to false when deploying under a GitOps project that cannot manage resources in kube-system, and create the RoleBinding out-of-band instead. (#13049, @amy)
+
+### Bug or Regression
+
+- AFS: Fixed a Denial of Service (DoS) vulnerability where deleting a LocalQueue could cause the Kueue scheduler to hang during AdmissionFairSharing calculations. (#13264, @Vaishnav88sk)
+- AFS: Fixed a race in Admission Fair Sharing penalty updates where concurrent workload operations could lose penalty changes, causing LocalQueues to receive incorrect priority. (#13287, @MaysaMacedo)
+- ElasticJobsViaWorkloadSlices: Fixed a bug that allowed a replacement Workload slice to reference a Workload from another namespace when both used the same ClusterQueue, potentially causing the unrelated Workload to be treated and finished as the replaced slice. Workload slice replacements are now restricted to Workloads in the same namespace. (#13082, @mykysha)
+- ElasticJobsViaWorkloadSlices: Fixed a bug that could cause elastic Jobs to
+  stall after Pods succeeded or failed, because terminal Pods continued to count
+  against the active Workload slice's admitted PodSet count and prevented
+  replacement Pods from being ungated. (#13203, @garg02)
+- ElasticJobsViaWorkloadSlices: Fixed a bug where an elastic job could permanently fail to start (FailedToStart) due to stale Kueue-owned annotations on the pod template, e.g. after its workload was deleted, or after eviction of a previously scaled-up job. (#13132, @mcochner)
+- ElasticJobsViaWorkloadSlices: Fixed a bug where reclaimable Pod accounting after scaling down an elastic Job could reserve quota for Pods that were no longer running. Reserved quota now tracks the remaining running Pods for indexed and non-indexed Jobs. (#13178, @Shreesha001)
+- ElasticJobsViaWorkloadSlices: Fixed a bug where scaling down an elastic Job could leave a stale reclaimablePods count, causing Kueue to account for less quota than the Job's remaining Pods were using. (#13044, @Shreesha001)
+- KueueViz: Fixed a security issue in kueueviz where WebSocket connections continued streaming cluster data after a bearer token expired or was revoked.
+  Connections are now closed within 30 seconds of token invalidation. (#13164, @Vaishnav88sk)
+- KueueViz: Navigating to an invalid cohort now displays a graceful error message instead of crashing the UI. (#13247, @Vaishnav88sk)
+- KueueViz: Prevent workload detail pages from crashing when Kubernetes Events have missing or invalid timestamps. (#13208, @YQ-Wang)
+- MultiKueue: Fixed a bug where a remote Workload finishing with reason OutOfSync was mirrored as a terminal finish, leaving the manager Job stranded. Kueue now resets the MultiKueue AdmissionCheck to Retry, retries the Workload, and emits a warning event identifying the worker cluster. (#13087, @Smuger)
+- MultiKueue: Fixed a bug where a transient watch reconnect to a worker cluster could evict a running admitted workload. Kueue now measures the worker-lost grace from when the worker cluster's connection first dropped, rather than from the admission check's transition time, and retries immediately only when the reserving worker is reachable but its remote workload is gone. (#12999, @kevin85421)
+- MultiKueue: Fixed a bug where admitted workloads could remain stuck instead of being evicted and retried after `workerLostTimeout` when reconnecting to a worker cluster failed after its connection configuration changed. (#13188, @kevin85421)
+- MultiKueue: Fixes an observability bug where Pods scheduled in a worker cluster could still appear unscheduled
+  in the manager cluster (as `PodScheduled=False` would be preserved). The `PodScheduled` condition is now
+  synchronized from the worker cluster, while preserving `SchedulingGated` for unschedulable Pods to avoid spurious 
+  scale-ups. (#13198, @fg91)
+- Observability: Fix verbose DRS logs failing to report DRS values due to JSON parsing error when handling fair sharing weight set to 0. (#13156, @kshalot)
+- RayJob, RayCluster, RayService, JobSet, MPIJob, and Kubeflow Trainer jobs: Fixed a bug where changing a running job's pod set count, for example adding a worker group to a running RayCluster, could crash the Kueue controller during reconciliation. (#13111, @ivnovakov)
+- TAS & Scheduling: Fixed a bug where Workloads owned by a single Pod could be reassigned after eviction or during TAS node hot swap, even though the existing Pod could not consume the new assignment. The fix applies when the SkipReassignmentForPodOwnedWorkloads feature gate is enabled. The gate is Beta and enabled by default in 0.19+, and Alpha and disabled by default in the 0.17 and 0.18 release branches. (#12980, @yakticus)
+- TAS: Added a fix for premature node replacement when a node remains NotReady while the workload's Pods are still running, which could cause the topology assignment to diverge from the actual Pod placement and corrupt per-node capacity accounting. The termination-driven behavior applies when TASReplaceNodeDueToNotReadyOverFixedTime is disabled. The gate is deprecated and disabled by default in 0.19+, and Beta and enabled by default in the 0.17 and 0.18 release branches. (#13097, @yakticus)
+- TAS: Fixed a bug where a PodSet slice size that did not evenly divide its count could make the topology ungater panic repeatedly, so the workload's Pods stayed stuck gated. The ungater no longer panics and ungates the Pods that fit the topology assignment. (#13266, @ivnovakov)
+- TAS: Fixed a bug where a PodSet with `subGroupIndexLabel` set but a missing or zero `subGroupCount` could crash the tas-ungater controller. Kueue now falls back to greedy domain assignment for these pods instead of panicking. (#13072, @reruno)
+- TAS: Fixed a performance bug that caused remaining capacity to be repeatedly recalculated and resource maps to be unnecessarily copied during workload evaluation, particularly when evaluating multiple preemption candidate sets in
+  large clusters. The fix is guarded by the Beta `TASCachingRemainingResources` feature gate, which is enabled by default. (#13234, @j-skiba)
+- TAS: domain selection is now deterministic when multiple domains tie on score; ties are broken by the domains' levelValues ordering. (#12052, @mvanhorn)
+- TAS: fixed excessive scheduling latency for workloads requiring preemption caused by repeatedly evaluating node selectors, tolerations, and affinity for each preemption simulation. The optimization is controlled by the beta `TASCacheNodeMatchResults` feature gate, enabled by default. (#13205, @j-skiba)
+- VisibilityOnDemand: Fixed a bug where a large or negative `limit` query parameter on the pending-workloads endpoints could crash the Kueue controller manager via memory exhaustion or a panic. The `limit` is now capped at 100000. (#13052, @reruno)
+
+### Other (Cleanup or Flake)
+
+- Observability: Introduced logging of node replacements by NodeHotSwap. (#13215, @dkaluza)
+- Observability: Introduced logging of unhealthy nodes on workload updates. (#13272, @dkaluza)
+- TAS: Improved scheduling evaluation performance and reduced memory allocations for Topology-Aware Scheduling (TAS). (#13326, @j-skiba)
+- TAS: improved workload evaluation performance by optimizing domain-ordering tie-breaks for sibling node domains with equal available capacity. (#13332, @j-skiba)
+
 ## v0.17.7
 
 Changes since `v0.17.6`:

--- a/site/content/en/v0.17/docs/_index.md
+++ b/site/content/en/v0.17/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.17
-  version: v0.17.7
-  chart_version: 0.17.7
+  version: v0.17.8
+  chart_version: 0.17.8
 cascade:
   type: docs
   params:
     docs_minor: v0.17
-    version: v0.17.7
-    chart_version: 0.17.7
+    version: v0.17.8
+    chart_version: 0.17.8
 title: "Documentation"
 linkTitle: "Documentation"
 weight: 20

--- a/site/content/en/v0.17/docs/concepts/topology_aware_scheduling.md
+++ b/site/content/en/v0.17/docs/concepts/topology_aware_scheduling.md
@@ -173,13 +173,21 @@ You can disable it by editing the `TASReplaceNodeOnPodTermination` feature gate.
 for instructions on configuring feature gates.
 {{% /alert %}}
 
-By default, the node is assumed to have failed if its `conditions.Status.Ready`
-is not `True` for at least 30 seconds or if the node is missing (removed from the cluster).
-Since Kueue v0.13, the `TASReplaceNodeOnPodTermination` feature, introduced an additional heuristic:
-a node is also considered failed if it is `NotReady` and the workload's Pods scheduled on that node are either terminated or terminating.
-If this happens Kueue will immediately look for replacement without waiting 30 seconds.
+By default, the node is assumed to have failed if it is missing (removed from the
+cluster), or if its `conditions.Status.Ready` is not `True` and the workload's Pods
+scheduled on that node are either terminated or terminating. A node with
+still-running Pods is not considered failed, no matter how long its
+`conditions.Status.Ready` has not been `True`: nodes can recover after an arbitrary
+amount of time, and reassigning while the Pods are alive makes the stored assignment
+diverge from where the Pods actually run.
 
-Note that those two heuristics are mutually exclusive and depend on the value of the `TASReplaceNodeOnPodTermination` feature gate.
+Before v0.19, a node was additionally assumed to have failed once its
+`conditions.Status.Ready` was not `True` for at least 30 seconds, regardless of Pod
+state. This fixed-time marking is deprecated: it remains available behind the
+`TASReplaceNodeDueToNotReadyOverFixedTime` feature gate (enabled by default in
+v0.17–v0.18, disabled by default and deprecated since v0.19) and is planned for
+removal. Disabling `TASReplaceNodeOnPodTermination` retains the pre-v0.14 behavior of
+marking the node after the fixed time regardless of Pod state.
 
 Note that finding a replacement node that meets all the requirements (e.g. the same type of machine placed in the rack that Kueue had previously assigned to the workload) may not always be possible.
 If a workload is big enough to cover the whole topology domain (e.g. block or rack) it's inevitable that there will be no replacement within the same domain.
@@ -198,6 +206,45 @@ for instructions on configuring feature gates.
 {{% /alert %}}
 
 By default, Kueue tries to find a replacement for a failed node until it succeeds or until the workload is evicted (for example, by `waitForPodsReady.recoveryTimeout`). To prevent Kueue from retrying indefinitely, you can enable the `TASFailedNodeReplacementFailFast` feature gate. When enabled, Kueue will only attempt to find a replacement node once. If it fails, it will not try again, and the workload will get evicted and requeued.
+
+#### Skip reassignment for Workloads owned by a single Pod
+{{< feature-state state="alpha" for_version="v0.17" >}}
+{{% alert title="Note" color="primary" %}}
+`SkipReassignmentForPodOwnedWorkloads` is an alpha feature, disabled by default in v0.17.
+
+You can disable it by editing the `SkipReassignmentForPodOwnedWorkloads` feature gate. Refer to the
+[Installation guide](/v0.17/docs/installation/#change-the-feature-gates-configuration)
+for instructions on configuring feature gates.
+{{% /alert %}}
+
+Node replacement assumes that the workload's controller re-creates pods within the
+same Workload (as Job, JobSet or LeaderWorkerSet do), so that the re-created pods can
+follow the updated topology assignment. A Workload owned by a single Pod — bare pods
+and, for example, Deployment replicas managed through the
+[pod integration](/v0.17/docs/tasks/run/plain_pods/) — does not have this property: the
+Workload is deleted together with its pod, so no future pod can consume a replacement
+assignment. Replacing a node for such a Workload only makes its stored assignment
+diverge from the node its still-running pod occupies, which corrupts the per-node
+capacity accounting: the pod's real node is treated as free and gets over-admitted,
+while the replacement node is blocked for other admissions.
+
+With the `SkipReassignmentForPodOwnedWorkloads` feature gate enabled, Kueue keeps the
+existing topology assignment of a Workload owned by exactly one Pod instead of
+computing a replacement. The failed node is still tracked in
+`.status.unhealthyNodes` and the field is cleared on the next successful scheduling
+pass. Recovery happens through the pod lifecycle: when the pod terminates, its owning
+controller (for example a ReplicaSet) creates a new pod, which arrives as a new
+Workload and is admitted with a fresh assignment. Workloads with any other owner,
+including pod groups (which can receive user-created replacement pods into the same
+Workload), keep the replacement behavior described above.
+
+The gate also covers the eviction requeue path. Without it, a pod-owned Workload
+evicted by preemption is requeued and re-admitted with a freshly computed
+assignment while its pod is still draining the termination grace period on the
+original node — an assignment no pod can consume, blocking the newly assigned
+node's capacity for the full grace period. With the gate enabled, evicted pod-owned
+Workloads get `Requeued=False` instead: the Workload finishes with its pod, and the
+owning controller's replacement pod arrives as a new Workload.
 
 #### Usage Scenarios
 
@@ -239,10 +286,21 @@ The following table summarizes the behavior based on the combination of the feat
 | `FNR` | `RNO` | `FNFF` | End Behavior |
 | :---- | :---- | :---- | :----------- |
 | `false` | *any* | *any* | **Hot swap is disabled.**<br>Workloads will not have failed nodes replaced and may get stuck. |
-| `true` | `false` | `false` | **Default Hot Swap**<ul><li>**Trigger**: Node is `NotReady` for > 30 seconds.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
-| `true` | `true` | `false` | **Hot Swap with Pod Termination Trigger**<ul><li>**Trigger**: Node is `NotReady` for > 30s, OR a workload pod is terminating.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
-| `true` | `false` | `true` | **Fast Hot Swap**<ul><li>**Trigger**: Node is `NotReady` for > 30 seconds.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
-| `true` | `true` | `true` | **Fast Hot Swap with Pod Termination Trigger**<ul><li>**Trigger**: Node is `NotReady`, AND a workload pod is terminating.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
+| `true` | *any* | `false` | **Default Hot Swap**<ul><li>**Trigger**: Node is `NotReady` AND its workload pods are terminating or terminated.</li><li>**Behavior**: Retries replacement until it succeeds or the workload is evicted.</li></ul> |
+| `true` | *any* | `true` | **Fast Hot Swap**<ul><li>**Trigger**: Node is `NotReady` AND its workload pods are terminating or terminated.</li><li>**Behavior**: Attempts replacement **only once**. Evicts the workload if it fails.</li></ul> |
+
+With the deprecated `TASReplaceNodeDueToNotReadyOverFixedTime` gate enabled, the
+not-ready trigger depends on `TASReplaceNodeOnPodTermination` (`RNO`):
+- `RNO` enabled: the node is treated as failed when its workload Pods are terminating
+  or terminated, or after 30 seconds of `NotReady`, whichever comes first.
+- `RNO` disabled: the node is treated as failed only after 30 seconds of `NotReady`
+  (the pre-v0.14 behavior), regardless of Pod state.
+
+With the gate disabled (the default since v0.19), Pod termination is the only
+not-ready trigger while `RNO` remains enabled (its default); disabling `RNO`
+retains the fixed-time marking. Nodes that are deleted or lack a `Ready`
+condition are treated as failed immediately in all configurations. To disable node
+replacement entirely, use the `TASFailedNodeReplacement` feature gate instead.
 
 **Recommended configuration**
 

--- a/site/content/en/v0.17/docs/tasks/run/leaderworkerset.md
+++ b/site/content/en/v0.17/docs/tasks/run/leaderworkerset.md
@@ -129,7 +129,7 @@ a group suffix to the LeaderWorkerSet name, the effective LWS name limit is
 **39 characters**.
 
 Enable the alpha
-[`WorkloadIdentifierAnnotations`](/v0.17/docs/installation/#feature-gates-for-alpha-and-beta-features)
+[`WorkloadIdentifierAnnotations`](/v0.17/docs/getting-started/installation/#feature-gates-for-alpha-and-beta-features)
 feature gate to store the identifier in an annotation instead, removing
 Kueue's label-length constraint. With the feature gate enabled, the effective
 limit shifts to the upstream LWS constraint of **51 characters**

--- a/site/content/zh-CN/v0.17/docs/_index.md
+++ b/site/content/zh-CN/v0.17/docs/_index.md
@@ -2,14 +2,14 @@
 type: docs
 params:
   docs_minor: v0.17
-  version: v0.17.7
-  chart_version: 0.17.7
+  version: v0.17.8
+  chart_version: 0.17.8
 cascade:
   type: docs
   params:
     docs_minor: v0.17
-    version: v0.17.7
-    chart_version: 0.17.7
+    version: v0.17.8
+    chart_version: 0.17.8
 title: "文档"
 linkTitle: "文档"
 weight: 20


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Update main with the latest v0.17.8.

#### Which issue(s) this PR fixes:
Part of #13255

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English and Chinese documentation to reflect the v0.17.8 release and chart version.
  - Expanded topology-aware scheduling guidance, including node failure detection, reassignment behavior, and feature-gate interactions.
  - Corrected the troubleshooting link for long LeaderWorkerSet names.
- **Bug Fixes**
  - Documented fixes and regressions addressed across scheduling, observability, integrations, visualization, and workload management.
- **New Features**
  - Added upgrade guidance and documented a new Helm configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->