### PR TITLE
test: cover independent RayCluster worker autoscaling

### DIFF
--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -184,6 +184,11 @@ func (j *ClusterWrapper) SchedulingGate(name string) *ClusterWrapper {
 	return j
 }
 
+func (j *ClusterWrapper) WithAutoscalerOptions(value *rayv1.AutoscalerOptions) *ClusterWrapper {
+	j.Spec.AutoscalerOptions = value
+	return j
+}
+
 func (j *ClusterWrapper) ScaleFirstWorkerGroup(replicas int32) *ClusterWrapper {
 	j.Spec.WorkerGroupSpecs[0].Replicas = &replicas
 	return j

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -35,8 +35,15 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
+// Detached actors are scoped to a Ray namespace, so creation and termination
+// scripts must use the same namespace.
 const rayActorNamespace = "kueue-e2e"
 
+// createDetachedActorScript holds one unit of a custom Ray resource with a
+// detached actor. Because every Ray node advertises zero CPUs, the actor can
+// only run in the worker group that exports the requested custom resource,
+// forcing the autoscaler to scale that group. Looking up the actor first makes
+// the script safe to retry after a transient pod exec failure.
 func createDetachedActorScript(actorName, resourceName string) string {
 	return fmt.Sprintf(`import ray
 
@@ -46,15 +53,23 @@ ray.init(namespace=%q)
 class Actor:
     pass
 
-Actor.options(name=%q, lifetime="detached").remote()
-`, rayActorNamespace, resourceName, actorName)
+try:
+    ray.get_actor(%q)
+except ValueError:
+    Actor.options(name=%q, lifetime="detached").remote()
+`, rayActorNamespace, resourceName, actorName, actorName)
 }
 
 func terminateDetachedActorScript(actorName string) string {
 	return fmt.Sprintf(`import ray
 
 ray.init(namespace=%q)
-ray.kill(ray.get_actor(%q))
+try:
+    actor = ray.get_actor(%q)
+except ValueError:
+    pass
+else:
+    ray.kill(actor)
 `, rayActorNamespace, actorName)
 }
 
@@ -73,6 +88,8 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			Obj()
 		gomega.Expect(k8sClient.Create(ctx, rf)).To(gomega.Succeed())
 
+		// At peak the RayCluster requests 1 CPU for the head, 500m for the
+		// autoscaler sidecar, and 400m for each of the two workers.
 		cq = utiltestingapi.MakeClusterQueue("kuberay-autoscaling-cq-" + ns.Name).
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas(rf.Name).
@@ -108,6 +125,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 
 		kuberayTestImage := util.GetKuberayTestImage()
 		rayCluster := testingraycluster.MakeCluster("raycluster-multi-podset", ns.Name).
+			Suspend(true).
 			Queue(lq.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			WithEnableAutoscaling(new(true)).
@@ -118,6 +136,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
 			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
 			Obj()
+		// Keep scale-down transitions within the e2e test timeout.
 		rayCluster.Spec.AutoscalerOptions = &rayv1.AutoscalerOptions{IdleTimeoutSeconds: ptr.To[int32](10)}
 
 		workerA := rayCluster.Spec.WorkerGroupSpecs[0].DeepCopy()
@@ -161,8 +180,10 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 
 		runOnHead := func(script string) {
 			gomega.Expect(headPod.Spec.Containers).NotTo(gomega.BeEmpty())
-			_, _, err := util.KExecute(ctx, cfg, restClient, ns.Name, headPod.Name, headPod.Spec.Containers[0].Name, []string{"python", "-c", script})
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Eventually(func(g gomega.Gomega) {
+				_, stderr, err := util.KExecute(ctx, cfg, restClient, ns.Name, headPod.Name, headPod.Spec.Containers[0].Name, []string{"python", "-c", script})
+				g.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", string(stderr))
+			}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 		}
 
 		expectWorkerGroups := func(expected map[string]int32) {
@@ -208,7 +229,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 					podSetCounts[string(podSet.Name)] = podSet.Count
 				}
 				for groupName, count := range expected {
-					g.Expect(podSetCounts[groupName]).To(gomega.Equal(count))
+					g.Expect(podSetCounts).To(gomega.HaveKeyWithValue(groupName, count))
 				}
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Kueue did not account for the worker groups independently", workloadList))
 		}

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -35,15 +35,8 @@ import (
 	"sigs.k8s.io/kueue/test/util"
 )
 
-// Detached actors are scoped to a Ray namespace, so creation and termination
-// scripts must use the same namespace.
 const rayActorNamespace = "kueue-e2e"
 
-// createDetachedActorScript holds one unit of a custom Ray resource with a
-// detached actor. Because every Ray node advertises zero CPUs, the actor can
-// only run in the worker group that exports the requested custom resource,
-// forcing the autoscaler to scale that group. Looking up the actor first makes
-// the script safe to retry after a transient pod exec failure.
 func createDetachedActorScript(actorName, resourceName string) string {
 	return fmt.Sprintf(`import ray
 

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -109,7 +110,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 		rayCluster := testingraycluster.MakeCluster("raycluster-multi-podset", ns.Name).
 			Queue(lq.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			WithEnableAutoscaling(ptr.To(true)).
+			WithEnableAutoscaling(new(true)).
 			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
 			RayStartParam(rayv1.HeadNode, "num-cpus", "0").
 			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
@@ -144,7 +145,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayCluster), createdRayCluster)).To(gomega.Succeed())
 				g.Expect(ptr.Deref(createdRayCluster.Spec.Suspend, true)).To(gomega.BeFalse())
