### PR TITLE
test: add RayCluster worker Pod lookup helper

### DIFF
--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -92,13 +92,14 @@ func rayServeCurlCmd(rayServiceName, query string) []string {
 	return []string{"curl", "-sS", "--fail", "--max-time", "60", "--retry", "5", "--retry-connrefused", "--retry-delay", "2", fmt.Sprintf("http://%s:8000/%s", serveSvcName, query)}
 }
 
-func waitForRayServiceReadyToServe(rayService *rayv1.RayService) {
+func waitForRayServiceReadyToServe(rayService *rayv1.RayService) *rayv1.RayService {
 	createdRayService := &rayv1.RayService{}
 	gomega.Eventually(func(g gomega.Gomega) {
 		g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
 		g.Expect(createdRayService.Spec.RayClusterSpec.Suspend).To(gomega.Equal(new(false)))
 		g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 	}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayService did not become ready to serve", createdRayService))
+	return createdRayService
 }
 
 func startServeClientPod(ns string) *corev1.Pod {
@@ -124,23 +125,6 @@ var _ = ginkgo.Describe("Kuberay", ginkgo.Label("area:singlecluster", "feature:k
 		clusterQueueName   string
 		localQueueName     string
 	)
-
-	getRunningRayWorkerPodNames := func(g gomega.Gomega) []string {
-		pods := &corev1.PodList{}
-		g.Expect(k8sClient.List(ctx, pods,
-			client.InNamespace(ns.Name),
-			client.MatchingLabels{
-				"ray.io/node-type": "worker",
-			},
-		)).To(gomega.Succeed())
-		var podNames []string
-		for _, pod := range pods.Items {
-			if strings.Contains(pod.Name, "workers") && pod.Status.Phase == corev1.PodRunning {
-				podNames = append(podNames, pod.Name)
-			}
-		}
-		return podNames
-	}
 
 	ginkgo.BeforeEach(func() {
 		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "kuberay-e2e-")
@@ -369,14 +353,15 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("No admitted workload found in namespace", workloadList))
 		})
 
+		createdRayJob := &rayv1.RayJob{}
 		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
-			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
+		rayClusterKey := client.ObjectKey{Namespace: createdRayJob.Namespace, Name: createdRayJob.Status.RayClusterName}
 
 		ginkgo.By("Waiting for 3 pods in rayjob namespace", func() {
 			// 3 rayjob pods: head, worker, submitter job
@@ -390,8 +375,9 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 		ginkgo.By("Waiting for exactly 1 worker pod", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workerPodNames := getRunningRayWorkerPodNames(g)
-				g.Expect(workerPodNames).To(gomega.HaveLen(1), "Expected exactly 1 pod with 'workers' in the name")
+				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(workerPods).To(gomega.HaveLen(1), "Expected exactly 1 running worker Pod")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
 		})
 
@@ -408,32 +394,30 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 		ginkgo.By("Waiting for all 2 worker pods to be running", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers := getRunningRayWorkerPodNames(g)
+				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe 2 running worker pods", podList))
 		})
 
 		var deletedPodName string
 		ginkgo.By("Deleting one worker pod", func() {
-			runningWorkers := getRunningRayWorkerPodNames(gomega.Default)
+			runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(runningWorkers).NotTo(gomega.BeEmpty())
-			deletedPodName = runningWorkers[0]
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      deletedPodName,
-					Namespace: ns.Name,
-				},
-			}
-			gomega.Expect(k8sClient.Delete(ctx, pod)).To(gomega.Succeed())
+			deletedPodName = runningWorkers[0].Name
+			gomega.Expect(k8sClient.Delete(ctx, &runningWorkers[0])).To(gomega.Succeed())
 		})
 
 		ginkgo.By("Waiting for a new worker pod to replace the deleted one", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers := getRunningRayWorkerPodNames(g)
+				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods after replacement")
-				g.Expect(runningWorkers).NotTo(gomega.ContainElement(deletedPodName),
-					"Deleted pod should not be present among running workers")
+				for _, pod := range runningWorkers {
+					g.Expect(pod.Name).NotTo(gomega.Equal(deletedPodName), "Deleted pod should not be present among running workers")
+				}
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList(fmt.Sprintf("Replacement worker pod did not appear after deleting %q", deletedPodName), podList))
 		})
 
