### PR TITLE
fix(pod): warn when fast-admission pods have diverging role hashes

### DIFF
--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -1251,6 +1251,10 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 	var keptPods []corev1.Pod
 	var excessActivePods []corev1.Pod
 	var replacedInactivePods []corev1.Pod
+	// matchedActivePods collects the UIDs of active pods that matched one of
+	// the workload's roles (pod sets) below. Any active pod left out of this
+	// set has a role hash that is absent from the workload.
+	matchedActivePods := make(sets.Set[types.UID], len(activePods))
 
 	for _, ps := range workload.Spec.PodSets {
 		// Find all the active and inactive pods of the role
@@ -1267,6 +1271,11 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 		roleInactivePods := utilslices.Pick(inactivePods, hasRoleFunc)
 		if len(roleHashErrors) > 0 {
 			return nil, nil, fmt.Errorf("failed to calculate pod role hash: %w", errors.Join(roleHashErrors...))
+		}
+		// roleActivePods matched this pod set's role hash (via hasRoleFunc),
+		// so record them as matched.
+		for _, rp := range roleActivePods {
+			matchedActivePods.Insert(rp.GetUID())
 		}
 
 		absentPods += p.countAbsentPods(ps, len(roleActivePods))
@@ -1295,6 +1304,31 @@ func (p *Pod) FindMatchingWorkloads(ctx context.Context, c client.Client, r even
 
 	if len(keptPods) == 0 || !p.equivalentToWorkload(workload, jobPodSets) {
 		return nil, []*kueue.Workload{workload}, nil
+	}
+
+	// At this point the workload is kept as equivalent to the group. However,
+	// an active pod whose role hash is absent from the workload's pod sets was
+	// not matched by any role above (it is not in matchedActivePods) and is not
+	// cleaned up either, so it stays gated indefinitely with no feedback. This
+	// happens with fast admission: the workload is built from the first
+	// runnable pod as a single-role pod set (constructGroupPodSetsFast), and a
+	// later member with a different role hash never matches it. Emit a warning
+	// so the misconfiguration is surfaced to the user instead of failing
+	// silently (see https://github.com/kubernetes-sigs/kueue/issues/13242).
+	for i := range activePods {
+		// Skip pods that matched one of the workload's roles above.
+		if matchedActivePods.Has(activePods[i].GetUID()) {
+			continue
+		}
+		// Recompute the hash only to include it in the warning message; the
+		// match decision was already made via matchedActivePods.
+		hash, err := getRoleHash(activePods[i])
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to calculate pod role hash: %w", err)
+		}
+		errMsg := fmt.Sprintf("pod '%s' role hash '%s' does not match any role in the group workload '%s'",
+			activePods[i].GetName(), hash, groupName)
+		r.Eventf(p.Object(), nil, corev1.EventTypeWarning, jobframework.ReasonErrWorkloadCompose, "ErrWorkloadCompose", errMsg)
 	}
 
 	// Do not clean up more pods until observing previous operations

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -28,6 +29,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -935,6 +937,72 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 
 					util.ExpectPodsJustFinalized(ctx, k8sClient, pod1LookupKey, pod2LookupKey)
 				})
