### PR TITLE
Fix scheduler panic when logging a TAS domain without usage

### DIFF
--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package scheduler
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -30,10 +32,12 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
+	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -890,6 +894,100 @@ func TestSnapshot(t *testing.T) {
 						}
 					}
 				}
+			}
+		})
+	}
+}
+
+// TestSnapshotLog is a sanity check for logging the snapshot, which the
+// scheduler does on every scheduling cycle when running with high verbosity.
+func TestSnapshotLog(t *testing.T) {
+	testCases := map[string]struct {
+		nodes []*corev1.Node
+		// wantFreeCapacityPerDomain holds one entry per logged "TAS Snapshot
+		// Free Capacity" line, so a case can also assert that nothing is logged.
+		wantFreeCapacityPerDomain []any
+	}{
+		"domain with capacity, but no admitted TAS workloads": {
+			nodes: []*corev1.Node{
+				node.MakeNode("node-a").
+					Label(corev1.LabelHostname, "node-a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			wantFreeCapacityPerDomain: []any{`{"node-a":{"freeCapacity":{"cpu":"2","pods":"10"},"tasUsage":{}}}`},
+		},
+		"multiple domains are reported in a stable order": {
+			nodes: []*corev1.Node{
+				node.MakeNode("node-b").
+					Label(corev1.LabelHostname, "node-b").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("5"),
+					}).
+					Ready().
+					Obj(),
+				node.MakeNode("node-a").
+					Label(corev1.LabelHostname, "node-a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			wantFreeCapacityPerDomain: []any{`{"node-a":{"freeCapacity":{"cpu":"2","pods":"10"},"tasUsage":{}},"node-b":{"freeCapacity":{"cpu":"1","pods":"5"},"tasUsage":{}}}`},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			clientBuilder := utiltesting.NewClientBuilder()
+			_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+			cache := New(clientBuilder.Build())
+
+			cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("tas-flavor").TopologyName("topology").Obj())
+			cache.AddOrUpdateTopology(log, utiltestingapi.MakeDefaultOneLevelTopology("topology"))
+			cq := utiltestingapi.MakeClusterQueue("tas-cq").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-flavor").Resource(corev1.ResourceCPU, "10").Obj()).
+				Obj()
+			if err := cache.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("Failed adding ClusterQueue: %v", err)
+			}
+			for _, n := range tc.nodes {
+				cache.TASCache().SyncNode(n)
+			}
+
+			snapshot, err := cache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("Failed building snapshot: %v", err)
+			}
+
+			var entries []map[string]any
+			capturingLog := funcr.NewJSON(func(obj string) {
+				entry := make(map[string]any)
+				if err := json.Unmarshal([]byte(obj), &entry); err != nil {
+					t.Errorf("Failed to parse log entry %q: %v", obj, err)
+					return
+				}
+				entries = append(entries, entry)
+			}, funcr.Options{})
+
+			snapshot.Log(capturingLog)
+
+			var gotFreeCapacityPerDomain []any
+			for _, entry := range entries {
+				if entry["msg"] == "TAS Snapshot Free Capacity" {
+					gotFreeCapacityPerDomain = append(gotFreeCapacityPerDomain, entry["freeCapacityPerDomain"])
+				}
+			}
+			if diff := cmp.Diff(tc.wantFreeCapacityPerDomain, gotFreeCapacityPerDomain); diff != "" {
+				t.Errorf("Unexpected logged TAS free capacity (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -375,54 +375,31 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
 }
 
-func (s *TASFlavorSnapshot) freeCapacityPerDomain() map[utiltas.TopologyDomainID]resources.Requests {
-	freeCapacityPerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
-
-	for domainID, leaf := range s.leaves {
-		freeCapacityPerDomain[domainID] = leaf.freeCapacity.Clone()
-	}
-
-	return freeCapacityPerDomain
-}
-
-func (s *TASFlavorSnapshot) tasUsagePerDomain() map[utiltas.TopologyDomainID]resources.Requests {
-	tasUsagePerDomain := make(map[utiltas.TopologyDomainID]resources.Requests, len(s.leaves))
-
-	for domainID, leaf := range s.leaves {
-		tasUsagePerDomain[domainID] = leaf.tasUsage.Clone()
-	}
-
-	return tasUsagePerDomain
-}
-
 type domainCapacityDetails struct {
 	FreeCapacity map[corev1.ResourceName]string `json:"freeCapacity"`
 	TasUsage     map[corev1.ResourceName]string `json:"tasUsage"`
 }
 
-func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
-	freeCapacityPerDomain := s.freeCapacityPerDomain()
-	tasUsagePerDomain := s.tasUsagePerDomain()
+func (s *TASFlavorSnapshot) resourceDetails(requests resources.Requests) map[corev1.ResourceName]string {
+	if requests == nil {
+		// A leaf keeps its requests nil until the first update, so a domain with
+		// capacity, but without admitted TAS workloads, has a nil tasUsage.
+		return map[corev1.ResourceName]string{}
+	}
+	details := make(map[corev1.ResourceName]string, requests.Len())
+	requests.ForEach(func(resourceName corev1.ResourceName, value int64) {
+		details[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
+	})
+	return details
+}
 
+func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
-	for _, domain := range slices.Sorted(maps.Keys(freeCapacityPerDomain)) {
-		freeCapacity := freeCapacityPerDomain[domain]
-		tasUsage := tasUsagePerDomain[domain]
-
-		freeCapacityDetails := make(map[corev1.ResourceName]string, freeCapacity.Len())
-		freeCapacity.ForEach(func(resourceName corev1.ResourceName, value int64) {
-			freeCapacityDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
-		})
-
-		tasUsageDetails := make(map[corev1.ResourceName]string, tasUsage.Len())
-		tasUsage.ForEach(func(resourceName corev1.ResourceName, value int64) {
-			tasUsageDetails[resourceName] = s.resourceFormatter.ResourceQuantityString(resourceName, value)
-		})
-
-		details[domain] = domainCapacityDetails{
-			FreeCapacity: freeCapacityDetails,
-			TasUsage:     tasUsageDetails,
+	for domainID, leaf := range s.leaves {
+		details[domainID] = domainCapacityDetails{
+			FreeCapacity: s.resourceDetails(leaf.freeCapacity),
+			TasUsage:     s.resourceDetails(leaf.tasUsage),
 		}
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -36,42 +36,84 @@ import (
 )
 
 func TestFreeCapacityPerDomain(t *testing.T) {
-	snapshot := &TASFlavorSnapshot{
-		leaves: leafDomainByID{
-			"domain2": &leafDomain{
-				freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
-					corev1.ResourceCPU:    1000,
-					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
-				}),
-				tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
-					corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
-					corev1.ResourceCPU:    500,
-				}),
+	cases := map[string]struct {
+		// leaves is a function, so that the requests are built with the
+		// VectorizedResourceRequests feature gate already set.
+		leaves   func() leafDomainByID
+		expected string
+	}{
+		"domains with free capacity and TAS usage": {
+			leaves: func() leafDomainByID {
+				return leafDomainByID{
+					"domain2": &leafDomain{
+						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+							corev1.ResourceCPU:    1000,
+							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
+						}),
+						tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
+							corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
+							corev1.ResourceCPU:    500,
+						}),
+					},
+					"domain1": &leafDomain{
+						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+							corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
+							corev1.ResourceCPU:    2000,
+							"nvidia.com/gpu":      1,
+						}),
+						tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
+							corev1.ResourceCPU:    500,
+							"nvidia.com/gpu":      1,
+							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
+						}),
+					},
+				}
 			},
-			"domain1": &leafDomain{
-				freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
-					corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
-					corev1.ResourceCPU:    2000,
-					"nvidia.com/gpu":      1,
-				}),
-				tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
-					corev1.ResourceCPU:    500,
-					"nvidia.com/gpu":      1,
-					corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
-				}),
+			expected: `{"domain1":{"freeCapacity":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"tasUsage":{"cpu":"500m","memory":"2Gi","nvidia.com/gpu":"1"}},"domain2":{"freeCapacity":{"cpu":"1","memory":"2Gi"},"tasUsage":{"cpu":"500m","memory":"1Gi"}}}`,
+		},
+		"domain with free capacity, but without TAS usage": {
+			leaves: func() leafDomainByID {
+				return leafDomainByID{
+					"domain1": &leafDomain{
+						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+							corev1.ResourceCPU: 1000,
+						}),
+						// tasUsage is left nil, as there is no TAS workload
+						// admitted in the domain.
+					},
+				}
 			},
