### PR TITLE
Fall back to base ordering on LocalQueue lookup errors

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -887,7 +887,8 @@ func buildSnapshotSort(
 			}
 			lqWeight, ok := getLQWeight(lqKey)
 			if !ok {
-				continue
+				slices.SortFunc(elements, baseCmp)
+				return
 			}
 			usageCache[lqKey] = afs.CalculateUsage(consumed, penalty, lqWeight, fsResWeights)
 		}

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -860,7 +860,7 @@ func buildSnapshotSort(
 		ns, name := utilqueue.MustParseLocalQueueReference(lqKey)
 		lqWeight, err := afs.ResolveLQWeight(ctx, cl, client.ObjectKey{Namespace: ns, Name: string(name)})
 		if err != nil {
-			log.V(2).Error(err, "Failed to get LocalQueue for FS weight", "localQueue", klog.KRef(ns, string(name)))
+			log.V(2).Error(err, "Failed to get LocalQueue for FS weight; falling back to base ordering for snapshot", "localQueue", klog.KRef(ns, string(name)))
 			return 0, false
 		}
 		return lqWeight, true
@@ -887,6 +887,9 @@ func buildSnapshotSort(
 			}
 			lqWeight, ok := getLQWeight(lqKey)
 			if !ok {
+				// A partial FS usage cache would mix fair-sharing and base comparisons,
+				// which can be non-transitive. Fall back to base ordering for the whole
+				// snapshot. See Kueue#12534.
 				slices.SortFunc(elements, baseCmp)
 				return
 			}

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package queue
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -31,6 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -411,6 +415,64 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	lqLookupErr := errors.New("temporary LocalQueue lookup error")
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(
+			utiltestingapi.MakeLocalQueue("higher-usage", defaultNamespace).Obj(),
+			utiltestingapi.MakeLocalQueue("lower-usage", defaultNamespace).Obj(),
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if key.Name == "unavailable" {
+					return lqLookupErr
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	afsConsumedResources := queueafs.NewAfsConsumedResources()
+	afsConsumedResources.Set("default/higher-usage", corev1.ResourceList{resourceGPU: resource.MustParse("20")}, now)
+	afsConsumedResources.Set("default/lower-usage", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
+
+	cq, err := newClusterQueue(
+		ctx,
+		cl,
+		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
+		defaultOrdering,
+		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1}},
+		nil,
+		afsConsumedResources,
+	)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	// Put the unavailable LocalQueue last so the usage cache is partially
+	// populated before its lookup fails.
+	elements := []*workload.Info{
+		workload.NewInfo(utiltestingapi.MakeWorkload("higher-usage", defaultNamespace).
+			Queue("higher-usage").Priority(2).Creation(now).UID("uid-2").Obj()),
+		workload.NewInfo(utiltestingapi.MakeWorkload("lower-usage", defaultNamespace).
+			Queue("lower-usage").Priority(1).Creation(now).UID("uid-1").Obj()),
+		workload.NewInfo(utiltestingapi.MakeWorkload("unavailable", defaultNamespace).
+			Queue("unavailable").Priority(3).Creation(now).UID("uid-3").Obj()),
+	}
+
+	cq.snapshotSort(elements)
+
+	got := make([]string, len(elements))
+	for i, wInfo := range elements {
+		got[i] = wInfo.Obj.Name
+	}
+	want := []string{"unavailable", "higher-usage", "lower-usage"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("unexpected base ordering (-want,+got):\n%s", diff)
 	}
 }
 

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -454,14 +454,17 @@ func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 	}
 
 	// Put the unavailable LocalQueue last so the usage cache is partially
-	// populated before its lookup fails.
+	// populated before its lookup fails. The priorities reproduce the
+	// contradictory ordering from Kueue#12534: fair sharing puts lower-usage
+	// before higher-usage, while base ordering puts higher-usage before
+	// unavailable and unavailable before lower-usage.
 	elements := []*workload.Info{
 		workload.NewInfo(utiltestingapi.MakeWorkload("higher-usage", defaultNamespace).
-			Queue("higher-usage").Priority(2).Creation(now).UID("uid-2").Obj()),
+			Queue("higher-usage").Priority(3).Creation(now).UID("uid-2").Obj()),
 		workload.NewInfo(utiltestingapi.MakeWorkload("lower-usage", defaultNamespace).
 			Queue("lower-usage").Priority(1).Creation(now).UID("uid-1").Obj()),
 		workload.NewInfo(utiltestingapi.MakeWorkload("unavailable", defaultNamespace).
-			Queue("unavailable").Priority(3).Creation(now).UID("uid-3").Obj()),
+			Queue("unavailable").Priority(2).Creation(now).UID("uid-3").Obj()),
 	}
 
 	cq.snapshotSort(elements)
@@ -470,7 +473,7 @@ func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 	for i, wInfo := range elements {
 		got[i] = wInfo.Obj.Name
 	}
-	want := []string{"unavailable", "higher-usage", "lower-usage"}
+	want := []string{"higher-usage", "unavailable", "lower-usage"}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("unexpected base ordering (-want,+got):\n%s", diff)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `ClusterQueue.Snapshot()` pre-computes fair-sharing usage, a LocalQueue lookup error can leave the usage cache partially populated. The resulting comparator uses fair-sharing order for pairs whose weights were cached and base order for pairs involving the failed lookup. Mixing those rules can make the comparator non-transitive and produce inconsistent ordering.

This change immediately sorts the entire snapshot with the established base comparator when any LocalQueue weight lookup fails. Partially computed fair-sharing usage is never used.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/12534

#### Special notes for your reviewer:

The regression test injects a transient lookup error after two successful LocalQueue lookups, ensuring the usage cache is already partially populated. Without the fix, the test fails because the two cached queues are still ordered by fair-sharing usage. With the fix, all workloads use base ordering.

The change was also applied on top of https://github.com/kubernetes-sigs/kueue/pull/13427. Both snapshot regression tests passed 100 iterations, and the combined queue race suite passed.

Validation:

- Regression test fails on the base commit with the mixed ordering and passes with the fix
- `go test ./pkg/cache/queue -run '^TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError$' -count=100`
- `go test -race ./pkg/cache/queue/... -count=1`
- `go test ./pkg/cache/... -count=1`
- `go vet ./pkg/cache/queue/...`
- `golangci-lint` for `./pkg/cache/queue/...` (0 issues)
- Combined with PR 13427: both focused tests passed 100 iterations and `go test -race ./pkg/cache/queue/... -count=1` passed

The full `make verify` was also attempted. Generated-code, API lint, Helm, and Go lint checks completed without code-related findings, and no generated-file drift remained. The target returned non-zero because the local Docker CLI lacks Buildx `--load` support and its ShellCheck container could not access scripts from the `/private/tmp` worktree.

AI assistance was used to help implement and review this change. The author reviewed and tested the resulting code and takes responsibility for it.

#### Does this PR introduce a user-facing change?

```release-note
AdmissionFairSharing: Fixed transient LocalQueue lookup errors causing a pending-Workload snapshot to mix
fair-sharing comparisons with standard queue ordering, resulting in a non-transitive comparator and inconsistent
admission order. When a lookup fails, the entire snapshot now falls back to standard queue ordering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload snapshot ordering when LocalQueue information is temporarily unavailable.
  * When fair-sharing weight lookup fails, snapshots now fall back to consistent base ordering to avoid incomplete or inconsistent results.
* **Tests**
  * Added coverage for the LocalQueue lookup failure scenario to ensure correct fallback ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->