### PR TITLE
MultiKueue: support Concurrent Admission preemption

### DIFF
--- a/apis/kueue/v1beta1/clusterqueue_types.go
+++ b/apis/kueue/v1beta1/clusterqueue_types.go
@@ -32,6 +32,7 @@ const (
 	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks        = "MultipleMultiKueueAdmissionChecks"
 	ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor = "MultiKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonMultiKueueWithProvisioningRequest        = "MultiKueueWithProvisioningRequest"
+	ClusterQueueActiveReasonMultiKueueWithConcurrentAdmission        = "MultiKueueWithConcurrentAdmission"
 	ClusterQueueActiveReasonTopologyNotFound                         = "TopologyNotFound"
 	ClusterQueueActiveReasonUnknown                                  = "Unknown"
 	ClusterQueueActiveReasonReady                                    = "Ready"

--- a/apis/kueue/v1beta2/clusterqueue_types.go
+++ b/apis/kueue/v1beta2/clusterqueue_types.go
@@ -42,6 +42,7 @@ const (
 	ClusterQueueActiveReasonMultipleMultiKueueAdmissionChecks        = "MultipleMultiKueueAdmissionChecks"
 	ClusterQueueActiveReasonMultiKueueAdmissionCheckAppliedPerFlavor = "MultiKueueAdmissionCheckAppliedPerFlavor"
 	ClusterQueueActiveReasonMultiKueueWithProvisioningRequest        = "MultiKueueWithProvisioningRequest"
+	ClusterQueueActiveReasonMultiKueueWithConcurrentAdmission        = "MultiKueueWithConcurrentAdmission"
 	ClusterQueueActiveReasonTopologyNotFound                         = "TopologyNotFound"
 	ClusterQueueActiveReasonUnknown                                  = "Unknown"
 	ClusterQueueActiveReasonReady                                    = "Ready"

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -179,6 +179,9 @@ func (c *clusterQueue) updateClusterQueue(
 	c.isStopped = ptr.Deref(in.Spec.StopPolicy, kueue.None) != kueue.None
 
 	c.AdmissionChecks = admissioncheck.NewAdmissionChecks(in)
+	if features.Enabled(features.ConcurrentAdmission) {
+		c.ConcurrentAdmissionPolicy = in.Spec.ConcurrentAdmissionPolicy
+	}
 
 	if in.Spec.Preemption != nil {
 		c.Preemption = *in.Spec.Preemption
@@ -203,9 +206,6 @@ func (c *clusterQueue) updateClusterQueue(
 
 	c.FairWeight = parseFairWeight(in.Spec.FairSharing)
 	c.AdmissionScope = in.Spec.AdmissionScope
-	if features.Enabled(features.ConcurrentAdmission) {
-		c.ConcurrentAdmissionPolicy = in.Spec.ConcurrentAdmissionPolicy
-	}
 	return nil
 }
 
@@ -259,7 +259,9 @@ func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
 		len(c.multiKueueAdmissionChecks) > 1 ||
 		len(c.perFlavorMultiKueueAdmissionChecks) > 0 ||
 		// provisioning requests should not be used on manager cluster with multikueue
-		(len(c.multiKueueAdmissionChecks) > 0 && len(c.provisioningAdmissionChecks) > 0) {
+		(len(c.multiKueueAdmissionChecks) > 0 && len(c.provisioningAdmissionChecks) > 0) ||
+		// concurrent admission should only be used on worker clusters with multikueue
+		(len(c.multiKueueAdmissionChecks) > 0 && c.ConcurrentAdmissionEnabled()) {
 		status = pending
 	}
 	if c.Status == terminating {
@@ -341,6 +343,11 @@ func (c *clusterQueue) inactiveReason() (string, string) {
 			reasons = append(reasons, kueue.ClusterQueueActiveReasonMultiKueueWithProvisioningRequest)
 			messages = append(messages, fmt.Sprintf("Cannot use both MultiKueue and ProvisioningRequest AdmissionChecks together, found: %s, %s",
 				stringsutils.Join(c.multiKueueAdmissionChecks, ","), stringsutils.Join(c.provisioningAdmissionChecks, ",")))
+		}
+
+		if len(c.multiKueueAdmissionChecks) > 0 && c.ConcurrentAdmissionEnabled() {
+			reasons = append(reasons, kueue.ClusterQueueActiveReasonMultiKueueWithConcurrentAdmission)
+			messages = append(messages, "Cannot use ConcurrentAdmission on a ClusterQueue with a MultiKueue AdmissionCheck")
 		}
 
 		if features.Enabled(features.TopologyAwareScheduling) && len(c.tasFlavors) > 0 {

--- a/pkg/cache/scheduler/clusterqueue_test.go
+++ b/pkg/cache/scheduler/clusterqueue_test.go
@@ -25,6 +25,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -178,8 +179,15 @@ func TestClusterQueueUpdate(t *testing.T) {
 }
 
 func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ConcurrentAdmission, true)
+
 	cqWithAC := utiltestingapi.MakeClusterQueue("cq").
 		AdmissionChecks("check1", "check2", "check3").
+		Obj()
+
+	cqWithACAndConcurrentAdmission := utiltestingapi.MakeClusterQueue("cq-concurrent").
+		AdmissionChecks("check1", "check2", "check3").
+		ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
 		Obj()
 
 	cqWithACStrategy := utiltestingapi.MakeClusterQueue("cq2").
@@ -367,6 +375,28 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 			wantMessage: `Can't admit new workloads: Cannot use both MultiKueue and ProvisioningRequest AdmissionChecks together, found: check1, check3.`,
 		},
 		{
+			name:     "Active clusterQueue with both MultiKueue and ConcurrentAdmission",
+			cq:       cqWithACAndConcurrentAdmission,
+			cqStatus: active,
+			admissionChecks: map[kueue.AdmissionCheckReference]AdmissionCheck{
+				"check1": {
+					Active:     true,
+					Controller: kueue.MultiKueueControllerName,
+				},
+				"check2": {
+					Active:     true,
+					Controller: "controller2",
+				},
+				"check3": {
+					Active:     true,
+					Controller: "controller3",
+				},
+			},
+			wantStatus:  pending,
+			wantReason:  kueue.ClusterQueueActiveReasonMultiKueueWithConcurrentAdmission,
+			wantMessage: "Can't admit new workloads: Cannot use ConcurrentAdmission on a ClusterQueue with a MultiKueue AdmissionCheck.",
+		},
+		{
 			name:     "Terminating clusterQueue updated with valid AC list",
 			cq:       cqWithAC,
 			cqStatus: terminating,
@@ -503,6 +533,27 @@ func TestClusterQueueUpdateWithAdmissionCheck(t *testing.T) {
 				t.Errorf("Unexpected inactiveMessage (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestClusterQueueMultiKueueWithConcurrentAdmissionFeatureDisabled(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ConcurrentAdmission, false)
+	_, log := utiltesting.ContextWithLog(t)
+
+	cache := New(utiltesting.NewFakeClient())
+	cache.admissionChecks["multikueue"] = AdmissionCheck{
+		Active:     true,
+		Controller: kueue.MultiKueueControllerName,
+	}
+	cq, err := cache.newClusterQueue(log, utiltestingapi.MakeClusterQueue("cq").
+		AdmissionChecks("multikueue").
+		ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+		Obj())
+	if err != nil {
+		t.Fatalf("failed to create clusterQueue: %v", err)
+	}
+	if cq.Status != active {
+		t.Errorf("clusterQueue should remain active when ConcurrentAdmission is disabled, got %v", cq.Status)
 	}
 }
 

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,12 +58,13 @@ import (
 )
 
 const (
-	ConcurrentAdmissionController  = "concurrent-admission-controller"
-	ReasonCreatedVariant           = "CreatedVariant"
-	ReasonDeletedVariant           = "DeletedVariant"
-	ReasonActivatedVariant         = "ActivatedVariant"
-	ReasonDeactivatedVariant       = "DeactivatedVariant"
-	ReasonPreemptionUngatedVariant = "PreemptionUngatedVariant"
+	ConcurrentAdmissionController    = "concurrent-admission-controller"
+	ReasonCreatedVariant             = "CreatedVariant"
+	ReasonDeletedVariant             = "DeletedVariant"
+	ReasonActivatedVariant           = "ActivatedVariant"
+	ReasonDeactivatedVariant         = "DeactivatedVariant"
+	ReasonPreemptionUngatedVariant   = "PreemptionUngatedVariant"
+	ReasonVariantsNotPreemptionGated = "VariantsNotPreemptionGated"
 
 	preemptionTimeout = 5 * time.Minute
 )
@@ -228,6 +230,13 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	if len(parent.Spec.PreemptionGates) > 0 {
+		if err := r.syncInheritedPreemptionGateStates(ctx, parent, variants); err != nil {
+			log.Error(err, "Failed to sync inherited preemption gate states")
+			return ctrl.Result{}, err
+		}
+	}
+
 	log.V(3).Info("Deactivating variants if needed")
 	if err := r.deactivateVariants(ctx, parent, variants, cq, flavorOrder); err != nil {
 		log.Error(err, "Failed to deactivate variants")
@@ -238,6 +247,13 @@ func (r *variantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.activateVariants(ctx, parent, variants, cq, flavorOrder); err != nil {
 		log.Error(err, "Failed to activate variants")
 		return ctrl.Result{}, err
+	}
+
+	if len(parent.Spec.PreemptionGates) > 0 {
+		if err := r.syncVariantPreemptionSignal(ctx, parent, variants); err != nil {
+			log.Error(err, "Failed to sync variant preemption signal")
+			return ctrl.Result{}, err
+		}
 	}
 
 	if err := r.syncAdmissionStatus(ctx, parent, variants); err != nil {
@@ -365,6 +381,10 @@ func generateVariant(parent *kueue.Workload, flavor kueue.ResourceFlavorReferenc
 		Spec:   parent.Spec,
 		Status: parent.Status,
 	}
+	// The Parent condition aggregates Variant state. A new Variant must report
+	// that it is blocked on preemption gates independently.
+	variant.Status.Conditions = slices.Clone(variant.Status.Conditions)
+	apimeta.RemoveStatusCondition(&variant.Status.Conditions, kueue.WorkloadBlockedOnPreemptionGates)
 	variant.Spec.PreemptionGates = slices.Clone(variant.Spec.PreemptionGates)
 	workload.EnsurePreemptionGateOnSpec(variant, controllerconsts.ConcurrentAdmissionPreemptionGate)
 	delete(variant.Labels, controllerconsts.ConcurrentAdmissionParentLabelKey)
@@ -651,6 +671,90 @@ func (r *variantReconciler) syncPodsReadyCond(parent, variant *kueue.Workload) b
 		return false
 	}
 	return apimeta.SetStatusCondition(&variant.Status.Conditions, *parentCond)
+}
+
+func updateInheritedPreemptionGateStates(parent, variant *kueue.Workload) bool {
+	inheritedGates := make(map[string]struct{}, len(parent.Spec.PreemptionGates))
+	for _, gate := range parent.Spec.PreemptionGates {
+		inheritedGates[gate.Name] = struct{}{}
+	}
+
+	updated := false
+	for _, parentState := range parent.Status.PreemptionGates {
+		if _, inherited := inheritedGates[parentState.Name]; !inherited {
+			continue
+		}
+
+		variantStateIdx := slices.IndexFunc(variant.Status.PreemptionGates, func(state kueue.PreemptionGateState) bool {
+			return state.Name == parentState.Name
+		})
+		if variantStateIdx == -1 {
+			variant.Status.PreemptionGates = append(variant.Status.PreemptionGates, parentState)
+			updated = true
+			continue
+		}
+		if !equality.Semantic.DeepEqual(variant.Status.PreemptionGates[variantStateIdx], parentState) {
+			variant.Status.PreemptionGates[variantStateIdx] = parentState
+			updated = true
+		}
+	}
+	return updated
+}
+
+func (r *variantReconciler) syncInheritedPreemptionGateStates(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload) error {
+	for i := range variants {
+		variant := &variants[i]
+		if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, variant, r.clock, func(wl *kueue.Workload) (bool, error) {
+			return updateInheritedPreemptionGateStates(parent, wl), nil
+		}, workloadpatching.WithRetryOnConflict()); err != nil {
+			return fmt.Errorf("syncing inherited preemption gate states to variant %s: %w", klog.KObj(variant), err)
+		}
+	}
+	return nil
+}
+
+func oldestPreemptionGatedVariant(variants []*kueue.Workload) (*kueue.Workload, *metav1.Condition) {
+	var oldestVariant *kueue.Workload
+	var oldestCondition *metav1.Condition
+	for _, variant := range variants {
+		condition := workload.BlockedOnPreemptionGatesCondition(variant)
+		if condition == nil {
+			continue
+		}
+		if oldestCondition == nil || condition.LastTransitionTime.Before(&oldestCondition.LastTransitionTime) {
+			oldestVariant = variant
+			oldestCondition = condition
+		}
+	}
+	return oldestVariant, oldestCondition
+}
+
+func (r *variantReconciler) syncVariantPreemptionSignal(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload) error {
+	blockedVariant, blockedCondition := oldestPreemptionGatedVariant(admissibleVariants(variants))
+	if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, parent, r.clock, func(wl *kueue.Workload) (bool, error) {
+		if blockedCondition == nil {
+			current := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadBlockedOnPreemptionGates)
+			if current == nil || current.Status != metav1.ConditionTrue {
+				return false, nil
+			}
+			return apimeta.SetStatusCondition(&wl.Status.Conditions, metav1.Condition{
+				Type:               kueue.WorkloadBlockedOnPreemptionGates,
+				Status:             metav1.ConditionFalse,
+				Reason:             ReasonVariantsNotPreemptionGated,
+				Message:            "No Variant Workload is blocked on preemption gates",
+				ObservedGeneration: wl.Generation,
+				LastTransitionTime: metav1.NewTime(r.clock.Now()),
+			}), nil
+		}
+
+		condition := *blockedCondition.DeepCopy()
+		condition.Message = fmt.Sprintf("Variant Workload %q is blocked on preemption gates", klog.KObj(blockedVariant))
+		condition.ObservedGeneration = wl.Generation
+		return apimeta.SetStatusCondition(&wl.Status.Conditions, condition), nil
+	}, workloadpatching.WithRetryOnConflict()); err != nil {
+		return fmt.Errorf("syncing variant preemption signal to parent %s: %w", klog.KObj(parent), err)
+	}
+	return nil
 }
 
 func (r *variantReconciler) syncAdmissionStatus(ctx context.Context, parent *kueue.Workload, variants []kueue.Workload) error {

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -784,6 +784,170 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"parent preemption gate state is synchronized to existing variants": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				PreemptionGateStates(kueue.PreemptionGateState{
+					Name:               otherGate.Name,
+					Position:           kueue.PreemptionGatePositionOpen,
+					LastTransitionTime: metav1.NewTime(fakeNow),
+				}).
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(
+						kueue.PreemptionGateState{
+							Name:               otherGate.Name,
+							Position:           kueue.PreemptionGatePositionClosed,
+							LastTransitionTime: metav1.NewTime(fakeNow.Add(-time.Minute)),
+						},
+						caGateState(kueue.PreemptionGatePositionOpen, fakeNow.Add(-time.Minute)),
+					).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				PreemptionGateStates(kueue.PreemptionGateState{
+					Name:               otherGate.Name,
+					Position:           kueue.PreemptionGatePositionOpen,
+					LastTransitionTime: metav1.NewTime(fakeNow),
+				}).
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(
+						kueue.PreemptionGateState{
+							Name:               otherGate.Name,
+							Position:           kueue.PreemptionGatePositionOpen,
+							LastTransitionTime: metav1.NewTime(fakeNow),
+						},
+						caGateState(kueue.PreemptionGatePositionOpen, fakeNow.Add(-time.Minute)),
+					).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+		},
+		"variant preemption signal is synchronized to the parent": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				PreemptionGateStates(kueue.PreemptionGateState{
+					Name:               otherGate.Name,
+					Position:           kueue.PreemptionGatePositionClosed,
+					LastTransitionTime: metav1.NewTime(fakeNow.Add(-time.Minute)),
+				}).
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(
+						kueue.PreemptionGateState{
+							Name:               otherGate.Name,
+							Position:           kueue.PreemptionGatePositionClosed,
+							LastTransitionTime: metav1.NewTime(fakeNow.Add(-time.Minute)),
+						},
+						caGateState(kueue.PreemptionGatePositionClosed, fakeNow.Add(-time.Minute)),
+					).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				PreemptionGateStates(kueue.PreemptionGateState{
+					Name:               otherGate.Name,
+					Position:           kueue.PreemptionGatePositionClosed,
+					LastTransitionTime: metav1.NewTime(fakeNow.Add(-time.Minute)),
+				}).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadBlockedOnPreemptionGates,
+					Status:             metav1.ConditionTrue,
+					Reason:             kueue.PreemptionGated,
+					Message:            `Variant Workload "default/wl-variant-spot" is blocked on preemption gates`,
+					LastTransitionTime: metav1.NewTime(fakeNow),
+				}).
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(
+						kueue.PreemptionGateState{
+							Name:               otherGate.Name,
+							Position:           kueue.PreemptionGatePositionClosed,
+							LastTransitionTime: metav1.NewTime(fakeNow.Add(-time.Minute)),
+						},
+						caGateState(kueue.PreemptionGatePositionOpen, fakeNow),
+					).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantResult: reconcile.Result{RequeueAfter: preemptionTimeout},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "default", Name: "wl-variant-spot"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    ReasonPreemptionUngatedVariant,
+					Message:   `Opened preemption gate for variant workload "default/wl-variant-spot"`,
+				},
+			},
+		},
+		"parent preemption signal is cleared when no variant is blocked": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				Condition(blockedOnPreemptionCondition(fakeNow.Add(-time.Minute))).
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(caGateState(kueue.PreemptionGatePositionOpen, fakeNow.Add(-time.Minute))).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq-spot-only").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadBlockedOnPreemptionGates,
+					Status:             metav1.ConditionFalse,
+					Reason:             ReasonVariantsNotPreemptionGated,
+					Message:            "No Variant Workload is blocked on preemption gates",
+					LastTransitionTime: metav1.NewTime(fakeNow),
+				}).
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq-spot-only").
+					AllowedFlavors("spot").
+					PreemptionGates(otherGate, caGate()).
+					PreemptionGateStates(caGateState(kueue.PreemptionGatePositionOpen, fakeNow.Add(-time.Minute))).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+		},
 		"admitted variant syncs admission to parent": {
 			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq").
@@ -1164,19 +1328,21 @@ func TestReconcile(t *testing.T) {
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
+				Condition(blockedOnPreemptionCondition(fakeNow.Add(-time.Minute))).
 				Obj(),
 			variantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
 					AllowedFlavors("reservation").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					Obj(),
 				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration").
 					AllowedFlavors("on-demand").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "on-demand", metav1.Now().Time).
@@ -1185,15 +1351,17 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
 					AllowedFlavors("spot").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
+					Condition(blockedOnPreemptionCondition(fakeNow)).
 					Obj(),
 			},
 			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
 				Queue("lq-migration").
 				Request(corev1.ResourceCPU, "1").
 				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				PreemptionGates(otherGate).
 				Admission(utiltestingapi.MakeAdmission("cq-migration", "main").
 					PodSets(kueue.PodSetAssignment{
 						Name: "main",
@@ -1215,19 +1383,26 @@ func TestReconcile(t *testing.T) {
 					Reason:  "QuotaReserved",
 					Message: "Quota reserved in ClusterQueue cq-migration",
 				}).
+				Condition(metav1.Condition{
+					Type:               kueue.WorkloadBlockedOnPreemptionGates,
+					Status:             metav1.ConditionFalse,
+					Reason:             ReasonVariantsNotPreemptionGated,
+					Message:            "No Variant Workload is blocked on preemption gates",
+					LastTransitionTime: metav1.NewTime(fakeNow),
+				}).
 				Obj(),
 			wantVariantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-variant-reservation", "default").
 					Queue("lq-migration").
 					AllowedFlavors("reservation").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					Obj(),
 				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
 					Queue("lq-migration").
 					AllowedFlavors("on-demand").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					SimpleReserveQuota("cq-migration", "on-demand", metav1.Now().Time).
@@ -1236,10 +1411,11 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
 					Queue("lq-migration").
 					AllowedFlavors("spot").
-					PreemptionGates(caGate()).
+					PreemptionGates(otherGate, caGate()).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Request(corev1.ResourceCPU, "1").
 					Active(false).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -2410,5 +2586,28 @@ func TestCreateVariantsAlreadyExists(t *testing.T) {
 
 	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(existing), &kueue.Workload{}); err != nil {
 		t.Fatalf("pre-existing variant should still exist: %v", err)
+	}
+}
+
+func TestGenerateVariantDoesNotCopyPreemptionSignal(t *testing.T) {
+	parent := utiltestingapi.MakeWorkload("parent-wl", "default").
+		Condition(blockedOnPreemptionCondition(time.Now())).
+		Condition(metav1.Condition{
+			Type:   kueue.WorkloadPodsReady,
+			Status: metav1.ConditionFalse,
+			Reason: "PodsNotReady",
+		}).
+		Obj()
+
+	variant := generateVariant(parent, "spot")
+
+	if got := workload.BlockedOnPreemptionGatesCondition(variant); got != nil {
+		t.Errorf("generated Variant should not inherit the Parent preemption signal, got %v", got)
+	}
+	if got := apimeta.FindStatusCondition(variant.Status.Conditions, kueue.WorkloadPodsReady); got == nil {
+		t.Error("generated Variant should preserve unrelated Parent conditions")
+	}
+	if got := workload.BlockedOnPreemptionGatesCondition(parent); got == nil {
+		t.Error("generating a Variant should not mutate the Parent conditions")
 	}
 }

--- a/site/content/en/docs/concepts/concurrent_admission.md
+++ b/site/content/en/docs/concepts/concurrent_admission.md
@@ -153,9 +153,26 @@ Concurrent Admission currently has the following constraints:
 - A `ClusterQueue` with `.spec.concurrentAdmissionPolicy` must have exactly one
   `resourceGroup`.
 - The `resourceGroup` can contain at most 16 ResourceFlavors.
+- A `ClusterQueue` that uses a MultiKueue AdmissionCheck is marked inactive if
+  it defines `.spec.concurrentAdmissionPolicy`. Configure Concurrent Admission
+  on the worker cluster's ClusterQueue instead.
 - The `concurrentAdmissionPolicy` field is immutable after the `ClusterQueue` is
   created.
 - `TryPreferredFlavors` is the only supported migration mode.
+
+## MultiKueue
+
+Concurrent Admission can be used on MultiKueue worker clusters. The manager
+ClusterQueue should use the MultiKueue AdmissionCheck without defining
+`.spec.concurrentAdmissionPolicy`, while the corresponding worker
+ClusterQueues define their Concurrent Admission policies.
+
+When MultiKueue orchestrated preemption is enabled, a worker reports a
+Variant's preemption signal through its Parent Workload. MultiKueue opens the
+Parent's preemption gate, and Concurrent Admission propagates the gate state to
+the Variants. The Concurrent Admission gate continues to control which sibling
+Variants can attempt preemption and opens them in preference order, subject to
+the preemption timeout.
 
 ## What's next?
 

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -228,6 +228,9 @@ configuration details.
 ## Limitations
 
 - We do not currently support running the manager cluster as one of the workers for itself.
+- Concurrent Admission policies are supported on worker ClusterQueues. A
+  manager ClusterQueue that combines a MultiKueue AdmissionCheck with a
+  Concurrent Admission policy is marked inactive.
 - For job types without `managedBy` support (StatefulSet, LeaderWorkerSet), the job status on the
   manager cluster may not reflect the actual status from the worker cluster. This is because the
   local job controller continuously updates status based on local (gated) pods. The job execution

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -40,7 +40,9 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
+	workloadconcurrentadmission "sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
+	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -537,7 +539,99 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 
 	ginkgo.When("MultiKueueOrchestratedPreemption is enabled", func() {
 		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ConcurrentAdmission, true)
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueOrchestratedPreemption, true)
+		})
+
+		ginkgo.It("Should propagate preemption gates through ConcurrentAdmission variants", func() {
+			reservationFlavor := utiltestingapi.MakeResourceFlavor("ca-reservation").Obj()
+			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, reservationFlavor)
+			spotFlavor := utiltestingapi.MakeResourceFlavor("ca-spot").Obj()
+			util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, spotFlavor)
+
+			caCq := utiltestingapi.MakeClusterQueue("ca-cq").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(reservationFlavor.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(spotFlavor.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, caCq)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, caCq, true)
+				util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, spotFlavor, true)
+				util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, reservationFlavor, true)
+			})
+
+			managerCaLq := utiltestingapi.MakeLocalQueue("ca-lq", managerNs.Name).ClusterQueue(managerCq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, managerCaLq)
+			workerCaLq := utiltestingapi.MakeLocalQueue(managerCaLq.Name, worker1Ns.Name).ClusterQueue(caCq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, workerCaLq)
+
+			job := testingjob.MakeJob("job-with-concurrent-admission", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerCaLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "1").
+				Obj()
+			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+			wlKey := types.NamespacedName{
+				Name:      workloadjob.GetWorkloadNameForJob(job.Name, job.UID),
+				Namespace: managerNs.Name,
+			}
+
+			remoteParent := &kueue.Workload{}
+			var variants []kueue.Workload
+			ginkgo.By("Waiting for the remote parent and its variants", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, remoteParent)).To(gomega.Succeed())
+					g.Expect(workloadconcurrentadmission.IsParent(remoteParent)).To(gomega.BeTrue())
+
+					list := &kueue.WorkloadList{}
+					g.Expect(worker1TestCluster.client.List(worker1TestCluster.ctx, list, client.InNamespace(worker1Ns.Name))).To(gomega.Succeed())
+					variants = nil
+					for i := range list.Items {
+						if workloadconcurrentadmission.GetParentWorkloadName(&list.Items[i]) == remoteParent.Name {
+							variants = append(variants, list.Items[i])
+						}
+					}
+					g.Expect(variants).To(gomega.HaveLen(2))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Reporting a preemption signal from one variant", func() {
+				gomega.Expect(workloadpatching.PatchAdmissionStatus(
+					worker1TestCluster.ctx,
+					worker1TestCluster.client,
+					&variants[0],
+					util.RealClock,
+					func(wl *kueue.Workload) (bool, error) {
+						return workload.SetBlockedOnPreemptionGatesCondition(
+							wl,
+							util.RealClock.Now(),
+							kueue.PreemptionGated,
+							"Preemption is blocked by a preemption gate",
+						), nil
+					},
+					workloadpatching.WithRetryOnConflict(),
+				)).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying MultiKueue opens the parent gate and ConcurrentAdmission propagates it", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, wlKey, remoteParent)).To(gomega.Succeed())
+					g.Expect(workload.HasOpenPreemptionGate(remoteParent, constants.MultiKueuePreemptionGate)).To(gomega.BeTrue())
+
+					list := &kueue.WorkloadList{}
+					g.Expect(worker1TestCluster.client.List(worker1TestCluster.ctx, list, client.InNamespace(worker1Ns.Name))).To(gomega.Succeed())
+					variantsFound := 0
+					for i := range list.Items {
+						if workloadconcurrentadmission.GetParentWorkloadName(&list.Items[i]) != remoteParent.Name {
+							continue
+						}
+						variantsFound++
+						g.Expect(workload.HasOpenPreemptionGate(&list.Items[i], constants.MultiKueuePreemptionGate)).To(gomega.BeTrue())
+					}
+					g.Expect(variantsFound).To(gomega.Equal(2))
+				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+			})
 		})
 
 		ginkgo.It("Should treat manager-level and worker-level preemption gates independently", func() {

--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/provisioning"
+	"sigs.k8s.io/kueue/pkg/controller/concurrentadmission"
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -123,6 +124,9 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		configuration,
 		core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations},
 	)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
