### PR TITLE
refactor: scope integration manager state

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -451,7 +451,13 @@ func main() {
 	}
 }
 
-func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration, integrationManager *jobframework.IntegrationManager, resourceSliceAPIAvailable bool) error {
+func setupIndexes(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	cfg *configapi.Configuration,
+	integrationManager *jobframework.IntegrationManager,
+	resourceSliceAPIAvailable bool,
+) error {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	if err != nil {
 		return err

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -67,6 +67,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
 	"sigs.k8s.io/kueue/pkg/controller/failurerecovery"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
@@ -94,13 +95,12 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	// Ensure linking of the job controllers.
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme             = runtime.NewScheme()
+	setupLog           = ctrl.Log.WithName("setup")
+	integrationManager = jobs.NewIntegrationManager()
 )
 
 func init() {
@@ -117,7 +117,7 @@ func init() {
 	utilruntime.Must(inventoryv1alpha1.AddToScheme(scheme))
 	// Add any additional framework integration types.
 	utilruntime.Must(
-		jobframework.ForEachIntegration(func(_ string, cb jobframework.IntegrationCallbacks) error {
+		integrationManager.ForEachIntegration(func(_ string, cb jobframework.IntegrationCallbacks) error {
 			if cb.AddToScheme != nil {
 				return cb.AddToScheme(scheme)
 			}
@@ -164,7 +164,7 @@ func main() {
 	}
 
 	// Validates the configuration after it has been loaded and feature gates have been set.
-	if err := config.Validate(&cfg, scheme).ToAggregate(); err != nil {
+	if err := config.Validate(&cfg, scheme, integrationManager).ToAggregate(); err != nil {
 		setupLog.Error(err, "Unable to validate the configuration")
 		os.Exit(1)
 	}
@@ -376,7 +376,7 @@ func main() {
 
 	resourceSliceAPIAvailable := utildra.CheckResourceSliceAPIAvailable(mgr)
 
-	if err := setupIndexes(ctx, mgr, &cfg, resourceSliceAPIAvailable); err != nil {
+	if err := setupIndexes(ctx, mgr, &cfg, integrationManager, resourceSliceAPIAvailable); err != nil {
 		setupLog.Error(err, "Unable to setup indexes")
 		os.Exit(1)
 	}
@@ -417,7 +417,7 @@ func main() {
 		ResourceFormatter:         resourceFormatter,
 		ResourceSliceAPIAvailable: resourceSliceAPIAvailable,
 	}
-	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, controllerOpts); err != nil {
+	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, integrationManager, controllerOpts); err != nil {
 		setupLog.Error(err, "Unable to setup controllers")
 		os.Exit(1)
 	}
@@ -451,7 +451,7 @@ func main() {
 	}
 }
 
-func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration, resourceSliceAPIAvailable bool) error {
+func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration, integrationManager *jobframework.IntegrationManager, resourceSliceAPIAvailable bool) error {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	if err != nil {
 		return err
@@ -486,9 +486,10 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 	}
 
 	indexOpts := []jobframework.Option{
+		jobframework.WithIntegrationManager(integrationManager),
 		jobframework.WithEnabledFrameworks(cfg.Integrations.Frameworks),
 	}
-	return jobframework.SetupIndexes(ctx, mgr.GetFieldIndexer(), indexOpts...)
+	return integrationManager.SetupIndexes(ctx, mgr.GetFieldIndexer(), indexOpts...)
 }
 
 func setupControllers(
@@ -498,6 +499,7 @@ func setupControllers(
 	queues *qcache.Manager,
 	cfg *configapi.Configuration,
 	serverVersionFetcher *kubeversion.ServerVersionFetcher,
+	integrationManager *jobframework.IntegrationManager,
 	opts core.SetupControllersOpts,
 ) error {
 	if failedCtrl, err := core.SetupControllers(mgr, queues, cCache, cfg, opts); err != nil {
@@ -526,7 +528,7 @@ func setupControllers(
 	}
 
 	if features.Enabled(features.MultiKueue) {
-		adapters, err := jobframework.GetMultiKueueAdapters(sets.New(cfg.Integrations.Frameworks...))
+		adapters, err := integrationManager.GetMultiKueueAdapters(sets.New(cfg.Integrations.Frameworks...))
 		if err != nil {
 			return fmt.Errorf("could not get the enabled multikueue adapters: %w", err)
 		}
@@ -583,6 +585,7 @@ func setupControllers(
 
 	labelKeysToCopy, annotationsToCopy := getLabelsAndAnnotationsToCopy(cfg)
 	jfOpts := []jobframework.Option{
+		jobframework.WithIntegrationManager(integrationManager),
 		jobframework.WithManageJobsWithoutQueueName(cfg.ManageJobsWithoutQueueName),
 		jobframework.WithWaitForPodsReady(cfg.WaitForPodsReady),
 		jobframework.WithKubeServerVersion(serverVersionFetcher),
@@ -604,7 +607,7 @@ func setupControllers(
 	}
 	jfOpts = append(jfOpts, jobframework.WithManagedJobsNamespaceSelector(nsSelector))
 
-	if err := jobframework.SetupControllers(ctx, mgr, setupLog, jfOpts...); err != nil {
+	if err := integrationManager.SetupControllers(ctx, mgr, setupLog, jfOpts...); err != nil {
 		return fmt.Errorf(
 			"unable to create controller or webhook for kubernetesVersion %v: %w",
 			serverVersionFetcher.GetServerVersion(),

--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -40,9 +40,7 @@ import (
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/clientgetter"
 	"sigs.k8s.io/kueue/cmd/kueuectl/app/flags"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-
-	// Ensure linking of the job controllers.
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var (
@@ -77,6 +75,7 @@ type PodOptions struct {
 	ForGVK                 schema.GroupVersionKind
 	ForObject              *unstructured.Unstructured
 	PodLabelSelector       string
+	IntegrationManager     *jobframework.IntegrationManager
 
 	Clientset k8s.Interface
 
@@ -85,8 +84,9 @@ type PodOptions struct {
 
 func NewPodOptions(streams genericiooptions.IOStreams) *PodOptions {
 	return &PodOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
-		IOStreams:  streams,
+		PrintFlags:         genericclioptions.NewPrintFlags("").WithTypeSetter(scheme.Scheme),
+		IntegrationManager: jobs.NewIntegrationManager(),
+		IOStreams:          streams,
 	}
 }
 
@@ -229,7 +229,7 @@ func (o *PodOptions) getForObject(infos []*resource.Info) (*unstructured.Unstruc
 
 // getPodLabelSelector returns the podLabels used as a standard selector for jobs
 func (o *PodOptions) getPodLabelSelector() (string, error) {
-	cbs, ok := jobframework.GetIntegrationByGVK(o.ForGVK)
+	cbs, ok := o.IntegrationManager.GetIntegrationByGVK(o.ForGVK)
 	if !ok {
 		return "", nil
 	}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -88,11 +88,11 @@ var (
 )
 
 // Validate checks the configuration for invalid values.
-func Validate(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorList {
+func Validate(c *configapi.Configuration, scheme *runtime.Scheme, integrationManager *jobframework.IntegrationManager) field.ErrorList {
 	var allErrs field.ErrorList
 	allErrs = append(allErrs, validateWaitForPodsReady(c)...)
-	allErrs = append(allErrs, validateIntegrations(c, scheme)...)
-	allErrs = append(allErrs, validateMultiKueue(c)...)
+	allErrs = append(allErrs, validateIntegrations(c, scheme, integrationManager)...)
+	allErrs = append(allErrs, validateMultiKueue(c, integrationManager)...)
 	allErrs = append(allErrs, validateFairSharing(c)...)
 	allErrs = append(allErrs, validateAdmissionFairSharing(c)...)
 	allErrs = append(allErrs, validateInternalCertManagement(c)...)
@@ -153,7 +153,7 @@ func validateInternalCertManagement(c *configapi.Configuration) field.ErrorList 
 	return allErrs
 }
 
-func validateMultiKueue(c *configapi.Configuration) field.ErrorList {
+func validateMultiKueue(c *configapi.Configuration, integrationManager *jobframework.IntegrationManager) field.ErrorList {
 	var allErrs field.ErrorList
 	if c.MultiKueue != nil {
 		if c.MultiKueue.GCInterval != nil && c.MultiKueue.GCInterval.Duration < 0 {
@@ -177,7 +177,7 @@ func validateMultiKueue(c *configapi.Configuration) field.ErrorList {
 				enabledIntegrations = sets.New(c.Integrations.Frameworks...)
 			}
 
-			builtInAdapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
+			builtInAdapters, err := integrationManager.GetMultiKueueAdapters(enabledIntegrations)
 			if err != nil {
 				allErrs = append(allErrs, field.InternalError(path, err))
 			}
@@ -308,7 +308,7 @@ func validateWaitForPodsReady(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
-func validateIntegrations(c *configapi.Configuration, scheme *runtime.Scheme) field.ErrorList {
+func validateIntegrations(c *configapi.Configuration, scheme *runtime.Scheme, integrationManager *jobframework.IntegrationManager) field.ErrorList {
 	var allErrs field.ErrorList
 	if c.Integrations == nil {
 		return field.ErrorList{field.Required(integrationsPath, "cannot be empty")}
@@ -318,9 +318,9 @@ func validateIntegrations(c *configapi.Configuration, scheme *runtime.Scheme) fi
 	}
 
 	managedFrameworks := sets.New[string]()
-	availableBuiltInFrameworks := jobframework.GetIntegrationsList()
+	availableBuiltInFrameworks := integrationManager.GetIntegrationsList()
 	for idx, framework := range c.Integrations.Frameworks {
-		if cb, found := jobframework.GetIntegration(framework); !found {
+		if cb, found := integrationManager.GetIntegration(framework); !found {
 			allErrs = append(allErrs, field.NotSupported(integrationsFrameworksPath.Index(idx), framework, availableBuiltInFrameworks))
 		} else if gvk, err := apiutil.GVKForObject(cb.JobType, scheme); err == nil {
 			if managedFrameworks.Has(gvk.String()) {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 )
 
@@ -1795,7 +1796,7 @@ func TestValidate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			if diff := cmp.Diff(tc.wantErr, Validate(tc.cfg, testScheme), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, Validate(tc.cfg, testScheme, jobs.NewIntegrationManager()), cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
 				t.Errorf("Unexpected returned error (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
+++ b/pkg/controller/admissionchecks/multikueue/clusterqueue_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -453,7 +453,7 @@ func TestCQReconcile(t *testing.T) {
 				WithStatusSubresource(tc.cq).
 				Build()
 
-			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
 			cRec := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 			cRec.rootContext = ctx

--- a/pkg/controller/admissionchecks/multikueue/indexer_test.go
+++ b/pkg/controller/admissionchecks/multikueue/indexer_test.go
@@ -32,6 +32,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -48,7 +49,7 @@ func getClientBuilder(ctx context.Context) *fake.ClientBuilder {
 	utilruntime.Must(kueue.AddToScheme(scheme))
 	utilruntime.Must(inventoryv1alpha1.AddToScheme(scheme))
 
-	utilruntime.Must(jobframework.ForEachIntegration(func(_ string, cb jobframework.IntegrationCallbacks) error {
+	utilruntime.Must(jobs.NewIntegrationManager().ForEachIntegration(func(_ string, cb jobframework.IntegrationCallbacks) error {
 		if cb.MultiKueueAdapter != nil && cb.AddToScheme != nil {
 			return cb.AddToScheme(scheme)
 		}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -50,13 +50,12 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var (
@@ -683,7 +682,7 @@ func TestUpdateConfig(t *testing.T) {
 			builder = builder.WithStatusSubresource(slices.Map(tc.clusters, func(c *kueue.MultiKueueCluster) client.Object { return c })...)
 			c := builder.Build()
 
-			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
 			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, tc.cpAccessProvider, nil, recorder)
 
@@ -842,7 +841,7 @@ func TestReconnectBackoff(t *testing.T) {
 			builder = builder.WithStatusSubresource(&kueue.MultiKueueCluster{})
 			c := builder.Build()
 
-			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			recorder := &utiltesting.EventRecorder{}
 			reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 			reconciler.rootContext = ctx
@@ -898,7 +897,7 @@ func TestDisconnectedClientReconnectsWithSameConfig(t *testing.T) {
 	builder = builder.WithStatusSubresource(&kueue.MultiKueueCluster{})
 	c := builder.Build()
 
-	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	recorder := &utiltesting.EventRecorder{}
 	reconciler := newClustersReconciler(c, TestNamespace, 0, defaultOrigin, nil, adapters, &testClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
@@ -1078,7 +1077,7 @@ func TestRemoteClientGC(t *testing.T) {
 			worker1Builder = worker1Builder.WithLists(&kueue.WorkloadList{Items: tc.workersWorkloads}, &batchv1.JobList{Items: tc.workersJobs})
 			worker1Client := NewNeverCachingClient(worker1Builder.Build())
 
-			adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+			adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 			w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)
 			w1remoteClient.client = worker1Client
 			w1remoteClient.connState.markConnected()

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2410,7 +2410,7 @@ func setupAdmittedMetricTest(ctx context.Context, t *testing.T, acState kueue.Ch
 		).
 		Build()
 
-	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
 	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -46,6 +46,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
@@ -55,8 +56,6 @@ import (
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var errFake = errors.New("fake error")
@@ -2118,7 +2117,7 @@ func TestWlReconcile(t *testing.T) {
 				)
 
 				managerClient := managerBuilder.Build()
-				adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+				adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 				recorder := &utiltesting.EventRecorder{}
 				cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, recorder)
 
@@ -2300,7 +2299,7 @@ func TestOrphanedRemoteWorkloadCleanedAfterReconnect(t *testing.T) {
 		)
 	managerClient := managerBuilder.Build()
 
-	adapters, _ := jobframework.GetMultiKueueAdapters(sets.New("batch/job"))
+	adapters, _ := jobs.NewIntegrationManager().GetMultiKueueAdapters(sets.New("batch/job"))
 	cRec := newClustersReconciler(managerClient, TestNamespace, 0, defaultOrigin, nil, adapters, nil, nil, nil)
 
 	w1remoteClient := newRemoteClient(managerClient, nil, nil, nil, defaultOrigin, "", adapters)

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -72,12 +72,14 @@ func (w *BaseWebhook[T]) Default(ctx context.Context, obj T) error {
 	job := w.FromObject(obj)
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Applying defaults")
-	if err := w.IntegrationManager.ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
-		return err
-	}
-	w.IntegrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())
-	if err := w.IntegrationManager.ApplyDefaultForSuspend(ctx, job, w.Client, w.ManageJobsWithoutQueueName, w.ManagedJobsNamespaceSelector); err != nil {
-		return err
+	if w.IntegrationManager != nil {
+		if err := w.IntegrationManager.ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
+			return err
+		}
+		w.IntegrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())
+		if err := w.IntegrationManager.ApplyDefaultForSuspend(ctx, job, w.Client, w.ManageJobsWithoutQueueName, w.ManagedJobsNamespaceSelector); err != nil {
+			return err
+		}
 	}
 	ApplyDefaultForManagedBy(job, w.Queues, w.Cache, log)
 	return nil

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -35,6 +35,7 @@ import (
 
 // BaseWebhook applies basic defaulting and validation for jobs.
 type BaseWebhook[T any] struct {
+	IntegrationManager           *IntegrationManager
 	Client                       client.Client
 	ManageJobsWithoutQueueName   bool
 	ManagedJobsNamespaceSelector labels.Selector
@@ -47,6 +48,7 @@ func BaseWebhookFactory[T runtime.Object](obj T, fromObject func(T) GenericJob) 
 	return func(mgr ctrl.Manager, opts ...Option) error {
 		options := ProcessOptions(opts...)
 		wh := &BaseWebhook[T]{
+			IntegrationManager:           options.IntegrationManager,
 			Client:                       mgr.GetClient(),
 			ManageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 			ManagedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -70,11 +72,11 @@ func (w *BaseWebhook[T]) Default(ctx context.Context, obj T) error {
 	job := w.FromObject(obj)
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Applying defaults")
-	if err := ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
+	if err := w.IntegrationManager.ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())
-	if err := ApplyDefaultForSuspend(ctx, job, w.Client, w.ManageJobsWithoutQueueName, w.ManagedJobsNamespaceSelector); err != nil {
+	w.IntegrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())
+	if err := w.IntegrationManager.ApplyDefaultForSuspend(ctx, job, w.Client, w.ManageJobsWithoutQueueName, w.ManagedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	ApplyDefaultForManagedBy(job, w.Queues, w.Cache, log)

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -49,6 +49,7 @@ func TestBaseWebhookDefault(t *testing.T) {
 		manageJobsWithoutQueueName   bool
 		managedJobsNamespaceSelector labels.Selector
 		defaultLqExist               bool
+		withoutIntegrationManager    bool
 		featureGates                 map[featuregate.Feature]bool
 		job                          *batchv1.Job
 		want                         *batchv1.Job
@@ -79,6 +80,12 @@ func TestBaseWebhookDefault(t *testing.T) {
 			defaultLqExist: false,
 			job:            utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
 			want:           utiljob.MakeJob("job", metav1.NamespaceDefault).Obj(),
+		},
+		"does not panic without an integration manager": {
+			defaultLqExist:            true,
+			withoutIntegrationManager: true,
+			job:                       utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
+			want:                      utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("queue").Obj(),
 		},
 		"ManagedByDefaulting, targeting multikueue local queue": {
 			job: utiljob.MakeJob("job", metav1.NamespaceDefault).Queue("multikueue").Obj(),
@@ -199,7 +206,12 @@ func TestBaseWebhookDefault(t *testing.T) {
 				Return(features.Enabled(features.MultiKueue) && (tc.job.Spec.ManagedBy == nil || *tc.job.Spec.ManagedBy == batchv1.JobControllerName)).
 				AnyTimes()
 
+			integrationManager := jobframework.NewIntegrationManager()
+			if tc.withoutIntegrationManager {
+				integrationManager = nil
+			}
 			w := &jobframework.BaseWebhook[*mockJob]{
+				IntegrationManager:           integrationManager,
 				Client:                       cl,
 				ManageJobsWithoutQueueName:   tc.manageJobsWithoutQueueName,
 				ManagedJobsNamespaceSelector: tc.managedJobsNamespaceSelector,

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -34,9 +34,9 @@ import (
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
-func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient client.Client,
+func (m *IntegrationManager) ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient client.Client,
 	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) error {
-	suspend, err := WorkloadShouldBeSuspended(ctx, job.Object(), k8sClient, manageJobsWithoutQueueName, managedJobsNamespaceSelector)
+	suspend, err := m.WorkloadShouldBeSuspended(ctx, job.Object(), k8sClient, manageJobsWithoutQueueName, managedJobsNamespaceSelector)
 	if err != nil {
 		return err
 	}
@@ -46,13 +46,13 @@ func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient clien
 	return nil
 }
 
-func ApplyDefaultLocalQueue(ctx context.Context, k8sClient client.Client, jobObj client.Object, defaultQueueExist func(string) bool, managedJobsNamespaceSelector labels.Selector) error {
+func (m *IntegrationManager) ApplyDefaultLocalQueue(ctx context.Context, k8sClient client.Client, jobObj client.Object, defaultQueueExist func(string) bool, managedJobsNamespaceSelector labels.Selector) error {
 	if !defaultQueueExist(jobObj.GetNamespace()) {
 		return nil
 	}
 	if QueueNameForObject(jobObj) == "" {
 		// Do not default the queue-name for a job whose owner is already managed by Kueue
-		if IsOwnerManagedByKueueForObject(jobObj) {
+		if m.IsOwnerManagedByKueueForObject(jobObj) {
 			return nil
 		}
 		if managed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), managedJobsNamespaceSelector); err != nil {
@@ -70,14 +70,14 @@ func ApplyDefaultLocalQueue(ctx context.Context, k8sClient client.Client, jobObj
 	return nil
 }
 
-func ApplyDefaultWorkloadPriorityClass(ctx context.Context, c client.Client, jobObj client.Object) {
+func (m *IntegrationManager) ApplyDefaultWorkloadPriorityClass(ctx context.Context, c client.Client, jobObj client.Object) {
 	if !features.Enabled(features.WorkloadPriorityClassDefaulting) {
 		return
 	}
 	if WorkloadPriorityClassName(jobObj) != "" {
 		return
 	}
-	if IsOwnerManagedByKueueForObject(jobObj) {
+	if m.IsOwnerManagedByKueueForObject(jobObj) {
 		return
 	}
 	exists, err := utilpriority.DefaultWorkloadPriorityClassExist(ctx, c)

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -46,7 +46,13 @@ func (m *IntegrationManager) ApplyDefaultForSuspend(ctx context.Context, job Gen
 	return nil
 }
 
-func (m *IntegrationManager) ApplyDefaultLocalQueue(ctx context.Context, k8sClient client.Client, jobObj client.Object, defaultQueueExist func(string) bool, managedJobsNamespaceSelector labels.Selector) error {
+func (m *IntegrationManager) ApplyDefaultLocalQueue(
+	ctx context.Context,
+	k8sClient client.Client,
+	jobObj client.Object,
+	defaultQueueExist func(string) bool,
+	managedJobsNamespaceSelector labels.Selector,
+) error {
 	if !defaultQueueExist(jobObj.GetNamespace()) {
 		return nil
 	}

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -35,7 +35,8 @@ import (
 )
 
 func TestWorkloadShouldBeSuspended(t *testing.T) {
-	t.Cleanup(EnableIntegrationsForTest(t, "batch/job"))
+	integrationManager := newDefaultsIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	managedNamespace := utiltesting.MakeNamespaceWrapper("managed-ns").Label(corev1.LabelMetadataName, "managed-ns").Obj()
 	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Obj()
 	parent := utiltestingjob.MakeJob("parent", managedNamespace.Name).UID("parent").Queue("default").Obj()
@@ -101,7 +102,7 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			suspend, err := WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector)
+			suspend, err := integrationManager.WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector)
 			if err != nil {
 				t.Errorf("Got error: %v", err)
 			}
@@ -168,7 +169,8 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 }
 
 func TestApplyDefaultWorkloadPriorityClass(t *testing.T) {
-	t.Cleanup(EnableIntegrationsForTest(t, "batch/job"))
+	integrationManager := newDefaultsIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	parent := utiltestingjob.MakeJob("parent", "default").UID("parent").Queue("default").Obj()
 
 	defaultWPC := &kueue.WorkloadPriorityClass{
@@ -230,11 +232,25 @@ func TestApplyDefaultWorkloadPriorityClass(t *testing.T) {
 				builder = builder.WithObjects(tc.wpcObjects...)
 			}
 			k8sClient := builder.Build()
-			ApplyDefaultWorkloadPriorityClass(ctx, k8sClient, tc.job)
+			integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, k8sClient, tc.job)
 			got := tc.job.GetLabels()[constants.WorkloadPriorityClassLabel]
 			if got != tc.wantPriorityClassLabel {
 				t.Errorf("unexpected priority class label: got %q, want %q", got, tc.wantPriorityClassLabel)
 			}
 		})
 	}
+}
+
+func newDefaultsIntegrationManager(t *testing.T) *IntegrationManager {
+	t.Helper()
+	manager := NewIntegrationManager()
+	if err := manager.RegisterIntegration("batch/job", IntegrationCallbacks{
+		GVK:           batchv1.SchemeGroupVersion.WithKind("Job"),
+		NewReconciler: testNewReconciler,
+		SetupWebhook:  testSetupWebhook,
+		JobType:       &batchv1.Job{},
+	}); err != nil {
+		t.Fatalf("RegisterIntegration() error = %v", err)
+	}
+	return manager
 }

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -114,6 +114,8 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 }
 
 func TestApplyDefaultLocalQueue(t *testing.T) {
+	integrationManager := newDefaultsIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	managedNamespace := utiltesting.MakeNamespaceWrapper("managed-ns").Label(corev1.LabelMetadataName, "managed-ns").Obj()
 	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Obj()
 	ls := &metav1.LabelSelector{
@@ -156,7 +158,7 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 				return true
 			}
 
-			if err := ApplyDefaultLocalQueue(ctx, cl, tc.job, defaultQueueExist, namespaceSelector); err != nil {
+			if err := integrationManager.ApplyDefaultLocalQueue(ctx, cl, tc.job, defaultQueueExist, namespaceSelector); err != nil {
 				t.Fatalf("ApplyDefaultLocalQueue() returned error: %v", err)
 			}
 

--- a/pkg/controller/jobframework/integrationmanager.go
+++ b/pkg/controller/jobframework/integrationmanager.go
@@ -103,7 +103,8 @@ func (i *IntegrationCallbacks) matchingOwnerReference(ownerRef *metav1.OwnerRefe
 	return ownerReferenceMatchingGVK(ownerRef, i.getGVK())
 }
 
-type integrationManager struct {
+// IntegrationManager stores the integrations configured for one Kueue manager.
+type IntegrationManager struct {
 	names                         []string
 	integrations                  map[string]IntegrationCallbacks
 	enabledIntegrations           set.Set[string]
@@ -113,9 +114,124 @@ type integrationManager struct {
 	mu                            sync.RWMutex
 }
 
-var manager integrationManager
+// NewIntegrationManager creates an empty integration manager.
+func NewIntegrationManager() *IntegrationManager {
+	return &IntegrationManager{}
+}
 
-func (m *integrationManager) register(name string, cb IntegrationCallbacks) error {
+// RegisterIntegration registers a framework with this manager.
+func (m *IntegrationManager) RegisterIntegration(name string, cb IntegrationCallbacks) error {
+	return m.register(name, cb)
+}
+
+// RegisterExternalJobType registers an externally managed job type with this manager.
+func (m *IntegrationManager) RegisterExternalJobType(kindArg string) error {
+	return m.registerExternal(kindArg)
+}
+
+// ForEachIntegration calls f for each framework registered with this manager.
+func (m *IntegrationManager) ForEachIntegration(f func(name string, cb IntegrationCallbacks) error) error {
+	return m.forEach(f)
+}
+
+// EnableIntegration marks a registered integration as enabled for this manager.
+func (m *IntegrationManager) EnableIntegration(name string) {
+	m.enableIntegration(name)
+}
+
+// EnableIntegrationsForTest enables integrations and restores the previous state when the test finishes.
+func (m *IntegrationManager) EnableIntegrationsForTest(tb testing.TB, names ...string) func() {
+	tb.Helper()
+	old := m.getEnabledIntegrations()
+	for _, name := range names {
+		m.enableIntegration(name)
+	}
+	return func() {
+		m.mu.Lock()
+		m.enabledIntegrations = old
+		m.mu.Unlock()
+	}
+}
+
+// EnableExternalIntegrationsForTest registers external job types and restores the previous state when the test finishes.
+func (m *IntegrationManager) EnableExternalIntegrationsForTest(tb testing.TB, names ...string) func() {
+	tb.Helper()
+	old := maps.Clone(m.externalIntegrations)
+	for _, name := range names {
+		if err := m.registerExternal(name); err != nil {
+			tb.Fatalf("failed to register external framework: %q", name)
+		}
+	}
+	return func() {
+		m.mu.Lock()
+		m.externalIntegrations = old
+		m.mu.Unlock()
+	}
+}
+
+// GetIntegration returns the callbacks registered for name.
+func (m *IntegrationManager) GetIntegration(name string) (IntegrationCallbacks, bool) {
+	return m.get(name)
+}
+
+// GetIntegrationByGVK returns the callbacks registered for gvk.
+func (m *IntegrationManager) GetIntegrationByGVK(gvk schema.GroupVersionKind) (IntegrationCallbacks, bool) {
+	for _, name := range m.getList() {
+		integration, ok := m.get(name)
+		if ok && integration.matchingGVK(gvk) {
+			return integration, true
+		}
+	}
+	return IntegrationCallbacks{}, false
+}
+
+// GetIntegrationsList returns the frameworks registered with this manager.
+func (m *IntegrationManager) GetIntegrationsList() []string {
+	return m.getList()
+}
+
+// HasImplicitlyEnabledFramework returns whether gvk maps to an implicitly enabled framework.
+func (m *IntegrationManager) HasImplicitlyEnabledFramework(gvk schema.GroupVersionKind) bool {
+	name, found := m.gvkToName[gvk]
+	return found && m.implicitlyEnabledIntegrations.Has(name)
+}
+
+// IsOwnerManagedByKueueForObject returns true if the provided object's owner
+// can be managed by Kueue through this manager.
+func (m *IntegrationManager) IsOwnerManagedByKueueForObject(obj client.Object) bool {
+	if owner := metav1.GetControllerOf(obj); owner != nil {
+		return m.getJobTypeForOwner(owner) != nil
+	}
+	return false
+}
+
+// GetEmptyOwnerObject returns an empty object for owner when this manager can manage it.
+func (m *IntegrationManager) GetEmptyOwnerObject(owner *metav1.OwnerReference) client.Object {
+	if jt := m.getJobTypeForOwner(owner); jt != nil {
+		return jt.DeepCopyObject().(client.Object)
+	}
+	return nil
+}
+
+// GetMultiKueueAdapters returns adapters for enabled integrations registered with this manager.
+func (m *IntegrationManager) GetMultiKueueAdapters(enabledIntegrations sets.Set[string]) (map[string]MultiKueueAdapter, error) {
+	ret := map[string]MultiKueueAdapter{}
+	if err := m.forEach(func(intName string, cb IntegrationCallbacks) error {
+		if cb.MultiKueueAdapter != nil && enabledIntegrations.Has(intName) {
+			gvk := cb.MultiKueueAdapter.GVK().String()
+			if _, found := ret[gvk]; found {
+				return fmt.Errorf("multiple adapters for GVK: %q", gvk)
+			}
+			ret[gvk] = cb.MultiKueueAdapter
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+func (m *IntegrationManager) register(name string, cb IntegrationCallbacks) error {
 	if m.integrations == nil {
 		m.integrations = make(map[string]IntegrationCallbacks)
 	}
@@ -146,7 +262,7 @@ func (m *integrationManager) register(name string, cb IntegrationCallbacks) erro
 	return nil
 }
 
-func (m *integrationManager) registerExternal(kindArg string) error {
+func (m *IntegrationManager) registerExternal(kindArg string) error {
 	if m.externalIntegrations == nil {
 		m.externalIntegrations = make(map[string]runtime.Object)
 	}
@@ -168,7 +284,7 @@ func (m *integrationManager) registerExternal(kindArg string) error {
 	return nil
 }
 
-func (m *integrationManager) forEach(f func(name string, cb IntegrationCallbacks) error) error {
+func (m *IntegrationManager) forEach(f func(name string, cb IntegrationCallbacks) error) error {
 	for _, name := range m.names {
 		if err := f(name, m.integrations[name]); err != nil {
 			return err
@@ -177,23 +293,23 @@ func (m *integrationManager) forEach(f func(name string, cb IntegrationCallbacks
 	return nil
 }
 
-func (m *integrationManager) get(name string) (IntegrationCallbacks, bool) {
+func (m *IntegrationManager) get(name string) (IntegrationCallbacks, bool) {
 	cb, f := m.integrations[name]
 	return cb, f
 }
 
-func (m *integrationManager) getExternal(kindArg string) (runtime.Object, bool) {
+func (m *IntegrationManager) getExternal(kindArg string) (runtime.Object, bool) {
 	jt, f := m.externalIntegrations[kindArg]
 	return jt, f
 }
 
-func (m *integrationManager) getEnabledIntegrations() set.Set[string] {
+func (m *IntegrationManager) getEnabledIntegrations() set.Set[string] {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.enabledIntegrations.Clone()
 }
 
-func (m *integrationManager) enableIntegration(name string) {
+func (m *IntegrationManager) enableIntegration(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.enabledIntegrations == nil {
@@ -203,14 +319,14 @@ func (m *integrationManager) enableIntegration(name string) {
 	}
 }
 
-func (m *integrationManager) getList() []string {
+func (m *IntegrationManager) getList() []string {
 	ret := make([]string, len(m.names))
 	copy(ret, m.names)
 	slices.Sort(ret)
 	return ret
 }
 
-func (m *integrationManager) isKnownOwner(ownerRef *metav1.OwnerReference) bool {
+func (m *IntegrationManager) isKnownOwner(ownerRef *metav1.OwnerReference) bool {
 	for _, cbs := range m.integrations {
 		if cbs.matchingOwnerReference(ownerRef) {
 			return true
@@ -227,7 +343,7 @@ func (m *integrationManager) isKnownOwner(ownerRef *metav1.OwnerReference) bool 
 	return ownerRef.Kind == "ReplicaSet" && ownerRef.APIVersion == appsv1.SchemeGroupVersion.String()
 }
 
-func (m *integrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference) runtime.Object {
+func (m *IntegrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference) runtime.Object {
 	for jobKey := range m.getEnabledIntegrations() {
 		cbs, found := m.integrations[jobKey]
 		if found && cbs.matchingOwnerReference(ownerRef) {
@@ -243,7 +359,7 @@ func (m *integrationManager) getJobTypeForOwner(ownerRef *metav1.OwnerReference)
 	return nil
 }
 
-func (m *integrationManager) checkEnabledListDependencies(enabledSet sets.Set[string]) error {
+func (m *IntegrationManager) checkEnabledListDependencies(enabledSet sets.Set[string]) error {
 	enabled := enabledSet.UnsortedList()
 	slices.Sort(enabled)
 	for _, integration := range enabled {
@@ -260,138 +376,12 @@ func (m *integrationManager) checkEnabledListDependencies(enabledSet sets.Set[st
 	return nil
 }
 
-// RegisterIntegration registers a new framework, returns an error when
-// attempting to register multiple frameworks with the same name or if a
-// mandatory callback is missing.
-func RegisterIntegration(name string, cb IntegrationCallbacks) error {
-	return manager.register(name, cb)
-}
-
-// RegisterExternalJobType registers a new externally-managed Kind, returns an error
-// if kindArg cannot be parsed as a Kind.version.group.
-func RegisterExternalJobType(kindArg string) error {
-	return manager.registerExternal(kindArg)
-}
-
-// ForEachIntegration loops through the registered list of frameworks calling f,
-// if at any point f returns an error the loop is stopped and that error is returned.
-func ForEachIntegration(f func(name string, cb IntegrationCallbacks) error) error {
-	return manager.forEach(f)
-}
-
-// EnableIntegration marks the integration identified by name as enabled.
-func EnableIntegration(name string) {
-	manager.enableIntegration(name)
-}
-
-// EnableIntegrationsForTest - should be used only in tests
-// Mark the frameworks identified by names and return a revert function.
-func EnableIntegrationsForTest(tb testing.TB, names ...string) func() {
-	tb.Helper()
-	old := manager.getEnabledIntegrations()
-	for _, name := range names {
-		manager.enableIntegration(name)
-	}
-	return func() {
-		manager.mu.Lock()
-		manager.enabledIntegrations = old
-		manager.mu.Unlock()
-	}
-}
-
-// EnableExternalIntegrationsForTest - should be used only in tests
-// Mark the frameworks identified by names and return a revert function.
-func EnableExternalIntegrationsForTest(tb testing.TB, names ...string) func() {
-	tb.Helper()
-	old := maps.Clone(manager.externalIntegrations)
-	for _, name := range names {
-		if err := manager.registerExternal(name); err != nil {
-			tb.Fatalf("failed to register external framework: %q", name)
-		}
-	}
-	return func() {
-		manager.mu.Lock()
-		manager.externalIntegrations = old
-		manager.mu.Unlock()
-	}
-}
-
-// GetIntegration looks-up the framework identified by name in the currently registered
-// list of frameworks returning its callbacks and true if found.
-func GetIntegration(name string) (IntegrationCallbacks, bool) {
-	return manager.get(name)
-}
-
-// GetIntegrationByGVK looks-up the framework identified by GroupVersionKind in the currently
-// registered list of frameworks returning its callbacks and true if found.
-func GetIntegrationByGVK(gvk schema.GroupVersionKind) (IntegrationCallbacks, bool) {
-	for _, name := range manager.getList() {
-		integration, ok := GetIntegration(name)
-		if ok && integration.matchingGVK(gvk) {
-			return integration, true
-		}
-	}
-	return IntegrationCallbacks{}, false
-}
-
-// HasImplicitlyEnabledFramework returns true if the given GVK maps to an implicitly enabled framework.
-func HasImplicitlyEnabledFramework(gvk schema.GroupVersionKind) bool {
-	name, found := manager.gvkToName[gvk]
-	if !found {
-		return false
-	}
-	return manager.implicitlyEnabledIntegrations.Has(name)
-}
-
 func ownerReferenceMatchingGVK(ownerRef *metav1.OwnerReference, gvk schema.GroupVersionKind) bool {
 	apiVersion, kind := gvk.ToAPIVersionAndKind()
 	return ownerRef.APIVersion == apiVersion && ownerRef.Kind == kind
 }
 
-// GetIntegrationsList returns the list of currently registered frameworks.
-func GetIntegrationsList() []string {
-	return manager.getList()
-}
-
-// IsOwnerManagedByKueueForObject returns true if the provided object has an owner,
-// and this owner can be managed by Kueue.
-func IsOwnerManagedByKueueForObject(obj client.Object) bool {
-	if owner := metav1.GetControllerOf(obj); owner != nil {
-		return manager.getJobTypeForOwner(owner) != nil
-	}
-	return false
-}
-
-// GetEmptyOwnerObject returns an empty object of the owner's type,
-// returns nil if the owner is not manageable by kueue.
-func GetEmptyOwnerObject(owner *metav1.OwnerReference) client.Object {
-	if jt := manager.getJobTypeForOwner(owner); jt != nil {
-		return jt.DeepCopyObject().(client.Object)
-	}
-	return nil
-}
-
-// GetMultiKueueAdapters returns the map containing the MultiKueue adapters for the
-// registered and enabled integrations.
-// An error is returned if more then one adapter is registers for one object type.
-func GetMultiKueueAdapters(enabledIntegrations sets.Set[string]) (map[string]MultiKueueAdapter, error) {
-	ret := map[string]MultiKueueAdapter{}
-	if err := manager.forEach(func(intName string, cb IntegrationCallbacks) error {
-		if cb.MultiKueueAdapter != nil && enabledIntegrations.Has(intName) {
-			gvk := cb.MultiKueueAdapter.GVK().String()
-			if _, found := ret[gvk]; found {
-				return fmt.Errorf("multiple adapters for GVK: %q", gvk)
-			}
-			ret[gvk] = cb.MultiKueueAdapter
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return ret, nil
-}
-
-func (m *integrationManager) collectImplicitlyEnabledIntegrations(enabledFrameworks sets.Set[string]) sets.Set[string] {
+func (m *IntegrationManager) collectImplicitlyEnabledIntegrations(enabledFrameworks sets.Set[string]) sets.Set[string] {
 	result := sets.New[string]()
 	for frameworkName := range enabledFrameworks {
 		callbacks, found := m.get(frameworkName)
@@ -408,6 +398,6 @@ func (m *integrationManager) collectImplicitlyEnabledIntegrations(enabledFramewo
 	return result
 }
 
-func (m *integrationManager) setImplicitlyEnabledIntegrations(implicitlyIntegrations sets.Set[string]) {
+func (m *IntegrationManager) setImplicitlyEnabledIntegrations(implicitlyIntegrations sets.Set[string]) {
 	m.implicitlyEnabledIntegrations = implicitlyIntegrations
 }

--- a/pkg/controller/jobframework/integrationmanager_test.go
+++ b/pkg/controller/jobframework/integrationmanager_test.go
@@ -82,7 +82,7 @@ var (
 
 func TestRegister(t *testing.T) {
 	cases := map[string]struct {
-		manager              *integrationManager
+		manager              *IntegrationManager
 		integrationName      string
 		integrationCallbacks IntegrationCallbacks
 		wantError            error
@@ -90,7 +90,7 @@ func TestRegister(t *testing.T) {
 		wantCallbacks        IntegrationCallbacks
 	}{
 		"successful": {
-			manager: &integrationManager{
+			manager: &IntegrationManager{
 				names: []string{"oldFramework"},
 				integrations: map[string]IntegrationCallbacks{
 					"oldFramework": testIntegrationCallbacks,
@@ -103,7 +103,7 @@ func TestRegister(t *testing.T) {
 			wantCallbacks:        testIntegrationCallbacks,
 		},
 		"duplicate name": {
-			manager: &integrationManager{
+			manager: &IntegrationManager{
 				names: []string{"newFramework"},
 				integrations: map[string]IntegrationCallbacks{
 					"newFramework": testIntegrationCallbacks,
@@ -116,7 +116,7 @@ func TestRegister(t *testing.T) {
 			wantCallbacks:        testIntegrationCallbacks,
 		},
 		"missing NewReconciler": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				SetupWebhook:          testSetupWebhook,
@@ -129,7 +129,7 @@ func TestRegister(t *testing.T) {
 			wantList:  []string{},
 		},
 		"missing SetupWebhook": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				NewReconciler:         testNewReconciler,
@@ -142,7 +142,7 @@ func TestRegister(t *testing.T) {
 			wantList:  []string{},
 		},
 		"missing JobType": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				NewReconciler:         testNewReconciler,
@@ -155,7 +155,7 @@ func TestRegister(t *testing.T) {
 			wantList:  []string{},
 		},
 		"missing SetupIndexes": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				NewReconciler:         testNewReconciler,
@@ -174,7 +174,7 @@ func TestRegister(t *testing.T) {
 			},
 		},
 		"missing AddToScheme": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				NewReconciler:         testNewReconciler,
@@ -193,7 +193,7 @@ func TestRegister(t *testing.T) {
 			},
 		},
 		"missing CanSupportIntegration": {
-			manager:         &integrationManager{},
+			manager:         &IntegrationManager{},
 			integrationName: "newFramework",
 			integrationCallbacks: IntegrationCallbacks{
 				NewReconciler: testNewReconciler,
@@ -255,13 +255,13 @@ func compareCallbacks(x, y any) bool {
 
 func TestRegisterExternal(t *testing.T) {
 	cases := map[string]struct {
-		manager   *integrationManager
+		manager   *IntegrationManager
 		kindArg   string
 		wantError error
 		wantGVK   *schema.GroupVersionKind
 	}{
 		"successful 1": {
-			manager: &integrationManager{
+			manager: &IntegrationManager{
 				names: []string{"oldFramework"},
 				integrations: map[string]IntegrationCallbacks{
 					"oldFramework": testIntegrationCallbacks,
@@ -272,7 +272,7 @@ func TestRegisterExternal(t *testing.T) {
 			wantGVK:   &schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"},
 		},
 		"successful 2": {
-			manager: &integrationManager{
+			manager: &IntegrationManager{
 				externalIntegrations: map[string]runtime.Object{
 					"Job.v1.batch": &batchv1.Job{TypeMeta: metav1.TypeMeta{Kind: "Job", APIVersion: "batch/v1"}},
 				},
@@ -282,7 +282,7 @@ func TestRegisterExternal(t *testing.T) {
 			wantGVK:   &schema.GroupVersionKind{Group: "workload.codeflare.dev", Version: "v1beta2", Kind: "AppWrapper"},
 		},
 		"malformed kind arg": {
-			manager:   &integrationManager{},
+			manager:   &IntegrationManager{},
 			kindArg:   "batch/job",
 			wantError: errFrameworkNameFormat,
 			wantGVK:   nil,
@@ -329,7 +329,7 @@ func TestForEach(t *testing.T) {
 
 	for tcName, tc := range cases {
 		t.Run(tcName, func(t *testing.T) {
-			manager := integrationManager{}
+			manager := IntegrationManager{}
 			for _, name := range tc.registered {
 				if err := manager.register(name, testIntegrationCallbacks); err != nil {
 					t.Fatalf("unable to register %s, %s", name, err.Error())
@@ -385,7 +385,7 @@ func TestGetJobTypeForOwner(t *testing.T) {
 		return ret
 	}()
 
-	mgr := integrationManager{
+	mgr := IntegrationManager{
 		names: []string{"manageK1", "dontManage", "manageK2", "disabledK4"},
 		integrations: map[string]IntegrationCallbacks{
 			"dontManage": dontManage,
@@ -447,6 +447,35 @@ func TestGetJobTypeForOwner(t *testing.T) {
 	}
 }
 
+func TestIntegrationManagersAreIsolated(t *testing.T) {
+	callbacks := testIntegrationCallbacks
+	callbacks.GVK = corev1.SchemeGroupVersion.WithKind("Pod")
+
+	first := NewIntegrationManager()
+	if err := first.RegisterIntegration("batch/job", callbacks); err != nil {
+		t.Fatalf("RegisterIntegration() error = %v", err)
+	}
+	first.enableIntegration("batch/job")
+
+	second := NewIntegrationManager()
+	if err := second.RegisterIntegration("batch/job", callbacks); err != nil {
+		t.Fatalf("RegisterIntegration() error = %v", err)
+	}
+
+	controller := true
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+		APIVersion: corev1.SchemeGroupVersion.String(),
+		Kind:       "Pod",
+		Controller: &controller,
+	}}}}
+	if !first.IsOwnerManagedByKueueForObject(pod) {
+		t.Error("first manager did not manage its enabled integration")
+	}
+	if second.IsOwnerManagedByKueueForObject(pod) {
+		t.Error("second manager observed the first manager's enabled integration")
+	}
+}
+
 func TestEnabledIntegrationsDependencies(t *testing.T) {
 	cases := map[string]struct {
 		integrationsDependencies map[string][]string
@@ -483,7 +512,7 @@ func TestEnabledIntegrationsDependencies(t *testing.T) {
 	}
 	for tcName, tc := range cases {
 		t.Run(tcName, func(t *testing.T) {
-			manager := integrationManager{
+			manager := IntegrationManager{
 				integrations: map[string]IntegrationCallbacks{},
 			}
 			for integration, deps := range tc.integrationsDependencies {
@@ -539,7 +568,7 @@ func TestImplicitlyEnabledIntegrations(t *testing.T) {
 	}
 	for tcName, tc := range cases {
 		t.Run(tcName, func(t *testing.T) {
-			mgr := integrationManager{
+			mgr := IntegrationManager{
 				integrations: map[string]IntegrationCallbacks{},
 			}
 			for integration, implicitDeps := range tc.integrationsImplicit {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -285,6 +285,9 @@ func NewReconciler(
 	record events.EventRecorder,
 	opts ...Option) *JobReconciler {
 	options := ProcessOptions(opts...)
+	if options.IntegrationManager == nil {
+		options.IntegrationManager = NewIntegrationManager()
+	}
 
 	return &JobReconciler{
 		integrationManager:           options.IntegrationManager,

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -94,6 +94,7 @@ type WorkloadRetentionPolicy struct {
 
 // JobReconciler reconciles a GenericJob object
 type JobReconciler struct {
+	integrationManager           *IntegrationManager
 	cache                        *schdcache.Cache
 	client                       client.Client
 	record                       events.EventRecorder
@@ -130,6 +131,7 @@ type Options struct {
 	WorkloadRetentionPolicy      WorkloadRetentionPolicy
 	RoleTracker                  *roletracker.RoleTracker
 	CustomLabels                 *metrics.CustomLabels
+	IntegrationManager           *IntegrationManager
 	NoopWebhook                  bool
 }
 
@@ -259,6 +261,13 @@ func WithCustomLabels(cl *metrics.CustomLabels) Option {
 	}
 }
 
+// WithIntegrationManager sets the integration manager used by controllers and webhooks.
+func WithIntegrationManager(manager *IntegrationManager) Option {
+	return func(o *Options) {
+		o.IntegrationManager = manager
+	}
+}
+
 // WithNoopWebhook sets the integration webhook to noopWebhook.
 // This is needed when the integration is disabled.
 func WithNoopWebhook(noop bool) Option {
@@ -278,6 +287,7 @@ func NewReconciler(
 	options := ProcessOptions(opts...)
 
 	return &JobReconciler{
+		integrationManager:           options.IntegrationManager,
 		cache:                        options.Cache,
 		client:                       client,
 		record:                       record,
@@ -346,7 +356,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		// Skipping traversal to top-level ancestor job because this is already a top-level job.
 		isTopLevelJob = true
 	} else {
-		ancestorJob, err = FindAncestorJobManagedByKueue(ctx, r.client, object, r.manageJobsWithoutQueueName)
+		ancestorJob, err = r.integrationManager.FindAncestorJobManagedByKueue(ctx, r.client, object, r.manageJobsWithoutQueueName)
 		if err != nil {
 			if errors.Is(err, ErrManagedOwnersChainLimitReached) {
 				errMsg := fmt.Sprintf("Terminated search for Kueue-managed Job because ancestor depth exceeded limit of %d", managedOwnersChainLimit)
@@ -859,7 +869,7 @@ func (r *JobReconciler) getLatestNotFinishedWorkloadForObject(ctx context.Contex
 // Job (queue-name) -> JobSet -> AppWrapper (queue-name) => AppWrapper
 // Job (queue-name) -> JobSet (queue-name) -> AppWrapper (queue-name) => AppWrapper
 // Job -> JobSet (disabled) -> AppWrapper => AppWrapper
-func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj client.Object, manageJobsWithoutQueueName bool) (client.Object, error) {
+func (m *IntegrationManager) FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj client.Object, manageJobsWithoutQueueName bool) (client.Object, error) {
 	log := ctrl.LoggerFrom(ctx)
 	seen := sets.New[types.UID]()
 	currentObj := jobObj
@@ -881,7 +891,7 @@ func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj 
 			return topLevelJob, nil
 		}
 
-		if !manager.isKnownOwner(owner) {
+		if !m.isKnownOwner(owner) {
 			log.V(3).Info(
 				"stop walking up as the owner is not known",
 				"currentObj", klog.KObj(currentObj),
@@ -889,7 +899,7 @@ func FindAncestorJobManagedByKueue(ctx context.Context, c client.Client, jobObj 
 			)
 			return topLevelJob, nil
 		}
-		parentObj := GetEmptyOwnerObject(owner)
+		parentObj := m.GetEmptyOwnerObject(owner)
 		managed := parentObj != nil
 		if parentObj == nil {
 			parentObj = &metav1.PartialObjectMetadata{

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -1019,6 +1020,14 @@ func TestProcessOptionsWithIntegrationManager(t *testing.T) {
 
 	if options.IntegrationManager != manager {
 		t.Error("ProcessOptions() did not preserve the integration manager")
+	}
+}
+
+func TestNewReconcilerInitializesIntegrationManager(t *testing.T) {
+	reconciler := NewReconciler(nil, nil)
+	integrationManager := reflect.ValueOf(reconciler).Elem().FieldByName("integrationManager")
+	if integrationManager.IsNil() {
+		t.Error("NewReconciler() integrationManager is nil")
 	}
 }
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -52,6 +52,7 @@ import (
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/podset"
@@ -64,8 +65,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/jobset"
 	testingmpijob "sigs.k8s.io/kueue/pkg/util/testingjobs/mpijob"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 
 	. "sigs.k8s.io/kueue/pkg/controller/jobframework"
 )
@@ -925,8 +924,9 @@ func TestFindAncestorJobManagedByKueue(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			t.Cleanup(EnableIntegrationsForTest(t, tc.integrations...))
-			t.Cleanup(EnableExternalIntegrationsForTest(t, tc.externalFrameworks...))
+			integrationManager := jobs.NewIntegrationManager()
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.integrations...))
+			t.Cleanup(integrationManager.EnableExternalIntegrationsForTest(t, tc.externalFrameworks...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 			recorder := &utiltesting.EventRecorder{}
 			builder := utiltesting.NewClientBuilder(kfmpi.AddToScheme, awv1beta2.AddToScheme, v1alpha2.AddToScheme)
@@ -935,7 +935,7 @@ func TestFindAncestorJobManagedByKueue(t *testing.T) {
 				builder = builder.WithObjects(tc.job)
 			}
 			cl := builder.Build()
-			gotManaged, gotErr := FindAncestorJobManagedByKueue(ctx, cl, tc.job, tc.manageJobsWithoutQueueName)
+			gotManaged, gotErr := integrationManager.FindAncestorJobManagedByKueue(ctx, cl, tc.job, tc.manageJobsWithoutQueueName)
 			if diff := cmp.Diff(tc.wantManaged, gotManaged, cmp.Options{
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 				cmpopts.EquateEmpty(),
@@ -1009,6 +1009,16 @@ func TestProcessOptions(t *testing.T) {
 				t.Errorf("Unexpected error from ProcessOptions (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestProcessOptionsWithIntegrationManager(t *testing.T) {
+	manager := NewIntegrationManager()
+
+	options := ProcessOptions(WithIntegrationManager(manager))
+
+	if options.IntegrationManager != manager {
+		t.Error("ProcessOptions() did not preserve the integration manager")
 	}
 }
 

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -49,11 +49,11 @@ var (
 // this function needs to be called after the certs get ready because the controllers won't work
 // until the webhooks are operating, and the webhook won't work until the
 // certs are all in place.
-func SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
-	return manager.setupControllers(ctx, mgr, log, opts...)
+func (m *IntegrationManager) SetupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+	return m.setupControllers(ctx, mgr, log, opts...)
 }
 
-func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
+func (m *IntegrationManager) setupControllers(ctx context.Context, mgr ctrl.Manager, log logr.Logger, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
 	implicitlyEnabledIntegrations := m.collectImplicitlyEnabledIntegrations(options.EnabledFrameworks)
@@ -65,7 +65,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 	}
 
 	for fwkName := range options.EnabledExternalFrameworks {
-		if err := RegisterExternalJobType(fwkName); err != nil {
+		if err := m.RegisterExternalJobType(fwkName); err != nil {
 			return err
 		}
 	}
@@ -114,7 +114,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 	})
 }
 
-func (m *integrationManager) setupControllerAndWebhook(ctx context.Context, mgr ctrl.Manager, name string, fwkNamePrefix string, cb IntegrationCallbacks, options Options, opts ...Option) error {
+func (m *IntegrationManager) setupControllerAndWebhook(ctx context.Context, mgr ctrl.Manager, name string, fwkNamePrefix string, cb IntegrationCallbacks, options Options, opts ...Option) error {
 	if r, err := cb.NewReconciler(
 		ctx,
 		mgr.GetClient(),
@@ -181,11 +181,11 @@ func restMappingExists(mgr ctrl.Manager, gvk schema.GroupVersionKind) error {
 // they can easily setup indexers for the in-house custom jobs.
 //
 // Note that the second argument, "indexer" needs to be the fieldIndexer obtained from the Manager.
-func SetupIndexes(ctx context.Context, indexer client.FieldIndexer, opts ...Option) error {
+func (m *IntegrationManager) SetupIndexes(ctx context.Context, indexer client.FieldIndexer, opts ...Option) error {
 	options := ProcessOptions(opts...)
 
-	allEnabledIntegrations := options.EnabledFrameworks.Union(manager.collectImplicitlyEnabledIntegrations(options.EnabledFrameworks))
-	return ForEachIntegration(func(name string, cb IntegrationCallbacks) error {
+	allEnabledIntegrations := options.EnabledFrameworks.Union(m.collectImplicitlyEnabledIntegrations(options.EnabledFrameworks))
+	return m.ForEachIntegration(func(name string, cb IntegrationCallbacks) error {
 		if allEnabledIntegrations.Has(name) {
 			if err := cb.SetupIndexes(ctx, indexer); err != nil {
 				return fmt.Errorf("jobFrameworkName %q: %w", name, err)

--- a/pkg/controller/jobframework/setup_test.go
+++ b/pkg/controller/jobframework/setup_test.go
@@ -128,9 +128,9 @@ func TestSetupControllers(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			manager := integrationManager{}
+			manager := NewIntegrationManager()
 			for name, cbs := range availableIntegrations {
-				err := manager.register(name, cbs)
+				err := manager.RegisterIntegration(name, cbs)
 				if err != nil {
 					t.Fatalf("Unexpected error while registering %q: %s", name, err)
 				}
@@ -164,7 +164,7 @@ func TestSetupControllers(t *testing.T) {
 				t.Fatalf("Failed to setup manager: %v", err)
 			}
 
-			gotError := manager.setupControllers(ctx, mgr, logger, tc.opts...)
+			gotError := manager.SetupControllers(ctx, mgr, logger, tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotError, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Errorf("Unexpected error from SetupControllers (-want,+got):\n%s", diff)
 			}
@@ -172,7 +172,7 @@ func TestSetupControllers(t *testing.T) {
 			if len(tc.delayedGVKs) > 0 {
 				simulateDelayedIntegration(mgr, tc.delayedGVKs)
 				for _, gvk := range tc.delayedGVKs {
-					testDelayedIntegration(&manager, gvk.Group+"/"+strings.ToLower(gvk.Kind))
+					testDelayedIntegration(manager, gvk.Group+"/"+strings.ToLower(gvk.Kind))
 				}
 			}
 
@@ -206,7 +206,7 @@ func simulateDelayedIntegration(mgr ctrlmgr.Manager, delayedGVKs []*schema.Group
 	}
 }
 
-func testDelayedIntegration(manager *integrationManager, crdName string) {
+func testDelayedIntegration(manager *IntegrationManager, crdName string) {
 	for {
 		_, ok := manager.getEnabledIntegrations()[crdName]
 		if ok {
@@ -260,12 +260,23 @@ func TestSetupIndexes(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			manager := NewIntegrationManager()
+			if err := manager.RegisterIntegration("batch/job", IntegrationCallbacks{
+				NewReconciler: testNewReconciler,
+				SetupWebhook:  testSetupWebhook,
+				JobType:       &batchv1.Job{},
+				SetupIndexes: func(ctx context.Context, indexer client.FieldIndexer) error {
+					return SetupWorkloadOwnerIndex(ctx, indexer, batchv1.SchemeGroupVersion.WithKind("Job"))
+				},
+			}); err != nil {
+				t.Fatalf("Unexpected error while registering batch/job: %s", err)
+			}
 			ctx, _ := utiltesting.ContextWithLog(t)
 			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			builder := utiltesting.NewClientBuilder().WithObjects(utiltesting.MakeNamespace(testNamespace))
-			gotIndexerErr := SetupIndexes(ctx, utiltesting.AsIndexer(builder), tc.opts...)
+			gotIndexerErr := manager.SetupIndexes(ctx, utiltesting.AsIndexer(builder), tc.opts...)
 			if diff := cmp.Diff(tc.wantError, gotIndexerErr, cmpopts.EquateErrors()); len(diff) != 0 {
 				t.Fatalf("Unexpected setupIndexer error (-want,+got):\n%s", diff)
 			}

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -110,10 +110,10 @@ func RecordWorkloadCreationLatency(ctx context.Context, job client.Object, jobKi
 }
 
 // WorkloadShouldBeSuspended determines whether jobObj should be default suspended on creation
-func WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sClient client.Client,
+func (m *IntegrationManager) WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sClient client.Client,
 	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) (bool, error) {
 	// Do not default suspend a job whose ancestor is already managed by Kueue
-	ancestorJob, err := FindAncestorJobManagedByKueue(ctx, k8sClient, jobObj, manageJobsWithoutQueueName)
+	ancestorJob, err := m.FindAncestorJobManagedByKueue(ctx, k8sClient, jobObj, manageJobsWithoutQueueName)
 	if err != nil || ancestorJob != nil {
 		return false, err
 	}

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -253,7 +253,6 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 }
 
 func TestValidateJobOnUpdate(t *testing.T) {
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	fieldString := field.NewPath("metadata").Child("labels").Key(constants.QueueLabel).String()
 	testCases := map[string]struct {
 		oldJob            *batchv1.Job
@@ -428,7 +427,6 @@ func TestValidateJobOnUpdate(t *testing.T) {
 }
 
 func TestValidateJobOnCreate(t *testing.T) {
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
 	elasticAnnotationPath := field.NewPath("metadata", "annotations").Key(workloadslicing.EnabledAnnotationKey)
 	testCases := map[string]struct {
 		job          *batchv1.Job

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -56,8 +55,8 @@ var (
 var _ admission.Defaulter[*awv1beta2.AppWrapper] = &jobframework.BaseWebhook[*awv1beta2.AppWrapper]{}
 var _ admission.Validator[*awv1beta2.AppWrapper] = &jobframework.BaseWebhook[*awv1beta2.AppWrapper]{}
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		NewJob:            NewJob,
 		GVK:               gvk,
 		NewReconciler:     NewReconciler,
@@ -66,7 +65,7 @@ func init() {
 		SetupIndexes:      SetupIndexes,
 		AddToScheme:       awv1beta2.AddToScheme,
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch

--- a/pkg/controller/jobs/deployment/deployment_controller.go
+++ b/pkg/controller/jobs/deployment/deployment_controller.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
@@ -36,8 +35,8 @@ const (
 	FrameworkName = "deployment"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:                    SetupIndexes,
 		NewReconciler:                   jobframework.NewNoopReconcilerFactory(gvk),
 		GVK:                             gvk,
@@ -45,7 +44,7 @@ func init() {
 		JobType:                         &appsv1.Deployment{},
 		AddToScheme:                     appsv1.AddToScheme,
 		ImplicitlyEnabledFrameworkNames: []string{"pod"},
-	}))
+	})
 }
 
 type Deployment appsv1.Deployment

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -37,6 +37,7 @@ import (
 )
 
 type Webhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -46,6 +47,7 @@ type Webhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -72,11 +74,11 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 	log := ctrl.LoggerFrom(ctx).WithName("deployment-webhook")
 	log.V(5).Info("Propagating queue-name")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, deployment.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, deployment.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, deployment.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())
+	suspend, err := wh.integrationManager.WorkloadShouldBeSuspended(ctx, deployment.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/deployment/deployment_webhook_test.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook_test.go
@@ -154,7 +154,8 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "pod"))
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
 			cqCache := schdcache.New(client)
@@ -167,8 +168,9 @@ func TestDefault(t *testing.T) {
 				}
 			}
 			w := &Webhook{
-				client: client,
-				queues: queueManager,
+				integrationManager: integrationManager,
+				client:             client,
+				queues:             queueManager,
 			}
 
 			if err := w.Default(ctx, tc.deployment); err != nil {
@@ -357,8 +359,6 @@ func TestValidateCreate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
-
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
 
@@ -632,8 +632,6 @@ func TestValidateUpdate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
-
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
 
@@ -650,4 +648,13 @@ func TestValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestIntegrationManager(t *testing.T) *jobframework.IntegrationManager {
+	t.Helper()
+	manager := jobframework.NewIntegrationManager()
+	if err := RegisterIntegration(manager); err != nil {
+		t.Fatalf("RegisterIntegration() error = %v", err)
+	}
+	return manager
 }

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -61,15 +60,15 @@ const (
 	StoppingAnnotation                       = "kueue.x-k8s.io/stopping"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
 		SetupWebhook:      SetupWebhook,
 		JobType:           &batchv1.Job{},
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4483,8 +4483,18 @@ func TestReconciler(t *testing.T) {
 					}
 				}
 				recorder := &utiltesting.EventRecorder{}
-				reconciler, err := NewReconciler(ctx, kClient, indexer, recorder,
-					append(tc.reconcilerOptions, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(schdcache.New(kClient)), jobframework.WithClock(testingclock.NewFakeClock(now)))...)
+				reconciler, err := NewReconciler(
+					ctx,
+					kClient,
+					indexer,
+					recorder,
+					append(
+						tc.reconcilerOptions,
+						jobframework.WithIntegrationManager(integrationManager),
+						jobframework.WithCache(schdcache.New(kClient)),
+						jobframework.WithClock(testingclock.NewFakeClock(now)),
+					)...,
+				)
 				if err != nil {
 					t.Errorf("Error creating the reconciler: %v", err)
 				}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -599,7 +599,8 @@ func TestReconciler(t *testing.T) {
 	)
 	clusterQueueNameWith100Chars := strings.Repeat("cq", 50)
 
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, FrameworkName))
+	integrationManager := newTestIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, FrameworkName))
 	baseJobWrapper := utiltestingjob.MakeJob("job", "ns").
 		Suspend(true).
 		Queue(localQueueName).
@@ -4483,7 +4484,7 @@ func TestReconciler(t *testing.T) {
 				}
 				recorder := &utiltesting.EventRecorder{}
 				reconciler, err := NewReconciler(ctx, kClient, indexer, recorder,
-					append(tc.reconcilerOptions, jobframework.WithCache(schdcache.New(kClient)), jobframework.WithClock(testingclock.NewFakeClock(now)))...)
+					append(tc.reconcilerOptions, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(schdcache.New(kClient)), jobframework.WithClock(testingclock.NewFakeClock(now)))...)
 				if err != nil {
 					t.Errorf("Error creating the reconciler: %v", err)
 				}

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -66,6 +66,7 @@ func applyWorkloadSliceSchedulingGate(job *Job) {
 }
 
 type JobWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -77,6 +78,7 @@ type JobWebhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &JobWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -104,11 +106,11 @@ func (w *JobWebhook) Default(ctx context.Context, obj *batchv1.Job) error {
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -41,6 +41,7 @@ import (
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -49,8 +50,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/webhook"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	testutil "sigs.k8s.io/kueue/test/util"
-
-	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 )
 
 var (

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -50,8 +50,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	testutil "sigs.k8s.io/kueue/test/util"
 
-	// without this only the job framework is registered
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 )
 
 var (
@@ -1228,8 +1227,10 @@ func TestDefault(t *testing.T) {
 					}
 				}
 			}
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			w := &JobWebhook{
+				integrationManager:           integrationManager,
 				client:                       cl,
 				manageJobsWithoutQueueName:   tc.manageJobsWithoutQueueName,
 				managedJobsNamespaceSelector: labels.Everything(),
@@ -1245,6 +1246,17 @@ func TestDefault(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestIntegrationManager(t *testing.T) *jobframework.IntegrationManager {
+	t.Helper()
+	manager := jobframework.NewIntegrationManager()
+	for _, registerIntegration := range []func(*jobframework.IntegrationManager) error{RegisterIntegration, mpijob.RegisterIntegration} {
+		if err := registerIntegration(manager); err != nil {
+			t.Fatalf("RegisterIntegration() error = %v", err)
+		}
+	}
+	return manager
 }
 
 func Test_applyWorkloadSliceSchedulingGate(t *testing.T) {

--- a/pkg/controller/jobs/jobs.go
+++ b/pkg/controller/jobs/jobs.go
@@ -16,20 +16,55 @@ limitations under the License.
 
 package jobs
 
-// Reference the job framework integration packages to ensure linking.
 import (
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/deployment"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/sparkapplication"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/deployment"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
+	kubeflowjobs "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/sparkapplication"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 )
+
+// NewIntegrationManager creates an integration manager with all built-in job
+// integrations registered.
+func NewIntegrationManager() *jobframework.IntegrationManager {
+	manager := jobframework.NewIntegrationManager()
+	utilruntime.Must(RegisterIntegrations(manager))
+	return manager
+}
+
+// RegisterIntegrations registers all built-in job integrations with manager.
+func RegisterIntegrations(manager *jobframework.IntegrationManager) error {
+	for _, register := range []func(*jobframework.IntegrationManager) error{
+		appwrapper.RegisterIntegration,
+		deployment.RegisterIntegration,
+		job.RegisterIntegration,
+		jobset.RegisterIntegration,
+		kubeflowjobs.RegisterIntegrations,
+		leaderworkerset.RegisterIntegration,
+		mpijob.RegisterIntegration,
+		pod.RegisterIntegration,
+		raycluster.RegisterIntegration,
+		rayjob.RegisterIntegration,
+		rayservice.RegisterIntegration,
+		sparkapplication.RegisterIntegration,
+		statefulset.RegisterIntegration,
+		trainjob.RegisterIntegration,
+	} {
+		if err := register(manager); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/jobs/jobs_test.go
+++ b/pkg/controller/jobs/jobs_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobs
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
+)
+
+func TestNewIntegrationManager(t *testing.T) {
+	first := NewIntegrationManager()
+	second := NewIntegrationManager()
+
+	if got := first.GetIntegrationsList(); len(got) == 0 {
+		t.Fatal("first manager has no built-in integrations")
+	}
+	if diff := cmp.Diff(first.GetIntegrationsList(), second.GetIntegrationsList()); diff != "" {
+		t.Fatalf("built-in integrations differ between managers (-first +second):\n%s", diff)
+	}
+}
+
+func TestIntegrationManagersKeepEnabledIntegrationsIsolated(t *testing.T) {
+	first := NewIntegrationManager()
+	second := NewIntegrationManager()
+	first.EnableIntegration(job.FrameworkName)
+
+	controller := true
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{OwnerReferences: []metav1.OwnerReference{{
+		APIVersion: batchv1.SchemeGroupVersion.String(),
+		Kind:       "Job",
+		Controller: &controller,
+	}}}}
+
+	if !first.IsOwnerManagedByKueueForObject(pod) {
+		t.Error("first manager did not manage its enabled Job integration")
+	}
+	if second.IsOwnerManagedByKueueForObject(pod) {
+		t.Error("second manager observed the first manager's enabled Job integration")
+	}
+}

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,8 +43,8 @@ var (
 	FrameworkName = "jobset.x-k8s.io/jobset"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -53,7 +52,7 @@ func init() {
 		JobType:           &jobsetapi.JobSet{},
 		AddToScheme:       jobsetapi.AddToScheme,
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -39,6 +39,7 @@ var (
 )
 
 type JobSetWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -50,6 +51,7 @@ type JobSetWebhook struct {
 func SetupJobSetWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &JobSetWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -77,11 +79,11 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj *jobsetapi.JobSet) erro
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, obj)
-	if err := jobframework.ApplyDefaultForSuspend(ctx, jobSet, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, obj)
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, jobSet, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -50,8 +49,8 @@ var _ admission.Validator[*kftraining.JAXJob] = &jobframework.BaseWebhook[*kftra
 // +kubebuilder:webhook:path=/mutate-kubeflow-org-v1-jaxjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=jaxjobs,verbs=create,versions=v1,name=mjaxjob.kb.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-kubeflow-org-v1-jaxjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=jaxjobs,verbs=create;update,versions=v1,name=vjaxjob.kb.io,admissionReviewVersions=v1
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -59,7 +58,7 @@ func init() {
 		JobType:           &kftraining.JAXJob{},
 		AddToScheme:       kftraining.AddToScheme,
 		MultiKueueAdapter: kubeflowjob.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, fromObject),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/kubeflow/jobs/jobs.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jobs.go
@@ -16,11 +16,27 @@ limitations under the License.
 
 package jobs
 
-// Reference the job framework integration packages to ensure linking.
 import (
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/jaxjob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/paddlejob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/tfjob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/xgboostjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/jaxjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/paddlejob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/pytorchjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/tfjob"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs/xgboostjob"
 )
+
+// RegisterIntegrations registers all built-in Kubeflow job integrations with manager.
+func RegisterIntegrations(manager *jobframework.IntegrationManager) error {
+	for _, register := range []func(*jobframework.IntegrationManager) error{
+		jaxjob.RegisterIntegration,
+		paddlejob.RegisterIntegration,
+		pytorchjob.RegisterIntegration,
+		tfjob.RegisterIntegration,
+		xgboostjob.RegisterIntegration,
+	} {
+		if err := register(manager); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -50,8 +49,8 @@ var _ admission.Validator[*kftraining.PaddleJob] = &jobframework.BaseWebhook[*kf
 // +kubebuilder:webhook:path=/mutate-kubeflow-org-v1-paddlejob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=paddlejobs,verbs=create,versions=v1,name=mpaddlejob.kb.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-kubeflow-org-v1-paddlejob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=paddlejobs,verbs=create;update,versions=v1,name=vpaddlejob.kb.io,admissionReviewVersions=v1
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -59,7 +58,7 @@ func init() {
 		JobType:           &kftraining.PaddleJob{},
 		AddToScheme:       kftraining.AddToScheme,
 		MultiKueueAdapter: kubeflowjob.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, fromObject),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -50,8 +49,8 @@ var _ admission.Validator[*kftraining.PyTorchJob] = &jobframework.BaseWebhook[*k
 // +kubebuilder:webhook:path=/mutate-kubeflow-org-v1-pytorchjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=pytorchjobs,verbs=create,versions=v1,name=mpytorchjob.kb.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-kubeflow-org-v1-pytorchjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=pytorchjobs,verbs=create;update,versions=v1,name=vpytorchjob.kb.io,admissionReviewVersions=v1
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -59,7 +58,7 @@ func init() {
 		JobType:           &kftraining.PyTorchJob{},
 		AddToScheme:       kftraining.AddToScheme,
 		MultiKueueAdapter: kubeflowjob.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, fromObject),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -50,8 +49,8 @@ var _ admission.Validator[*kftraining.TFJob] = &jobframework.BaseWebhook[*kftrai
 // +kubebuilder:webhook:path=/mutate-kubeflow-org-v1-tfjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=tfjobs,verbs=create,versions=v1,name=mtfjob.kb.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-kubeflow-org-v1-tfjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=tfjobs,verbs=create;update,versions=v1,name=vtfjob.kb.io,admissionReviewVersions=v1
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -59,7 +58,7 @@ func init() {
 		JobType:           &kftraining.TFJob{},
 		AddToScheme:       kftraining.AddToScheme,
 		MultiKueueAdapter: kubeflowjob.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, fromObject),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -50,8 +49,8 @@ var _ admission.Validator[*kftraining.XGBoostJob] = &jobframework.BaseWebhook[*k
 // +kubebuilder:webhook:path=/mutate-kubeflow-org-v1-xgboostjob,mutating=true,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=xgboostjobs,verbs=create,versions=v1,name=mxgboostjob.kb.io,admissionReviewVersions=v1
 // +kubebuilder:webhook:path=/validate-kubeflow-org-v1-xgboostjob,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=xgboostjobs,verbs=create;update,versions=v1,name=vxgboostjob.kb.io,admissionReviewVersions=v1
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -59,7 +58,7 @@ func init() {
 		JobType:           &kftraining.XGBoostJob{},
 		AddToScheme:       kftraining.AddToScheme,
 		MultiKueueAdapter: kubeflowjob.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, fromObject),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_controller.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -48,8 +47,8 @@ const (
 
 var errInvalidLeaderWorkerSetReplicas = errors.New("invalid LeaderWorkerSet replicas")
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:                    SetupIndexes,
 		NewReconciler:                   NewReconciler,
 		SetupWebhook:                    SetupWebhook,
@@ -58,7 +57,7 @@ func init() {
 		ImplicitlyEnabledFrameworkNames: []string{"pod"},
 		GVK:                             gvk,
 		MultiKueueAdapter:               &multiKueueAdapter{},
-	}))
+	})
 }
 
 type LeaderWorkerSet leaderworkersetv1.LeaderWorkerSet

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -78,6 +78,7 @@ type workloadToCreate struct {
 }
 
 type Reconciler struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	logName                      string
 	record                       events.EventRecorder
@@ -95,6 +96,7 @@ func NewReconciler(_ context.Context, client client.Client, _ client.FieldIndexe
 	options := jobframework.ProcessOptions(opts...)
 
 	return &Reconciler{
+		integrationManager:           options.IntegrationManager,
 		client:                       client,
 		logName:                      "leaderworkerset-reconciler",
 		record:                       eventRecorder,
@@ -585,7 +587,7 @@ func (r *Reconciler) handle(obj client.Object) bool {
 	ctx := ctrl.LoggerInto(context.Background(), log)
 
 	// Handle only leaderworkerset managed by kueue.
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws, r.client, r.manageJobsWithoutQueueName, r.managedJobsNamespaceSelector)
+	suspend, err := r.integrationManager.WorkloadShouldBeSuspended(ctx, lws, r.client, r.manageJobsWithoutQueueName, r.managedJobsNamespaceSelector)
 	if err != nil {
 		log.Error(err, "Failed to determine if the LeaderWorkerSet should be managed by Kueue")
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -43,6 +43,7 @@ import (
 )
 
 type Webhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -52,6 +53,7 @@ type Webhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -77,11 +79,11 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 	log := ctrl.LoggerFrom(ctx).WithName("leaderworkerset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, obj, wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, obj, wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)
+	suspend, err := wh.integrationManager.WorkloadShouldBeSuspended(ctx, lws.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
 	}
@@ -192,7 +194,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj *leaderwor
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldLeaderWorkerSet.Object(), newLeaderWorkerSet.Object())...)
 	}
 
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newLeaderWorkerSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := wh.integrationManager.WorkloadShouldBeSuspended(ctx, newLeaderWorkerSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -36,6 +36,7 @@ import (
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -189,7 +190,8 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			builder := utiltesting.NewClientBuilder()
@@ -204,6 +206,7 @@ func TestDefault(t *testing.T) {
 			}
 
 			w := &Webhook{
+				integrationManager:         integrationManager,
 				client:                     cli,
 				manageJobsWithoutQueueName: tc.manageJobsWithoutQueueName,
 				queues:                     queueManager,
@@ -874,14 +877,15 @@ func TestValidateCreate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "pod"))
 			for _, integration := range tc.integrations {
-				jobframework.EnableIntegrationsForTest(t, integration)
+				integrationManager.EnableIntegration(integration)
 			}
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
-			w := &Webhook{client: client}
+			w := &Webhook{integrationManager: integrationManager, client: client}
 			ctx, _ := utiltesting.ContextWithLog(t)
 			warns, err := w.ValidateCreate(ctx, tc.lws)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
@@ -1534,11 +1538,12 @@ func TestValidateUpdate(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			integrationManager := newTestIntegrationManager(t)
 			for _, integration := range tc.integrations {
-				jobframework.EnableIntegrationsForTest(t, integration)
+				integrationManager.EnableIntegration(integration)
 			}
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			wh := &Webhook{}
+			wh := &Webhook{integrationManager: integrationManager}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 			_, err := wh.ValidateUpdate(ctx, tc.oldObj, tc.newObj)
@@ -1547,4 +1552,15 @@ func TestValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestIntegrationManager(t *testing.T) *jobframework.IntegrationManager {
+	t.Helper()
+	manager := jobframework.NewIntegrationManager()
+	for _, registerIntegration := range []func(*jobframework.IntegrationManager) error{RegisterIntegration, pod.RegisterIntegration} {
+		if err := registerIntegration(manager); err != nil {
+			t.Fatalf("RegisterIntegration() error = %v", err)
+		}
+	}
+	return manager
 }

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,8 +41,8 @@ var (
 	FrameworkName = "kubeflow.org/mpijob"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -51,7 +50,7 @@ func init() {
 		JobType:           &kfmpi.MPIJob{},
 		AddToScheme:       kfmpi.AddToScheme,
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -53,6 +53,7 @@ var (
 )
 
 type MpiJobWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -65,6 +66,7 @@ type MpiJobWebhook struct {
 func SetupMPIJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &MpiJobWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -93,11 +95,11 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj *v2beta1.MPIJob) error 
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, mpiJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, mpiJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, mpiJob.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, mpiJob, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, mpiJob.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, mpiJob, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/tools/events"

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -93,15 +93,15 @@ var (
 	realClock                      = clock.RealClock{}
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
 		SetupWebhook:      SetupWebhook,
 		JobType:           &corev1.Pod{},
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch
@@ -116,14 +116,15 @@ func init() {
 
 type Reconciler struct {
 	*jobframework.JobReconciler
-	expectationsStore *expectations.Store
-	clock             clock.Clock
+	integrationManager *jobframework.IntegrationManager
+	expectationsStore  *expectations.Store
+	clock              clock.Clock
 }
 
 const controllerName = "v1_pod"
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	return r.ReconcileGenericJob(ctx, req, NewPod(WithExcessPodExpectations(r.expectationsStore), WithClock(r.clock)))
+	return r.ReconcileGenericJob(ctx, req, NewPod(WithExcessPodExpectations(r.expectationsStore), WithClock(r.clock), WithIntegrationManager(r.integrationManager)))
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -147,13 +148,15 @@ func NewJob() jobframework.GenericJob {
 func NewReconciler(_ context.Context, c client.Client, _ client.FieldIndexer, record events.EventRecorder, opts ...jobframework.Option) (jobframework.JobReconcilerInterface, error) {
 	options := jobframework.ProcessOptions(opts...)
 	return &Reconciler{
-		JobReconciler:     jobframework.NewReconciler(c, record, opts...),
-		expectationsStore: expectations.NewStore("finalizedPods"),
-		clock:             options.Clock,
+		JobReconciler:      jobframework.NewReconciler(c, record, opts...),
+		integrationManager: options.IntegrationManager,
+		expectationsStore:  expectations.NewStore("finalizedPods"),
+		clock:              options.Clock,
 	}, nil
 }
 
 type Pod struct {
+	integrationManager    *jobframework.IntegrationManager
 	pod                   corev1.Pod
 	key                   types.NamespacedName
 	isFound               bool
@@ -193,6 +196,12 @@ func WithExcessPodExpectations(store *expectations.Store) PodOption {
 func WithClock(clock clock.Clock) PodOption {
 	return func(pod *Pod) {
 		pod.clock = clock
+	}
+}
+
+func WithIntegrationManager(manager *jobframework.IntegrationManager) PodOption {
+	return func(pod *Pod) {
+		pod.integrationManager = manager
 	}
 }
 
@@ -603,7 +612,7 @@ func (p *Pod) Skip(ctx context.Context) bool {
 		log.V(3).Info("Skipping pod, not managed by Kueue", constants.ManagedByKueueLabelKey, v, "labelSet", ok)
 		return true
 	}
-	if jobframework.HasImplicitlyEnabledFramework(p.pod.GroupVersionKind()) &&
+	if p.integrationManager != nil && p.integrationManager.HasImplicitlyEnabledFramework(p.pod.GroupVersionKind()) &&
 		p.pod.GetAnnotations()[podconstants.SuspendedByParentAnnotation] == "" {
 		log.V(3).Info("Pod Integration was implicitly enabled but object lacks parent annotation, skipping")
 		return true

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -57,9 +57,6 @@ import (
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 )
 
 type keyUIDs struct {
@@ -6907,7 +6904,8 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 }
 
 func TestIsPodOwnerManagedByQueue(t *testing.T) {
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job", "ray.io/raycluster"))
+	integrationManager := newTestIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job", "ray.io/raycluster"))
 	testCases := map[string]struct {
 		ownerReference metav1.OwnerReference
 		wantRes        bool
@@ -6948,7 +6946,7 @@ func TestIsPodOwnerManagedByQueue(t *testing.T) {
 
 			pod.OwnerReferences = append(pod.OwnerReferences, tc.ownerReference)
 
-			if managedByKueue := jobframework.IsOwnerManagedByKueueForObject(pod); tc.wantRes != managedByKueue {
+			if managedByKueue := integrationManager.IsOwnerManagedByKueueForObject(pod); tc.wantRes != managedByKueue {
 				t.Errorf("Unexpected 'IsOwnerManagedByKueueForObject' result\n want: %t\n got: %t)", tc.wantRes, managedByKueue)
 			}
 		})

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -53,6 +53,7 @@ var (
 )
 
 type PodWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	queues                       *qcache.Manager
 	manageJobsWithoutQueueName   bool
@@ -65,6 +66,7 @@ type PodWebhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &PodWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		queues:                       options.Queues,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
@@ -143,7 +145,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 		}
 
 		// Do not suspend a Pod whose owner is already managed by Kueue
-		ancestorJob, err := jobframework.FindAncestorJobManagedByKueue(ctx, w.client, pod.Object(), w.manageJobsWithoutQueueName)
+		ancestorJob, err := w.integrationManager.FindAncestorJobManagedByKueue(ctx, w.client, pod.Object(), w.manageJobsWithoutQueueName)
 		if err != nil || ancestorJob != nil {
 			return err
 		}
@@ -157,7 +159,7 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 			pod.pod.Labels[ctrlconstants.QueueLabel] = string(ctrlconstants.DefaultLocalQueueName)
 		}
 
-		jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, pod.Object())
+		w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, pod.Object())
 
 		suspend = jobframework.QueueNameForObject(pod.Object()) != "" || w.manageJobsWithoutQueueName
 		if suspend {
@@ -208,7 +210,7 @@ func (w *PodWebhook) ValidateCreate(ctx context.Context, obj *corev1.Pod) (admis
 	allErrs := jobframework.ValidateJobOnCreate(pod)
 	allErrs = append(allErrs, validateCommon(pod)...)
 
-	if warn := warningForPodManagedLabel(pod); warn != "" {
+	if warn := warningForPodManagedLabel(w.integrationManager, pod); warn != "" {
 		warnings = append(warnings, warn)
 	}
 
@@ -233,7 +235,7 @@ func (w *PodWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *corev1.
 	}
 
 	if _, suspendByParent := newPod.pod.Annotations[podconstants.SuspendedByParentAnnotation]; !suspendByParent {
-		if warn := warningForPodManagedLabel(newPod); warn != "" {
+		if warn := warningForPodManagedLabel(w.integrationManager, newPod); warn != "" {
 			warnings = append(warnings, warn)
 		}
 	}
@@ -264,9 +266,9 @@ func validateManagedLabel(pod *Pod) field.ErrorList {
 }
 
 // warningForPodManagedLabel returns a warning message if the pod has a managed label, and it's parent is managed by kueue
-func warningForPodManagedLabel(p *Pod) string {
+func warningForPodManagedLabel(integrationManager *jobframework.IntegrationManager, p *Pod) string {
 	managedLabel := p.pod.GetLabels()[constants.ManagedByKueueLabelKey]
-	if managedLabel == constants.ManagedByKueueLabelValue && jobframework.IsOwnerManagedByKueueForObject(p.Object()) {
+	if managedLabel == constants.ManagedByKueueLabelValue && integrationManager.IsOwnerManagedByKueueForObject(p.Object()) {
 		return fmt.Sprintf("pod owner is managed by kueue, label '%s=%s' might lead to unexpected behaviour",
 			constants.ManagedByKueueLabelKey, constants.ManagedByKueueLabelValue)
 	}

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -41,7 +41,11 @@ import (
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	kubeflowjobs "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -52,10 +56,6 @@ import (
 	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	testingtfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
 	testingxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/kubeflow/jobs"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 )
 
 func TestDefault(t *testing.T) {
@@ -645,7 +645,8 @@ func TestDefault(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			builder := utiltesting.NewClientBuilder(rayv1.AddToScheme, kfmpi.AddToScheme, kftraining.AddToScheme, appsv1.AddToScheme)
 			builder = builder.WithObjects(tc.initObjects...)
 			cli := builder.Build()
@@ -663,6 +664,7 @@ func TestDefault(t *testing.T) {
 			}
 
 			w := &PodWebhook{
+				integrationManager:           integrationManager,
 				client:                       cli,
 				queues:                       queueManager,
 				manageJobsWithoutQueueName:   tc.manageJobsWithoutQueueName,
@@ -772,7 +774,8 @@ func TestGetRoleHash(t *testing.T) {
 }
 
 func TestValidateCreate(t *testing.T) {
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
+	integrationManager := newTestIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
 		pod          *corev1.Pod
 		wantErr      error
@@ -1032,7 +1035,8 @@ func TestValidateCreate(t *testing.T) {
 			cli := builder.Build()
 
 			w := &PodWebhook{
-				client: cli,
+				integrationManager: integrationManager,
+				client:             cli,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -1049,7 +1053,8 @@ func TestValidateCreate(t *testing.T) {
 }
 
 func TestValidateUpdate(t *testing.T) {
-	t.Cleanup(jobframework.EnableIntegrationsForTest(t, "batch/job"))
+	integrationManager := newTestIntegrationManager(t)
+	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	testCases := map[string]struct {
 		oldPod       *corev1.Pod
 		newPod       *corev1.Pod
@@ -1348,7 +1353,8 @@ func TestValidateUpdate(t *testing.T) {
 			cli := builder.Build()
 
 			w := &PodWebhook{
-				client: cli,
+				integrationManager: integrationManager,
+				client:             cli,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -1362,4 +1368,21 @@ func TestValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestIntegrationManager(t *testing.T) *jobframework.IntegrationManager {
+	t.Helper()
+	manager := jobframework.NewIntegrationManager()
+	for _, registerIntegration := range []func(*jobframework.IntegrationManager) error{
+		RegisterIntegration,
+		workloadjob.RegisterIntegration,
+		kubeflowjobs.RegisterIntegrations,
+		mpijob.RegisterIntegration,
+		raycluster.RegisterIntegration,
+	} {
+		if err := registerIntegration(manager); err != nil {
+			t.Fatalf("RegisterIntegration() error = %v", err)
+		}
+	}
+	return manager
 }

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -45,8 +44,8 @@ const (
 	FrameworkName       = "ray.io/raycluster"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:  SetupIndexes,
 		NewJob:        NewJob,
 		NewReconciler: NewReconciler,
@@ -55,7 +54,7 @@ func init() {
 		AddToScheme:   rayv1.AddToScheme,
 		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
 			ray.WithElasticReplicaSync(elasticReplicaSync())),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -47,6 +47,7 @@ var (
 )
 
 type RayClusterWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	queues                       *qcache.Manager
 	manageJobsWithoutQueueName   bool
@@ -61,6 +62,7 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		opt(&options)
 	}
 	wh := &RayClusterWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		queues:                       options.Queues,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
@@ -87,11 +89,11 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj *rayv1.RayCluster) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,8 +50,8 @@ const (
 	FrameworkName          = "ray.io/rayjob"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            newJob,
 		NewReconciler:     NewReconciler,
@@ -60,7 +59,7 @@ func init() {
 		JobType:           &rayv1.RayJob{},
 		AddToScheme:       rayv1.AddToScheme,
 		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -41,6 +41,7 @@ var (
 )
 
 type RayJobWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	queues                       *qcache.Manager
 	manageJobsWithoutQueueName   bool
@@ -52,6 +53,7 @@ type RayJobWebhook struct {
 func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &RayJobWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		queues:                       options.Queues,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
@@ -78,11 +80,11 @@ func (w *RayJobWebhook) Default(ctx context.Context, obj *rayv1.RayJob) error {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.V(5).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -52,8 +51,8 @@ const (
 	FrameworkName       = "ray.io/rayservice"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            newJob,
 		NewReconciler:     NewReconciler,
@@ -61,7 +60,7 @@ func init() {
 		JobType:           &rayv1.RayService{},
 		AddToScheme:       rayv1.AddToScheme,
 		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -45,6 +45,7 @@ var (
 )
 
 type RayServiceWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	queues                       *qcache.Manager
 	manageJobsWithoutQueueName   bool
@@ -63,6 +64,7 @@ func SetupRayServiceWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		opt(&options)
 	}
 	wh := &RayServiceWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		queues:                       options.Queues,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
@@ -89,11 +91,11 @@ func (w *RayServiceWebhook) Default(ctx context.Context, obj *rayv1.RayService) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,8 +48,8 @@ const (
 	executorPodSetName = "executor"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:          SetupIndexes,
 		NewJob:                NewJob,
 		NewReconciler:         NewReconciler,
@@ -58,7 +57,7 @@ func init() {
 		JobType:               &sparkv1beta2.SparkApplication{},
 		AddToScheme:           sparkv1beta2.AddToScheme,
 		CanSupportIntegration: CanSupportIntegration,
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=sparkoperator.k8s.io,resources=sparkapplications,verbs=get;list;watch;update;patch;delete

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -44,6 +44,7 @@ var (
 )
 
 type SparkApplicationWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	queues                       *qcache.Manager
 	manageJobsWithoutQueueName   bool
@@ -54,6 +55,7 @@ type SparkApplicationWebhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &SparkApplicationWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		queues:                       options.Queues,
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
@@ -81,11 +83,11 @@ func (w *SparkApplicationWebhook) Default(ctx context.Context, obj *sparkv1beta2
 	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
-	if err := jobframework.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())
+	if err := w.integrationManager.ApplyDefaultForSuspend(ctx, job, w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultForManagedBy(job, w.queues, w.cache, log)

--- a/pkg/controller/jobs/statefulset/statefulset_controller.go
+++ b/pkg/controller/jobs/statefulset/statefulset_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -39,8 +38,8 @@ const (
 	FrameworkName = "statefulset"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:                    SetupIndexes,
 		NewReconciler:                   NewReconciler,
 		NewAdditionalReconcilers:        []jobframework.ReconcilerFactory{NewPodReconciler},
@@ -50,7 +49,7 @@ func init() {
 		ImplicitlyEnabledFrameworkNames: []string{"pod"},
 		GVK:                             gvk,
 		MultiKueueAdapter:               &multiKueueAdapter{},
-	}))
+	})
 }
 
 type StatefulSet appsv1.StatefulSet

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -68,6 +68,7 @@ var (
 )
 
 type Reconciler struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	record                       events.EventRecorder
 	logName                      string
@@ -394,6 +395,7 @@ func NewReconciler(_ context.Context, client client.Client, _ client.FieldIndexe
 	options := jobframework.ProcessOptions(opts...)
 
 	return &Reconciler{
+		integrationManager:           options.IntegrationManager,
 		client:                       client,
 		record:                       eventRecorder,
 		logName:                      "statefulset-reconciler",
@@ -441,7 +443,7 @@ func (r *Reconciler) handle(obj client.Object) bool {
 	}
 
 	// Handle only statefulset managed by kueue.
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, sts, r.client, r.manageJobsWithoutQueueName, r.managedJobsNamespaceSelector)
+	suspend, err := r.integrationManager.WorkloadShouldBeSuspended(ctx, sts, r.client, r.manageJobsWithoutQueueName, r.managedJobsNamespaceSelector)
 	if err != nil {
 		log.Error(err, "Failed to determine if the StatefulSet should be managed by Kueue")
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -41,6 +41,7 @@ import (
 )
 
 type Webhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -50,6 +51,7 @@ type Webhook struct {
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -82,11 +84,11 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 
 	log.V(5).Info("Propagating queue-name")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, ss.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, ss.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, ss.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())
+	suspend, err := wh.integrationManager.WorkloadShouldBeSuspended(ctx, ss.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
 	}
@@ -171,7 +173,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldStatefulSet.Object(), newStatefulSet.Object())...)
 	}
 
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newStatefulSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := wh.integrationManager.WorkloadShouldBeSuspended(ctx, newStatefulSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/leaderworkerset"
+	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -152,7 +153,8 @@ func TestDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.enableIntegrations...))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.enableIntegrations...))
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			builder := utiltesting.NewClientBuilder().WithObjects(tc.initObjs...)
@@ -167,6 +169,7 @@ func TestDefault(t *testing.T) {
 			}
 
 			w := &Webhook{
+				integrationManager:         integrationManager,
 				client:                     cli,
 				manageJobsWithoutQueueName: tc.manageJobsWithoutQueueName,
 				queues:                     queueManager,
@@ -364,10 +367,11 @@ func TestValidateCreate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, "pod"))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "pod"))
 			builder := utiltesting.NewClientBuilder()
 			client := builder.Build()
-			w := &Webhook{client: client}
+			w := &Webhook{integrationManager: integrationManager, client: client}
 			ctx, _ := utiltesting.ContextWithLog(t)
 			warns, err := w.ValidateCreate(ctx, tc.sts)
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.IgnoreFields(field.Error{}, "BadValue", "Detail")); diff != "" {
@@ -1045,14 +1049,16 @@ func TestValidateUpdate(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-			t.Cleanup(jobframework.EnableIntegrationsForTest(t, tc.integrations...))
+			integrationManager := newTestIntegrationManager(t)
+			t.Cleanup(integrationManager.EnableIntegrationsForTest(t, tc.integrations...))
 
 			client := utiltesting.NewClientBuilder(awv1beta2.AddToScheme, leaderworkersetv1.AddToScheme).
 				WithRuntimeObjects(tc.objs...).
 				Build()
 
 			wh := &Webhook{
-				client: client,
+				integrationManager: integrationManager,
+				client:             client,
 			}
 
 			ctx, _ := utiltesting.ContextWithLog(t)
@@ -1062,4 +1068,20 @@ func TestValidateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func newTestIntegrationManager(t *testing.T) *jobframework.IntegrationManager {
+	t.Helper()
+	manager := jobframework.NewIntegrationManager()
+	for _, registerIntegration := range []func(*jobframework.IntegrationManager) error{
+		RegisterIntegration,
+		appwrapper.RegisterIntegration,
+		leaderworkerset.RegisterIntegration,
+		pod.RegisterIntegration,
+	} {
+		if err := registerIntegration(manager); err != nil {
+			t.Fatalf("RegisterIntegration() error = %v", err)
+		}
+	}
+	return manager
 }

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -55,8 +54,8 @@ var (
 	TrainJobControllerName = "trainer.kubeflow.org/trainjob-controller"
 )
 
-func init() {
-	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
+func RegisterIntegration(m *jobframework.IntegrationManager) error {
+	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
 		SetupIndexes:      SetupIndexes,
 		NewJob:            NewJob,
 		NewReconciler:     NewReconciler,
@@ -64,7 +63,7 @@ func init() {
 		JobType:           &kftrainer.TrainJob{},
 		AddToScheme:       kftrainer.AddToScheme,
 		MultiKueueAdapter: &multiKueueAdapter{},
-	}))
+	})
 }
 
 // +kubebuilder:rbac:groups=trainer.kubeflow.org,resources=trainjobs,verbs=get;list;watch;update;patch

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -34,6 +34,7 @@ import (
 )
 
 type TrainJobWebhook struct {
+	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
 	manageJobsWithoutQueueName   bool
 	managedJobsNamespaceSelector labels.Selector
@@ -45,6 +46,7 @@ type TrainJobWebhook struct {
 func SetupTrainJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &TrainJobWebhook{
+		integrationManager:           options.IntegrationManager,
 		client:                       mgr.GetClient(),
 		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
 		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
@@ -72,12 +74,12 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	log := ctrl.LoggerFrom(ctx).WithName("trainjob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, trainJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, trainJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
-	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())
+	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())
 	jobframework.ApplyDefaultForManagedBy(trainJob, w.queues, w.cache, log)
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, trainJob.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
+	suspend, err := w.integrationManager.WorkloadShouldBeSuspended(ctx, trainJob.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
 	if err != nil {
 		return err
 	}

--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -110,7 +109,8 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 }
 
 func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.IntegrationManager {
-	integrationManager := jobcontrollers.NewIntegrationManager()
+	integrationManager := jobframework.NewIntegrationManager()
+	gomega.Expect(workloadjob.RegisterIntegration(integrationManager)).To(gomega.Succeed())
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/integration/multikueue/scheduler/suite_test.go
+++ b/test/integration/multikueue/scheduler/suite_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -105,6 +106,11 @@ func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) c
 }
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {
+	setupManager(ctx, mgr)
+}
+
+func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.IntegrationManager {
+	integrationManager := jobcontrollers.NewIntegrationManager()
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -112,6 +118,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	preemptionExpectations := preemptexpectations.New()
 	queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
 	queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+	jobOptions := []jobframework.Option{
+		jobframework.WithIntegrationManager(integrationManager),
+		jobframework.WithCache(cCache),
+		jobframework.WithQueues(queues),
+	}
+	integrationManager.EnableIntegration(workloadjob.FrameworkName)
 
 	configuration := &config.Configuration{}
 	mgr.GetScheme().Default(configuration)
@@ -135,12 +147,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = jobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadjob.SetupWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadjob.SetupWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = provisioning.SetupIndexer(ctx, mgr.GetFieldIndexer())
@@ -165,6 +177,8 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	)
 	err = sched.Start(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return integrationManager
 }
 
 func managerAndMultiKueueSetup(
@@ -174,12 +188,12 @@ func managerAndMultiKueueSetup(
 	enabledIntegrations sets.Set[string],
 	dispatcherName string,
 ) {
-	managerSetup(ctx, mgr)
+	integrationManager := setupManager(ctx, mgr)
 
 	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	adapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
+	adapters, err := integrationManager.GetMultiKueueAdapters(enabledIntegrations)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -44,7 +44,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/admissionchecks/multikueue"
-	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -1312,7 +1312,7 @@ var _ = ginkgo.Describe("Manager quota automation feature gate", ginkgo.Label("a
 				err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				adapters, err := jobframework.GetMultiKueueAdapters(defaultEnabledIntegrations)
+				adapters, err := jobcontrollers.NewIntegrationManager().GetMultiKueueAdapters(defaultEnabledIntegrations)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,
@@ -1349,7 +1349,7 @@ var _ = ginkgo.Describe("Manager quota automation feature gate", ginkgo.Label("a
 				err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-				adapters, err := jobframework.GetMultiKueueAdapters(defaultEnabledIntegrations)
+				adapters, err := jobcontrollers.NewIntegrationManager().GetMultiKueueAdapters(defaultEnabledIntegrations)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 				err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadaw "sigs.k8s.io/kueue/pkg/controller/jobs/appwrapper"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	workloadjobset "sigs.k8s.io/kueue/pkg/controller/jobs/jobset"
@@ -173,12 +174,17 @@ func resourceFormatterForCounterResource(resourceName corev1.ResourceName) *reso
 }
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {
+	setupManager(ctx, mgr)
+}
+
+func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.IntegrationManager {
 	options, _ := ctx.Value(managerSetupOptionsKey{}).(managerSetupOptions)
 	resourceFormatter := options.resourceFormatter
 	if resourceFormatter == nil {
 		resourceFormatter = resources.NewResourceFormatter()
 	}
 
+	integrationManager := jobcontrollers.NewIntegrationManager()
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -192,6 +198,27 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		qcache.WithResourceFormatter(resourceFormatter),
 	}
 	queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+	jobOptions := []jobframework.Option{
+		jobframework.WithIntegrationManager(integrationManager),
+		jobframework.WithCache(cCache),
+		jobframework.WithQueues(queues),
+	}
+	for _, frameworkName := range []string{
+		workloadjob.FrameworkName,
+		workloadjobset.FrameworkName,
+		workloadtfjob.FrameworkName,
+		workloadpaddlejob.FrameworkName,
+		workloadpytorchjob.FrameworkName,
+		workloadxgboostjob.FrameworkName,
+		workloadmpijob.FrameworkName,
+		workloadpod.FrameworkName,
+		workloadrayjob.FrameworkName,
+		workloadraycluster.FrameworkName,
+		workloadaw.FrameworkName,
+		workloadtrainjob.FrameworkName,
+	} {
+		integrationManager.EnableIntegration(frameworkName)
+	}
 
 	configuration := &config.Configuration{}
 	mgr.GetScheme().Default(configuration)
@@ -218,12 +245,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = jobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadjob.SetupWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadjob.SetupWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadjobset.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -233,12 +260,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = jobsetReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadjobset.SetupJobSetWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadjobset.SetupJobSetWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadtfjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -248,12 +275,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = tfjobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadtfjob.SetupTFJobWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadtfjob.SetupTFJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadpaddlejob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -263,12 +290,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = paddleJobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadpaddlejob.SetupPaddleJobWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadpaddlejob.SetupPaddleJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadpytorchjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -278,16 +305,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = pyTorchJobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadpytorchjob.SetupPyTorchJobWebhook(
-		mgr,
-		jobframework.WithCache(cCache),
-		jobframework.WithQueues(queues),
-	)
+	err = workloadpytorchjob.SetupPyTorchJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadxgboostjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -297,16 +320,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = xgboostJobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadxgboostjob.SetupXGBoostJobWebhook(
-		mgr,
-		jobframework.WithCache(cCache),
-		jobframework.WithQueues(queues),
-	)
+	err = workloadxgboostjob.SetupXGBoostJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadmpijob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -316,12 +335,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = mpiJobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadmpijob.SetupMPIJobWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadmpijob.SetupMPIJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadpod.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -331,7 +350,7 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = podReconciller.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -348,12 +367,9 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	mjnsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadpod.SetupWebhook(
-		mgr,
-		jobframework.WithCache(cCache),
-		jobframework.WithQueues(queues),
-		jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
-	)
+	podWebhookOptions := append([]jobframework.Option{}, jobOptions...)
+	podWebhookOptions = append(podWebhookOptions, jobframework.WithManagedJobsNamespaceSelector(mjnsSelector))
+	err = workloadpod.SetupWebhook(mgr, podWebhookOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadrayjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -363,12 +379,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = rayJobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadrayjob.SetupRayJobWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadrayjob.SetupRayJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadraycluster.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -378,16 +394,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = rayClusterReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadraycluster.SetupRayClusterWebhook(
-		mgr,
-		jobframework.WithCache(cCache),
-		jobframework.WithQueues(queues),
-	)
+	err = workloadraycluster.SetupRayClusterWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadaw.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -397,12 +409,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = appwrapperReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadaw.SetupAppWrapperWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadaw.SetupAppWrapperWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadtrainjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
@@ -412,12 +424,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = trainjobreconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadtrainjob.SetupTrainJobWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadtrainjob.SetupTrainJobWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = provisioning.SetupIndexer(ctx, mgr.GetFieldIndexer())
@@ -430,6 +442,8 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 
 	err = provReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return integrationManager
 }
 
 func managerAndMultiKueueSetup(
@@ -439,12 +453,12 @@ func managerAndMultiKueueSetup(
 	enabledIntegrations sets.Set[string],
 	dispatcherName string,
 ) {
-	managerSetup(ctx, mgr)
+	integrationManager := setupManager(ctx, mgr)
 
 	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	adapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
+	adapters, err := integrationManager.GetMultiKueueAdapters(enabledIntegrations)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,

--- a/test/integration/multikueue/tas/suite_test.go
+++ b/test/integration/multikueue/tas/suite_test.go
@@ -41,7 +41,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
-	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
@@ -112,7 +111,8 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 }
 
 func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.IntegrationManager {
-	integrationManager := jobcontrollers.NewIntegrationManager()
+	integrationManager := jobframework.NewIntegrationManager()
+	gomega.Expect(workloadjob.RegisterIntegration(integrationManager)).To(gomega.Succeed())
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/test/integration/multikueue/tas/suite_test.go
+++ b/test/integration/multikueue/tas/suite_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
@@ -107,6 +108,11 @@ func createCluster(setupFnc framework.ManagerSetup, apiFeatureGates ...string) c
 }
 
 func managerSetup(ctx context.Context, mgr manager.Manager) {
+	setupManager(ctx, mgr)
+}
+
+func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.IntegrationManager {
+	integrationManager := jobcontrollers.NewIntegrationManager()
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -114,6 +120,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	preemptionExpectations := preemptexpectations.New()
 	queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
 	queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
+	jobOptions := []jobframework.Option{
+		jobframework.WithIntegrationManager(integrationManager),
+		jobframework.WithCache(cCache),
+		jobframework.WithQueues(queues),
+	}
+	integrationManager.EnableIntegration(workloadjob.FrameworkName)
 
 	configuration := &config.Configuration{}
 	mgr.GetScheme().Default(configuration)
@@ -143,12 +155,12 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = jobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = workloadjob.SetupWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadjob.SetupWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = provisioning.SetupIndexer(ctx, mgr.GetFieldIndexer())
@@ -171,6 +183,8 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 	)
 	err = sched.Start(ctx)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return integrationManager
 }
 
 func managerAndMultiKueueSetup(
@@ -180,12 +194,12 @@ func managerAndMultiKueueSetup(
 	enabledIntegrations sets.Set[string],
 	dispatcherName string,
 ) {
-	managerSetup(ctx, mgr)
+	integrationManager := setupManager(ctx, mgr)
 
 	err := multikueue.SetupIndexer(ctx, mgr.GetFieldIndexer(), managersConfigNamespace.Name)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	adapters, err := jobframework.GetMultiKueueAdapters(enabledIntegrations)
+	adapters, err := integrationManager.GetMultiKueueAdapters(enabledIntegrations)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = multikueue.SetupControllers(mgr, managersConfigNamespace.Name,

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -85,6 +86,7 @@ func runJobController(opts *managerSetupOpts) {
 
 func managerSetup(options ...managerSetupOption) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
 		var opts managerSetupOpts
 		for _, opt := range options {
 			opt(&opts)
@@ -114,15 +116,15 @@ func managerSetup(options ...managerSetupOption) framework.ManagerSetup {
 				ctx,
 				mgr.GetClient(),
 				mgr.GetFieldIndexer(),
-				mgr.GetEventRecorder(constants.JobControllerName))
+				mgr.GetEventRecorder(constants.JobControllerName), jobframework.WithIntegrationManager(integrationManager))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = job.SetupIndexes(ctx, mgr.GetFieldIndexer())
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			err = jobReconciler.SetupWithManager(mgr)
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			err = job.SetupWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+			err = job.SetupWebhook(mgr, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			jobframework.EnableIntegration(job.FrameworkName)
+			integrationManager.EnableIntegration(job.FrameworkName)
 		}
 
 		failedCtrl, err := core.SetupControllers(

--- a/test/integration/singlecluster/controller/jobframework/setup/suite_test.go
+++ b/test/integration/singlecluster/controller/jobframework/setup/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
@@ -45,10 +46,10 @@ func TestAPIs(t *testing.T) {
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
-		gomega.Expect(jobframework.SetupIndexes(ctx, mgr.GetFieldIndexer(), opts...)).NotTo(gomega.HaveOccurred())
-		// The integration manager is a shared state and that after enabled a framework
-		// will remain enabled until the end of the test suite.
-		gomega.Expect(jobframework.SetupControllers(ctx, mgr, ginkgo.GinkgoLogr, opts...)).NotTo(gomega.HaveOccurred())
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
+		gomega.Expect(integrationManager.SetupIndexes(ctx, mgr.GetFieldIndexer(), opts...)).NotTo(gomega.HaveOccurred())
+		gomega.Expect(integrationManager.SetupControllers(ctx, mgr, ginkgo.GinkgoLogr, opts...)).NotTo(gomega.HaveOccurred())
 
 		failedWebhook, err := webhooks.Setup(mgr, nil)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)

--- a/test/integration/singlecluster/controller/jobs/job/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
@@ -69,6 +70,8 @@ var _ = ginkgo.AfterSuite(func() {
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
 		reconciler, err := job.NewReconciler(
 			ctx,
 			mgr.GetClient(),
@@ -86,7 +89,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		failedWebhook, err := webhooks.Setup(mgr, nil)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
-		jobframework.EnableIntegration(job.FrameworkName)
+		integrationManager.EnableIntegration(job.FrameworkName)
 	}
 }
 

--- a/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/mpijob"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
@@ -108,11 +109,12 @@ func controllersSetup(
 	preemptionExpectations *expectations.Store,
 	opts ...jobframework.Option,
 ) (*schdcache.Cache, *qcache.Manager, *config.Configuration) {
+	integrationManager := jobcontrollers.NewIntegrationManager()
 	cCache := schdcache.New(mgr.GetClient())
 	queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptionExpectations)}
 	queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
 
-	opts = append(opts, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	opts = append(opts, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 
 	reconciler, err := mpijob.NewReconciler(
 		ctx,
@@ -129,7 +131,7 @@ func controllersSetup(
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = mpijob.SetupMPIJobWebhook(mgr, opts...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	jobframework.EnableIntegration(mpijob.FrameworkName)
+	integrationManager.EnableIntegration(mpijob.FrameworkName)
 	configuration := &config.Configuration{}
 	mgr.GetScheme().Default(configuration)
 	failedCtrl, err := core.SetupControllers(

--- a/test/integration/singlecluster/controller/jobs/pod/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/controller/tas"
@@ -91,6 +92,8 @@ func managerSetup(
 	}
 	queueOptions = append(queueOptions, qcache.WithPreemptionExpectations(preemptionExpectations))
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -122,7 +125,7 @@ func managerSetup(
 			opts...)
 		err = jobReconciler.SetupWithManager(mgr)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		jobframework.EnableIntegration(job.FrameworkName)
+		integrationManager.EnableIntegration(job.FrameworkName)
 
 		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
 		opts = append(opts, jobframework.WithQueues(queues), jobframework.WithCache(cCache))

--- a/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/elasticjobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -70,6 +71,8 @@ var _ = ginkgo.AfterSuite(func() {
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
 		reconciler, err := raycluster.NewReconciler(
 			ctx,
 			mgr.GetClient(),
@@ -89,7 +92,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		failedWebhook, err := webhooks.Setup(mgr, nil)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
-		jobframework.EnableIntegration(rayjob.FrameworkName)
+		integrationManager.EnableIntegration(rayjob.FrameworkName)
 	}
 }
 

--- a/test/integration/singlecluster/controller/jobs/statefulset/suite_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
 	"sigs.k8s.io/kueue/pkg/scheduler"
@@ -70,6 +71,8 @@ var _ = ginkgo.AfterSuite(func() {
 
 func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager))
 		err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -134,7 +137,7 @@ func managerSetup(opts ...jobframework.Option) framework.ManagerSetup {
 		failedWebhook, err := webhooks.Setup(mgr, nil)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
 
-		jobframework.EnableIntegration(statefulset.FrameworkName)
+		integrationManager.EnableIntegration(statefulset.FrameworkName)
 
 		discoveryClient, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/singlecluster/conversion/suite_test.go
+++ b/test/integration/singlecluster/conversion/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/core"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -66,6 +67,7 @@ var _ = ginkgo.AfterSuite(func() {
 })
 
 func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
+	integrationManager := jobcontrollers.NewIntegrationManager()
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -93,15 +95,15 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 		ctx,
 		mgr.GetClient(),
 		mgr.GetFieldIndexer(),
-		mgr.GetEventRecorder(constants.JobControllerName))
+		mgr.GetEventRecorder(constants.JobControllerName), jobframework.WithIntegrationManager(integrationManager))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = workloadjob.SetupIndexes(ctx, mgr.GetFieldIndexer())
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	err = jobReconciler.SetupWithManager(mgr)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	err = workloadjob.SetupWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+	err = workloadjob.SetupWebhook(mgr, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	jobframework.EnableIntegration(workloadjob.FrameworkName)
+	integrationManager.EnableIntegration(workloadjob.FrameworkName)
 
 	sched := scheduler.New(
 		queues,

--- a/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/raycluster_webhook_test.go
@@ -65,6 +65,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 	ginkgo.When("With manageJobsWithoutQueueName enabled", func() {
 		ginkgo.BeforeEach(func() {
 			fwk.StartManager(ctx, cfg, managerSetup(func(mgr ctrl.Manager, opts ...jobframework.Option) error {
+				integrationManager := jobframework.ProcessOptions(opts...).IntegrationManager
 				reconciler, err := raycluster.NewReconciler(
 					ctx,
 					mgr.GetClient(),
@@ -94,7 +95,7 @@ var _ = ginkgo.Describe("RayCluster Webhook", func() {
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
 				err = workloadrayjob.SetupRayJobWebhook(mgr, opts...)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
-				jobframework.EnableIntegration(workloadrayjob.FrameworkName)
+				integrationManager.EnableIntegration(workloadrayjob.FrameworkName)
 
 				failedWebhook, err := webhooks.Setup(mgr, nil)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -30,6 +30,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	jobcontrollers "sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
@@ -71,14 +72,15 @@ var _ = ginkgo.AfterSuite(func() {
 
 func managerSetup(setup func(ctrl.Manager, ...jobframework.Option) error, opts ...jobframework.Option) framework.ManagerSetup {
 	return func(ctx context.Context, mgr manager.Manager) {
+		integrationManager := jobcontrollers.NewIntegrationManager()
 		cCache := schdcache.New(mgr.GetClient())
 		preemptExpectations := preemptexpectations.New()
 		queueOptions := []qcache.Option{qcache.WithPreemptionExpectations(preemptExpectations)}
 		queues := util.NewManagerForIntegrationTests(ctx, mgr.GetClient(), cCache, queueOptions...)
-		opts = append(opts, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
+		opts = append(opts, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 
 		err := setup(mgr, opts...)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		jobframework.EnableIntegration(job.FrameworkName)
+		integrationManager.EnableIntegration(job.FrameworkName)
 	}
 }


### PR DESCRIPTION
 #### What type of PR is this?                                                  
                                                                                 
  /kind cleanup                                                                  
  /area integrations                                                             
  /area multikueue                                                               
  /area testing                                                                  
                                                                                 
  #### What this PR does / why we need it:                                       
                                                                                 
  Removes the Job Framework package-global integration manager and scopes        
  integration state to each Kueue manager instance.                              
                                                                                 
  Previously, built-in integrations registered themselves through package `init` 
  functions into a shared Job Framework registry. Runtime state such as enabled  
  frameworks, external framework types, GVK lookups, and implicitly enabled      
  integrations could therefore leak between independently started managers—for   
  example, MultiKueue worker managers in the same process.                       
                                                                                 
  This change makes `jobframework.IntegrationManager` the owner of that state and
  injects it through runtime consumers.                                          
                                                                                 
  Key changes:                                                                   
                                                                                 
  - Replaces the package-global manager and forwarding helpers with              
  `IntegrationManager` receiver methods.                                         
  - Replaces `init`-based built-in registration with explicit registration       
  functions and `jobs.NewIntegrationManager()`.                                  
  - Creates and injects one manager at each composition root:                    
    - `cmd/kueue`                                                                
    - configuration validation                                                   
    - `kueuectl list pods`                                                       
    - Job Framework reconcilers and webhooks                                     
    - custom job webhooks and Pod ownership/defaulting paths                     
    - MultiKueue and single-cluster integration-test manager setups              
  - Updates adapter lookup so each MultiKueue manager uses its own integration   
  registry.                                                                      
  - Adds isolation coverage proving that enabling an integration on one manager  
  does not affect owner lookup on another manager.                               
  - Preserves registration order, existing callbacks, feature-gate behavior, and 
  user-facing configuration semantics.                                           
                                                                                 
  #### Which issue(s) this PR fixes:                                             
                                                                                 
  Fixes #13231                                                                   
                                                                                 
  #### Special notes for your reviewer:                                         
AI usage disclosure: AI assitance was used to assist with implementation and   
  validation; the changes were reviewed before submission.                       
                                                                                 
  #### Does this PR introduce a user-facing change?                              
                                                                                 
  ```release-note                                                                
  NONE                                                                           
```                                                                       

  #### Validation:                                                               
                                                                                 
  - Passed under native WSL:                                                     
                                                                                 
    go test ./pkg/controller/jobframework ./pkg/controller/jobs/... ./pkg/       
    config ./cmd/kueue ./cmd/kueuectl/app/list -count=1                          
                                                                                 
  - The full MultiKueue envtest suite was attempted but exceeded its 10-minute   
    timeout without diagnostics.                                                 
                                                                                 
  - make verify could not complete from the Windows-mounted WSL worktree because 
    go list ./... blocked in filesystem I/O.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added instance-based integration management for controllers, indexes, webhooks, configuration validation, and pod listing.
  * Enabled per-setup integration configuration, isolated integration state, and MultiKueue adapter resolution.

* **Bug Fixes**
  * Webhook defaulting now safely handles setups without integration configuration.
  * Integration registration and configuration errors are surfaced during startup and setup instead of causing implicit failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->