### PR TITLE
[release-0.18] Guard against non-positive LocalQueue fair-sharing weight

### DIFF
--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -75,6 +75,10 @@ func TestScheduleForAFS(t *testing.T) {
 			FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
 			ClusterQueue("cq1").
 			Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-zero", "default").
+			FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("0"))}).
+			ClusterQueue("cq1").
+			Obj(),
 	}
 
 	cases := map[string]struct {
@@ -164,6 +168,94 @@ func TestScheduleForAFS(t *testing.T) {
 							).
 							Obj(),
 					).
+					Obj(),
+			},
+		},
+		// A LocalQueue with weight 0 must be the most disadvantaged, so its
+		// workload loses admission to a normal-weight queue even though it was
+		// submitted first. Both queues start idle on purpose: only 0 usage over
+		// 0 weight yields NaN, which sorts ahead of every real value; any
+		// non-zero usage already yields +Inf and sorts last.
+		"does not prioritize a zero-weight localqueue": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
+			initialUsage: map[string]corev1.ResourceList{
+				"lq-a":    {corev1.ResourceCPU: resource.MustParse("0")},
+				"lq-zero": {corev1.ResourceCPU: resource.MustParse("0")},
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-z1", "default").
+					Queue("lq-zero").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-a1", "default").
+					Queue("lq-a").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now.Add(1 * time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue cq1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("cq1").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment("one").
+									Assignment(corev1.ResourceCPU, "default", "8").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-z1", "default").
+					Queue("lq-zero").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor default, 8 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("8"),
+						},
+					}).
 					Obj(),
 			},
 		},

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"math"
 	"slices"
 	"strings"
 	"time"
@@ -479,6 +480,10 @@ func CalcFSUsageFromResources(consumed, penalty corev1.ResourceList, lqWeight fl
 			weight = 1
 		}
 		usage += weight * resVal.AsApproximateFloat64()
+	}
+	// Avoid dividing by a non-positive weight: 0/0 is NaN, which would sort the queue first instead of last.
+	if lqWeight <= 0 {
+		return math.Inf(1)
 	}
 	return usage / lqWeight
 }

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -3757,6 +3758,40 @@ func TestCalcFSUsageFromResourcesWithDRA(t *testing.T) {
 			got := CalcFSUsageFromResources(tc.consumed, tc.penalty, tc.lqWeight, tc.resWeights)
 			if got != tc.wantUsage {
 				t.Errorf("CalcFSUsageFromResources() = %v, want %v", got, tc.wantUsage)
+			}
+		})
+	}
+}
+
+func TestCalcFSUsageFromResourcesWithNonPositiveWeight(t *testing.T) {
+	tests := map[string]struct {
+		consumed corev1.ResourceList
+		lqWeight float64
+	}{
+		"zero weight, idle queue (no usage)": {
+			consumed: corev1.ResourceList{},
+			lqWeight: 0,
+		},
+		"zero weight, active queue": {
+			consumed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			lqWeight: 0,
+		},
+		"negative weight": {
+			consumed: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			lqWeight: -1,
+		},
+	}
+
+	// A non-positive weight must yield +Inf usage so the LocalQueue is sorted
+	// last in the admission order, never NaN (which would sort it first).
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := CalcFSUsageFromResources(tc.consumed, corev1.ResourceList{}, tc.lqWeight, nil)
+			if math.IsNaN(got) {
+				t.Fatalf("CalcFSUsageFromResources() = NaN, want +Inf")
+			}
+			if !math.IsInf(got, 1) {
+				t.Errorf("CalcFSUsageFromResources() = %v, want +Inf", got)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #13481 on release-0.18.

#13481: Guard against non-positive LocalQueue fair-sharing weight

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Backports #13481 to release-0.18. The change stops a LocalQueue with `fairSharing.weight: 0` from being treated as the *least* used queue: dividing usage by a zero weight yields `NaN` (for an idle queue, `0/0`), and `NaN` sorts ahead of every real value, so the zero-weight queue jumped to the front of the admission order instead of the back. A non-positive weight now returns `+Inf`, matching `DRS.PreciseWeightedShare`.

#### Which issue(s) this PR fixes:

Related to #13479

#### Special notes for your reviewer:

The conflict resolution is limited to the release-branch adaptation required by that relocation:

- `pkg/workload/workload.go` — the non-positive weight guard in `CalcFSUsageFromResources` (on main this is `admissionfairsharing.CalculateUsage`).
- `pkg/workload/workload_test.go` — the unit test, renamed to `TestCalcFSUsageFromResourcesWithNonPositiveWeight` to match the release-0.18 function, placed next to the existing `TestCalcFSUsageFromResourcesWithDRA`.
- `pkg/scheduler/scheduler_afs_test.go` — unchanged from the source PR; it applied cleanly.

`pkg/util/admissionfairsharing` is untouched on this branch.

Validation:

- `go test ./pkg/workload/... ./pkg/scheduler/... -count=1`
- `go vet ./pkg/workload/... ./pkg/scheduler/...`
- Confirmed the backport is not vacuous: with the guard reverted, `TestScheduleForAFS` fails on release-0.18, so the scheduler regression test still reproduces the original bug on this branch.

#### Does this PR introduce a user-facing change?

```release-note
AFS: Fixed a bug where a LocalQueue with `fairSharing.weight: 0` could be prioritized for admission instead of deprioritized when AdmissionFairSharing is enabled.
```
