### PR TITLE
Automated cherry pick of #12797: Keep the sticky workload consistent during ClusterQueue heap and snapshot sorts

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -73,12 +73,18 @@ var (
 // considered sticky until it is admitted, unschedulable, or deleted.
 // See Kueue#6929 and Kueue#7101 for motivation.
 //
-// The workloadName field is accessed concurrently: Snapshot sorts a copy of
-// the pending workloads (via baseCompareFunc -> matches) without holding the
-// ClusterQueue's rwm lock, while RequeueIfNotPresent sets it during preemption.
-// It is a single field with only whole-value read/store/clear, so an
-// atomic.Pointer synchronizes every access regardless of the caller's locking
-// (nil means no sticky workload).
+// The workloadName field is accessed concurrently and drives both the CQ heap
+// ordering and the Snapshot ordering used by the visibility server. Two
+// mechanisms keep every sort transitive (see Kueue#12740):
+//   - Writes (set/clear) happen under the ClusterQueue's rwm lock, so heap
+//     operations, which also hold the lock, never observe it changing mid-sort.
+//   - Snapshot sorts a copy of the pending workloads without holding the lock,
+//     so it captures the sticky workload once per sort via capturedMatcher()
+//     instead of re-reading it on every comparison.
+//
+// The field holds a single whole value (nil means no sticky workload), so an
+// atomic.Pointer keeps individual reads and writes memory-safe on top of the
+// ordering guarantees above.
 type stickyWorkload struct {
 	workloadName atomic.Pointer[workload.Reference]
 }
@@ -86,6 +92,21 @@ type stickyWorkload struct {
 func (s *stickyWorkload) matches(workload workload.Reference) bool {
 	name := s.workloadName.Load()
 	return name != nil && *name == workload
+}
+
+// capturedMatcher captures the current sticky workload once and returns a
+// predicate bound to that fixed value. A sort that compares through the returned
+// predicate stays transitive even if set/clear runs concurrently, because every
+// comparison in that sort observes the same sticky workload. See Kueue#12740.
+func (s *stickyWorkload) capturedMatcher() func(workload.Reference) bool {
+	name := s.workloadName.Load()
+	if name == nil {
+		return func(workload.Reference) bool { return false }
+	}
+	captured := *name
+	return func(key workload.Reference) bool {
+		return captured == key
+	}
 }
 
 func (s *stickyWorkload) clear() {
@@ -221,13 +242,15 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, wo workload.
 		opt(options)
 	}
 	sw := stickyWorkload{}
-	log := ctrl.LoggerFrom(ctx)
-	baseCmp := baseCompareFunc(log, wo, &sw)
-	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, &sw)
+	// The heap comparator reads the sticky workload live on every comparison;
+	// this is safe because sticky writes and heap operations both hold rwm.
+	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, sw.matches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
+	// Snapshot sorts without the lock, so it captures the sticky workload once
+	// per sort rather than reading it live. See Kueue#12740.
 	snapshotSort := buildSnapshotSort(
-		ctx, compareFunc, baseCmp, client,
+		ctx, wo, &sw, client,
 		options.enableAdmissionFs, options.fsResWeights,
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
@@ -409,10 +432,20 @@ func (c *ClusterQueue) DeleteFromLocalQueue(log logr.Logger, q *LocalQueue, role
 // or if there was a call to QueueInadmissibleWorkloads after a call to Pop,
 // the workload will be pushed back to heap directly. Otherwise, the workload
 // will be put into the inadmissibleWorkloads.
-func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool) bool {
+func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info, immediate bool, reason RequeueReason) bool {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
+	// When preemptions are in-progress, keep re-attempting the same workload at
+	// the head for BestEffortFIFO queues (see documentation of stickyWorkload).
+	// The sticky workload is set under the lock so heap operations, which also
+	// hold the lock, never observe it changing mid-sort. See Kueue#12740.
+	if reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO {
+		if logV := log.V(5); logV.Enabled() {
+			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", key)
+		}
+		c.sw.set(key)
+	}
 	c.forgetInflightByKey(key)
 
 	inadmissibleWl := c.inadmissibleWorkloads.get(key)
@@ -623,25 +656,28 @@ func (c *ClusterQueue) Snapshot() []*workload.Info {
 }
 
 // buildSnapshotSort returns a function that sorts workload elements for Snapshot().
-// When fair-sharing is enabled, it pre-computes FS usage per LocalQueue from
+// The sort runs without holding the ClusterQueue lock, so it captures the sticky
+// workload once per sort (via stickyWorkload.capturedMatcher) to keep the comparison
+// transitive even if the sticky workload changes concurrently. See Kueue#12740.
+// When fair-sharing is enabled, it also pre-computes FS usage per LocalQueue from
 // deep-copied AFS state to avoid inconsistent comparisons from concurrent updates.
 func buildSnapshotSort(
 	ctx context.Context,
-	compareFunc func(a, b *workload.Info) int,
-	baseCmp func(a, b *workload.Info) int,
+	wo workload.Ordering,
+	sw *stickyWorkload,
 	cl client.Client,
 	enableAdmissionFs bool,
 	fsResWeights map[corev1.ResourceName]float64,
 	afsEntryPenalties *queueafs.AfsEntryPenalties,
 	afsConsumedResources *queueafs.AfsConsumedResources,
 ) func(elements []*workload.Info) {
+	log := ctrl.LoggerFrom(ctx)
 	if !enableAdmissionFs {
 		return func(elements []*workload.Info) {
-			slices.SortFunc(elements, compareFunc)
+			slices.SortFunc(elements, baseCompareFunc(log, wo, sw.capturedMatcher()))
 		}
 	}
 
-	log := ctrl.LoggerFrom(ctx)
 	getLQWeight := func(lqKey utilqueue.LocalQueueReference) (float64, bool) {
 		if cl == nil {
 			return 1, true
@@ -659,6 +695,9 @@ func buildSnapshotSort(
 	}
 
 	return func(elements []*workload.Info) {
+		// Capture the sticky workload once so the sort stays transitive without
+		// holding the lock. See Kueue#12740.
+		baseCmp := baseCompareFunc(log, wo, sw.capturedMatcher())
 		usageCache := make(map[utilqueue.LocalQueueReference]float64)
 		for _, wInfo := range elements {
 			lqKey := utilqueue.KeyFromWorkload(wInfo.Obj)
@@ -736,17 +775,7 @@ func (c *ClusterQueue) Active() bool {
 // The workload should not be reinserted if it's already in the ClusterQueue.
 // Returns true if the workload was inserted.
 func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.Info, reason RequeueReason) bool {
-	// when preemptions are in-progress, we keep attempting to
-	// schedule the same workload for BestEffortFIFO queues. See
-	// documentation of stickyWorkload for more details
 	log := ctrl.LoggerFrom(ctx)
-	if reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO {
-		if logV := log.V(5); logV.Enabled() {
-			logV.Info("Setting sticky workload", "clusterQueue", wInfo.ClusterQueue, "workload", workload.Key(wInfo.Obj))
-		}
-		c.sw.set(workload.Key(wInfo.Obj))
-	}
-
 	var immediate bool
 	if c.queueingStrategy == kueue.StrictFIFO {
 		immediate = reason != RequeueReasonNamespaceMismatch
@@ -755,14 +784,17 @@ func (c *ClusterQueue) RequeueIfNotPresent(ctx context.Context, wInfo *workload.
 			reason == RequeueReasonPendingPreemption ||
 			reason == RequeueReasonPreemptionFailed
 	}
-	return c.requeueIfNotPresent(log, wInfo, immediate)
+	return c.requeueIfNotPresent(log, wInfo, immediate, reason)
 }
 
 // baseCompareFunc orders workloads by sticky status, priority, timestamp, and UID.
-func baseCompareFunc(log logr.Logger, wo workload.Ordering, sw *stickyWorkload) func(a, b *workload.Info) int {
+// stickyMatches reports whether a workload is the sticky one; callers pass a
+// live matcher (stickyWorkload.matches) for the heap or a captured one
+// (stickyWorkload.capturedMatcher) for the lock-free Snapshot sort. See Kueue#12740.
+func baseCompareFunc(log logr.Logger, wo workload.Ordering, stickyMatches func(workload.Reference) bool) func(a, b *workload.Info) int {
 	return func(a, b *workload.Info) int {
-		aSticky := sw.matches(workload.Key(a.Obj))
-		bSticky := sw.matches(workload.Key(b.Obj))
+		aSticky := stickyMatches(workload.Key(a.Obj))
+		bSticky := stickyMatches(workload.Key(b.Obj))
 		if aSticky != bSticky {
 			if aSticky {
 				logStickyWorkloadSelectionIfVerbose(log, a.Obj)
@@ -800,10 +832,10 @@ func queueOrderingFunc(
 	enableAdmissionFs bool,
 	afsEntryPenalties *queueafs.AfsEntryPenalties,
 	afsConsumedResources *queueafs.AfsConsumedResources,
-	sw *stickyWorkload,
+	stickyMatches func(workload.Reference) bool,
 ) func(a, b *workload.Info) int {
 	log := ctrl.LoggerFrom(ctx)
-	baseCmp := baseCompareFunc(log, wo, sw)
+	baseCmp := baseCompareFunc(log, wo, stickyMatches)
 	if !enableAdmissionFs {
 		return baseCmp
 	}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package queue
 
 import (
+	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -287,7 +288,7 @@ func TestPushOrUpdateGenerationChanged(t *testing.T) {
 			// Simulate RequeueWorkload with info.Update: inadmissible entry gets new generation.
 			updatedInfo := workload.NewInfo(tc.updatedWorkload)
 			updatedInfo.LastEvaluatedGeneration = head.LastEvaluatedGeneration
-			cq.requeueIfNotPresent(log, updatedInfo, false)
+			cq.requeueIfNotPresent(log, updatedInfo, false, RequeueReasonGeneric)
 
 			// PushOrUpdate from informer event with the updated workload.
 			cq.PushOrUpdate(workload.NewInfo(tc.updatedWorkload))
@@ -399,7 +400,7 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 				cq.PushOrUpdate(workload.NewInfo(w))
 			}
 			for _, w := range tc.inadmissibleWorkloads {
-				cq.requeueIfNotPresent(log, workload.NewInfo(w), false)
+				cq.requeueIfNotPresent(log, workload.NewInfo(w), false, RequeueReasonGeneric)
 			}
 
 			firstSnap := cq.Snapshot()
@@ -529,6 +530,101 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 	}
 }
 
+// TestSnapshotConsistentUnderConcurrentStickyChange guards against Kueue#12740:
+// Snapshot sorts a copy of the pending workloads without holding the
+// ClusterQueue lock, so the comparator must observe a single, consistent sticky
+// workload for the whole sort. If it re-read the sticky workload on every
+// comparison, a concurrent change could make the ordering non-transitive and
+// corrupt the Snapshot order. This is a logic bug, not a data race: the atomic
+// pointer already makes each access memory-safe, so -race does not catch it.
+//
+// With equal priority and creation timestamp, every valid Snapshot is either the
+// pure UID order or exactly one workload (the sticky one) pulled to the front
+// followed by the rest in UID order. Any other permutation means the sort
+// observed the sticky workload changing mid-sort.
+func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, nil,
+		&kueue.ClusterQueue{
+			Spec: kueue.ClusterQueueSpec{
+				QueueingStrategy: kueue.BestEffortFIFO,
+			},
+		},
+		defaultOrdering,
+		nil, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	now := time.Now().Truncate(time.Second)
+	// Names are listed in UID order; equal priority and creation timestamp make
+	// UID the only tiebreak once stickiness is accounted for.
+	names := []string{"wl1", "wl2", "wl3", "wl4", "wl5", "wl6"}
+	keys := make([]workload.Reference, len(names))
+	for i, name := range names {
+		wl := utiltestingapi.MakeWorkload(name, defaultNamespace).
+			Creation(now).UID(types.UID(fmt.Sprintf("uid-%d", i))).Obj()
+		cq.PushOrUpdate(workload.NewInfo(wl))
+		keys[i] = workload.Key(wl)
+	}
+
+	// Valid orderings: pure UID order, or any single workload pulled to the front.
+	valid := [][]string{slices.Clone(names)}
+	for i := range names {
+		order := []string{names[i]}
+		for j := range names {
+			if j != i {
+				order = append(order, names[j])
+			}
+		}
+		valid = append(valid, order)
+	}
+	isValid := func(got []string) bool {
+		for _, v := range valid {
+			if slices.Equal(got, v) {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Writer: continuously churn the sticky workload so it can change while a
+	// Snapshot sort is in flight. It sets the field directly (bypassing the
+	// lock) to force a change mid-sort, which the lock-free Snapshot must
+	// tolerate; the fix makes it capture the value once per sort.
+	stop := make(chan struct{})
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				for _, k := range keys {
+					cq.sw.set(k)
+				}
+				cq.sw.clear()
+			}
+		}
+	}()
+	// Block until the writer is scheduled, so the loop below cannot finish before
+	// any churn has happened and pass vacuously.
+	<-started
+	defer close(stop)
+
+	for i := range 2000 {
+		snap := cq.Snapshot()
+		got := make([]string, len(snap))
+		for j, wInfo := range snap {
+			got[j] = wInfo.Obj.Name
+		}
+		if !isValid(got) {
+			t.Fatalf("call %d: non-transitive Snapshot ordering %v; sticky workload changed mid-sort", i+1, got)
+		}
+	}
+}
+
 func Test_DeleteFromLocalQueue(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	cq := newClusterQueueImpl(ctx, nil, defaultOrdering, testingclock.NewFakeClock(time.Now()))
@@ -549,7 +645,7 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 
 	for _, w := range inadmissibleWorkloads {
 		wInfo := workload.NewInfo(w)
-		cq.requeueIfNotPresent(log, wInfo, false)
+		cq.requeueIfNotPresent(log, wInfo, false, RequeueReasonGeneric)
 		qImpl.AddOrUpdate(wInfo)
 	}
 
@@ -736,10 +832,10 @@ func TestClusterQueueImpl(t *testing.T) {
 			}
 
 			for _, w := range test.inadmissibleWorkloadsToRequeue {
-				cq.requeueIfNotPresent(log, w, false)
+				cq.requeueIfNotPresent(log, w, false, RequeueReasonGeneric)
 			}
 			for _, w := range test.admissibleWorkloadsToRequeue {
-				cq.requeueIfNotPresent(log, w, true)
+				cq.requeueIfNotPresent(log, w, true, RequeueReasonGeneric)
 			}
 
 			for _, w := range test.workloadsToUpdate {
@@ -786,7 +882,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 	// Simulate requeuing during scheduling attempt.
 	head := cq.Pop()
 	queueInadmissibleWorkloads(ctx, cq, cl)
-	cq.requeueIfNotPresent(log, head, false)
+	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric)
 
 	activeWorkloads, _ = cq.Dump()
 	wantActiveWorkloads = []workload.Reference{workload.Key(wl)}
@@ -796,7 +892,7 @@ func TestQueueInadmissibleWorkloadsDuringScheduling(t *testing.T) {
 
 	// Simulating scheduling again without requeuing.
 	head = cq.Pop()
-	cq.requeueIfNotPresent(log, head, false)
+	cq.requeueIfNotPresent(log, head, false, RequeueReasonGeneric)
 	activeWorkloads, _ = cq.Dump()
 	wantActiveWorkloads = nil
 	if diff := cmp.Diff(wantActiveWorkloads, activeWorkloads, cmpDump...); diff != "" {


### PR DESCRIPTION
Manual cherry-pick of #12797 onto `release-0.17`, requested in https://github.com/kubernetes-sigs/kueue/pull/12797#issuecomment-5019760277 — the automated cherry-pick bot failed to apply on this branch.

/cc @mimowo

#### What this fixes

Backports the ClusterQueue sticky-workload consistency fix (Kueue#12740): the sticky workload is now set under the `rwm` lock, and the lock-free Snapshot sort captures it once per sort via `capturedMatcher()`, so the comparison stays transitive and cannot corrupt the CQ heap or the visibility snapshot ordering.

#### Conflict resolution — please review carefully, this branch needed adaptation

`release-0.17` predates a couple of `main`-only refactors, so this is **not** a byte-for-byte port of #12797. The behavioural change (sticky set moves under the lock; Snapshot captures it once) is identical; the mechanics were adapted to `release-0.17`:

- **`requeueIfNotPresent` signature.** The fix moves the sticky-set from the unlocked public `RequeueIfNotPresent` into the locked private `requeueIfNotPresent`. On `main` that private method already takes `reason`; on `release-0.17` it did not, so I threaded `reason RequeueReason` through it (single caller, updated) rather than pulling in the wider `main` refactor.
- **Sticky condition.** `release-0.17` has no `RequeueReasonPendingMigration`, so the guard stays `reason == RequeueReasonPendingPreemption && c.queueingStrategy == kueue.BestEffortFIFO`, matching the condition already in this branch's public method.
- **Dropped `main`-only content the 3-way merge tried to pull in.** The upstream diff's context carried the `wasTracked` / `pendingResourcesTotal` inflight-accounting block and the `TestPendingResources` / `TestPendingInLocalQueueCountsInflight` tests. None of that exists on `release-0.17`, so it is excluded here. Only `TestSnapshotConsistentUnderConcurrentStickyChange` — the regression test that actually belongs to #12797 — is added, and it compiles against this branch's `newClusterQueue` signature.
- Pre-existing tests that call the private method now pass the neutral `RequeueReasonGeneric` so their behaviour is unchanged.

#### Verification

- `go build ./pkg/...`, `go vet ./pkg/cache/queue/...` clean
- `go test ./pkg/cache/queue/...` green, including `TestSnapshotConsistentUnderConcurrentStickyChange`
- `go test -race` on the sticky-workload / requeue paths clean
