### PR TITLE
Count permanently failed indexes as reclaimable Pods

### DIFF
--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -17,8 +17,10 @@ limitations under the License.
 package job
 
 import (
+	"cmp"
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -217,24 +219,27 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
 	completions := ptr.Deref(j.Spec.Completions, parallelism)
 
-	// Indexed Job: derive the succeeded count from completedIndexes, ignoring
-	// indexes >= completions. After an elastic scale-down, Status.Succeeded may
-	// still include the removed indexes (kueue#13117).
-	succeeded := j.Status.Succeeded
+	// Indexed Job: derive the terminal count from completedIndexes and
+	// failedIndexes, ignoring indexes >= completions. Status counters may still
+	// include indexes removed by an elastic scale-down (kueue#13117).
+	terminalCount := j.Status.Succeeded
 	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
-		succeeded = completedIndexesCount(log, j.Status.CompletedIndexes, completions)
-		log.V(3).Info("Derived completed pods from completedIndexes for Indexed Job",
+		failedIndexes := ptr.Deref(j.Status.FailedIndexes, "")
+		terminalCount = terminalIndexesCount(log, j.Status.CompletedIndexes, failedIndexes, completions)
+		log.V(3).Info("Derived terminal pods from index status for Indexed Job",
 			"completedIndexes", j.Status.CompletedIndexes,
+			"failedIndexes", failedIndexes,
 			"completions", completions,
-			"derivedSucceeded", succeeded,
-			"statusSucceeded", j.Status.Succeeded)
+			"derivedTerminal", terminalCount,
+			"statusSucceeded", j.Status.Succeeded,
+			"statusFailed", j.Status.Failed)
 	}
 
-	// A single-pod Job or one with no completed pods has nothing to reclaim; so
+	// A single-pod Job or one with no terminal pods has nothing to reclaim; so
 	// does one whose remaining work still fills every parallel slot.
 	reclaimable := int32(0)
-	if parallelism > 1 && succeeded > 0 {
-		if remaining := max(completions-succeeded, 0); remaining < parallelism {
+	if parallelism > 1 && terminalCount > 0 {
+		if remaining := max(completions-terminalCount, 0); remaining < parallelism {
 			reclaimable = parallelism - remaining
 		}
 	}
@@ -242,7 +247,7 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	log.V(3).Info("Computed reclaimable pods for Job",
 		"parallelism", parallelism,
 		"completions", completions,
-		"succeeded", succeeded,
+		"terminalCount", terminalCount,
 		"reclaimable", reclaimable)
 
 	if reclaimable == 0 {
@@ -254,33 +259,56 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	}}, nil
 }
 
