### PR TITLE
[release-0.18] test: add RayCluster head Pod lookup helper

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -141,18 +141,6 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		return podNames
 	}
 
-	getRayHeadPod := func(g gomega.Gomega) corev1.Pod {
-		pods := &corev1.PodList{}
-		g.Expect(k8sClient.List(ctx, pods,
-			client.InNamespace(ns.Name),
-			client.MatchingLabels{
-				"ray.io/node-type": "head",
-			},
-		)).To(gomega.Succeed())
-		g.Expect(pods.Items).NotTo(gomega.BeEmpty())
-		return pods.Items[0]
-	}
-
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "kuberay-e2e-")
 		resourceFlavorName = "kuberay-rf-" + ns.Name
@@ -715,7 +703,13 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 		// container KubeRay actually injects into the head Pod.
 		ginkgo.By("Checking the accounted submitter resources match the real head Pod", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				headPod := getRayHeadPod(g)
+				createdRayJob := &rayv1.RayJob{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
+				headPod, err := util.GetRayClusterHeadPod(ctx, k8sClient, client.ObjectKey{
+					Namespace: ns.Name,
+					Name:      createdRayJob.Status.RayClusterName,
+				})
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				submitter := findContainer(headPod.Spec.Containers, "ray-job-submitter")
 				g.Expect(submitter).NotTo(gomega.BeNil(), "KubeRay should inject the submitter container into the head Pod")
 				g.Expect(kueueSubmitterRequests.Cpu().Cmp(*submitter.Resources.Requests.Cpu())).To(gomega.Equal(0),

--- a/test/util/kuberay.go
+++ b/test/util/kuberay.go
@@ -1,0 +1,45 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	kuberayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetRayClusterHeadPod returns the only head Pod associated with the RayCluster.
+func GetRayClusterHeadPod(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey) (*corev1.Pod, error) {
+	pods := &corev1.PodList{}
+	if err := c.List(ctx, pods,
+		client.InNamespace(rayClusterKey.Namespace),
+		client.MatchingLabels{
+			kuberayutils.RayClusterLabelKey:  rayClusterKey.Name,
+			kuberayutils.RayNodeTypeLabelKey: string(rayv1.HeadNode),
+		},
+	); err != nil {
+		return nil, err
+	}
+	if len(pods.Items) != 1 {
+		return nil, fmt.Errorf("expected exactly one head Pod for RayCluster %s, got %d", rayClusterKey, len(pods.Items))
+	}
+	return &pods.Items[0], nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Cherry pick of #13421 on release-0.18: adds the reusable `GetRayClusterHeadPod` test utility (selecting the head Pod by both RayCluster name and Ray node type, so tests cannot accidentally pick up another RayCluster's head Pod in the same namespace) and migrates the KubeRay e2e head Pod lookups to it.

**Conflict resolution:** the autoscaler-sidecar spec touched by the original patch exists only on `main` and is not brought along; everything else applies as on `main` (the `getRayHeadPod` closure is removed — its former RayService call sites were already removed on this branch by the #13430 backport of #13423).

_This PR was prepared with AI assistance (Claude Code)._

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
