### PR TITLE
Fix table of content generation instructions in KEP template

### DIFF
--- a/keps/NNNN-template/README.md
+++ b/keps/NNNN-template/README.md
@@ -13,7 +13,7 @@ template.
 
 Ensure the TOC is wrapped with
   <code>&lt;!-- toc --&rt;&lt;!-- /toc --&rt;</code>
-tags, and then generate with `hack/update-toc.sh`.
+tags, build the mdtoc tool with `make mdtoc` and then generate the TOC with `hack/tools/mdtoc/generate.sh`.
 -->
 
 <!-- toc -->


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
TOC generation command in KEP template is out of date, leading to errors like:
```
hack/update-toc.sh: No such file or directory
``` 
This PR updates instructions, so that KEP writers can update TOC without additional hassle. 

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the KEP template instructions for generating the table of contents.
  * Replaced the previous command with the current two-step process for building and running the TOC generator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->