### PR TITLE
Sort GreaterKeys results alphabetically in both Requests implementations

### DIFF
--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -39,6 +39,10 @@ type Requests interface {
 	// FloorToZero replaces negative resource values with zero.
 	FloorToZero()
 	ToResourceList(formatter *ResourceFormatter) corev1.ResourceList
+	// GreaterKeys returns the keys where the receiver is greater than other,
+	// sorted alphabetically for deterministic output.
 	GreaterKeys(other Requests) []corev1.ResourceName
+	// GreaterKeysRL returns the keys where the receiver is greater than the
+	// ResourceList value, sorted alphabetically for deterministic output.
 	GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"maps"
 	"math"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -146,7 +147,8 @@ func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 	return q.Value()
 }
 
-// GreaterKeys returns keys where the receiver is greater than other.
+// GreaterKeys returns keys where the receiver is greater than other,
+// sorted alphabetically for deterministic output.
 func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(r) == 0 || isEmpty(other) {
 		return nil
@@ -161,6 +163,7 @@ func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(result) == 0 {
 		return nil
 	}
+	slices.Sort(result)
 	return result
 }
 

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -291,6 +291,17 @@ func TestGreaterKeys(t *testing.T) {
 			},
 			want: nil,
 		},
+		"multiple_greater_sorted": {
+			a: MapRequests{
+				"r2": 2,
+				"r1": 2,
+			},
+			b: MapRequests{
+				"r2": 1,
+				"r1": 1,
+			},
+			want: []corev1.ResourceName{"r1", "r2"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -221,7 +221,8 @@ func (sr *SliceRequests) ToResourceList(formatter *ResourceFormatter) corev1.Res
 	return ret
 }
 
-// GreaterKeys returns keys where the receiver is greater than other.
+// GreaterKeys returns keys where the receiver is greater than other,
+// sorted alphabetically for deterministic output.
 func (sr *SliceRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if sr.IsEmpty() || isEmpty(other) {
 		return nil
@@ -237,6 +238,7 @@ func (sr *SliceRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 			result = append(result, entry.name)
 		}
 	}
+	slices.Sort(result)
 	return result
 }
 

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -726,6 +726,17 @@ func TestSliceRequests_GreaterKeys(t *testing.T) {
 			}),
 			want: []corev1.ResourceName{corev1.ResourceCPU},
 		},
+		"multiple greater keys sorted alphabetically": {
+			req: NewSliceRequests(MapRequests{
+				corev1.ResourceCPU:  2000,
+				corev1.ResourcePods: 10,
+			}),
+			other: MapRequests{
+				corev1.ResourceCPU:  1000,
+				corev1.ResourcePods: 5,
+			},
+			want: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourcePods},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
+++ b/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2a0910XBA20Z 0001020000")

--- a/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
+++ b/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
@@ -1,2 +1,0 @@
-go test fuzz v1
-[]byte("2a0910XBA20Z 0001020000")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
`MapRequests.GreaterKeys` returns keys in Go map iteration order, which is random. `SliceRequests.GreaterKeys` returns them in its internal hash order. The two implementations disagree, and the order leaks into LimitRange validation error messages through `field.Invalid`, so the message text depends on which implementation produced it.

This PR sorts the result alphabetically in both implementations, following the tie-break convention in `CountInWithLimitingResource`, and documents the order on the `Requests` interface. The failing fuzz input is committed as a regression seed, so plain `go test` replays it from now on.

The mismatch was found by running `FuzzSliceRequestsEquivalence` with real fuzzing (see #13468). The existing seeds do not cover the GreaterKeys operations, so only fuzzing could reach it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Did not open issue, related: #13338 
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource comparison results are now returned in consistent alphabetical order, improving predictability across requests.

* **Tests**
  * Added coverage for sorted results when multiple resources differ.
  * Added an additional fuzz test case for request equivalence behavior.

* **Documentation**
  * Clarified that resource keys returned from comparisons are sorted alphabetically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->