### PR TITLE
Use dependabot to bump golang and distroless versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,8 @@ updates:
       - "/cmd/kueueviz/backend"
       - "/cmd/kueueviz/frontend"
       - "/hack/debugpod"
+      - "/hack/images/distroless"
+      - "/hack/images/golang"
       - "/hack/releasing/krew-release-bot"
       - "/hack/testing/agnhost"
       - "/hack/testing/cypress"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,6 @@ else
 endif
 
 GO_CMD ?= go
-# Use go.mod go version as a single source of truth of GO version.
-GO_VERSION := $(shell awk '/^go /{split($$2, v, "."); print v[1] "." v[2]}' go.mod|head -n1)
 
 GIT_TAG ?= $(shell git describe --tags --dirty --always)
 GIT_COMMIT ?= $(shell git rev-parse HEAD)
@@ -66,9 +64,8 @@ RAYMINI_VERSION ?= 0.0.4
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
-BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+BASE_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/distroless/Dockerfile" | awk '{print $$2}')
+BUILDER_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/golang/Dockerfile" | awk '{print $$2}')
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/cmd/experimental/kueue-populator/Dockerfile
+++ b/cmd/experimental/kueue-populator/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -10,9 +10,7 @@ GO_FMT ?= gofmt
 
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/../../..
 BIN_DIR := $(ROOT_DIR)/bin
-
-# Use go.mod go version as a single source of truth of GO version.
-GO_VERSION := $(shell awk '/^go /{split($$2, v, "."); print v[1] "." v[2]}' $(ROOT_DIR)/go.mod|head -n1)
+HACK_DIR := $(ROOT_DIR)/hack
 
 HELM := $(BIN_DIR)/helm
 ENVTEST := $(BIN_DIR)/setup-envtest
@@ -44,9 +42,9 @@ IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(GIT_TAG)
 
 # Use distroless as minimal base image to package the manager binary
-BASE_IMAGE ?= gcr.io/distroless/static:nonroot
-BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+BASE_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/distroless/Dockerfile" | awk '{print $$2}')
+BUILDER_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/golang/Dockerfile" | awk '{print $$2}')
 CGO_ENABLED ?= 0
 
 $(YQ):

--- a/cmd/experimental/kueue-priority-booster/Dockerfile
+++ b/cmd/experimental/kueue-priority-booster/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/experimental/kueue-priority-booster/Makefile
+++ b/cmd/experimental/kueue-priority-booster/Makefile
@@ -10,9 +10,7 @@ GO_FMT ?= gofmt
 
 ROOT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))/../../..
 BIN_DIR := $(ROOT_DIR)/bin
-
-# Use go.mod go version as a single source of truth of GO version.
-GO_VERSION := $(shell awk '/^go /{split($$2, v, "."); print v[1] "." v[2]}' $(ROOT_DIR)/go.mod|head -n1)
+HACK_DIR := $(ROOT_DIR)/hack
 
 ENVTEST := $(BIN_DIR)/setup-envtest
 GINKGO := $(BIN_DIR)/ginkgo
@@ -40,9 +38,9 @@ IMAGE_REPO := $(IMAGE_REGISTRY)/$(IMAGE_NAME)
 IMAGE_TAG := $(IMAGE_REPO):$(GIT_TAG)
 
 # Use distroless as minimal base image to package the manager binary
-BASE_IMAGE ?= gcr.io/distroless/static:nonroot
-BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+BASE_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/distroless/Dockerfile" | awk '{print $$2}')
+BUILDER_IMAGE ?= $(shell grep '^FROM' "${HACK_DIR}/images/golang/Dockerfile" | awk '{print $$2}')
 CGO_ENABLED ?= 0
 
 $(GOTESTSUM):

--- a/cmd/importer/Dockerfile
+++ b/cmd/importer/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILDER_IMAGE
-ARG BASE_IMAGE
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 # Build the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 

--- a/cmd/kueueviz/backend/Dockerfile
+++ b/cmd/kueueviz/backend/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage
-ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
+ARG BUILDER_IMAGE=public.ecr.aws/docker/library/golang:1.26
+ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder
 
 COPY cmd/kueueviz/backend/go.mod cmd/kueueviz/backend/go.sum ./

--- a/hack/images/distroless/Dockerfile
+++ b/hack/images/distroless/Dockerfile
@@ -1,0 +1,1 @@
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240

--- a/hack/images/golang/Dockerfile
+++ b/hack/images/golang/Dockerfile
@@ -1,0 +1,1 @@
+FROM public.ecr.aws/docker/library/golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Use dependabot to bump golang and distroless versions.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13381

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized container image builds across application and experimental components by using shared Dockerfile-defined base image selections.
  * Simplified build configuration by deriving builder and runtime image defaults from the common image definitions, ensuring consistency across components.
  * Updated Docker build defaults to use tag-based image references (with shared definitions maintained for aligned builds).
* **Maintenance**
  * Expanded automated dependency updates to scan additional Docker image directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->