### PR TITLE
Fix MapRequests count overflow in TAS placement

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -208,7 +208,9 @@ func CountInWithLimitingResource(requests Requests, capacity Requests) (int32, c
 			// than or equal to 1", permanently wedging the workload. A
 			// negative "fits N times" is meaningless; treat it as 0 so the
 			// scheduler skips the over-subscribed domain instead.
-			count = max(int32(cap/rValue), 0)
+			// Clamp the upper bound before converting to int32 to avoid
+			// overflowing large capacity-to-request ratios.
+			count = int32(max(0, min(cap/rValue, math.MaxInt32)))
 		}
 		// Tie-break between CPU and memory counts to ensure deterministic results.
 		if result == nil || count < *result || (count == *result && rName < limitingResource) {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -232,6 +232,16 @@ func TestCountInWithLimitingResource(t *testing.T) {
 			wantCount:            0,
 			wantLimitingResource: corev1.ResourceCPU,
 		},
+		"count above int32 is clamped to MaxInt32": {
+			requests: MapRequests{
+				corev1.ResourceMemory: 1,
+			},
+			capacity: MapRequests{
+				corev1.ResourceMemory: math.MaxInt32 + 1,
+			},
+			wantCount:            math.MaxInt32,
+			wantLimitingResource: corev1.ResourceMemory,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"math"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -215,6 +216,11 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			opChoice: opCountIn,
 			m1:       MapRequests{},
 			m2:       MapRequests{corev1.ResourceCPU: 100},
+		},
+		{
+			opChoice: opCountIn,
+			m1:       MapRequests{corev1.ResourceMemory: 1},
+			m2:       MapRequests{corev1.ResourceMemory: math.MaxInt32 + 1},
 		},
 		{
 			opChoice: opSet,

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -272,6 +272,49 @@ func TestScheduleForTAS(t *testing.T) {
 
 		featureGates map[featuregate.Feature]bool
 	}{
+		"initial scheduling; one-byte memory request fits on a 2Gi node with vectorized requests disabled": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("tiny-memory", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceMemory, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/tiny-memory": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceMemory, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "tiny-memory", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "tiny-memory", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.VectorizedResourceRequests: false,
+			},
+		},
 		// Verifies TAS reads memory from PodSpec (1.5Gi/pod) not from quota-derived values.
 		// Each node has 2Gi memory, so 2 pods cannot fit on a single node.
 		"initial scheduling; TAS uses podspec memory for placement": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When `VectorizedResourceRequests` is disabled, the map-backed request implementation converted the capacity-to-request ratio to `int32` before clamping it. Ratios greater than `math.MaxInt32` therefore wrapped to a negative value and were clamped to zero, causing TAS to reject nodes that had sufficient capacity.

This change clamps the ratio before the `int32` conversion, matching the behavior of `SliceRequests`.

It adds:

- a resource calculation regression test for ratios above `math.MaxInt32`
- a scheduler-level TAS regression test using a 2Gi node and a one-byte memory request

Validation:

- `go test ./pkg/resources -count=1`
- `go test ./pkg/scheduler -count=1`
- `go vet ./pkg/resources ./pkg/scheduler`
- formatting and diff checks

`make verify` could not start in the local environment because GNU sed is not installed.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

AI usage disclosure: This PR was developed with assistance from OpenAI Codex. The contributor reviewed and validated the changes and tests.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where workloads were rejected when a node capacity-to-request ratio exceeded the int32 range and the VectorizedResourceRequests feature gate was disabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented resource fit calculations from overflowing for very large capacity-to-request ratios by safely clamping before converting to the maximum supported integer value.
* **Tests**
  * Added a test case covering clamping to the maximum integer when computed fits would otherwise exceed the supported range, including the identified limiting resource.
  * Expanded scheduling test coverage for small memory requests when vectorized resource requests are disabled, including admission placement and quota/admission events.
  * Enhanced fuzz coverage with additional math-based boundary seeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->