### PR TITLE
Handle missing LocalQueues in fair-sharing snapshot ordering

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -853,7 +854,12 @@ func buildSnapshotSort(
 		}
 		ns, name := utilqueue.MustParseLocalQueueReference(lqKey)
 		var lq kueue.LocalQueue
-		if err := cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: string(name)}, &lq); err != nil {
+		lqObjKey := client.ObjectKey{Namespace: ns, Name: string(name)}
+		if err := cl.Get(ctx, lqObjKey, &lq); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.V(3).Info("LocalQueue is missing, gracefully falling back to the default weight (1.0)", "localQueue", lqObjKey)
+				return 1, true
+			}
 			log.V(2).Error(err, "Failed to get LocalQueue for FS weight", "localQueue", klog.KRef(ns, string(name)))
 			return 0, false
 		}

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -853,17 +852,12 @@ func buildSnapshotSort(
 			return 1, true
 		}
 		ns, name := utilqueue.MustParseLocalQueueReference(lqKey)
-		var lq kueue.LocalQueue
-		lqObjKey := client.ObjectKey{Namespace: ns, Name: string(name)}
-		if err := cl.Get(ctx, lqObjKey, &lq); err != nil {
-			if apierrors.IsNotFound(err) {
-				log.V(3).Info("LocalQueue is missing, gracefully falling back to the default weight (1.0)", "localQueue", lqObjKey)
-				return 1, true
-			}
+		lqWeight, err := afs.ResolveLQWeight(ctx, cl, client.ObjectKey{Namespace: ns, Name: string(name)})
+		if err != nil {
 			log.V(2).Error(err, "Failed to get LocalQueue for FS weight", "localQueue", klog.KRef(ns, string(name)))
 			return 0, false
 		}
-		return afs.LQWeightAsFloat64(&lq), true
+		return lqWeight, true
 	}
 
 	return func(elements []*workload.Info) {

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -479,6 +479,45 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 	}
 }
 
+func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	afsConsumedResources := queueafs.NewAfsConsumedResources()
+	afsConsumedResources.Set("default/existing", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
+	afsConsumedResources.Set("default/missing", corev1.ResourceList{resourceGPU: resource.MustParse("15")}, now)
+
+	cq, err := newClusterQueue(
+		ctx,
+		utiltesting.NewClientBuilder().
+			WithObjects(utiltestingapi.MakeLocalQueue("existing", defaultNamespace).Obj()).
+			Build(),
+		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
+		defaultOrdering,
+		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1}},
+		nil,
+		afsConsumedResources,
+	)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	// Base ordering favors the missing queue by priority, while fair sharing with
+	// the default weight favors the existing queue by usage (10 < 15).
+	for _, wl := range []*kueue.Workload{
+		utiltestingapi.MakeWorkload("existing-low-priority", defaultNamespace).
+			Queue("existing").Priority(1).Creation(now).UID("uid-1").Obj(),
+		utiltestingapi.MakeWorkload("missing-high-priority", defaultNamespace).
+			Queue("missing").Priority(2).Creation(now).UID("uid-2").Obj(),
+	} {
+		cq.PushOrUpdate(workload.NewInfo(wl))
+	}
+
+	got := cq.Snapshot()
+	if got[0].Obj.Name != "existing-low-priority" {
+		t.Errorf("workload from missing LocalQueue should use the default weight: got %q first", got[0].Obj.Name)
+	}
+}
+
 // TestSnapshotConcurrentWithRequeueNoDataRace guards against a data race on the
 // sticky workload: Snapshot sorts a copy of the pending workloads through the
 // comparator (which reads stickyWorkload.workloadName) without holding the

--- a/pkg/util/admissionfairsharing/admission_fair_sharing.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing.go
@@ -17,11 +17,15 @@ limitations under the License.
 package admissionfairsharing
 
 import (
+	"context"
 	"maps"
 	"math"
 	"slices"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -60,6 +64,21 @@ func LQWeightAsFloat64(lq *kueue.LocalQueue) float64 {
 		return lq.Spec.FairSharing.Weight.AsApproximateFloat64()
 	}
 	return 1
+}
+
+// ResolveLQWeight returns the fair-sharing weight of the referenced LocalQueue.
+// A missing LocalQueue falls back to the default weight (1.0) so that its
+// Workloads keep participating in fair-sharing comparisons.
+func ResolveLQWeight(ctx context.Context, c client.Client, lqObjKey client.ObjectKey) (float64, error) {
+	var lq kueue.LocalQueue
+	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
+		if apierrors.IsNotFound(err) {
+			ctrl.LoggerFrom(ctx).V(3).Info("LocalQueue is missing, gracefully falling back to the default weight (1.0)", "localQueue", lqObjKey)
+			return 1, nil
+		}
+		return 0, err
+	}
+	return LQWeightAsFloat64(&lq), nil
 }
 
 // CalculateUsage computes fair-sharing usage from consumed resources and penalties.

