### PR TITLE
e2e: reach RayService through the serve Service instead of port-forward

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -17,17 +17,17 @@ limitations under the License.
 package extended
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"strconv"
 	"strings"
-	"time"
+	"sync"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -43,6 +43,7 @@ import (
 	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	utilpodset "sigs.k8s.io/kueue/pkg/util/podset"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
@@ -85,6 +86,33 @@ const (
 	// to avoid Ray auto-sizing it too large for the constrained test environment.
 	objectStoreMemory = "100000000"
 )
+
+func rayServeCurlCmd(rayServiceName, query string) []string {
+	serveSvcName := rayutils.GenerateServeServiceName(rayServiceName)
+	return []string{"curl", "-sS", "--fail", "--max-time", "60", "--retry", "5", "--retry-connrefused", "--retry-delay", "2", fmt.Sprintf("http://%s:8000/%s", serveSvcName, query)}
+}
+
+func waitForRayServiceReadyToServe(rayService *rayv1.RayService) {
+	createdRayService := &rayv1.RayService{}
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+		g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
+		g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
+	}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayService did not become ready to serve", createdRayService))
+}
+
+func startServeClientPod(ns string) *corev1.Pod {
+	pod := testingpod.MakePod("serve-client", ns).
+		Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+		TerminationGracePeriod(1).
+		Obj()
+	gomega.Expect(k8sClient.Create(ctx, pod)).To(gomega.Succeed())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(gomega.Succeed())
+		g.Expect(pod.Status.Phase).To(gomega.Equal(corev1.PodRunning))
+	}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+	return pod
+}
 
 var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:kuberay"), func() {
 	var (
@@ -922,35 +950,16 @@ app = HelloWorld.bind()`,
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, createdWorkload)
 		})
 
-		ginkgo.By("Checking the RayService is running", func() {
-			createdRayService := &rayv1.RayService{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
-				g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
-				g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayService did not become ready", createdRayService))
+		ginkgo.By("Waiting for the RayService to be ready to serve traffic", func() {
+			waitForRayServiceReadyToServe(rayService)
 		})
 
-		ginkgo.By("Verifying the RayService responds to HTTP requests via port-forward", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				headPodName := getRayHeadPod(g).Name
-
-				// Port-forward to the head pod on port 8000 (Ray Serve default)
-				localPort, stopChan, err := util.KPortForward(cfg, restClient, ns.Name, headPodName, 8000)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				defer close(stopChan)
-
-				// Send HTTP GET to the Ray Serve endpoint
-				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", localPort))
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				defer resp.Body.Close()
-
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-
-				body, err := io.ReadAll(resp.Body)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(strings.TrimSpace(string(body))).To(gomega.ContainSubstring("Hello, World!"))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("Verifying the RayService responds to HTTP requests via the serve service", func() {
+			clientPod := startServeClientPod(ns.Name)
+			cmd := rayServeCurlCmd(rayService.Name, "")
+			stdout, stderr, err := util.KExecute(ctx, cfg, restClient, ns.Name, clientPod.Name, clientPod.Spec.Containers[0].Name, cmd)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", string(stderr))
+			gomega.Expect(string(stdout)).To(gomega.ContainSubstring("Hello, World!"))
 		})
 	})
 
@@ -1181,36 +1190,16 @@ app = HelloWorld.bind()`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.By("Checking the RayService is running", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				createdRayService := &rayv1.RayService{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
-				g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
-				g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("Waiting for the RayService to be ready to serve traffic", func() {
+			waitForRayServiceReadyToServe(rayService)
 		})
 
-		// Set up port-forwarding to the head pod for sending HTTP requests
-		var localPort int
-		var stopChan chan struct{}
-		gomega.Eventually(func(g gomega.Gomega) {
-			headPodName := getRayHeadPod(g).Name
-			var err error
-			localPort, stopChan, err = util.KPortForward(cfg, restClient, ns.Name, headPodName, 8000)
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-		}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-		defer close(stopChan)
-
-		ginkgo.By("Verifying the RayService responds to HTTP requests via port-forward", func() {
-			gomega.Eventually(func(g gomega.Gomega) {
-				resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", localPort))
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				defer resp.Body.Close()
-				g.Expect(resp.StatusCode).To(gomega.Equal(http.StatusOK))
-				body, err := io.ReadAll(resp.Body)
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(strings.TrimSpace(string(body))).To(gomega.ContainSubstring("Hello, World!"))
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+		clientPod := startServeClientPod(ns.Name)
+		ginkgo.By("Verifying the RayService responds to HTTP requests via the serve service", func() {
+			cmd := rayServeCurlCmd(rayService.Name, "")
+			stdout, stderr, err := util.KExecute(ctx, cfg, restClient, ns.Name, clientPod.Name, clientPod.Spec.Containers[0].Name, cmd)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred(), "stderr: %s", string(stderr))
+			gomega.Expect(string(stdout)).To(gomega.ContainSubstring("Hello, World!"))
 		})
 
 		ginkgo.By("Waiting for worker count to be zero due to autoscaling", func() {
@@ -1225,15 +1214,20 @@ app = HelloWorld.bind()`,
 			// the target_ongoing_requests=1 threshold, triggering Ray Serve autoscaling.
 			// With max_replicas_per_node=1, new serve replicas require new Ray worker
 			// nodes, which triggers the RayCluster autoscaler to add workers.
+			cmd := rayServeCurlCmd(rayService.Name, "?delay=10")
+			loadCtx, cancelLoad := context.WithCancel(ctx)
+			var wg sync.WaitGroup
 			for range 10 {
-				go func() {
-					reqClient := &http.Client{Timeout: 60 * time.Second}
-					resp, err := reqClient.Get(fmt.Sprintf("http://localhost:%d/?delay=10", localPort))
-					if err == nil && resp != nil {
-						resp.Body.Close()
-					}
-				}()
+				wg.Go(func() {
+					// Each exec blocks until its slow request completes; errors are
+					// ignored — the assertion below observes the resulting scale-up.
+					_, _, _ = util.KExecute(loadCtx, cfg, restClient, ns.Name, clientPod.Name, clientPod.Spec.Containers[0].Name, cmd)
+				})
 			}
+			ginkgo.DeferCleanup(func() {
+				cancelLoad()
+				wg.Wait()
+			})
 		})
 
 		ginkgo.By("Waiting for worker count to increase due to autoscaling", func() {

--- a/test/util/e2e.go
+++ b/test/util/e2e.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -57,8 +55,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
@@ -798,59 +794,6 @@ func CreatePrometheusClient(cfg *rest.Config) prometheusv1.API {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	return prometheusv1.NewAPI(client)
-}
-
-// KPortForward establishes a port-forward connection to a pod and returns
-// the local port, a stop channel to close the connection, and any error.
-func KPortForward(cfg *rest.Config, restClient *rest.RESTClient, ns, podName string, remotePort int) (int, chan struct{}, error) {
-	// Build the URL to the pod's portforward endpoint
-	url := restClient.Post().
-		Resource("pods").
-		Namespace(ns).
-		Name(podName).
-		SubResource("portforward").
-		URL()
-
-	// Create SPDY transport
-	transport, upgrader, err := spdy.RoundTripperFor(cfg)
-	if err != nil {
-		return 0, nil, fmt.Errorf("creating SPDY round tripper: %w", err)
-	}
-
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", url)
-
-	// Setup channels
-	stopChan := make(chan struct{})
-	readyChan := make(chan struct{})
-
-	// Use port 0 so the OS atomically assigns a free local port, avoiding the
-	// TOCTOU race of finding a port and then trying to bind it separately.
-	ports := []string{fmt.Sprintf("0:%d", remotePort)}
-
-	// Create port forwarder
-	pf, err := portforward.New(dialer, ports, stopChan, readyChan, io.Discard, io.Discard)
-	if err != nil {
-		return 0, nil, fmt.Errorf("creating port forwarder: %w", err)
-	}
-
-	// Run in goroutine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- pf.ForwardPorts()
-	}()
-
-	// Wait for ready or error
-	select {
-	case <-readyChan:
-		forwardedPorts, err := pf.GetPorts()
-		if err != nil {
-			close(stopChan)
-			return 0, nil, fmt.Errorf("getting forwarded ports: %w", err)
-		}
-		return int(forwardedPorts[0].Local), stopChan, nil
-	case err := <-errChan:
-		return 0, nil, fmt.Errorf("port forward failed: %w", err)
-	}
 }
 
 func SetResourceNominalQuota(cq *kueue.ClusterQueue, resourceName corev1.ResourceName, value string) *kueue.ClusterQueue {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

The RayService e2e specs reached Ray Serve by port-forwarding to the head pod, which required looking up the head pod and tunneling through SPDY.

Port-forwarding is not needed: RayService exposes the `<name>-serve-svc` Service for serving traffic (see the [RayService quick-start](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/rayservice-quick-start.html)). The specs now curl that Service from a small agnhost client pod — the same pattern as KubeRay's own [e2e tests](https://github.com/ray-project/kuberay/blob/148f70e2270267d90db51b3b7fe2360d7113c649/ray-operator/test/e2erayservice/rayservice_ha_test.go) — so they no longer look up the head pod at all.

The specs wait for the `RayServiceReady` condition before sending requests, and the now-unused `KPortForward` helper is removed.

_This PR was prepared with AI assistance (Claude Code)._

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

- The client pod uses the already-preloaded agnhost image (ships curl) and carries no queue label, so kueue does not manage it.
- `curl` retries refused connections (`--retry-connrefused`): `RayServiceReady` is a control-plane signal and endpoint programming on the client's node can lag behind it briefly. Without the retry this reproduced locally as `curl: (7)` about half a second after the condition turned true.
- Both affected specs carry `requires:fullray`, which presubmit CI excludes (it runs raymini), so they were verified locally against a kind cluster with `rayproject/ray:2.56.0`: 10 consecutive focused runs, 10/10 passing (2 specs each).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RayService end-to-end HTTP verification by waiting for “ready to serve” readiness before issuing requests.
  * Updated HTTP request flows to use in-cluster service access instead of local port forwarding, reducing test flakiness.
  * Enhanced autoscaling end-to-end traffic generation with retry-enabled in-cluster requests and concurrent execution.
* **Tests / Chores**
  * Removed the old port-forward-based e2e helper utility that was no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->