+			expected: `{"domain1":{"freeCapacity":{"cpu":"1"},"tasUsage":{}}}`,
+		},
+		"domain without free capacity and without TAS usage": {
+			leaves: func() leafDomainByID {
+				return leafDomainByID{"domain1": &leafDomain{}}
+			},
+			expected: `{"domain1":{"freeCapacity":{},"tasUsage":{}}}`,
+		},
+		"snapshot without domains": {
+			leaves:   func() leafDomainByID { return leafDomainByID{} },
+			expected: `{}`,
 		},
 	}
 
-	expected := `{"domain1":{"freeCapacity":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"tasUsage":{"cpu":"500m","memory":"2Gi","nvidia.com/gpu":"1"}},"domain2":{"freeCapacity":{"cpu":"1","memory":"2Gi"},"tasUsage":{"cpu":"500m","memory":"1Gi"}}}`
-	var wantErr error
+	for name, tc := range cases {
+		for _, enableVectorizedRequests := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s, VectorizedResourceRequests=%t", name, enableVectorizedRequests), func(t *testing.T) {
+				features.SetFeatureGateDuringTest(t, features.VectorizedResourceRequests, enableVectorizedRequests)
 
-	got, gotErr := snapshot.SerializeFreeCapacityPerDomain()
-	if diff := cmp.Diff(wantErr, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
-		t.Errorf("Unexpected error (-want,+got):\n%s", diff)
-	}
-	if diff := cmp.Diff(expected, got); diff != "" {
-		t.Errorf("SerializeFreeCapacityPerDomain() mismatch (-expected +got):\n%s", diff)
+				snapshot := &TASFlavorSnapshot{leaves: tc.leaves()}
+				var wantErr error
+
+				got, gotErr := snapshot.SerializeFreeCapacityPerDomain()
+				if diff := cmp.Diff(wantErr, gotErr, cmpopts.EquateErrors()); len(diff) != 0 {
+					t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tc.expected, got); diff != "" {
+					t.Errorf("SerializeFreeCapacityPerDomain() mismatch (-expected +got):\n%s", diff)
+				}
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

`SerializeFreeCapacityPerDomain` panics on a nil `resources.Requests`. `resources.Requests` is an interface, and a leaf domain leaves `tasUsage` nil until the first TAS usage is accounted for, so calling `Clone()` on it dereferences nil. The result is a crash-looping scheduler on any TAS-enabled cluster running at `-v=6` that has a topology domain with capacity but no admitted TAS workloads.

The serialization only formats the requests, it never mutates them. So it now reads them directly and nil-checks instead of cloning into a `resources.CreateEmpty()` instance. That removes the panic and also drops a per-domain allocation from the logging path. A domain with no TAS usage serializes as `"tasUsage":{}`, so the output shape is unchanged.

Domain ordering is also unchanged. `details` is marshalled by `encoding/json`, which sorts map keys, so the output stays sorted without an explicit sort over `s.leaves`.

#### Which issue(s) this PR fixes:

Fixes #13426

#### Does this PR introduce a user-facing change?
```release-note
TAS: Fixed a bug where the scheduler panicked and crash-looped when logging the snapshot at verbosity `>= 6`, if a topology domain had capacity but no admitted TAS workloads.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TAS free-capacity reporting, including accurate resource usage details when capacity or usage data is missing or empty.
  - Ensured capacity information is consistently serialized across synchronized domains.

- **Tests**
  - Added coverage for TAS snapshot logs, including free CPU and pod capacity, stable domain ordering, and empty usage.
  - Expanded validation across populated, partially populated, and empty capacity scenarios, with vectorized resource requests enabled and disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->