### PR TITLE
TAS: enable nodeports plugin in WAS simulator for hostPort feasibility

### DIFF
--- a/pkg/cache/scheduler/scheduling_simulator_default.go
+++ b/pkg/cache/scheduler/scheduling_simulator_default.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
@@ -37,9 +38,13 @@ func newDefaultSimulator() simulator.SchedulingSimulator {
 	return &defaultSimulator{}
 }
 
-func (s *defaultSimulator) NewFeasibilityChecker(_ context.Context, nodes []*corev1.Node) (simulator.NodeFeasibilityChecker, error) {
+func (s *defaultSimulator) NewFeasibilityChecker(_ context.Context, _ []*corev1.Node) (simulator.NodeFeasibilityChecker, error) {
 	return &defaultChecker{}, nil
 }
+
+func (s *defaultSimulator) TrackPod(_ *corev1.Pod) {}
+
+func (s *defaultSimulator) UntrackPod(_ client.ObjectKey) {}
 
 type defaultChecker struct{}
 

--- a/pkg/cache/scheduler/simulator/interface.go
+++ b/pkg/cache/scheduler/simulator/interface.go
@@ -21,6 +21,7 @@ import (
 	"iter"
 
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NodeFeasibilityChecker determines which topology leaves can satisfy pod requirements.
@@ -28,9 +29,14 @@ type NodeFeasibilityChecker interface {
 	FindFeasibleNodes(ctx context.Context, candidates iter.Seq[Candidate], requirements *PodRequirements, stats *NodeExclusionStats) ([]MatchedCandidate, error)
 }
 
-// SchedulingSimulator acts as a factory for the feasibility checker.
+// SchedulingSimulator acts as a factory for the feasibility checker and
+// maintains any per-pod state that its plugins require (e.g. hostPort tracking).
 type SchedulingSimulator interface {
 	NewFeasibilityChecker(ctx context.Context, nodes []*corev1.Node) (NodeFeasibilityChecker, error)
+	// TrackPod notifies the simulator that a pod is running on a node.
+	TrackPod(pod *corev1.Pod)
+	// UntrackPod notifies the simulator that a pod has been removed.
+	UntrackPod(key client.ObjectKey)
 }
 
 func AsCandidates[C Candidate](seq iter.Seq[C]) iter.Seq[Candidate] {

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -127,14 +127,24 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 	}
 }
 
-// Update may add a pod to the cache, or
-// delete a terminated pod.
-func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) {
+// UpdateNonTASUsage updates the non-TAS resource usage cache for the pod.
+func (t *tasCache) UpdateNonTASUsage(pod *corev1.Pod, log logr.Logger) {
 	t.nonTasUsageCache.update(pod, log)
 }
 
-func (t *tasCache) DeletePodByKey(key client.ObjectKey, log logr.Logger) {
+// DeleteNonTASUsageByKey removes the pod from the non-TAS resource usage cache.
+func (t *tasCache) DeleteNonTASUsageByKey(key client.ObjectKey, log logr.Logger) {
 	t.nonTasUsageCache.delete(key, log)
+}
+
+// TrackPod notifies the scheduling simulator that a pod is running on a node.
+func (t *tasCache) TrackPod(pod *corev1.Pod) {
+	t.schedulingSimulator.TrackPod(pod)
+}
+
+// UntrackPod notifies the scheduling simulator that a pod has been removed.
+func (t *tasCache) UntrackPod(key client.ObjectKey) {
+	t.schedulingSimulator.UntrackPod(key)
 }
 
 func (t *tasCache) SyncNode(node *corev1.Node) {

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -7831,7 +7831,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 					NodeLabels:   tc.nodeLabels,
 				}
 				for _, pod := range tc.pods {
-					tasCache.Update(&pod, log)
+					tasCache.UpdateNonTASUsage(&pod, log)
 				}
 				tasFlavorCache := tasCache.NewTASFlavorCache(topologyInformation, flavorInformation)
 				if len(tc.priorOwnUsage) > 0 {
@@ -8303,7 +8303,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 				tasCache.SyncNode(&tc.nodes[i])
 			}
 			for i := range tc.pods {
-				tasCache.Update(&tc.pods[i], log)
+				tasCache.UpdateNonTASUsage(&tc.pods[i], log)
 			}
 			tcLevels := tc.levels
 			if tcLevels == nil {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -100,7 +100,7 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 						Request(corev1.ResourceMemory, "1Gi").
 						StatusPhase(corev1.PodRunning).
 						Obj()
-					tasCache.Update(pod, log)
+					tasCache.UpdateNonTASUsage(pod, log)
 				}
 			}
 

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -6,16 +6,23 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/backend/cache"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/scheduler-library/pkg/framework"
 	schedLibSimulator "sigs.k8s.io/scheduler-library/pkg/simulator"
 	schedLibSnapshot "sigs.k8s.io/scheduler-library/pkg/upstreamsync/snapshot"
 
@@ -23,16 +30,35 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 )
 
