### PR TITLE
Promote TLSOptions to stable

### DIFF
--- a/keps/8190-tls-security-profiles/README.md
+++ b/keps/8190-tls-security-profiles/README.md
@@ -284,12 +284,15 @@ When the feature gate is enabled, TLS options can be set for the golang servers.
 #### Stable
 
 - Adoption of feature
+- No negative feedback from beta users
+- The `TLSOptions` feature gate is locked to enabled by default in 0.20 and will be removed in 0.22
 
 ## Implementation History
 
 - 2025-12: KEP proposed based on issues #8190 and OCPKUEUE-450
 - 2026-01: KEP approved
 - 2026-05: CurvePreferences support added (issue #10698), following upstream Kubernetes --tls-curve-preferences flag (k/k PR #137115)
+- 2026-07: Graduated to stable (issue #10704); `TLSOptions` feature gate locked to enabled in 0.20
 
 ## Drawbacks
 

--- a/keps/8190-tls-security-profiles/kep.yaml
+++ b/keps/8190-tls-security-profiles/kep.yaml
@@ -14,19 +14,20 @@ see-also:
 replaces:
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: beta
+stage: stable
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "0.16"
+latest-milestone: "0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   beta: "0.16"
+  stable: "0.20"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled
 feature-gates:
   - name: TLSOptions
-disable-supported: true
+disable-supported: false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -969,7 +969,7 @@ objectRetentionPolicies:
 	}
 }
 
-func TestTLSOptionsFeatureGate(t *testing.T) {
+func TestTLSOptions(t *testing.T) {
 	testScheme := runtime.NewScheme()
 	err := configapi.AddToScheme(testScheme)
 	if err != nil {
@@ -1020,15 +1020,12 @@ webhook:
 	testcases := []struct {
 		name              string
 		configFile        string
-		featureGates      map[featuregate.Feature]bool
 		wantConfiguration configapi.Configuration
-		verifyTLSApplied  bool
 		wantError         error
 	}{
 		{
-			name:         "TLS config applied when feature gate enabled",
-			configFile:   tlsConfigWithCipherSuites,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
+			name:       "TLS config with cipher suites is applied",
+			configFile: tlsConfigWithCipherSuites,
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.SchemeGroupVersion.String(),
@@ -1074,64 +1071,10 @@ webhook:
 					},
 				},
 			},
-			verifyTLSApplied: true,
 		},
 		{
-			name:         "TLS config NOT applied when feature gate disabled",
-			configFile:   tlsConfigWithCipherSuites,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.SchemeGroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
-				ManageJobsWithoutQueueName: false,
-				InternalCertManagement: &configapi.InternalCertManagement{
-					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
-				},
-				WaitForPodsReady: defaultWaitForPodsReady,
-
-				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
-				},
-				Integrations: &configapi.Integrations{
-					Frameworks: []string{job.FrameworkName},
-				},
-				MultiKueue: &configapi.MultiKueue{
-					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
-					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
-				},
-				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      corev1.LabelMetadataName,
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system", "kueue-system"},
-						},
-					},
-				},
-				ControllerManager: configapi.ControllerManager{
-					TLS: &configapi.TLSOptions{
-						MinVersion: "VersionTLS12",
-						CipherSuites: []string{
-							"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-							"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-						},
-					},
-				},
-			},
-			verifyTLSApplied: false,
-		},
-		{
-			name:         "TLS 1.3 config applied when feature gate enabled",
-			configFile:   tlsConfigTLS13,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
+			name:       "TLS 1.3 config is applied",
+			configFile: tlsConfigTLS13,
 			wantConfiguration: configapi.Configuration{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configapi.SchemeGroupVersion.String(),
@@ -1174,116 +1117,16 @@ webhook:
 					},
 				},
 			},