+			})
+
+			ginkgo.It("Should surface a warning when fast-admission pods have diverging role hashes", func() {
+				// Regression test for https://github.com/kubernetes-sigs/kueue/issues/13242
+				//
+				// With fast admission the group Workload is built from the first
+				// runnable pod via constructGroupPodSetsFast, producing a single
+				// role PodSet. If a later member of the group has a different
+				// role hash, FindMatchingWorkloads partitions active pods strictly
+				// by the Workload's existing PodSets, so the divergent pod matches
+				// no role and is silently gated forever with no event. (There is
+				// no delete/recreate churn: the single-role Workload keeps a
+				// stable identity because equivalentToWorkload never sees the
+				// missing role.) The fix detects active pods whose role hash is
+				// absent from the Workload during FindMatchingWorkloads and emits
+				// a Warning event so the misconfiguration is reported.
+				wlLookupKey := types.NamespacedName{Namespace: ns.Name, Name: "test-group"}
+
+				ginkgo.By("Creating the first fast-admission pod (role-a)")
+				pod1 := testingpod.MakePod("test-pod1", ns.Name).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					RoleHash("role-a").
+					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+					Queue("test-queue").
+					Obj()
+				util.MustCreate(ctx, k8sClient, pod1)
+
+				ginkgo.By("Waiting for the single-role Workload to be created from the first pod")
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.Spec.PodSets).Should(gomega.HaveLen(1))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				firstUID := createdWorkload.UID
+
+				ginkgo.By("Creating a second group member with a diverging role hash (role-b)")
+				pod2 := testingpod.MakePod("test-pod2", ns.Name).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					RoleHash("role-b").
+					Annotation(podconstants.GroupFastAdmissionAnnotationKey, podconstants.GroupFastAdmissionAnnotationValue).
+					Queue("test-queue").
+					Obj()
+				util.MustCreate(ctx, k8sClient, pod2)
+
+				ginkgo.By("Checking a Warning event is emitted for the divergent pod")
+				gomega.Eventually(func(g gomega.Gomega) {
+					found, err := utiltesting.HasMatchingEventAppeared(ctx, k8sClient, func(e *eventsv1.Event) bool {
+						return e.Reason == jobframework.ReasonErrWorkloadCompose &&
+							e.Type == corev1.EventTypeWarning &&
+							e.Regarding.Namespace == ns.Name &&
+							strings.Contains(e.Note, "pod 'test-pod2'") &&
+							strings.Contains(e.Note, "role hash 'role-b'") &&
+							strings.Contains(e.Note, "does not match any role in the group workload 'test-group'")
+					})
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(found).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Checking the Workload is not deleted and recreated (no reconcile churn)")
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+					g.Expect(createdWorkload.UID).Should(gomega.Equal(firstUID),
+						"Workload was recreated, indicating unexpected reconcile churn")
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 			})
 
 			ginkgo.It("Should keep the running pod group with the queue name if workload is evicted", framework.SlowSpec, func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With fast admission, a pod group's Workload is built from the first runnable pod via `constructGroupPodSetsFast`, which produces a single-role PodSet. It does not verify that the other group members share that role hash.

If a fast-admission group contains pods with diverging role hashes, `FindMatchingWorkloads` partitions active pods strictly by the Workload's existing pod sets, so the divergent pods match no role. They are then neither kept nor cleaned up, and are silently gated forever with no event surfaced to the user.

While investigating the reproduction I confirmed that this does NOT produce the delete/recreate churn originally hypothesized: the single-role Workload keeps a stable identity because `equivalentToWorkload` uses a `<` count comparison and never observes the missing role, so it is judged equivalent and is not deleted. I verified this with an envtest integration run: over ~12s the Workload UID stayed constant (no churn), both pods stayed gated, and zero events were emitted. The real problem is a silently un-admitted pod, not an infinite reconciliation loop.

This PR detects active pods whose role hash is absent from the Workload's pod sets in `FindMatchingWorkloads` (only when the Workload is otherwise kept, so the normal out-of-sync replacement path is unaffected) and emits a Warning event, so the misconfiguration is surfaced instead of failing silently. It also adds an integration test covering the diverging-role-hash fast-admission case.

#### Which issue(s) this PR fixes:

Fixes #13242

#### Special notes for your reviewer:

The guard is intentionally placed in `FindMatchingWorkloads` rather than `constructGroupPodSetsFast`. `constructGroupPodSetsFast` only runs at initial Workload construction, when typically only the first pod is present in the cache, so a check there does not catch the divergent pod that arrives later. `FindMatchingWorkloads` runs on every reconcile and is the only place the orphaned pod is observable in steady state.

#### Does this PR introduce a user-facing change?

```release-note
Fixed an issue where pods in a fast-admission pod group with diverging role hashes were silently gated with no feedback. A warning event is now emitted to surface the misconfiguration.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warning events when active pods have role hashes that do not match any role in their workload group.
  * Improved visibility into pod-group composition mismatches without disrupting existing workloads.
  * Prevented unnecessary workload deletion or recreation when role-hash differences are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->