@@ -569,14 +553,15 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("No admitted workload found in namespace", workloadList))
 		})
 
+		createdRayJob := &rayv1.RayJob{}
 		ginkgo.By("Waiting for the RayJob cluster become ready", func() {
-			createdRayJob := &rayv1.RayJob{}
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
 				g.Expect(createdRayJob.Spec.Suspend).To(gomega.BeFalse())
 				g.Expect(createdRayJob.Status.JobDeploymentStatus).To(gomega.Equal(rayv1.JobDeploymentStatusRunning))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("RayJob cluster did not become ready", createdRayJob))
 		})
+		rayClusterKey := client.ObjectKey{Namespace: createdRayJob.Namespace, Name: createdRayJob.Status.RayClusterName}
 
 		// The Ray autoscaler can scale workers past minReplicas before the RayJob
 		// transitions to JobDeploymentStatusRunning, so the initial pod and worker
@@ -592,8 +577,9 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 
 		ginkgo.By("Waiting for at least 1 worker pod", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				workerPodNames := getRunningRayWorkerPodNames(g)
-				g.Expect(workerPodNames).ToNot(gomega.BeEmpty(), "Expected at least 1 pod with 'workers' in the name")
+				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(workerPods).ToNot(gomega.BeEmpty(), "Expected at least 1 running worker Pod")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), "Expected at least 1 worker pod")
 		})
 
@@ -609,8 +595,9 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 
 		ginkgo.By("Waiting for second scale-up to 5 workers due to high parallelism tasks", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				currentPodNames := getRunningRayWorkerPodNames(g)
-				g.Expect(currentPodNames).To(gomega.HaveLen(5), "Expected exactly 5 pods with 'workers' in the name after second scale-up")
+				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
+				g.Expect(workerPods).To(gomega.HaveLen(5), "Expected exactly 5 running worker Pods after second scale-up")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), "Did not scale up to 5 worker pods")
 		})
 
