### PR TITLE
perf: skip generated packages in ci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -77,6 +77,9 @@ linters:
       context-background: true
       context-todo: true
   exclusions:
+    generated: strict
+    paths:
+      - zz_generated\..+\.go$
     warn-unused: true
     presets:
       - std-error-handling
@@ -114,4 +117,7 @@ formatters:
       max-len: 200
       reformat-tags: false
   exclusions:
+    generated: strict
+    paths:
+      - zz_generated\..+\.go$
     warn-unused: true

--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -19,6 +19,8 @@ CONTAINER_ENGINE ?= $(shell command -v podman 2>/dev/null || command -v docker 2
 SKILLSAW_VERSION := $(shell grep '^FROM' "${TESTING_DIR}/skillsaw/Dockerfile" | cut -d: -f2 | cut -d@ -f1)
 SKILLSAW_IMAGE := "ghcr.io/stbenjam/skillsaw:${SKILLSAW_VERSION}"
 VERIFY_NPROCS ?= 8
+# Number of modules to lint concurrently in ci-lint (xargs -P). 0 = as many as possible.
+CI_LINT_NPROCS ?= 0
 # Output sync mode for parallel verification. Set to empty to disable.
 # Requires GNU Make 4.0+. Values: target, line, recurse, or empty.
 ifeq ($(shell uname),Darwin)
@@ -116,8 +118,22 @@ verify-checks: verify-ci-lint verify-lint-api verify-fmt-verify verify-e2e-commo
 # Giving the wrapper its own recipe body is the only way to enforce ordering
 # without recursive $(MAKE).
 
+# Lint each module in parallel; drop generated packages (client-go/, internal/mocks/)
+# from the target list — golangci-lint's path/generated exclusions only filter reported
+# issues, not the analysis work, so they must be excluded before the linter runs.
 define _ci_lint_recipe
-find . \( -path ./site -o -path ./bin -o -path ./vendor \) -prune -false -o -name go.mod -exec dirname {} \; | xargs -I {} sh -c 'cd "{}" && $(GOLANGCI_LINT) run $(GOLANGCI_LINT_FIX) --timeout 15m0s --config "$(PROJECT_DIR)/.golangci.yaml"'
+@find . \( -path ./site -o -path ./bin -o -path ./vendor \) -prune -false -o -name go.mod -exec dirname {} \; \
+	| xargs -P $(CI_LINT_NPROCS) -n 1 sh -c ' \
+		cd "$$1" || exit 1; \
+		dirs=$$($(GO_CMD) list -f "{{.Dir}}" ./... \
+			| grep -vE "/(client-go|internal/mocks)(/|$$)" \
+			| sed "s|^$$(pwd)/|./|"); \
+		[ -n "$$dirs" ] || exit 0; \
+		$(GOLANGCI_LINT) run $(GOLANGCI_LINT_FIX) \
+			--allow-parallel-runners \
+			--timeout 15m0s \
+			--config "$(PROJECT_DIR)/.golangci.yaml" \
+			$$dirs' sh
 endef
 
 define _lint_api_recipe


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
`make ci-lint` analyzed fully generated packages (`client-go/`, `internal/mocks/`). golangci-lint path/generated exclusions only filter reported issues *after* analysis, so those ~300 generated files were still analyzed on every run.

This PR:
- Excludes `client-go/` and `internal/mocks/` from each module's `go list ./...` target set, so golangci-lint never analyzes them. Hand-written packages (`apis`, `cmd`, `pkg`, `test`, `hack`) are still fully linted.
- Marks `zz_generated*` / generated files as excluded in `.golangci.yaml`.
- Lints each Go module concurrently (`xargs -P`, configurable via `CI_LINT_NPROCS`, default `0` = as many as possible) and passes `--allow-parallel-runners` so the concurrent golangci-lint instances don't contend on the startup file lock.

Local cold-cache root-module measurement: ~208s → ~173s (~17% faster). Warm cache is already fast, so the gain is small. Per-module parallelism additionally overlaps the smaller modules with the dominant root-module run.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
- Benchmark was root module only, golangci-lint cache cleared between cold runs, Go build cache kept.
- Concurrent runners overlap, so on a memory-constrained machine `CI_LINT_NPROCS` can be lowered, e.g. `make ci-lint CI_LINT_NPROCS=2`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