-type wasSimulator struct {
-	sim *schedLibSimulator.SchedulingSimulator
+type snapshotFactory func(ctx context.Context, pods []*corev1.Pod, nodes []*corev1.Node) (*schedLibSnapshot.ClusterSnapshot, error)
+
+// podTracker maintains per-node pod state for scheduler plugins that need
+// existing pod information.
+type podTracker struct {
+	mu sync.RWMutex
+	// podsByNode maps node names to the set of tracked pods on that node.
+	podsByNode map[string]map[types.UID]*corev1.Pod
+	// podIndex maps each tracked pod to its current node so that TrackPod can
+	// remove the old entry when a pod migrates between nodes.
+	podIndex map[types.NamespacedName]podNodeInfo
 }
 
-func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.SchedulingSimulator, error) {
-	cfg := &schedulerconfig.KubeSchedulerConfiguration{
+// podNodeInfo records which node a tracked pod is placed on.
+type podNodeInfo struct {
+	nodeName string
+	podUID   types.UID
+}
+
+type wasSimulator struct {
+	newSnapshot snapshotFactory
+	pods        podTracker
+}
+
+func newWASSchedulerConfig() *schedulerconfig.KubeSchedulerConfiguration {
+	return &schedulerconfig.KubeSchedulerConfiguration{
 		Profiles: []schedulerconfig.KubeSchedulerProfile{
 			{
 				SchedulerName: "default-scheduler",
-				// List of plugins available in the Kubernetes scheduler by default:
 				// https://kubernetes.io/docs/reference/scheduling/config/#scheduling-plugins
 				Plugins: &schedulerconfig.Plugins{
 					QueueSort: schedulerconfig.PluginSet{
@@ -45,11 +71,13 @@ func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.Sc
 						Enabled: []schedulerconfig.Plugin{
 							{Name: tainttoleration.Name},
 							{Name: nodeaffinity.Name},
+							{Name: nodeports.Name},
 						},
 					},
 					PreFilter: schedulerconfig.PluginSet{
 						Enabled: []schedulerconfig.Plugin{
 							{Name: nodeaffinity.Name},
+							{Name: nodeports.Name},
 						},
 					},
 				},
@@ -62,34 +90,114 @@ func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.Sc
 			},
 		},
 	}
+}
 
-	roClient, err := schedLibSimulator.NewReadonlyClient(restConfig)
-	if err != nil {
+func newWASSimulator(ctx context.Context, client kubernetes.Interface) (simulator.SchedulingSimulator, error) {
+	cfg := newWASSchedulerConfig()
+	informerFactory := informers.NewSharedInformerFactory(client, 0)
+
+	// Register node and pod informers with the factory; sync errors are caught by AsError() below.
+	_ = informerFactory.Core().V1().Nodes().Informer()
+	_ = informerFactory.Core().V1().Pods().Informer()
+	informerFactory.StartWithContext(ctx)
+	if err := informerFactory.WaitForCacheSyncWithContext(ctx).AsError(); err != nil {
 		return nil, err
 	}
 
-	// Use a fake client to not maintain any informer stores for the integration,
-	// as the plugins that are currently in use do not require any state.
-	// In the future, when using plugins like DRA, which rely on the informers,
-	// the InformerFactory has to be properly populated (for example by passing `nil`
-	// to `NewSchedulingSimulator`, which instantiates the default informers).
-	fakeClient := fake.NewSimpleClientset()
-	informerFactory := informers.NewSharedInformerFactory(fakeClient, 0)
-
-	sim, err := schedLibSimulator.NewSchedulingSimulator(ctx, cfg, roClient, informerFactory)
-	if err != nil {
-		return nil, err
+	snapshotFn := func(ctx context.Context, pods []*corev1.Pod, nodes []*corev1.Node) (*schedLibSnapshot.ClusterSnapshot, error) {
+		snap := cache.NewSnapshot(pods, nodes)
+		profiles, err := framework.NewProfileMap(ctx, client, informerFactory, snap, cfg)
+		if err != nil {
+			return nil, err
+		}
+		return schedLibSnapshot.New(snap, profiles), nil
 	}
 
-	return &wasSimulator{sim: sim}, nil
+	return &wasSimulator{
+		newSnapshot: snapshotFn,
+		pods: podTracker{
+			podsByNode: make(map[string]map[types.UID]*corev1.Pod),
+			podIndex:   make(map[types.NamespacedName]podNodeInfo),
+		},
+	}, nil
+}
+
+// NewWASSimulatorForTest creates a WAS simulator backed by a fake client,
+// suitable for unit tests that need the full production plugin pipeline.
+func NewWASSimulatorForTest(ctx context.Context) (simulator.SchedulingSimulator, error) {
+	return newWASSimulator(ctx, fake.NewSimpleClientset())
+}
+
+func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.SchedulingSimulator, error) {
+	// TODO(#13534): when DRA plugins are added, use a real client here
+	// instead of the fake so the informer factory is populated.
+	if _, err := schedLibSimulator.NewReadonlyClient(restConfig); err != nil {
+		return nil, err
+	}
+	return newWASSimulator(ctx, fake.NewSimpleClientset())
 }
 
 func (s *wasSimulator) NewFeasibilityChecker(ctx context.Context, nodes []*corev1.Node) (simulator.NodeFeasibilityChecker, error) {
-	clusterSnap, err := s.sim.NewClusterSnapshot(ctx, nil, nodes)
+	pods := s.pods.podsForNodes(nodes)
+	clusterSnap, err := s.newSnapshot(ctx, pods, nodes)
 	if err != nil {
 		return nil, err
 	}
 	return &wasChecker{snap: clusterSnap}, nil
+}
+
+func (s *wasSimulator) TrackPod(pod *corev1.Pod) {
+	s.pods.track(pod)
+}
+
+func (s *wasSimulator) UntrackPod(key types.NamespacedName) {
+	s.pods.untrack(key)
+}
+
+func (t *podTracker) podsForNodes(nodes []*corev1.Node) []*corev1.Pod {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var pods []*corev1.Pod
+	for _, node := range nodes {
+		for _, pod := range t.podsByNode[node.Name] {
+			pods = append(pods, pod)
+		}
+	}
+	return pods
+}
+
+func (t *podTracker) track(pod *corev1.Pod) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := client.ObjectKeyFromObject(pod)
+	if old, found := t.podIndex[key]; found {
+		delete(t.podsByNode[old.nodeName], old.podUID)
+		if len(t.podsByNode[old.nodeName]) == 0 {
+			delete(t.podsByNode, old.nodeName)
+		}
+	}
+	node := pod.Spec.NodeName
+	if t.podsByNode[node] == nil {
+		t.podsByNode[node] = make(map[types.UID]*corev1.Pod)
+	}
+	t.podsByNode[node][pod.UID] = pod
+	t.podIndex[key] = podNodeInfo{nodeName: node, podUID: pod.UID}
+}
+
+func (t *podTracker) untrack(key types.NamespacedName) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	old, found := t.podIndex[key]
+	if !found {
+		return
+	}
+	delete(t.podsByNode[old.nodeName], old.podUID)
+	if len(t.podsByNode[old.nodeName]) == 0 {
+		delete(t.podsByNode, old.nodeName)
+	}
+	delete(t.podIndex, key)
 }
 
 type wasChecker struct {

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -1,0 +1,205 @@
+//go:build !exclude_scheduler_library
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package was
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+type testCandidate struct {
+	node          *corev1.Node
+	id            utiltas.TopologyDomainID
+	affinityScore int64
+}
+
+func (c *testCandidate) GetNode() *corev1.Node           { return c.node }
+func (c *testCandidate) GetID() utiltas.TopologyDomainID { return c.id }
+func (c *testCandidate) GetAffinityScore() int64         { return c.affinityScore }
+func (c *testCandidate) SetAffinityScore(score int64)    { c.affinityScore = score }
+
+func TestNodePortsFeasibility(t *testing.T) {
+	ctx := t.Context()
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{corev1.LabelHostname: "node1"}},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	nodes := []*corev1.Node{node1, node2}
+
+	existingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "default", UID: "uid-1"},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			Containers: []corev1.Container{{
+				Name:  "c",
+				Image: "busybox",
+				Ports: []corev1.ContainerPort{{
+					ContainerPort: 8080,
+					HostPort:      8080,
+					Protocol:      corev1.ProtocolTCP,
+				}},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	tests := map[string]struct {
+		pods         []*corev1.Pod
+		candidatePod corev1.PodTemplateSpec
+		wantFeasible map[string]bool
+	}{
+		"hostPort conflict excludes node with occupied port": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+							HostPort:      8080,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node2": true},
+		},
+		"different hostPort has no conflict": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 9090,
+							HostPort:      9090,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+		"pod without hostPort passes through unaffected": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+		"no existing pods means all nodes feasible": {
+			pods: nil,
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+							HostPort:      8080,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim, err := NewWASSimulatorForTest(ctx)
+			if err != nil {
+				t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+			}
+
+			candidates := func(yield func(simulator.Candidate) bool) {
+				for _, n := range nodes {
+					if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+						return
+					}
+				}
+			}
+
+			for _, pod := range tc.pods {
+				sim.TrackPod(pod)
+			}
+			checker, err := sim.NewFeasibilityChecker(ctx, nodes)
+			if err != nil {
+				t.Fatalf("NewFeasibilityCheckerWithPods failed: %v", err)
+			}
+
+			stats := &simulator.NodeExclusionStats{}
+			results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+				PodTemplate: &tc.candidatePod,
+			}, stats)
+			if err != nil {
+				t.Fatalf("FindFeasibleNodes failed: %v", err)
+			}
+
+			gotNames := make(map[string]bool)
+			for _, r := range results {
+				gotNames[r.GetNode().Name] = true
+			}
+
+			if len(gotNames) != len(tc.wantFeasible) {
+				t.Errorf("got feasible nodes %v, want %v", gotNames, tc.wantFeasible)
+				return
+			}
+			for n := range tc.wantFeasible {
+				if !gotNames[n] {
+					t.Errorf("expected node %s to be feasible, got %v", n, gotNames)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/tas/constants.go
+++ b/pkg/controller/tas/constants.go
@@ -23,7 +23,7 @@ const (
 	TASResourceFlavorController = "tas-resource-flavor-controller"
 	TASTopologyUngater          = "tas-topology-ungater"
 	TASNodeController           = "tas-node-controller"
-	TASNonTasUsageController    = "tas-non-tas-usage-controller"
+	TASPodUsageController       = "tas-pod-usage-controller"
 )
 
 const (

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -43,8 +43,8 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 	if ctrlName, err := nodeRec.SetupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}
-	nonTasUsageController := newNonTasUsageReconciler(mgr.GetClient(), cache, roleTracker)
-	if ctrlName, err := nonTasUsageController.SetupWithManager(mgr); err != nil {
+	podUsageController := newPodUsageReconciler(mgr.GetClient(), cache, roleTracker)
+	if ctrlName, err := podUsageController.SetupWithManager(mgr); err != nil {
 		return ctrlName, err
 	}
 	return "", nil

--- a/pkg/controller/tas/pod_usage_controller.go
+++ b/pkg/controller/tas/pod_usage_controller.go
@@ -36,30 +36,31 @@ import (
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
-func newNonTasUsageReconciler(k8sClient client.Client, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *NonTasUsageReconciler {
-	return &NonTasUsageReconciler{
+func newPodUsageReconciler(k8sClient client.Client, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *PodUsageReconciler {
+	return &PodUsageReconciler{
 		k8sClient:   k8sClient,
 		cache:       cache,
 		roleTracker: roleTracker,
 	}
 }
 
-// NonTasUsageReconciler monitors pods to update
-// the TAS cache with non-TAS usage.
-type NonTasUsageReconciler struct {
+// PodUsageReconciler monitors all scheduled pods to update the TAS cache
+// with non-TAS resource usage and to feed the scheduling simulator with
+// pod state for feasibility checks.
+type PodUsageReconciler struct {
 	k8sClient   client.Client
 	cache       *schdcache.Cache
 	roleTracker *roletracker.RoleTracker
 }
 
-var _ reconcile.Reconciler = (*NonTasUsageReconciler)(nil)
-var _ predicate.TypedPredicate[*corev1.Pod] = (*NonTasUsageReconciler)(nil)
+var _ reconcile.Reconciler = (*PodUsageReconciler)(nil)
+var _ predicate.TypedPredicate[*corev1.Pod] = (*PodUsageReconciler)(nil)
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
-func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PodUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := klog.FromContext(ctx).WithValues("pod", req.NamespacedName)
-	log.V(3).Info("Non-TAS usage cache reconciling")
+	log.V(3).Info("Pod usage cache reconciling")
 	var pod corev1.Pod
 	err := r.k8sClient.Get(ctx, req.NamespacedName, &pod)
 	if err != nil {
@@ -67,16 +68,27 @@ func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		log.V(5).Info("Idempotently deleting not found pod")
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
+		r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log)
+		r.cache.TASCache().UntrackPod(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
-	if belongsToNonTASCache(&pod) {
-		r.cache.TASCache().Update(&pod, log)
+	if isScheduledAndRunning(&pod) {
+		r.cache.TASCache().TrackPod(&pod)
 	} else {
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
+		r.cache.TASCache().UntrackPod(req.NamespacedName)
+	}
+
+	if belongsToNonTASCache(&pod) {
+		r.cache.TASCache().UpdateNonTASUsage(&pod, log)
+	} else {
+		r.cache.TASCache().DeleteNonTASUsageByKey(req.NamespacedName, log)
 	}
 	return ctrl.Result{}, nil
+}
+
+func isScheduledAndRunning(pod *corev1.Pod) bool {
+	return pod != nil && len(pod.Spec.NodeName) > 0 && !utilpod.IsTerminated(pod)
 }
 
 func belongsToNonTASCache(pod *corev1.Pod) bool {
@@ -87,7 +99,6 @@ func belongsToNonTASCache(pod *corev1.Pod) bool {
 		return false
 	}
 	if len(pod.Spec.NodeName) == 0 {
-		// Skip unscheduled pods as they don't use any capacity.
 		return false
 	}
 	if utilpod.IsTerminated(pod) {
@@ -96,33 +107,26 @@ func belongsToNonTASCache(pod *corev1.Pod) bool {
 	return true
 }
 
-func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
-	return belongsToNonTASCache(e.Object)
+func (r *PodUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
+	return isScheduledAndRunning(e.Object)
 }
 
-func shouldReconcilePodUpdate(oldPod, newPod *corev1.Pod) bool {
-	return belongsToNonTASCache(oldPod) != belongsToNonTASCache(newPod)
+func (r *PodUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
+	return isScheduledAndRunning(e.ObjectOld) != isScheduledAndRunning(e.ObjectNew) ||
+		belongsToNonTASCache(e.ObjectOld) != belongsToNonTASCache(e.ObjectNew)
 }
 
-func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
-	return shouldReconcilePodUpdate(e.ObjectOld, e.ObjectNew)
+func (r *PodUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
+	return len(e.Object.Spec.NodeName) > 0
 }
 
-func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {
-	// Don't filter on terminal phase: if the informer skips the Running→Terminated
-	// Update and delivers only the Delete event with the pod already Succeeded/Failed,
-	// the pod's usage would never be removed from the cache. DeletePodByKey is
-	// idempotent, so double-removal is safe.
-	return len(e.Object.Spec.NodeName) > 0 && !utiltas.IsTAS(e.Object)
-}
-
-func (r *NonTasUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {
+func (r *PodUsageReconciler) Generic(event.TypedGenericEvent[*corev1.Pod]) bool {
 	return false
 }
 
-func (r *NonTasUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, error) {
-	return TASNonTasUsageController, ctrl.NewControllerManagedBy(mgr).
-		Named(TASNonTasUsageController).
+func (r *PodUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, error) {
+	return TASPodUsageController, ctrl.NewControllerManagedBy(mgr).
+		Named(TASPodUsageController).
 		WatchesRawSource(source.TypedKind(
 			mgr.GetCache(),
 			&corev1.Pod{},
@@ -133,6 +137,6 @@ func (r *NonTasUsageReconciler) SetupWithManager(mgr ctrl.Manager) (string, erro
 			NeedLeaderElection:      new(false),
 			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[corev1.SchemeGroupVersion.WithKind("Pod").GroupKind().String()],
 		}).
-		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASNonTasUsageController)).
+		WithLogConstructor(roletracker.NewLogConstructor(r.roleTracker, TASPodUsageController)).
 		Complete(r)
 }

--- a/pkg/controller/tas/pod_usage_controller_test.go
+++ b/pkg/controller/tas/pod_usage_controller_test.go
@@ -76,8 +76,8 @@ func TestBelongsToNonTASCache(t *testing.T) {
 	}
 }
 
-func TestNonTasUsageReconcilerCreate(t *testing.T) {
-	reconciler := &NonTasUsageReconciler{}
+func TestPodUsageReconcilerCreate(t *testing.T) {
+	reconciler := &PodUsageReconciler{}
 
 	tests := []struct {
 		name string
@@ -100,7 +100,7 @@ func TestNonTasUsageReconcilerCreate(t *testing.T) {
 				NodeName("node-a").
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
 				Obj(),
-			want: false,
+			want: true,
 		},
 		{
 			name: "terminated scheduled non-TAS pod",
@@ -118,14 +118,9 @@ func TestNonTasUsageReconcilerCreate(t *testing.T) {
 	}
 }
 
-func TestNonTasUsageReconcilerDelete(t *testing.T) {
-	reconciler := &NonTasUsageReconciler{}
+func TestPodUsageReconcilerDelete(t *testing.T) {
+	reconciler := &PodUsageReconciler{}
 
-	// Delete should return true for any scheduled non-TAS pod regardless of phase,
-	// so that we always attempt to remove it from the cache. The informer may deliver
-	// the Delete event with the pod already Succeeded if it missed the Running→Succeeded
-	// Update; without reconciling in that case, the pod's usage would never be subtracted.
-	// DeletePodByKey is idempotent, so double-removal is safe.
 	tests := []struct {
 		name string
 		pod  *corev1.Pod
@@ -147,7 +142,7 @@ func TestNonTasUsageReconcilerDelete(t *testing.T) {
 				NodeName("node-a").
 				Annotation(kueue.PodSetRequiredTopologyAnnotation, "rack").
 				Obj(),
-			want: false,
+			want: true,
 		},
 		{
 			name: "terminated scheduled non-TAS pod",
@@ -165,7 +160,7 @@ func TestNonTasUsageReconcilerDelete(t *testing.T) {
 	}
 }
 
-func TestShouldReconcilePodUpdate(t *testing.T) {
+func TestPodUsageReconcilerUpdatePredicate(t *testing.T) {
 	tests := []struct {
 		name   string
 		oldPod *corev1.Pod
@@ -244,18 +239,22 @@ func TestShouldReconcilePodUpdate(t *testing.T) {
 		},
 	}
 
+	reconciler := &PodUsageReconciler{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldReconcilePodUpdate(tc.oldPod, tc.newPod)
+			got := reconciler.Update(event.TypedUpdateEvent[*corev1.Pod]{
+				ObjectOld: tc.oldPod,
+				ObjectNew: tc.newPod,
+			})
 			if got != tc.want {
-				t.Errorf("shouldReconcilePodUpdate() = %v, want %v", got, tc.want)
+				t.Errorf("Update() = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestNonTasUsageReconcilerUpdate(t *testing.T) {
-	reconciler := &NonTasUsageReconciler{}
+func TestPodUsageReconcilerUpdate(t *testing.T) {
+	reconciler := &PodUsageReconciler{}
 	oldPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj()
 	newPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj()
 

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3524,7 +3524,7 @@ func TestScheduleForTAS(t *testing.T) {
 						}
 					}
 					for _, pod := range tc.pods {
-						cqCache.TASCache().Update(&pod, log)
+						cqCache.TASCache().UpdateNonTASUsage(&pod, log)
 					}
 					initiallyAdmittedWorkloads := sets.New[workload.Reference]()
 					for _, w := range testWls {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area was


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Partially addresses https://github.com/kubernetes-sigs/kueue/issues/13534

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: enable hostPort conflict detection to node feasibility checks, skipping nodes with occupied host ports when `SchedulerLibraryIntegration` is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scheduling now maintains pod-specific state as pods are added, updated, or removed.
  * Feasibility checks use current pod placement and account for `hostPort` and protocol conflicts.
  * Scheduler evaluations now use up-to-date snapshots of nodes and tracked pods.

* **Bug Fixes**
  * Prevents scheduling candidates from being considered feasible when their requested port is already in use.
  * Ensures removed pods no longer block their previously reserved ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->