### PR TITLE
docs: extend TAS documentation with LWS podset grouping examples

### DIFF
--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -220,7 +220,7 @@ Some distributed workloads, such as [LeaderWorkerSet](/docs/tasks/run/leaderwork
 
 By default, Kueue evaluates TAS constraints for each `PodSet` independently, which could result in the Leader and Workers being scheduled into completely different topology domains, drastically increasing network latency.
 
-To prevent this, you can use the `kueue.x-k8s.io/podset-group-name` annotation in conjunction with a required or preferred topology annotation. By assigning the exact same group name to multiple Pod templates, you instruct Kueue to treat them as a single atomic unit and enforce their topology request in the exact same topology domain.
+To prevent this, you can use the `kueue.x-k8s.io/podset-group-name` annotation in conjunction with a required or preferred topology annotation. By assigning the exact same group name to multiple Pod templates, you instruct Kueue to treat them as a single atomic unit and co-locate them in the same topology domain (strictly enforced for required placement, and best-effort for preferred placement).
 
 ### Example: LeaderWorkerSet Rack-Level Co-location
 

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -245,7 +245,7 @@ kubectl get pods -l leaderworkerset.sigs.k8s.io/name=nginx-leaderworkerset \
 
 The output is similar to the following:
 
-```
+```text
 NAME                             NODE           GROUP   WORKER
 nginx-leaderworkerset-0          kind-worker    0       0
 nginx-leaderworkerset-0-1        kind-worker2   0       1
@@ -253,6 +253,27 @@ nginx-leaderworkerset-0-2        kind-worker3   0       2
 nginx-leaderworkerset-1          kind-worker5   1       0
 nginx-leaderworkerset-1-1        kind-worker6   1       1
 nginx-leaderworkerset-1-2        kind-worker7   1       2
+```
+
+To confirm the topology of the assigned nodes, list their labels:
+
+```shell
+kubectl get nodes -l cloud.provider.com/node-group=tas-group \
+  -L cloud.provider.com/topology-block,cloud.provider.com/topology-rack
+```
+
+The output is similar to the following:
+
+```text
+NAME           STATUS   ROLES    AGE   VERSION   TOPOLOGY-BLOCK   TOPOLOGY-RACK
+kind-worker    Ready    <none>   5m    v1.31.0   b1               r1
+kind-worker2   Ready    <none>   5m    v1.31.0   b1               r1
+kind-worker3   Ready    <none>   5m    v1.31.0   b1               r1
+kind-worker4   Ready    <none>   5m    v1.31.0   b1               r2
+kind-worker5   Ready    <none>   5m    v1.31.0   b2               r1
+kind-worker6   Ready    <none>   5m    v1.31.0   b2               r1
+kind-worker7   Ready    <none>   5m    v1.31.0   b2               r1
+kind-worker8   Ready    <none>   5m    v1.31.0   b2               r2
 ```
 
 Observe that all Pods belonging to group `0` (the Leader at worker index `0` and its Workers at indices `1` and `2`) are placed on nodes within the same rack, and all Pods for group `1` are placed on nodes within a different rack. The Leader and Workers within each group are never split across racks.

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -220,11 +220,11 @@ Some distributed workloads, such as [LeaderWorkerSet](/docs/tasks/run/leaderwork
 
 By default, Kueue evaluates TAS constraints for each `PodSet` independently, which could result in the Leader and Workers being scheduled into completely different topology domains, drastically increasing network latency.
 
-To prevent this, you can use the `kueue.x-k8s.io/podset-group-name` annotation. By assigning the exact same group name to multiple Pod templates, you instruct Kueue to treat them as a single atomic unit and force them into the exact same topology domain.
+To prevent this, you can use the `kueue.x-k8s.io/podset-group-name` annotation in conjunction with a required or preferred topology annotation. By assigning the exact same group name to multiple Pod templates, you instruct Kueue to treat them as a single atomic unit and enforce their topology request in the exact same topology domain.
 
 ### Example: LeaderWorkerSet Rack-Level Co-location
 
-The following example requires Kueue to schedule both the Leader PodSet and the Worker PodSet into the exact same rack by using the `podset-group-name: "lws-group"` annotation on both templates.
+The following example requires Kueue to schedule both the Leader PodSet and the Worker PodSet into the exact same rack by setting both the `kueue.x-k8s.io/podset-required-topology` and `kueue.x-k8s.io/podset-group-name: "lws-group"` annotations on both templates.
 
 {{< include "examples/serving-workloads/sample-leaderworkerset-tas.yaml" "yaml" >}}
 

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -228,6 +228,41 @@ The following example requires Kueue to schedule both the Leader PodSet and the 
 
 {{< include "examples/serving-workloads/sample-leaderworkerset-tas.yaml" "yaml" >}}
 
+Submit the LeaderWorkerSet using `kubectl create`:
+
+```shell
+kubectl create -f https://kueue.sigs.k8s.io/examples/serving-workloads/sample-leaderworkerset-tas.yaml
+```
+
+#### Verify rack co-location
+
+After the LeaderWorkerSet is admitted, list all Pods and the node they were assigned to, along with the rack label of that node:
+
+```shell
+kubectl get pods -l leaderworkerset.sigs.k8s.io/name=nginx-leaderworkerset \
+  -o custom-columns='NAME:.metadata.name,NODE:.spec.nodeName,GROUP:.metadata.labels.leaderworkerset\.sigs\.k8s\.io/group-index,WORKER:.metadata.labels.leaderworkerset\.sigs\.k8s\.io/worker-index'
+```
+
+The output is similar to the following:
+
+```
+NAME                             NODE           GROUP   WORKER
+nginx-leaderworkerset-0          kind-worker    0       0
+nginx-leaderworkerset-0-1        kind-worker2   0       1
+nginx-leaderworkerset-0-2        kind-worker3   0       2
+nginx-leaderworkerset-1          kind-worker5   1       0
+nginx-leaderworkerset-1-1        kind-worker6   1       1
+nginx-leaderworkerset-1-2        kind-worker7   1       2
+```
+
+Observe that all Pods belonging to group `0` (the Leader at worker index `0` and its Workers at indices `1` and `2`) are placed on nodes within the same rack, and all Pods for group `1` are placed on nodes within a different rack. The Leader and Workers within each group are never split across racks.
+
+To see the authoritative topology placement chosen by Kueue, inspect the `topologyAssignment` field on the corresponding `Workload`:
+
+```shell
+kubectl get workloads.kueue.x-k8s.io -o yaml | grep -A 10 topologyAssignment
+```
+
 ## Advanced topics
 
 The page above covers the three basic TAS annotations. Kueue also supports

--- a/site/content/en/docs/tasks/run/topology_aware_scheduling.md
+++ b/site/content/en/docs/tasks/run/topology_aware_scheduling.md
@@ -214,6 +214,20 @@ kubectl -n default get workloads.kueue.x-k8s.io <workload-name> -o yaml
 That field lists the topology levels and domain values into which each PodSet
 was placed. It is the authoritative signal that TAS was applied.
 
+## Co-locating multiple PodSets (PodSet Grouping)
+
+Some distributed workloads, such as [LeaderWorkerSet](/docs/tasks/run/leaderworkerset), define their computing requirements across multiple, distinct Pod templates (e.g., one template for the Leader, and another for the Workers). Kueue translates these templates into separate `PodSets` within a single `Workload`.
+
+By default, Kueue evaluates TAS constraints for each `PodSet` independently, which could result in the Leader and Workers being scheduled into completely different topology domains, drastically increasing network latency.
+
+To prevent this, you can use the `kueue.x-k8s.io/podset-group-name` annotation. By assigning the exact same group name to multiple Pod templates, you instruct Kueue to treat them as a single atomic unit and force them into the exact same topology domain.
+
+### Example: LeaderWorkerSet Rack-Level Co-location
+
+The following example requires Kueue to schedule both the Leader PodSet and the Worker PodSet into the exact same rack by using the `podset-group-name: "lws-group"` annotation on both templates.
+
+{{< include "examples/serving-workloads/sample-leaderworkerset-tas.yaml" "yaml" >}}
+
 ## Advanced topics
 
 The page above covers the three basic TAS annotations. Kueue also supports
@@ -232,7 +246,7 @@ additional placement behavior:
   [Balanced Placement](/docs/concepts/topology_aware_scheduling#balanced-placement).
 - **PodSet groups** - co-locate multiple PodSets of a single workload in the
   same topology domain using `kueue.x-k8s.io/podset-group-name`. See
-  [Configure Topology Aware Scheduling for LeaderWorkerSet](/docs/tasks/run/leaderworkerset#configure-topology-aware-scheduling)
+  [Co-locating multiple PodSets](#co-locating-multiple-podsets-podset-grouping)
   for a working example.
 - **PodSet slices** - split a PodSet into fixed-size slices, each pinned to a
   single domain, using `kueue.x-k8s.io/podset-slice-required-topology` and

--- a/site/static/examples/serving-workloads/sample-leaderworkerset-tas.yaml
+++ b/site/static/examples/serving-workloads/sample-leaderworkerset-tas.yaml
@@ -39,6 +39,5 @@ spec:
           resources:
             requests:
               cpu: "200m"
-              nvidia.com/gpu: "1"
           ports:
           - containerPort: 80


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area tas
/area website

#### What this PR does / why we need it:
This PR extends the Topology-Aware Scheduling (TAS) documentation to include clear, working examples of PodSet grouping using LeaderWorkerSet (LWS). 

Previously, the main TAS documentation page only used standard batch `Jobs` for its examples. PodSet grouping—which is critical for 2-level workloads like LWS to prevent Leaders and Workers from being placed in different topology domains—was only briefly mentioned as a bullet point.

This PR adds a dedicated **"Co-locating multiple PodSets (PodSet Grouping)"** section directly into `topology_aware_scheduling.md`. It clearly explains the `kueue.x-k8s.io/podset-group-name` annotation and embeds the existing LWS e2e test YAML (`sample-leaderworkerset-tas.yaml`) to provide users with a concrete, ready-to-use example of rack-level co-location.

#### Which issue(s) this PR fixes:
Fixes #13518

#### Special notes for your reviewer:
This acts as a follow-up to the recent TAS documentation expansions (such as the JobSets TAS PR). Note that the documentation deliberately avoids the term "2-level scheduling" in favor of "Co-locating multiple PodSets" to remain clear and prevent any confusion with Kueue's "Multi-layer topology" slicing feature.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Co-locating multiple PodSets (PodSet Grouping)” section to explain how related Pod templates are scheduled as a single atomic unit within the same topology domain.
  * Documented the `kueue.x-k8s.io/podset-group-name` annotation, including required and best-effort behaviors.
  * Included a rack-level co-location example with verification steps.
  * Updated the “PodSet groups” Advanced Topics link to reference the new in-page section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->