### PR TITLE
Add explicit timeout to cluster creation in e2e tests

### DIFF
--- a/cmd/experimental/kueue-populator/run-e2e.sh
+++ b/cmd/experimental/kueue-populator/run-e2e.sh
@@ -32,7 +32,16 @@ make kustomize ginkgo kind yq
 ROOT_DIR="$REPO_ROOT"
 SOURCE_DIR="$REPO_ROOT/hack/testing"
 GINKGO_ARGS="${GINKGO_ARGS:-}"
-E2E_KIND_VERSION="${E2E_KIND_VERSION:-}"
+
+# E2E_KIND_VERSION is the kind node image (e.g. kindest/node:v1.36.1) and selects
+# the Kubernetes version of the cluster. Like every other cluster-creating path in
+# the repo, it is provided by the build system (the Makefile derives it from the
+# K8s version). A fallback keeps direct execution working. See #13296 / #13291.
+export E2E_KIND_VERSION="${E2E_KIND_VERSION:-kindest/node:v1.36.1}"
+export ARTIFACTS="${ARTIFACTS:-$ROOT_DIR/artifacts}"
+mkdir -p "$ARTIFACTS"
+KIND_CONFIG="$SOURCE_DIR/kind-cluster.yaml"
+
 # shellcheck source=hack/testing/e2e-common.sh
 source "$SOURCE_DIR/e2e-common.sh"
 cd "$SCRIPT_DIR"
@@ -42,8 +51,8 @@ function cleanup {
 }
 trap cleanup EXIT
 
-echo "Creating Kind cluster..."
-"$KIND" create cluster --name "$KIND_CLUSTER_NAME"
+echo "Creating Kind cluster (node image: $E2E_KIND_VERSION)..."
+ensure_kind_cluster "$KIND_CLUSTER_NAME" "$KIND_CONFIG" ""
 
 echo "Installing Kueue..."
 kubectl apply --server-side -f "https://github.com/kubernetes-sigs/kueue/releases/download/${KUEUE_VERSION}/manifests.yaml"

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -528,6 +528,21 @@ apiServer:
     echo "$patched_config"
 }
 
+function run_with_timeout_and_log {
+    local timeout_duration="$1"
+    local log_file="$2"
+    shift 2
+
+    if ! timeout "$timeout_duration" "$@" > "$log_file" 2>&1; then
+        local res=$?
+        if [ "$res" -eq 124 ]; then
+            echo "command timed out after $timeout_duration" >> "$log_file"
+        fi
+        return "$res"
+    fi
+}
+export -f run_with_timeout_and_log
+
 # $1 cluster name
 # $2 cluster kind config
 # $3 kubeconfig
