### PR TITLE
Capture race-detector reports as CI artifacts

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -107,7 +107,12 @@ FULLRAY_EXCLUDE := $(if $(filter "raymini",$(USE_RAY_FOR_TESTS)), && !requires:f
 .PHONY: test
 test: gotestsum ## Run tests. Set UNIT_TOTAL_SHARDS and UNIT_SHARD_INDEX to run a specific shard.
 	mkdir -p $(ARTIFACTS)
-	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
+# GORACE log_path makes the race detector write each report to
+# $(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX).<pid> so it is archived as a CI artifact.
+# Otherwise the report only goes to stderr, which gotestsum discards when a package
+# fails under -race without an attributed test failure (kueue issue 13290). The file is
+# written only when a race is actually detected, so green runs stay clean.
+	GORACE="log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
 
 ## Label Taxonomy:
 ##   Controllers: controller:workload, controller:localqueue, controller:clusterqueue, controller:admissioncheck, controller:resourceflavor, controller:provisioning


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake
/area testing
/area multikueue
/hold

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
> **🚧 DO NOT MERGE, diagnostic PR.** Intentionally kept open to gather information about a CI flake; it is not meant to be merged. It only adds race-report capture and changes no product behavior. Held with `/hold`.

We have an intermittent data-race failure in `pkg/controller/admissionchecks/multikueue` unit tests. We could **not** reproduce it neither locally nor on a remote cluster and when it does fail in CI the race report is **swallowed**: the race detector prints to stderr and the binary exits 66 while every `Test*` still passes, so `gotestsum` records only the terminal `FAIL` line in its summary and junit. The actual race stacks never reach an artifact. That combination can't reproduce on demand, and the report isn't captured when it does fail, is exactly why we're adding this.

This sets `GORACE=log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)` on the `test` target, so the race detector writes each report to `$(ARTIFACTS)/race-shard-N.<pid>`, which CI archives alongside `junit`/`cover`. The file is written **only** when a race is actually detected, so passing runs produce no extra artifacts.

Verified locally:
- a deliberately racy test writes the full report (both racing accesses with `file:line` plus goroutine-creation stacks) to `race.<pid>`, and nothing to stdout;
- a passing race-instrumented build writes no file (no artifact litter);
- `make -n test` parses cleanly; the path resolves absolute and picks up the shard suffix (`race-shard-1.<pid>`).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #13290 

#### Special notes for your reviewer:

**Please do not merge — this PR is a diagnostic instrument, not a fix.** It is meant to run in CI and gather evidence for the intermittent `-race` failure in `pkg/controller/admissionchecks/multikueue`, tracked in kubernetes-sigs/kueue#13290. Reproduction was attempted both locally and on a remote cluster without success, so we're using CI itself to capture the report: once this is running, the next occurrence will archive `race-shard-N.<pid>` with the exact stacks, and we'll open a **separate** PR with the real fix. Held with `/hold`; per the flake-PR convention I'm not using `Fixes` and will link the issue in a comment.

Disclosure: this change was developed with AI assistance (Claude Code). The investigation, change, and local verification were reviewed by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Race detector reports are now saved as test artifacts, ensuring they remain available even when no specific test failure is attributed.

* **Tests**
  * Improved race-test reporting with clearer artifact output and handling across optional test shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->