### PR TITLE
test: avoid capturing mutable workload in scheduler deadlock test

### DIFF
--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -3528,6 +3528,10 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				Request(corev1.ResourceCPU, "1").
 				Obj()
 
+			// Snapshot the name: reading wl1 from the callbacks would race with
+			// Create() decoding the API response into it.
+			wl1Name := wl1.Name
+
 			setFakeSubResourcePatchSpec(func(obj client.Object) (fakeClientUsage, error) {
 				wl, ok := obj.(*kueue.Workload)
 				if !ok {
@@ -3535,7 +3539,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				}
 
 				// Intercept wl1 admission patch
-				if wl.Name == wl1.Name && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved) && !meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
+				if wl.Name == wl1Name && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved) && !meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
 					if admissionPatchCount.Add(1) == 1 {
 						admissionPatchStarted <- struct{}{}
 					}
@@ -3551,7 +3555,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 				if !ok {
 					return fallThrough, nil
 				}
-				if wl.Name == wl1.Name && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved) && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
+				if wl.Name == wl1Name && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadQuotaReserved) && meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted) {
 					// The first request evicting wl1 will set both the quota reservation and eviction, as this status is assumed in the cache.
 					// We wait here until the admission patch overwrites the eviction and only then continue with the next scheduling cycle.
 					<-continueSchedulingAfterAdmissionPatch


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The latest main occurrence of #13058 was the first one with #13333's race instrumentation, and it captured a concrete race report.

The race is in the test "Should not deadlock the preempting workloads" (#12331): the interceptor callbacks capture wl1, while k8sClient.Create(ctx, wl1) is still decoding the API response into the same object. Although value-benign, the race detector exits after all specs pass, producing the long-standing "102/102 passed, yet Test Suite Failed" signature.

This PR snapshots the workload name before registering the callbacks, avoiding access to the mutable wl1 object.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13058. This fixes the data race captured in the latest main occurrence. 
Since the release-0.17 failure predates #12331, we don't yet know if it has the same root cause.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler regression-test reliability by preventing workload identity checks from changing during admission and eviction race scenarios.
  * Reduced the risk of intermittent test failures caused by concurrent object updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->