### PR TITLE
Add /promote-pull ChatOps command

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -37,7 +37,9 @@ Please do not remove items from the checklist
   - Upload the files in the `release-artifacts` folder to the draft release.
 - [ ] Promote images and Helm Charts to production:
   - [ ] Use `/wait-for-images` to await for the staging images.
-  - [ ] Run `./hack/releasing/promote_pull.sh $VERSION` to submit the promotion PR
+  - [ ] Run `/promote-pull` ChatOps command (or locally: `./hack/releasing/promote_pull.sh $VERSION`)
+        to submit the promotion PR. Re-running is safe: it updates the existing PR rather than
+        opening a second one.
   - [ ] Wait for the PR to be merged <!-- K8S_IO_PULL --> <!-- example kubernetes/k8s.io#7899 -->
   - [ ] Use `/wait-for-prod-images` to verify that the promoted images are available.
 - [ ] Use `/publish-release` to publish the release prepared at the [GitHub releases page](https://github.com/kubernetes-sigs/kueue/releases).

--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -37,9 +37,13 @@ Please do not remove items from the checklist
   - Upload the files in the `release-artifacts` folder to the draft release.
 - [ ] Promote images and Helm Charts to production:
   - [ ] Use `/wait-for-images` to await for the staging images.
-  - [ ] Run `/promote-pull` ChatOps command (or locally: `./hack/releasing/promote_pull.sh $VERSION`)
+  - [ ] Run `/promote-pull` ChatOps command (or locally: `GITHUB_USER=<your-user> ./hack/releasing/promote_pull.sh $VERSION`)
         to submit the promotion PR. Re-running is safe: it updates the existing PR rather than
         opening a second one.
+        *Note: the ChatOps command needs the `KUEUE_RELEASE_BOT_TOKEN` secret and the
+        `KUEUE_RELEASE_BOT_USER` variable; until they are configured it validates everything up to
+        the push and reports which piece is missing. Setup steps are in
+        [`hack/releasing/promote_pull/README.md`](https://github.com/kubernetes-sigs/kueue/blob/main/hack/releasing/promote_pull/README.md).*
   - [ ] Wait for the PR to be merged <!-- K8S_IO_PULL --> <!-- example kubernetes/k8s.io#7899 -->
   - [ ] Use `/wait-for-prod-images` to verify that the promoted images are available.
 - [ ] Use `/publish-release` to publish the release prepared at the [GitHub releases page](https://github.com/kubernetes-sigs/kueue/releases).

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -632,6 +632,7 @@ jobs:
       - name: Check Promotion Credential
         id: credential
         env:
+          GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
           PROMOTION_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
           PROMOTION_USER: ${{ vars.KUEUE_RELEASE_BOT_USER }}
         run: |
@@ -645,8 +646,15 @@ jobs:
           # placeholder owner exists only to let that dry run proceed — a real
           # push always uses vars.KUEUE_RELEASE_BOT_USER.
           if [ -n "$PROMOTION_TOKEN" ] && [ -n "$PROMOTION_USER" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
+            if gh repo view "${PROMOTION_USER}/k8s.io" --json name >/dev/null 2>&1; then
+              echo "available=true" >> "$GITHUB_OUTPUT"
+              echo "owner=$PROMOTION_USER" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "available=false" >> "$GITHUB_OUTPUT"
             echo "owner=$PROMOTION_USER" >> "$GITHUB_OUTPUT"
+            echo "missing=fork \`${PROMOTION_USER}/k8s.io\` (create it with \`gh repo fork kubernetes/k8s.io\` as that account)" >> "$GITHUB_OUTPUT"
+            echo "Fork ${PROMOTION_USER}/k8s.io not found; continuing as a dry run."
             exit 0
           fi
 

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -629,6 +629,13 @@ jobs:
       contents: read
       issues: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
       - name: Check Promotion Credential
         id: credential
         env:
@@ -674,13 +681,6 @@ jobs:
           echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
           echo "Promotion credential incomplete ($MISSING); continuing as a dry run."
 
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: main
-          persist-credentials: false
-
       - name: Checkout kubernetes/k8s.io
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -718,7 +718,6 @@ jobs:
         id: promote
         env:
           GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
           RELEASE_ISSUE_NUMBER: ${{ github.event.issue.number }}
           VERSION: ${{ needs.authorize.outputs.version }}
           GITHUB_USER: ${{ steps.credential.outputs.owner }}
@@ -728,6 +727,7 @@ jobs:
           KUBERNETES_SIGS_KUEUE_MAIN_REPO_ORG: ${{ github.repository_owner }}
           KUBERNETES_SIGS_KUEUE_MAIN_REPO_NAME: ${{ github.event.repository.name }}
           CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
+          CREDENTIAL_MISSING: ${{ steps.credential.outputs.missing }}
         run: |
           if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
             export DRY_RUN=1
@@ -738,68 +738,52 @@ jobs:
           SCRIPT_EXIT_CODE=${PIPESTATUS[1]}
           set -e
 
-          PR_URL=$(sed -n 's/^+++ Promotion pull request: //p' /tmp/promote-pull.log | tail -n 1)
-          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-          if [ -z "$PR_URL" ]; then
-            echo "action=none" >> "$GITHUB_OUTPUT"
-          elif grep -q '^+++ Pull request already open' /tmp/promote-pull.log; then
-            echo "action=updated" >> "$GITHUB_OUTPUT"
-          else
-            echo "action=created" >> "$GITHUB_OUTPUT"
-          fi
-          echo "exit_code=${SCRIPT_EXIT_CODE}" >> "$GITHUB_OUTPUT"
-          exit 0
-
-      - name: Report Result
-        if: always()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          VERSION: ${{ needs.authorize.outputs.version }}
-          CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
-          CREDENTIAL_MISSING: ${{ steps.credential.outputs.missing }}
-          SCRIPT_EXIT_CODE: ${{ steps.promote.outputs.exit_code }}
-          PR_URL: ${{ steps.promote.outputs.pr_url }}
-          PR_ACTION: ${{ steps.promote.outputs.action }}
-        run: |
-          if [ ! -f /tmp/promote-pull.log ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the job failed before the promotion script ran. Check the workflow logs."
+          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
+            echo "message=❌ Failed to submit the promotion pull request for \`$VERSION\`: ${CREDENTIAL_MISSING:-the promotion credential} is not configured. Everything up to the push was validated; nothing was pushed." >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           # The DRY_RUN bookkeeping lines are informational but already carry the
-          # !!! prefix used for error details, so they must not leak into the
-          # failure comment.
-          ERR_MSG=$(grep -E '^!!!' /tmp/promote-pull.log \
+          # !!! prefix used for error details, so they must not be reported as
+          # the failure reason.
+          ERR_LINE=$(grep -E '^!!!' /tmp/promote-pull.log \
             | grep -v 'because you set DRY_RUN' \
             | grep -v '^!!! Skipping deletion of branch' \
-            | grep -v '^!!! No branches specified for cleanup' || true)
+            | grep -v '^!!! No branches specified for cleanup' \
+            | head -n 1 | sed 's/^!!! //' || true)
 
-          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the credential required to push to the kubernetes/k8s.io fork is not configured (missing ${CREDENTIAL_MISSING:-configuration}). Everything up to the push was validated; nothing was pushed and no pull request was created."
+          if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
+            echo "message=❌ Failed to submit the promotion pull request for \`$VERSION\`: ${ERR_LINE:-check workflow logs for details}." >> "$GITHUB_OUTPUT"
+            exit $SCRIPT_EXIT_CODE
+          fi
+
+          # The script can exit 0 without producing a PR; the job must not.
+          PR_URL=$(sed -n 's/^+++ Promotion pull request: //p' /tmp/promote-pull.log | tail -n 1)
+          if [ -z "$PR_URL" ]; then
+            echo "message=❌ The promotion script for \`$VERSION\` completed without creating a pull request." >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
-          if [ "$SCRIPT_EXIT_CODE" != "0" ] || [ "$PR_ACTION" = "none" ] || [ -z "$PR_URL" ]; then
-            if [ -z "$ERR_MSG" ]; then
-              ERR_MSG="Check workflow logs for details."
-            fi
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`.
-
-          **Error details:**
-          \`\`\`text
-          ${ERR_MSG}
-          \`\`\`"
-            # The script can exit 0 having produced no PR; the job must not.
-            EXIT_CODE="${SCRIPT_EXIT_CODE:-1}"
-            if [ "$EXIT_CODE" = "0" ]; then
-              EXIT_CODE=1
-            fi
-            exit "$EXIT_CODE"
+          if grep -q '^+++ Pull request already open' /tmp/promote-pull.log; then
+            PR_ACTION="updated"
+          else
+            PR_ACTION="created"
           fi
+          echo "message=✅ Promotion pull request for \`$VERSION\` has been ${PR_ACTION}: ${PR_URL}" >> "$GITHUB_OUTPUT"
 
-          gh issue comment "$ISSUE_NUMBER" --body "✅ Promotion pull request for \`$VERSION\` has been ${PR_ACTION}.
-          Link: ${PR_URL}"
+      - name: Report Success
+        if: ${{ success() }}
+        uses: ./.github/actions/report-result
+        with:
+          command: ${{ needs.authorize.outputs.command }}
+          message: ${{ steps.promote.outputs.message }}
+
+      - name: Report Failure
+        if: ${{ failure() }}
+        uses: ./.github/actions/report-result
+        with:
+          command: ${{ needs.authorize.outputs.command }}
+          message: ${{ steps.promote.outputs.message || '❌ Failed to submit the promotion pull request.' }}
 
   publish-release:
     name: Publish Release

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -738,11 +738,6 @@ jobs:
           SCRIPT_EXIT_CODE=${PIPESTATUS[1]}
           set -e
 
-          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
-            echo "message=❌ Failed to submit the promotion pull request for \`$VERSION\`: ${CREDENTIAL_MISSING:-the promotion credential} is not configured. Everything up to the push was validated; nothing was pushed." >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-
           # The DRY_RUN bookkeeping lines are informational but already carry the
           # !!! prefix used for error details, so they must not be reported as
           # the failure reason.
@@ -755,6 +750,11 @@ jobs:
           if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
             echo "message=❌ Failed to submit the promotion pull request for \`$VERSION\`: ${ERR_LINE:-check workflow logs for details}." >> "$GITHUB_OUTPUT"
             exit $SCRIPT_EXIT_CODE
+          fi
+
+          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
+            echo "message=❌ Failed to submit the promotion pull request for \`$VERSION\`: ${CREDENTIAL_MISSING:-the promotion credential} is not configured. Everything up to the push was validated; nothing was pushed." >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           # The script can exit 0 without producing a PR; the job must not.

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -21,6 +21,7 @@ jobs:
        contains(github.event.comment.body, '/wait-for-images') ||
        contains(github.event.comment.body, '/wait-for-prod-images') ||
        contains(github.event.comment.body, '/prepare-pull') ||
+       contains(github.event.comment.body, '/promote-pull') ||
        contains(github.event.comment.body, '/publish-release'))
     outputs:
       command: ${{ steps.parse.outputs.command }}
@@ -97,6 +98,8 @@ jobs:
               exit 1
             fi
             echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/promote-pull[[:space:]]*$'; then
+            COMMAND="promote-pull"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/publish-release[[:space:]]*$'; then
             COMMAND="publish-release"
           else
@@ -615,6 +618,144 @@ jobs:
         with:
           command: ${{ needs.authorize.outputs.command }}
           message: ${{ steps.prep_pull.outputs.message || '❌ Failed to prepare pull requests.' }}
+
+  promote-pull:
+    name: Promote Pull
+    runs-on: ubuntu-latest
+    needs: authorize
+    timeout-minutes: 30
+    if: ${{ needs.authorize.outputs.command == 'promote-pull' }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check Promotion Credential
+        id: credential
+        env:
+          PROMOTION_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
+        run: |
+          # When the credential is missing the job still runs everything up to
+          # the push, so a rehearsal validates the checkout, the remote wiring
+          # and the manifest insertion instead of exiting before reaching them.
+          if [ -z "$PROMOTION_TOKEN" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Promotion credential is not configured; continuing as a dry run."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: main
+          persist-credentials: false
+
+      - name: Checkout kubernetes/k8s.io
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: kubernetes/k8s.io
+          ref: main
+          path: k8s.io
+          persist-credentials: false
+
+      - name: Install Crane
+        uses: imjasonh/setup-crane@feee3b6bb0d4c68370f256a4502498c9227e5c6b # v0.7
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Configure Git and GH CLI
+        env:
+          GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
+          FORK_OWNER: ${{ vars.KUEUE_RELEASE_BOT_USER }}
+        run: |
+          git config --global user.name "kueue-release-bot"
+          git config --global user.email "kueue-release-bot@kubernetes.io"
+          gh auth setup-git
+
+          # A fresh checkout of kubernetes/k8s.io has a single remote named
+          # origin pointing at upstream — the inverse of the script's
+          # workstation defaults, which expect origin to be a personal fork.
+          if [ "$CREDENTIAL_AVAILABLE" = "true" ]; then
+            git -C k8s.io remote add fork "https://github.com/${FORK_OWNER}/k8s.io.git"
+          fi
+
+      - name: Run Promote Pull
+        id: promote
+        env:
+          GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          RELEASE_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          GITHUB_USER: ${{ vars.KUEUE_RELEASE_BOT_USER || 'kueue-release-bot' }}
+          KUBERNETES_K8S_IO_PATH: ${{ github.workspace }}/k8s.io
+          KUBERNETES_K8S_IO_UPSTREAM_REMOTE: origin
+          KUBERNETES_K8S_IO_FORK_REMOTE: fork
+          KUBERNETES_SIGS_KUEUE_MAIN_REPO_ORG: ${{ github.repository_owner }}
+          KUBERNETES_SIGS_KUEUE_MAIN_REPO_NAME: ${{ github.event.repository.name }}
+          CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
+        run: |
+          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
+            export DRY_RUN=1
+          fi
+
+          set +e
+          yes y | ./hack/releasing/promote_pull.sh "$VERSION" 2>&1 | tee /tmp/promote-pull.log
+          SCRIPT_EXIT_CODE=${PIPESTATUS[1]}
+          set -e
+
+          PR_URL=$(sed -n 's/^+++ Promotion pull request: //p' /tmp/promote-pull.log | tail -n 1)
+          echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          if grep -q '^+++ Pull request already open' /tmp/promote-pull.log; then
+            echo "action=updated" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=created" >> "$GITHUB_OUTPUT"
+          fi
+          echo "exit_code=${SCRIPT_EXIT_CODE}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Report Result
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
+          SCRIPT_EXIT_CODE: ${{ steps.promote.outputs.exit_code }}
+          PR_URL: ${{ steps.promote.outputs.pr_url }}
+          PR_ACTION: ${{ steps.promote.outputs.action }}
+        run: |
+          # The DRY_RUN bookkeeping lines are informational but already carry the
+          # !!! prefix used for error details, so they must not leak into the
+          # failure comment.
+          ERR_MSG=$(grep -E '^!!!' /tmp/promote-pull.log \
+            | grep -v 'because you set DRY_RUN' \
+            | grep -v '^!!! Skipping deletion of branch' \
+            | grep -v '^!!! No branches specified for cleanup' || true)
+
+          if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the credential required to push to the kubernetes/k8s.io fork is not configured. Everything up to the push was validated; nothing was pushed and no pull request was created."
+            exit 1
+          fi
+
+          if [ "$SCRIPT_EXIT_CODE" != "0" ]; then
+            if [ -z "$ERR_MSG" ]; then
+              ERR_MSG="Check workflow logs for details."
+            fi
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`.
+
+          **Error details:**
+          \`\`\`text
+          ${ERR_MSG}
+          \`\`\`"
+            exit "$SCRIPT_EXIT_CODE"
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" --body "✅ Promotion pull request for \`$VERSION\` has been ${PR_ACTION}.
+          Link: ${PR_URL}"
 
   publish-release:
     name: Publish Release

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -633,16 +633,38 @@ jobs:
         id: credential
         env:
           PROMOTION_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
+          PROMOTION_USER: ${{ vars.KUEUE_RELEASE_BOT_USER }}
         run: |
-          # When the credential is missing the job still runs everything up to
-          # the push, so a rehearsal validates the checkout, the remote wiring
-          # and the manifest insertion instead of exiting before reaching them.
-          if [ -z "$PROMOTION_TOKEN" ]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "Promotion credential is not configured; continuing as a dry run."
-          else
+          # The owner is resolved once here and reused for both the fork remote
+          # and the PR head, so the branch is never pushed to one account and the
+          # pull request opened against another.
+          #
+          # When either half is missing the job still runs everything up to the
+          # push, so a rehearsal validates the checkout, the remote wiring and the
+          # manifest insertion instead of exiting before reaching them. The
+          # placeholder owner exists only to let that dry run proceed — a real
+          # push always uses vars.KUEUE_RELEASE_BOT_USER.
+          if [ -n "$PROMOTION_TOKEN" ] && [ -n "$PROMOTION_USER" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
+            echo "owner=$PROMOTION_USER" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          MISSING=""
+          if [ -z "$PROMOTION_TOKEN" ]; then
+            MISSING="secret \`KUEUE_RELEASE_BOT_TOKEN\`"
+          fi
+          if [ -z "$PROMOTION_USER" ]; then
+            if [ -n "$MISSING" ]; then
+              MISSING="$MISSING and "
+            fi
+            MISSING="${MISSING}variable \`KUEUE_RELEASE_BOT_USER\`"
+          fi
+
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "owner=${PROMOTION_USER:-kueue-release-bot}" >> "$GITHUB_OUTPUT"
+          echo "missing=$MISSING" >> "$GITHUB_OUTPUT"
+          echo "Promotion credential incomplete ($MISSING); continuing as a dry run."
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -671,7 +693,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
-          FORK_OWNER: ${{ vars.KUEUE_RELEASE_BOT_USER }}
+          FORK_OWNER: ${{ steps.credential.outputs.owner }}
         run: |
           git config --global user.name "kueue-release-bot"
           git config --global user.email "kueue-release-bot@kubernetes.io"
@@ -691,7 +713,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           RELEASE_ISSUE_NUMBER: ${{ github.event.issue.number }}
           VERSION: ${{ needs.authorize.outputs.version }}
-          GITHUB_USER: ${{ vars.KUEUE_RELEASE_BOT_USER || 'kueue-release-bot' }}
+          GITHUB_USER: ${{ steps.credential.outputs.owner }}
           KUBERNETES_K8S_IO_PATH: ${{ github.workspace }}/k8s.io
           KUBERNETES_K8S_IO_UPSTREAM_REMOTE: origin
           KUBERNETES_K8S_IO_FORK_REMOTE: fork
@@ -710,7 +732,9 @@ jobs:
 
           PR_URL=$(sed -n 's/^+++ Promotion pull request: //p' /tmp/promote-pull.log | tail -n 1)
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
-          if grep -q '^+++ Pull request already open' /tmp/promote-pull.log; then
+          if [ -z "$PR_URL" ]; then
+            echo "action=none" >> "$GITHUB_OUTPUT"
+          elif grep -q '^+++ Pull request already open' /tmp/promote-pull.log; then
             echo "action=updated" >> "$GITHUB_OUTPUT"
           else
             echo "action=created" >> "$GITHUB_OUTPUT"
@@ -719,15 +743,22 @@ jobs:
           exit 0
 
       - name: Report Result
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           VERSION: ${{ needs.authorize.outputs.version }}
           CREDENTIAL_AVAILABLE: ${{ steps.credential.outputs.available }}
+          CREDENTIAL_MISSING: ${{ steps.credential.outputs.missing }}
           SCRIPT_EXIT_CODE: ${{ steps.promote.outputs.exit_code }}
           PR_URL: ${{ steps.promote.outputs.pr_url }}
           PR_ACTION: ${{ steps.promote.outputs.action }}
         run: |
+          if [ ! -f /tmp/promote-pull.log ]; then
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the job failed before the promotion script ran. Check the workflow logs."
+            exit 1
+          fi
+
           # The DRY_RUN bookkeeping lines are informational but already carry the
           # !!! prefix used for error details, so they must not leak into the
           # failure comment.
@@ -737,11 +768,11 @@ jobs:
             | grep -v '^!!! No branches specified for cleanup' || true)
 
           if [ "$CREDENTIAL_AVAILABLE" != "true" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the credential required to push to the kubernetes/k8s.io fork is not configured. Everything up to the push was validated; nothing was pushed and no pull request was created."
+            gh issue comment "$ISSUE_NUMBER" --body "❌ Failed to submit the promotion pull request for \`$VERSION\`: the credential required to push to the kubernetes/k8s.io fork is not configured (missing ${CREDENTIAL_MISSING:-configuration}). Everything up to the push was validated; nothing was pushed and no pull request was created."
             exit 1
           fi
 
-          if [ "$SCRIPT_EXIT_CODE" != "0" ]; then
+          if [ "$SCRIPT_EXIT_CODE" != "0" ] || [ "$PR_ACTION" = "none" ] || [ -z "$PR_URL" ]; then
             if [ -z "$ERR_MSG" ]; then
               ERR_MSG="Check workflow logs for details."
             fi
@@ -751,7 +782,12 @@ jobs:
           \`\`\`text
           ${ERR_MSG}
           \`\`\`"
-            exit "$SCRIPT_EXIT_CODE"
+            # The script can exit 0 having produced no PR; the job must not.
+            EXIT_CODE="${SCRIPT_EXIT_CODE:-1}"
+            if [ "$EXIT_CODE" = "0" ]; then
+              EXIT_CODE=1
+            fi
+            exit "$EXIT_CODE"
           fi
 
           gh issue comment "$ISSUE_NUMBER" --body "✅ Promotion pull request for \`$VERSION\` has been ${PR_ACTION}.

--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -89,6 +89,11 @@ if ! command -v gh > /dev/null; then
   exit 1
 fi
 
+if ! command -v crane > /dev/null; then
+  echo "!!! crane is not installed. Please install it or use the github action step."
+  exit 1
+fi
+
 if [[ "$#" -ne 1 ]]; then
   echo "${0} <version>"
   echo
@@ -97,8 +102,12 @@ if [[ "$#" -ne 1 ]]; then
   echo "  Example:"
   echo "    $0 v0.13.2"
   echo
+  echo "  Requires the 'gh' and 'crane' tools in PATH."
+  echo
   echo "  Set the DRY_RUN environment var to skip git push and creating PR."
   echo "  When DRY_RUN is set the script will leave you in a branch containing the commits."
+  echo
+  echo "  Set RELEASE_ISSUE_NUMBER to skip looking the release issue up by title."
   echo
   echo "  Set KUBERNETES_K8S_IO_UPSTREAM_REMOTE (default: upstream) and KUBERNETES_K8S_IO_FORK_REMOTE (default: origin)"
   echo "  to override the default remote names to what you have locally."
@@ -140,7 +149,10 @@ fi
 
 RELEASE_ISSUE_NAME="Release ${RELEASE_VERSION}"
 
-RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" --search "in:title ${RELEASE_ISSUE_NAME}" | awk '{print $1}' || true)
+RELEASE_ISSUE_NUMBER="${RELEASE_ISSUE_NUMBER:-}"
+if [ -z "$RELEASE_ISSUE_NUMBER" ]; then
+  RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" --search "in:title ${RELEASE_ISSUE_NAME}" | awk '{print $1}' || true)
+fi
 if [ -z "$RELEASE_ISSUE_NUMBER" ]; then
   echo "!!! No release issue found for version ${RELEASE_VERSION}. Please create 'Release ${RELEASE_VERSION}' issue first."
   exit 1
@@ -184,12 +196,27 @@ function cleanup {
 }
 trap cleanup EXIT
 
+# Set by make_pr to the promotion pull request, whether it was just created or
+# already existed.
+K8S_IO_PR_URL=""
+
 # $1 - base branch
 # $2 - remote branch
 # $3 - pr name
 function make_pr() {
   local rel
   rel="$(basename "$1")"
+
+  local existing
+  existing=$(gh pr list --repo="${KUBERNETES_K8S_IO_MAIN_REPO}" --head "${GITHUB_USER}:$2" \
+    --state open --json url --jq '.[0].url' 2>/dev/null || true)
+  if [[ -n "${existing}" ]]; then
+    echo
+    echo "+++ Pull request already open for ${GITHUB_USER}:$2; the push updated it."
+    K8S_IO_PR_URL="${existing}"
+    echo "+++ Promotion pull request: ${K8S_IO_PR_URL}"
+    return
+  fi
 
   echo
   echo "+++ Creating a pull request on GitHub repo ${KUBERNETES_K8S_IO_MAIN_REPO} at ${GITHUB_USER}:$2 for ${rel}"
@@ -203,7 +230,8 @@ Part of ${KUBERNETES_SIGS_KUEUE_MAIN_REPO}#${RELEASE_ISSUE_NUMBER}
 EOF
 )
 
-   gh pr create --title="$3" --body="${pr_text}" --head "${GITHUB_USER}:$2" --base "${rel}" --repo="${KUBERNETES_K8S_IO_MAIN_REPO}"
+  K8S_IO_PR_URL=$(gh pr create --title="$3" --body="${pr_text}" --head "${GITHUB_USER}:$2" --base "${rel}" --repo="${KUBERNETES_K8S_IO_MAIN_REPO}")
+  echo "+++ Promotion pull request: ${K8S_IO_PR_URL}"
 }
 
 # $1 - images file
@@ -307,6 +335,15 @@ function insert_image() {
     }
     # Print all other lines unchanged
     { print; }
+
+    # The component may be the last one in the file, with no following
+    # "- name:" line to flush the entry against. Without this the digest is
+    # dropped silently.
+    END {
+      if (in_component && !inserted) {
+        print new_line;
+      }
+    }
   ' "${images_file}" > "$tmp_file"
 
   mv "$tmp_file" "$IMAGES_FILE"
@@ -325,9 +362,28 @@ function get_image_full_name() {
 }
 
 # $1 - full image name
-function get_image_details() {
+function get_image_digest() {
   local full_image_name="$1"
-  gcloud container images describe "${full_image_name}" --verbosity error --format json || true
+  crane digest "${full_image_name}" 2>/dev/null || true
+}
+
+function verify_digests_inserted() {
+  local images_file="$1"
+  shift
+
+  local entry name digest missing=()
+  for entry in "$@"; do
+    name="${entry%% *}"
+    digest="${entry#* }"
+    if ! grep -q "${digest}" "${images_file}"; then
+      missing+=("${name}@${digest}")
+    fi
+  done
+
+  if [[ ${#missing[@]} -gt 0 ]]; then
+    echo "!!! Failed to insert ${#missing[@]} digest(s) into ${images_file}: ${missing[*]}"
+    exit 1
+  fi
 }
 
 # $1 - base branch
@@ -338,6 +394,8 @@ function prepare_local_branch() {
   git checkout -b "$2" "${KUBERNETES_K8S_IO_UPSTREAM_REMOTE}/$1"
   clean_branches+=("$2")
 
+  local expected_digests=()
+  local name version full_image_name digest
   while IFS= read -r name; do
     if should_skip_image "${name}" "${RELEASE_VERSION}" "${IMAGES_FILE}"; then
       echo "+++ Skipping ${name} on historical branch release v0.${MINOR}"
@@ -350,14 +408,18 @@ function prepare_local_branch() {
     fi
 
     full_image_name=$(get_image_full_name "$name" "$version")
-    image_details=$(get_image_details "$full_image_name")
-    if [ -z "$image_details" ]; then
-      echo " !!! Image \"${full_image_name}\" is not found."
+    digest=$(get_image_digest "$full_image_name")
+    if [ -z "$digest" ]; then
+      echo "!!! Image \"${full_image_name}\" is not found. Run /wait-for-images and try again."
       exit 1
     fi
-    digest=$(echo "$image_details" | jq -r '.image_summary.digest')
     insert_image "$IMAGES_FILE" "$version" "$digest" "$name"
+    expected_digests+=("${name} ${digest}")
   done < <("${YQ}" e '.[] | .name' "${IMAGES_FILE}")
+
+  if [[ ${#expected_digests[@]} -gt 0 ]]; then
+    verify_digests_inserted "${IMAGES_FILE}" "${expected_digests[@]}"
+  fi
 
   git add .
   git commit -m "$3"
@@ -381,11 +443,12 @@ function push_and_create_pr() {
 
   read -p "+++ Proceed (anything other than 'y' aborts it)? [y/N] " -r
   if ! [[ "${REPLY}" =~ ^[yY]$ ]]; then
-    echo "Aborting." >&2
-  else
-    git push "${KUBERNETES_K8S_IO_FORK_REMOTE}" -f "${3}:${2}"
-    make_pr "$1" "$2" "$4"
+    echo "!!! Aborted: the push was not confirmed, so no promotion PR was submitted." >&2
+    exit 1
   fi
+
+  git push "${KUBERNETES_K8S_IO_FORK_REMOTE}" -f "${3}:${2}"
+  make_pr "$1" "$2" "$4"
 }
 
 K8S_IO_BRANCH="kueue-promote-${RELEASE_VERSION}"
@@ -398,11 +461,13 @@ declare -r K8S_IO_PR_NAME
 prepare_local_branch main "${K8S_IO_BRANCH_UNIQUE}" "${K8S_IO_PR_NAME}"
 push_and_create_pr main "${K8S_IO_BRANCH}" "${K8S_IO_BRANCH_UNIQUE}" "${K8S_IO_PR_NAME}"
 
-K8S_IO_PR_NUMBER=$(gh pr list --repo="${KUBERNETES_K8S_IO_MAIN_REPO}" | grep "${K8S_IO_PR_NAME}" | awk '{print $1}' || true)
-if [ -n "$K8S_IO_PR_NUMBER" ]; then
+if [ -n "${K8S_IO_PR_URL}" ]; then
+  K8S_IO_PR_NUMBER="$(basename "${K8S_IO_PR_URL}")"
   NEW_RELEASE_ISSUE_BODY=${RELEASE_ISSUE_BODY//<!-- K8S_IO_PULL -->/${KUBERNETES_K8S_IO_MAIN_REPO}#${K8S_IO_PR_NUMBER}}
-  echo "+++ Editing release issue ${RELEASE_ISSUE_NUMBER} on GitHub repo ${KUBERNETES_SIGS_KUEUE_MAIN_REPO}"
-  gh issue edit "${RELEASE_ISSUE_NUMBER}" --body "${NEW_RELEASE_ISSUE_BODY}" --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" || {
-    echo "!!! Failed to edit release issue \"${RELEASE_ISSUE_NAME}\": gh issue edit command failed."
-  }
+  if [ "${NEW_RELEASE_ISSUE_BODY}" != "${RELEASE_ISSUE_BODY}" ]; then
+    echo "+++ Editing release issue ${RELEASE_ISSUE_NUMBER} on GitHub repo ${KUBERNETES_SIGS_KUEUE_MAIN_REPO}"
+    gh issue edit "${RELEASE_ISSUE_NUMBER}" --body "${NEW_RELEASE_ISSUE_BODY}" --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" || {
+      echo "!!! Failed to edit release issue \"${RELEASE_ISSUE_NAME}\": gh issue edit command failed."
+    }
+  fi
 fi

--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -151,7 +151,8 @@ RELEASE_ISSUE_NAME="Release ${RELEASE_VERSION}"
 
 RELEASE_ISSUE_NUMBER="${RELEASE_ISSUE_NUMBER:-}"
 if [ -z "$RELEASE_ISSUE_NUMBER" ]; then
-  RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" --search "in:title ${RELEASE_ISSUE_NAME}" | awk '{print $1}' || true)
+  RELEASE_ISSUE_NUMBER=$(gh issue list --repo="${KUBERNETES_SIGS_KUEUE_MAIN_REPO}" \
+    --search "in:title ${RELEASE_ISSUE_NAME}" --limit 1 --json number --jq '.[0].number // empty' || true)
 fi
 if [ -z "$RELEASE_ISSUE_NUMBER" ]; then
   echo "!!! No release issue found for version ${RELEASE_VERSION}. Please create 'Release ${RELEASE_VERSION}' issue first."
@@ -364,7 +365,7 @@ function get_image_full_name() {
 # $1 - full image name
 function get_image_digest() {
   local full_image_name="$1"
-  crane digest "${full_image_name}" 2>/dev/null || true
+  crane digest "${full_image_name}"
 }
 
 function verify_digests_inserted() {
@@ -375,7 +376,7 @@ function verify_digests_inserted() {
   for entry in "$@"; do
     name="${entry%% *}"
     digest="${entry#* }"
-    if ! grep -q "${digest}" "${images_file}"; then
+    if ! grep -qF "${digest}" "${images_file}"; then
       missing+=("${name}@${digest}")
     fi
   done
@@ -408,9 +409,9 @@ function prepare_local_branch() {
     fi
 
     full_image_name=$(get_image_full_name "$name" "$version")
-    digest=$(get_image_digest "$full_image_name")
-    if [ -z "$digest" ]; then
-      echo "!!! Image \"${full_image_name}\" is not found. Run /wait-for-images and try again."
+    if ! digest=$(get_image_digest "$full_image_name"); then
+      echo "!!! Failed to resolve the digest for \"${full_image_name}\" (see the crane error above)."
+      echo "!!! If the image is not published yet, run /wait-for-images and try again."
       exit 1
     fi
     insert_image "$IMAGES_FILE" "$version" "$digest" "$name"

--- a/hack/releasing/promote_pull.sh
+++ b/hack/releasing/promote_pull.sh
@@ -209,8 +209,10 @@ function make_pr() {
   rel="$(basename "$1")"
 
   local existing
-  existing=$(gh pr list --repo="${KUBERNETES_K8S_IO_MAIN_REPO}" --head "${GITHUB_USER}:$2" \
-    --state open --json url --jq '.[0].url' 2>/dev/null || true)
+  existing=$(gh pr list --repo="${KUBERNETES_K8S_IO_MAIN_REPO}" --head "$2" --state open \
+    --json url,headRepositoryOwner 2>/dev/null \
+    | jq -r --arg owner "${GITHUB_USER}" \
+      '[.[] | select(.headRepositoryOwner.login == $owner)][0].url // empty' || true)
   if [[ -n "${existing}" ]]; then
     echo
     echo "+++ Pull request already open for ${GITHUB_USER}:$2; the push updated it."

--- a/hack/releasing/promote_pull/README.md
+++ b/hack/releasing/promote_pull/README.md
@@ -1,0 +1,185 @@
+# `promote_pull.sh`
+
+Script: [`../promote_pull.sh`](../promote_pull.sh) · ChatOps: `/promote-pull`
+
+Performs the "Promote images and Helm Charts to production" step of the release checklist in
+[`NEW_RELEASE.md`](../../../.github/ISSUE_TEMPLATE/NEW_RELEASE.md). It moves a release's
+container images and Helm charts from the staging registry to production `registry.k8s.io` by
+adding their digests to Kueue's image manifest in `kubernetes/k8s.io` and opening a pull
+request there.
+
+For release `v0.19.0` the PR adds one line per released artifact to
+`registry.k8s.io/images/k8s-staging-kueue/images.yaml`:
+
+```diff
+ - name: kueue
+   dmap:
++    "sha256:6fe2cbe4...": ["v0.19.0"]
+     "sha256:eb37cb0c...": ["v0.18.4"]
+```
+
+The command **submits** the PR. Review and merge stay with `kubernetes/k8s.io` approvers.
+
+For the release process as a whole see [`RELEASE.md`](../../../RELEASE.md); the ChatOps
+commands are defined in [`release-utils.yml`](../../../.github/workflows/release-utils.yml).
+
+---
+
+## Repository configuration
+
+Promotion writes to **another repository**, so `secrets.GITHUB_TOKEN` cannot do it — that token
+is scoped to `kubernetes-sigs/kueue` and can neither push to a `kubernetes/k8s.io` fork nor open
+a pull request there. Two settings must exist before `/promote-pull` can succeed:
+
+| Setting | Kind | Value |
+|---|---|---|
+| `KUEUE_RELEASE_BOT_TOKEN` | repository **secret** | A token belonging to the bot account |
+| `KUEUE_RELEASE_BOT_USER` | repository **variable** | That account's GitHub login |
+
+### Step by step
+
+1. **Choose the account that will own the fork.** It must be a real GitHub account — the login
+   is used as the pull request head owner. A dedicated bot account is recommended so the
+   capability does not depend on any individual maintainer.
+
+2. **Fork `kubernetes/k8s.io` as that account.** Nothing in the automation creates the fork;
+   it only pushes to one that already exists.
+
+   ```bash
+   gh repo fork kubernetes/k8s.io --clone=false
+   ```
+
+3. **Create a token for that account.** It needs write access to the fork only — not to
+   `kubernetes/k8s.io`, and not to `kubernetes-sigs/kueue`.
+
+   - Fine-grained PAT (preferred): repository access limited to `<owner>/k8s.io`, with
+     **Contents: Read and write** and **Pull requests: Read and write**.
+   - Classic PAT: `public_repo`.
+
+4. **Add the secret** in `kubernetes-sigs/kueue` → Settings → Secrets and variables → Actions →
+   Secrets → New repository secret, named `KUEUE_RELEASE_BOT_TOKEN`.
+
+5. **Add the variable** in the same place under Variables → New repository variable, named
+   `KUEUE_RELEASE_BOT_USER`, set to the account login from step 1.
+
+6. **Verify** by commenting `/promote-pull` on a release issue. Before the settings exist the
+   command reports exactly which piece is missing, so a partial setup is easy to diagnose:
+
+   | State | Reported |
+   |---|---|
+   | Neither configured | `missing secret KUEUE_RELEASE_BOT_TOKEN and variable KUEUE_RELEASE_BOT_USER` |
+   | Secret only | `missing variable KUEUE_RELEASE_BOT_USER` |
+   | Variable only | `missing secret KUEUE_RELEASE_BOT_TOKEN` |
+   | Both set, no fork | `missing fork <owner>/k8s.io (create it with gh repo fork kubernetes/k8s.io as that account)` |
+
+### Before the settings exist
+
+The command still runs. It performs the checkout, the remote wiring, the digest lookups and the
+manifest insertion under `DRY_RUN`, then stops before the push and reports the missing piece.
+That makes an unconfigured `/promote-pull` a useful rehearsal rather than a no-op — a genuine
+failure in that path is reported as itself, not masked by the credential message.
+
+## Usage
+
+From the release issue, after `/wait-for-images` confirms the staging artifacts:
+
+```
+/promote-pull
+```
+
+The command takes no arguments; the version comes from the `Release vX.Y.Z` issue title.
+Re-running is safe — see [Safety properties](#safety-properties).
+
+Locally — requires a `kubernetes/k8s.io` clone with an `upstream` remote and your fork as
+`origin`, plus an authenticated `gh` and `crane` on `PATH`:
+
+```bash
+GITHUB_USER=<your-gh-user> ./hack/releasing/promote_pull.sh v0.19.0
+```
+
+Inspect before submitting — does everything except push and open the PR, leaving the branch and
+commit in place:
+
+```bash
+DRY_RUN=1 GITHUB_USER=<your-gh-user> ./hack/releasing/promote_pull.sh v0.19.0
+```
+
+Then confirm the diff touches one file and nothing else:
+
+```bash
+git -C ../../kubernetes/k8s.io diff --stat HEAD~1
+```
+
+Expect `registry.k8s.io/images/k8s-staging-kueue/images.yaml`. Anything else is a bug.
+
+## Environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GITHUB_USER` | *(required)* | Owner of the `kubernetes/k8s.io` fork to push to, and the PR head owner |
+| `GH_TOKEN` | `gh auth` session | Credential for `gh` |
+| `DRY_RUN` | unset | Skip the push and the PR |
+| `RELEASE_ISSUE_NUMBER` | unset | Use this release issue instead of searching by title |
+| `KUBERNETES_REPOS_PATH` | `../../kubernetes` | Where Kubernetes org clones live |
+| `KUBERNETES_K8S_IO_PATH` | `$KUBERNETES_REPOS_PATH/k8s.io` | The `k8s.io` clone |
+| `KUBERNETES_K8S_IO_UPSTREAM_REMOTE` | `upstream` | Remote to branch from |
+| `KUBERNETES_K8S_IO_FORK_REMOTE` | `origin` | Remote to push to |
+| `KUBERNETES_K8S_IO_MAIN_REPO_ORG` / `_NAME` | derived from the upstream remote | Repository the PR is opened against |
+
+Names and defaults match [`ci_pull.sh`](../ci_pull.sh) and
+[`prepare_pull.sh`](../prepare_pull.sh), so an environment that works for those works here.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | A promotion pull request exists — created, or already open and updated by the push |
+| `1` | A precondition failed, a digest could not be resolved or inserted, the push was declined, or the push/PR failed |
+| `2` | Usage error — wrong argument count |
+
+Every failure prints a `!!! `-prefixed line. That prefix is the contract the workflow greps to
+build the failure message, so new failure paths must use it.
+
+## Safety properties
+
+- **Idempotent.** The remote branch name is stable per version (`kueue-promote-vX.Y.Z`) and the
+  push is a force push, so a re-run refreshes the open pull request with current digests. The
+  script finds the existing PR and reports it rather than trying to open a second one.
+- **No partial promotions.** Every artifact digest is resolved before anything is committed, and
+  after insertion each digest is confirmed present in `images.yaml`. A digest that fails to land
+  aborts the run before the push. Promoting an incomplete set is worse than promoting nothing.
+- **Only the manifest changes.** The edit is a line-oriented `awk` pass, not a YAML round-trip,
+  so every other byte of this shared file is untouched — which is what keeps the diff reviewable.
+- **Historical release lines are respected.** An artifact introduced after the release line being
+  promoted (for example `kueue-priority-booster` on `0.17`) is skipped, not treated as an error.
+- **Charts drop the `v`.** Image entries are recorded as `vX.Y.Z`, chart entries as `X.Y.Z`,
+  matching the manifest's existing convention.
+- **Never merges.** The pull request is submitted only.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `credential ... is not configured (missing ...)` | Setup incomplete | Follow [Repository configuration](#repository-configuration); the message names the missing piece |
+| `missing fork <owner>/k8s.io` | The bot account has no fork | `gh repo fork kubernetes/k8s.io --clone=false` as that account |
+| `Failed to resolve the digest for "..."` | Staging artifact not published, or a registry/auth error | Run `/wait-for-images` first; the crane error just above says which it was |
+| `Failed to insert N digest(s) into images.yaml` | The manifest has an unexpected shape | Inspect it — the script refuses rather than promoting a partial set |
+| `Aborted: the push was not confirmed` | The confirmation prompt got no `y` | Locally, answer `y`; in CI the workflow feeds it |
+| `!!! Dirty tree. Clean up and try again.` | Uncommitted changes in the `k8s.io` clone | Stash or commit them |
+| `crane is not installed` | Missing dependency | Install [crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane); CI installs it via `setup-crane` |
+| `No release issue found` | No open `Release vX.Y.Z` issue | Promotion runs while the release issue is still open |
+| Command comment gets no response | Actor not in `OWNERS_ALIASES`, or malformed issue title | Check `release-team` / `kueue-approvers` membership and the `Release vX.Y.Z` title |
+
+## Tests
+
+Shell lint (needs a container engine):
+
+```bash
+make shell-lint
+```
+
+The ChatOps path cannot be tested before merge: `issue_comment` workflows run from the default
+branch, so a PR branch's version of the job never fires. Validate changes with a local
+`DRY_RUN=1` run, or a full rehearsal against a personal fork by pointing
+`KUBERNETES_K8S_IO_MAIN_REPO_ORG`, `KUBERNETES_K8S_IO_UPSTREAM_REMOTE` and
+`KUBERNETES_K8S_IO_FORK_REMOTE` at it, so nothing upstream is touched.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area release

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Adds a /promote-pull ChatOps command so the release team can submit the image and chart promotion PR against kubernetes/k8s.io by commenting on the Release vX.Y.Z issue. This was the last step in the release checklist that still required a local clone of kubernetes/k8s.io, a personal fork of it, and authenticated gcloud, it now needs nothing but comment access.

Making hack/releasing/promote_pull.sh safe to run unattended turned up two pre-existing bugs, both fixed here:

1. insert_image could silently drop an artifact. The awk program emits the new digest line only before a lower-versioned entry, or when it reaches the next - name: component. There is no END rule, so when the target component is the last one in images.yaml and has no strictly-lower existing version, the digest disappears with no error and exit status 0. This is reachable: should_skip_image deliberately does not skip an artifact with no promotion history, so the first-ever promotion of a new image takes exactly this path.
2. push_and_create_pr exited 0 when the push was declined. It wrote "Aborting." to stderr and fell out of the if, so the script exited 0 having created nothing. Under automation that would post a ✅ comment with no PR behind it.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13358 

#### Special notes for your reviewer:
How the two bugs were found, and how the changes were checked. Both were reproduced against the
unmodified script with a temporary harness that stubbed `crane` and `gh` on `PATH` and drove the
script against a throwaway `kubernetes/k8s.io` working copy. The trailing-artifact case produced a
manifest byte-identical to its input with exit status 0; the declined-push case exited 0 with no PR.
After the fixes, sixteen cases passed, insertion ordering, chart `v`-stripping, historical-line
skipping, unresolvable artifacts, re-run idempotency, placeholder handling, and local invocation.

**This command cannot succeed end to end until a credential is provisioned.** Pushing a branch to a
fork of `kubernetes/k8s.io` and opening a cross-repository PR is beyond `secrets.GITHUB_TOKEN`, and
this repository uses no other secret today. The job reads:

| Setting | Kind | Purpose |
|---|---|---|
| `KUEUE_RELEASE_BOT_TOKEN` | repository secret | Push the promotion branch, open the PR |
| `KUEUE_RELEASE_BOT_USER` | repository variable | Owner of the `kubernetes/k8s.io` fork |

Until then the command reports a clear "credential is not configured" failure. Related:
https://github.com/kubernetes-sigs/kueue/issues/13357.


AI usage disclosure: this change was developed with AI assistance (Claude Code), per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance). All changes were reviewed and tested by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/promote-pull` ChatOps command to create or update image promotion pull requests.
  * Release automation now reports whether a promotion pull request was created or updated, with direct links and clear success or failure messages.

* **Bug Fixes**
  * Improved image digest handling and validation when updating image metadata, including edge-case fixes.

* **Documentation**
  * Updated the “New Release” checklist with `/promote-pull`, safe re-run guidance, and a local fallback command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->