+
+	failedCtrl, err = concurrentadmission.SetupControllers(mgr, queues, configuration, nil)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 
 	failedWebhook, err := webhooks.Setup(mgr, nil)

--- a/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
+++ b/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
@@ -642,6 +642,118 @@ var _ = ginkgo.Describe("Concurrent Admission", func() {
 		})
 	})
 
+	ginkgo.When("Variants inherit an external preemption gate", func() {
+		var cq *kueue.ClusterQueue
+		var lq *kueue.LocalQueue
+		var flavorReservation *kueue.ResourceFlavor
+		var flavorSpot *kueue.ResourceFlavor
+
+		ginkgo.BeforeEach(func() {
+			flavorReservation = utiltestingapi.MakeResourceFlavor("reservation").Obj()
+			util.MustCreate(ctx, k8sClient, flavorReservation)
+
+			flavorSpot = utiltestingapi.MakeResourceFlavor("spot").Obj()
+			util.MustCreate(ctx, k8sClient, flavorSpot)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-external-preemption-gate").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorReservation.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorSpot, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, flavorReservation, true)
+		})
+
+		ginkgo.It("syncs variant preemption signals to the parent and the parent gate state back to every variant", func() {
+			parentWl := utiltestingapi.MakeWorkload("parent-wl-external-preemption-gate", ns.Name).
+				Request(corev1.ResourceCPU, "1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				ParentVariant().
+				PreemptionGates(kueue.PreemptionGate{Name: controllerconstants.MultiKueuePreemptionGate}).
+				Obj()
+
+			ginkgo.By("Creating the parent workload", func() {
+				util.MustCreate(ctx, k8sClient, parentWl)
+			})
+
+			var reservationVariant *kueue.Workload
+			ginkgo.By("Waiting for both variants", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+
+					reservationVariant = getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)
+					g.Expect(reservationVariant).ToNot(gomega.BeNil())
+					g.Expect(getVariantByFlavor(list, parentWl.Name, flavorSpot.Name)).ToNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Reporting that the reservation variant is blocked on preemption gates", func() {
+				gomega.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, reservationVariant, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+					return workload.SetBlockedOnPreemptionGatesCondition(
+						wl,
+						util.RealClock.Now(),
+						kueue.PreemptionGated,
+						"Preemption is blocked by a preemption gate",
+					), nil
+				}, workloadpatching.WithRetryOnConflict())).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying the signal reaches the parent and only one ConcurrentAdmission gate opens", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentWl), parentWl)).To(gomega.Succeed())
+					g.Expect(workload.BlockedOnPreemptionGatesCondition(parentWl)).ToNot(gomega.BeNil())
+
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+					reservationVariant = getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)
+					spotVariant := getVariantByFlavor(list, parentWl.Name, flavorSpot.Name)
+					g.Expect(reservationVariant).ToNot(gomega.BeNil())
+					g.Expect(spotVariant).ToNot(gomega.BeNil())
+					g.Expect(workload.HasOpenPreemptionGate(reservationVariant, controllerconstants.ConcurrentAdmissionPreemptionGate)).To(gomega.BeTrue())
+					g.Expect(workload.HasOpenPreemptionGate(spotVariant, controllerconstants.ConcurrentAdmissionPreemptionGate)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Opening the external preemption gate on the parent", func() {
+				gomega.Expect(workloadpatching.PatchAdmissionStatus(ctx, k8sClient, parentWl, util.RealClock, func(wl *kueue.Workload) (bool, error) {
+					return workload.OpenPreemptionGate(
+						wl,
+						controllerconstants.MultiKueuePreemptionGate,
+						metav1.NewTime(util.RealClock.Now()),
+					), nil
+				}, workloadpatching.WithRetryOnConflict())).To(gomega.Succeed())
+			})
+
+			ginkgo.By("Verifying the external gate opens on every variant without changing the ConcurrentAdmission gates", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					list := &kueue.WorkloadList{}
+					g.Expect(k8sClient.List(ctx, list, client.InNamespace(ns.Name))).To(gomega.Succeed())
+
+					reservationVariant = getVariantByFlavor(list, parentWl.Name, flavorReservation.Name)
+					spotVariant := getVariantByFlavor(list, parentWl.Name, flavorSpot.Name)
+					g.Expect(reservationVariant).ToNot(gomega.BeNil())
+					g.Expect(spotVariant).ToNot(gomega.BeNil())
+					g.Expect(workload.HasOpenPreemptionGate(reservationVariant, controllerconstants.MultiKueuePreemptionGate)).To(gomega.BeTrue())
+					g.Expect(workload.HasOpenPreemptionGate(spotVariant, controllerconstants.MultiKueuePreemptionGate)).To(gomega.BeTrue())
+					g.Expect(workload.HasOpenPreemptionGate(reservationVariant, controllerconstants.ConcurrentAdmissionPreemptionGate)).To(gomega.BeTrue())
+					g.Expect(workload.HasOpenPreemptionGate(spotVariant, controllerconstants.ConcurrentAdmissionPreemptionGate)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	})
+
 	ginkgo.When("Should react to changes in the ClusterQueue's resource flavors", func() {
 		var cq *kueue.ClusterQueue
 		var lq *kueue.LocalQueue

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -809,6 +809,8 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 		})
 
 		ginkgo.It("Should prevent workload admission due to multikueue contraints", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ConcurrentAdmission, true)
