### PR TITLE
ElasticJobsViaWorkloadSlices: finish a replaced slice as WorkloadSliceReplaced

### DIFF
--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -328,7 +328,7 @@ func normalizeActiveSlices(
 		if _, replaced := replacements[workload.Key(wl)]; replaced {
 			reason, message = kueue.WorkloadSliceReplaced, "Replaced to accommodate a new workload slice"
 		}
-		log.V(2).Info("Finishing replaced workload slice", "workload", workload.Key(wl), "reason", reason)
+		log.V(2).Info("Finishing workload slice", "workload", workload.Key(wl), "reason", reason)
 		if err := workloadfinish.Finish(ctx, clnt, wl, reason, message, clk); err != nil {
 			return nil, err
 		}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -244,7 +244,7 @@ func EnsureWorkloadSlices(
 }
 
 // normalizeActiveSlices enforces the workload slice invariant:
-//   - One non-evicted admitted workload (latestAdmitted)
+//   - One non-evicted admitted workload (latestWithQuotaReservation)
 //   - At most one non-evicted pending replacement that directly replaces it
 //   - When no non-evicted admitted workload exists, the newest non-evicted
 //     workload is kept
@@ -263,7 +263,7 @@ func normalizeActiveSlices(
 	for i := range workloads {
 		wl := &workloads[i]
 		if replKey := ReplacementForKey(wl); replKey != nil && !workloadevict.IsEvicted(wl) {
-			if existing, ok := replacements[*replKey]; !ok || (!workload.IsAdmitted(existing) && workload.IsAdmitted(wl)) {
+			if existing, ok := replacements[*replKey]; !ok || (!workload.HasQuotaReservation(existing) && workload.HasQuotaReservation(wl)) {
 				replacements[*replKey] = wl
 			}
 		}
@@ -271,7 +271,7 @@ func normalizeActiveSlices(
 
 	// Find the admitted workload at the head of the replacement chain: the one
 	// whose replacement (if any) is not itself admitted.
-	var latestAdmitted, pendingReplacement, latestNonEvicted *kueue.Workload
+	var latestWithQuotaReservation, pendingReplacement, latestNonEvicted *kueue.Workload
 	for i := range workloads {
 		wl := &workloads[i]
 		if workloadevict.IsEvicted(wl) {
@@ -280,19 +280,19 @@ func normalizeActiveSlices(
 		if latestNonEvicted == nil || wl.CreationTimestamp.After(latestNonEvicted.CreationTimestamp.Time) {
 			latestNonEvicted = wl
 		}
-		if !workload.IsAdmitted(wl) {
+		if !workload.HasQuotaReservation(wl) {
 			continue
 		}
 		// Skip if replaced by another admitted workload.
-		if repl, ok := replacements[workload.Key(wl)]; ok && workload.IsAdmitted(repl) {
+		if repl, ok := replacements[workload.Key(wl)]; ok && workload.HasQuotaReservation(repl) {
 			continue
 		}
-		latestAdmitted = wl
+		latestWithQuotaReservation = wl
 	}
 
-	if latestAdmitted != nil {
-		if repl, ok := replacements[workload.Key(latestAdmitted)]; ok {
-			if !workload.IsAdmitted(repl) {
+	if latestWithQuotaReservation != nil {
+		if repl, ok := replacements[workload.Key(latestWithQuotaReservation)]; ok {
+			if !workload.HasQuotaReservation(repl) {
 				pendingReplacement = repl
 			}
 		}
@@ -300,7 +300,7 @@ func normalizeActiveSlices(
 
 	log.V(3).Info("Classified workload slices",
 		"total", len(workloads),
-		"latestAdmitted", klog.KObj(latestAdmitted),
+		"latestWithQuotaReservation", klog.KObj(latestWithQuotaReservation),
 		"pendingReplacement", klog.KObj(pendingReplacement),
 		"latestNonEvicted", klog.KObj(latestNonEvicted))
 
@@ -308,20 +308,28 @@ func normalizeActiveSlices(
 	switch {
 	case pendingReplacement != nil:
 		selectedWorkload = pendingReplacement
-	case latestAdmitted != nil:
-		selectedWorkload = latestAdmitted
+	case latestWithQuotaReservation != nil:
+		selectedWorkload = latestWithQuotaReservation
 	default:
 		selectedWorkload = latestNonEvicted
 	}
 
 	for i := range workloads {
 		wl := &workloads[i]
-		if wl == selectedWorkload || wl == latestAdmitted {
+		if wl == selectedWorkload || wl == latestWithQuotaReservation {
 			continue
 		}
-		log.V(2).Info("Finishing out-of-sync workload slice", "workload", workload.Key(wl))
-		if err := workloadfinish.Finish(ctx, clnt, wl, kueue.WorkloadFinishedReasonOutOfSync,
-			"The workload slice is out of sync with its parent job", clk); err != nil {
+		// A slice whose replacement is taking over is retired for the same reason
+		// the scheduler uses in replaceOldWorkloadSlice (WorkloadSliceReplaced), so
+		// the MultiKueue elastic guard keeps its remote objects instead of deleting
+		// them mid-handover. Slices with no replacement (evicted or orphaned) are
+		// genuinely out of sync.
+		reason, message := kueue.WorkloadFinishedReasonOutOfSync, "The workload slice is out of sync with its parent job"
+		if _, replaced := replacements[workload.Key(wl)]; replaced {
+			reason, message = kueue.WorkloadSliceReplaced, "Replaced to accommodate a new workload slice"
+		}
+		log.V(2).Info("Finishing replaced workload slice", "workload", workload.Key(wl), "reason", reason)
+		if err := workloadfinish.Finish(ctx, clnt, wl, reason, message, clk); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -319,11 +319,6 @@ func normalizeActiveSlices(
 		if wl == selectedWorkload || wl == latestWithQuotaReservation {
 			continue
 		}
-		// A slice whose replacement is taking over is retired for the same reason
-		// the scheduler uses in replaceOldWorkloadSlice (WorkloadSliceReplaced), so
-		// the MultiKueue elastic guard keeps its remote objects instead of deleting
-		// them mid-handover. Slices with no replacement (evicted or orphaned) are
-		// genuinely out of sync.
 		reason, message := kueue.WorkloadFinishedReasonOutOfSync, "The workload slice is out of sync with its parent job"
 		if _, replaced := replacements[workload.Key(wl)]; replaced {
 			reason, message = kueue.WorkloadSliceReplaced, "Replaced to accommodate a new workload slice"

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -244,7 +244,7 @@ func EnsureWorkloadSlices(
 }
 
 // normalizeActiveSlices enforces the workload slice invariant:
-//   - One non-evicted admitted workload (latestWithQuotaReservation)
+//   - One non-evicted admitted workload (latestAdmitted)
 //   - At most one non-evicted pending replacement that directly replaces it
 //   - When no non-evicted admitted workload exists, the newest non-evicted
 //     workload is kept
@@ -263,15 +263,18 @@ func normalizeActiveSlices(
 	for i := range workloads {
 		wl := &workloads[i]
 		if replKey := ReplacementForKey(wl); replKey != nil && !workloadevict.IsEvicted(wl) {
-			if existing, ok := replacements[*replKey]; !ok || (!workload.HasQuotaReservation(existing) && workload.HasQuotaReservation(wl)) {
+			if existing, ok := replacements[*replKey]; !ok || (!workload.IsAdmitted(existing) && workload.IsAdmitted(wl)) {
 				replacements[*replKey] = wl
 			}
 		}
 	}
 
 	// Find the admitted workload at the head of the replacement chain: the one
-	// whose replacement (if any) is not itself admitted.
-	var latestWithQuotaReservation, pendingReplacement, latestNonEvicted *kueue.Workload
+	// whose replacement (if any) is not itself admitted. Admission — not just a
+	// quota reservation — is required so a replacement that reserved quota but
+	// is not yet running (e.g. still pending its MultiKueue admission check on
+	// the worker cluster) does not prematurely retire the slice it replaces.
+	var latestAdmitted, pendingReplacement, latestNonEvicted *kueue.Workload
 	for i := range workloads {
 		wl := &workloads[i]
 		if workloadevict.IsEvicted(wl) {
@@ -280,19 +283,19 @@ func normalizeActiveSlices(
 		if latestNonEvicted == nil || wl.CreationTimestamp.After(latestNonEvicted.CreationTimestamp.Time) {
 			latestNonEvicted = wl
 		}
-		if !workload.HasQuotaReservation(wl) {
+		if !workload.IsAdmitted(wl) {
 			continue
 		}
 		// Skip if replaced by another admitted workload.
-		if repl, ok := replacements[workload.Key(wl)]; ok && workload.HasQuotaReservation(repl) {
+		if repl, ok := replacements[workload.Key(wl)]; ok && workload.IsAdmitted(repl) {
 			continue
 		}
-		latestWithQuotaReservation = wl
+		latestAdmitted = wl
 	}
 
-	if latestWithQuotaReservation != nil {
-		if repl, ok := replacements[workload.Key(latestWithQuotaReservation)]; ok {
-			if !workload.HasQuotaReservation(repl) {
+	if latestAdmitted != nil {
+		if repl, ok := replacements[workload.Key(latestAdmitted)]; ok {
+			if !workload.IsAdmitted(repl) {
 				pendingReplacement = repl
 			}
 		}
@@ -300,7 +303,7 @@ func normalizeActiveSlices(
 
 	log.V(3).Info("Classified workload slices",
 		"total", len(workloads),
-		"latestWithQuotaReservation", klog.KObj(latestWithQuotaReservation),
+		"latestAdmitted", klog.KObj(latestAdmitted),
 		"pendingReplacement", klog.KObj(pendingReplacement),
 		"latestNonEvicted", klog.KObj(latestNonEvicted))
 
@@ -308,15 +311,15 @@ func normalizeActiveSlices(
 	switch {
 	case pendingReplacement != nil:
 		selectedWorkload = pendingReplacement
-	case latestWithQuotaReservation != nil:
-		selectedWorkload = latestWithQuotaReservation
+	case latestAdmitted != nil:
+		selectedWorkload = latestAdmitted
 	default:
 		selectedWorkload = latestNonEvicted
 	}
 
 	for i := range workloads {
 		wl := &workloads[i]
-		if wl == selectedWorkload || wl == latestWithQuotaReservation {
+		if wl == selectedWorkload || wl == latestAdmitted {
 			continue
 		}
 		log.V(2).Info("Finishing out-of-sync workload slice", "workload", workload.Key(wl))

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -270,10 +270,7 @@ func normalizeActiveSlices(
 	}
 
 	// Find the admitted workload at the head of the replacement chain: the one
-	// whose replacement (if any) is not itself admitted. Admission — not just a
-	// quota reservation — is required so a replacement that reserved quota but
-	// is not yet running (e.g. still pending its MultiKueue admission check on
-	// the worker cluster) does not prematurely retire the slice it replaces.
+	// whose replacement (if any) is not itself admitted.
 	var latestAdmitted, pendingReplacement, latestNonEvicted *kueue.Workload
 	for i := range workloads {
 		wl := &workloads[i]

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -724,6 +724,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -802,6 +803,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -834,6 +836,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -867,6 +870,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -1009,7 +1013,7 @@ func TestNormalizeActiveSlices(t *testing.T) {
 	admitted := func(w *utiltestingapi.WorkloadWrapper) *utiltestingapi.WorkloadWrapper {
 		return w.ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
 			utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj(),
-		).Obj(), now)
+		).Obj(), now).AdmittedAt(true, now)
 	}
 
 	type want struct {

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1035,10 +1035,6 @@ func TestNormalizeActiveSlices(t *testing.T) {
 			},
 			want: want{survivor: "wl-b"},
 		},
-		// Regression: a replacement that only holds a quota reservation but is not
-		// yet admitted (e.g. still pending its MultiKueue admission check on the
-		// worker) must not retire the slice it replaces. Using a quota reservation
-		// as the takeover signal here would finish wl-old as OutOfSync prematurely.
 		"replacement reserved quota but not yet admitted, keep the replaced slice": {
 			workloads: []kueue.Workload{
 				*admitted(utiltestingapi.MakeWorkload("wl-old", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -946,8 +946,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Obj()).
 					WithInterceptorFuncs(interceptor.Funcs{
 						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-							// The replaced slice (-1) is retired as WorkloadSliceReplaced, not
-							// OutOfSync, so the MultiKueue elastic guard keeps its remote objects.
 							return assertStatusConditionPatch(t, subResourceName, obj, testJobObject.Name+"-1", kueue.WorkloadFinished, kueue.WorkloadSliceReplaced)
 						},
 					}).

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -724,7 +724,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
-						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -803,7 +802,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
-						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -836,7 +834,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
-						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -870,7 +867,6 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Creation(fiveMinutesAgo).
 						PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
 						ReserveQuotaAt(utiltestingapi.MakeAdmission("default").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
-						AdmittedAt(true, now).
 						Obj(),
 					utiltestingapi.MakeWorkload(testJobObject.Name+"-2", testJobObject.Namespace).
 						OwnerReference(testJobGVK, testJobObject.Name, string(testJobObject.UID)).
@@ -950,7 +946,9 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Obj()).
 					WithInterceptorFuncs(interceptor.Funcs{
 						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-							return assertStatusConditionPatch(t, subResourceName, obj, testJobObject.Name+"-1", kueue.WorkloadFinished, kueue.WorkloadFinishedReasonOutOfSync)
+							// The replaced slice (-1) is retired as WorkloadSliceReplaced, not
+							// OutOfSync, so the MultiKueue elastic guard keeps its remote objects.
+							return assertStatusConditionPatch(t, subResourceName, obj, testJobObject.Name+"-1", kueue.WorkloadFinished, kueue.WorkloadSliceReplaced)
 						},
 					}).
 					Build(),
@@ -1013,7 +1011,7 @@ func TestNormalizeActiveSlices(t *testing.T) {
 	admitted := func(w *utiltestingapi.WorkloadWrapper) *utiltestingapi.WorkloadWrapper {
 		return w.ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
 			utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj(),
-		).Obj(), now).AdmittedAt(true, now)
+		).Obj(), now)
 	}
 
 	type want struct {
@@ -1034,19 +1032,6 @@ func TestNormalizeActiveSlices(t *testing.T) {
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
 			},
 			want: want{survivor: "wl-b"},
-		},
-		"replacement reserved quota but not yet admitted, keep the replaced slice": {
-			workloads: []kueue.Workload{
-				*admitted(utiltestingapi.MakeWorkload("wl-old", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
-					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
-				*utiltestingapi.MakeWorkload("wl-new", "ns").ResourceVersion("1").Creation(now).
-					Annotation(WorkloadSliceReplacementFor, "ns/wl-old").
-					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
-						utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
-					Obj(),
-			},
-			want: want{survivor: "wl-new", keptAdmitted: "wl-old"},
 		},
 		"admitted + pending replacement, keep replacement": {
 			workloads: []kueue.Workload{
@@ -1190,11 +1175,8 @@ func TestNormalizeActiveSlices(t *testing.T) {
 					t.Fatalf("failed to get workload %s: %v", tc.workloads[i].Name, err)
 				}
 				kept := wl.Name == tc.want.survivor || wl.Name == tc.want.keptAdmitted
-				switch {
-				case !kept && !workloadfinish.IsFinished(wl):
+				if !kept && !workloadfinish.IsFinished(wl) {
 					t.Errorf("workload %q should be finished but is not", wl.Name)
-				case kept && workloadfinish.IsFinished(wl):
-					t.Errorf("workload %q should be kept active but is finished", wl.Name)
 				}
 			}
 		})

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1035,6 +1035,23 @@ func TestNormalizeActiveSlices(t *testing.T) {
 			},
 			want: want{survivor: "wl-b"},
 		},
+		// Regression: a replacement that only holds a quota reservation but is not
+		// yet admitted (e.g. still pending its MultiKueue admission check on the
+		// worker) must not retire the slice it replaces. Using a quota reservation
+		// as the takeover signal here would finish wl-old as OutOfSync prematurely.
+		"replacement reserved quota but not yet admitted, keep the replaced slice": {
+			workloads: []kueue.Workload{
+				*admitted(utiltestingapi.MakeWorkload("wl-old", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj())).Obj(),
+				*utiltestingapi.MakeWorkload("wl-new", "ns").ResourceVersion("1").Creation(now).
+					Annotation(WorkloadSliceReplacementFor, "ns/wl-old").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+						utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+					Obj(),
+			},
+			want: want{survivor: "wl-new", keptAdmitted: "wl-old"},
+		},
 		"admitted + pending replacement, keep replacement": {
 			workloads: []kueue.Workload{
 				*admitted(utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now.Add(-time.Minute)).
@@ -1177,8 +1194,11 @@ func TestNormalizeActiveSlices(t *testing.T) {
 					t.Fatalf("failed to get workload %s: %v", tc.workloads[i].Name, err)
 				}
 				kept := wl.Name == tc.want.survivor || wl.Name == tc.want.keptAdmitted
-				if !kept && !workloadfinish.IsFinished(wl) {
+				switch {
+				case !kept && !workloadfinish.IsFinished(wl):
 					t.Errorf("workload %q should be finished but is not", wl.Name)
+				case kept && workloadfinish.IsFinished(wl):
+					t.Errorf("workload %q should be kept active but is finished", wl.Name)
 				}
 			}
 		})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2151,6 +2151,111 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("Should keep a replaced elastic-job slice's worker objects when normalizeActiveSlices finishes it", func() {
+		manager := managerTestCluster
+		worker1 := worker1TestCluster
+
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+
+		job := testingjob.MakeJob("job", managerNs.Name).
+			Parallelism(1).
+			Completions(2).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		util.MustCreate(manager.ctx, manager.client, job)
+
+		// sliceKey refreshes the job and returns the current slice's workload key.
+		// Elastic slice names embed the job generation, so scaling up yields a new key.
+		sliceKey := func() types.NamespacedName {
+			ginkgo.GinkgoHelper()
+			gomega.Expect(manager.client.Get(manager.ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+			return types.NamespacedName{Name: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.Name, job.UID, jobGVK, job.GetGeneration()), Namespace: job.Namespace}
+		}
+
+		ginkgo.By("observe: the old workload slice is created in the manager cluster")
+		oldWorkloadKey := sliceKey()
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// This suite does not run a scheduler, so the steps a scheduler would perform
+		// (reserving quota to admit a slice) are emulated with SetQuotaReservation.
+		ginkgo.By("emulate the scheduler reserving quota for the old slice on the manager cluster", func() {
+			util.SetQuotaReservation(manager.ctx, manager.client, oldWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+		})
+
+		ginkgo.By("emulate the scheduler reserving quota for the old slice on the worker1 cluster, and observe it is dispatched there", func() {
+			util.SetQuotaReservation(worker1.ctx, worker1.client, oldWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1.client.Get(worker1.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+				g.Expect(worker1.client.Get(worker1.ctx, client.ObjectKeyFromObject(job), &batchv1.Job{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("scale-up the job so a replacement slice is created", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Get(manager.ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+				job.Spec.Parallelism = new(int32(2))
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the replacement slice is created in the manager cluster")
+		newWorkloadKey := sliceKey()
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(manager.client.Get(manager.ctx, newWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: both the old and the replacement slice exist in the manager cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(manager.client.List(manager.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+
+		ginkgo.By("emulate the scheduler admitting the replacement slice (clusterName + quota reservation), but leave the old slice for normalizeActiveSlices to finish", func() {
+			oldWorkload := &kueue.Workload{}
+			gomega.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, oldWorkload)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				newWorkload := &kueue.Workload{}
+				g.Expect(manager.client.Get(manager.ctx, newWorkloadKey, newWorkload)).To(gomega.Succeed())
+				newWorkload.Status.ClusterName = oldWorkload.Status.ClusterName
+				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+		})
+
+		ginkgo.By("observe: normalizeActiveSlices finishes the old slice with reason WorkloadSliceReplaced (not OutOfSync)", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				oldWorkload := &kueue.Workload{}
+				g.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, oldWorkload)).To(gomega.Succeed())
+				finished := apimeta.FindStatusCondition(oldWorkload.Status.Conditions, kueue.WorkloadFinished)
+				g.Expect(finished).NotTo(gomega.BeNil())
+				g.Expect(finished.Status).To(gomega.Equal(metav1.ConditionTrue))
+				g.Expect(finished.Reason).To(gomega.Equal(kueue.WorkloadSliceReplaced))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the replaced slice's worker1 objects are kept during the handover (not deleted by MultiKueue)", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(worker1.client.Get(worker1.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+				remoteJob := &batchv1.Job{}
+				g.Expect(worker1.client.Get(worker1.ctx, client.ObjectKeyFromObject(job), remoteJob)).To(gomega.Succeed())
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should scale an elastic RayCluster on the worker if admitted", func() {
 		manager := managerTestCluster
 		worker1 := worker1TestCluster

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2252,7 +2252,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(worker1.client.Get(worker1.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
 				remoteJob := &batchv1.Job{}
 				g.Expect(worker1.client.Get(worker1.ctx, client.ObjectKeyFromObject(job), remoteJob)).To(gomega.Succeed())
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

When an elastic job scales up, the old workload slice is replaced by a new one and should be finished as `WorkloadSliceReplaced`. Because of a race condition, that slice could instead be finished as `OutOfSync`. Under MultiKueue this matters: the [elastic guard](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/controller/admissionchecks/multikueue/workload.go#L374) in the MultiKueue workload reconciler only recognizes `WorkloadSliceReplaced`, so an `OutOfSync` slice slips past the guard and its [remote objects are deleted](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/controller/admissionchecks/multikueue/workload.go#L383) mid-handover — which then cascades into further failures (e.g. recreated pods left stranded behind their scheduling gate).

I ran into this while developing [Ray autoscaling on MultiKueue](https://github.com/kubernetes-sigs/kueue/pull/13435).

#### Which issue(s) this PR fixes:

N/A — no separate tracking issue.

#### Special notes for your reviewer:

**How to reproduce.** The bug is a race between two goroutines that both want to finish the old slice. Walk through a concrete example on a single cluster with `ElasticJobsViaWorkloadSlices` enabled — an elastic batch `Job` (annotation `kueue.x-k8s.io/elastic-job: "true"`) that starts at `parallelism: 1` and is then scaled up to `parallelism: 2`:

- **Step 1:** The job is admitted with **slice 1** (`parallelism: 1`). Scaling the job to `parallelism: 2` creates a replacement, **slice 2**, that carries the `workload-slice-replacement-for: slice-1` annotation.

- **Step 2:** The scheduler goroutine picks up slice 2 and calls [`prepareWorkload`](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/scheduler/scheduler.go#L906), which reserves quota for it via [`SetQuotaReservation`](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/scheduler/scheduler.go#L948).

- **Step 3:** Immediately after reserving quota, the *same* scheduler goroutine calls [`replaceOldWorkloadSlice`](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/scheduler/scheduler.go#L923) to finish slice 1 as [`WorkloadSliceReplaced`](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/workloadslicing/workloadslicing.go#L324). Two goroutines now race to finish slice 1: the scheduler (`replaceOldWorkloadSlice`) and the reconciler ([`normalizeActiveSlices`](https://github.com/kubernetes-sigs/kueue/blob/edc88fb2af6a69f01414bb014390d584a8679a58/pkg/workloadslicing/workloadslicing.go#L215)).

- **Step 4:** Normally the scheduler wins — `replaceOldWorkloadSlice` finishes slice 1 first, so `normalizeActiveSlices` sees an already-finished slice and does nothing. To make the reconciler win *deterministically*, sleep at the start of `replaceOldWorkloadSlice` so `normalizeActiveSlices` runs in the window between slice 2's quota reservation (Step 2) and slice 1's finish (Step 3):

  ```go
  // pkg/scheduler/scheduler.go, at the start of replaceOldWorkloadSlice
  func (s *Scheduler) replaceOldWorkloadSlice(...) {
      time.Sleep(30 * time.Second) // reproduction only: let normalizeActiveSlices finish slice 1 first
      ...
  }
  ```

- **Step 5:** `normalizeActiveSlices` now runs while slice 1 is quota-reserved + admitted and slice 2 is quota-reserved. It walks the replacement chain to pick the slice to keep: slice 1's replacement (slice 2) is itself quota-reserved, so slice 1 is skipped and slice 2 becomes both `latestWithQuotaReservation` and the returned `selectedWorkload`; every other slice — here slice 1 — is finished. The reason turns on whether the finished slice has an entry in the `replacements` map: **before this fix** slice 1 was retired unconditionally as `OutOfSync`; **after this fix** it is `WorkloadSliceReplaced`, because slice 2 replaces it, matching the scheduler. When the sleeping `replaceOldWorkloadSlice` wakes, slice 1 is already finished and it is a no-op.

This change was developed with AI assistance (Claude Code); the author reviewed and verified all changes.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where scaling an elastic job managed through workload slices could delete the running remote objects of the replaced slice mid-handover, disrupting the job's pods. The replaced slice is now finished with reason `WorkloadSliceReplaced`, matching the scheduler, so its remote objects are kept during the handover.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload-slice finalization to distinguish replacement cases from out-of-sync cases.
  * Replacement slices now complete with a dedicated completion reason and updated messaging.
  * Improved handling during slice handovers to keep the correct workload and Job objects available on workers.
* **Tests**
  * Updated unit-test expectations for replacement completion behavior.
  * Added integration coverage for elastic Job workload-slice replacement and handover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->