### PR TITLE
scheduler: periodically retry inadmissible workloads

### DIFF
--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,8 +36,9 @@ import (
 )
 
 const (
-	requeueBatchPeriod     = 1 * time.Second
-	requeueLongBatchPeriod = 10 * time.Second
+	requeueBatchPeriod              = 1 * time.Second
+	requeueLongBatchPeriod          = 10 * time.Second
+	periodicInadmissibleRetryPeriod = 5 * time.Minute
 )
 
 func getRequeueBatchPeriod() time.Duration {
@@ -241,9 +243,11 @@ type requeueRequest struct {
 // workqueueRequeuer satisfies the inadmissibleRequeuer
 // interface, implemented via a workqueue.TypedDelayingQueue.
 type workqueueRequeuer struct {
-	manager     *Manager
-	queue       workqueue.TypedDelayingInterface[requeueRequest]
-	batchPeriod time.Duration
+	manager             *Manager
+	queue               workqueue.TypedDelayingInterface[requeueRequest]
+	batchPeriod         time.Duration
+	periodicRetryPeriod time.Duration
+	clock               clock.WithTicker
 }
 
 func NewRequeuer(opts ...RequeuerOption) *workqueueRequeuer {
@@ -254,8 +258,10 @@ func NewRequeuer(opts ...RequeuerOption) *workqueueRequeuer {
 		opt(&options)
 	}
 	return &workqueueRequeuer{
-		queue:       workqueue.NewTypedDelayingQueue[requeueRequest](),
-		batchPeriod: options.batchPeriod,
+		queue:               workqueue.NewTypedDelayingQueue[requeueRequest](),
+		batchPeriod:         options.batchPeriod,
+		periodicRetryPeriod: periodicInadmissibleRetryPeriod,
+		clock:               realClock,
 	}
 }
 
@@ -274,6 +280,7 @@ func (r *workqueueRequeuer) setManager(manager *Manager) {
 func (r *workqueueRequeuer) Start(ctx context.Context) error {
 	log := ctrl.LoggerFrom(ctx).WithName("inadmissible_workload_requeue_worker")
 	ctx = ctrl.LoggerInto(ctx, log)
+	go r.retryInadmissiblePeriodically(ctx)
 	go func() {
 		<-ctx.Done()
 		r.queue.ShutDown()
@@ -285,6 +292,19 @@ func (r *workqueueRequeuer) Start(ctx context.Context) error {
 		}
 		r.reconcile(ctx, item)
 		r.queue.Done(item)
+	}
+}
+
+func (r *workqueueRequeuer) retryInadmissiblePeriodically(ctx context.Context) {
+	ticker := r.clock.NewTicker(r.periodicRetryPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C():
+			NotifyRetryInadmissible(r.manager, sets.New(r.manager.GetClusterQueueNames()...))
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package queue
 
 import (
+	"context"
 	"maps"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
 
 	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -36,7 +40,8 @@ func TestNewRequeuer(t *testing.T) {
 	}
 
 	type want struct {
-		batchPeriod time.Duration
+		batchPeriod         time.Duration
+		periodicRetryPeriod time.Duration
 	}
 
 	testCases := map[string]struct {
@@ -50,7 +55,8 @@ func TestNewRequeuer(t *testing.T) {
 				},
 			},
 			want: want{
-				batchPeriod: time.Second,
+				batchPeriod:         time.Second,
+				periodicRetryPeriod: 5 * time.Minute,
 			},
 		},
 		"SchedulerLongRequeueInterval feature enabled": {
@@ -60,7 +66,8 @@ func TestNewRequeuer(t *testing.T) {
 				},
 			},
 			want: want{
-				batchPeriod: 10 * time.Second,
+				batchPeriod:         10 * time.Second,
+				periodicRetryPeriod: 5 * time.Minute,
 			},
 		},
 		"custom batch period": {
@@ -70,7 +77,8 @@ func TestNewRequeuer(t *testing.T) {
 				},
 			},
 			want: want{
-				batchPeriod: 10 * time.Millisecond,
+				batchPeriod:         10 * time.Millisecond,
+				periodicRetryPeriod: 5 * time.Minute,
 			},
 		},
 	}
@@ -81,7 +89,76 @@ func TestNewRequeuer(t *testing.T) {
 			if diff := cmp.Diff(tc.want.batchPeriod, requeuer.batchPeriod); len(diff) != 0 {
 				t.Errorf("Unexpected requeue batch period (-want,+got):\n%s", diff)
 			}
+			if diff := cmp.Diff(tc.want.periodicRetryPeriod, requeuer.periodicRetryPeriod); len(diff) != 0 {
+				t.Errorf("Unexpected periodic retry period (-want,+got):\n%s", diff)
+			}
 		})
+	}
+}
+
+func TestWorkqueueRequeuer_PeriodicRetry(t *testing.T) {
+	const retryPeriod = time.Minute
+	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cl := utiltesting.NewFakeClient(utiltesting.MakeNamespace("ns"))
+	manager, _ := NewManagerForUnitTestsWithRequeuer(cl, nil)
+	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding ClusterQueue: %v", err)
+	}
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Failed adding LocalQueue: %v", err)
+	}
+	wl := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Creation(time.Now()).Obj()
+	if err := cl.Create(ctx, wl); err != nil {
+		t.Fatalf("Failed adding Workload to client: %v", err)
+	}
+	manager.getClusterQueue("cq").popCycle++
+	manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+	if got := manager.DumpInadmissible(); len(got["cq"]) != 1 {
+		t.Fatalf("Workload is not in the inadmissible queue: %v", got)
+	}
+
+	fakeClock := testingclock.NewFakeClock(time.Now())
+	requeuer := NewRequeuer(WithBatchPeriod(0))
+	requeuer.clock = fakeClock
+	requeuer.periodicRetryPeriod = retryPeriod
+	requeuer.setManager(manager)
+	manager.requeuer = requeuer
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- requeuer.Start(ctx)
+	}()
+	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
+		return fakeClock.HasWaiters(), nil
+	}); err != nil {
+		t.Fatalf("Periodic retry did not start: %v", err)
+	}
+
+	fakeClock.Step(retryPeriod - time.Nanosecond)
+	if got := manager.DumpInadmissible(); len(got["cq"]) != 1 {
+		t.Fatalf("Workload retried before the periodic interval elapsed: %v", got)
+	}
+
+	fakeClock.Step(time.Nanosecond)
+	if err := wait.PollUntilContextTimeout(t.Context(), time.Millisecond, time.Second, true, func(context.Context) (bool, error) {
+		return len(manager.Dump()["cq"]) == 1, nil
+	}); err != nil {
+		t.Fatalf("Periodic retry did not move the Workload to the active heap: %v", err)
+	}
+
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Requeuer returned an error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Requeuer did not stop after context cancellation")
 	}
 }
 

