### PR TITLE
self-nominate amy as approver for pkg/scheduler

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -30,6 +30,8 @@ aliases:
     - amy
     - kannon92
     - pbundyra
+  scheduler-approvers:
+    - amy
   hugo-approvers:
     - mbobrovskyi
   infra-approvers:

--- a/pkg/scheduler/OWNERS
+++ b/pkg/scheduler/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- scheduler-approvers


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Self-nomination for approver on `pkg/scheduler/`. (Plainly, I've clocked in ALOT of time debugging scheduler.go core production issues and feel qualified to review bugs related to scheduling logic.)

I have been working on Kueue's scheduling path from the production-operator side: reporting and root-causing scheduling bugs hit, breaking them into tractable upstream issues, and reviewing the fixes. I am currently in `kueue-reviewers`, and an approver for `agent-approvers`.

This PR adds a `scheduler-approvers` alias and a `pkg/scheduler/OWNERS` that references it. 

<details>
<summary><b>1. Head-of-ClusterQueue blocking</b></summary>

I defined this problem class for the project, decomposed it into sub-issues, and drove the design discussion that led to the merged fix.

- #6970 — Head of CQ Blocking Tracker, the umbrella issue collecting the class.
- #6143 — Serialized pod preemption problem for scheduler. Separated the failure into two orthogonal axes that the project then used as shared vocabulary: horizontal stalls across CQs on preemption-target overlap within a single `schedule()` invocation, and vertical stalls within a CQ waiting on preemption completion across invocations.
- #6488, #6489, #6496, #6260 — sub-issues split out of #6143, with implementation plans naming the specific `pkg/scheduler/scheduler.go` blocks involved.
- #6929 — proposed the "keep popping until an admissible head, stop at a priority change" approach, and argued against time-based backoff because it lets a lower-priority workload slip in during the backoff window and violate in-CQ priority ordering. This is the direction gabesaba implemented in #7157 (`[BestEffortFIFO] Implement Sticky ClusterQueue Head Policy`).
- #6947 — on gabesaba's inadmissible-workload-blocks-CQ report, made the same argument against exponential backoff and folded the thread into the tracker.
- #7301 — triaged the sticky-head regression report, separating "one extra preemption" from "infinite preemption loop" before it was escalated further.

My own attempt at the horizontal half was #6541, which touched `pkg/scheduler/scheduler.go`, `preemption/preemption.go`, `preemption/preempted_workloads.go`, `preemption/classical/candidate_generator.go`, and `cache/scheduler/clusterqueue_snapshot.go`. I closed it in favour of the upstream direction; mimowo's #12419 covers that half now. Supporting artifacts: KEP #6776 and e2e reproduction #6125.

</details>

<details>
<summary><b>2. Fair sharing / DRS debugging</b></summary>

- #6577 — reported CQs failing to reclaim guarantees under fair sharing, and traced it to DRS/DWS integer division rounding to zero for high-weight ClusterQueues. I built an instrumented image (#6593) with the exact rounding-detection logging, ran it in production, and confirmed DRS=0 values in tournament logs for CQs that were demonstrably borrowing. pajakd's #6617 fixed it; gabesaba's #6925 then removed the `max(1, int(dws))` special case and cites #6577 in its description.
- #6621 — follow-up on what the tiebreaker should be for DWS values that collapse into the same integer bucket, since `max(1, int(dws))` makes very different borrowing/weight combinations compare equal.
- #7101 — `LessThanOrEqualToFinalShare` plus infinite preemption on v0.13.5, with a minimal repro and a full tournament DRS log dump.
- #6219 — reclamation disappeared as a preemption reason after enabling fair sharing, found across several days of production preemption-reason data.
- #6581 — proposal to allow one preemption target to be attributed to multiple preemptors.
- #10171 — on tskillian's `borrowWithinCohort` proposal, pushed back on the premise that a workload inside nominal quota can be preempted at all, asked for an e2e demonstrating it, and flagged the interaction with `reclaimWithinCohort`.

</details>

<details>
<summary><b>3. Merged code in the scheduler tree</b></summary>

- #6656 — logging to verify target selection for fair sharing (`pkg/scheduler/logging.go`, `preemption/preemption.go`, `pkg/util/logging/logging.go`)
- #6669 — compile-time check that `Target` implements `ObjectRefProvider` (`preemption/preemption.go`)
- #6873 — workload and job UIDs in preemption logs (`preemption/preemption.go`)
- #5923 — metric for duration between workload podsReady and preemption (`preemption/preemption.go`, `pkg/metrics`, `pkg/workload`)
- #10485 — pending workload resource metric (`pkg/scheduler/flavorassigner/flavorassigner.go`, `pkg/cache/queue`, `pkg/metrics`)
- #5985 and cherry-pick #6027 — incorrect admission from wrong borrowable resource when a ClusterQueue in a cohort is deleted (`pkg/cache`, scheduler integration tests)
- #6819 — fixed `Previously` prefixing on preemption/eviction conditions
- #6032 — cleaned up silenced errors in `pkg/cache`

The `Preempted` event and condition message format that the `kueue-who-preempted` runbook relies on came out of this line of work.

</details>

<details>
<summary><b>4. Review record on scheduler-area PRs</b></summary>

- #11252 metrics: workload-level preemption count gauge — corrected the stated rationale for choosing a Gauge over a Counter (`CounterVec` supports `DeletePartialMatch` the same way, and `ClearClusterQueueMetrics` already relies on it), asked for a feature gate given per-workload cardinality following the `LocalQueueMetrics` precedent, and caught that clearing preemption history on the first finished reconcile defeats `workloadRetention.afterFinished`.
- #7338 Expose contextualized fair sharing weights for ClusterQueues as metrics — argued the DRS values are only meaningful grouped within a tournament, and worked through whether scheduling-cycle correlation belongs in the metric or in logs given a 15s scrape interval.
- #7117 Introduce `MayStopSearch` in place of `Borrow`/`Preempt` — reviewed the flavor-fungibility semantics and proposed clearer wording for the `ReadyToUse` / `TryNextFlavor` field documentation.
- #6925 [Fair Sharing] Fix Rounding Bug — the follow-up that removed the `max(1, int(dws))` special case across `fair_sharing_iterator.go` and `preemption/fairsharing/`.
- #6617 Fix fairsharing reclamation bug — the fix for the DRS rounding bug I reported in #6577.

Adjacent admission and quota reviews: #13044, #12766, #13178, #13126, #13486 — the reclaimable-pods and quota-leak series. Scheduling KEP reviews:  #11720 (observability of inadmissible workloads), #10145 (MultiKueue Global Quotas), #8864 (Uber ClusterQueues).

</details>

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

One thing to weigh openly: I have no merged commit that modifies `pkg/scheduler/scheduler.go` itself. My merged code in this tree is in `logging.go`, `preemption/preemption.go`, and `flavorassigner/flavorassigner.go`. The case here rests on problem ownership, review depth in `preemption/` and fair sharing, and the report-to-upstream-fix chains above rather than on line count in that one file. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