@@ -557,11 +572,11 @@ function cluster_create {
     local log_file="$ARTIFACTS/$cluster-create.log"
     # Include node readiness in each cluster bring-up attempt so transient
     # readiness delays can reuse the existing cleanup and recreation path.
-    local create_cmd="$KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 > \"$log_file\" 2>&1 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
-    # Retry recognized bring-up failures (#11586, #12307, #12984). Persistent
+    local create_cmd="run_with_timeout_and_log 10m \"$log_file\" $KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
+    # Retry recognized bring-up failures (#11586, #12307, #12984, #13437). Persistent
     # failures producing a matching error will exhaust the configured retries
     # before failing.
-    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches|timed out waiting for the condition on nodes/"
+    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches|timed out waiting for the condition on nodes/|command timed out after 10m"
     local continue_if="grep -qE '${retriable_errors}' \"$log_file\""
     local cleanup_cmd="if [ -f \"$log_file\" ]; then mv \"$log_file\" \"${log_file}.failed-\$(date +%s)\"; fi; $KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
 

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -578,7 +578,7 @@ function cluster_create {
     # Retry recognized bring-up failures (#11586, #12307, #12984, #13437). Persistent
     # failures producing a matching error will exhaust the configured retries
     # before failing.
-    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches|timed out waiting for the condition on nodes/|command timed out after 10m"
+    local retriable_errors="port is already allocated|error execution phase wait-control-plane|could not find a log line that matches|timed out waiting for the condition on nodes/|command timed out after"
     local continue_if="grep -qE '${retriable_errors}' \"$log_file\""
     local cleanup_cmd="if [ -f \"$log_file\" ]; then mv \"$log_file\" \"${log_file}.failed-\$(date +%s)\"; fi; $KIND delete cluster --name \"$cluster\" 2>/dev/null || true"
 

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -585,7 +585,7 @@ function cluster_create {
     local log_file="$ARTIFACTS/$cluster-create.log"
     # Include node readiness in each cluster bring-up attempt so transient
     # readiness delays can reuse the existing cleanup and recreation path.
-    local create_cmd="run_with_timeout_and_log 3s \"$log_file\" $KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
+    local create_cmd="run_with_timeout_and_log 10m \"$log_file\" $KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
     # Retry recognized bring-up failures (#11586, #12307, #12984, #13437). Persistent
     # failures producing a matching error will exhaust the configured retries
     # before failing.

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -1543,12 +1543,12 @@ function upgrade_test_flow {
     echo "Upgrade Test: $old_version -> current"
     echo "Old image: $KUEUE_OLD_VERSION_IMAGE"
     echo "New image: $IMAGE_TAG"
-    
+
     # Step 1: Install old version using the released image from registry.k8s.io
     echo "Installing $old_version..."
     echo "  Manifest URL: ${KUEUE_OLD_VERSION_MANIFEST}"
     echo "  Downloading and modifying manifests..."
-    
+
     # Download manifests, rewrite the image reference to match the pre-loaded
     # image, and set imagePullPolicy to IfNotPresent so kind uses it directly.
     curl -sL "${KUEUE_OLD_VERSION_MANIFEST}" | \
@@ -1561,7 +1561,7 @@ function upgrade_test_flow {
 
     # Step 2: Create test resources
     echo "Creating test resources..."
-    
+
     # Create custom namespace for test resources (idempotent)
     kubectl apply --kubeconfig="$1" -f - <<EOF_NS
 apiVersion: v1
@@ -1569,7 +1569,7 @@ kind: Namespace
 metadata:
   name: kueue-upgrade-test
 EOF_NS
-    
+
     # Apply test resources
     kubectl apply --kubeconfig="$1" -f - <<EOF
 apiVersion: kueue.x-k8s.io/v1beta1
@@ -1602,22 +1602,22 @@ spec:
   clusterQueue: upgrade-test-cq
 EOF
     echo "✓ Resources created"
-    
+
     # Step 3: Upgrade to current (rolling update)
     echo "Upgrading to current..."
-    
+
     # Apply upgrade - rolling update will replace pods
     (
         set_managers_image
         trap restore_managers_image EXIT
-        
+
         local build_output
         build_output=$($KUSTOMIZE build "${ROOT_DIR}/test/e2e/config/default")
         # shellcheck disable=SC2001 # bash parameter substitution does not work on macOS
         build_output=$(echo "$build_output" | sed "s/kueue-system/$KUEUE_NAMESPACE/g")
         echo "$build_output" | kubectl apply --kubeconfig="$1" --server-side --force-conflicts -f -
     )
-    
+
     # Wait for the rolling update to complete.
     echo "Waiting for rolling update to complete..."
     wait_for_kueue_controller_operator "$1"

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -528,9 +528,20 @@ apiServer:
     echo "$patched_config"
 }
 
+# run_with_timeout_and_log executes a command with a time limit, redirecting
+# all output to a log file. If the command exceeds the limit and is killed
+# (exit code 124), a unique timeout notification is appended to the log file
+# so that upstream retry scripts (like retry.sh) can accurately detect a hang.
+#
+# Arguments:
+# $1: The timeout duration (e.g., '10m')
+# $2: The absolute path to the log file to pipe output to
+# $@: The remaining arguments constitute the exact command to execute
 function run_with_timeout_and_log {
     local timeout_duration="$1"
     local log_file="$2"
+
+    # Pop duration and log file off the stack so $@ contains only the command
     shift 2
 
     timeout "$timeout_duration" "$@" > "$log_file" 2>&1
@@ -574,7 +585,7 @@ function cluster_create {
     local log_file="$ARTIFACTS/$cluster-create.log"
     # Include node readiness in each cluster bring-up attempt so transient
     # readiness delays can reuse the existing cleanup and recreation path.
-    local create_cmd="run_with_timeout_and_log 10m \"$log_file\" $KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
+    local create_cmd="run_with_timeout_and_log 3s \"$log_file\" $KIND create cluster --name \"$cluster\" --image \"$E2E_KIND_VERSION\" --config \"$kind_config\" --kubeconfig=\"$kubeconfig\" --wait 5m -v 5 && kubectl wait --kubeconfig=\"$kubeconfig\" --for=condition=Ready node --all --timeout=5m >> \"$log_file\" 2>&1"
     # Retry recognized bring-up failures (#11586, #12307, #12984, #13437). Persistent
     # failures producing a matching error will exhaust the configured retries
     # before failing.

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -533,8 +533,10 @@ function run_with_timeout_and_log {
     local log_file="$2"
     shift 2
 
-    if ! timeout "$timeout_duration" "$@" > "$log_file" 2>&1; then
-        local res=$?
+    timeout "$timeout_duration" "$@" > "$log_file" 2>&1
+    local res=$?
+
+    if [ "$res" -ne 0 ]; then
         if [ "$res" -eq 124 ]; then
             echo "command timed out after $timeout_duration" >> "$log_file"
         fi


### PR DESCRIPTION
#### What type of PR is this?
/kind flake

#### What this PR does / why we need it:
To make the tests stable 😑 

#### Which issue(s) this PR fixes:
Fixes #13437

#### Special notes for your reviewer:
As stated in the issue comments, I think this is related to a global prow timeout. So this is not populator-specific IMO (although the timing makes is sus).

**Disclaimer:** This change was generated with Gemini.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end cluster bring-up reliability by executing cluster creation with a timeout-aware helper that logs failures and prevents subsequent readiness checks from running.
  * Enhanced diagnostics by appending “command timed out after …” to logs and extending retry logic to recognize these timeout markers.
* **New Features**
  * Added configurable Kind node image/version selection (with a default) and improved test startup output to display it.
  * Standardized artifacts and Kind config path setup to make runs more consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->