### PR TITLE
Refactor release-utils.yml

### DIFF
--- a/.github/actions/create-draft-release/action.yml
+++ b/.github/actions/create-draft-release/action.yml
@@ -1,0 +1,88 @@
+name: Create Draft Release
+description: Creates (or recreates) a GitHub draft release for the given version tag.
+
+inputs:
+  version:
+    description: Release version, formatted as vX.Y.Z (X - major, Y - minor, Z - patch; e.g. v0.10.0)
+    required: true
+  changelog:
+    description: Release notes / changelog content
+    required: true
+  repo:
+    description: Target repository in owner/name format
+    required: true
+
+outputs:
+  outcome:
+    description: What happened to the release — "created" or "updated"
+    value: ${{ steps.draft.outputs.outcome }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create Draft Release
+      id: draft
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+        CHANGELOG: ${{ inputs.changelog }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        TARGET_REPO: ${{ inputs.repo }}
+      run: |
+        RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
+        
+        if [ -z "$CHANGELOG" ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`: No changelog found in the issue description."
+          exit 1
+        elif [ "$RELEASE_STATE" = "published" ]; then
+          BODY="❌️ Release \`$VERSION\` is already published. Skipping draft release creation/update to avoid overwriting a live release."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+          exit 1
+        elif [ "$RELEASE_STATE" = "draft" ]; then
+          echo "Draft release \`$VERSION\` already exists. Deleting it first to perform a clean update..."
+          set +e
+          gh release delete "$VERSION" --repo "$TARGET_REPO" --yes
+          DELETE_EXIT=$?
+          set -e
+          if [ $DELETE_EXIT -ne 0 ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to delete existing draft release \`$VERSION\`."
+            exit 1
+          fi
+          OUTCOME="updated"
+        else
+          OUTCOME="created"
+        fi
+
+        set +e
+        make release-artifacts IMAGE_REGISTRY=registry.k8s.io/kueue GIT_TAG="$VERSION"
+        MAKE_EXIT=$?
+        set -e
+
+        if [ $MAKE_EXIT -ne 0 ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to build release artifacts for \`$VERSION\`."
+          exit 1
+        fi
+
+        # Create a draft release.
+        set +e
+        echo "Creating \`$VERSION\` release."
+        
+        gh release create "$VERSION" \
+          --verify-tag \
+          --repo "$TARGET_REPO" \
+          --title "$VERSION" \
+          --notes "$CHANGELOG" \
+          --draft \
+          release-artifacts/*
+        RELEASE_EXIT=$?
+        set -e
+
+        if [ $RELEASE_EXIT -ne 0 ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`."
+          exit 1
+        fi
+
+        echo "outcome=$OUTCOME" >> "$GITHUB_OUTPUT"

--- a/.github/actions/create-release-tag/action.yml
+++ b/.github/actions/create-release-tag/action.yml
@@ -1,0 +1,87 @@
+name: Create Release Tag
+description: Validates the changelog, creates an annotated git tag from the changelog, and pushes it to origin.
+
+inputs:
+  version:
+    description: Release version, formatted as vX.Y.Z (X - major, Y - minor, Z - patch; e.g. v0.10.0)
+    required: true
+  changelog:
+    description: Changelog content used as the tag annotation body
+    required: true
+  repo:
+    description: Target repository in owner/name format
+    required: true
+
+outputs:
+  outcome:
+    description: What happened to the tag — "created" or "updated"
+    value: ${{ steps.tag.outputs.outcome }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create and Push Tag
+      id: tag
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        CHANGELOG: ${{ inputs.changelog }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        TARGET_REPO: ${{ inputs.repo }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
+        
+        if [ "$RELEASE_STATE" = "published" ]; then
+          BODY="❌ Release \`$VERSION\` is already published. Skipping tag creation/update to avoid overwriting a live release."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+          exit 1
+        fi
+        
+        if [ -z "$CHANGELOG" ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release tag \`$VERSION\`: No changelog found in the issue description. Make sure the issue has the Markdown block under \`## Changelog\`."
+          exit 1
+        fi
+
+        # Prepare tag message
+        NOTES_FILE=$(mktemp)
+        printf "%s\n\n%s\n" "$VERSION" "$CHANGELOG" > "$NOTES_FILE"
+
+        # Configure git identity
+        git config --global user.name "kueue-release-bot"
+        git config --global user.email "kueue-release-bot@kubernetes.io"
+        gh auth setup-git
+
+        # Clear existing tag
+        TAG_EXISTS=false
+        if git tag -l | grep -q "^${VERSION}$" || git ls-remote --tags origin "$VERSION" | grep -q "refs/tags/${VERSION}$"; then
+          TAG_EXISTS=true
+          git tag -d "$VERSION" 2>/dev/null || true
+          git push origin --delete "$VERSION" 2>/dev/null || true
+        fi
+
+        # Create and push the tag
+        PUSH_EXIT=0
+        set +e
+        git tag -a "$VERSION" -F "$NOTES_FILE"
+        TAG_EXIT=$?
+        if [ $TAG_EXIT -eq 0 ]; then
+          git push origin "$VERSION"
+          PUSH_EXIT=$?
+        fi
+        set -e
+        rm -f "$NOTES_FILE"
+
+        if [ $TAG_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create or push release tag \`$VERSION\`."
+          exit 1
+        fi
+
+        OUTCOME="created"
+        if [ "$TAG_EXISTS" = "true" ]; then
+          OUTCOME="updated"
+        fi
+
+        echo "outcome=$OUTCOME" >> "$GITHUB_OUTPUT"

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -1,0 +1,49 @@
+name: Publish Release
+description: Publishes a GitHub draft release.
+
+inputs:
+  version:
+    description: Release version, formatted as vX.Y.Z (X - major, Y - minor, Z - patch; e.g. v0.10.0)
+    required: true
+  repo:
+    description: Target repository in owner/name format
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Publish Release
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        VERSION: ${{ inputs.version }}
+        ISSUE_NUMBER: ${{ github.event.issue.number }}
+        TARGET_REPO: ${{ inputs.repo }}
+      run: |
+        RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
+            --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
+        
+        if [ "$RELEASE_STATE" = "published" ]; then
+          BODY="❌️ Release \`$VERSION\` is already published."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+          exit 1
+        elif [ -z "$RELEASE_STATE" ]; then
+          BODY="❌ Release \`$VERSION\` not found. Please create a draft release first using \`/create-draft-release\`."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
+          exit 1
+        fi
+
+        # Publish the draft release.
+        set +e
+        gh release edit "$VERSION" \
+          --repo "$TARGET_REPO" \
+          --draft=false
+        EDIT_EXIT=$?
+        set -e
+
+        if [ $EDIT_EXIT -ne 0 ]; then
+          gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`."
+          exit 1
+        fi

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -288,71 +288,41 @@ jobs:
     permissions:
       contents: write
       issues: write
-    env:
-      BRANCH: ${{ needs.authorize.outputs.branch }}
-      ISSUE_NUMBER: ${{ github.event.issue.number }}
-      CHANGELOG: ${{ needs.authorize.outputs.changelog }}
     steps:
-      - name: Checkout repository
+      - name: Checkout release branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ needs.authorize.outputs.branch }}
           persist-credentials: false
 
+      - name: Checkout automation actions from main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: .automation
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Create and Push Tag
+        id: tag
+        uses: ./.automation/.github/actions/create-release-tag
+        with:
+          version: ${{ needs.authorize.outputs.version }}
+          changelog: ${{ needs.authorize.outputs.changelog }}
+          repo: ${{ github.repository }}
+
+      - name: Post Success Comment
         env:
-          VERSION: ${{ needs.authorize.outputs.version }}
-          ISSUE_BODY: ${{ github.event.issue.body }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CHANGELOG: ${{ needs.authorize.outputs.changelog }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          OUTCOME: ${{ steps.tag.outputs.outcome }}
         run: |
-          if [ -z "$CHANGELOG" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release tag \`$VERSION\`: No changelog found in the issue description. Make sure the issue has the Markdown block under \`## Changelog\`."
-            exit 1
-          fi
-          
-          # Prepare tag message
-          NOTES_FILE=$(mktemp)
-          printf "%s\n\n%s\n" "$VERSION" "$CHANGELOG" > "$NOTES_FILE"
-
-          # Configure git identity
-          git config --global user.name "kueue-release-bot"
-          git config --global user.email "kueue-release-bot@kubernetes.io"
-          gh auth setup-git
-          
-          # Clear existing tag
-          TAG_EXISTS=false
-          if git tag -l | grep -q "^${VERSION}$" || git ls-remote --tags origin "$VERSION" | grep -q "refs/tags/${VERSION}$"; then
-            TAG_EXISTS=true
-            git tag -d "$VERSION" 2>/dev/null || true
-            git push origin --delete "$VERSION" 2>/dev/null || true
-          fi
-
-          # Create and push the tag
-          PUSH_EXIT=0
-          set +e
-          git tag -a "$VERSION" -F "$NOTES_FILE"
-          TAG_EXIT=$?
-          if [ $TAG_EXIT -eq 0 ]; then
-            git push origin "$VERSION"
-            PUSH_EXIT=$?
-          fi
-          set -e
-          rm -f "$NOTES_FILE"
-          
-          if [ $TAG_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create or push release tag \`$VERSION\`."
-            exit 1
-          fi
-          
-          # Log successful creation/update
-          ACTION="created"
-          if [ "$TAG_EXISTS" = "true" ]; then
-            ACTION="updated"
-          fi
-          
-          gh issue comment "$ISSUE_NUMBER" --body "✅ Release tag \`$VERSION\` has been successfully ${ACTION}."
+          BODY="✅ Release tag \`$VERSION\` has been successfully ${OUTCOME}."
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
 
   create-draft-release:
     name: Create Draft Release
@@ -364,11 +334,20 @@ jobs:
       contents: write
       issues: write
     steps:
-      - name: Checkout repository
+      - name: Checkout release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ needs.authorize.outputs.version }}
+          persist-credentials: false
+
+      - name: Checkout automation actions from main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          path: .automation
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Set up Go
@@ -376,57 +355,21 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Build Release Artifacts
-        env:
-          VERSION: ${{ needs.authorize.outputs.version }}
-        run: |
-          make release-artifacts IMAGE_REGISTRY=registry.k8s.io/kueue GIT_TAG="$VERSION"
-
       - name: Create Draft Release
+        id: draft
+        uses: ./.automation/.github/actions/create-draft-release
+        with:
+          version: ${{ needs.authorize.outputs.version }}
+          changelog: ${{ needs.authorize.outputs.changelog }}
+          repo: ${{ github.repository }}
+
+      - name: Post Success Comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-          VERSION: ${{ needs.authorize.outputs.version }}
-          TARGET_REPO: ${{ github.repository }}
-          CHANGELOG: ${{ needs.authorize.outputs.changelog }}
+          OUTPUT: ${{ steps.draft.outputs.outcome }}
         run: |
-          ACTION="created"
-
-          # Check if a release for this version already exists (draft or published).
-          RELEASE_STATE=$(gh release list --repo "$TARGET_REPO" --exclude-drafts=false --json tagName,isDraft 2>/dev/null | \
-            jq -r --arg ver "$VERSION" '.[] | select(.tagName == $ver) | if .isDraft then "draft" else "published" end')
-
-          if [ "$RELEASE_STATE" = "published" ]; then
-            BODY="⚠️ Release \`$VERSION\` is already published. Skipping draft release creation to avoid overwriting a live release."
-            echo "$BODY"
-            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
-            exit 0
-          elif [ "$RELEASE_STATE" = "draft" ]; then
-            echo "Draft release \`$VERSION\` already exists. Deleting it first to perform a clean update..."
-            gh release delete "$VERSION" --repo "$TARGET_REPO" --yes
-            ACTION="updated"
-          fi
-
-          # Create a draft release.
-          set +e
-          echo "Creating \`$VERSION\` release."
-          gh release create "$VERSION" \
-            --verify-tag \
-            --repo "$TARGET_REPO" \
-            --title "$VERSION" \
-            --notes "$CHANGELOG" \
-            --draft \
-            release-artifacts/*
-          RELEASE_EXIT=$?
-          set -e
-
-          if [ $RELEASE_EXIT -ne 0 ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`."
-            exit 1
-          fi
-
-          # Post a comment to the GitHub issue.
-          BODY="✅ Draft release has been successfully ${ACTION}."
+          BODY="✅ Draft release has been successfully ${OUTPUT}."
           echo "$BODY"
           gh issue comment "$ISSUE_NUMBER" --body "$BODY"
 
@@ -500,49 +443,18 @@ jobs:
           persist-credentials: false
 
       - name: Publish Release
+        uses: ./.github/actions/publish-release
+        with:
+          version: ${{ needs.authorize.outputs.version }}
+          repo: ${{ github.repository }}
+
+      - name: Post Success Comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           VERSION: ${{ needs.authorize.outputs.version }}
-          COMMAND: ${{ needs.authorize.outputs.command }}
         run: |
-          # Check the current state of the release.
-          RELEASE_STATE=$(gh release list --repo "$GITHUB_REPOSITORY" --exclude-drafts=false --json tagName,isDraft 2>/dev/null | \
-            jq -r --arg ver "$VERSION" '.[] | select(.tagName == $ver) | if .isDraft then "draft" else "published" end')
-
-          if [ "$RELEASE_STATE" = "published" ]; then
-            BODY="⚠️ Release \`$VERSION\` is already published."
-            echo "$BODY"
-            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
-            exit 0
-          elif [ -z "$RELEASE_STATE" ]; then
-            BODY="❌ Release \`$VERSION\` not found. Please create a draft release first using \`/create-draft-release\`."
-            echo "$BODY"
-            gh issue comment "$ISSUE_NUMBER" --body "$BODY"
-            exit 1
-          fi
-
-          # Publish the draft release.
-          set +e
-          gh release edit "$VERSION" \
-            --repo "$GITHUB_REPOSITORY" \
-            --draft=false
-          EDIT_EXIT=$?
-          set -e
-
-          if [ $EDIT_EXIT -ne 0 ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`."
-            exit 1
-          fi
-
-          # Construct the release URL and inject it into the issue body.
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}"
-          CURRENT_BODY=$(gh issue view "$ISSUE_NUMBER" --json body -q .body)
-          UPDATED_BODY=$(printf '%s' "$CURRENT_BODY" | sed "s|<!-- RELEASE_LINK -->|${RELEASE_URL}|")
-          if [ "$CURRENT_BODY" != "$UPDATED_BODY" ]; then
-            gh issue edit "$ISSUE_NUMBER" --body "$UPDATED_BODY"
-          fi
-
           BODY="$(cat <<EOF
           ✅ Release \`$VERSION\` has been successfully published.
           Link: ${RELEASE_URL}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area release

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Refactor release-utils.yml

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12763

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable release automation for creating annotated release tags, creating/updating draft releases, and publishing drafts.
  * Release automation detects whether releases already exist and reports whether outputs were **created** or **updated**.
* **Improvements**
  * Streamlined release workflows by delegating release operations to shared, reusable composite actions.
  * Improved reliability and messaging by adding early safety checks (avoids overwriting published releases) and more detailed issue comments on failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->