@@ -1185,8 +1172,13 @@ app = HelloWorld.bind()`,
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		var rayClusterKey client.ObjectKey
 		ginkgo.By("Waiting for the RayService to be ready to serve traffic", func() {
-			waitForRayServiceReadyToServe(rayService)
+			createdRayService := waitForRayServiceReadyToServe(rayService)
+			rayClusterKey = client.ObjectKey{
+				Namespace: createdRayService.Namespace,
+				Name:      createdRayService.Status.ActiveServiceStatus.RayClusterName,
+			}
 		})
 
 		clientPod := startServeClientPod(ns.Name)
@@ -1199,7 +1191,8 @@ app = HelloWorld.bind()`,
 
 		ginkgo.By("Waiting for worker count to be zero due to autoscaling", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers := getRunningRayWorkerPodNames(g)
+				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.BeEmpty(), "Expected 0 running worker pod before sending load")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -1227,7 +1220,8 @@ app = HelloWorld.bind()`,
 
 		ginkgo.By("Waiting for worker count to increase due to autoscaling", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers := getRunningRayWorkerPodNames(g)
+				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(len(runningWorkers)).To(gomega.BeNumerically(">", 1),
 					fmt.Sprintf("Expected more than %d running worker pods after autoscaling", 1))
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -375,7 +375,7 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 		ginkgo.By("Waiting for exactly 1 worker pod", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(workerPods).To(gomega.HaveLen(1), "Expected exactly 1 running worker Pod")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Expected exactly 1 worker pod", podList))
@@ -394,7 +394,7 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 		ginkgo.By("Waiting for all 2 worker pods to be running", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				runningWorkers, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe 2 running worker pods", podList))
@@ -402,7 +402,7 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 
 		var deletedPodName string
 		ginkgo.By("Deleting one worker pod", func() {
-			runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+			runningWorkers, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			gomega.Expect(runningWorkers).NotTo(gomega.BeEmpty())
 			deletedPodName = runningWorkers[0].Name
@@ -412,7 +412,7 @@ print(ray.get([my_task.remote(i, 10) for i in range(20)]))`,
 		ginkgo.By("Waiting for a new worker pod to replace the deleted one", func() {
 			podList := &corev1.PodList{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				runningWorkers, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.HaveLen(2), "Expected 2 running worker pods after replacement")
 				for _, pod := range runningWorkers {
@@ -577,7 +577,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 
 		ginkgo.By("Waiting for at least 1 worker pod", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(workerPods).ToNot(gomega.BeEmpty(), "Expected at least 1 running worker Pod")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), "Expected at least 1 worker pod")
@@ -595,7 +595,7 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 
 		ginkgo.By("Waiting for second scale-up to 5 workers due to high parallelism tasks", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(workerPods).To(gomega.HaveLen(5), "Expected exactly 5 running worker Pods after second scale-up")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), "Did not scale up to 5 worker pods")
@@ -1191,7 +1191,7 @@ app = HelloWorld.bind()`,
 
 		ginkgo.By("Waiting for worker count to be zero due to autoscaling", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				runningWorkers, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(runningWorkers).To(gomega.BeEmpty(), "Expected 0 running worker pod before sending load")
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
@@ -1220,7 +1220,7 @@ app = HelloWorld.bind()`,
 
 		ginkgo.By("Waiting for worker count to increase due to autoscaling", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				runningWorkers, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, rayClusterKey)
+				runningWorkers, err := util.GetRayClusterWorkerPods(ctx, k8sClient, rayClusterKey, corev1.PodRunning)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(len(runningWorkers)).To(gomega.BeNumerically(">", 1),
 					fmt.Sprintf("Expected more than %d running worker pods after autoscaling", 1))

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -212,15 +212,13 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, gi
 			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, client.ObjectKey{
-						Namespace: rayjob.Namespace,
-						Name:      rayjob.Status.RayClusterName,
-					})
-					g.Expect(err).NotTo(gomega.HaveOccurred())
-					gotAssignment := readAssignedNodes(workerPods)
-					g.Expect(gotAssignment).Should(gomega.HaveLen(workerReplicas))
-				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, client.ObjectKey{
+					Namespace: rayjob.Namespace,
+					Name:      rayjob.Status.RayClusterName,
+				})
+				gomega.Expect(err).NotTo(gomega.HaveOccurred())
+				gotAssignment := readAssignedNodes(workerPods)
+				gomega.Expect(gotAssignment).Should(gomega.HaveLen(workerReplicas))
 			})
 		})
 	})

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -212,9 +212,15 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, gi
 			})
 
 			ginkgo.By("verify the assignment of pods are as expected with rank-based ordering", func() {
-				gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
-				gotAssignment := readAssignedNodes(pods.Items)
-				gomega.Expect(gotAssignment).Should(gomega.HaveLen(workerReplicas))
+				gomega.Eventually(func(g gomega.Gomega) {
+					workerPods, err := util.GetRunningRayClusterWorkerPods(ctx, k8sClient, client.ObjectKey{
+						Namespace: rayjob.Namespace,
+						Name:      rayjob.Status.RayClusterName,
+					})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					gotAssignment := readAssignedNodes(workerPods)
+					g.Expect(gotAssignment).Should(gomega.HaveLen(workerReplicas))
+				}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})
@@ -223,9 +229,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, gi
 func readAssignedNodes(pods []corev1.Pod) set.Set[string] {
 	assignment := set.New[string]()
 	for _, pod := range pods {
-		if role := pod.Labels["ray.io/node-type"]; role == "worker" {
-			assignment = assignment.Insert(pod.Spec.NodeName)
-		}
+		assignment = assignment.Insert(pod.Spec.NodeName)
 	}
 	return assignment
 }

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, gi
 				workerPods, err := util.GetRayClusterWorkerPods(ctx, k8sClient, client.ObjectKey{
 					Namespace: rayjob.Namespace,
 					Name:      rayjob.Status.RayClusterName,
-				})
+				}, "")
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				gotAssignment := readAssignedNodes(workerPods)
 				gomega.Expect(gotAssignment).Should(gomega.HaveLen(workerReplicas))

--- a/test/util/kuberay.go
+++ b/test/util/kuberay.go
@@ -43,3 +43,24 @@ func GetRayClusterHeadPod(ctx context.Context, c client.Client, rayClusterKey cl
 	}
 	return &pods.Items[0], nil
 }
+
+// GetRunningRayClusterWorkerPods returns the running worker Pods associated with the RayCluster.
+func GetRunningRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey) ([]corev1.Pod, error) {
+	pods := &corev1.PodList{}
+	if err := c.List(ctx, pods,
+		client.InNamespace(rayClusterKey.Namespace),
+		client.MatchingLabels{
+			kuberayutils.RayClusterLabelKey:  rayClusterKey.Name,
+			kuberayutils.RayNodeTypeLabelKey: string(rayv1.WorkerNode),
+		},
+	); err != nil {
+		return nil, err
+	}
+	runningPods := make([]corev1.Pod, 0, len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			runningPods = append(runningPods, pod)
+		}
+	}
+	return runningPods, nil
+}

