### PR TITLE
Automated cherry pick of #13191: flake: Docker build failure during the e2e test CI pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=docker.io/library/golang:1.26
+ARG BUILDER_IMAGE=gcr.io/library/golang:1.26
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+ARG BUILDER_IMAGE=docker.io/library/golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=docker.io/library/golang:1.26@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+ARG BUILDER_IMAGE=docker.io/library/golang:1.26
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=gcr.io/library/golang:1.26
+ARG BUILDER_IMAGE=golang:1.26
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # defaulted ARGs need to be declared first
-ARG BUILDER_IMAGE=golang:1.26
+ARG BUILDER_IMAGE=golang:1.26@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 ARG BASE_IMAGE=gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 # compilation stage for the manager binary
 FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} AS builder

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ image-local-push: image-local-build
 
 .PHONY: image-build
 image-build:
+  $(HACK_DIR)/testing/retry.sh --attempts 5 --delay 2 --exponential --stream -- \
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_TAG) \
 		-t $(IMAGE_REPO):$(RELEASE_BRANCH) \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= golang:$(GO_VERSION)
+BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= docker.io/$(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
+BUILDER_IMAGE ?= docker.io/$(BASE_BUILDER_IMAGE):$(GO_VERSION)
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,14 @@ YAML_PROCESSOR_LOG_LEVEL ?= info
 
 IMAGE_PUSH_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh --attempts 7 --delay 2 --exponential --stream --continue-if "grep -qiE 'context deadline exceeded' {output}" -- env
 
+IMAGE_BUILD_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh \
+	--attempts 3 \
+	--delay 2 \
+	--exponential \
+	--stream \
+	--continue-if "grep -qiE '(context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized)' {output}" \
+	-- env
+
 MAKE_TIMING ?= $(if $(filter 1 true TRUE yes YES on ON,$(CI)),1,0)
 MAKE_TIMING_MIN_SECONDS ?= 1
 MAKE_TIMING_COMMANDS ?= 0
@@ -244,6 +252,7 @@ image-local-push: PUSH=--push
 image-local-push: image-local-build
 
 .PHONY: image-build
+image-build: IMAGE_BUILD_CMD := $(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD)
 image-build:
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_TAG) \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
+BUILDER_IMAGE ?= docker.io/$(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:32c0e6e5c4f6707717051091b4d0b077464a679eaab563e11474efc5328e2aa5
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info
@@ -245,7 +245,6 @@ image-local-push: image-local-build
 
 .PHONY: image-build
 image-build:
-  $(HACK_DIR)/testing/retry.sh --attempts 5 --delay 2 --exponential --stream -- \
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_TAG) \
 		-t $(IMAGE_REPO):$(RELEASE_BRANCH) \

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)
+BUILDER_IMAGE ?= $(BASE_BUILDER_IMAGE):$(GO_VERSION)@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= docker.io/$(BASE_BUILDER_IMAGE):$(GO_VERSION)
+BUILDER_IMAGE ?= gcr.io/library/$(BASE_BUILDER_IMAGE):$(GO_VERSION)
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ RAYMINI_VERSION ?= 0.0.4
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 BASE_IMAGE ?= gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 BASE_BUILDER_IMAGE ?= golang
-BUILDER_IMAGE ?= gcr.io/library/$(BASE_BUILDER_IMAGE):$(GO_VERSION)
+BUILDER_IMAGE ?= golang:$(GO_VERSION)
 CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,8 @@ CGO_ENABLED ?= 0
 
 YAML_PROCESSOR_LOG_LEVEL ?= info
 
-IMAGE_PUSH_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh --attempts 7 --delay 2 --exponential --stream --continue-if "grep -qiE 'context deadline exceeded' {output}" -- env
-
 IMAGE_BUILD_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh \
-	--attempts 3 \
+	--attempts 7 \
 	--delay 2 \
 	--exponential \
 	--stream \
@@ -247,7 +245,6 @@ image-local-build:
 
 # Build the multiplatform container image locally and push to repo.
 .PHONY: image-local-push
-image-local-push: export IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 image-local-push: PUSH=--push
 image-local-push: image-local-build
 
@@ -276,7 +273,6 @@ image-pushing-postsubmit:
 	$(MAKE) -j5 image-push helm-chart-push kueueviz-image-push kueue-populator-image-push kueue-priority-booster-image-push
 
 .PHONY: image-push
-image-push: IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 image-push: PUSH=--push
 image-push: image-build
 
@@ -425,7 +421,7 @@ update-security-insights: yq
 # Developers don't need to build this image, as it will be available as us-central1-docker.pkg.dev/k8s-staging-images/kueue/debug
 .PHONY: debug-image-push
 debug-image-push: ## Build and push the debug image to the registry
-	$(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD) \
+	$(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_REGISTRY)/debug:$(GIT_TAG) \
 		-t $(IMAGE_REGISTRY)/debug:$(RELEASE_BRANCH) \
 		--platform=$(PLATFORMS) \
