### PR TITLE
KEP-13243: MultiKueue worker-side Ray in-tree autoscaling for elastic jobs

### DIFF
--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -90,9 +90,6 @@ remains the quota authority.
   Kueue's existing workload slicing.
 - Extending reverse elastic sync to non-Ray integrations in this KEP (the adapter
   hooks are designed to generalize, but only Ray is implemented here).
-- A webhook-level authz guard preventing tenants from hand-setting the
-  runtime replica-size annotation on their own RayJob (tracked as a follow-up;
-  value validation is present).
 - Manager-driven and worker-driven resizing of the *same* object at the same
   time; a given elastic object is resized by one side.
 
@@ -153,10 +150,6 @@ ClusterQueue quota (through slice replacement) rather than blocked or reverted.
   mode the forward sync never pushes replicas; its only remaining duty is
   repointing the remote's prebuilt-workload marker at the current slice
   (idempotent). Replicas flow one way — worker→manager — while autoscaling is on.
-- **A tenant forges replica counts via the runtime annotation.** The reflected
-  value is parsed and a malformed annotation is ignored (the manager falls back to
-  the spec counts). An authz-level guard against a tenant hand-setting the
-  annotation is a documented follow-up.
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
@@ -311,8 +304,8 @@ Alpha:
 
 Beta (tentative):
 
-- Address the documented follow-ups: authz guard for the runtime replica-size
-  annotation, and an optional time bound on the resize tolerance.
+- Address the documented follow-up: an optional time bound on the resize
+  tolerance.
 - Metrics/observability for reverse-sync resizes.
 - Broader soak/e2e coverage in CI (fullray periodic jobs).
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -38,9 +38,7 @@ to a worker cluster through MultiKueue, and the manager-driven forward sync
 ([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885)) propagates
 manager-side resizes down to that worker copy. But when the workload is meant to
 be resized by the [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html), there