--- a/test/util/kuberay.go
+++ b/test/util/kuberay.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"fmt"
-	"slices"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	kuberayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -46,9 +45,9 @@ func GetRayClusterHeadPod(ctx context.Context, c client.Client, rayClusterKey cl
 }
 
 // GetRayClusterWorkerPods returns the worker Pods associated with the RayCluster
-// whose phase matches one of the provided phases. If no phase is provided, it
-// returns all associated worker Pods.
-func GetRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey, phases ...corev1.PodPhase) ([]corev1.Pod, error) {
+// whose phase matches the provided phase. If phase is empty, it returns all
+// associated worker Pods.
+func GetRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey, phase corev1.PodPhase) ([]corev1.Pod, error) {
 	pods := &corev1.PodList{}
 	if err := c.List(ctx, pods,
 		client.InNamespace(rayClusterKey.Namespace),
@@ -59,12 +58,12 @@ func GetRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey
 	); err != nil {
 		return nil, err
 	}
-	if len(phases) == 0 {
+	if phase == "" {
 		return pods.Items, nil
 	}
 	filteredPods := make([]corev1.Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
-		if slices.Contains(phases, pod.Status.Phase) {
+		if pod.Status.Phase == phase {
 			filteredPods = append(filteredPods, pod)
 		}
 	}

--- a/test/util/kuberay.go
+++ b/test/util/kuberay.go
@@ -19,6 +19,7 @@ package util
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	kuberayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
@@ -44,8 +45,10 @@ func GetRayClusterHeadPod(ctx context.Context, c client.Client, rayClusterKey cl
 	return &pods.Items[0], nil
 }
 
-// GetRunningRayClusterWorkerPods returns the running worker Pods associated with the RayCluster.
-func GetRunningRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey) ([]corev1.Pod, error) {
+// GetRayClusterWorkerPods returns the worker Pods associated with the RayCluster
+// whose phase matches one of the provided phases. If no phase is provided, it
+// returns all associated worker Pods.
+func GetRayClusterWorkerPods(ctx context.Context, c client.Client, rayClusterKey client.ObjectKey, phases ...corev1.PodPhase) ([]corev1.Pod, error) {
 	pods := &corev1.PodList{}
 	if err := c.List(ctx, pods,
 		client.InNamespace(rayClusterKey.Namespace),
@@ -56,11 +59,14 @@ func GetRunningRayClusterWorkerPods(ctx context.Context, c client.Client, rayClu
 	); err != nil {
 		return nil, err
 	}
-	runningPods := make([]corev1.Pod, 0, len(pods.Items))
+	if len(phases) == 0 {
+		return pods.Items, nil
+	}
+	filteredPods := make([]corev1.Pod, 0, len(pods.Items))
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == corev1.PodRunning {
-			runningPods = append(runningPods, pod)
+		if slices.Contains(phases, pod.Status.Phase) {
+			filteredPods = append(filteredPods, pod)
 		}
 	}
-	return runningPods, nil
+	return filteredPods, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations
/area testing

#### What this PR does / why we need it:

Adds a shared `GetRayClusterWorkerPods` test helper that identifies worker Pods using the same namespace, RayCluster, and node-type labels as KubeRay's `RayClusterWorkerPodsAssociationOptions`. Callers can optionally filter the result by Pod phase.

The TAS and single-cluster KubeRay end-to-end tests now use the helper instead of listing all Pods in the namespace and filtering worker Pods locally. This also removes the name-based `getRunningRayWorkerPodNames` helper and prepares a reusable helper for #13376.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The selector follows KubeRay's association logic:
https://github.com/ray-project/kuberay/blob/master/ray-operator/controllers/ray/common/association.go#L93

AI tooling was used to help implement and review this change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation of RayJob and RayService worker scaling, readiness, and replacement behavior.
  * Updated rank-ordering checks to evaluate assignments from the relevant worker pods.
  * Added consistent filtering of worker pods by RayCluster and pod phase for more reliable test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->