### PR TITLE
cleanup: remove verbose error logging from release automation actions

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -203,13 +203,8 @@ jobs:
           set -e
 
           if [ $BRANCH_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
-            ERR_MSG=$(cat err.log)
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release branch \`$BRANCH\`.
-          
-            **Error details:**
-            \`\`\`text
-            ${ERR_MSG}
-            \`\`\`"
+            cat err.log
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release branch \`$BRANCH\`."
             exit 1
           fi
 
@@ -348,13 +343,8 @@ jobs:
           rm -f "$NOTES_FILE"
           
           if [ $TAG_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
-            ERR_MSG=$(cat err.log)
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create or push release tag \`$VERSION\`.
-            
-            **Error details:**
-            \`\`\`text
-            ${ERR_MSG}
-            \`\`\`"
+            cat err.log
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create or push release tag \`$VERSION\`."
             exit 1
           fi
           
@@ -433,14 +423,8 @@ jobs:
           set -e
 
           if [ $RELEASE_EXIT -ne 0 ]; then
-            ERR_MSG="$(cat err.log)"
-            echo "$ERR_MSG"
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`.
-
-            **Error details:**
-            \`\`\`text
-            ${ERR_MSG}
-            \`\`\`"
+            cat err.log
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`."
             exit 1
           fi
 
@@ -495,17 +479,8 @@ jobs:
           set -e
 
           if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
-            # Extract any line starting with !!! as error details
-            ERR_MSG=$(grep -E '^!!!' /tmp/prepare-pull.log || true)
-            if [ -z "$ERR_MSG" ]; then
-              ERR_MSG="Check workflow logs for details."
-            fi
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to prepare pull requests for version \`$VERSION\` (target: \`$TARGET\`).
-            
-            **Error details:**
-            \`\`\`text
-            ${ERR_MSG}
-            \`\`\`"
+            cat /tmp/prepare-pull.log
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to prepare pull requests for version \`$VERSION\` (target: \`$TARGET\`)."
             exit $SCRIPT_EXIT_CODE
           fi
 
@@ -560,14 +535,8 @@ jobs:
           set -e
 
           if [ $EDIT_EXIT -ne 0 ]; then
-            ERR_MSG="$(cat err.log)"
-            echo "$ERR_MSG"
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`.
-
-            **Error details:**
-            \`\`\`text
-            ${ERR_MSG}
-            \`\`\`"
+            cat err.log
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`."
             exit 1
           fi
 

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -194,16 +194,15 @@ jobs:
 
           # Create and push the branch from main
           set +e
-          git checkout -b "$BRANCH" 2> err.log
+          git checkout -b "$BRANCH"
           BRANCH_EXIT=$?
           if [ $BRANCH_EXIT -eq 0 ]; then
-            git push origin "$BRANCH" 2>> err.log
+            git push origin "$BRANCH"
             PUSH_EXIT=$?
           fi
           set -e
 
           if [ $BRANCH_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
-            cat err.log
             gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create release branch \`$BRANCH\`."
             exit 1
           fi
@@ -333,17 +332,16 @@ jobs:
           # Create and push the tag
           PUSH_EXIT=0
           set +e
-          git tag -a "$VERSION" -F "$NOTES_FILE" 2> err.log
+          git tag -a "$VERSION" -F "$NOTES_FILE"
           TAG_EXIT=$?
           if [ $TAG_EXIT -eq 0 ]; then
-            git push origin "$VERSION" 2>> err.log
+            git push origin "$VERSION"
             PUSH_EXIT=$?
           fi
           set -e
           rm -f "$NOTES_FILE"
           
           if [ $TAG_EXIT -ne 0 ] || [ $PUSH_EXIT -ne 0 ]; then
-            cat err.log
             gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create or push release tag \`$VERSION\`."
             exit 1
           fi
@@ -418,12 +416,11 @@ jobs:
             --title "$VERSION" \
             --notes "$CHANGELOG" \
             --draft \
-            release-artifacts/* 2> err.log
+            release-artifacts/*
           RELEASE_EXIT=$?
           set -e
 
           if [ $RELEASE_EXIT -ne 0 ]; then
-            cat err.log
             gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to create draft release \`$VERSION\`."
             exit 1
           fi
@@ -474,12 +471,11 @@ jobs:
           UPSTREAM_REMOTE: origin
         run: |
           set +e
-          yes y | ./hack/releasing/prepare_pull.sh --target "$TARGET" "$VERSION" 2>&1 | tee /tmp/prepare-pull.log
+          yes y | ./hack/releasing/prepare_pull.sh --target "$TARGET" "$VERSION"
           SCRIPT_EXIT_CODE=${PIPESTATUS[1]}
           set -e
 
           if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
-            cat /tmp/prepare-pull.log
             gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to prepare pull requests for version \`$VERSION\` (target: \`$TARGET\`)."
             exit $SCRIPT_EXIT_CODE
           fi
@@ -530,12 +526,11 @@ jobs:
           set +e
           gh release edit "$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
-            --draft=false 2> err.log
+            --draft=false
           EDIT_EXIT=$?
           set -e
 
           if [ $EDIT_EXIT -ne 0 ]; then
-            cat err.log
             gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to publish release \`$VERSION\`."
             exit 1
           fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area release
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR cleans up the release automation scripts in `.github/workflows/release-utils.yml`. It removes the verbose `**Error details:**` sections (which often dumped unhelpful or redundant bash standard errors directly into issue comments) because the underlying GH Action workflows now provide direct links to the execution logs (as introduced in #13390). This prevents issue comment spam and focuses developers on the actual workflow logs.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13397

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified release workflow failure notifications to rely on exit codes only.
  * Release failures now trigger a single, concise issue comment instead of parsing or attaching extracted “error details.”
  * Release operations still halt safely on errors, with cleaner and more consistent failure messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->