### PR TITLE
Fix misleading reporting of limiting resource name

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -45,9 +45,10 @@ import (
 
 // PodSetTestCase defines a test case for a single podset in the consolidated test.
 type PodSetTestCase struct {
-	podSetName         string
-	topologyRequest    *kueue.PodSetTopologyRequest
-	requests           resources.MapRequests
+	podSetName      string
+	topologyRequest *kueue.PodSetTopologyRequest
+	requests        resources.Requests
+
 	count              int32
 	tolerations        []corev1.Toleration
 	nodeSelector       map[string]string
@@ -1623,6 +1624,38 @@ func TestFindTopologyAssignments(t *testing.T) {
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1`,
 			}},
 		},
+		"node allocatable capacity completely used by non-TAS pod; empty remainingCapacity": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x3").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("1"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("running1", "test-ns").NodeName("x3").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(corev1.LabelHostname),
+				},
+				requests: func() resources.Requests {
+					sr := resources.ResourceListToSliceRequests(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")})
+					return &sr
+				}(),
+
+				count:      1,
+				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1`,
+			}},
+		},
+
 		"include usage from non-TAS pods; pod usage": {
 			// this test case ensures we are counting pods properly
 			// when aggregating non-tas pod usage by node.

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -283,7 +283,7 @@ func (sr *SliceRequests) CountIn(capacity Requests) int32 {
 }
 
 func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName) {
-	if sr.IsEmpty() || isEmpty(capacity) {
+	if sr.IsEmpty() {
 		return 0, emptyResourceName
 	}
 
@@ -299,7 +299,7 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 			if j < len(*capSR) && (*capSR)[j].cmp(entry) == 0 {
 				capVal = (*capSR)[j].value
 			}
-		} else {
+		} else if capacity != nil {
 			capVal = capacity.GetValue(entry.name)
 		}
 

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -181,6 +181,16 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
 			m2:       MapRequests{corev1.ResourceMemory: 50, corev1.ResourcePods: 100},
 		},
+		{
+			opChoice: opCountIn,
+			m1:       MapRequests{corev1.ResourceCPU: 100, corev1.ResourceMemory: 200},
+			m2:       MapRequests{},
+		},
+		{
+			opChoice: opCountIn,
+			m1:       MapRequests{},
+			m2:       MapRequests{corev1.ResourceCPU: 100},
+		},
 	}
 
 	for _, s := range seeds {

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -420,7 +420,13 @@ func TestSliceRequests_CountIn(t *testing.T) {
 			capacity: nil,
 			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
 			wantCnt:  0,
-			wantRes:  "",
+			wantRes:  corev1.ResourceCPU,
+		},
+		"empty capacity": {
+			capacity: &SliceRequests{},
+			request:  NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000}),
+			wantCnt:  0,
+			wantRes:  corev1.ResourceCPU,
 		},
 		"nil receiver": {
 			capacity: NewSliceRequests(MapRequests{corev1.ResourceCPU: 10000}),

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -2066,6 +2066,47 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 		},
+		"workload does not get scheduled as node capacity is completely used by non-TAS pod": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("1"),
+					}).
+					Ready().
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("test-pending", "test-ns").NodeName("x1").
+					StatusPhase(corev1.PodRunning).
+					Request(corev1.ResourceCPU, "1").
+					Request(corev1.ResourceMemory, "1Gi").
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/foo"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "foo", kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed, "Warning").
+					Message(`couldn't assign flavors to pod set one: topology "tas-single-level" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1`).
+					Obj(),
+			},
+		},
 		"workload gets admitted next to already admitted workload, multiple resources used": {
 			nodes:           defaultSingleNode,
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/area tas

#### What this PR does / why we need it:

The limiting resource name reported by `CountInWithLimitingResource` was incorrectly returning an empty resource name when the capacity of a leaf was empty.

The limiting resource name is used for generating NoFit message, not during the scheduling decisions.

`MapRequests` doesn't skip the limiting resource name - https://github.com/kubernetes-sigs/kueue/blob/2ad28aa497a9d07787ba00c92397c53d33c1ce38/pkg/resources/requests.go#L181

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
TAS: Fixed regression where admission failure events for Topology-Aware Scheduling (TAS) missed reporting the limiting resource when a node's remaining capacity was zero.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of capacity limits when capacity is absent or empty, correcting which limiting resource is reported.
  * Refinements to scheduling/TAS admission logic to better handle scenarios where remaining node capacity is fully consumed.

* **Tests**
  * Expanded fuzz and unit test coverage for empty request/capacity edge cases.
  * Updated scheduling/TAS admission test scenarios and fixtures for more precise node and pod resource demands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->