-				g.Expect(createdRayCluster.Status.State).To(gomega.Equal(rayv1.Ready))
+				g.Expect(meta.IsStatusConditionTrue(createdRayCluster.Status.Conditions, string(rayv1.HeadPodReady))).To(gomega.BeTrue())
 				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(0)))
 
 				headPods := &corev1.PodList{}

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extended
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workload"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+const rayActorNamespace = "kueue-e2e"
+
+func createDetachedActorScript(actorName, resourceName string) string {
+	return fmt.Sprintf(`import ray
+
+ray.init(namespace=%q)
+
+@ray.remote(num_cpus=0, resources={%q: 1})
+class Actor:
+    pass
+
+Actor.options(name=%q, lifetime="detached").remote()
+`, rayActorNamespace, resourceName, actorName)
+}
+
+func terminateDetachedActorScript(actorName string) string {
+	return fmt.Sprintf(`import ray
+
+ray.init(namespace=%q)
+ray.kill(ray.get_actor(%q))
+`, rayActorNamespace, actorName)
+}
+
+var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
+	var (
+		ns *corev1.Namespace
+		rf *kueue.ResourceFlavor
+		cq *kueue.ClusterQueue
+		lq *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "kuberay-autoscaling-e2e-")
+		rf = utiltestingapi.MakeResourceFlavor("kuberay-autoscaling-rf-"+ns.Name).
+			NodeLabel("instance-type", "on-demand").
+			Obj()
+		gomega.Expect(k8sClient.Create(ctx, rf)).To(gomega.Succeed())
+
+		cq = utiltestingapi.MakeClusterQueue("kuberay-autoscaling-cq-" + ns.Name).
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(rf.Name).
+					Resource(corev1.ResourceCPU, "3").
+					Resource(corev1.ResourceMemory, "2Gi").
+					Obj(),
+			).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+		lq = utiltestingapi.MakeLocalQueue("kuberay-autoscaling-lq-"+ns.Name, ns.Name).
+			ClusterQueue(cq.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, rf, true)
+		util.ExpectAllPodsInNamespaceDeleted(ctx, k8sClient, ns)
+	})
+
+	ginkgo.It("Should scale RayCluster worker groups independently", ginkgo.Label("shard:kuberay-b"), func() {
+		const (
+			workerGroupA = "workers-a"
+			workerGroupB = "workers-b"
+			rayResourceA = "worker_a"
+			rayResourceB = "worker_b"
+			actorA       = "actor-a"
+			actorB       = "actor-b"
+		)
+
+		kuberayTestImage := util.GetKuberayTestImage()
+		rayCluster := testingraycluster.MakeCluster("raycluster-multi-podset", ns.Name).
+			Queue(lq.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			WithEnableAutoscaling(ptr.To(true)).
+			RequestAndLimit(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RayStartParam(rayv1.HeadNode, "num-cpus", "0").
+			RayStartParam(rayv1.HeadNode, "object-store-memory", objectStoreMemory).
+			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
+			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
+			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
+			Obj()
+		rayCluster.Spec.AutoscalerOptions = &rayv1.AutoscalerOptions{IdleTimeoutSeconds: ptr.To[int32](10)}
+
+		workerA := rayCluster.Spec.WorkerGroupSpecs[0].DeepCopy()
+		workerA.GroupName = workerGroupA
+		workerA.Replicas = ptr.To[int32](0)
+		workerA.MinReplicas = ptr.To[int32](0)
+		workerA.MaxReplicas = ptr.To[int32](1)
+		workerA.RayStartParams = map[string]string{
+			"num-cpus":            "0",
+			"object-store-memory": objectStoreMemory,
+			"resources":           fmt.Sprintf(`'{%q: 1}'`, rayResourceA),
+		}
+		workerB := workerA.DeepCopy()
+		workerB.GroupName = workerGroupB
+		workerB.RayStartParams["resources"] = fmt.Sprintf(`'{%q: 1}'`, rayResourceB)
+		rayCluster.Spec.WorkerGroupSpecs = []rayv1.WorkerGroupSpec{*workerA, *workerB}
+
+		ginkgo.By("Creating an elastic RayCluster with two independently scalable worker groups", func() {
+			gomega.Expect(k8sClient.Create(ctx, rayCluster)).To(gomega.Succeed())
+		})
+
+		var headPod corev1.Pod
+		ginkgo.By("Waiting for the zero-worker RayCluster to become ready", func() {
+			createdRayCluster := &rayv1.RayCluster{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayCluster), createdRayCluster)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdRayCluster.Spec.Suspend, true)).To(gomega.BeFalse())
+				g.Expect(createdRayCluster.Status.State).To(gomega.Equal(rayv1.Ready))
+				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(0)))
+
+				headPods := &corev1.PodList{}
+				g.Expect(k8sClient.List(ctx, headPods,
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"ray.io/node-type": "head"},
+				)).To(gomega.Succeed())
+				g.Expect(headPods.Items).To(gomega.HaveLen(1))
+				g.Expect(headPods.Items[0].Status.Phase).To(gomega.Equal(corev1.PodRunning))
+				headPod = headPods.Items[0]
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayCluster did not become ready", createdRayCluster))
+		})
+
+		runOnHead := func(script string) {
+			gomega.Expect(headPod.Spec.Containers).NotTo(gomega.BeEmpty())
+			_, _, err := util.KExecute(ctx, cfg, restClient, ns.Name, headPod.Name, headPod.Spec.Containers[0].Name, []string{"python", "-c", script})
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+
+		expectWorkerGroups := func(expected map[string]int32) {
+			createdRayCluster := &rayv1.RayCluster{}
+			workerPods := &corev1.PodList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayCluster), createdRayCluster)).To(gomega.Succeed())
+				g.Expect(k8sClient.List(ctx, workerPods,
+					client.InNamespace(ns.Name),
+					client.MatchingLabels{"ray.io/node-type": "worker"},
+				)).To(gomega.Succeed())
+
+				actualReplicas := make(map[string]int32, len(createdRayCluster.Spec.WorkerGroupSpecs))
+				for i := range createdRayCluster.Spec.WorkerGroupSpecs {
+					group := &createdRayCluster.Spec.WorkerGroupSpecs[i]
+					actualReplicas[group.GroupName] = ptr.Deref(group.Replicas, 0)
+				}
+				g.Expect(actualReplicas).To(gomega.Equal(expected))
+
+				runningPods := make(map[string]int32, len(expected))
+				for i := range workerPods.Items {
+					pod := &workerPods.Items[i]
+					if pod.Status.Phase == corev1.PodRunning {
+						runningPods[pod.Labels["ray.io/group"]]++
+					}
+				}
+				for groupName, count := range expected {
+					g.Expect(runningPods[groupName]).To(gomega.Equal(count))
+				}
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayCluster worker groups did not reach the expected sizes", createdRayCluster))
+		}
+
+		expectKueueAccounting := func(expected map[string]int32) {
+			workloadList := &kueue.WorkloadList{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				activeWorkloads := util.FindNonFinishedWorkloads(workloadList.Items)
+				g.Expect(activeWorkloads).To(gomega.HaveLen(1))
+				g.Expect(workload.IsAdmitted(&activeWorkloads[0])).To(gomega.BeTrue())
+				podSetCounts := make(map[string]int32, len(activeWorkloads[0].Spec.PodSets))
+				for i := range activeWorkloads[0].Spec.PodSets {
+					podSet := &activeWorkloads[0].Spec.PodSets[i]
+					podSetCounts[string(podSet.Name)] = podSet.Count
+				}
+				for groupName, count := range expected {
+					g.Expect(podSetCounts[groupName]).To(gomega.Equal(count))
+				}
+			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Kueue did not account for the worker groups independently", workloadList))
+		}
+
+		ginkgo.By("Requesting only the first worker group's custom resource", func() {
+			runOnHead(createDetachedActorScript(actorA, rayResourceA))
+			expected := map[string]int32{workerGroupA: 1, workerGroupB: 0}
+			expectWorkerGroups(expected)
+			expectKueueAccounting(expected)
+		})
+
+		ginkgo.By("Requesting the second worker group's custom resource without changing the first group", func() {
+			runOnHead(createDetachedActorScript(actorB, rayResourceB))
+			expected := map[string]int32{workerGroupA: 1, workerGroupB: 1}
+			expectWorkerGroups(expected)
+			expectKueueAccounting(expected)
+		})
+
+		ginkgo.By("Terminating the first actor without scaling down the second worker group", func() {
+			runOnHead(terminateDetachedActorScript(actorA))
+			expected := map[string]int32{workerGroupA: 0, workerGroupB: 1}
+			expectWorkerGroups(expected)
+			expectKueueAccounting(expected)
+		})
+
+		ginkgo.By("Terminating the second actor and returning both worker groups to zero", func() {
+			runOnHead(terminateDetachedActorScript(actorB))
+			expected := map[string]int32{workerGroupA: 0, workerGroupB: 0}
+			expectWorkerGroups(expected)
+			expectKueueAccounting(expected)
+		})
+	})
+})

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -66,6 +66,39 @@ else:
 `, rayActorNamespace, actorName)
 }
 
+// specReplicasPerWorkerGroup returns the desired replica count of every worker
+// group in the RayCluster spec, keyed by group name.
+func specReplicasPerWorkerGroup(rayCluster *rayv1.RayCluster) map[string]int32 {
+	replicas := make(map[string]int32, len(rayCluster.Spec.WorkerGroupSpecs))
+	for i := range rayCluster.Spec.WorkerGroupSpecs {
+		group := &rayCluster.Spec.WorkerGroupSpecs[i]
+		replicas[group.GroupName] = ptr.Deref(group.Replicas, 0)
+	}
+	return replicas
+}
+
+// findRunningPodsPerWorkerGroup counts the RayCluster's running worker Pods,
+// keyed by worker group name.
+func findRunningPodsPerWorkerGroup(g gomega.Gomega, rayClusterKey client.ObjectKey) map[string]int32 {
+	workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	counts := make(map[string]int32, len(workerPods))
+	for i := range workerPods {
+		counts[workerPods[i].Labels["ray.io/group"]]++
+	}
+	return counts
+}
+
+// podSetCountsByName returns the Workload's PodSet counts keyed by PodSet name.
+func podSetCountsByName(wl *kueue.Workload) map[string]int32 {
+	counts := make(map[string]int32, len(wl.Spec.PodSets))
+	for i := range wl.Spec.PodSets {
+		podSet := &wl.Spec.PodSets[i]
+		counts[string(podSet.Name)] = podSet.Count
+	}
+	return counts
+}
+
 var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
 	var (
 		ns *corev1.Namespace
@@ -178,20 +211,9 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			createdRayCluster := &rayv1.RayCluster{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayCluster), createdRayCluster)).To(gomega.Succeed())
-				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, client.ObjectKeyFromObject(rayCluster), corev1.PodRunning)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(specReplicasPerWorkerGroup(createdRayCluster)).To(gomega.Equal(expected))
 
-				actualReplicas := make(map[string]int32, len(createdRayCluster.Spec.WorkerGroupSpecs))
-				for i := range createdRayCluster.Spec.WorkerGroupSpecs {
-					group := &createdRayCluster.Spec.WorkerGroupSpecs[i]
-					actualReplicas[group.GroupName] = ptr.Deref(group.Replicas, 0)
-				}
-				g.Expect(actualReplicas).To(gomega.Equal(expected))
-
-				runningPods := make(map[string]int32, len(expected))
-				for i := range workerPods {
-					runningPods[workerPods[i].Labels["ray.io/group"]]++
-				}
+				runningPods := findRunningPodsPerWorkerGroup(g, client.ObjectKeyFromObject(rayCluster))
 				for groupName, count := range expected {
 					g.Expect(runningPods[groupName]).To(gomega.Equal(count))
 				}
@@ -205,11 +227,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 				activeWorkloads := util.FindNonFinishedWorkloads(workloadList.Items)
 				g.Expect(activeWorkloads).To(gomega.HaveLen(1))
 				g.Expect(workload.IsAdmitted(&activeWorkloads[0])).To(gomega.BeTrue())
-				podSetCounts := make(map[string]int32, len(activeWorkloads[0].Spec.PodSets))
-				for i := range activeWorkloads[0].Spec.PodSets {
-					podSet := &activeWorkloads[0].Spec.PodSets[i]
-					podSetCounts[string(podSet.Name)] = podSet.Count
-				}
+				podSetCounts := podSetCountsByName(&activeWorkloads[0])
 				for groupName, count := range expected {
 					g.Expect(podSetCounts).To(gomega.HaveKeyWithValue(groupName, count))
 				}

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -151,7 +151,7 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			gomega.Expect(k8sClient.Create(ctx, rayCluster)).To(gomega.Succeed())
 		})
 
-		var headPod corev1.Pod
+		var headPod *corev1.Pod
 		ginkgo.By("Waiting for the zero-worker RayCluster to become ready", func() {
 			createdRayCluster := &rayv1.RayCluster{}
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -160,14 +160,10 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 				g.Expect(meta.IsStatusConditionTrue(createdRayCluster.Status.Conditions, string(rayv1.HeadPodReady))).To(gomega.BeTrue())
 				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(0)))
 
-				headPods := &corev1.PodList{}
-				g.Expect(k8sClient.List(ctx, headPods,
-					client.InNamespace(ns.Name),
-					client.MatchingLabels{"ray.io/node-type": "head"},
-				)).To(gomega.Succeed())
-				g.Expect(headPods.Items).To(gomega.HaveLen(1))
-				g.Expect(headPods.Items[0].Status.Phase).To(gomega.Equal(corev1.PodRunning))
-				headPod = headPods.Items[0]
+				var err error
+				headPod, err = util.GetRayClusterHeadPod(ctx, k8sClient, client.ObjectKeyFromObject(rayCluster))
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(headPod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayCluster did not become ready", createdRayCluster))
 		})
 

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -128,9 +128,8 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
 			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
 			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
+			WithAutoscalerOptions(&rayv1.AutoscalerOptions{IdleTimeoutSeconds: ptr.To[int32](1)}).
 			Obj()
-		// Keep scale-down transitions within the e2e test timeout.
-		rayCluster.Spec.AutoscalerOptions = &rayv1.AutoscalerOptions{IdleTimeoutSeconds: ptr.To[int32](10)}
 
 		workerA := rayCluster.Spec.WorkerGroupSpecs[0].DeepCopy()
 		workerA.GroupName = workerGroupA

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -177,13 +177,10 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 
 		expectWorkerGroups := func(expected map[string]int32) {
 			createdRayCluster := &rayv1.RayCluster{}
-			workerPods := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayCluster), createdRayCluster)).To(gomega.Succeed())
-				g.Expect(k8sClient.List(ctx, workerPods,
-					client.InNamespace(ns.Name),
-					client.MatchingLabels{"ray.io/node-type": "worker"},
-				)).To(gomega.Succeed())
+				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, client.ObjectKeyFromObject(rayCluster), corev1.PodRunning)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 
 				actualReplicas := make(map[string]int32, len(createdRayCluster.Spec.WorkerGroupSpecs))
 				for i := range createdRayCluster.Spec.WorkerGroupSpecs {
@@ -193,11 +190,8 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 				g.Expect(actualReplicas).To(gomega.Equal(expected))
 
 				runningPods := make(map[string]int32, len(expected))
-				for i := range workerPods.Items {
-					pod := &workerPods.Items[i]
-					if pod.Status.Phase == corev1.PodRunning {
-						runningPods[pod.Labels["ray.io/group"]]++
-					}
+				for i := range workerPods {
+					runningPods[workerPods[i].Labels["ray.io/group"]]++
 				}
 				for groupName, count := range expected {
 					g.Expect(runningPods[groupName]).To(gomega.Equal(count))


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area testing

#### What this PR does / why we need it:

Adds an end-to-end test for an elastic standalone RayCluster with two worker groups that can autoscale independently.

The test uses distinct Ray custom resources and detached actors to exercise these transitions:

- only the first worker group scales up
- both worker groups are running
- only the second worker group remains running
- both worker groups scale back to zero

Each transition verifies the RayCluster replica counts, running worker pods, and Kueue Workload PodSet accounting.

#### Which issue(s) this PR fixes:

Fixes #13364

#### Special notes for your reviewer:

AI assistance was used to help implement and review this change. The author reviewed and tested the resulting code and takes responsibility for it.

Tests:

- `go test -mod=mod ./test/e2e/singlecluster/extended -run '^$'`
- `go vet -mod=mod ./test/e2e/singlecluster/extended`
- focused KubeRay extended e2e test run 50 consecutive times on a local Kind cluster: **50 passed, 0 failed**
  - commit: `bbdf59b95733ee20778c4a81e3e6bdf7d19f7e49`
  - environment: Kind v0.32.0, Kubernetes v1.36.1, Ginkgo v2.32.0, KubeRay v1.6.2, `ray-project-mini:0.0.4`
  - total Ginkgo runtime: 1h23m49.766s
  - per-attempt runtime: mean 100.376s, min 94.894s, max 105.316s
  - command:

    ```bash
    make \
      KIND_CLUSTER_NAME=kueue-13364-flake50 \
      "GINKGO_ARGS=--label-filter='feature:kuberay && shard:kuberay-b' --focus='Should scale RayCluster worker groups independently' --repeat=49 --timeout=3h" \
      test-e2e-extended-shard-2
    ```

  `--repeat=49` runs the initial attempt plus 49 repeats. No flakiness was observed in these 50 attempts.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for single-cluster “multi-PodSet autoscaling” with two independently autoscaled worker groups and workload slicing enabled.
  * Uses a detached, named Ray actor to trigger scaling per group, verifying group-specific scale-up/scale-down as actors are created and terminated.
  * Confirms RayCluster head readiness, per-group worker replica counts, and Kueue workload admission/accounting after each lifecycle step.

* **New Features**
  * Added test wrapper chaining to set RayCluster autoscaler options for simpler autoscaling scenario setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->