### PR TITLE
test: stabilize kube-system deployment readiness check

### DIFF
--- a/test/e2e/sequential/baseline/managejobswithoutqueuename_test.go
+++ b/test/e2e/sequential/baseline/managejobswithoutqueuename_test.go
@@ -268,7 +268,7 @@ var _ = ginkgo.Describe("ManageJobsWithoutQueueName", ginkgo.Label("feature:mana
 					for _, pod := range pods.Items {
 						g.Expect(pod.Status.Phase).Should(gomega.Equal(corev1.PodRunning))
 					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("verifying that deleting the deployment removes the pods", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/area testing

#### Which issue(s) this PR fixes:

Fixes #13339

> The pod took about 31 seconds to reach the Running phase, exceeding the existing 10-second timeout and causing  the assertion to fail. The timeout has been extended to 45 seconds.

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by allowing additional time for system deployment pods to reach the running state during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->