@@ -437,6 +433,7 @@ importer-build:
 	$(GO_BUILD_ENV) $(GO_CMD) build -ldflags="$(LD_FLAGS)" -o bin/importer cmd/importer/main.go
 
 .PHONY: importer-image-build
+importer-image-build: IMAGE_BUILD_CMD := $(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD)
 importer-image-build:
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_REGISTRY)/importer:$(GIT_TAG) \
@@ -450,7 +447,6 @@ importer-image-build:
 		-f ./cmd/importer/Dockerfile ./
 
 .PHONY: importer-image-push
-importer-image-push: IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 importer-image-push: PUSH=--push
 importer-image-push: importer-image-build
 
@@ -463,6 +459,7 @@ importer-image: importer-image-build
 
 # Build the kueueviz dashboard images (frontend and backend)
 .PHONY: kueueviz-image-build
+kueueviz-image-build: IMAGE_BUILD_CMD := $(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD)
 kueueviz-image-build:
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_TAG_KUEUEVIZ_BACKEND) \
@@ -483,7 +480,6 @@ kueueviz-image-build:
 		-f ./cmd/kueueviz/frontend/Dockerfile ./cmd/kueueviz/frontend
 
 .PHONY: kueueviz-image-push
-kueueviz-image-push: IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 kueueviz-image-push: PUSH=--push
 kueueviz-image-push: kueueviz-image-build
 
@@ -497,6 +493,7 @@ kueueviz-image: kueueviz-image-build
 .PHONY: kueue-populator-image-build
 kueue-populator-image-build:
 	$(MAKE) -C cmd/experimental/kueue-populator image-build \
+	  IMAGE_BUILD_CMD="$(subst ",\",$(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD))" \
 		IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		IMAGE_TAG=$(IMAGE_TAG_KUEUE_POPULATOR) \
 		PLATFORMS="$(PLATFORMS)" \
@@ -507,7 +504,6 @@ kueue-populator-image-build:
 		IMAGE_BUILD_EXTRA_OPTS="$(IMAGE_BUILD_EXTRA_OPTS) -t $(IMAGE_REPO_KUEUE_POPULATOR):$(RELEASE_BRANCH)"
 
 .PHONY: kueue-populator-image-push
-kueue-populator-image-push: export IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 kueue-populator-image-push: PUSH=--push
 kueue-populator-image-push: kueue-populator-image-build
 
@@ -521,6 +517,7 @@ kueue-populator-image: kueue-populator-image-build
 .PHONY: kueue-priority-booster-image-build
 kueue-priority-booster-image-build:
 	$(MAKE) -C cmd/experimental/kueue-priority-booster image-build \
+	  IMAGE_BUILD_CMD="$(subst ",\",$(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD))" \
 		IMAGE_REGISTRY=$(IMAGE_REGISTRY) \
 		IMAGE_TAG=$(IMAGE_TAG_KUEUE_PRIORITY_BOOSTER) \
 		PLATFORMS="$(PLATFORMS)" \
@@ -531,7 +528,6 @@ kueue-priority-booster-image-build:
 		IMAGE_BUILD_EXTRA_OPTS="$(IMAGE_BUILD_EXTRA_OPTS) -t $(IMAGE_REPO_KUEUE_PRIORITY_BOOSTER):$(RELEASE_BRANCH)"
 
 .PHONY: kueue-priority-booster-image-push
-kueue-priority-booster-image-push: export IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 kueue-priority-booster-image-push: PUSH=--push
 kueue-priority-booster-image-push: kueue-priority-booster-image-build
 
@@ -572,6 +568,7 @@ generate-metrics-tables: metricsdoc
 
 # Build the ray-project-mini image
 .PHONY: ray-project-mini-image-build
+ray-project-mini-image-build: IMAGE_BUILD_CMD := $(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD)
 ray-project-mini-image-build:
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_REGISTRY)/ray-project-mini:$(RAYMINI_VERSION) \
@@ -583,7 +580,6 @@ ray-project-mini-image-build:
 		-f ./hack/testing/ray-mini/Dockerfile ./
 
 .PHONY: ray-project-mini-image-build-push
-ray-project-mini-image-build-push: IMAGE_BUILD_CMD := $(IMAGE_PUSH_RETRY) $(IMAGE_BUILD_CMD)
 ray-project-mini-image-build-push: PUSH=--push
 ray-project-mini-image-build-push: ray-project-mini-image-build
 
@@ -595,6 +591,7 @@ kind-ray-project-mini-image-build: ray-project-mini-image-build
 
 # Build the secretreader-plugin image
 .PHONY: secretreader-plugin-image-build
+secretreader-plugin-image-build: IMAGE_BUILD_CMD := $(IMAGE_BUILD_RETRY) $(IMAGE_BUILD_CMD)
 secretreader-plugin-image-build:
 	$(IMAGE_BUILD_CMD) \
 		-t $(IMAGE_REGISTRY)/secretreader-plugin:$(CLUSTERPROFILE_PLUGIN_IMAGE_VERSION) \


### PR DESCRIPTION
Cherry pick of #13191 on release-0.19.

#13191: flake: Docker build failure during the e2e test CI pipeline

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake

/area release

```release-note
NONE
```