### PR TITLE
Replace fixed sleep with stability poll in kueueviz debounce test

### DIFF
--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -395,9 +395,7 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return fetchCalls.Load() > 1
 				}, "expected at least one update after burst of informer events")
 
-				time.Sleep(700 * time.Millisecond)
-
-				calls := fetchCalls.Load()
+				calls := waitForStableCount(t, testTimeout, 10*time.Millisecond, 3*debounceDelay, fetchCalls.Load)
 				if calls >= events+1 {
 					t.Fatalf("data fetch calls = %d, want less than %d due to debounce", calls, events+1)
 				}
@@ -534,4 +532,31 @@ func waitUntil(t *testing.T, timeout, interval time.Duration, condition func() b
 	}
 
 	t.Fatalf("timeout after %v: %s", timeout, failMessage)
+}
+
+// waitForStableCount polls count until it stops changing for stableFor, then
+// returns the settled value. This is used instead of a fixed sleep to wait
+// out a debounce window: it fails fast once the value has genuinely
+// stabilized rather than guessing a fixed margin, and gives an informative
+// failure message (last observed value) if it never stabilizes.
+func waitForStableCount(t *testing.T, timeout, interval, stableFor time.Duration, count func() int64) int64 {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	last := count()
+	lastChange := time.Now()
+	for {
+		current := count()
+		if current != last {
+			last = current
+			lastChange = time.Now()
+		} else if time.Since(lastChange) >= stableFor {
+			return last
+		}
+
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout after %v waiting for count to stabilize: last value = %d", timeout, last)
+		}
+		time.Sleep(interval)
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area dashboard

#### What this PR does / why we need it:

The `"debounces rapid informer events into fewer sendData calls"` test in`cmd/kueueviz/backend/handlers/websocket_handler_test.go` used a flat `time.Sleep(700 * time.Millisecond)` (3.5x the 200ms `debounceDelay`) to assume a burst of informer events had finished debouncing before reading
`fetchCalls`. 
The two `waitUntil` calls immediately above it in the same test correctly poll for a condition with a real timeout; this one assertion didn't, and gave no diagnostic if the margin was ever too tight under CI load or GC pauses it would just silently read whatever count happened to exist after the sleep.

Adds `waitForStableCount`, a small helper next to the existing `waitUntil`, that polls the counter until it stops changing for a stability window (`3*debounceDelay`) instead of guessing a fixed margin, with a real timeout and an informative failure message (last observed value) if it never stabilizes.

This is a flaky-test fix, not a failing test today per the PR template guidance for flakes, no `Fixes #` is used and there's no separate issue;
the test itself is the record. This is the third of three self-found, validated candidates from a kueue robustness/coverage sweep (see kueue#13488, kueue#13548 for the other two).

#### Special notes for your reviewer:

I verified `waitForStableCount` actually has teeth two ways, both reverted
before this diff:
1. Temporarily set `debounceDelay` to 5s  the earlier `waitUntil` check ("expected at least one update after burst of informer events") failed with its own 2s timeout, confirming the whole test correctly reacts to a broken debounce.
2. Temporarily set the `stableFor` argument at the call site to an unreachable 10s `waitForStableCount` failed with `timeout after 2s waiting for count to stabilize: last value = 2`, confirming its own timeout path fires with the intended diagnostic message. That message is exactly the improvement over the old blind sleep, which had no equivalent failure signal.

Test-only change `websocket_handler.go` (production code) is untouched confirmed via `git diff` before committing.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
