### PR TITLE
Remove the MultiKueueAllowInsecureKubeconfigs feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -220,14 +220,6 @@ const (
 	// Enable all updates to Workload objects to use Patch Merge instead of Patch Apply.
 	WorkloadRequestUseMergePatch featuregate.Feature = "WorkloadRequestUseMergePatch"
 
-	// owner: @mszadkow
-	//
-	// Allow insecure kubeconfigs in MultiKueue setup.
-	// Requires careful consideration as it may lead to security issues.
-	//
-	// Deprecated: locked to its default value (false) in 0.19; planned to be removed in 0.20.
-	MultiKueueAllowInsecureKubeconfigs featuregate.Feature = "MultiKueueAllowInsecureKubeconfigs"
-
 	// owner: @kannon92
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/12144
 	//
@@ -643,12 +635,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	WorkloadRequestUseMergePatch: {
 		{Version: version.MustParse("0.14"), Default: false, PreRelease: featuregate.Alpha},
 	},
-	MultiKueueAllowInsecureKubeconfigs: {
-		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Deprecated},
-		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Deprecated, LockToDefault: true}, // remove in 0.20
-	},
-
 	MultiKueueKubeConfigPathValidation: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -198,3 +198,13 @@
   stage: GA
   from: "0.17"
   to: "0.19"
+- feature: MultiKueueAllowInsecureKubeconfigs
+  default: false
+  stage: Alpha
+  from: "0.15"
+  to: "0.16"
+- feature: MultiKueueAllowInsecureKubeconfigs
+  default: false
+  stage: Deprecated
+  from: "0.17"
+  to: "0.19"

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -203,20 +203,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
-- name: MultiKueueAllowInsecureKubeconfigs
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.15"
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.17"
-  - default: false
-    lockToDefault: true
-    preRelease: Deprecated
-    version: "0.19"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -109,16 +109,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
-- name: HierarchicalCohorts
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "0.11"
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "0.17"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true
@@ -213,20 +203,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
-- name: MultiKueueAllowInsecureKubeconfigs
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.15"
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.17"
-  - default: false
-    lockToDefault: true
-    preRelease: Deprecated
-    version: "0.19"
 - name: MultiKueueClusterProfile
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Removes the `MultiKueueAllowInsecureKubeconfigs` feature gate. It was deprecated in 0.17 and locked to its default (`false`) in 0.19 (#12366), with the insecure code path already removed and the MultiKueue Kind dev setup migrated to CA-based kubeconfigs (#12289). As noted in https://github.com/kubernetes-sigs/kueue/issues/12284#issuecomment, the gate remained a locked no-op for 0.19 and can be removed in 0.20.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12284

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `WorkloadRequestUseMergePatch` feature gate (Alpha), disabled by default, to enable merge-patch handling for workload requests.
* **Removed Features**
  * Removed the `MultiKueueAllowInsecureKubeconfigs` feature gate from available configuration and updated generated versioned feature lists, including recording it as removed for additional release stage/version ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->