### PR TITLE
TAS: group order-insensitive domains before encoding

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1359,30 +1359,43 @@ The main motivation behind the new format is the etcd size limit of 1.5MiB per s
 
 The `TASAssignmentsEncodingByHostnamePrefix` feature gate is Beta (enabled by default) starting in v0.19. It only
 changes how v1beta2 `TopologyAssignment` objects are encoded: no node-pool or topology meaning is inferred from
-hostnames, and decoding preserves domain order and Pod counts. Disabling the feature gate restores the previous
-single-slice encoder but does not affect reading existing multi-slice assignments. New assignments must then fit the
-single-slice representation and object-size limit; otherwise they can fail to persist.
+hostnames, and Pod counts remain paired with their domains. For assignments whose domain order has no rank-assignment
+or elastic scale-down semantics, the scheduler permits multiple selected prefix keys (including the empty key for
+domains without a reusable prefix) to be ordered by key while preserving the original order within each key group.
+Kueue uses that grouped candidate only when it is smaller than the order-preserving encoding. The scheduler does not
+permit grouping for rank-aware PodSets or elastic Workloads, and v1beta1-to-v1beta2 conversion is order-preserving
+because it lacks the parent PodSet context needed to prove that reordering is safe. Disabling the feature gate restores
+the previous order-preserving single-slice encoder but does not affect reading existing multi-slice assignments. New
+assignments must then fit the single-slice representation and object-size limit; otherwise they can fail to persist.
 
 On upgrade, existing `TopologyAssignment`s remain unchanged. If the assignment of an admitted Workload is later
 recomputed, for example during node hot swap, Kueue re-encodes the entire assignment using the currently enabled
 algorithm.
 
-When the feature gate is enabled, Kueue builds the hostname-prefix encoding first. If it needs multiple slices but the
-assignment is within the per-slice domain limit, Kueue serializes both encodings and keeps the smaller one. Assignments
-that exceed the per-slice domain limit always use the hostname-prefix encoding. When the lowest topology level is
-`kubernetes.io/hostname`, Kueue:
+When the feature gate is enabled, Kueue always builds the order-preserving hostname-prefix encoding. When the caller
+allows reordering, Kueue also builds the grouped hostname-prefix encoding and compares their serialized sizes. If the
+assignment is within the per-slice domain limit, the single-slice encoding is a third candidate. This comparison keeps
+grouping from increasing object size when it disrupts higher-level universal values. Assignments that exceed the
+per-slice domain limit always use one of the two hostname-prefix encodings. When the caller allows reordering and the
+lowest topology level is `kubernetes.io/hostname`, Kueue:
 
 1. Finds reusable hostname prefixes ending in `-`, preferring the longest prefix shared by multiple domains.
-2. Splits consecutive domains with the same selected prefix into runs without reordering domains.
-3. Backs off to shorter prefixes when the runs would exceed the `TopologyAssignment` slice-count limit, and chunks
+2. When multiple selected prefix groups are present, stably groups domains by prefix without mutating the internal
+   assignment. Assignments with no reusable prefix, a single prefix group, or domains already grouped in prefix order
+   avoid the copy and grouping pass.
+3. Splits consecutive domains with the same selected prefix into runs.
+4. Backs off to shorter prefixes when the runs would exceed the `TopologyAssignment` slice-count limit, and chunks
    every run at the per-slice domain limit.
-4. Compacts each resulting slice independently, including common prefixes and suffixes, universal topology values,
+5. Compacts each resulting slice independently, including common prefixes and suffixes, universal topology values,
    and universal Pod counts.
 
-The encoder does not sort domains. The scheduler orders domains by their full topology values before producing
-hostname-only assignments, and the encoder preserves that order so encoding and decoding remain mutually inverse.
-When the lowest topology level is not `kubernetes.io/hostname`, no prefix is reusable, or no prefix selection fits the
-slice limit, Kueue forms a single compact slice until the per-slice domain limit requires domain-count chunking.
+The scheduler orders domains by their full topology values before encoding. For multi-level assignments, higher-level
+values are the primary sort key and can leave hostnames with common prefixes non-consecutive. Grouping by prefix closes
+that gap and means encoding followed by decoding preserves the placement counts but not necessarily the original
+domain order. For rank-aware PodSets, where rank-based ungating uses the encoded order, and elastic Workloads, where
+scale-down truncates the encoded order, Kueue skips grouping and keeps the scheduler's full-topology order. When the
+lowest topology level is not `kubernetes.io/hostname`, no prefix is reusable, or no prefix selection fits the slice
+limit, Kueue forms a single compact slice until the per-slice domain limit requires domain-count chunking.
 
 For example, the consecutive domains
 `gke-c-pool-a-hash1-aa: 3`, `gke-c-pool-a-hash1-bb: 3`,

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -37,6 +37,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption/classical"
@@ -88,6 +89,8 @@ func (a *Assignment) UpdateForTASResult(log logr.Logger, cq *schdcache.ClusterQu
 	for psName, psResult := range result {
 		psAssignment := a.podSetAssignmentByName(psName)
 		psAssignment.TopologyAssignment = psResult.TopologyAssignment
+		psAssignment.CanGroupTopologyDomainsByHostnamePrefix =
+			psResult.TopologyAssignment != nil && canGroupTopologyDomainsByHostnamePrefix(wl.Obj, psName)
 		if psResult.TopologyAssignment != nil && psAssignment.DelayedTopologyRequest != nil {
 			psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
 		}
@@ -334,6 +337,10 @@ type PodSetAssignment struct {
 	TopologyAssignment     *tas.TopologyAssignment
 	DelayedTopologyRequest *kueue.DelayedTopologyRequestState
 
+	// CanGroupTopologyDomainsByHostnamePrefix is true only when domain order
+	// carries no rank-aware or elastic scale-down semantics.
+	CanGroupTopologyDomainsByHostnamePrefix bool
+
 	FlavorAssignmentAttempts []FlavorAssignmentAttempt
 }
 
@@ -393,12 +400,17 @@ func (psa *PodSetAssignment) toAPI(log logr.Logger) kueue.PodSetAssignment {
 		flavors[res] = flvAssignment.Name
 		resourceUsage[res] = psa.Requests[res]
 	}
+	topologyAssignment := tas.V1Beta2From(
+		psa.TopologyAssignment,
+		tas.WithLogger(log),
+		tas.WithHostnamePrefixGroupingAllowed(psa.CanGroupTopologyDomainsByHostnamePrefix),
+	)
 	return kueue.PodSetAssignment{
 		Name:                   psa.Name,
 		Flavors:                flavors,
 		ResourceUsage:          resourceUsage,
 		Count:                  new(psa.Count),
-		TopologyAssignment:     tas.V1Beta2From(psa.TopologyAssignment, tas.WithLogger(log)),
+		TopologyAssignment:     topologyAssignment,
 		DelayedTopologyRequest: psa.DelayedTopologyRequest,
 	}
 }
@@ -837,6 +849,14 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		assignment.resolveNoFitReason(a.cq)
 	}
 	return assignment