-is no path for those worker-side resizes to travel back to the manager. As a
-result, the manager's quota accounting drifts from reality and the manager can
-overwrite the autoscaler's changes, tearing down the running job.
+is no path for those worker-side resizes to travel back to the manager.
 
 This KEP proposes the missing **worker→manager** direction — a *reverse elastic
 sync* in the shared Ray adapter — so an autoscaler-driven resize on the worker

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -12,7 +12,6 @@
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
-  - [Background: manager-driven forward sync](#background-manager-driven-forward-sync)
   - [Reverse elastic sync](#reverse-elastic-sync)
     - [RayCluster](#raycluster)
     - [RayJob](#rayjob)
@@ -149,16 +148,6 @@ temporarily.
   during handover (see below).
 
 ## Design Details
-
-### Background: manager-driven forward sync
-
-[#12885](https://github.com/kubernetes-sigs/kueue/pull/12885) established the
-manager→worker direction for elastic RayClusters: a resize on the manager is
-propagated to the remote copy. To keep scaling strictly manager-driven, in-tree
-autoscaling on a MultiKueue-managed elastic RayCluster is currently rejected at
-admission ([#13244](https://github.com/kubernetes-sigs/kueue/pull/13244)). This
-KEP adds the opposite direction and, for autoscaling objects, retains
-`enableInTreeAutoscaling` on the remote copy, lifting that rejection.
 
 ### Reverse elastic sync
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -147,10 +147,6 @@ temporarily.
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
-- **Pods stranded behind scheduling gates after slice replacement.** Fixed by the
-  merged prerequisite [#13489](https://github.com/kubernetes-sigs/kueue/pull/13489):
-  a replaced slice is finished as `WorkloadSliceReplaced`, so MultiKueue's elastic
-  guard no longer deletes the slice (and its chain root) mid-handover.
 
 ## Design Details
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -326,9 +326,8 @@ Beta (tentative):
 
 - Adds a second sync direction to the Ray adapter, increasing the surface area of
   MultiKueue's elastic handling and the number of interleavings to reason about.
-- Retaining `enableInTreeAutoscaling` on the remote copy makes the worker a
-  source of truth for replica counts, which must be carefully bounded to the
-  manager-declared range to keep the manager as the quota authority.
+- Retaining `enableInTreeAutoscaling` on the remote copy makes the worker, rather
+  than the manager, the source of truth for the worker replica count.
 
 ## Alternatives
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -19,8 +19,6 @@
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
-    - [Unit tests](#unit-tests)
-    - [Integration tests](#integration-tests)
     - [e2e tests](#e2e-tests)
   - [Graduation Criteria](#graduation-criteria)
 - [Implementation History](#implementation-history)
@@ -288,24 +286,6 @@ necessary to implement this enhancement.
 #### Prerequisite testing updates
 
 None beyond the coverage described below.
-
-#### Unit tests
-
-- Reverse-sync `Runtime{Fetch, Apply}` for RayCluster (reads its own remote copy)
-  and RayJob (reads the child RayCluster), including the `UID-generation` revision,
-  count-neutral updates that must not re-annotate or mint a slice, the
-  suspended-remote skip, and the malformed-annotation fallback to spec counts.
-- Workload-slice naming folds in the reflected revision
-  (`GetWorkloadNameExtraPart`): a fresh reflected count yields a new slice name.
-- Adapter-wiring validation: `Runtime` (with `Fetch` and `Apply`) required when
-  `AutoscalingEnabled` is set.
-- Jobframework worker-side resize tolerance, gated on the origin label.
-
-#### Integration tests
-
-- MultiKueue elastic RayCluster/RayJob resize handover: worker-originated resize
-  reflected onto the manager; slice replacement on scale-up; in-place update on
-  scale-down; no `OutOfSync` churn; quota reservation exact.
 
 #### e2e tests
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -43,10 +43,7 @@ is no path for those worker-side resizes to travel back to the manager.
 This KEP proposes the missing **worker→manager** direction — a *reverse elastic
 sync* in the shared Ray adapter — so an autoscaler-driven resize on the worker
 cluster is reflected onto the manager object, and the manager re-reserves quota
-through its existing workload-slicing machinery. It also covers the two
-supporting changes required to make the handover non-disruptive: a worker-side
-resize tolerance in the jobframework, and a fix to the elastic-job ungater so it
-does not strand pods when MultiKueue deletes the root of a slice chain.
+through its existing workload-slicing machinery.
 
 ## Motivation
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -70,7 +70,7 @@ remains the quota authority.
 
 ### Goals
 
-- Let the Ray in-tree autoscaler resize a MultiKueue-dispatched elastic
+- Let the Ray Autoscaler resize a MultiKueue-dispatched elastic
   `RayCluster` or `RayJob` on the worker cluster, and reflect that resize back
   onto the manager object.
 - Keep the manager as the single quota authority: worker-originated resizes flow
@@ -343,7 +343,7 @@ Beta (tentative):
 ## Alternatives
 
 - **Manager-driven only (status quo).** Simple and already shipped, but blocks
-  every use case that needs the worker's in-tree autoscaler.
+  every use case that needs the worker's Ray Autoscaler.
 - **Reject `enableInTreeAutoscaling` for MultiKueue elastic Ray objects.**
   [#13244](https://github.com/kubernetes-sigs/kueue/pull/13244) takes this stance
   as an interim guard until this support exists; it prevents silent misbehavior

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -128,8 +128,10 @@ temporarily.
 
 ### Notes/Constraints/Caveats
 
-- The feature applies only to elastic (`ElasticJobsViaWorkloadSlices`) Ray objects
-  dispatched through MultiKueue with `enableInTreeAutoscaling` set.
+- The feature is gated by the new `MultiKueueRayInTreeAutoscaling` feature gate
+  (alpha, off by default) and applies only to elastic
+  (`ElasticJobsViaWorkloadSlices`) Ray objects dispatched through MultiKueue with
+  `enableInTreeAutoscaling` set.
 - Only per-worker-group replica counts move in the worker→manager direction, and
   only as annotations — the manager spec is never rewritten. Structural changes
   (adding/removing worker groups, resource shapes) remain manager-owned.
@@ -327,12 +329,15 @@ None beyond the coverage described below.
 
 ### Graduation Criteria
 
-The feature follows the standard Kueue maturity progression, riding the existing
-`ElasticJobsViaWorkloadSlices` alpha feature gate together with MultiKueue.
+The feature follows the standard Kueue maturity progression on its own
+`MultiKueueRayInTreeAutoscaling` feature gate; it additionally requires
+`ElasticJobsViaWorkloadSlices` and MultiKueue.
 
 **Alpha**: Reverse elastic sync is implemented for RayCluster and RayJob behind the
-`ElasticJobsViaWorkloadSlices` gate, with basic functionality covered by tests and
-accompanying documentation.
+`MultiKueueRayInTreeAutoscaling` gate (off by default), with basic functionality
+covered by tests and accompanying documentation. While the gate is off, the
+validating webhook keeps rejecting `enableInTreeAutoscaling` on a
+MultiKueue-managed elastic Ray object, exactly as it does today.
 
 **Beta**: Positive feedback from Alpha, broader test coverage, and any documented
 follow-ups addressed.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -166,6 +166,10 @@ The end-to-end flow of a worker-side autoscaler resize:
 5. The manager's PodSets follow the reflected counts, so the workload-slicing
    machinery **re-reserves quota**: a freshly named replacement slice on scale-up,
    or an in-place update on scale-down.
+6. On scale-up the admitted slice changes name, so the forward sync **repoints**
+   the worker job's prebuilt-workload marker to the new slice — its only duty in
+   autoscaling mode — keeping the already-running worker job linked to the current
+   slice.
 
 The subsections below detail each step.
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -196,8 +196,11 @@ Each reconcile of an autoscaling object:
 
 1. `Fetch(remoteClient, remoteJob)` reads the effective per-worker-group pod counts
    from the worker cluster, plus a `UID-generation` **revision** of the object that
-   holds those counts. A suspended remote is skipped (its counts were restored by
-   the worker's Kueue while stopping the job, not set by the autoscaler).
+   holds those counts. The revision's role is to give each reflected scale-up a
+   distinct workload-slice name (details under [Workload-slice
+   naming](#workload-slice-naming-under-annotation-reflection)). A suspended remote
+   is skipped (its counts were restored by the worker's Kueue while stopping the
+   job, not set by the autoscaler).
 2. `Apply(localJob, counts, revision)` records them on the **manager** copy as two
    annotations — `raycluster-podset-replica-sizes` (the counts) and
    `raycluster-generation` (the revision) — leaving the manager spec untouched.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -296,11 +296,22 @@ transiently differ from its admitted slice's count. Without tolerance, the **wor
 cluster's** Kueue would finish that workload `OutOfSync` and tear the job down.
 This KEP adds a resize tolerance in the jobframework that applies **on the worker
 cluster** — scoped to the MultiKueue-dispatched copy via the origin label — so a
-transient mismatch during handover is not treated as divergence:
+transient mismatch during handover is not treated as divergence.
 
-- On scale-up, extra pods stay behind scheduling gates and are never admitted
-  past quota.
-- On scale-down, the workload briefly over-reserves and is never under-reserved.
+**Scale-up.** KubeRay creates the new worker pods immediately, but each lands
+behind the `kueue.x-k8s.io/elastic-job` scheduling gate; the worker's ungater
+releases them — up to the granted count — only once the manager has admitted the
+replacement slice. Until then the job's desired count exceeds the admitted
+slice's: the tolerance absorbs that gap, and the gates keep it from becoming
+scheduled pods beyond quota.
+
+**Scale-down.** The two sides proceed independently: KubeRay makes sure the pods
+the autoscaler lists in `workersToDelete` are eventually deleted, without
+waiting for the workload's in-place update, and the reverse sync shrinks the
+slice without waiting for those pods to terminate. If that eventual guarantee
+proves insufficient, a future refinement could defer the workload update until
+KubeRay has cleared `workersToDelete` — that is, until the listed pods are
+actually gone.
 
 ### Test Plan
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -135,10 +135,19 @@ temporarily.
 
 ### Risks and Mitigations
 
-- **The manager overwrites an autoscaler resize (fight loop).** In autoscaling
-  mode the forward sync never pushes replicas; its only remaining duty is
-  repointing the remote's prebuilt-workload marker at the current slice
-  (idempotent). Replicas flow one way — worker→manager — while autoscaling is on.
+- **The owner of the worker group's `replicas` differs with and without
+  autoscaling.** **Without** autoscaling the manager owns them: a manager-side
+  `replicas` edit is allowed, and the existing forward sync
+  ([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885), which implements
+  elastic RayCluster sync from the manager to the worker) propagates it down to the
+  worker copy's workload. **With** autoscaling on, the Ray autoscaler on the worker
+  cluster owns them instead, and they flow the other way — worker→manager — through
+  the reverse sync.
+  The reason for the split: if both the manager and the autoscaler could write the
+  worker group's `replicas`, they would fight (fight loop). So while autoscaling is
+  on, a mutating webhook on the manager pins the worker group's `replicas` and
+  reverts any manager-side edit, keeping the autoscaler as the single writer —
+  matching the Non-Goal of resizing the same object from both sides.
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
@@ -289,18 +298,18 @@ None beyond the coverage described below.
 
 #### e2e tests
 
-- Real-autoscaler e2e (extended MultiKueue suite: manager + worker clusters,
-  KubeRay operator on the workers), scaling driven by detached Ray actors that each
-  require a per-worker resource so the actual Ray autoscaler resizes the group. A
-  standalone RayCluster and a RayJob's child are each driven **up (2) → down (0) →
-  up (1)**, and every resize is reflected onto the manager. Assertions cover the
-  manager runtime annotation, the worker `DesiredWorkerReplicas` and Running
-  worker-pod count, the ClusterQueue admitted count, and — on **both** the manager
-  and the worker cluster — exactly one live, admitted workload slice reserving the
-  reflected count. The slice lifecycle is checked by slice **name** (in-place on
-  scale-down, fresh replacement on scale-up), which keeps the assertions robust to
-  the autoscaler transiently overshooting the requested count. Worker RayCluster
-  not torn down mid-handover; MultiKueue GC clean after deletion.
+- **Real-autoscaler e2e** (extended MultiKueue suite: manager + worker clusters,
+  KubeRay operator on the workers). Two scenarios run on this same setup:
+
+  - *Single-resize lifecycle*: a standalone RayCluster and a RayJob's child are each
+    driven **up (2) → down (0) → up (1)**; in-place slice update on scale-down, fresh
+    replacement on scale-up; worker RayCluster not torn down mid-handover; MultiKueue
+    GC clean after deletion.
+  - *Sequential scale-ups*: two consecutive scale-ups on the standalone RayCluster,
+    each adding one worker pod (**0 → 1 → 2**). Ensures that while the manager has
+    admitted only the first scale-up's slice, the worker schedules exactly one extra
+    worker pod, not two — the second pod stays gated until the manager admits the
+    second scale-up's slice.
 
 ### Graduation Criteria
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -113,17 +113,16 @@ which feed the manager's PodSets derivation and the workload-slice name.
 
 ### User Stories
 
-#### Story 1: Multi-modal inference
+#### Story 1: Online and offline inference
 
-A multi-modal inference pipeline processes data through stages with very different
-resource needs — for example, CPU workers for image decoding and GPU workers for
-captioning. Ray's autoscaler sizes each worker group independently to match
-per-stage demand:
+The Ray autoscaler sizes each worker group independently to match its demand:
 
 - Online inference is served by a long-lived `RayService`; its worker groups scale
   up as request load rises and back down when it subsides.
-- Offline / batch inference runs as a `RayCluster` or `RayJob`; its worker groups
-  scale with the batch in flight.
+- Offline / batch inference runs as a `RayCluster` or `RayJob` over multi-modal
+  data whose stages need different resources — for example CPU workers for image
+  decoding and GPU workers for captioning — so the autoscaler grows and shrinks
+  each worker group as the batch moves through the pipeline.
 
 #### Story 2: Colocated training and evaluation
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -71,7 +71,7 @@ response to the actual resource demands of the application:
 Many real workloads depend on it — mixed online/offline inference, and training
 colocated with evaluation in a single long-lived RayCluster. The manager-driven-only
 model shuts out every such use case. To unblock them, the resize decision must be
-allowed to *originate on the worker* and flow back to the manager, which remains
+allowed to *originate on the worker* and *flow back to the manager*, which remains
 the quota authority.
 
 ### Goals

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -7,7 +7,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [User Stories](#user-stories)
-    - [Story 1: Online/offline inference](#story-1-onlineoffline-inference)
+    - [Story 1: Online and offline inference](#story-1-online-and-offline-inference)
     - [Story 2: Colocated training and evaluation](#story-2-colocated-training-and-evaluation)
   - [Notes/Constraints/Caveats](#notesconstraintscaveats)
   - [Risks and Mitigations](#risks-and-mitigations)

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -17,7 +17,6 @@
     - [RayJob](#rayjob)
     - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
-  - [Retaining enableInTreeAutoscaling on the remote copy](#retaining-enableintreeautoscaling-on-the-remote-copy)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
     - [Unit tests](#unit-tests)
@@ -279,13 +278,6 @@ transient mismatch during handover is not treated as divergence:
 - On scale-up, extra pods stay behind scheduling gates and are never admitted
   past quota.
 - On scale-down, the workload briefly over-reserves and is never under-reserved.
-
-### Retaining enableInTreeAutoscaling on the remote copy
-
-In autoscaling mode the remote copy keeps `enableInTreeAutoscaling`, so the worker
-runs the autoscaler sidecar (accounted for in the head PodSet). The forward sync
-never pushes replicas in this mode; its only duty is repointing the remote's
-prebuilt-workload marker at the current slice, which is idempotent.
 
 ### Test Plan
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -159,7 +159,8 @@ The end-to-end flow of a worker-side autoscaler resize:
    editing the worker RayCluster's replicas; KubeRay then adds or removes worker
    pods.
 4. On the next manager reconcile, the adapter's reverse-sync **`Fetch`** reads the
-   worker's effective per-worker-group counts plus a revision, and **`Apply`**
+   effective per-worker-group counts from the worker-side RayCluster's **spec**
+   plus a revision, and **`Apply`**
    records them on the manager copy as annotations — the manager spec is never
    touched.
 5. The manager's PodSets follow the reflected counts, so the workload-slicing
@@ -184,8 +185,9 @@ manager spec untouched.
 
 ```go
 type RuntimeReplicaSync[PtrT any] struct {
-	// Fetch reads the effective per-worker-group pod counts from the worker
-	// cluster, plus a revision identifying the observed runtime state.
+	// Fetch reads the effective per-worker-group pod counts from the
+	// worker-side RayCluster's spec, plus a revision identifying the observed
+	// runtime state.
 	Fetch func(ctx context.Context, remoteClient client.Client, remoteJob PtrT) (
 		counts map[kueue.PodSetReference]int32, revision string, found bool, err error)
 	// Apply records them onto the manager copy (as annotations), returning
@@ -197,9 +199,10 @@ type RuntimeReplicaSync[PtrT any] struct {
 Each reconcile of an autoscaling object:
 
 1. `Fetch(remoteClient, remoteJob)` reads the effective per-worker-group pod counts
-   from the worker cluster, plus a `UID-generation` **revision** of the object that
-   holds those counts. The revision's role is to give each reflected scale-up a
-   distinct workload-slice name (details under [Workload-slice
+   from the worker-side RayCluster's **spec** (the object's own remote copy, or a
+   RayJob's child cluster), plus a `UID-generation` **revision** of the object that
+   holds those counts. The revision's role is to give each reflected
+   scale-up a distinct workload-slice name (details under [Workload-slice
    naming](#workload-slice-naming-under-annotation-reflection)).
 2. `Apply(localJob, counts, revision)` records them on the **manager** copy as two
    annotations — `raycluster-podset-replica-sizes` (the counts) and
@@ -225,8 +228,8 @@ The two `Fetch` implementations map onto these:
 
 #### RayCluster
 
-The worker replicas live on the remote RayCluster copy itself, so `Fetch` reads
-that copy directly; the revision is the remote RayCluster's `UID-generation`.
+The worker replicas live on the remote RayCluster copy's spec, so `Fetch` reads
+that spec directly; the revision is the remote RayCluster's `UID-generation`.
 
 ```go
 // RayCluster: Fetch reads the remote RayCluster copy itself.
@@ -235,9 +238,10 @@ revision := fmt.Sprintf("%s-%d", remoteCluster.UID, remoteCluster.Generation)
 
 #### RayJob
 
-The worker replicas live on the **child RayCluster** that KubeRay creates on the
-worker cluster (the child never exists on the manager), so `Fetch` reads the child
-by `status.rayClusterName`; the revision is the child's `UID-generation`.
+The worker replicas live on the spec of the **child RayCluster** that KubeRay
+creates on the worker cluster (the child never exists on the manager), so `Fetch`
+resolves the child by `status.rayClusterName` and reads its spec; the revision is
+the child's `UID-generation`.
 
 ```go
 // RayJob: Fetch reads the child RayCluster (status.rayClusterName) on the worker.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -47,22 +47,7 @@ through its existing workload-slicing machinery.
 
 ## Motivation
 
-The [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html) is the natural way to run elastic Ray
-workloads — it grows and shrinks worker groups in response to the actual resource
-demands of the application:
-
-- Step 1: the user runs a Ray application (submitting tasks, actors, or placement
-  groups) on the RayCluster.
-- Step 2: the Ray Autoscaler observes that demand and decides to scale, editing
-  the RayCluster CR — raising a worker group's `replicas` to add workers, or
-  listing specific pods in `scaleStrategy.workersToDelete` to remove them.
-- Step 3: KubeRay reconciles the updated CR and creates or deletes the worker
-  pods.
-
-Many real workloads depend on it — mixed online/offline inference, and training
-colocated with evaluation in a single long-lived RayCluster.
-
-MultiKueue today supports only a *manager-driven* resize model for such
+MultiKueue today supports only a *manager-driven* resize model for elastic Ray
 workloads, built on the forward sync from
 [#12885](https://github.com/kubernetes-sigs/kueue/pull/12885):
 
@@ -77,10 +62,23 @@ for a MultiKueue-managed elastic RayCluster at admission
 ([#13244](https://github.com/kubernetes-sigs/kueue/pull/13244)), because there is
 no path for a worker-side autoscaler resize to reach the manager.
 
-That is a reasonable stopgap, but it blocks every use case that relies on the
-worker's own autoscaler. To unblock them, the resize decision must be allowed to
-*originate on the worker* and flow back to the manager, which remains the quota
-authority.
+But the [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html)
+is the natural way to run these workloads — it grows and shrinks worker groups in
+response to the actual resource demands of the application:
+
+- Step 1: the user runs a Ray application (submitting tasks, actors, or placement
+  groups) on the RayCluster.
+- Step 2: the Ray Autoscaler observes that demand and decides to scale, editing
+  the RayCluster CR — raising a worker group's `replicas` to add workers, or
+  listing specific pods in `scaleStrategy.workersToDelete` to remove them.
+- Step 3: KubeRay reconciles the updated CR and creates or deletes the worker
+  pods.
+
+Many real workloads depend on it — mixed online/offline inference, and training
+colocated with evaluation in a single long-lived RayCluster. Blocking it is a
+reasonable stopgap, but it shuts out every such use case. To unblock them, the
+resize decision must be allowed to *originate on the worker* and flow back to the
+manager, which remains the quota authority.
 
 ### Goals
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -113,13 +113,21 @@ which feed the manager's PodSets derivation and the workload-slice name.
 
 ### User Stories
 
-#### Story 1: Online/offline inference
+#### Story 1: Multi-modal inference
 
-A team runs a long-lived RayCluster serving online inference, with the in-tree
-autoscaler adding worker replicas as offline batch inference demand spikes and
-removing them when it subsides. They want Kueue/MultiKueue to place this cluster
-on a worker cluster with spare quota and keep the manager's quota books accurate
-as the autoscaler resizes it — without the manager fighting the autoscaler.
+A multi-modal inference pipeline processes data through stages with very different
+resource needs — for example, CPU workers for image decoding and GPU workers for
+captioning. Ray's autoscaler sizes each worker group independently to match
+per-stage demand:
+
+- Online inference is served by a long-lived `RayService`; its worker groups scale
+  up as request load rises and back down when it subsides.
+- Offline / batch inference runs as a `RayCluster` or `RayJob`; its worker groups
+  scale with the batch in flight.
+
+The team wants Kueue/MultiKueue to place these workloads on a worker cluster with
+spare quota and keep the manager's quota books accurate as the autoscaler resizes
+each worker group — without the manager fighting the autoscaler.
 
 #### Story 2: Colocated training and evaluation
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -37,7 +37,7 @@ Kueue can dispatch an elastic RayCluster or RayJob (`ElasticJobsViaWorkloadSlice
 to a worker cluster through MultiKueue, and the manager-driven forward sync
 ([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885)) propagates
 manager-side resizes down to that worker copy. But when the workload is meant to
-be resized by the **Ray in-tree autoscaler running on the worker cluster**, there
+be resized by the [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html), there
 is no path for those worker-side resizes to travel back to the manager. As a
 result, the manager's quota accounting drifts from reality and the manager can
 overwrite the autoscaler's changes, tearing down the running job.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -156,8 +156,21 @@ guarded by an `AutoscalingEnabled` predicate that turns the reverse direction on
 only when the object runs the worker autoscaler. Wiring is validated when the
 adapter is built: if `AutoscalingEnabled` is set, `Runtime` (with both `Fetch` and
 `Apply`) is required. Both RayCluster and RayJob use the same hook — the reflection
-is **annotation-based for both**, leaving the manager spec untouched. Each
-reconcile of an autoscaling object:
+is **annotation-based for both**, leaving the manager spec untouched.
+
+```go
+type RuntimeReplicaSync[PtrT any] struct {
+	// Fetch reads the effective per-worker-group pod counts from the worker
+	// cluster, plus a revision identifying the observed runtime state.
+	Fetch func(ctx context.Context, remoteClient client.Client, remoteJob PtrT) (
+		counts map[kueue.PodSetReference]int32, revision string, found bool, err error)
+	// Apply records them onto the manager copy (as annotations), returning
+	// whether anything changed.
+	Apply func(localJob client.Object, counts map[kueue.PodSetReference]int32, revision string) bool
+}
+```
+
+Each reconcile of an autoscaling object:
 
 1. `Fetch(remoteClient, remoteJob)` reads the effective per-worker-group pod counts
    from the worker cluster, plus a `UID-generation` **revision** of the object that
@@ -181,11 +194,22 @@ The only per-type difference is **where `Fetch` reads the live worker replicas**
 The worker replicas live on the remote RayCluster copy itself, so `Fetch` reads
 that copy directly; the revision is the remote RayCluster's `UID-generation`.
 
+```go
+// RayCluster: Fetch reads the remote RayCluster copy itself.
+revision := fmt.Sprintf("%s-%d", remoteCluster.UID, remoteCluster.Generation)
+```
+
 #### RayJob
 
 The worker replicas live on the **child RayCluster** that KubeRay creates on the
 worker cluster (the child never exists on the manager), so `Fetch` reads the child
 by `status.rayClusterName`; the revision is the child's `UID-generation`.
+
+```go
+// RayJob: Fetch reads the child RayCluster (status.rayClusterName) on the worker.
+child := getRemoteChild(remoteJob.Status.RayClusterName)
+revision := fmt.Sprintf("%s-%d", child.UID, child.Generation)
+```
 
 #### Workload-slice naming under annotation reflection
 
@@ -199,6 +223,18 @@ fold the `raycluster-generation` revision into the slice name
 reflected worker `UID-generation`, which advances on every worker-side resize. The
 UID component keeps the name unique across a remote recreation, whose generation
 restarts from 1.
+
+```go
+func GetWorkloadNameExtraPart(obj metav1.Object) string {
+	extra := strconv.FormatInt(obj.GetGeneration(), 10) // manager generation (frozen under annotation reflection)
+	if rev := obj.GetAnnotations()[RayClusterGenerationAnnotation]; rev != "" {
+		extra += "_" + rev // reflected worker UID-generation, advances on every resize
+	}
+	return extra
+}
+
+// slice name = <kind>-<name>-sha1(Kind "\n" Group "\n" name "\n" UID "\n" extra)[:5]
+```
 
 ### Worker-side resize tolerance
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -1,0 +1,307 @@
+# KEP-13243: MultiKueue Worker-Side Ray In-Tree Autoscaling for Elastic Jobs
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [User Stories](#user-stories)
+    - [Story 1: Online/offline inference](#story-1-onlineoffline-inference)
+    - [Story 2: Colocated training and evaluation](#story-2-colocated-training-and-evaluation)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Background: manager-driven forward sync](#background-manager-driven-forward-sync)
+  - [Reverse elastic sync](#reverse-elastic-sync)
+    - [RayCluster: spec reflection](#raycluster-spec-reflection)
+    - [RayJob: runtime reflection](#rayjob-runtime-reflection)
+  - [Worker-side resize tolerance](#worker-side-resize-tolerance)
+  - [ElasticJobUngater: resolving a deleted slice-chain root](#elasticjobungater-resolving-a-deleted-slice-chain-root)
+  - [Retaining enableInTreeAutoscaling on the remote copy](#retaining-enableintreeautoscaling-on-the-remote-copy)
+  - [Test Plan](#test-plan)
+    - [Prerequisite testing updates](#prerequisite-testing-updates)
+    - [Unit tests](#unit-tests)
+    - [Integration tests](#integration-tests)
+    - [e2e tests](#e2e-tests)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+Kueue can dispatch an elastic RayCluster or RayJob (`ElasticJobsViaWorkloadSlices`)
+to a worker cluster through MultiKueue, and the manager-driven forward sync
+([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885)) propagates
+manager-side resizes down to that worker copy. But when the workload is meant to
+be resized by the **Ray in-tree autoscaler running on the worker cluster**, there
+is no path for those worker-side resizes to travel back to the manager. As a
+result, the manager's quota accounting drifts from reality and the manager can
+overwrite the autoscaler's changes, tearing down the running job.
+
+This KEP proposes the missing **worker→manager** direction — a *reverse elastic
+sync* in the shared Ray adapter — so an autoscaler-driven resize on the worker
+cluster is reflected onto the manager object, and the manager re-reserves quota
+through its existing workload-slicing machinery. It also covers the two
+supporting changes required to make the handover non-disruptive: a worker-side
+resize tolerance in the jobframework, and a fix to the elastic-job ungater so it
+does not strand pods when MultiKueue deletes the root of a slice chain.
+
+## Motivation
+
+Ray's in-tree autoscaler is the natural way to run elastic Ray workloads: it
+grows and shrinks worker groups in response to the actual resource demands of the
+application (pending tasks, actors, placement groups). Many real workloads depend
+on it — mixed online/offline inference, and training colocated with evaluation in
+a single long-lived RayCluster.
+
+MultiKueue today forces such workloads into a *manager-driven* model: the
+forward sync clears `enableInTreeAutoscaling` on the remote copy so the worker's
+autoscaler cannot fight the manager, as documented in
+[#12885](https://github.com/kubernetes-sigs/kueue/pull/12885):
+
+> Because scaling is manager-driven, the remote copy must not run the in-tree Ray
+> autoscaler (which would otherwise fight the manager by editing replicas on the
+> worker cluster); the adapter clears `enableInTreeAutoscaling` on the remote copy
+> of an elastic RayCluster.
+
+That is correct for manager-driven resizing, but it blocks every use case that
+relies on the worker's own autoscaler. To unblock them, the resize decision must
+be allowed to *originate on the worker* and flow back to the manager, which
+remains the quota authority.
+
+### Goals
+
+- Let the Ray in-tree autoscaler resize a MultiKueue-dispatched elastic
+  `RayCluster` or `RayJob` on the worker cluster, and reflect that resize back
+  onto the manager object.
+- Keep the manager as the single quota authority: worker-originated resizes flow
+  through the manager's workload-slicing admission (quota re-reservation), never
+  bypass it.
+- Make the resize handover non-disruptive to the running job: no false
+  `OutOfSync` finish, no stranded pods, no quota under-reservation.
+- Bound what the worker autoscaler is allowed to request to the manager-declared
+  `[minReplicas, maxReplicas]` range.
+
+### Non-Goals
+
+- A brand-new autoscaling algorithm — this reuses Ray's in-tree autoscaler and
+  Kueue's existing workload slicing.
+- Extending reverse elastic sync to non-Ray integrations in this KEP (the adapter
+  hooks are designed to generalize, but only Ray is implemented here).
+- A webhook-level authz guard preventing tenants from hand-setting the
+  runtime replica-size annotation on their own RayJob (tracked as a follow-up;
+  value validation is present).
+- Manager-driven and worker-driven resizing of the *same* object at the same
+  time; a given elastic object is resized by one side.
+
+## Proposal
+
+Add a **reverse elastic sync** to the shared Ray adapter that detects an
+autoscaler-driven resize of the remote (worker) copy and reflects it onto the
+manager object, where the existing workload-slicing machinery re-reserves quota.
+Two type-specific mechanisms are used, chosen by where the worker replica counts
+actually live, and grouped as mutually-exclusive hook structs validated at wiring
+time:
+
+- **RayCluster** — replicas live on the CR spec, so the worker resize is written
+  back onto the manager RayCluster spec.
+- **RayJob** — replicas live on the child RayCluster that KubeRay creates on the
+  worker, so the child's per-group counts are reflected onto the manager RayJob
+  as annotations that feed the manager's PodSets derivation.
+
+Two supporting changes make the handover safe: a worker-scoped resize tolerance
+in the jobframework, and an ungater fix for deleted slice-chain roots.
+
+### User Stories
+
+#### Story 1: Online/offline inference
+
+A team runs a long-lived RayCluster serving online inference, with the in-tree
+autoscaler adding worker replicas as offline batch inference demand spikes and
+removing them when it subsides. They want Kueue/MultiKueue to place this cluster
+on a worker cluster with spare quota and keep the manager's quota books accurate
+as the autoscaler resizes it — without the manager fighting the autoscaler.
+
+#### Story 2: Colocated training and evaluation
+
+A team colocates a training job and periodic evaluation actors in the same
+RayCluster. Evaluation bursts cause the autoscaler to grow the cluster
+temporarily. They want those autoscaler-driven resizes admitted against their
+ClusterQueue quota (through slice replacement) rather than blocked or reverted.
+
+### Notes/Constraints/Caveats
+
+- The feature applies only to elastic (`ElasticJobsViaWorkloadSlices`) Ray objects
+  dispatched through MultiKueue with `enableInTreeAutoscaling` set.
+- Only `Replicas` moves in the worker→manager direction. Structural changes
+  (adding/removing worker groups, resource shapes) remain manager-owned.
+- Counts outside the manager-declared `[minReplicas, maxReplicas]` cannot
+  legitimately come from the autoscaler and are ignored.
+
+### Risks and Mitigations
+
+- **The manager overwrites an autoscaler resize (fight loop).** In autoscaling
+  mode the forward sync never pushes replicas; its only remaining duty is
+  repointing the remote's prebuilt-workload marker at the current slice
+  (idempotent). Replicas flow one way — worker→manager — while autoscaling is on.
+- **A tenant forges replica counts via the runtime annotation.** The reflected
+  value is validated (parseable, within `[min,max]`); a malformed annotation
+  falls back to the spec counts. An authz-level guard is a documented follow-up.
+- **The handover finishes the workload `OutOfSync` and tears the job down.** A
+  worker-scoped resize tolerance absorbs the transient job/slice count mismatch
+  during handover (see below).
+- **Pods stranded behind scheduling gates after slice replacement.** The ungater
+  fix resolves the slice chain through any surviving member when its root has been
+  deleted by MultiKueue.
+
+## Design Details
+
+### Background: manager-driven forward sync
+
+[#12885](https://github.com/kubernetes-sigs/kueue/pull/12885) established the
+manager→worker direction for elastic RayClusters: a resize on the manager is
+propagated to the remote copy, and the remote copy runs with
+`enableInTreeAutoscaling` cleared so it cannot self-resize. This KEP adds the
+opposite direction and, for autoscaling objects, retains
+`enableInTreeAutoscaling` on the remote copy.
+
+### Reverse elastic sync
+
+The shared Ray adapter gains reverse-sync hooks, grouped as two mutually
+exclusive structs and validated when the adapter is wired:
+
+- `Spec{Push, Reflect, Counts}` — used when worker replicas live on the CR.
+- `Runtime{Fetch, Apply}` — used when worker replicas live on a child object.
+
+#### RayCluster: spec reflection
+
+For an elastic RayCluster, the worker replicas live directly on the remote CR.
+When the worker autoscaler resizes the remote copy, the adapter's `Reflect` hook
+writes the new `Replicas` back onto the manager RayCluster spec. The manager's
+workload-slicing machinery observes the spec change and re-reserves quota (slice
+replacement on scale-up; in-place slice update on scale-down). Only `Replicas`
+is reflected, and only within the manager-declared `[minReplicas, maxReplicas]`.
+
+#### RayJob: runtime reflection
+
+For an elastic RayJob, the worker replicas live on the child RayCluster that
+KubeRay creates on the worker cluster, not on the RayJob spec. The adapter
+reflects the child's per-group counts, plus a `childUID-generation` revision, onto
+the manager RayJob as annotations. Those annotations feed the manager's PodSets
+derivation (gated on `spec.managedBy`) and workload-slice naming. Count-neutral
+child updates (same per-group counts) do not mint a replacement slice; the
+revision distinguishes a genuine resize from an unrelated child update.
+
+### Worker-side resize tolerance
+
+During a resize handover, the job's observed count on the worker can transiently
+differ from the admitted slice's count. Without tolerance, that mismatch finishes
+the workload `OutOfSync` and tears the job down. This KEP adds a resize tolerance
+in the jobframework, scoped to MultiKueue-dispatched copies via the origin label,
+so a transient mismatch during handover is not treated as divergence:
+
+- On scale-up, extra pods stay behind scheduling gates and are never admitted
+  past quota.
+- On scale-down, the workload briefly over-reserves and is never under-reserved.
+
+### ElasticJobUngater: resolving a deleted slice-chain root
+
+The worker-side `ElasticJobUngater` resolves a slice chain by loading its root
+workload. On a MultiKueue worker, the manager deletes the remote copy of a
+replaced slice, so the chain's root can be gone while newer slices and gated pods
+that name the chain key still exist. The ungater previously dead-ended there,
+leaving pods `SchedulingGated` forever. It now falls back to resolving the chain
+through any surviving member (a workload whose `workloadslicing.SliceName`
+matches the chain key).
+
+### Retaining enableInTreeAutoscaling on the remote copy
+
+In autoscaling mode the remote copy keeps `enableInTreeAutoscaling`, so the worker
+runs the autoscaler sidecar (accounted for in the head PodSet). The forward sync
+never pushes replicas in this mode; its only duty is repointing the remote's
+prebuilt-workload marker at the current slice, which is idempotent.
+
+### Test Plan
+
+[x] I/we understand the owners of the involved components may require updates to
+existing tests to make this code solid enough prior to committing the changes
+necessary to implement this enhancement.
+
+#### Prerequisite testing updates
+
+None beyond the coverage described below.
+
+#### Unit tests
+
+- Reverse-sync hooks for RayCluster (spec reflection) and RayJob (runtime
+  reflection), including the `[min,max]` clamp, the `childUID-generation`
+  revision, count-neutral updates that must not mint a slice, and the
+  malformed-annotation fallback to spec counts.
+- Hook-pairing validation (`Spec`/`Runtime` mutually exclusive) at wiring time.
+- Jobframework worker-side resize tolerance, gated on the origin label.
+- ElasticJobUngater chain resolution when the root is deleted (fail-without,
+  pass-with).
+
+#### Integration tests
+
+- MultiKueue elastic RayCluster/RayJob resize handover: worker-originated resize
+  reflected onto the manager; slice replacement on scale-up; in-place update on
+  scale-down; no `OutOfSync` churn; quota reservation exact.
+
+#### e2e tests
+
+- Real-autoscaler e2e on two kind clusters (KubeRay operator on the worker,
+  scaling driven via `ray.autoscaler.sdk.request_resources`): RayCluster 1→3→1
+  and RayJob child 1→3→1 reflected onto the manager; scale-up replaces the slice
+  (admitted by the real scheduler, prebuilt marker repointed), scale-down updates
+  the slice in place; post-handover pods reach `Running`; ClusterQueue
+  reservation exact including the autoscaler sidecar; MultiKueue GC clean after
+  deletion.
+
+### Graduation Criteria
+
+Alpha:
+
+- Reverse elastic sync implemented for RayCluster and RayJob behind the existing
+  `ElasticJobsViaWorkloadSlices` gate + MultiKueue.
+- Unit, integration, and real-autoscaler e2e coverage as above.
+
+Beta (tentative):
+
+- Address the documented follow-ups: authz guard for the runtime replica-size
+  annotation, and an optional time bound on the resize tolerance.
+- Metrics/observability for reverse-sync resizes.
+- Broader soak/e2e coverage in CI (fullray periodic jobs).
+
+## Implementation History
+
+- 2026-07-26: KEP drafted.
+- Prototype and verification in
+  [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) (reverse elastic
+  sync, worker-side resize tolerance, ungater chain-root fix; verified with unit,
+  integration, and real-autoscaler e2e).
+
+## Drawbacks
+
+- Adds a second sync direction to the Ray adapter, increasing the surface area of
+  MultiKueue's elastic handling and the number of interleavings to reason about.
+- Retaining `enableInTreeAutoscaling` on the remote copy makes the worker a
+  source of truth for replica counts, which must be carefully bounded to the
+  manager-declared range to keep the manager as the quota authority.
+
+## Alternatives
+
+- **Manager-driven only (status quo).** Simple and already shipped, but blocks
+  every use case that needs the worker's in-tree autoscaler.
+- **Reject `enableInTreeAutoscaling` for MultiKueue elastic Ray objects.**
+  [#13244](https://github.com/kubernetes-sigs/kueue/pull/13244) takes this stance
+  as an interim guard until this support exists; it prevents silent misbehavior
+  but does not deliver worker-side autoscaling. Once this KEP lands, that
+  rejection is lifted.
+- **Run the autoscaler on the manager against the remote cluster's metrics.**
+  Requires the manager to reach worker-cluster application metrics and duplicates
+  the autoscaler's placement logic across the MultiKueue boundary; rejected as
+  more complex and less faithful to how Ray autoscaling works.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -17,7 +17,6 @@
     - [RayJob](#rayjob)
     - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
-  - [Handover safety under frequent slice replacement](#handover-safety-under-frequent-slice-replacement)
   - [Retaining enableInTreeAutoscaling on the remote copy](#retaining-enableintreeautoscaling-on-the-remote-copy)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -280,17 +279,6 @@ transient mismatch during handover is not treated as divergence:
 - On scale-up, extra pods stay behind scheduling gates and are never admitted
   past quota.
 - On scale-down, the workload briefly over-reserves and is never under-reserved.
-
-### Handover safety under frequent slice replacement
-
-Worker-driven resizing replaces workload slices frequently. When a slice is
-replaced, the manager's MultiKueue reconciler recognizes the old slice only when
-it is finished as `WorkloadSliceReplaced`; a slice mistakenly finished as
-`OutOfSync` slips past that guard and its remote objects are deleted mid-handover,
-which can strand the scaled pods behind scheduling gates. This feature therefore
-depends on the merged
-[#13489](https://github.com/kubernetes-sigs/kueue/pull/13489), which finishes a
-replaced slice as `WorkloadSliceReplaced` and closes that race.
 
 ### Retaining enableInTreeAutoscaling on the remote copy
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -198,9 +198,7 @@ Each reconcile of an autoscaling object:
    from the worker cluster, plus a `UID-generation` **revision** of the object that
    holds those counts. The revision's role is to give each reflected scale-up a
    distinct workload-slice name (details under [Workload-slice
-   naming](#workload-slice-naming-under-annotation-reflection)). A suspended remote
-   is skipped (its counts were restored by the worker's Kueue while stopping the
-   job, not set by the autoscaler).
+   naming](#workload-slice-naming-under-annotation-reflection)).
 2. `Apply(localJob, counts, revision)` records them on the **manager** copy as two
    annotations — `raycluster-podset-replica-sizes` (the counts) and
    `raycluster-generation` (the revision) — leaving the manager spec untouched.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -340,7 +340,3 @@ major outstanding bugs.
   as an interim guard until this support exists; it prevents silent misbehavior
   but does not deliver worker-side autoscaling. Once this KEP lands, that
   rejection is lifted.
-- **Run the autoscaler on the manager against the remote cluster's metrics.**
-  Requires the manager to reach worker-cluster application metrics and duplicates
-  the autoscaler's placement logic across the MultiKueue boundary; rejected as
-  more complex and less faithful to how Ray autoscaling works.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -47,7 +47,7 @@ through its existing workload-slicing machinery.
 
 ## Motivation
 
-Ray's in-tree autoscaler is the natural way to run elastic Ray workloads: it
+The [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html) is the natural way to run elastic Ray workloads: it
 grows and shrinks worker groups in response to the actual resource demands of the
 application (pending tasks, actors, placement groups). Many real workloads depend
 on it — mixed online/offline inference, and training colocated with evaluation in
@@ -84,7 +84,7 @@ remains the quota authority.
 
 ### Non-Goals
 
-- A brand-new autoscaling algorithm — this reuses Ray's in-tree autoscaler and
+- A brand-new autoscaling algorithm — this reuses the Ray Autoscaler and
   Kueue's existing workload slicing.
 - Extending reverse elastic sync to non-Ray integrations in this KEP (the adapter
   hooks are designed to generalize, but only Ray is implemented here).

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -14,8 +14,9 @@
 - [Design Details](#design-details)
   - [Background: manager-driven forward sync](#background-manager-driven-forward-sync)
   - [Reverse elastic sync](#reverse-elastic-sync)
-    - [RayCluster: spec reflection](#raycluster-spec-reflection)
-    - [RayJob: runtime reflection](#rayjob-runtime-reflection)
+    - [RayCluster](#raycluster)
+    - [RayJob](#rayjob)
+    - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
   - [ElasticJobUngater: resolving a deleted slice-chain root](#elasticjobungater-resolving-a-deleted-slice-chain-root)
   - [Retaining enableInTreeAutoscaling on the remote copy](#retaining-enableintreeautoscaling-on-the-remote-copy)
@@ -82,8 +83,9 @@ remains the quota authority.
   bypass it.
 - Make the resize handover non-disruptive to the running job: no false
   `OutOfSync` finish, no stranded pods, no quota under-reservation.
-- Bound what the worker autoscaler is allowed to request to the manager-declared
-  `[minReplicas, maxReplicas]` range.
+- Keep the reflected worker count bounded to the RayCluster's own
+  `[minReplicas, maxReplicas]`, which the Ray autoscaler already enforces on the
+  worker cluster.
 
 ### Non-Goals
 
@@ -100,17 +102,20 @@ remains the quota authority.
 ## Proposal
 
 Add a **reverse elastic sync** to the shared Ray adapter that detects an
-autoscaler-driven resize of the remote (worker) copy and reflects it onto the
-manager object, where the existing workload-slicing machinery re-reserves quota.
-Two type-specific mechanisms are used, chosen by where the worker replica counts
-actually live, and grouped as mutually-exclusive hook structs validated at wiring
-time:
+autoscaler-driven resize on the worker cluster and reflects it onto the manager
+object **as annotations, leaving the manager spec untouched**, where the existing
+workload-slicing machinery re-reserves quota. A single `Runtime{Fetch, Apply}`
+hook drives it for both types; only *where the live worker replicas are read*
+differs:
 
-- **RayCluster** — replicas live on the CR spec, so the worker resize is written
-  back onto the manager RayCluster spec.
-- **RayJob** — replicas live on the child RayCluster that KubeRay creates on the
-  worker, so the child's per-group counts are reflected onto the manager RayJob
-  as annotations that feed the manager's PodSets derivation.
+- **RayCluster** — the replicas live on the remote RayCluster copy itself.
+- **RayJob** — the replicas live on the child RayCluster that KubeRay creates on
+  the worker (the child never exists on the manager), so its per-group counts are
+  read from there.
+
+In both cases `Apply` records the counts (and a revision) on the manager copy as
+the `raycluster-podset-replica-sizes` and `raycluster-generation` annotations,
+which feed the manager's PodSets derivation and the workload-slice name.
 
 Two supporting changes make the handover safe: a worker-scoped resize tolerance
 in the jobframework, and an ungater fix for deleted slice-chain roots.
@@ -136,10 +141,11 @@ ClusterQueue quota (through slice replacement) rather than blocked or reverted.
 
 - The feature applies only to elastic (`ElasticJobsViaWorkloadSlices`) Ray objects
   dispatched through MultiKueue with `enableInTreeAutoscaling` set.
-- Only `Replicas` moves in the worker→manager direction. Structural changes
+- Only per-worker-group replica counts move in the worker→manager direction, and
+  only as annotations — the manager spec is never rewritten. Structural changes
   (adding/removing worker groups, resource shapes) remain manager-owned.
-- Counts outside the manager-declared `[minReplicas, maxReplicas]` cannot
-  legitimately come from the autoscaler and are ignored.
+- The reflected count is whatever the worker autoscaler settled on, which the
+  RayCluster's own `[minReplicas, maxReplicas]` already bounds on the worker side.
 
 ### Risks and Mitigations
 
@@ -148,8 +154,9 @@ ClusterQueue quota (through slice replacement) rather than blocked or reverted.
   repointing the remote's prebuilt-workload marker at the current slice
   (idempotent). Replicas flow one way — worker→manager — while autoscaling is on.
 - **A tenant forges replica counts via the runtime annotation.** The reflected
-  value is validated (parseable, within `[min,max]`); a malformed annotation
-  falls back to the spec counts. An authz-level guard is a documented follow-up.
+  value is parsed and a malformed annotation is ignored (the manager falls back to
+  the spec counts). An authz-level guard against a tenant hand-setting the
+  annotation is a documented follow-up.
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
@@ -170,30 +177,54 @@ opposite direction and, for autoscaling objects, retains
 
 ### Reverse elastic sync
 
-The shared Ray adapter gains reverse-sync hooks, grouped as two mutually
-exclusive structs and validated when the adapter is wired:
+The shared Ray adapter gains a single reverse-sync hook, `Runtime{Fetch, Apply}`,
+guarded by an `AutoscalingEnabled` predicate that turns the reverse direction on
+only when the object runs the worker autoscaler. Wiring is validated when the
+adapter is built: if `AutoscalingEnabled` is set, `Runtime` (with both `Fetch` and
+`Apply`) is required. Both RayCluster and RayJob use the same hook — the reflection
+is **annotation-based for both**, leaving the manager spec untouched. Each
+reconcile of an autoscaling object:
 
-- `Spec{Push, Reflect, Counts}` — used when worker replicas live on the CR.
-- `Runtime{Fetch, Apply}` — used when worker replicas live on a child object.
+1. `Fetch(remoteClient, remoteJob)` reads the effective per-worker-group pod counts
+   from the worker cluster, plus a `UID-generation` **revision** of the object that
+   holds those counts. A suspended remote is skipped (its counts were restored by
+   the worker's Kueue while stopping the job, not set by the autoscaler).
+2. `Apply(localJob, counts, revision)` records them on the **manager** copy as two
+   annotations — `raycluster-podset-replica-sizes` (the counts) and
+   `raycluster-generation` (the revision) — leaving the manager spec untouched.
+   Equality is decided on the counts alone, so a count-neutral revision bump does
+   not re-annotate or mint a replacement slice.
 
-#### RayCluster: spec reflection
+The manager's PodSets derivation reads `raycluster-podset-replica-sizes` (gated on
+`spec.managedBy`), so its admitted PodSet counts follow the worker autoscaler, and
+the workload-slicing machinery re-reserves quota — slice replacement on scale-up,
+in-place slice update on scale-down.
 
-For an elastic RayCluster, the worker replicas live directly on the remote CR.
-When the worker autoscaler resizes the remote copy, the adapter's `Reflect` hook
-writes the new `Replicas` back onto the manager RayCluster spec. The manager's
-workload-slicing machinery observes the spec change and re-reserves quota (slice
-replacement on scale-up; in-place slice update on scale-down). Only `Replicas`
-is reflected, and only within the manager-declared `[minReplicas, maxReplicas]`.
+The only per-type difference is **where `Fetch` reads the live worker replicas**:
 
-#### RayJob: runtime reflection
+#### RayCluster
 
-For an elastic RayJob, the worker replicas live on the child RayCluster that
-KubeRay creates on the worker cluster, not on the RayJob spec. The adapter
-reflects the child's per-group counts, plus a `childUID-generation` revision, onto
-the manager RayJob as annotations. Those annotations feed the manager's PodSets
-derivation (gated on `spec.managedBy`) and workload-slice naming. Count-neutral
-child updates (same per-group counts) do not mint a replacement slice; the
-revision distinguishes a genuine resize from an unrelated child update.
+The worker replicas live on the remote RayCluster copy itself, so `Fetch` reads
+that copy directly; the revision is the remote RayCluster's `UID-generation`.
+
+#### RayJob
+
+The worker replicas live on the **child RayCluster** that KubeRay creates on the
+worker cluster (the child never exists on the manager), so `Fetch` reads the child
+by `status.rayClusterName`; the revision is the child's `UID-generation`.
+
+#### Workload-slice naming under annotation reflection
+
+Because the reverse sync reflects onto the manager as **annotations**, it never
+bumps the manager object's `metadata.generation`. The elastic workload-slice name
+must still change on each reflected scale-up so the manager mints a fresh
+replacement slice — a same-named slice would fail to create ("already exists") and
+leave the scaled worker pods gated. Both the RayJob and RayCluster jobs therefore
+fold the `raycluster-generation` revision into the slice name
+(`GetWorkloadNameExtraPart`): the name keys on the manager `generation` **and** the
+reflected worker `UID-generation`, which advances on every worker-side resize. The
+UID component keeps the name unique across a remote recreation, whose generation
+restarts from 1.
 
 ### Worker-side resize tolerance
 
@@ -236,11 +267,14 @@ None beyond the coverage described below.
 
 #### Unit tests
 
-- Reverse-sync hooks for RayCluster (spec reflection) and RayJob (runtime
-  reflection), including the `[min,max]` clamp, the `childUID-generation`
-  revision, count-neutral updates that must not mint a slice, and the
-  malformed-annotation fallback to spec counts.
-- Hook-pairing validation (`Spec`/`Runtime` mutually exclusive) at wiring time.
+- Reverse-sync `Runtime{Fetch, Apply}` for RayCluster (reads its own remote copy)
+  and RayJob (reads the child RayCluster), including the `UID-generation` revision,
+  count-neutral updates that must not re-annotate or mint a slice, the
+  suspended-remote skip, and the malformed-annotation fallback to spec counts.
+- Workload-slice naming folds in the reflected revision
+  (`GetWorkloadNameExtraPart`): a fresh reflected count yields a new slice name.
+- Adapter-wiring validation: `Runtime` (with `Fetch` and `Apply`) required when
+  `AutoscalingEnabled` is set.
 - Jobframework worker-side resize tolerance, gated on the origin label.
 - ElasticJobUngater chain resolution when the root is deleted (fail-without,
   pass-with).
@@ -253,13 +287,18 @@ None beyond the coverage described below.
 
 #### e2e tests
 
-- Real-autoscaler e2e on two kind clusters (KubeRay operator on the worker,
-  scaling driven via `ray.autoscaler.sdk.request_resources`): RayCluster 1→3→1
-  and RayJob child 1→3→1 reflected onto the manager; scale-up replaces the slice
-  (admitted by the real scheduler, prebuilt marker repointed), scale-down updates
-  the slice in place; post-handover pods reach `Running`; ClusterQueue
-  reservation exact including the autoscaler sidecar; MultiKueue GC clean after
-  deletion.
+- Real-autoscaler e2e (extended MultiKueue suite: manager + worker clusters,
+  KubeRay operator on the workers), scaling driven by detached Ray actors that each
+  require a per-worker resource so the actual Ray autoscaler resizes the group. A
+  standalone RayCluster and a RayJob's child are each driven **up (2) → down (0) →
+  up (1)**, and every resize is reflected onto the manager. Assertions cover the
+  manager runtime annotation, the worker `DesiredWorkerReplicas` and Running
+  worker-pod count, the ClusterQueue admitted count, and — on **both** the manager
+  and the worker cluster — exactly one live, admitted workload slice reserving the
+  reflected count. The slice lifecycle is checked by slice **name** (in-place on
+  scale-down, fresh replacement on scale-up), which keeps the assertions robust to
+  the autoscaler transiently overshooting the requested count. Worker RayCluster
+  not torn down mid-handover; MultiKueue GC clean after deletion.
 
 ### Graduation Criteria
 
@@ -282,7 +321,14 @@ Beta (tentative):
 - Prototype and verification in
   [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) (reverse elastic
   sync, worker-side resize tolerance, ungater chain-root fix; verified with unit,
-  integration, and real-autoscaler e2e).
+  integration, and real-autoscaler e2e — including on real GPU clusters).
+- 2026-08-01: reverse sync unified onto a single annotation-based
+  `Runtime{Fetch, Apply}` for both RayCluster and RayJob — RayCluster no longer
+  writes back to the manager spec; the reflected size reuses the existing
+  `raycluster-podset-replica-sizes` annotation; the elastic workload-slice name
+  folds in the reflected revision so annotation-only reflection still mints fresh
+  slices; e2e specs hardened to up/down/up with name-based, overshoot-tolerant
+  slice assertions.
 
 ## Drawbacks
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -206,7 +206,16 @@ The manager's PodSets derivation reads `raycluster-podset-replica-sizes` (gated 
 the workload-slicing machinery re-reserves quota — slice replacement on scale-up,
 in-place slice update on scale-down.
 
-The only per-type difference is **where `Fetch` reads the live worker replicas**:
+The only per-type difference is **where `Fetch` reads the live worker replicas**,
+which splits the job types into two kinds:
+
+1. The worker replica counts can be read **directly from the object's own CR** —
+   the object itself carries them (e.g. a standalone `RayCluster`).
+2. The counts are **not** on the object's CR and must be read from a **child
+   resource** the framework creates on the worker (e.g. `RayJob`, whose child
+   `RayCluster` is created by KubeRay).
+
+The two `Fetch` implementations map onto these:
 
 #### RayCluster
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -167,9 +167,8 @@ The end-to-end flow of a worker-side autoscaler resize:
    machinery **re-reserves quota**: a freshly named replacement slice on scale-up,
    or an in-place update on scale-down.
 6. On scale-up the admitted slice changes name, so the forward sync **repoints**
-   the worker job's prebuilt-workload marker to the new slice — its only duty in
-   autoscaling mode — keeping the already-running worker job linked to the current
-   slice.
+   the worker job's prebuilt-workload marker to the new slice, keeping the
+   already-running worker job linked to the current slice.
 
 The subsections below detail each step.
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -111,12 +111,6 @@ In both cases `Apply` records the counts (and a revision) on the manager copy as
 the `raycluster-podset-replica-sizes` and `raycluster-generation` annotations,
 which feed the manager's PodSets derivation and the workload-slice name.
 
-The handover is made safe by a worker-scoped resize tolerance in the jobframework
-(this KEP), together with the already-merged
-[#13489](https://github.com/kubernetes-sigs/kueue/pull/13489), which finishes a
-replaced slice as `WorkloadSliceReplaced` so MultiKueue does not delete a slice
-mid-handover and strand its pods.
-
 ### User Stories
 
 #### Story 1: Online/offline inference

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -47,11 +47,20 @@ through its existing workload-slicing machinery.
 
 ## Motivation
 
-The [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html) is the natural way to run elastic Ray workloads: it
-grows and shrinks worker groups in response to the actual resource demands of the
-application (pending tasks, actors, placement groups). Many real workloads depend
-on it — mixed online/offline inference, and training colocated with evaluation in
-a single long-lived RayCluster.
+The [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html) is the natural way to run elastic Ray
+workloads — it grows and shrinks worker groups in response to the actual resource
+demands of the application:
+
+- Step 1: the user runs a Ray application (submitting tasks, actors, or placement
+  groups) on the RayCluster.
+- Step 2: the Ray Autoscaler observes that demand and decides to scale, editing
+  the RayCluster CR — raising a worker group's `replicas` to add workers, or
+  listing specific pods in `scaleStrategy.workersToDelete` to remove them.
+- Step 3: KubeRay reconciles the updated CR and creates or deletes the worker
+  pods.
+
+Many real workloads depend on it — mixed online/offline inference, and training
+colocated with evaluation in a single long-lived RayCluster.
 
 MultiKueue today supports only a *manager-driven* resize model for such
 workloads, built on the forward sync from

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -71,8 +71,8 @@ response to the actual resource demands of the application:
 Many real workloads depend on it — mixed online/offline inference, and training
 colocated with evaluation in a single long-lived RayCluster. The manager-driven-only
 model shuts out every such use case. To unblock them, the resize decision must be
-allowed to *originate on the worker* and *flow back to the manager*, which remains
-the quota authority.
+allowed to **originate on the worker** and **flow back to the manager**, which
+remains the quota authority.
 
 ### Goals
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -125,16 +125,11 @@ per-stage demand:
 - Offline / batch inference runs as a `RayCluster` or `RayJob`; its worker groups
   scale with the batch in flight.
 
-The team wants Kueue/MultiKueue to place these workloads on a worker cluster with
-spare quota and keep the manager's quota books accurate as the autoscaler resizes
-each worker group — without the manager fighting the autoscaler.
-
 #### Story 2: Colocated training and evaluation
 
 A team colocates a training job and periodic evaluation actors in the same
 RayCluster. Evaluation bursts cause the autoscaler to grow the cluster
-temporarily. They want those autoscaler-driven resizes admitted against their
-ClusterQueue quota (through slice replacement) rather than blocked or reverted.
+temporarily.
 
 ### Notes/Constraints/Caveats
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -18,6 +18,7 @@
     - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
   - [Manager-side replicas pinning](#manager-side-replicas-pinning)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
+  - [Triggering the reverse sync](#triggering-the-reverse-sync)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
     - [e2e tests](#e2e-tests)
@@ -317,6 +318,20 @@ slice without waiting for those pods to terminate. If that eventual guarantee
 proves insufficient, a future refinement could defer the workload update until
 KubeRay has cleared `workersToDelete` — that is, until the listed pods are
 actually gone.
+
+### Triggering the reverse sync
+
+A resize must wake the manager's workload reconcile. MultiKueue watches each
+worker object and maps it back to a workload through its prebuilt-workload marker.
+
+- **RayCluster** — the autoscaler edits the watched RayCluster itself, so the
+  reconcile wakes directly.
+- **RayJob** — the autoscaler edits the child RayCluster. The wake-up relies on
+  KubeRay mirroring the child's status into `RayJob.status`.
+
+As a possible follow-up, the child RayCluster event could wake the RayJob
+reconcile directly, removing the dependency on KubeRay's status mirroring. This
+is not a priority, since KubeRay always performs that status mirroring.
 
 ### Test Plan
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -320,21 +320,11 @@ major outstanding bugs.
 ## Implementation History
 
 - 2026-07-26: KEP drafted.
-- Prototype and verification in
-  [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) (reverse elastic
-  sync, worker-side resize tolerance; verified with unit, integration, and
-  real-autoscaler e2e — including on real GPU clusters).
-- 2026-08-01: reverse sync unified onto a single annotation-based
-  `Runtime{Fetch, Apply}` for both RayCluster and RayJob — RayCluster no longer
-  writes back to the manager spec; the reflected size reuses the existing
-  `raycluster-podset-replica-sizes` annotation; the elastic workload-slice name
-  folds in the reflected revision so annotation-only reflection still mints fresh
-  slices; e2e specs hardened to up/down/up with name-based, overshoot-tolerant
-  slice assertions.
-- The initially-prototyped ElasticJobUngater chain-root workaround was dropped in
-  favor of the merged root-cause fix
-  [#13489](https://github.com/kubernetes-sigs/kueue/pull/13489) (finish a replaced
-  slice as `WorkloadSliceReplaced`).
+- 2026-07: Prototyped in
+  [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) — reverse elastic
+  sync and worker-side resize tolerance for RayCluster and RayJob.
+- 2026-08: Reverse sync unified onto a single annotation-based
+  `Runtime{Fetch, Apply}`, leaving the manager spec untouched.
 
 ## Drawbacks
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -18,7 +18,7 @@
     - [RayJob](#rayjob)
     - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
-  - [ElasticJobUngater: resolving a deleted slice-chain root](#elasticjobungater-resolving-a-deleted-slice-chain-root)
+  - [Handover safety under frequent slice replacement](#handover-safety-under-frequent-slice-replacement)
   - [Retaining enableInTreeAutoscaling on the remote copy](#retaining-enableintreeautoscaling-on-the-remote-copy)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -112,8 +112,11 @@ In both cases `Apply` records the counts (and a revision) on the manager copy as
 the `raycluster-podset-replica-sizes` and `raycluster-generation` annotations,
 which feed the manager's PodSets derivation and the workload-slice name.
 
-Two supporting changes make the handover safe: a worker-scoped resize tolerance
-in the jobframework, and an ungater fix for deleted slice-chain roots.
+The handover is made safe by a worker-scoped resize tolerance in the jobframework
+(this KEP), together with the already-merged
+[#13489](https://github.com/kubernetes-sigs/kueue/pull/13489), which finishes a
+replaced slice as `WorkloadSliceReplaced` so MultiKueue does not delete a slice
+mid-handover and strand its pods.
 
 ### User Stories
 
@@ -155,9 +158,10 @@ ClusterQueue quota (through slice replacement) rather than blocked or reverted.
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
-- **Pods stranded behind scheduling gates after slice replacement.** The ungater
-  fix resolves the slice chain through any surviving member when its root has been
-  deleted by MultiKueue.
+- **Pods stranded behind scheduling gates after slice replacement.** Fixed by the
+  merged prerequisite [#13489](https://github.com/kubernetes-sigs/kueue/pull/13489):
+  a replaced slice is finished as `WorkloadSliceReplaced`, so MultiKueue's elastic
+  guard no longer deletes the slice (and its chain root) mid-handover.
 
 ## Design Details
 
@@ -233,15 +237,16 @@ so a transient mismatch during handover is not treated as divergence:
   past quota.
 - On scale-down, the workload briefly over-reserves and is never under-reserved.
 
-### ElasticJobUngater: resolving a deleted slice-chain root
+### Handover safety under frequent slice replacement
 
-The worker-side `ElasticJobUngater` resolves a slice chain by loading its root
-workload. On a MultiKueue worker, the manager deletes the remote copy of a
-replaced slice, so the chain's root can be gone while newer slices and gated pods
-that name the chain key still exist. The ungater previously dead-ended there,
-leaving pods `SchedulingGated` forever. It now falls back to resolving the chain
-through any surviving member (a workload whose `workloadslicing.SliceName`
-matches the chain key).
+Worker-driven resizing replaces workload slices frequently. When a slice is
+replaced, the manager's MultiKueue reconciler recognizes the old slice only when
+it is finished as `WorkloadSliceReplaced`; a slice mistakenly finished as
+`OutOfSync` slips past that guard and its remote objects are deleted mid-handover,
+which can strand the scaled pods behind scheduling gates. This feature therefore
+depends on the merged
+[#13489](https://github.com/kubernetes-sigs/kueue/pull/13489), which finishes a
+replaced slice as `WorkloadSliceReplaced` and closes that race.
 
 ### Retaining enableInTreeAutoscaling on the remote copy
 
@@ -271,8 +276,6 @@ None beyond the coverage described below.
 - Adapter-wiring validation: `Runtime` (with `Fetch` and `Apply`) required when
   `AutoscalingEnabled` is set.
 - Jobframework worker-side resize tolerance, gated on the origin label.
-- ElasticJobUngater chain resolution when the root is deleted (fail-without,
-  pass-with).
 
 #### Integration tests
 
@@ -315,8 +318,8 @@ Beta (tentative):
 - 2026-07-26: KEP drafted.
 - Prototype and verification in
   [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) (reverse elastic
-  sync, worker-side resize tolerance, ungater chain-root fix; verified with unit,
-  integration, and real-autoscaler e2e — including on real GPU clusters).
+  sync, worker-side resize tolerance; verified with unit, integration, and
+  real-autoscaler e2e — including on real GPU clusters).
 - 2026-08-01: reverse sync unified onto a single annotation-based
   `Runtime{Fetch, Apply}` for both RayCluster and RayJob — RayCluster no longer
   writes back to the manager spec; the reflected size reuses the existing
@@ -324,6 +327,10 @@ Beta (tentative):
   folds in the reflected revision so annotation-only reflection still mints fresh
   slices; e2e specs hardened to up/down/up with name-based, overshoot-tolerant
   slice assertions.
+- The initially-prototyped ElasticJobUngater chain-root workaround was dropped in
+  favor of the merged root-cause fix
+  [#13489](https://github.com/kubernetes-sigs/kueue/pull/13489) (finish a replaced
+  slice as `WorkloadSliceReplaced`).
 
 ## Drawbacks
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -78,7 +78,8 @@ remains the quota authority.
 
 - Let the Ray Autoscaler resize a MultiKueue-dispatched elastic
   `RayCluster` or `RayJob` on the worker cluster, and reflect that resize back
-  onto the manager object.
+  onto the manager object — and extend the same mechanism to `RayService` once its
+  zero-downtime / incremental upgrade support is complete.
 - Keep the manager as the single quota authority: worker-originated resizes flow
   through the manager's workload-slicing admission (quota re-reservation), never
   bypass it.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -16,6 +16,7 @@
     - [RayCluster](#raycluster)
     - [RayJob](#rayjob)
     - [Workload-slice naming under annotation reflection](#workload-slice-naming-under-annotation-reflection)
+  - [Manager-side replicas pinning](#manager-side-replicas-pinning)
   - [Worker-side resize tolerance](#worker-side-resize-tolerance)
   - [Test Plan](#test-plan)
     - [Prerequisite testing updates](#prerequisite-testing-updates)
@@ -136,18 +137,11 @@ temporarily.
 ### Risks and Mitigations
 
 - **The owner of the worker group's `replicas` differs with and without
-  autoscaling.** **Without** autoscaling the manager owns them: a manager-side
-  `replicas` edit is allowed, and the existing forward sync
-  ([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885), which implements
-  elastic RayCluster sync from the manager to the worker) propagates it down to the
-  worker copy's workload. **With** autoscaling on, the Ray autoscaler on the worker
-  cluster owns them instead, and they flow the other way — worker→manager — through
-  the reverse sync.
-  The reason for the split: if both the manager and the autoscaler could write the
-  worker group's `replicas`, they would fight (fight loop). So while autoscaling is
-  on, a mutating webhook on the manager pins the worker group's `replicas` and
-  reverts any manager-side edit, keeping the autoscaler as the single writer —
-  matching the Non-Goal of resizing the same object from both sides.
+  autoscaling.** Without autoscaling the manager owns them; with autoscaling on, the
+  worker autoscaler does, and letting both write the same fields would fight. While
+  autoscaling is on, a validating webhook on the manager rejects manager-side
+  `replicas` edits (see
+  [Manager-side replicas pinning](#manager-side-replicas-pinning)).
 - **The handover finishes the workload `OutOfSync` and tears the job down.** A
   worker-scoped resize tolerance absorbs the transient job/slice count mismatch
   during handover (see below).
@@ -272,6 +266,19 @@ func GetWorkloadNameExtraPart(obj metav1.Object) string {
 
 // slice name = <kind>-<name>-sha1(Kind "\n" Group "\n" name "\n" UID "\n" extra)[:5]
 ```
+
+### Manager-side replicas pinning
+
+While the worker autoscaler owns the replicas, a **validating webhook** on the
+manager cluster rejects manager-side edits to the pinned fields. Without it, the
+forward sync ([#12885](https://github.com/kubernetes-sigs/kueue/pull/12885))
+propagates a manager-side edit down to the worker copy, where it lands on the same
+fields the autoscaler writes: two writers, each overwriting the other's value in an
+endless fight loop. The webhook keeps the autoscaler as the single writer.
+
+Pinned field paths:
+
+- `RayCluster`: `spec.workerGroupSpecs[*].replicas`
 
 ### Worker-side resize tolerance
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -137,8 +137,6 @@ temporarily.
 - Only per-worker-group replica counts move in the worker→manager direction, and
   only as annotations — the manager spec is never rewritten. Structural changes
   (adding/removing worker groups, resource shapes) remain manager-owned.
-- The reflected count is whatever the worker autoscaler settled on, which the
-  RayCluster's own `[minReplicas, maxReplicas]` already bounds on the worker side.
 
 ### Risks and Mitigations
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -253,6 +253,11 @@ revision := fmt.Sprintf("%s-%d", child.UID, child.Generation)
 
 #### Workload-slice naming under annotation reflection
 
+The `raycluster-generation` annotation predates this KEP:
+[#9960](https://github.com/kubernetes-sigs/kueue/pull/9960) introduced it for
+RayJob and RayService with the child RayCluster's bare `generation`, skipping
+standalone RayClusters. Here the reflected value is `UID-generation` instead.
+
 Because the reverse sync reflects onto the manager as **annotations**, it never
 bumps the manager object's `metadata.generation`. The elastic workload-slice name
 must still change on each reflected scale-up so the manager mints a fresh

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -304,18 +304,18 @@ None beyond the coverage described below.
 
 ### Graduation Criteria
 
-Alpha:
+The feature follows the standard Kueue maturity progression, riding the existing
+`ElasticJobsViaWorkloadSlices` alpha feature gate together with MultiKueue.
 
-- Reverse elastic sync implemented for RayCluster and RayJob behind the existing
-  `ElasticJobsViaWorkloadSlices` gate + MultiKueue.
-- Unit, integration, and real-autoscaler e2e coverage as above.
+**Alpha**: Reverse elastic sync is implemented for RayCluster and RayJob behind the
+`ElasticJobsViaWorkloadSlices` gate, with basic functionality covered by tests and
+accompanying documentation.
 
-Beta (tentative):
+**Beta**: Positive feedback from Alpha, broader test coverage, and any documented
+follow-ups addressed.
 
-- Address the documented follow-up: an optional time bound on the resize
-  tolerance.
-- Metrics/observability for reverse-sync resizes.
-- Broader soak/e2e coverage in CI (fullray periodic jobs).
+**Stable (GA)**: The feature has spent at least one release cycle in beta with no
+major outstanding bugs.
 
 ## Implementation History
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -149,6 +149,26 @@ temporarily.
 
 ## Design Details
 
+The end-to-end flow of a worker-side autoscaler resize:
+
+1. An elastic, autoscaling `RayCluster` (or `RayJob`) is dispatched through
+   MultiKueue and runs on a **worker** cluster with `enableInTreeAutoscaling` on;
+   the **manager** holds the admitted workload slice (the quota).
+2. A Ray application on the worker creates pending tasks, actors, or placement
+   groups.
+3. The **Ray Autoscaler** grows or shrinks the worker group to meet that demand,
+   editing the worker RayCluster's replicas; KubeRay then adds or removes worker
+   pods.
+4. On the next manager reconcile, the adapter's reverse-sync **`Fetch`** reads the
+   worker's effective per-worker-group counts plus a revision, and **`Apply`**
+   records them on the manager copy as annotations — the manager spec is never
+   touched.
+5. The manager's PodSets follow the reflected counts, so the workload-slicing
+   machinery **re-reserves quota**: a freshly named replacement slice on scale-up,
+   or an in-place update on scale-down.
+
+The subsections below detail each step.
+
 ### Reverse elastic sync
 
 The shared Ray adapter gains a single reverse-sync hook, `Runtime{Fetch, Apply}`,

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -56,12 +56,6 @@ workloads, built on the forward sync from
 - Step 2: MultiKueue forward-syncs the new count to the worker copy.
 - Step 3: the worker's KubeRay adjusts the worker pods to match.
 
-The worker's own Ray Autoscaler — the component that actually observes task/actor
-demand — cannot be used at all: MultiKueue **rejects** `enableInTreeAutoscaling`
-for a MultiKueue-managed elastic RayCluster at admission
-([#13244](https://github.com/kubernetes-sigs/kueue/pull/13244)), because there is
-no path for a worker-side autoscaler resize to reach the manager.
-
 But the [Ray Autoscaler](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/configuring-autoscaling.html)
 is the natural way to run these workloads — it grows and shrinks worker groups in
 response to the actual resource demands of the application:
@@ -75,10 +69,10 @@ response to the actual resource demands of the application:
   pods.
 
 Many real workloads depend on it — mixed online/offline inference, and training
-colocated with evaluation in a single long-lived RayCluster. Blocking it is a
-reasonable stopgap, but it shuts out every such use case. To unblock them, the
-resize decision must be allowed to *originate on the worker* and flow back to the
-manager, which remains the quota authority.
+colocated with evaluation in a single long-lived RayCluster. The manager-driven-only
+model shuts out every such use case. To unblock them, the resize decision must be
+allowed to *originate on the worker* and flow back to the manager, which remains
+the quota authority.
 
 ### Goals
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -82,11 +82,6 @@ remains the quota authority.
 - Keep the manager as the single quota authority: worker-originated resizes flow
   through the manager's workload-slicing admission (quota re-reservation), never
   bypass it.
-- Make the resize handover non-disruptive to the running job: no false
-  `OutOfSync` finish, no stranded pods, no quota under-reservation.
-- Keep the reflected worker count bounded to the RayCluster's own
-  `[minReplicas, maxReplicas]`, which the Ray autoscaler already enforces on the
-  worker cluster.
 
 ### Non-Goals
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -153,10 +153,9 @@ temporarily.
 
 The shared Ray adapter gains a single reverse-sync hook, `Runtime{Fetch, Apply}`,
 guarded by an `AutoscalingEnabled` predicate that turns the reverse direction on
-only when the object runs the worker autoscaler. Wiring is validated when the
-adapter is built: if `AutoscalingEnabled` is set, `Runtime` (with both `Fetch` and
-`Apply`) is required. Both RayCluster and RayJob use the same hook — the reflection
-is **annotation-based for both**, leaving the manager spec untouched.
+only when the object runs the worker autoscaler. Both RayCluster and RayJob use
+the same hook — the reflection is **annotation-based for both**, leaving the
+manager spec untouched.
 
 ```go
 type RuntimeReplicaSync[PtrT any] struct {

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -323,8 +323,6 @@ major outstanding bugs.
 - 2026-07: Prototyped in
   [#13435](https://github.com/kubernetes-sigs/kueue/pull/13435) — reverse elastic
   sync and worker-side resize tolerance for RayCluster and RayJob.
-- 2026-08: Reverse sync unified onto a single annotation-based
-  `Runtime{Fetch, Apply}`, leaving the manager spec untouched.
 
 ## Drawbacks
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -270,11 +270,12 @@ func GetWorkloadNameExtraPart(obj metav1.Object) string {
 
 ### Worker-side resize tolerance
 
-During a resize handover, the job's observed count on the worker can transiently
-differ from the admitted slice's count. Without tolerance, that mismatch finishes
-the workload `OutOfSync` and tears the job down. This KEP adds a resize tolerance
-in the jobframework, scoped to MultiKueue-dispatched copies via the origin label,
-so a transient mismatch during handover is not treated as divergence:
+During a resize handover, the job's observed count **on the worker cluster** can
+transiently differ from its admitted slice's count. Without tolerance, the **worker
+cluster's** Kueue would finish that workload `OutOfSync` and tear the job down.
+This KEP adds a resize tolerance in the jobframework that applies **on the worker
+cluster** — scoped to the MultiKueue-dispatched copy via the origin label — so a
+transient mismatch during handover is not treated as divergence:
 
 - On scale-up, extra pods stay behind scheduling gates and are never admitted
   past quota.

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -168,6 +168,9 @@ The end-to-end flow of a worker-side autoscaler resize:
 6. On scale-up the admitted slice changes name, so the forward sync **repoints**
    the worker job's prebuilt-workload marker to the new slice, keeping the
    already-running worker job linked to the current slice.
+7. When the manager **suspends** the job (eviction, preemption, requeue), the
+   reflected annotations are **cleared** alongside the existing PodSets restore, so
+   re-admission reserves at the spec baseline rather than the last autoscaled size.
 
 The subsections below detail each step.
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -53,30 +53,25 @@ application (pending tasks, actors, placement groups). Many real workloads depen
 on it — mixed online/offline inference, and training colocated with evaluation in
 a single long-lived RayCluster.
 
-MultiKueue today forces such workloads into a *manager-driven* model: the
-forward sync clears `enableInTreeAutoscaling` on the remote copy so the worker's
-autoscaler cannot fight the manager, as documented in
+MultiKueue today supports only a *manager-driven* resize model for such
+workloads, built on the forward sync from
 [#12885](https://github.com/kubernetes-sigs/kueue/pull/12885):
-
-> Because scaling is manager-driven, the remote copy must not run the in-tree Ray
-> autoscaler (which would otherwise fight the manager by editing replicas on the
-> worker cluster); the adapter clears `enableInTreeAutoscaling` on the remote copy
-> of an elastic RayCluster.
-
-In this model a resize can only be initiated on the manager:
 
 - Step 1: a user (or an external controller) edits the manager RayCluster's
   replicas.
 - Step 2: MultiKueue forward-syncs the new count to the worker copy.
 - Step 3: the worker's KubeRay adjusts the worker pods to match.
 
-The Ray Autoscaler on the worker — which is what actually observes task/actor
-demand — is disabled and never gets to drive it.
+The worker's own Ray Autoscaler — the component that actually observes task/actor
+demand — cannot be used at all: MultiKueue **rejects** `enableInTreeAutoscaling`
+for a MultiKueue-managed elastic RayCluster at admission
+([#13244](https://github.com/kubernetes-sigs/kueue/pull/13244)), because there is
+no path for a worker-side autoscaler resize to reach the manager.
 
-That is correct for manager-driven resizing, but it blocks every use case that
-relies on the worker's own autoscaler. To unblock them, the resize decision must
-be allowed to *originate on the worker* and flow back to the manager, which
-remains the quota authority.
+That is a reasonable stopgap, but it blocks every use case that relies on the
+worker's own autoscaler. To unblock them, the resize decision must be allowed to
+*originate on the worker* and flow back to the manager, which remains the quota
+authority.
 
 ### Goals
 
@@ -179,10 +174,11 @@ ClusterQueue quota (through slice replacement) rather than blocked or reverted.
 
 [#12885](https://github.com/kubernetes-sigs/kueue/pull/12885) established the
 manager→worker direction for elastic RayClusters: a resize on the manager is
-propagated to the remote copy, and the remote copy runs with
-`enableInTreeAutoscaling` cleared so it cannot self-resize. This KEP adds the
-opposite direction and, for autoscaling objects, retains
-`enableInTreeAutoscaling` on the remote copy.
+propagated to the remote copy. To keep scaling strictly manager-driven, in-tree
+autoscaling on a MultiKueue-managed elastic RayCluster is currently rejected at
+admission ([#13244](https://github.com/kubernetes-sigs/kueue/pull/13244)). This
+KEP adds the opposite direction and, for autoscaling objects, retains
+`enableInTreeAutoscaling` on the remote copy, lifting that rejection.
 
 ### Reverse elastic sync
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -63,6 +63,16 @@ autoscaler cannot fight the manager, as documented in
 > worker cluster); the adapter clears `enableInTreeAutoscaling` on the remote copy
 > of an elastic RayCluster.
 
+In this model a resize can only be initiated on the manager:
+
+- Step 1: a user (or an external controller) edits the manager RayCluster's
+  replicas.
+- Step 2: MultiKueue forward-syncs the new count to the worker copy.
+- Step 3: the worker's KubeRay adjusts the worker pods to match.
+
+The Ray Autoscaler on the worker — which is what actually observes task/actor
+demand — is disabled and never gets to drive it.
+
 That is correct for manager-driven resizing, but it blocks every use case that
 relies on the worker's own autoscaler. To unblock them, the resize decision must
 be allowed to *originate on the worker* and flow back to the manager, which

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -187,31 +187,38 @@ the same hook — the reflection is **annotation-based for both**, leaving the
 manager spec untouched.
 
 ```go
+type FetchResult struct {
+	Counts   map[kueue.PodSetReference]int32
+	Revision string
+}
+
 type RuntimeReplicaSync[PtrT any] struct {
 	// Fetch reads the effective per-worker-group pod counts from the
 	// worker-side RayCluster's spec, plus a revision identifying the observed
-	// runtime state.
-	Fetch func(ctx context.Context, remoteClient client.Client, remoteJob PtrT) (
-		counts map[kueue.PodSetReference]int32, revision string, found bool, err error)
+	// runtime state. A nil result means the runtime object does not exist yet.
+	Fetch func(ctx context.Context, remoteClient client.Client, remoteJob PtrT) (*FetchResult, error)
 	// Apply records them onto the manager copy (as annotations), returning
 	// whether anything changed.
-	Apply func(localJob client.Object, counts map[kueue.PodSetReference]int32, revision string) bool
+	Apply func(localJob client.Object, result FetchResult) bool
 }
 ```
 
 Each reconcile of an autoscaling object:
 
-1. `Fetch(remoteClient, remoteJob)` reads the effective per-worker-group pod counts
-   from the worker-side RayCluster's **spec** (the object's own remote copy, or a
-   RayJob's child cluster), plus a `UID-generation` **revision** of the object that
-   holds those counts. The revision's role is to give each reflected
-   scale-up a distinct workload-slice name (details under [Workload-slice
+1. `Fetch(remoteClient, remoteJob)` returns a `FetchResult` with the effective
+   per-worker-group pod counts from the worker-side RayCluster's **spec** (the
+   object's own remote copy, or a RayJob's child cluster), plus a
+   `UID-generation` **revision** of the object that holds those counts. A nil
+   result means the runtime object does not exist yet and the sync is skipped.
+   The revision's role is to give each reflected scale-up a distinct
+   workload-slice name (details under [Workload-slice
    naming](#workload-slice-naming-under-annotation-reflection)).
-2. `Apply(localJob, counts, revision)` records them on the **manager** copy as two
-   annotations — `raycluster-podset-replica-sizes` (the counts) and
-   `raycluster-generation` (the revision) — leaving the manager spec untouched.
-   Equality is decided on the counts alone, so a count-neutral revision bump does
-   not re-annotate or mint a replacement slice.
+2. `Apply(localJob, result)` receives the `FetchResult` and records its counts
+   and revision on the **manager** copy as two annotations —
+   `raycluster-podset-replica-sizes` (the counts) and `raycluster-generation`
+   (the revision) — leaving the manager spec untouched. Equality is decided on
+   the counts alone, so a count-neutral revision bump does not re-annotate or mint
+   a replacement slice.
 
 The manager's PodSets derivation reads `raycluster-podset-replica-sizes` (gated on
 `spec.managedBy`), so its admitted PodSet counts follow the worker autoscaler, and

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -270,18 +270,6 @@ reflected worker `UID-generation`, which advances on every worker-side resize. T
 UID component keeps the name unique across a remote recreation, whose generation
 restarts from 1.
 
-```go
-func GetWorkloadNameExtraPart(obj metav1.Object) string {
-	extra := strconv.FormatInt(obj.GetGeneration(), 10) // manager generation (frozen under annotation reflection)
-	if rev := obj.GetAnnotations()[RayClusterGenerationAnnotation]; rev != "" {
-		extra += "_" + rev // reflected worker UID-generation, advances on every resize
-	}
-	return extra
-}
-
-// slice name = <kind>-<name>-sha1(Kind "\n" Group "\n" name "\n" UID "\n" extra)[:5]
-```
-
 ### Manager-side replicas pinning
 
 While the worker autoscaler owns the replicas, a **validating webhook** on the

--- a/keps/13243-multikueue-ray-worker-autoscaling/README.md
+++ b/keps/13243-multikueue-ray-worker-autoscaling/README.md
@@ -359,7 +359,10 @@ validating webhook keeps rejecting `enableInTreeAutoscaling` on a
 MultiKueue-managed elastic Ray object, exactly as it does today.
 
 **Beta**: Positive feedback from Alpha, broader test coverage, and any documented
-follow-ups addressed.
+follow-ups addressed. Re-evaluate whether to generalize the annotation-based
+replica-count and revision mechanism currently represented by
+`raycluster-podset-replica-sizes` and `raycluster-generation` for non-KubeRay
+integrations such as batch/Job and JobSet.
 
 **Stable (GA)**: The feature has spent at least one release cycle in beta with no
 major outstanding bugs.

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -5,12 +5,9 @@ authors:
 status: provisional
 creation-date: 2026-07-26
 reviewers:
-  - TBD
   - "@mimowo"
-  - "@tenzen-y"
 approvers:
   - "@mimowo"
-  - "@tenzen-y"
 
 see-also:
   - "/keps/77-dynamically-sized-jobs"
@@ -22,11 +19,11 @@ stage: alpha
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.19"
+latest-milestone: "v0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
-  alpha: "v0.19"
+  alpha: "v0.20"
   beta: TBD
   stable: TBD
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -1,0 +1,43 @@
+title: MultiKueue Worker-Side Ray In-Tree Autoscaling for Elastic Jobs
+kep-number: 13243
+authors:
+  - "@kevin85421"
+status: provisional
+creation-date: 2026-07-26
+reviewers:
+  - TBD
+  - "@mimowo"
+  - "@tenzen-y"
+approvers:
+  - "@mimowo"
+  - "@tenzen-y"
+
+see-also:
+  - "/keps/77-dynamically-sized-jobs"
+  - "/keps/693-multikueue"
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: alpha
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.19"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v0.19"
+  beta: TBD
+  stable: TBD
+
+# The following PRR answers are required at alpha release.
+# This feature does not introduce a new feature gate; it is enabled when the
+# existing ElasticJobsViaWorkloadSlices gate is on, MultiKueue is configured,
+# and the RayCluster/RayJob sets enableInTreeAutoscaling.
+feature-gates:
+  - name: ElasticJobsViaWorkloadSlices
+disable-supported: true
+
+# The following PRR answers are required at beta release.
+# metrics:
+#   - my_feature_metric

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -30,11 +30,11 @@ milestone:
   stable: TBD
 
 # The following PRR answers are required at alpha release.
-# This feature does not introduce a new feature gate; it is enabled when the
-# existing ElasticJobsViaWorkloadSlices gate is on, MultiKueue is configured,
-# and the RayCluster/RayJob sets enableInTreeAutoscaling.
+# The feature has its own alpha gate (off by default); it additionally requires
+# the ElasticJobsViaWorkloadSlices gate, MultiKueue, and the RayCluster/RayJob
+# setting enableInTreeAutoscaling.
 feature-gates:
-  - name: ElasticJobsViaWorkloadSlices
+  - name: MultiKueueRayInTreeAutoscaling
 disable-supported: true
 
 # The following PRR answers are required at beta release.

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -6,6 +6,7 @@ status: provisional
 creation-date: 2026-07-26
 reviewers:
   - "@mimowo"
+  - "@sohankunkerkar"
 approvers:
   - "@mimowo"
   - "@sohankunkerkar"

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -6,6 +6,7 @@ status: provisional
 creation-date: 2026-07-26
 reviewers:
   - "@mimowo"
+  - "@sohankunkerkar"
 approvers:
   - "@mimowo"
 

--- a/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
+++ b/keps/13243-multikueue-ray-worker-autoscaling/kep.yaml
@@ -6,9 +6,9 @@ status: provisional
 creation-date: 2026-07-26
 reviewers:
   - "@mimowo"
-  - "@sohankunkerkar"
 approvers:
   - "@mimowo"
+  - "@sohankunkerkar"
 
 see-also:
   - "/keps/77-dynamically-sized-jobs"


### PR DESCRIPTION
#### What type of PR is this?

/kind kep
/area multikueue
/area integrations

#### What this PR does / why we need it:

Draft KEP. Implementation prototype (POC): #13435. The POC has already been deployed to our production environment last Friday.

#### Which issue(s) this PR fixes:

Part of #13243

#### Special notes for your reviewer:

AI usage disclosure: this KEP was drafted with AI assistance (Claude Code); the author reviewed all content.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a proposal for worker-to-manager synchronization to support autoscaling Ray workloads across MultiKueue.
  * Documents how worker replica changes and revisions enable workload quota updates without modifying the manager configuration.
  * Covers support for RayCluster and RayJob workloads, configuration requirements, testing plans, and graduation criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->