+
 			cpuArchAFlavor = utiltestingapi.MakeResourceFlavor(flavorCPUArchA).Obj()
 			util.MustCreate(ctx, k8sClient, cpuArchAFlavor)
 
@@ -893,6 +895,32 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 					},
 				}, util.IgnoreConditionTimestampsAndObservedGeneration))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Concurrent Admission and MultiKueue are configured on the same ClusterQueue")
+			concurrentCq := utiltestingapi.MakeClusterQueue("bar-cq-concurrent").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavorCPUArchA).Resource(corev1.ResourceCPU, "5", "5").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorCPUArchB).Resource(corev1.ResourceCPU, "5", "5").Obj(),
+				).
+				Cohort("bar-cohort").
+				AdmissionChecks("check1").
+				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
+				Obj()
+			util.MustCreate(ctx, k8sClient, concurrentCq)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedCq kueue.ClusterQueue
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(concurrentCq), &updatedCq)).To(gomega.Succeed())
+				g.Expect(updatedCq.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+					{
+						Type:    kueue.ClusterQueueActive,
+						Status:  metav1.ConditionFalse,
+						Reason:  kueue.ClusterQueueActiveReasonMultiKueueWithConcurrentAdmission,
+						Message: "Can't admit new workloads: Cannot use ConcurrentAdmission on a ClusterQueue with a MultiKueue AdmissionCheck.",
+					},
+				}, util.IgnoreConditionTimestampsAndObservedGeneration))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, concurrentCq, true)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area multikueue
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Supports Concurrent Admission with MultiKueue orchestrated preemption on worker clusters. Variant preemption signals are propagated to the Parent Workload so MultiKueue can select a worker, while Parent gate states are synchronized back to every Variant. Manager ClusterQueues combining MultiKueue and Concurrent Admission are marked inactive because this configuration is unsupported.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12470

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue now supports Concurrent Admission preemption on worker clusters and prevents unsupported manager ClusterQueue configurations.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Concurrent Admission now synchronizes preemption-gate states between parent and variant workloads.
  * MultiKueue can report preemption signals through parent workloads and propagate gate updates to variants.
* **Bug Fixes**
  * ClusterQueues combining MultiKueue admission checks with Concurrent Admission are now clearly marked inactive with a specific status reason.
  * Generated variants no longer inherit aggregated parent preemption-blocked status.
* **Documentation**
  * Added guidance on MultiKueue and Concurrent Admission constraints, worker-cluster configuration, and preemption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->