### PR TITLE
Fix nolintlint unused on SA1019 fallback suppressions

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -555,7 +555,8 @@ func (s *Scheduler) waitForPodsReadyIfBlocked(ctx context.Context, log logr.Logg
 	if err := workloadpatching.PatchAdmissionStatus(ctx, s.client, wl, s.clock, func(wl *kueue.Workload) (bool, error) {
 		reason := workload.UnadmittedWorkloadReasonWithFallback(
 			kueue.WorkloadQuotaReservedReasonWaitingForPodsReady,
-			kueue.WorkloadWaiting, //nolint:staticcheck // SA1019: fallback
+			//nolint:staticcheck // SA1019: intentional deprecated fallback
+			kueue.WorkloadWaiting,
 		)
 		return workload.UnsetQuotaReservationWithCondition(wl, reason, "waiting for all admitted workloads to be in PodsReady condition", s.clock.Now()), nil
 	}, workloadpatching.WithLooseOnApply(), workloadpatching.WithRetryOnConflict()); err != nil {

--- a/pkg/util/testing/observability.go
+++ b/pkg/util/testing/observability.go
@@ -45,7 +45,8 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = kueue.WorkloadWaiting //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				cond.Reason = kueue.WorkloadWaiting
 			case kueue.WorkloadAdmissionGated:
 				// Keep as is
 			case kueue.WorkloadQuotaReservedReasonMisconfigured,
@@ -53,7 +54,8 @@ func AdjustConditionsForDisabledObservabilityInWorkloadController(conditions []m
 				kueue.WorkloadInadmissible:
 				cond.Reason = kueue.WorkloadInadmissible
 			default:
-				cond.Reason = kueue.WorkloadPending //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				cond.Reason = kueue.WorkloadPending
 			}
 		}
 		filtered = append(filtered, cond)
@@ -97,9 +99,11 @@ func AdjustConditionsForDisabledObservabilityInScheduler(conditions []metav1.Con
 		if cond.Type == kueue.WorkloadQuotaReserved && cond.Status == metav1.ConditionFalse {
 			switch cond.Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				cond.Reason = kueue.WorkloadWaiting //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				cond.Reason = kueue.WorkloadWaiting
 			default:
-				cond.Reason = kueue.WorkloadPending //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				cond.Reason = kueue.WorkloadPending
 			}
 		}
 		filtered = append(filtered, cond)
@@ -125,11 +129,13 @@ func AdjustEventsForDisabledObservabilityInScheduler(events []EventRecord) {
 		if events[i].EventType == corev1.EventTypeWarning {
 			switch events[i].Reason {
 			case kueue.WorkloadQuotaReservedReasonWaitingForPodsReady:
-				events[i].Reason = kueue.WorkloadWaiting //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				events[i].Reason = kueue.WorkloadWaiting
 			case kueue.WorkloadAdmissionGated, "SecondPassFailed", "DeprecatedPathUsage", "FailedCreate", "ErrWorkloadCompose", "JobNestingTooDeep":
 				// Keep warning events that are not related to QuotaReserved=False unadmitted reasons
 			default:
-				events[i].Reason = kueue.WorkloadPending //nolint:staticcheck // SA1019: legacy reason
+				//nolint:staticcheck // SA1019: intentional deprecated legacy reason
+				events[i].Reason = kueue.WorkloadPending
 			}
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Several intentional uses of deprecated `kueue.WorkloadWaiting` and `kueue.WorkloadPending` (legacy reasons when UnadmittedWorkloadsObservability is off) used trailing `//nolint:staticcheck` on the same line as the identifier.

With current golangci-lint and `nolintlint` (`require-specific` / `require-explanation`), that trailing form is reported as an unused nolint directive, while removing the directive causes SA1019. This PR moves the suppressions to the preceding line so both linters are satisfied.

Affected files:
- `pkg/scheduler/scheduler.go`
- `pkg/util/testing/observability.go`

#### Which issue(s) this PR fixes:

Fixes #13464

#### Special notes for your reviewer:

No behavior change — comment placement only. `make ci-lint` passes locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated internal compatibility annotations to support static analysis tooling.
  * No user-facing behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->