-			verifyTLSApplied: true,
 		},
 		{
-			name:         "invalid TLS config returns error when feature gate enabled",
-			configFile:   tlsConfigInvalid,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: true},
-			wantError:    ErrWebhookTLSParse,
-		},
-		{
-			name:         "invalid TLS config ignored when feature gate disabled",
-			configFile:   tlsConfigInvalid,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.SchemeGroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
-				ManageJobsWithoutQueueName: false,
-				InternalCertManagement: &configapi.InternalCertManagement{
-					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
-				},
-				WaitForPodsReady: defaultWaitForPodsReady,
-				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
-				},
-				Integrations: &configapi.Integrations{
-					Frameworks: []string{job.FrameworkName},
-				},
-				MultiKueue: &configapi.MultiKueue{
-					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
-					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
-				},
-				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      corev1.LabelMetadataName,
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system", "kueue-system"},
-						},
-					},
-				},
-				ControllerManager: configapi.ControllerManager{
-					TLS: &configapi.TLSOptions{
-						MinVersion: "InvalidVersion",
-					},
-				},
-			},
-			verifyTLSApplied: false,
-		},
-		{
-			name:         "TLS 1.3 config NOT applied when feature gate disabled",
-			configFile:   tlsConfigTLS13,
-			featureGates: map[featuregate.Feature]bool{features.TLSOptions: false},
-			wantConfiguration: configapi.Configuration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: configapi.SchemeGroupVersion.String(),
-					Kind:       "Configuration",
-				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
-				ManageJobsWithoutQueueName: false,
-				InternalCertManagement: &configapi.InternalCertManagement{
-					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
-				},
-				WaitForPodsReady: defaultWaitForPodsReady,
-
-				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
-				},
-				Integrations: &configapi.Integrations{
-					Frameworks: []string{job.FrameworkName},
-				},
-				MultiKueue: &configapi.MultiKueue{
-					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
-					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
-				},
-				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      corev1.LabelMetadataName,
-							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system", "kueue-system"},
-						},
-					},
-				},
-				ControllerManager: configapi.ControllerManager{
-					TLS: &configapi.TLSOptions{
-						MinVersion: "VersionTLS13",
-					},
-				},
-			},
-			verifyTLSApplied: false,
+			name:       "invalid TLS config returns error",
+			configFile: tlsConfigInvalid,
+			wantError:  ErrWebhookTLSParse,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Set the feature gate for this test
-			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-
 			options, cfg, err := Load(testScheme, tc.configFile)
 			if err != nil {
 				t.Fatalf("Unexpected error loading config: %v", err)
@@ -1314,21 +1157,13 @@ webhook:
 				t.Fatal("Expected WebhookServer to be created, but it was nil")
 			}
 
-			// Verify TLS options application based on feature gate
 			defaultServer, ok := options.WebhookServer.(*webhook.DefaultServer)
 			if !ok {
 				t.Fatalf("Expected WebhookServer to be *webhook.DefaultServer, got %T", options.WebhookServer)
 			}
 
-			// Check if TLSOpts are applied or not based on feature gate
-			if tc.verifyTLSApplied {
-				if len(defaultServer.Options.TLSOpts) == 0 {
-					t.Error("Expected TLSOpts to be applied when feature gate is enabled, but got none")
-				}
-			} else {
-				if len(defaultServer.Options.TLSOpts) > 0 {
-					t.Errorf("Expected TLSOpts NOT to be applied when feature gate is disabled, but got %d options", len(defaultServer.Options.TLSOpts))
-				}
+			if len(defaultServer.Options.TLSOpts) == 0 {
+				t.Error("Expected TLSOpts to be applied, but got none")
 			}
 		})
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -670,7 +670,8 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.20
 	},
 	TLSOptions: {
-		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.20 (https://github.com/kubernetes-sigs/kueue/issues/10704)
+		{Version: version.MustParse("0.16"), Default: true, PreRelease: featuregate.Beta},                    // GA in 0.20
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 0.22
 	},
 	RemoveFinalizersWithStrictPatch: {
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -511,6 +511,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.16"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.20"
 - name: TopologyAwareScheduling
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -511,6 +511,10 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.16"
+  - default: true
+    lockToDefault: true
+    preRelease: GA
+    version: "0.20"
 - name: TopologyAwareScheduling
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Promote TLSOptions to stable.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #10704 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Security: Promote TLSOptions to stable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TLS Security Profiles are now documented as stable.
  * TLS options are enabled by default and locked on in version 0.20, with planned removal of the feature toggle in 0.22.
* **Bug Fixes**
  * Invalid TLS configurations now consistently produce a configuration error instead of being silently ignored.
* **Documentation**
  * Updated maturity, milestone, graduation criteria, and feature-toggle lifecycle information for TLS Security Profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->