--- a/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
@@ -17,15 +17,75 @@ limitations under the License.
 package admissionfairsharing
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
+
+func TestResolveLQWeight(t *testing.T) {
+	errOther := errors.New("other error")
+	tests := map[string]struct {
+		localQueue *kueue.LocalQueue
+		getErr     error
+		wantWeight float64
+		wantErr    error
+	}{
+		"configured weight": {
+			localQueue: utiltestingapi.MakeLocalQueue("lq", "ns").
+				FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("2"))}).
+				Obj(),
+			wantWeight: 2,
+		},
+		"default weight": {
+			localQueue: utiltestingapi.MakeLocalQueue("lq", "ns").Obj(),
+			wantWeight: 1,
+		},
+		"missing LocalQueue": {
+			wantWeight: 1,
+		},
+		"other error": {
+			getErr:  errOther,
+			wantErr: errOther,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := utiltesting.NewClientBuilder()
+			if tc.localQueue != nil {
+				builder = builder.WithObjects(tc.localQueue)
+			}
+			if tc.getErr != nil {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+						return tc.getErr
+					},
+				})
+			}
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			gotWeight, err := ResolveLQWeight(ctx, builder.Build(), client.ObjectKey{Namespace: "ns", Name: "lq"})
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("ResolveLQWeight() error = %v, want %v", err, tc.wantErr)
+			}
+			if gotWeight != tc.wantWeight {
+				t.Errorf("ResolveLQWeight() = %v, want %v", gotWeight, tc.wantWeight)
+			}
+		})
+	}
+}
 
 func TestCalculateEntryPenaltyWithDRAResources(t *testing.T) {
 	afs := &config.AdmissionFairSharing{

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -30,7 +30,6 @@ import (
 	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -459,16 +458,11 @@ func (i *Info) CalcLocalQueueFSUsage(
 		penalty = afsEntryPenalties.Peek(lqKey)
 	}
 
-	var lq kueue.LocalQueue
 	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
-	if err := c.Get(ctx, lqObjKey, &lq); err != nil {
-		if apierrors.IsNotFound(err) {
-			ctrl.LoggerFrom(ctx).V(3).Info("LocalQueue is missing, gracefully falling back to the default weight (1.0)", "localQueue", lqObjKey)
-			return afs.CalculateUsage(consumed, penalty, 1.0, resWeights), nil
-		}
+	lqWeight, err := afs.ResolveLQWeight(ctx, c, lqObjKey)
+	if err != nil {
 		return 0, err
 	}
-	lqWeight := afs.LQWeightAsFloat64(&lq)
 	return afs.CalculateUsage(consumed, penalty, lqWeight, resWeights), nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ClusterQueue.Snapshot()` looks up each LocalQueue to calculate fair-sharing
usage. If a referenced LocalQueue has been deleted, the lookup returns
`NotFound`; the old code omitted that queue from the usage cache and could mix
fair-sharing comparisons with the base ordering.

This change uses the default weight of `1.0` for a missing LocalQueue, matching
`CalcLocalQueueFSUsage`, so its Workloads remain part of the fair-sharing
ordering.

#### Which issue(s) this PR fixes:

Related to https://github.com/kubernetes-sigs/kueue/issues/12534

#### Special notes for your reviewer:

The regression test gives the missing LocalQueue retained usage and a higher
base priority. It fails on the base commit because the old snapshot falls back
to priority, and passes with this change because fair-sharing usage determines
the order.

Handling non-`NotFound` LocalQueue lookup errors is intentionally left out of
this PR and can be addressed separately with focused semantics and coverage.

Validation:

- `go test ./pkg/cache/queue -run TestSnapshotUsesDefaultWeightForMissingLocalQueue -count=100`
- `go test -race ./pkg/cache/queue/... -count=1`
- `go test ./pkg/cache/... -count=1`
- `go vet ./pkg/cache/queue/...`
- `golangci-lint` for `./pkg/cache/queue/...` (0 issues)

The full `make verify` was also attempted. Its code-generation, API lint, Helm,
and main Go lint stages ran, but the local Docker CLI lacks Buildx `--load`
support and its shellcheck container cannot mount this `/private/tmp`
worktree. No generated-file drift remained.

AI assistance was used to help implement and review this change. The author reviewed and tested the resulting code and takes responsibility for it.

#### Does this PR introduce a user-facing change?

```release-note
AFS: Fixed pending Workload snapshot ordering when a referenced LocalQueue is missing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fair-sharing workload ordering when a referenced LocalQueue is missing by using the configured default weight.
  * Made LocalQueue weight resolution more reliable and consistent, with clearer failure handling when the LocalQueue cannot be retrieved for reasons other than “not found.”
* **Tests**
  * Added unit test coverage for snapshot ordering and LocalQueue weight resolution, including missing-LocalQueue scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->