-// completedIndexesCount returns the number of indexes listed in an Indexed Job's
-// status.completedIndexes that are below completions. completedIndexes uses the
-// Kubernetes format: an ascending, comma-separated list of intervals where each
-// interval is a single index ("3") or an inclusive range ("3-5"), e.g. "1,3-5,7".
-// Capping the intervals at completions gives the number of completed pods within
-// the current pod set even while status.Succeeded is briefly stale after a
-// scale-down (kueue#13117).
-func completedIndexesCount(log logr.Logger, completedIndexes string, completions int32) int32 {
-	if completedIndexes == "" || completions <= 0 {
+type indexInterval struct {
+	first int
+	last  int
+}
+
+// terminalIndexesCount returns the number of unique completed and failed indexes
+// below completions. Capping the intervals at completions keeps the count within
+// the current pod set while status counters are stale after a scale-down (kueue#13117).
+func terminalIndexesCount(log logr.Logger, completedIndexes, failedIndexes string, completions int32) int32 {
+	if completions <= 0 {
 		return 0
 	}
+
 	limit := int(completions)
-	count := 0
-	for interval := range strings.SplitSeq(completedIndexes, ",") {
-		first, last, ok := parseIndexRange(log, interval)
-		if !ok {
+	var intervals []indexInterval
+	for _, indexes := range []string{completedIndexes, failedIndexes} {
+		if indexes == "" {
 			continue
 		}
-		last = min(last, limit-1)
-		if first <= last {
-			count += last - first + 1
+		for interval := range strings.SplitSeq(indexes, ",") {
+			first, last, ok := parseIndexRange(log, interval)
+			if !ok {
+				continue
+			}
+			last = min(last, limit-1)
+			if first <= last {
+				intervals = append(intervals, indexInterval{first: first, last: last})
+			}
 		}
+	}
+	// Older supported Kubernetes versions don't reject overlapping completed and
+	// failed index sets, so count their union to avoid reclaiming quota twice.
+	slices.SortFunc(intervals, func(a, b indexInterval) int {
+		return cmp.Compare(a.first, b.first)
+	})
+
+	count := 0
+	lastCounted := -1
+	for _, interval := range intervals {
+		firstUncounted := max(interval.first, lastCounted+1)
+		if firstUncounted > interval.last {
+			continue
+		}
+		count += interval.last - firstUncounted + 1
+		lastCounted = interval.last
 	}
 	return int32(count)
 }
 
-// parseIndexRange parses a single completedIndexes interval ("3" or "3-5") into
+// parseIndexRange parses a single index interval ("3" or "3-5") into
 // its inclusive [first, last] bounds. It returns ok=false and logs when the
 // interval is malformed or descending; the Job controller always writes
 // well-formed, ascending indexes, so a failure here signals unexpected status
@@ -289,19 +317,19 @@ func parseIndexRange(log logr.Logger, interval string) (first, last int, ok bool
 	firstStr, lastStr, isRange := strings.Cut(interval, "-")
 	first, err := strconv.Atoi(firstStr)
 	if err != nil {
-		log.V(3).Info("Ignoring malformed completedIndexes interval", "interval", interval, "error", err)
+		log.V(3).Info("Ignoring malformed index interval", "interval", interval, "error", err)
 		return 0, 0, false
 	}
 	last = first
 	if isRange {
 		if last, err = strconv.Atoi(lastStr); err != nil {
-			log.V(3).Info("Ignoring malformed completedIndexes interval", "interval", interval, "error", err)
+			log.V(3).Info("Ignoring malformed index interval", "interval", interval, "error", err)
 			return 0, 0, false
 		}
 	}
 	// first is never negative, so only a descending range like "5-3" is invalid.
 	if last < first {
-		log.V(3).Info("Ignoring descending completedIndexes interval", "interval", interval)
+		log.V(3).Info("Ignoring descending index interval", "interval", interval)
 		return 0, 0, false
 	}
 	return first, last, true

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -219,9 +219,6 @@ func (j *Job) ReclaimablePods(ctx context.Context, _ client.Client) ([]kueue.Rec
 	parallelism := ptr.Deref(j.Spec.Parallelism, 1)
 	completions := ptr.Deref(j.Spec.Completions, parallelism)
 
-	// Indexed Job: derive the terminal count from completedIndexes and
-	// failedIndexes, ignoring indexes >= completions. Status counters may still
-	// include indexes removed by an elastic scale-down (kueue#13117).
 	terminalCount := j.Status.Succeeded
 	if ptr.Deref(j.Spec.CompletionMode, batchv1.NonIndexedCompletion) == batchv1.IndexedCompletion {
 		failedIndexes := ptr.Deref(j.Status.FailedIndexes, "")
@@ -264,9 +261,10 @@ type indexInterval struct {
 	last  int
 }
 
-// terminalIndexesCount returns the number of unique completed and failed indexes
-// below completions. Capping the intervals at completions keeps the count within
-// the current pod set while status counters are stale after a scale-down (kueue#13117).
+// terminalIndexesCount returns how many of an Indexed Job's indexes will never
+// run again: completed ones, plus failed ones that exhausted backoffLimitPerIndex.
+// Kueue can reclaim their quota. Indexes >= completions are ignored because an
+// elastic scale-down removed them, even if stale status still lists them (kueue#13117).
 func terminalIndexesCount(log logr.Logger, completedIndexes, failedIndexes string, completions int32) int32 {
 	if completions <= 0 {
 		return 0

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4584,6 +4584,7 @@ func TestTerminalIndexesCount(t *testing.T) {
 		"mixed intervals":               {completedIndexes: "0-4,7,9-11", completions: 10, want: 7},
 		"completed and failed indexes":  {completedIndexes: "0-2,7", failedIndexes: "3-5,8", completions: 10, want: 8},
 		"overlapping terminal indexes":  {completedIndexes: "0-4", failedIndexes: "3-7", completions: 10, want: 8},
+		"contained failed indexes":      {completedIndexes: "0-9", failedIndexes: "2-3", completions: 10, want: 10},
 		"surviving low indexes":         {completedIndexes: "0-8", completions: 10, want: 9},
 		"all completed within range":    {completedIndexes: "0-14", completions: 10, want: 10},
 		"range straddling the cap":      {completedIndexes: "5-19", completions: 10, want: 5},
@@ -4614,19 +4615,19 @@ func TestReclaimablePods(t *testing.T) {
 		j.Status.Failed = failed
 		j.Status.CompletedIndexes = completedIndexes
 		if failedIndexes != "" {
-			j.Spec.BackoffLimitPerIndex = new(int32(0))
+			j.Spec.BackoffLimitPerIndex = ptr.To[int32](0)
 			j.Status.FailedIndexes = new(failedIndexes)
 		}
 		return (*Job)(j)
 	}
 	retryableFailureJob := indexedJob(1, 1, "0", "")
-	retryableFailureJob.Spec.BackoffLimitPerIndex = new(int32(1))
+	retryableFailureJob.Spec.BackoffLimitPerIndex = ptr.To[int32](1)
 	cases := map[string]struct {
 		job  *Job
 		want []kueue.ReclaimablePod
 	}{
 		// An ordinary (non-elastic) Indexed Job must reclaim its completed indexes
-		// exactly as before, now that the count is derived from completedIndexes.
+		// exactly as before, now that the count is derived from the terminal index sets.
 		"indexed Job reclaims its completed indexes": {
 			job:  indexedJob(4, 0, "0-3", ""),
 			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 4}},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4604,13 +4604,14 @@ func TestTerminalIndexesCount(t *testing.T) {
 }
 
 func TestReclaimablePods(t *testing.T) {
-	indexedJob := func(succeeded int32, completedIndexes, failedIndexes string) *Job {
+	indexedJob := func(succeeded, failed int32, completedIndexes, failedIndexes string) *Job {
 		j := utiltestingjob.MakeJob("job", "ns").
 			Indexed(true).
 			Parallelism(8).
 			Completions(8).
 			Obj()
 		j.Status.Succeeded = succeeded
+		j.Status.Failed = failed
 		j.Status.CompletedIndexes = completedIndexes
 		if failedIndexes != "" {
 			j.Spec.BackoffLimitPerIndex = new(int32(0))
@@ -4618,6 +4619,8 @@ func TestReclaimablePods(t *testing.T) {
 		}
 		return (*Job)(j)
 	}
+	retryableFailureJob := indexedJob(1, 1, "0", "")
+	retryableFailureJob.Spec.BackoffLimitPerIndex = new(int32(1))
 	cases := map[string]struct {
 		job  *Job
 		want []kueue.ReclaimablePod
@@ -4625,18 +4628,22 @@ func TestReclaimablePods(t *testing.T) {
 		// An ordinary (non-elastic) Indexed Job must reclaim its completed indexes
 		// exactly as before, now that the count is derived from completedIndexes.
 		"indexed Job reclaims its completed indexes": {
-			job:  indexedJob(4, "0-3", ""),
+			job:  indexedJob(4, 0, "0-3", ""),
 			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 4}},
 		},
+		"indexed Job holds quota for a retryable failure": {
+			job:  retryableFailureJob,
+			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 1}},
+		},
 		"indexed Job reclaims completed and failed indexes": {
-			job:  indexedJob(1, "0", "1"),
+			job:  indexedJob(1, 1, "0", "1"),
 			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 2}},
 		},
 		// Status counters without terminal index sets should not happen with the
 		// native Job controller, but can with a custom spec.managedBy controller.
 		// We trust completedIndexes and failedIndexes and hold the quota.
 		"indexed Job with empty terminal indexes holds quota": {
-			job:  indexedJob(4, "", ""),
+			job:  indexedJob(4, 0, "", ""),
 			want: nil,
 		},
 	}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4569,17 +4569,21 @@ func TestCleanLabels(t *testing.T) {
 	}
 }
 
-func TestCompletedIndexesCount(t *testing.T) {
+func TestTerminalIndexesCount(t *testing.T) {
 	cases := map[string]struct {
 		completedIndexes string
+		failedIndexes    string
 		completions      int32
 		want             int32
 	}{
 		"empty":                         {completedIndexes: "", completions: 10, want: 0},
 		"zero completions":              {completedIndexes: "0-9", completions: 0, want: 0},
-		"single index":                  {completedIndexes: "0", completions: 10, want: 1},
+		"single completed index":        {completedIndexes: "0", completions: 10, want: 1},
+		"single failed index":           {failedIndexes: "1", completions: 10, want: 1},
 		"single range":                  {completedIndexes: "0-4", completions: 10, want: 5},
 		"mixed intervals":               {completedIndexes: "0-4,7,9-11", completions: 10, want: 7},
+		"completed and failed indexes":  {completedIndexes: "0-2,7", failedIndexes: "3-5,8", completions: 10, want: 8},
+		"overlapping terminal indexes":  {completedIndexes: "0-4", failedIndexes: "3-7", completions: 10, want: 8},
 		"surviving low indexes":         {completedIndexes: "0-8", completions: 10, want: 9},
 		"all completed within range":    {completedIndexes: "0-14", completions: 10, want: 10},
 		"range straddling the cap":      {completedIndexes: "5-19", completions: 10, want: 5},
@@ -4592,15 +4596,15 @@ func TestCompletedIndexesCount(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := completedIndexesCount(logr.Discard(), tc.completedIndexes, tc.completions); got != tc.want {
-				t.Errorf("completedIndexesCount(%q, %d) = %d, want %d", tc.completedIndexes, tc.completions, got, tc.want)
+			if got := terminalIndexesCount(logr.Discard(), tc.completedIndexes, tc.failedIndexes, tc.completions); got != tc.want {
+				t.Errorf("terminalIndexesCount(%q, %q, %d) = %d, want %d", tc.completedIndexes, tc.failedIndexes, tc.completions, got, tc.want)
 			}
 		})
 	}
 }
 
 func TestReclaimablePods(t *testing.T) {
-	indexedJob := func(succeeded int32, completedIndexes string) *Job {
+	indexedJob := func(succeeded int32, completedIndexes, failedIndexes string) *Job {
 		j := utiltestingjob.MakeJob("job", "ns").
 			Indexed(true).
 			Parallelism(8).
@@ -4608,6 +4612,10 @@ func TestReclaimablePods(t *testing.T) {
 			Obj()
 		j.Status.Succeeded = succeeded
 		j.Status.CompletedIndexes = completedIndexes
+		if failedIndexes != "" {
+			j.Spec.BackoffLimitPerIndex = new(int32(0))
+			j.Status.FailedIndexes = new(failedIndexes)
+		}
 		return (*Job)(j)
 	}
 	cases := map[string]struct {
@@ -4617,14 +4625,18 @@ func TestReclaimablePods(t *testing.T) {
 		// An ordinary (non-elastic) Indexed Job must reclaim its completed indexes
 		// exactly as before, now that the count is derived from completedIndexes.
 		"indexed Job reclaims its completed indexes": {
-			job:  indexedJob(4, "0-3"),
+			job:  indexedJob(4, "0-3", ""),
 			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 4}},
 		},
-		// Succeeded set without completedIndexes should not happen with the native
-		// Job controller (both are written in one update), but can with a custom
-		// spec.managedBy controller. We trust completedIndexes and hold the quota.
-		"indexed Job with empty completedIndexes holds quota": {
-			job:  indexedJob(4, ""),
+		"indexed Job reclaims completed and failed indexes": {
+			job:  indexedJob(1, "0", "1"),
+			want: []kueue.ReclaimablePod{{Name: kueue.DefaultPodSetName, Count: 2}},
+		},
+		// Status counters without terminal index sets should not happen with the
+		// native Job controller, but can with a custom spec.managedBy controller.
+		// We trust completedIndexes and failedIndexes and hold the quota.
+		"indexed Job with empty terminal indexes holds quota": {
+			job:  indexedJob(4, "", ""),
 			want: nil,
 		},
 	}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -2486,7 +2486,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			Indexed(true).
 			Parallelism(3).
 			Completions(3).
-			BackoffLimitPerIndex(0).
+			BackoffLimitPerIndex(1).
 			Obj()
 		testJob.Spec.MaxFailedIndexes = new(int32(3))
 
@@ -2499,12 +2499,53 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
+		ginkgo.By("waiting for the admitted job to reserve its full quota")
+		gomega.Eventually(func(g gomega.Gomega) {
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodClusterQ), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage).Should(gomega.ContainElement(kueue.FlavorUsage{
+				Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				Resources: []kueue.ResourceUsage{{
+					Name:     corev1.ResourceCPU,
+					Total:    resource.MustParse("300m"),
+					Borrowed: resource.MustParse("0"),
+				}},
+			}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("recording a failed attempt that can still be retried")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Status.Active = 2
+			testJob.Status.Failed = 1
+			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("retaining quota for the retryable index")
+		gomega.Consistently(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeEmpty())
+
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodClusterQ), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage).Should(gomega.ContainElement(kueue.FlavorUsage{
+				Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				Resources: []kueue.ResourceUsage{{
+					Name:     corev1.ResourceCPU,
+					Total:    resource.MustParse("300m"),
+					Borrowed: resource.MustParse("0"),
+				}},
+			}))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
 		ginkgo.By("marking one index completed and one permanently failed")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
 			testJob.Status.Active = 1
 			testJob.Status.Succeeded = 1
-			testJob.Status.Failed = 1
+			testJob.Status.Failed = 2
 			testJob.Status.CompletedIndexes = "0"
 			testJob.Status.FailedIndexes = new("1")
 			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -2488,7 +2488,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			Completions(3).
 			BackoffLimitPerIndex(1).
 			Obj()
-		testJob.Spec.MaxFailedIndexes = new(int32(3))
+		testJob.Spec.MaxFailedIndexes = ptr.To[int32](3)
 
 		ginkgo.By("creating and admitting the job")
 		util.MustCreate(ctx, k8sClient, testJob)
@@ -4673,9 +4673,9 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 	ginkgo.It("Should derive reclaimable pods from completedIndexes while status.Succeeded is stale after scale-down", framework.SlowSpec, func() {
 		// kueue#13117: shrinking completions makes status.Succeeded briefly
 		// over-count the removed high indexes until the Job controller recounts
-		// it. Deriving the reclaimable count from completedIndexes capped at the
-		// current completions gives the correct value immediately, avoiding a
-		// quota leak for the surviving running pods.
+		// it. Deriving the reclaimable count from completedIndexes and failedIndexes,
+		// capped at the current completions, gives the correct value immediately,
+		// avoiding a quota leak for the surviving running pods.
 		testJob := testingjob.MakeJob("scale-down-stale-succeeded", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 			SetAnnotation(workloadjob.JobCompletionsEqualParallelismAnnotation, "true").

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -2477,6 +2477,61 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		})
 	})
 
+	ginkgo.It("Should reclaim quota for permanently failed indexes", framework.SlowSpec, func() {
+		// Regression for kueue#13482: permanently failed indexes cannot run
+		// again, so retaining their quota over-reserves the ClusterQueue.
+		testJob := testingjob.MakeJob("failed-indexes", ns.Name).
+			Queue(kueue.LocalQueueName(prodLocalQ.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Indexed(true).
+			Parallelism(3).
+			Completions(3).
+			BackoffLimitPerIndex(0).
+			Obj()
+		testJob.Spec.MaxFailedIndexes = new(int32(3))
+
+		ginkgo.By("creating and admitting the job")
+		util.MustCreate(ctx, k8sClient, testJob)
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workload.IsAdmitted(&workloads.Items[0])).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("marking one index completed and one permanently failed")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Status.Active = 1
+			testJob.Status.Succeeded = 1
+			testJob.Status.Failed = 1
+			testJob.Status.CompletedIndexes = "0"
+			testJob.Status.FailedIndexes = new("1")
+			g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("reclaiming both terminal indexes and retaining quota for the active index")
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testJob.Namespace))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			g.Expect(workloads.Items[0].Status.ReclaimablePods).Should(gomega.BeComparableTo([]kueue.ReclaimablePod{
+				{Name: kueue.DefaultPodSetName, Count: 2},
+			}))
+
+			cq := &kueue.ClusterQueue{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodClusterQ), cq)).Should(gomega.Succeed())
+			g.Expect(cq.Status.FlavorsUsage).Should(gomega.ContainElement(kueue.FlavorUsage{
+				Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				Resources: []kueue.ResourceUsage{{
+					Name:     corev1.ResourceCPU,
+					Total:    resource.MustParse("100m"),
+					Borrowed: resource.MustParse("0"),
+				}},
+			}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should readmit preempted Job with priorityClass in alternative flavor", func() {
 		highPriorityClass := utiltesting.MakePriorityClass("high").PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sClient, highPriorityClass)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

For Indexed Jobs using `backoffLimitPerIndex`, indexes recorded in
`status.failedIndexes` are terminal and cannot run again. However,
`Job.ReclaimablePods` currently derives reclaimable quota only from
`status.completedIndexes`.

As a result, Kueue continues reserving quota for permanently failed indexes.
In the reproduction from #13482, a three-index Job with one completed index,
one permanently failed index, and one active index reserved `200m` instead of
the `100m` needed by the active index.

This change counts the union of completed and failed indexes below
`spec.completions`. Counting the union avoids reclaiming quota twice for
overlapping legacy status, while retaining the completions cap preserves the
Indexed Job scale-down accounting introduced by #13178.

#### Which issue(s) this PR fixes:

Fixes #13482

#### Special notes for your reviewer:

`status.failedIndexes` is used instead of `status.failed` because the latter
counts failed Pod attempts, including failures that can still be retried.
`failedIndexes` identifies indexes that have exhausted their per-index retry
limit.

The integration test updates the Job status directly and verifies Kueue's
Workload and ClusterQueue accounting boundary. The live reproduction described
in #13482 also converged to `reclaimable=2` and `reserved=100m` with the patched
controller.

Tests:

- `go test ./pkg/controller/jobs/job -count=1`
- Focused `test/integration/singlecluster/controller/jobs/job` regression test

AI assistance was used to draft this change. I reviewed the final code and test results.

#### Does this PR introduce a user-facing change?

```release-note
Job: Fixed a bug where failed indexes of Indexed Jobs using "backoffLimitPerIndex" continued to hold quota after being recorded in "status.failedIndexes".
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved quota reclamation for indexed Jobs by considering both completed and permanently failed index sets when determining reclaimable pods.
  - Prevented double-counting when completed and failed index ranges overlap and ensured only indexes within the configured completions window are counted.
  - Updated reclaimable pod behavior to avoid incorrect results during scale-down when progress indicators may be temporarily stale.

- **Tests**
  - Expanded unit tests to validate terminal-index counting across completed-only, failed-only, and mixed/overlapping ranges.
  - Added an integration test covering reclaim behavior for permanently failed indexed Jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->