+}
+
+func canGroupTopologyDomainsByHostnamePrefix(wl *kueue.Workload, podSetName kueue.PodSetReference) bool {
+	if wl == nil || wl.Annotations[constants.ElasticJobAnnotation] == "true" {
+		return false
+	}
+	podSet := podset.FindPodSetByName(wl.Spec.PodSets, podSetName)
+	return podSet != nil && (podSet.TopologyRequest == nil || podSet.TopologyRequest.PodIndexLabel == nil)
 }
 
 func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -36,6 +36,7 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	preemptioncommon "sigs.k8s.io/kueue/pkg/scheduler/preemption/common"
@@ -44,6 +45,123 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
+
+func TestCanGroupTopologyDomainsByHostnamePrefix(t *testing.T) {
+	// Elastic assignment order remains significant even if the feature is
+	// temporarily disabled while an existing Workload is processed.
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, false)
+	tests := map[string]struct {
+		workload *kueue.Workload
+		want     bool
+	}{
+		"regular topology request": {
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:            "main",
+						TopologyRequest: &kueue.PodSetTopologyRequest{},
+					}},
+				},
+			},
+			want: true,
+		},
+		"implicit topology assignment": {
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{Name: "main"}},
+				},
+			},
+			want: true,
+		},
+		"rank-aware topology request": {
+			workload: &kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name: "main",
+						TopologyRequest: &kueue.PodSetTopologyRequest{
+							PodIndexLabel: new("job.example.com/index"),
+						},
+					}},
+				},
+			},
+		},
+		"elastic workload": {
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.ElasticJobAnnotation: "true",
+					},
+				},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:            "main",
+						TopologyRequest: &kueue.PodSetTopologyRequest{},
+					}},
+				},
+			},
+		},
+		"missing PodSet": {
+			workload: &kueue.Workload{},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := canGroupTopologyDomainsByHostnamePrefix(tc.workload, "main"); got != tc.want {
+				t.Errorf("unexpected result: got %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPodSetAssignmentToAPI_hostnamePrefixDomainGrouping(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
+	domains := make([]tas.TopologyDomainAssignment, 40)
+	groupedDomains := make([]tas.TopologyDomainAssignment, 0, len(domains))
+	for i := range domains {
+		pool := "b"
+		if i%2 == 1 {
+			pool = "a"
+		}
+		domains[i] = tas.TopologyDomainAssignment{
+			Values: []string{fmt.Sprintf("pool-%s-node-%02d", pool, i)},
+			Count:  int32(i + 1),
+		}
+	}
+	for start := 1; start >= 0; start-- {
+		for i := start; i < len(domains); i += 2 {
+			groupedDomains = append(groupedDomains, domains[i])
+		}
+	}
+	tests := map[string]struct {
+		canGroup bool
+		want     []tas.TopologyDomainAssignment
+	}{
+		"preserves semantic order": {
+			want: domains,
+		},
+		"groups order-insensitive domains": {
+			canGroup: true,
+			want:     groupedDomains,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			psa := PodSetAssignment{
+				TopologyAssignment: &tas.TopologyAssignment{
+					Levels:  []string{corev1.LabelHostname},
+					Domains: domains,
+				},
+				CanGroupTopologyDomainsByHostnamePrefix: tc.canGroup,
+			}
+			got := tas.InternalFrom(psa.toAPI(logr.Discard()).TopologyAssignment).Domains
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected domains (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
 
 var (
 	statusComparer = cmp.Comparer(func(a, b Status) bool {

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -19,6 +19,7 @@ package tas
 import (
 	"encoding/json"
 	"iter"
+	"maps"
 	"slices"
 
 	"github.com/go-logr/logr"
@@ -42,7 +43,8 @@ type TopologyDomainAssignment struct {
 }
 
 type v1Beta2FromOptions struct {
-	logger logr.Logger
+	logger                      logr.Logger
+	allowHostnamePrefixGrouping bool
 }
 
 // V1Beta2FromOption configures V1Beta2From.
@@ -52,6 +54,15 @@ type V1Beta2FromOption func(*v1Beta2FromOptions)
 func WithLogger(logger logr.Logger) V1Beta2FromOption {
 	return func(options *v1Beta2FromOptions) {
 		options.logger = logger
+	}
+}
+
+// WithHostnamePrefixGroupingAllowed permits V1Beta2From to reorder domains by
+// selected hostname prefix when that encoding is smaller. It must not be
+// enabled when domain order carries rank-assignment or scale-down semantics.
+func WithHostnamePrefixGroupingAllowed(enabled bool) V1Beta2FromOption {
+	return func(options *v1Beta2FromOptions) {
+		options.allowHostnamePrefixGrouping = enabled
 	}
 }
 
@@ -279,58 +290,163 @@ func V1Beta2From(ta *TopologyAssignment, options ...V1Beta2FromOption) *kueue.To
 	if !features.Enabled(features.TASAssignmentsEncodingByHostnamePrefix) {
 		return singleCompactTopologyAssignmentEncoding(ta)
 	}
-	return compactTopologyAssignmentEncoding(opts.logger, ta)
+	return compactTopologyAssignmentEncoding(opts.logger, ta, opts.allowHostnamePrefixGrouping)
 }
 
-// compactTopologyAssignmentEncoding chooses the smaller serialized encoding
-// when both forms are valid. Assignments above the single-slice domain limit
-// always use hostname-prefix encoding.
-func compactTopologyAssignmentEncoding(log logr.Logger, ta *TopologyAssignment) *kueue.TopologyAssignment {
-	prefixEncoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(ta)
-	if len(prefixEncoded.Slices) <= 1 {
-		return prefixEncoded
-	}
-	if len(ta.Domains) > maxDomainsPerTopologyAssignmentSlice {
-		log.V(4).Info("Topology assignment exceeds the single-slice domain limit; using hostname-prefix encoding",
-			"domainCount", len(ta.Domains),
-			"maxDomainsPerSlice", maxDomainsPerTopologyAssignmentSlice,
-		)
-		return prefixEncoded
+// compactTopologyAssignmentEncoding chooses the smallest serialized encoding
+// from the valid order-preserving prefix, grouped prefix, and single-slice
+// candidates.
+func compactTopologyAssignmentEncoding(log logr.Logger, ta *TopologyAssignment, allowHostnamePrefixGrouping bool) *kueue.TopologyAssignment {
+	var orderPreservingPrefix *kueue.TopologyAssignment
+	var groupedPrefix *kueue.TopologyAssignment
+	if allowHostnamePrefixGrouping && len(ta.Domains) > 1 && len(ta.Levels) > 0 && IsLowestLevelHostname(ta.Levels) {
+		levelIdx := len(ta.Levels) - 1
+		prefixIndex := indexHostnamePrefixes(levelIdx, ta.Domains)
+		groupedKeys := selectHostnamePrefixKeys(levelIdx, ta.Domains, prefixIndex, true)
+		grouped, groupedKeys := topologyAssignmentForHostnamePrefixEncodingWithKeys(ta, groupedKeys)
+		if grouped != ta {
+			orderPreservingKeys := selectHostnamePrefixKeys(levelIdx, ta.Domains, prefixIndex, false)
+			orderPreservingPrefix = compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(ta, orderPreservingKeys)
+			groupedPrefix = compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(grouped, groupedKeys)
+		} else {
+			// Prefix keys are already grouped, so the grouped and
+			// order-preserving encodings are identical.
+			orderPreservingPrefix = compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(ta, groupedKeys)
+		}
+	} else {
+		orderPreservingPrefix = compactTopologyAssignmentEncodingWithHostnamePrefixRuns(ta)
 	}
 
-	singleEncoded := singleCompactTopologyAssignmentEncoding(ta)
-	prefixJSON, prefixErr := json.Marshal(prefixEncoded)
-	if prefixErr != nil {
-		log.Error(prefixErr, "Failed to marshal hostname-prefix topology assignment while comparing encodings",
-			"domainCount", len(ta.Domains),
-			"sliceCount", len(prefixEncoded.Slices),
+	candidates := []topologyAssignmentEncodingCandidate{{
+		name:       "order-preserving-prefix",
+		assignment: orderPreservingPrefix,
+	}}
+	if groupedPrefix != nil {
+		candidates = append(candidates, topologyAssignmentEncodingCandidate{
+			name:       "grouped-prefix",
+			assignment: groupedPrefix,
+		})
+	}
+
+	// A one-slice order-preserving prefix encoding is identical to the
+	// single-slice candidate.
+	if len(ta.Domains) <= maxDomainsPerTopologyAssignmentSlice && len(orderPreservingPrefix.Slices) > 1 {
+		candidates = append(candidates, topologyAssignmentEncodingCandidate{
+			name:       "single-slice",
+			assignment: singleCompactTopologyAssignmentEncoding(ta),
+		})
+	}
+
+	if len(candidates) == 1 {
+		if len(ta.Domains) > maxDomainsPerTopologyAssignmentSlice {
+			log.V(4).Info("Topology assignment exceeds the single-slice domain limit; using order-preserving hostname-prefix encoding",
+				"domainCount", len(ta.Domains),
+				"maxDomainsPerSlice", maxDomainsPerTopologyAssignmentSlice,
+			)
+		}
+		return orderPreservingPrefix
+	}
+	return smallestSerializedTopologyAssignmentEncoding(log, len(ta.Domains), candidates)
+}
+
+type topologyAssignmentEncodingCandidate struct {
+	name       string
+	assignment *kueue.TopologyAssignment
+}
+
+func smallestSerializedTopologyAssignmentEncoding(log logr.Logger, domainCount int, candidates []topologyAssignmentEncodingCandidate) *kueue.TopologyAssignment {
+	best := candidates[0]
+	bestJSON, err := json.Marshal(best.assignment)
+	if err != nil {
+		log.Error(err, "Failed to marshal topology assignment while comparing encodings",
+			"domainCount", domainCount,
+			"encoding", best.name,
 		)
+		return best.assignment
 	}
-	singleJSON, singleErr := json.Marshal(singleEncoded)
-	if singleErr != nil {
-		log.Error(singleErr, "Failed to marshal single-slice topology assignment while comparing encodings",
-			"domainCount", len(ta.Domains),
-		)
+	candidateBytes := map[string]int{best.name: len(bestJSON)}
+
+	for _, candidate := range candidates[1:] {
+		candidateJSON, err := json.Marshal(candidate.assignment)
+		if err != nil {
+			log.Error(err, "Failed to marshal topology assignment while comparing encodings",
+				"domainCount", domainCount,
+				"encoding", candidate.name,
+			)
+			continue
+		}
+		candidateBytes[candidate.name] = len(candidateJSON)
+		if len(candidateJSON) < len(bestJSON) {
+			best = candidate
+			bestJSON = candidateJSON
+		}
 	}
-	if prefixErr != nil || singleErr != nil {
-		return prefixEncoded
-	}
-	if len(singleJSON) < len(prefixJSON) {
-		log.V(5).Info("Selected single-slice topology assignment encoding after serialized-size comparison",
-			"domainCount", len(ta.Domains),
-			"hostnamePrefixSliceCount", len(prefixEncoded.Slices),
-			"singleSliceBytes", len(singleJSON),
-			"hostnamePrefixBytes", len(prefixJSON),
-		)
-		return singleEncoded
-	}
-	log.V(6).Info("Selected hostname-prefix topology assignment encoding after serialized-size comparison",
-		"domainCount", len(ta.Domains),
-		"hostnamePrefixSliceCount", len(prefixEncoded.Slices),
-		"singleSliceBytes", len(singleJSON),
-		"hostnamePrefixBytes", len(prefixJSON),
+
+	log.V(5).Info("Selected topology assignment encoding after serialized-size comparison",
+		"domainCount", domainCount,
+		"encoding", best.name,
+		"encodingBytes", len(bestJSON),
+		"candidateBytes", candidateBytes,
 	)
-	return prefixEncoded
+	return best.assignment
+}
+
+// topologyAssignmentForHostnamePrefixEncoding selects reusable hostname prefix
+// keys and groups domains by key when multiple groups are present. Group keys
+// are ordered lexicographically, while the original order within each group is
+// preserved. The grouping uses shallow copies and leaves the caller's assignment
+// unchanged.
+func topologyAssignmentForHostnamePrefixEncoding(ta *TopologyAssignment) (*TopologyAssignment, []string) {
+	if len(ta.Domains) < 2 || len(ta.Levels) == 0 || !IsLowestLevelHostname(ta.Levels) {
+		return ta, nil
+	}
+
+	prefixKeys := reusableHostnamePrefixKeys(ta.Levels, ta.Domains)
+	return topologyAssignmentForHostnamePrefixEncodingWithKeys(ta, prefixKeys)
+}
+
+func topologyAssignmentForHostnamePrefixEncodingWithKeys(ta *TopologyAssignment, prefixKeys []string) (*TopologyAssignment, []string) {
+	if !hasMultiplePrefixKeys(prefixKeys) {
+		return ta, prefixKeys
+	}
+
+	if slices.IsSorted(prefixKeys) {
+		return ta, prefixKeys
+	}
+
+	domainsPerKey := make(map[string]int)
+	for _, key := range prefixKeys {
+		domainsPerKey[key]++
+	}
+	sortedKeys := slices.Sorted(maps.Keys(domainsPerKey))
+	nextIndex := make(map[string]int, len(sortedKeys))
+	next := 0
+	for _, key := range sortedKeys {
+		nextIndex[key] = next
+		next += domainsPerKey[key]
+	}
+
+	sortedDomains := make([]TopologyDomainAssignment, len(ta.Domains))
+	sortedPrefixKeys := make([]string, len(prefixKeys))
+	for i, key := range prefixKeys {
+		target := nextIndex[key]
+		sortedDomains[target] = ta.Domains[i]
+		sortedPrefixKeys[target] = key
+		nextIndex[key] = target + 1
+	}
+	return &TopologyAssignment{
+		Levels:  ta.Levels,
+		Domains: sortedDomains,
+	}, sortedPrefixKeys
+}
+
+func hasMultiplePrefixKeys(prefixKeys []string) bool {
+	for i := 1; i < len(prefixKeys); i++ {
+		if prefixKeys[i] != prefixKeys[0] {
+			return true
+		}
+	}
+	return false
 }
 
 // singleCompactTopologyAssignmentEncoding represents an empty assignment with no
@@ -347,7 +463,7 @@ func singleCompactTopologyAssignmentEncoding(ta *TopologyAssignment) *kueue.Topo
 	return out
 }
 
-// compactTopologyAssignmentEncodingWithHostnamePrefixRuns splits contiguous
+// compactTopologyAssignmentEncodingWithHostnamePrefixRuns splits consecutive
 // hostname-level domains with reusable hostname prefixes into multiple slices.
 // For example, for hostnames ["pool-a-node-0", "pool-a-node-1",
 // "pool-b-node-0"], the first two domains form a slice with prefix
@@ -360,18 +476,22 @@ func singleCompactTopologyAssignmentEncoding(ta *TopologyAssignment) *kueue.Topo
 // BenchmarkV1Beta2From results on an Intel i9-14900K were approximately 2-6 ms
 // for 40k-node cases and 20 ms for the sorted 150k-node GKE-style split case.
 func compactTopologyAssignmentEncodingWithHostnamePrefixRuns(ta *TopologyAssignment) *kueue.TopologyAssignment {
-	domains := ta.Domains
 	var prefixKeys []string
-	if len(domains) > 1 && len(ta.Levels) > 0 && IsLowestLevelHostname(ta.Levels) {
-		prefixKeys = reusableHostnamePrefixKeys(ta.Levels, domains)
+	if len(ta.Domains) > 1 && len(ta.Levels) > 0 && IsLowestLevelHostname(ta.Levels) {
+		levelIdx := len(ta.Levels) - 1
+		prefixIndex := indexHostnamePrefixes(levelIdx, ta.Domains)
+		prefixKeys = selectHostnamePrefixKeys(levelIdx, ta.Domains, prefixIndex, false)
 	}
+	return compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(ta, prefixKeys)
+}
 
+func compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(ta *TopologyAssignment, prefixKeys []string) *kueue.TopologyAssignment {
 	out := &kueue.TopologyAssignment{
 		Levels: ta.Levels,
 		Slices: []kueue.TopologyAssignmentSlice{},
 	}
 
-	for _, run := range compactDomainRuns(domains, prefixKeys) {
+	for _, run := range compactDomainRuns(ta.Domains, prefixKeys) {
 		for chunk := range slices.Chunk(run, maxDomainsPerTopologyAssignmentSlice) {
 			out.Slices = append(out.Slices, compactSliceEncoding(ta.Levels, chunk))
 		}
@@ -414,7 +534,7 @@ func compactDomainRuns(domains []TopologyDomainAssignment, prefixKeys []string) 
 func reusableHostnamePrefixKeys(levels []string, domains []TopologyDomainAssignment) []string {
 	levelIdx := len(levels) - 1
 	prefixIndex := indexHostnamePrefixes(levelIdx, domains)
-	return selectHostnamePrefixKeys(levelIdx, domains, prefixIndex)
+	return selectHostnamePrefixKeys(levelIdx, domains, prefixIndex, true)
 }
 
 type hostnamePrefixIndex struct {
@@ -467,12 +587,14 @@ func indexHostnamePrefixes(levelIdx int, domains []TopologyDomainAssignment) hos
 }
 
 // selectHostnamePrefixKeys tries prefix depths from longest to shortest until
-// the resulting grouping fits maxTopologyAssignmentSlices. This phase is
+// grouping equal keys would fit maxTopologyAssignmentSlices. When grouping is
+// disabled, it counts the existing consecutive runs instead. This phase is
 // O(n*m*k^2) in time and O(n) in additional space, where n is the number of
 // domains, m is the length of the longest domain, and k is the maximum number of
 // '-' characters in a domain.
-func selectHostnamePrefixKeys(levelIdx int, domains []TopologyDomainAssignment, prefixIndex hostnamePrefixIndex) []string {
+func selectHostnamePrefixKeys(levelIdx int, domains []TopologyDomainAssignment, prefixIndex hostnamePrefixIndex, groupEqualKeys bool) []string {
 	keys := make([]string, len(domains))
+	domainsPerKey := make(map[string]int)
 	for prefixDepth := prefixIndex.maxDepth; prefixDepth >= 1; prefixDepth-- {
 		clear(keys)
 		for i, domain := range domains {
@@ -488,16 +610,36 @@ func selectHostnamePrefixKeys(levelIdx int, domains []TopologyDomainAssignment, 
 			}
 		}
 
-		sliceCount := 0
+		keysSorted := true
+		orderedSliceCount := 0
 		start := 0
 		for i := 1; i < len(domains); i++ {
+			if keys[i] < keys[i-1] {
+				keysSorted = false
+			}
 			if keys[i] == keys[start] {
 				continue
 			}
-			sliceCount += chunkCount(i-start, maxDomainsPerTopologyAssignmentSlice)
+			orderedSliceCount += chunkCount(i-start, maxDomainsPerTopologyAssignmentSlice)
 			start = i
 		}
-		sliceCount += chunkCount(len(domains)-start, maxDomainsPerTopologyAssignmentSlice)
+		orderedSliceCount += chunkCount(len(domains)-start, maxDomainsPerTopologyAssignmentSlice)
+
+		sliceCount := orderedSliceCount
+		if groupEqualKeys && !keysSorted {
+			sliceCount = 0
+			clear(domainsPerKey)
+			for _, key := range keys {
+				domainCount := domainsPerKey[key]
+				if domainCount%maxDomainsPerTopologyAssignmentSlice == 0 {
+					sliceCount++
+					if sliceCount > maxTopologyAssignmentSlices {
+						break
+					}
+				}
+				domainsPerKey[key] = domainCount + 1
+			}
+		}
 
 		if sliceCount <= maxTopologyAssignmentSlices {
 			return keys

--- a/pkg/util/tas/tas_assignment_fuzz_test.go
+++ b/pkg/util/tas/tas_assignment_fuzz_test.go
@@ -18,8 +18,10 @@ package tas
 
 import (
 	"bytes"
+	stdcmp "cmp"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -114,7 +116,7 @@ func fuzzDomainInput(values ...string) []byte {
 	return bytes.Join(domains, []byte{0})
 }
 
-func verifyTopologyAssignmentJSONRoundTrip(t *testing.T, want *TopologyAssignment, encoded *kueue.TopologyAssignment) {
+func verifyTopologyAssignmentJSONRoundTrip(t *testing.T, want *TopologyAssignment, encoded *kueue.TopologyAssignment, options ...cmp.Option) {
 	t.Helper()
 	if got := TotalDomainCount(encoded); got != len(want.Domains) {
 		t.Fatalf("unexpected domain count: got %d, want %d", got, len(want.Domains))
@@ -137,9 +139,21 @@ func verifyTopologyAssignmentJSONRoundTrip(t *testing.T, want *TopologyAssignmen
 		t.Fatalf("unmarshalling compacted topology assignment: %v", err)
 	}
 	got := InternalFrom(&wire)
-	if diff := cmp.Diff(want, got, cmpopts.EquateEmpty()); diff != "" {
+	cmpOptions := append([]cmp.Option{cmpopts.EquateEmpty()}, options...)
+	if diff := cmp.Diff(want, got, cmpOptions...); diff != "" {
 		t.Fatalf("unexpected round trip (-want,+got):\n%s", diff)
 	}
+}
+
+func verifyTopologyAssignmentJSONRoundTripUnordered(t *testing.T, want *TopologyAssignment, encoded *kueue.TopologyAssignment) {
+	t.Helper()
+	domainLess := func(a, b TopologyDomainAssignment) bool {
+		if order := slices.Compare(a.Values, b.Values); order != 0 {
+			return order < 0
+		}
+		return stdcmp.Compare(a.Count, b.Count) < 0
+	}
+	verifyTopologyAssignmentJSONRoundTrip(t, want, encoded, cmpopts.SortSlices(domainLess))
 }
 
 func FuzzTopologyAssignmentCompactionRoundTrip(f *testing.F) {
@@ -153,8 +167,13 @@ func FuzzTopologyAssignmentCompactionRoundTrip(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, levelCount uint8, lowestLevelIsHostname bool, input []byte) {
 		want := topologyAssignmentFromFuzzInput(levelCount, lowestLevelIsHostname, input)
-		encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(want)
-		verifyTopologyAssignmentJSONRoundTrip(t, want, encoded)
+		prepared, prefixKeys := topologyAssignmentForHostnamePrefixEncoding(want)
+		encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(prepared, prefixKeys)
+		if prepared == want {
+			verifyTopologyAssignmentJSONRoundTrip(t, want, encoded)
+		} else {
+			verifyTopologyAssignmentJSONRoundTripUnordered(t, want, encoded)
+		}
 	})
 }
 

--- a/pkg/util/tas/tas_assignment_performance_test.go
+++ b/pkg/util/tas/tas_assignment_performance_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -33,8 +34,11 @@ import (
 )
 
 // maxTopologyAssignmentJSONBytes is the test budget used to verify assignment
-// scalability. The encoder does not branch on serialized size.
+// scalability. The encoder compares candidate sizes but does not branch on this
+// test-only budget.
 const maxTopologyAssignmentJSONBytes = 1_500_000
+
+var allowHostnamePrefixGrouping = WithHostnamePrefixGroupingAllowed(true)
 
 // Generate n hex numbers of given length,
 // ensuring they're distinct (and otherwise quasi-random).
@@ -195,7 +199,7 @@ func approxMaxNodesFor(tc performanceTestCase) int {
 	nodeNames := tc.naming.generate(ceiling)
 	found := sort.Search(ceiling/step, func(n int) bool {
 		// Here we rely on "well-prefixing"; see the comment on "nodeNaming".
-		return isTooLarge(V1Beta2From(internalSinglePodsOn(nodeNames[:n*step])))
+		return isTooLarge(V1Beta2From(internalSinglePodsOn(nodeNames[:n*step]), allowHostnamePrefixGrouping))
 	}) - 1
 	return found * step
 }
@@ -204,6 +208,7 @@ type performanceTestCase struct {
 	name               string
 	naming             namingScheme
 	targetNodeCount    int
+	minNodeLimit       int
 	sortNodeNames      bool
 	skipApproxMaxNodes bool
 }
@@ -229,6 +234,7 @@ var performanceTestCases = []performanceTestCase{
 			fixedPrefixAndSuffixLength: 20,
 		},
 		targetNodeCount: 40_000,
+		minNodeLimit:    140_000,
 	},
 	{
 		name: "pool-and-node-based naming (10 node pools)",
@@ -242,6 +248,7 @@ var performanceTestCases = []performanceTestCase{
 			fixedPrefixAndSuffixLength: 20,
 		},
 		targetNodeCount: 40_000,
+		minNodeLimit:    160_000,
 	},
 	{
 		name: "region-and-IP-based naming (100 regions)",
@@ -255,6 +262,7 @@ var performanceTestCases = []performanceTestCase{
 			fixedPrefixAndSuffixLength: 20,
 		},
 		targetNodeCount: 40_000,
+		minNodeLimit:    130_000,
 	},
 	{
 		name: "region-and-IP-based naming (1 region)",
@@ -288,20 +296,65 @@ func TestByteSizeLimit(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
 	for _, tc := range performanceTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ta := V1Beta2From(internalSinglePodsOn(tc.generateNodeNames(tc.targetNodeCount)))
+			ta := V1Beta2From(internalSinglePodsOn(tc.generateNodeNames(tc.targetNodeCount)), allowHostnamePrefixGrouping)
 			assertTopologyAssignmentSize(t, ta, tc.targetNodeCount)
 
 			if tc.skipApproxMaxNodes {
 				return
 			}
 			nodesLimit := approxMaxNodesFor(tc)
-			if nodesLimit < tc.targetNodeCount {
-				t.Errorf("Nodes limit for naming %q is too low: got approx. %d, want >= %d", tc.name, nodesLimit, tc.targetNodeCount)
+			minNodeLimit := max(tc.targetNodeCount, tc.minNodeLimit)
+			if nodesLimit < minNodeLimit {
+				t.Errorf("Nodes limit for naming %q is too low: got approx. %d, want >= %d", tc.name, nodesLimit, minNodeLimit)
 			} else {
 				t.Logf("Nodes limit for naming %q is approx. %d", tc.name, nodesLimit)
 			}
 		})
 	}
+}
+
+func TestV1Beta2From_prefersOrderPreservingPrefixEncodingForMultiLevelAssignment(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
+	const domainCount = maxDomainsPerTopologyAssignmentSlice + 1
+	internal := &TopologyAssignment{
+		Levels:  []string{"cloud.example.com/zone", corev1.LabelHostname},
+		Domains: make([]TopologyDomainAssignment, 0, domainCount),
+	}
+	zones := []string{strings.Repeat("a", 60), strings.Repeat("b", 60)}
+	nodeID := 0
+	for zone := range 2 {
+		for pool := range 2 {
+			groupSize := domainCount / 4
+			if zone == 0 && pool == 0 {
+				groupSize += domainCount % 4
+			}
+			for range groupSize {
+				internal.Domains = append(internal.Domains, TopologyDomainAssignment{
+					Values: []string{
+						zones[zone],
+						fmt.Sprintf("pool-%c-node-%06d", 'a'+pool, nodeID),
+					},
+					Count: 1,
+				})
+				nodeID++
+			}
+		}
+	}
+
+	orderPreserving := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
+	groupedInternal, prefixKeys := topologyAssignmentForHostnamePrefixEncoding(internal)
+	grouped := compactTopologyAssignmentEncodingWithHostnamePrefixRunsAndKeys(groupedInternal, prefixKeys)
+	if orderPreservingBytes, groupedBytes := len(jsonBytes(orderPreserving)), len(jsonBytes(grouped)); orderPreservingBytes >= groupedBytes {
+		t.Fatalf("test fixture does not favor order-preserving encoding: order-preserving=%d bytes, grouped=%d bytes", orderPreservingBytes, groupedBytes)
+	} else if groupedBytes <= maxTopologyAssignmentJSONBytes {
+		t.Fatalf("test fixture does not expose the persistence regression: grouped=%d bytes, limit=%d bytes", groupedBytes, maxTopologyAssignmentJSONBytes)
+	}
+
+	got := V1Beta2From(internal, allowHostnamePrefixGrouping)
+	if diff := cmp.Diff(orderPreserving, got); diff != "" {
+		t.Fatalf("did not select the smaller order-preserving prefix encoding (-want,+got):\n%s", diff)
+	}
+	assertTopologyAssignmentSize(t, got, domainCount)
 }
 
 func assertTopologyAssignmentSize(t *testing.T, ta *kueue.TopologyAssignment, wantDomains int) {
@@ -325,20 +378,21 @@ func assertTopologyAssignmentSize(t *testing.T, ta *kueue.TopologyAssignment, wa
 func BenchmarkV1Beta2From(b *testing.B) {
 	features.SetFeatureGateDuringTest(b, features.TASAssignmentsEncodingByHostnamePrefix, true)
 	for _, tc := range performanceTestCases {
-		nodeNames := tc.naming.generate(tc.targetNodeCount)
-
-		// For our current strategy (split into hostname prefix runs),
-		// having node names sorted matches scheduler-created hostname-only assignments.
-		// (This is because assignments are sorted by level values before encoding;
-		// for multi-level assignments, hostnames are only sorted within higher levels).
-		slices.Sort(nodeNames)
-		ta := internalSinglePodsOn(nodeNames)
-
-		desc := fmt.Sprintf("Naming scheme %q, %d nodes", tc.name, tc.targetNodeCount)
-		b.Run(desc, func(b *testing.B) {
-			for b.Loop() {
-				var _ = V1Beta2From(ta)
+		// Hostname-only scheduler assignments are sorted, while multi-level
+		// topology ordering can leave the encoded hostnames interleaved.
+		for _, sorted := range []bool{false, true} {
+			nodeNames := tc.naming.generate(tc.targetNodeCount)
+			if sorted {
+				slices.Sort(nodeNames)
 			}
-		})
+			ta := internalSinglePodsOn(nodeNames)
+
+			desc := fmt.Sprintf("Naming scheme %q, %d nodes, pre-sorted=%t", tc.name, tc.targetNodeCount, sorted)
+			b.Run(desc, func(b *testing.B) {
+				for b.Loop() {
+					var _ = V1Beta2From(ta, allowHostnamePrefixGrouping)
+				}
+			})
+		}
 	}
 }

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package tas
 
 import (
+	stdcmp "cmp"
 	"fmt"
 	"slices"
 	"testing"
@@ -867,24 +868,215 @@ func TestV1Beta2FromInternal_hostnamePrefixFeatureGateAndFallback(t *testing.T) 
 	}
 }
 
-func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns_preservesDomainOrder(t *testing.T) {
+func TestV1Beta2From_groupsDomainsByHostnamePrefix(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
+	internal := &TopologyAssignment{
+		Levels:  []string{corev1.LabelHostname},
+		Domains: make([]TopologyDomainAssignment, 40),
+	}
+	for i := range internal.Domains {
+		pool := "b"
+		if i%2 == 1 {
+			pool = "a"
+		}
+		internal.Domains[i] = TopologyDomainAssignment{
+			Values: []string{fmt.Sprintf("gke-c-pool-%s-hash-node-%02d", pool, i)},
+			Count:  int32(i + 1),
+		}
+	}
+	originalDomains := slices.Clone(internal.Domains)
+
+	encoded := V1Beta2From(internal, WithHostnamePrefixGroupingAllowed(true))
+	if gotSlices := len(encoded.Slices); gotSlices != 2 {
+		t.Fatalf("unexpected number of slices: got %d, want 2", gotSlices)
+	}
+	if diff := cmp.Diff(originalDomains, internal.Domains); diff != "" {
+		t.Fatalf("V1Beta2From mutated its input (-want,+got):\n%s", diff)
+	}
+
+	wantDomains := slices.Clone(originalDomains)
+	slices.SortFunc(wantDomains, func(a, b TopologyDomainAssignment) int {
+		return stdcmp.Compare(a.Values[0], b.Values[0])
+	})
+	if diff := cmp.Diff(wantDomains, InternalFrom(encoded).Domains); diff != "" {
+		t.Fatalf("unexpected grouped domain order (-want,+got):\n%s", diff)
+	}
+}
+
+func TestV1Beta2From_preservesDomainOrderByDefault(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, true)
 	internal := &TopologyAssignment{
 		Levels: []string{corev1.LabelHostname},
 		Domains: []TopologyDomainAssignment{
-			{Values: []string{"gke-c-pool-a-hash1-aa"}, Count: 1},
-			{Values: []string{"gke-c-pool-b-hash2-cc"}, Count: 2},
-			{Values: []string{"gke-c-pool-a-hash1-bb"}, Count: 3},
-			{Values: []string{"gke-c-pool-b-hash2-dd"}, Count: 4},
+			{Values: []string{"pool-b-node-1"}, Count: 1},
+			{Values: []string{"pool-a-node-1"}, Count: 2},
+			{Values: []string{"pool-b-node-2"}, Count: 3},
+			{Values: []string{"pool-a-node-2"}, Count: 4},
 		},
 	}
 
-	encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(internal)
-	if gotSlices := len(encoded.Slices); gotSlices != 4 {
-		t.Fatalf("unexpected number of slices: got %d, want 4", gotSlices)
+	got := InternalFrom(V1Beta2From(internal))
+	if diff := cmp.Diff(internal, got); diff != "" {
+		t.Fatalf("default encoding changed domain order (-want,+got):\n%s", diff)
 	}
-	got := InternalFrom(encoded)
-	if diff := cmp.Diff(internal.Domains, got.Domains); diff != "" {
-		t.Fatalf("hostname-prefix encoding must preserve domain order (-want,+got):\n%s", diff)
+}
+
+func TestTopologyAssignmentForHostnamePrefixEncoding(t *testing.T) {
+	tests := map[string]struct {
+		internal       *TopologyAssignment
+		want           *TopologyAssignment
+		wantPrefixKeys []string
+	}{
+		"groups by prefix and preserves order within each group": {
+			internal: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/zone", corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"zone-a", "pool-b-node-2"}, Count: 1},
+					{Values: []string{"zone-b", "pool-a-node-2"}, Count: 2},
+					{Values: []string{"zone-a", "pool-b-node-1"}, Count: 3},
+					{Values: []string{"zone-b", "pool-a-node-1"}, Count: 4},
+				},
+			},
+			want: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/zone", corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"zone-b", "pool-a-node-2"}, Count: 2},
+					{Values: []string{"zone-b", "pool-a-node-1"}, Count: 4},
+					{Values: []string{"zone-a", "pool-b-node-2"}, Count: 1},
+					{Values: []string{"zone-a", "pool-b-node-1"}, Count: 3},
+				},
+			},
+			wantPrefixKeys: []string{"pool-a-node-", "pool-a-node-", "pool-b-node-", "pool-b-node-"},
+		},
+		"groups prefixless domains from a hostname-sorted assignment": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"a-1"}, Count: 1},
+					{Values: []string{"a-2"}, Count: 2},
+					{Values: []string{"a0"}, Count: 3},
+					{Values: []string{"b-1"}, Count: 4},
+					{Values: []string{"b-2"}, Count: 5},
+					{Values: []string{"b0"}, Count: 6},
+				},
+			},
+			wantPrefixKeys: []string{"", "", "a-", "a-", "b-", "b-"},
+			want: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"a0"}, Count: 3},
+					{Values: []string{"b0"}, Count: 6},
+					{Values: []string{"a-1"}, Count: 1},
+					{Values: []string{"a-2"}, Count: 2},
+					{Values: []string{"b-1"}, Count: 4},
+					{Values: []string{"b-2"}, Count: 5},
+				},
+			},
+		},
+		"preserves duplicate hostname order within each group": {
+			internal: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/zone", corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"zone-b", "pool-b-node-a"}, Count: 2},
+					{Values: []string{"zone-a", "pool-a-node-a"}, Count: 3},
+					{Values: []string{"zone-a", "pool-a-node-a"}, Count: 1},
+					{Values: []string{"zone-b", "pool-b-node-b"}, Count: 4},
+				},
+			},
+			want: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/zone", corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"zone-a", "pool-a-node-a"}, Count: 3},
+					{Values: []string{"zone-a", "pool-a-node-a"}, Count: 1},
+					{Values: []string{"zone-b", "pool-b-node-a"}, Count: 2},
+					{Values: []string{"zone-b", "pool-b-node-b"}, Count: 4},
+				},
+			},
+		},
+		"preserves order for one prefix group": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"node-b"}, Count: 1},
+					{Values: []string{"node-a"}, Count: 2},
+				},
+			},
+			want: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"node-b"}, Count: 1},
+					{Values: []string{"node-a"}, Count: 2},
+				},
+			},
+		},
+		"preserves order without a reusable prefix": {
+			internal: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"nodeb"}, Count: 1},
+					{Values: []string{"nodea"}, Count: 2},
+				},
+			},
+			want: &TopologyAssignment{
+				Levels: []string{corev1.LabelHostname},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"nodeb"}, Count: 1},
+					{Values: []string{"nodea"}, Count: 2},
+				},
+			},
+		},
+		"preserves order without hostname": {
+			internal: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/rack"},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"rack-b"}, Count: 1},
+					{Values: []string{"rack-a"}, Count: 2},
+				},
+			},
+			want: &TopologyAssignment{
+				Levels: []string{"cloud.example.com/rack"},
+				Domains: []TopologyDomainAssignment{
+					{Values: []string{"rack-b"}, Count: 1},
+					{Values: []string{"rack-a"}, Count: 2},
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			originalDomains := slices.Clone(tc.internal.Domains)
+			got, prefixKeys := topologyAssignmentForHostnamePrefixEncoding(tc.internal)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected result (-want,+got):\n%s", diff)
+			}
+			if tc.wantPrefixKeys != nil {
+				if diff := cmp.Diff(tc.wantPrefixKeys, prefixKeys); diff != "" {
+					t.Errorf("prefix keys do not match sorted domains (-want,+got):\n%s", diff)
+				}
+			}
+			if diff := cmp.Diff(originalDomains, tc.internal.Domains); diff != "" {
+				t.Errorf("input was mutated (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestV1Beta2FromInternal_disabledHostnamePrefixEncodingPreservesDomainOrder(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASAssignmentsEncodingByHostnamePrefix, false)
+	internal := &TopologyAssignment{
+		Levels: []string{corev1.LabelHostname},
+		Domains: []TopologyDomainAssignment{
+			{Values: []string{"pool-b-node-1"}, Count: 1},
+			{Values: []string{"pool-a-node-1"}, Count: 2},
+			{Values: []string{"pool-b-node-2"}, Count: 3},
+			{Values: []string{"pool-a-node-2"}, Count: 4},
+		},
+	}
+
+	got := InternalFrom(V1Beta2From(internal, WithHostnamePrefixGroupingAllowed(true)))
+	if diff := cmp.Diff(internal, got); diff != "" {
+		t.Fatalf("disabled hostname-prefix encoding changed domain order (-want,+got):\n%s", diff)
 	}
 }
 
@@ -970,15 +1162,13 @@ func TestReusableHostnamePrefixKeys(t *testing.T) {
 }
 
 func TestReusableHostnamePrefixKeys_backsOffToFitSliceLimit(t *testing.T) {
-	domains := make([]TopologyDomainAssignment, maxTopologyAssignmentSlices+1)
+	domains := make([]TopologyDomainAssignment, 2*(maxTopologyAssignmentSlices+1))
 	want := make([]string, len(domains))
 	for i := range domains {
-		group := "x"
-		if i%2 == 1 {
-			group = "y"
-		}
-		domains[i].Values = []string{fmt.Sprintf("a-%s-%04d", group, i)}
-		want[i] = "a-"
+		group := i / 2
+		node := i % 2
+		domains[i].Values = []string{fmt.Sprintf("a-group-%04d-node-%d", group, node)}
+		want[i] = "a-group-"
 	}
 
 	got := reusableHostnamePrefixKeys([]string{corev1.LabelHostname}, domains)
@@ -987,18 +1177,37 @@ func TestReusableHostnamePrefixKeys_backsOffToFitSliceLimit(t *testing.T) {
 	}
 }
 
+func TestReusableHostnamePrefixKeys_backsOffWhenAGroupRequiresMultipleSlices(t *testing.T) {
+	const groupCount = maxTopologyAssignmentSlices
+	domains := make([]TopologyDomainAssignment, 0, maxDomainsPerTopologyAssignmentSlice+2*(groupCount-1)+1)
+	largeGroupDomain := TopologyDomainAssignment{Values: []string{"a-group-0000-node-0"}}
+	for range maxDomainsPerTopologyAssignmentSlice + 1 {
+		domains = append(domains, largeGroupDomain)
+	}
+	for group := 1; group < groupCount; group++ {
+		for node := range 2 {
+			domains = append(domains, TopologyDomainAssignment{
+				Values: []string{fmt.Sprintf("a-group-%04d-node-%d", group, node)},
+			})
+		}
+	}
+
+	got := reusableHostnamePrefixKeys([]string{corev1.LabelHostname}, domains)
+	if diff := cmp.Diff([]string{"a-group-"}, slices.Compact(got)); diff != "" {
+		t.Fatalf("expected prefix backoff after chunking exceeds the slice limit (-want,+got):\n%s", diff)
+	}
+}
+
 func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns_fallsBackWhenNoPrefixDepthFitsSliceLimit(t *testing.T) {
 	internal := &TopologyAssignment{
 		Levels:  []string{corev1.LabelHostname},
-		Domains: make([]TopologyDomainAssignment, maxTopologyAssignmentSlices+1),
+		Domains: make([]TopologyDomainAssignment, 2*(maxTopologyAssignmentSlices+1)),
 	}
 	for i := range internal.Domains {
-		prefix := "a-x"
-		if i%2 == 1 {
-			prefix = "b-y"
-		}
+		group := i / 2
+		node := i % 2
 		internal.Domains[i] = TopologyDomainAssignment{
-			Values: []string{fmt.Sprintf("%s-%04d", prefix, i)},
+			Values: []string{fmt.Sprintf("group%04d-node-%d", group, node)},
 			Count:  1,
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

The v1beta2 hostname-prefix encoder previously compacted only consecutive
prefix runs. The scheduler orders domains by their complete topology values,
so higher-level topology can interleave hostnames from the same pool and
prevent the prefix encoder from reaching its intended capacity.

This PR lets the scheduler opt into stable grouping by selected hostname
prefix before encoding. The option is deliberately off by default and is
enabled only for newly computed assignments whose domain order has no
rank-aware or elastic scale-down semantics. Rank-aware PodSets, Workloads
marked elastic, existing assignments, and v1beta1 conversion preserve their
original order.

The grouping pass:

- keeps Pod counts paired with their domains;
- preserves the scheduler order within each prefix group;
- leaves the internal assignment unmodified;
- avoids allocation when prefix keys are already grouped;
- compares grouped and order-preserving prefix encodings so grouping cannot
  regress multi-level assignment size; and
- includes the empty prefix key so prefixless domains cannot split reusable
  groups.

On an Apple M4 Pro, the approximate 1.5 MiB limits for the three interleaved
40k naming patterns increased from 46k domains on the base commit to 146k,
166k, and 133k domains. Encoding compressible interleaved inputs costs about
2.6-2.8x the base time because both prefix candidates are size-checked; inputs
that are already grouped or have no grouping benefit remain near the base
time.

AI usage disclosure: this PR was developed with assistance from OpenAI Codex.
I reviewed the changes and validation results.

#### Which issue(s) this PR fixes:

Fixes #12159

#### Special notes for your reviewer:

Validation:

- `make verify-ci-lint`
- `make verify-fmt-verify`
- `go test ./pkg/util/tas ./pkg/scheduler/flavorassigner ./pkg/cache/scheduler ./pkg/controller/tas ./pkg/workload ./apis/kueue/v1beta1 -count=1`
- `go test ./pkg/util/tas -run '^$' -fuzz '^FuzzTopologyAssignmentCompactionRoundTrip$' -fuzztime=20s` (186,556 executions in the final run)
- `go test ./pkg/util/tas -run '^$' -bench '^BenchmarkV1Beta2From$' -benchtime=300ms -count=2`

The aggregate `make verify` target could not finish in this local environment:
the installed Docker legacy builder rejects the npm dependency check's
`--load` flag, and the Docker-based ShellCheck could not open files from the
temporary worktree mount. Its Go lint, API lint, generated-code, Helm lint, and
53 Helm unit-test steps passed; the isolated Go lint and format targets above
also passed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
