### PR TITLE
Add test-fuzz Makefile target to run fuzz tests with fuzzing enabled

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -119,6 +119,9 @@ FUZZTIME ?= 5s
 
 .PHONY: test-fuzz
 test-fuzz: ## Run all fuzz tests with fuzzing enabled, FUZZTIME per target.
+# 'go test -fuzz' expects a bare fuzz function name, but grep emits whole source
+# lines. The sed replacement extracts the name, for example:
+#   "func FuzzSliceRequestsEquivalence(f *testing.F) {" -> "FuzzSliceRequestsEquivalence"
 	@$(GO_CMD) list -f '{{.ImportPath}} {{.Dir}}' ./... | while read -r pkg dir; do \
 		for target in $$(grep -hs '^func Fuzz' $$dir/*_test.go | $(SED) -E 's/^func (Fuzz[A-Za-z0-9_]*).*/\1/'); do \
 			echo "=== fuzzing $$target in $$pkg (budget $(FUZZTIME))"; \

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -114,6 +114,18 @@ test: gotestsum ## Run tests. Set UNIT_TOTAL_SHARDS and UNIT_SHARD_INDEX to run 
 # written only when a race is actually detected, so green runs stay clean.
 	GORACE="log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
 
+# Time budget for fuzzing each individual fuzz target.
+FUZZTIME ?= 30s
+
+.PHONY: test-fuzz
+test-fuzz: ## Run all fuzz tests with fuzzing enabled, FUZZTIME per target.
+	@$(GO_CMD) list -f '{{.ImportPath}} {{.Dir}}' ./... | while read -r pkg dir; do \
+		for target in $$(grep -hs '^func Fuzz' $$dir/*_test.go | $(SED) -E 's/^func (Fuzz[A-Za-z0-9_]*).*/\1/'); do \
+			echo "=== fuzzing $$target in $$pkg (budget $(FUZZTIME))"; \
+			$(GO_CMD) test $$pkg $(GOFLAGS) -run='^$$' -fuzz="^$$target$$" -fuzztime=$(FUZZTIME) || exit 1; \
+		done; \
+	done
+
 ## Label Taxonomy:
 ##   Controllers: controller:workload, controller:localqueue, controller:clusterqueue, controller:admissioncheck, controller:resourceflavor, controller:provisioning
 ##   Job Types: job:batch, job:pod, job:jobset, job:pytorch, job:tensorflow, job:mpi, job:paddle, job:xgboost, job:jax, job:train, job:ray, job:appwrapper, job:sparkapplication

--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -115,7 +115,7 @@ test: gotestsum ## Run tests. Set UNIT_TOTAL_SHARDS and UNIT_SHARD_INDEX to run 
 	GORACE="log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
 
 # Time budget for fuzzing each individual fuzz target.
-FUZZTIME ?= 30s
+FUZZTIME ?= 5s
 
 .PHONY: test-fuzz
 test-fuzz: ## Run all fuzz tests with fuzzing enabled, FUZZTIME per target.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The two existing fuzz tests only run as seed-only unit tests in `make test`. Without the `-fuzz` flag, the mutation engine never starts, so no real fuzzing happens today.

This PR adds a `test-fuzz` target. It discovers all `Fuzz*` functions in `*_test.go` files and fuzzes them one by one, each with a `FUZZTIME` budget (default 30s, overridable). Future fuzz tests are picked up automatically without Makefile changes.

Fuzzing has to be a separate target. `go test -fuzz` does not work with multiple packages, can match only one fuzz target per invocation, and runs forever without `-fuzztime`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
related #13468

#### Special notes for your reviewer:
Verified locally with `make test-fuzz FUZZTIME=5s`. Both targets enter fuzzing mode.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added Go fuzz testing support via a new `test-fuzz` command.
  * Introduced a configurable per-fuzz-target time budget (`FUZZTIME`), defaulting to **5 seconds**.
  * Fuzz tests run one entrypoint at a time and terminate immediately when the first fuzz run fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->