--- a/pkg/cache/queue/periodic_retry_benchmark_test.go
+++ b/pkg/cache/queue/periodic_retry_benchmark_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func BenchmarkNotifyRetryAllClusterQueues(b *testing.B) {
+	for _, clusterQueueCount := range []int{10, 100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("clusterqueues-%d", clusterQueueCount), func(b *testing.B) {
+			manager, requeuer := NewManagerForUnitTestsWithRequeuer(nil, nil)
+			for i := range clusterQueueCount {
+				cq := newClusterQueueImpl(b.Context(), nil, workload.Ordering{}, realClock)
+				cq.name = kueue.ClusterQueueReference(fmt.Sprintf("cq-%d", i))
+				manager.hm.AddClusterQueue(cq)
+			}
+
+			b.ResetTimer()
+			for b.Loop() {
+				NotifyRetryInadmissible(
+					manager,
+					sets.New(manager.GetClusterQueueNames()...),
+				)
+				requeuer.cqs.Clear()
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Inadmissible workloads are currently reconsidered only when Kueue observes a known resource or configuration event. If an event is missed or not modeled, an otherwise schedulable workload can remain inadmissible indefinitely.

This adds a five-minute safety retry to the existing `InadmissibleWorkloadRequeuer`. Each tick enumerates the current ClusterQueues and uses `NotifyRetryInadmissible`, preserving the existing delaying-workqueue batching and root-Cohort deduplication. It adds no API or configuration.

The retry uses a fixed wall-clock interval. Resetting the interval after every unrelated scheduling cycle could indefinitely postpone recovery for a workload affected by a missing event.

AI usage disclosure: I used OpenAI Codex to assist with investigation, implementation, and test design under my direction. I reviewed the patch and independently ran the evidence below.

Evidence:

- Regression proof: with the periodic worker start removed, `TestWorkqueueRequeuer_PeriodicRetry` fails with `Periodic retry did not start: context deadline exceeded`; restoring it makes the test pass.
- The fake-clock test proves no early retry, retry at the interval boundary, movement from the inadmissible map to the active heap, and clean `Start` shutdown on context cancellation.
- `go test ./pkg/cache/queue -run 'Test(NewRequeuer|WorkqueueRequeuer_PeriodicRetry|QueueInadmissibleWorkloads)$' -count=20`
- `go test -race ./pkg/cache/queue -run 'Test(NewRequeuer|WorkqueueRequeuer_PeriodicRetry|QueueInadmissibleWorkloads)$' -count=1`
- `go test ./pkg/cache/... -count=1`
- `go test ./pkg/scheduler/... -count=1`
- `go vet ./pkg/cache/queue`
- Kueue's pinned `golangci-lint` v2.12.2 on `./pkg/cache/queue/...`: 0 issues.

The committed benchmark measures the ClusterQueue enumeration/deduplication notification path, not subsequent workload processing. On an Apple M4 Pro, three 500 ms runs measured:

| ClusterQueues | Time/op | Allocations/op |
|---:|---:|---:|
| 10 | 0.66–0.70 µs | 4 |
| 100 | 5.48–5.49 µs | 4 |
| 1,000 | 70.2–71.1 µs | 6 |
| 10,000 | 0.860–0.868 ms | 34 |

The repository `make fmt-verify` wrapper could not start on this macOS host because GNU `sed` is unavailable. The three changed Go files pass direct `gofmt -d`, and `git diff --check` is clean.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/7139

#### Special notes for your reviewer:

The issue discussion also suggested triggering five minutes after the last scheduling cycle. I chose a fixed safety interval to avoid unrelated cycles starving recovery; I can revise this if maintainers prefer the inactivity-based interpretation.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inadmissible workloads are now retried automatically every five minutes.
  * Periodic retries cover all managed cluster queues and stop cleanly when processing is shut down.

* **Bug Fixes**
  * Workloads can return to active processing without requiring a separate retry trigger.

* **Tests**
  * Added coverage for timed retries, shutdown behavior, and retry performance at scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->