### PR TITLE
Fix silently dropped errors in SparkApplication addVolumes

### DIFF
--- a/pkg/controller/jobs/sparkapplication/sparkapplication_podset.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_podset.go
@@ -229,10 +229,14 @@ func addVolumes(pod *corev1.Pod, app *sparkv1beta2.SparkApplication) error {
 
 		if v, ok := volumeMap[m.Name]; ok {
 			if _, ok := addedVolumeMap[m.Name]; !ok {
-				_ = addVolume(pod, v)
+				if err := addVolume(pod, v); err != nil {
+					return err
+				}
 				addedVolumeMap[m.Name] = v
 			}
-			_ = addVolumeMount(pod, m)
+			if err := addVolumeMount(pod, m); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_podset_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_podset_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sparkapplication
+
+import (
+	"testing"
+
+	sparkv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
+	sparkcommon "github.com/kubeflow/spark-operator/v2/pkg/common"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func driverPod(containerName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				sparkcommon.LabelSparkRole: sparkcommon.SparkRoleDriver,
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: containerName},
+			},
+		},
+	}
+}
+
+func TestAddVolumeMount(t *testing.T) {
+	tests := map[string]struct {
+		pod     *corev1.Pod
+		wantErr bool
+	}{
+		"driver pod with matching container": {
+			pod:     driverPod(sparkcommon.SparkDriverContainerName),
+			wantErr: false,
+		},
+		"pod that is neither driver nor executor": {
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "not-spark"}},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := addVolumeMount(tc.pod, corev1.VolumeMount{Name: "data", MountPath: "/data"})
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("addVolumeMount() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestAddVolumes(t *testing.T) {
+	tests := map[string]struct {
+		pod             *corev1.Pod
+		app             *sparkv1beta2.SparkApplication
+		wantErr         bool
+		wantVolumes     []string
+		wantVolumeMount []string
+	}{
+		"adds a volume and mount that match by name": {
+			pod: driverPod(sparkcommon.SparkDriverContainerName),
+			app: &sparkv1beta2.SparkApplication{
+				Spec: sparkv1beta2.SparkApplicationSpec{
+					Volumes: []corev1.Volume{{Name: "data"}},
+					Driver: sparkv1beta2.DriverSpec{
+						SparkPodSpec: sparkv1beta2.SparkPodSpec{
+							VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+						},
+					},
+				},
+			},
+			wantVolumes:     []string{"data"},
+			wantVolumeMount: []string{"data"},
+		},
+		"skips a mount with no matching volume declared": {
+			pod: driverPod(sparkcommon.SparkDriverContainerName),
+			app: &sparkv1beta2.SparkApplication{
+				Spec: sparkv1beta2.SparkApplicationSpec{
+					Driver: sparkv1beta2.DriverSpec{
+						SparkPodSpec: sparkv1beta2.SparkPodSpec{
+							VolumeMounts: []corev1.VolumeMount{{Name: "unknown", MountPath: "/data"}},
+						},
+					},
+				},
+			},
+			wantVolumes:     nil,
+			wantVolumeMount: nil,
+		},
+		"skips localDir volume mounts": {
+			pod: driverPod(sparkcommon.SparkDriverContainerName),
+			app: &sparkv1beta2.SparkApplication{
+				Spec: sparkv1beta2.SparkApplicationSpec{
+					Volumes: []corev1.Volume{{Name: sparkcommon.SparkLocalDirVolumePrefix + "0"}},
+					Driver: sparkv1beta2.DriverSpec{
+						SparkPodSpec: sparkv1beta2.SparkPodSpec{
+							VolumeMounts: []corev1.VolumeMount{{Name: sparkcommon.SparkLocalDirVolumePrefix + "0", MountPath: "/tmp"}},
+						},
+					},
+				},
+			},
+			wantVolumes:     nil,
+			wantVolumeMount: nil,
+		},
+		"adds the volume once for two mounts referencing the same volume": {
+			pod: driverPod(sparkcommon.SparkDriverContainerName),
+			app: &sparkv1beta2.SparkApplication{
+				Spec: sparkv1beta2.SparkApplicationSpec{
+					Volumes: []corev1.Volume{{Name: "data"}},
+					Driver: sparkv1beta2.DriverSpec{
+						SparkPodSpec: sparkv1beta2.SparkPodSpec{
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "data", MountPath: "/data-a"},
+								{Name: "data", MountPath: "/data-b"},
+							},
+						},
+					},
+				},
+			},
+			wantVolumes:     []string{"data"},
+			wantVolumeMount: []string{"data", "data"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := addVolumes(tc.pod, tc.app)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("addVolumes() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			var gotVolumes []string
+			for _, v := range tc.pod.Spec.Volumes {
+				gotVolumes = append(gotVolumes, v.Name)
+			}
+			if len(gotVolumes) != len(tc.wantVolumes) {
+				t.Fatalf("pod.Spec.Volumes = %v, want %v", gotVolumes, tc.wantVolumes)
+			}
+			for i, name := range tc.wantVolumes {
+				if gotVolumes[i] != name {
+					t.Errorf("pod.Spec.Volumes[%d] = %v, want %v", i, gotVolumes[i], name)
+				}
+			}
+
+			var gotMounts []string
+			for _, m := range tc.pod.Spec.Containers[0].VolumeMounts {
+				gotMounts = append(gotMounts, m.Name)
+			}
+			if len(gotMounts) != len(tc.wantVolumeMount) {
+				t.Fatalf("container.VolumeMounts = %v, want %v", gotMounts, tc.wantVolumeMount)
+			}
+			for i, name := range tc.wantVolumeMount {
+				if gotMounts[i] != name {
+					t.Errorf("container.VolumeMounts[%d] = %v, want %v", i, gotMounts[i], name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

`addVolumes` in `pkg/controller/jobs/sparkapplication/sparkapplication_podset.go` discarded the errors returned by `addVolume` and `addVolumeMount` with `_ =`.`addVolumeMount` returns a real error (`"failed to add volumeMounts as Spark container not found"`) when it can't find the target container in the pod, and that error was being thrown away instead of surfaced to the caller of `mutateSparkPod`.

**Honest note on reachability:** under the current `findContainer` semantics, this specific path is not reachable through `addVolumes` today. `findContainer` only returns `-1` for pods that are neither driver nor executor (for
driver/executor pods it falls back to container index 0 via `max(slices.IndexFunc(...), 0)`), and `addVolumes` only calls `addVolumeMount` at all when the pod *is* a driver or executor pod. So this is a latent/ defensive fix, not one closing an actively-triggerable bug  I traced this fully and I'm not overstating it. It's still the correct fix: silently swallowing a real, non-trivial error is wrong regardless, and it becomes a live bug the moment `addVolumes` is reused elsewhere or `findContainer`'s fallback behavior changes. 
The file also had zero test coverage before this PR, so there was nothing protecting this code either way.

Also adds `sparkapplication_podset_test.go` the first tests this file has ever had covering `addVolumeMount` directly (including the actual error path, which I verified is real and testable in isolation) and `addVolumes` end-to-end (match-by-name, skip-unmatched-mount, skip-localDir-prefix, dedup-shared-volume).

Coverage: `addVolume`/`addVolumeMount` now at 100%, `addVolumes` at 90.5 (the uncovered 9.5% is exactly the two `return err` lines proven above to be unreachable via any realistic driver/executor pod).

#### Special notes for your reviewer:

No associated issue; found while reading the handler code for a previous PR in this repo. I verified `TestAddVolumeMount`'s error case has teeth by temporarily breaking `addVolumeMount`'s own `i < 0` check locally the test went red as expected, then I reverted. I also tried reverting *this PR's* fix (`addVolumes` propagation) and reran `TestAddVolumes`: it stayed green, confirming the reachability note above rather than contradicting it I'm surfacing that transparently rather than implying a red/green story exists for a branch that provably can't be exercised black-box today.

While tracing `findContainer`, I also noticed `pod.Spec.Containers[i]` with `i = max(IndexFunc(...), 0)` would panic on a driver/executor pod with zero containers. That's a separate, unrelated latent bug and out of scope here
not touched in this PR.

#### Does this PR introduce a user-facing change?

```release-note
SparkApplication: Fixed a bug where errors adding volumes or volume mounts to driver and executor Pods were silently ignored. Configuration errors are reported during reconciliation instead.
```