### PR TITLE
Guard against non-positive LocalQueue fair-sharing weight

### DIFF
--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -75,6 +75,10 @@ func TestScheduleForAFS(t *testing.T) {
 			FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
 			ClusterQueue("cq1").
 			Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-zero", "default").
+			FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("0"))}).
+			ClusterQueue("cq1").
+			Obj(),
 	}
 
 	cases := map[string]struct {
@@ -164,6 +168,94 @@ func TestScheduleForAFS(t *testing.T) {
 							).
 							Obj(),
 					).
+					Obj(),
+			},
+		},
+		// A LocalQueue with weight 0 must be the most disadvantaged, so its
+		// workload loses admission to a normal-weight queue even though it was
+		// submitted first. Both queues start idle on purpose: only 0 usage over
+		// 0 weight yields NaN, which sorts ahead of every real value; any
+		// non-zero usage already yields +Inf and sorts last.
+		"does not prioritize a zero-weight localqueue": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a":    {corev1.ResourceCPU: resource.MustParse("0")},
+				"lq-zero": {corev1.ResourceCPU: resource.MustParse("0")},
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-z1", "default").
+					Queue("lq-zero").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue cq1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("cq1").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("one").
+									Assignment(corev1.ResourceCPU, "default", "8").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-z1", "default").
+					Queue("lq-zero").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor default, 8 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("8"),
+						},
+					}).
 					Obj(),
 			},
 		},

--- a/pkg/util/admissionfairsharing/admission_fair_sharing.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing.go
@@ -94,6 +94,10 @@ func CalculateUsage(consumed, penalty corev1.ResourceList, lqWeight float64, res
 		}
 		usage += weight * resVal.AsApproximateFloat64()
 	}
+	// Avoid dividing by a non-positive weight: 0/0 is NaN, which would sort the queue first instead of last.
+	if lqWeight <= 0 {
+		return math.Inf(1)
+	}
 	return usage / lqWeight
 }
 

--- a/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
@@ -19,6 +19,7 @@ package admissionfairsharing
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -200,6 +201,40 @@ func TestCalculateUsageWithDRA(t *testing.T) {
 			got := CalculateUsage(tc.consumed, tc.penalty, tc.lqWeight, tc.resWeights)
 			if got != tc.wantUsage {
 				t.Errorf("CalculateUsage() = %v, want %v", got, tc.wantUsage)
+			}
+		})
+	}
+}
+
+func TestCalculateUsageWithNonPositiveWeight(t *testing.T) {
+	tests := map[string]struct {
+		consumed corev1.ResourceList
+		lqWeight float64
+	}{
+		"zero weight, idle queue (no usage)": {
+			consumed: corev1.ResourceList{},
+			lqWeight: 0,
+		},
+		"zero weight, active queue": {
+			consumed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			lqWeight: 0,
+		},
+		"negative weight": {
+			consumed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			lqWeight: -1,
+		},
+	}
+
+	// A non-positive weight must yield +Inf usage so the LocalQueue is sorted
+	// last in the admission order, never NaN (which would sort it first).
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := CalculateUsage(tc.consumed, corev1.ResourceList{}, tc.lqWeight, nil)
+			if math.IsNaN(got) {
+				t.Fatalf("CalculateUsage() = NaN, want +Inf")
+			}
+			if !math.IsInf(got, 1) {
+				t.Errorf("CalculateUsage() = %v, want +Inf", got)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
With AdmissionFairSharing enabled, `CalculateUsage` divided the per-LocalQueue usage score by the fair-sharing weight without guarding for zero. A LocalQueue with `fairSharing.weight: 0` (a value validation accepts) produced `0/0 = NaN` while idle, and since `NaN` sorts ahead of every real value in the admission ordering, that queue was served first instead of last, the opposite of the documented meaning of a zero weight.

This adds a guard so a non-positive weight yields an infinite usage, matching the ClusterQueue behavior in `DRS.PreciseWeightedShare`, which places the queue last in the admission order.

#### Which issue(s) this PR fixes:
Fixes #13479

#### Does this PR introduce a user-facing change?
```release-note
AFS: Fixed a bug where a LocalQueue with `fairSharing.weight: 0` could be prioritized for admission instead of deprioritized when AdmissionFairSharing is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FairSharing usage calculation for zero or negative queue weights by preventing invalid values and stabilizing admission ordering.
  * Ensured zero-weight queues do not outrank earlier workloads when usage would otherwise be ambiguous.

* **Tests**
  * Added unit coverage for non-positive weight handling, including verification of `+Inf` (not `NaN`).
  * Extended scheduler scenarios to confirm that workloads in zero-weight local queues are not prioritized over normal-weight workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->