### PR TITLE
fix(queue): stabilize heap comparator against transient LocalQueue lookup errors

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -200,8 +200,13 @@ type ClusterQueue struct {
 
 	AdmissionScope *kueue.AdmissionScope
 
-	afsEntryPenalties         *queueafs.AfsEntryPenalties
-	localQueuesInClusterQueue map[utilqueue.LocalQueueReference]bool
+	afsEntryPenalties *queueafs.AfsEntryPenalties
+
+	// lqWeights holds the LocalQueues that belong to this ClusterQueue, mapped to
+	// their fair-sharing weight. Presence denotes membership; the heap comparator
+	// reads the weight without a fallible API call, and missing entries fall back
+	// to weight 1.0. Guarded by rwm. See Kueue#13476.
+	lqWeights map[utilqueue.LocalQueueReference]float64
 
 	sw *stickyWorkload
 
@@ -310,9 +315,18 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		opt(options)
 	}
 	sw := stickyWorkload{}
-	// The heap comparator reads the sticky workload live on every comparison;
-	// this is safe because sticky writes and heap operations both hold rwm.
-	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, sw.matches)
+	// lqWeights is shared by reference with the ClusterQueue struct below so
+	// weight updates are visible to the comparator. All access holds rwm.
+	lqWeights := make(map[utilqueue.LocalQueueReference]float64)
+	getLQWeight := func(lqKey utilqueue.LocalQueueReference) float64 {
+		if w, ok := lqWeights[lqKey]; ok {
+			return w
+		}
+		return 1.0
+	}
+	// The comparator reads the sticky workload and cached weights live; safe
+	// because those writes and heap operations all hold rwm.
+	compareFunc := queueOrderingFunc(ctx, getLQWeight, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, sw.matches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
 	// Snapshot sorts without the lock, so it captures the sticky workload once
@@ -337,7 +351,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		rwm:                          sync.RWMutex{},
 		clock:                        clock,
 		afsEntryPenalties:            options.afsEntryPenalties,
-		localQueuesInClusterQueue:    make(map[utilqueue.LocalQueueReference]bool),
+		lqWeights:                    lqWeights,
 		sw:                           &sw,
 		pendingResourcesTotal:        make(map[corev1.ResourceName]int64),
 	}
@@ -498,14 +512,19 @@ func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 	return string(reason), ok
 }
 
-func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
+// RebuildHeap re-establishes the heap invariant after a LocalQueue's
+// fair-sharing usage changed. Workloads in the same LocalQueue share that usage,
+// so their order relative to each other is unchanged; what changes is their
+// position relative to every other LocalQueue's workloads, and all of them shift
+// at once. heap.Fix assumes a single element moved while the rest of the heap is
+// valid, so fixing these entries one by one can leave the heap invalid; instead
+// the whole heap is rebuilt in O(n) with heap.Init. lqName identifies the
+// LocalQueue whose reconcile triggered the rebuild and is used only for logging.
+func (c *ClusterQueue) RebuildHeap(log logr.Logger, lqName string) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	for _, wl := range c.heap.List() {
-		if string(wl.Obj.Spec.QueueName) == lqName {
-			c.heap.PushOrUpdate(wl)
-		}
-	}
+	log.V(3).Info("Rebuilding heap after LocalQueue fair-sharing usage change", "clusterQueue", c.name, "localQueue", lqName)
+	c.heap.Init()
 }
 
 // backoffWaitingTimeExpired returns true if the current time is after the requeueAt
@@ -890,10 +909,13 @@ func (c *ClusterQueue) Pop() *workload.Info {
 }
 
 // rebuildAll rebuilds the entire heap. Must be called with lock held.
+// A pending penalty can change the fair-sharing usage of several workloads from
+// the same LocalQueue at once, so they all shift relative to other LocalQueues'
+// workloads together. heap.Fix assumes a single element moved while the rest of
+// the heap is valid, so fixing these entries one by one can leave the heap
+// invalid; instead the whole invariant is re-established in O(n) with heap.Init.
 func (c *ClusterQueue) rebuildAll() {
-	for _, wl := range c.heap.List() {
-		c.heap.PushOrUpdate(wl)
-	}
+	c.heap.Init()
 }
 
 func (c *ClusterQueue) hasPendingPenalties() bool {
@@ -901,7 +923,7 @@ func (c *ClusterQueue) hasPendingPenalties() bool {
 		return false
 	}
 
-	for lqKey := range c.localQueuesInClusterQueue {
+	for lqKey := range c.lqWeights {
 		lqPenalty := c.afsEntryPenalties.Peek(lqKey)
 		if !resource.IsZero(lqPenalty) {
 			return true
@@ -1145,9 +1167,12 @@ func baseCompareFunc(log logr.Logger, wo workload.Ordering, stickyMatches func(w
 }
 
 // queueOrderingFunc composes fair-sharing usage (when enabled) with baseCompareFunc.
+// It reads the LocalQueue weight via getLQWeight (backed by the cached weights)
+// instead of a fallible API read, so a failed LocalQueue lookup can no longer flip
+// the ordering rule between comparisons. See Kueue#13476.
 func queueOrderingFunc(
 	ctx context.Context,
-	cl client.Client,
+	getLQWeight func(utilqueue.LocalQueueReference) float64,
 	wo workload.Ordering,
 	fsResWeights map[corev1.ResourceName]float64,
 	enableAdmissionFs bool,
@@ -1161,32 +1186,41 @@ func queueOrderingFunc(
 		return baseCmp
 	}
 	return func(a, b *workload.Info) int {
-		lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
-		lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
-		switch {
-		case errA != nil:
-			log.V(2).Error(errA, "Error determining LocalQueue usage")
-		case errB != nil:
-			log.V(2).Error(errB, "Error determining LocalQueue usage")
-		default:
-			log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(a.Obj.Namespace, string(a.Obj.Spec.QueueName)), "usage", lqAUsage)
-			log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(b.Obj.Namespace, string(b.Obj.Spec.QueueName)), "usage", lqBUsage)
-			if cmpResult := cmp.Compare(lqAUsage, lqBUsage); cmpResult != 0 {
-				return cmpResult
-			}
+		lqAUsage := a.ComputeLocalQueueFSUsage(getLQWeight(utilqueue.KeyFromWorkload(a.Obj)), fsResWeights, afsEntryPenalties, afsConsumedResources)
+		lqBUsage := b.ComputeLocalQueueFSUsage(getLQWeight(utilqueue.KeyFromWorkload(b.Obj)), fsResWeights, afsEntryPenalties, afsConsumedResources)
+		log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(a.Obj.Namespace, string(a.Obj.Spec.QueueName)), "usage", lqAUsage)
+		log.V(3).Info("Resource usage from LocalQueue", "localQueue", klog.KRef(b.Obj.Namespace, string(b.Obj.Spec.QueueName)), "usage", lqBUsage)
+		if cmpResult := cmp.Compare(lqAUsage, lqBUsage); cmpResult != 0 {
+			return cmpResult
 		}
 		return baseCmp(a, b)
 	}
 }
 
-func (c *ClusterQueue) addLocalQueue(lqKey utilqueue.LocalQueueReference) {
+func (c *ClusterQueue) addLocalQueue(lqKey utilqueue.LocalQueueReference, weight float64) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	c.localQueuesInClusterQueue[lqKey] = true
+	c.lqWeights[lqKey] = weight
 }
 
 func (c *ClusterQueue) deleteLocalQueue(lqKey utilqueue.LocalQueueReference) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	delete(c.localQueuesInClusterQueue, lqKey)
+	delete(c.lqWeights, lqKey)
+}
+
+// UpdateLocalQueueWeight refreshes the cached weight for a LocalQueue and, if it
+// changed, reheapifies the pending workloads so the heap stays ordered. The
+// LocalQueue's workloads keep their order relative to each other but all shift at
+// once relative to every other LocalQueue's workloads, so the whole heap
+// invariant is re-established in O(n) with heap.Init rather than fixing entries
+// individually (heap.Fix assumes only a single element moved). See Kueue#13476.
+func (c *ClusterQueue) UpdateLocalQueueWeight(lqKey utilqueue.LocalQueueReference, weight float64) {
+	c.rwm.Lock()
+	defer c.rwm.Unlock()
+	if old, ok := c.lqWeights[lqKey]; ok && old == weight {
+		return
+	}
+	c.lqWeights[lqKey] = weight
+	c.heap.Init()
 }

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -587,6 +587,83 @@ func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 	}
 }
 
+// TestHeapOrderingStableOnLocalQueueLookupError is a regression test for Kueue#13476.
+// The two workloads have fair-sharing order opposite to their priority order: wlHigh is
+// high priority in a high-usage queue, wlLow is low priority in a low-usage queue. With a
+// client that fails every LocalQueue lookup, the old comparator fell back to priority
+// ordering and popped wlHigh first. Now it reads the cached weight and stays on
+// fair-sharing ordering, popping wlLow first, consistently across repeated comparisons.
+func TestHeapOrderingStableOnLocalQueueLookupError(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	failingClient := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*kueue.LocalQueue); ok {
+				return errors.New("transient LocalQueue lookup error")
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	}).Build()
+
+	// lq1 high usage (10 GPU), lq2 low usage (1 GPU); both weight 1.0.
+	afsConsumedResources := queueafs.NewAfsConsumedResources()
+	afsConsumedResources.Set("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
+	afsConsumedResources.Set("default/lq2", corev1.ResourceList{resourceGPU: resource.MustParse("1")}, now)
+
+	penaltyMap := queueafs.NewPenaltyMap()
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cq, err := newClusterQueue(ctx, failingClient,
+		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
+		nil, defaultOrdering,
+		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1.0}},
+		penaltyMap, afsConsumedResources)
+	if err != nil {
+		t.Fatalf("failed to create ClusterQueue: %v", err)
+	}
+
+	// Seed the cached weights the way the manager's LocalQueue hooks do.
+	cq.addLocalQueue("default/lq1", 1.0)
+	cq.addLocalQueue("default/lq2", 1.0)
+
+	wlHigh := utiltestingapi.MakeWorkload("wl-high", defaultNamespace).
+		Queue("lq1").Priority(highPriority).Creation(now).UID("uid-high").Obj()
+	wlLow := utiltestingapi.MakeWorkload("wl-low", defaultNamespace).
+		Queue("lq2").Priority(lowPriority).Creation(now).UID("uid-low").Obj()
+
+	cq.PushOrUpdate(workload.NewInfo(wlHigh))
+	cq.PushOrUpdate(workload.NewInfo(wlLow))
+
+	// wlLow (lower usage) must pop first despite the failing client.
+	wantOrder := []workload.Reference{workload.Key(wlLow), workload.Key(wlHigh)}
+	var gotOrder []workload.Reference
+	for {
+		head := cq.Pop()
+		if head == nil {
+			break
+		}
+		gotOrder = append(gotOrder, workload.Key(head.Obj))
+	}
+	if diff := cmp.Diff(wantOrder, gotOrder); diff != "" {
+		t.Errorf("unexpected pop order with failing LocalQueue client (-want,+got):\n%s", diff)
+	}
+
+	// The comparator must stay consistent and antisymmetric across repeated calls.
+	a := workload.NewInfo(wlHigh)
+	b := workload.NewInfo(wlLow)
+	first := cq.compareFunc(a, b)
+	if first <= 0 {
+		t.Fatalf("expected wlLow (lower usage) to sort before wlHigh, got compare(high,low)=%d", first)
+	}
+	for i := range 100 {
+		if got := cq.compareFunc(a, b); got != first {
+			t.Fatalf("comparator inconsistent on call %d: got %d, want %d", i+1, got, first)
+		}
+		if got := cq.compareFunc(b, a); got != -first {
+			t.Fatalf("comparator not antisymmetric on call %d: compare(low,high)=%d, want %d", i+1, got, -first)
+		}
+	}
+}
+
 // TestSnapshotConcurrentWithRequeueNoDataRace guards against a data race on the
 // sticky workload: Snapshot sorts a copy of the pending workloads through the
 // comparator (which reads stickyWorkload.workloadName) without holding the

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -352,9 +352,11 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 	for _, q := range queues.Items {
 		qImpl := m.localQueues[queue.Key(&q)]
 		if qImpl != nil {
+			// Seed the cached weight before pushing workloads so the heap
+			// orders them under the correct weight from the first push.
+			cqImpl.addLocalQueue(queue.Key(&q), afs.LQWeightAsFloat64(&q))
 			added := cqImpl.AddFromLocalQueue(qImpl, m.roleTracker, m.customLabels)
 			addedWorkloads = addedWorkloads || added
-			cqImpl.addLocalQueue(queue.Key(&q))
 			if features.Enabled(features.UnadmittedWorkloadsObservability) {
 				log := ctrl.LoggerFrom(ctx)
 				for _, wInfo := range qImpl.items {
@@ -444,14 +446,14 @@ func (m *Manager) UpdateClusterQueue(ctx context.Context, cq *kueue.ClusterQueue
 	return nil
 }
 
-func (m *Manager) RebuildClusterQueue(cq *kueue.ClusterQueue, lqName string) error {
+func (m *Manager) RebuildClusterQueue(log logr.Logger, cq *kueue.ClusterQueue, lqName string) error {
 	m.Lock()
 	defer m.Unlock()
 	cqImpl := m.hm.ClusterQueue(kueue.ClusterQueueReference(cq.Name))
 	if cqImpl == nil {
 		return ErrClusterQueueDoesNotExist
 	}
-	cqImpl.RebuildLocalQueue(lqName)
+	cqImpl.RebuildHeap(log, lqName)
 	return nil
 }
 
@@ -500,7 +502,7 @@ func (m *Manager) addLocalQueueLocked(ctx context.Context, q *kueue.LocalQueue) 
 
 	cq := m.hm.ClusterQueue(qImpl.ClusterQueue)
 	if cq != nil {
-		cq.addLocalQueue(key)
+		cq.addLocalQueue(key, afs.LQWeightAsFloat64(q))
 	}
 
 	// Iterate through existing workloads, as workloads corresponding to this
@@ -581,12 +583,17 @@ func (m *Manager) UpdateLocalQueue(log logr.Logger, q *kueue.LocalQueue) error {
 		}
 		newCQ := m.hm.ClusterQueue(q.Spec.ClusterQueue)
 		if newCQ != nil {
+			// Seed the weight before pushing so the heap uses it from the start.
+			newCQ.addLocalQueue(queue.Key(q), afs.LQWeightAsFloat64(q))
 			newCQ.AddFromLocalQueue(qImpl, m.roleTracker, m.customLabels)
-			newCQ.addLocalQueue(queue.Key(q))
 			m.Broadcast()
 		}
 	}
 	qImpl.update(q)
+	// Sync the cached weight with the spec and reheapify if it changed.
+	if newCQ := m.hm.ClusterQueue(q.Spec.ClusterQueue); newCQ != nil {
+		newCQ.UpdateLocalQueueWeight(queue.Key(q), afs.LQWeightAsFloat64(q))
+	}
 	if cqChanged && features.Enabled(features.UnadmittedWorkloadsObservability) {
 		for _, wInfo := range qImpl.items {
 			m.updateUnadmittedWorkloadWithoutLock(log, wInfo.Obj)

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -2572,5 +2573,279 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 				t.Error("LastAssignment was carried by reference; it must be cloned so the two Infos do not alias")
 			}
 		})
+	}
+}
+
+// TestHeadsRespectLocalQueueWeightForPreexistingWorkloads guards the cached-weight
+// seeding order (Kueue#13476): LocalQueues (with their weights) are registered before
+// the ClusterQueue that adopts their pre-existing workloads, matching how the scheduler
+// wires things up. A zero-weight LocalQueue must be the most disadvantaged (+Inf usage),
+// so its workload pops last even though it was created first. If the weight were cached
+// after the workloads are pushed onto the heap, the zero-weight queue would default to
+// weight 1.0 and wrongly pop first.
+func TestHeadsRespectLocalQueueWeightForPreexistingWorkloads(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		ResourceWeights: map[corev1.ResourceName]float64{corev1.ResourceCPU: 1},
+	}
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj()
+	lqNormal := utiltestingapi.MakeLocalQueue("lq-normal", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+	lqZero := utiltestingapi.MakeLocalQueue("lq-zero", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("0"))}).Obj()
+
+	// wl-zero is created first, so under equal usage it would pop first by
+	// timestamp; the zero weight must override that.
+	wlZero := utiltestingapi.MakeWorkload("wl-zero", "default").
+		Queue("lq-zero").Creation(now).Obj()
+	wlNormal := utiltestingapi.MakeWorkload("wl-normal", "default").
+		Queue("lq-normal").Creation(now.Add(time.Second)).Obj()
+
+	cl := utiltesting.NewFakeClient(wlZero, wlNormal, lqNormal, lqZero, cq)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	manager := NewManagerForUnitTests(cl, nil, WithAdmissionFairSharing(afsConfig))
+
+	// Register the LocalQueues (and seed usage) before the ClusterQueue, so the
+	// CQ adopts the pre-existing workloads and must seed the weights before push.
+	for _, lq := range []*kueue.LocalQueue{lqNormal, lqZero} {
+		if err := manager.AddLocalQueue(ctx, lq); err != nil {
+			t.Fatalf("Failed adding LocalQueue %s: %v", lq.Name, err)
+		}
+	}
+	for _, lqName := range []string{"lq-normal", "lq-zero"} {
+		manager.AfsConsumedResources.Set(
+			queue.LocalQueueReference("default/"+lqName),
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")}, now)
+	}
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding ClusterQueue: %v", err)
+	}
+
+	got := popNamesFromCQ(manager.hm.ClusterQueue("cq"))
+	want := []workload.Reference{"default/wl-normal", "default/wl-zero"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("zero-weight LocalQueue was not disadvantaged (-want,+got):\n%s", diff)
+	}
+}
+
+// TestUpdateLocalQueueWeightReheapifies guards the reheapify on a weight change
+// (Kueue#13476): two LocalQueues start with equal, non-zero consumed usage and
+// weight 1, so their workloads order by creation time. Raising one LocalQueue's
+// weight through Manager.UpdateLocalQueue lowers its fair-sharing usage
+// (usage/weight), so its workload must move to the head on the next pop. Entry
+// penalties are left at zero so Pop's penalty-driven rebuildAll cannot mask a
+// missing reheapify in UpdateLocalQueueWeight.
+func TestUpdateLocalQueueWeightReheapifies(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		ResourceWeights: map[corev1.ResourceName]float64{corev1.ResourceCPU: 1},
+	}
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj()
+	lqA := utiltestingapi.MakeLocalQueue("lq-a", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+	lqB := utiltestingapi.MakeLocalQueue("lq-b", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+
+	// wl-a is created first, so with equal usage and weight it pops first.
+	wlA := utiltestingapi.MakeWorkload("wl-a", "default").
+		Queue("lq-a").Creation(now).Obj()
+	wlB := utiltestingapi.MakeWorkload("wl-b", "default").
+		Queue("lq-b").Creation(now.Add(time.Second)).Obj()
+
+	cl := utiltesting.NewFakeClient(wlA, wlB, lqA, lqB, cq)
+	ctx, log := utiltesting.ContextWithLog(t)
+	manager := NewManagerForUnitTests(cl, nil,
+		WithPreemptionExpectations(preemptexpectations.New()),
+		WithAdmissionFairSharing(afsConfig))
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding ClusterQueue: %v", err)
+	}
+	for _, lq := range []*kueue.LocalQueue{lqA, lqB} {
+		if err := manager.AddLocalQueue(ctx, lq); err != nil {
+			t.Fatalf("Failed adding LocalQueue %s: %v", lq.Name, err)
+		}
+	}
+	// Equal, non-zero usage; zero penalties so Pop does not rebuild the heap.
+	for _, lqName := range []string{"lq-a", "lq-b"} {
+		manager.AfsConsumedResources.Set(
+			queue.LocalQueueReference("default/"+lqName),
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}, now)
+	}
+	for _, wl := range []*kueue.Workload{wlA, wlB} {
+		if err := manager.AddOrUpdateWorkload(log, wl); err != nil {
+			t.Fatalf("Failed adding workload %s: %v", wl.Name, err)
+		}
+	}
+
+	// Raise lq-b's weight so its usage (4/2) drops below lq-a's (4/1); wl-b
+	// must now pop first even though it was created later.
+	lqB.Spec.FairSharing.Weight = new(resource.MustParse("2"))
+	if err := manager.UpdateLocalQueue(log, lqB); err != nil {
+		t.Fatalf("Failed updating LocalQueue lq-b: %v", err)
+	}
+
+	got := popNamesFromCQ(manager.hm.ClusterQueue("cq"))
+	want := []workload.Reference{"default/wl-b", "default/wl-a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("weight change did not reheapify the LocalQueue (-want,+got):\n%s", diff)
+	}
+}
+
+// TestUpdateLocalQueueWeightReheapifiesMultipleWorkloads guards that a weight
+// change reorders every affected workload at once (Kueue#13476). Two LocalQueues
+// hold two workloads each with equal, non-zero consumed usage and weight 1, so
+// they order by creation time (a1, b1, a2, b2). Raising lq-b's weight halves its
+// fair-sharing usage, so both lq-b workloads must move ahead of both lq-a ones.
+// lq-b's first workload was not the heap root, so the head must move and losing
+// the reheapify is observable on the very first pop. Fixing the moved entries one
+// by one can leave the heap invariant broken and pop the wrong workload; a single
+// whole-heap rebuild keeps every pop correct. Entry penalties are left at zero so
+// Pop's penalty-driven rebuildAll cannot mask a missing reheapify in
+// UpdateLocalQueueWeight.
+func TestUpdateLocalQueueWeightReheapifiesMultipleWorkloads(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		ResourceWeights: map[corev1.ResourceName]float64{corev1.ResourceCPU: 1},
+	}
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj()
+	lqA := utiltestingapi.MakeLocalQueue("lq-a", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+	lqB := utiltestingapi.MakeLocalQueue("lq-b", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+
+	// Interleave creation times so with equal usage and weight the heap orders
+	// them a1, b1, a2, b2, forcing the reheapify to move several entries at once.
+	wlA1 := utiltestingapi.MakeWorkload("wl-a1", "default").
+		Queue("lq-a").Creation(now).Obj()
+	wlB1 := utiltestingapi.MakeWorkload("wl-b1", "default").
+		Queue("lq-b").Creation(now.Add(time.Second)).Obj()
+	wlA2 := utiltestingapi.MakeWorkload("wl-a2", "default").
+		Queue("lq-a").Creation(now.Add(2 * time.Second)).Obj()
+	wlB2 := utiltestingapi.MakeWorkload("wl-b2", "default").
+		Queue("lq-b").Creation(now.Add(3 * time.Second)).Obj()
+
+	cl := utiltesting.NewFakeClient(wlA1, wlB1, wlA2, wlB2, lqA, lqB, cq)
+	ctx, log := utiltesting.ContextWithLog(t)
+	manager := NewManagerForUnitTests(cl, nil,
+		WithPreemptionExpectations(preemptexpectations.New()),
+		WithAdmissionFairSharing(afsConfig))
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding ClusterQueue: %v", err)
+	}
+	for _, lq := range []*kueue.LocalQueue{lqA, lqB} {
+		if err := manager.AddLocalQueue(ctx, lq); err != nil {
+			t.Fatalf("Failed adding LocalQueue %s: %v", lq.Name, err)
+		}
+	}
+	// Equal, non-zero usage; zero penalties so Pop does not rebuild the heap.
+	for _, lqName := range []string{"lq-a", "lq-b"} {
+		manager.AfsConsumedResources.Set(
+			queue.LocalQueueReference("default/"+lqName),
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}, now)
+	}
+	for _, wl := range []*kueue.Workload{wlA1, wlB1, wlA2, wlB2} {
+		if err := manager.AddOrUpdateWorkload(log, wl); err != nil {
+			t.Fatalf("Failed adding workload %s: %v", wl.Name, err)
+		}
+	}
+
+	// Raise lq-b's weight so its usage (4/2) drops below lq-a's (4/1); both
+	// lq-b workloads must now pop before both lq-a workloads.
+	lqB.Spec.FairSharing.Weight = new(resource.MustParse("2"))
+	if err := manager.UpdateLocalQueue(log, lqB); err != nil {
+		t.Fatalf("Failed updating LocalQueue lq-b: %v", err)
+	}
+
+	got := popNamesFromCQ(manager.hm.ClusterQueue("cq"))
+	want := []workload.Reference{"default/wl-b1", "default/wl-b2", "default/wl-a1", "default/wl-a2"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("weight change did not reheapify all affected workloads (-want,+got):\n%s", diff)
+	}
+}
+
+// TestUpdateLocalQueueWeightZeroReheapifies covers dropping a LocalQueue weight
+// to 0 through the runtime Manager.UpdateLocalQueue path (Kueue#13476). A weight
+// of 0 makes fair-sharing usage +Inf (CalculateUsage's non-positive-weight
+// fallback), so the affected LocalQueue becomes the most disadvantaged and its
+// workload must pop last. Both LocalQueues start with equal, non-zero usage and
+// weight 1, so wl-a (created first) would otherwise pop first; the zero weight
+// must override that. Entry penalties are left at zero so Pop's penalty-driven
+// rebuildAll cannot mask a missing reheapify in UpdateLocalQueueWeight.
+func TestUpdateLocalQueueWeightZeroReheapifies(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+
+	afsConfig := &configapi.AdmissionFairSharing{
+		ResourceWeights: map[corev1.ResourceName]float64{corev1.ResourceCPU: 1},
+	}
+	cq := utiltestingapi.MakeClusterQueue("cq").
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj()
+	lqA := utiltestingapi.MakeLocalQueue("lq-a", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+	lqB := utiltestingapi.MakeLocalQueue("lq-b", "default").
+		ClusterQueue("cq").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj()
+
+	// wl-a is created first, so with equal usage and weight it pops first.
+	wlA := utiltestingapi.MakeWorkload("wl-a", "default").
+		Queue("lq-a").Creation(now).Obj()
+	wlB := utiltestingapi.MakeWorkload("wl-b", "default").
+		Queue("lq-b").Creation(now.Add(time.Second)).Obj()
+
+	cl := utiltesting.NewFakeClient(wlA, wlB, lqA, lqB, cq)
+	ctx, log := utiltesting.ContextWithLog(t)
+	manager := NewManagerForUnitTests(cl, nil,
+		WithPreemptionExpectations(preemptexpectations.New()),
+		WithAdmissionFairSharing(afsConfig))
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding ClusterQueue: %v", err)
+	}
+	for _, lq := range []*kueue.LocalQueue{lqA, lqB} {
+		if err := manager.AddLocalQueue(ctx, lq); err != nil {
+			t.Fatalf("Failed adding LocalQueue %s: %v", lq.Name, err)
+		}
+	}
+	// Equal, non-zero usage; zero penalties so Pop does not rebuild the heap.
+	for _, lqName := range []string{"lq-a", "lq-b"} {
+		manager.AfsConsumedResources.Set(
+			queue.LocalQueueReference("default/"+lqName),
+			corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}, now)
+	}
+	for _, wl := range []*kueue.Workload{wlA, wlB} {
+		if err := manager.AddOrUpdateWorkload(log, wl); err != nil {
+			t.Fatalf("Failed adding workload %s: %v", wl.Name, err)
+		}
+	}
+
+	// Drop lq-a's weight to 0 so its usage becomes +Inf; wl-a must now pop last
+	// even though it was created first.
+	lqA.Spec.FairSharing.Weight = new(resource.MustParse("0"))
+	if err := manager.UpdateLocalQueue(log, lqA); err != nil {
+		t.Fatalf("Failed updating LocalQueue lq-a: %v", err)
+	}
+
+	got := popNamesFromCQ(manager.hm.ClusterQueue("cq"))
+	want := []workload.Reference{"default/wl-b", "default/wl-a"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("zero weight did not disadvantage the LocalQueue (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -226,7 +226,7 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
-		if err := r.queues.RebuildClusterQueue(&cq, queueObj.Name); err != nil {
+		if err := r.queues.RebuildClusterQueue(log, &cq, queueObj.Name); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: r.admissionFSConfig.UsageSamplingInterval.Duration}, nil

--- a/pkg/util/heap/heap.go
+++ b/pkg/util/heap/heap.go
@@ -122,6 +122,16 @@ func (h *Heap[T, K]) PushOrUpdate(obj *T) {
 	}
 }
 
+// Init re-establishes the heap invariant across all items in O(n). Use it after
+// the ordering keys of several items change at once (for example when a
+// LocalQueue fair-sharing weight changes and all its workloads are reordered
+// together), where fixing the affected items one by one with PushOrUpdate is
+// unsafe: each heap.Fix assumes only a single item moved, so a batch of changes
+// can leave the heap invalid.
+func (h *Heap[T, K]) Init() {
+	heap.Init(&h.data)
+}
+
 // PushIfNotPresent inserts an item to the queue. If an item with
 // the key is present in the map, no changes is made to the item.
 func (h *Heap[T, K]) PushIfNotPresent(obj *T) (added bool) {

--- a/pkg/util/heap/heap_test.go
+++ b/pkg/util/heap/heap_test.go
@@ -261,3 +261,35 @@ func TestHeap_List(t *testing.T) {
 		}
 	}
 }
+
+// TestHeap_Init verifies that Init re-establishes the heap invariant after the
+// ordering values of several items change at once. It mutates every item's value
+// in place (a batch reorder, as happens when a LocalQueue fair-sharing weight
+// changes and all its workloads move together) and checks that Init restores
+// ascending Pop order. Fixing the moved items one by one is unsafe here because
+// each heap.Fix assumes only a single item moved.
+func TestHeap_Init(t *testing.T) {
+	h := New(testHeapObjectKeyFunc, compareInts)
+	// Push already-ordered values so the backing array is a valid min-heap
+	// laid out as [0, 1, 2, 3].
+	for i := range 4 {
+		h.PushOrUpdate(mkHeapObj(string(rune('a'+i)), i))
+	}
+
+	// Fully reverse every value; the array [0, 1, 2, 3] is now [3, 2, 1, 0],
+	// which violates the heap invariant everywhere at once.
+	for i := range 4 {
+		h.GetByKey(string(rune('a' + i))).val = 3 - i
+	}
+
+	h.Init()
+
+	prev := -1
+	for h.Len() > 0 {
+		obj := h.Pop()
+		if obj.val < prev {
+			t.Fatalf("Init did not restore heap order: got %d after %d", obj.val, prev)
+		}
+		prev = obj.val
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -484,13 +484,16 @@ func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string)
 	return res
 }
 
-func (i *Info) CalcLocalQueueFSUsage(
-	ctx context.Context,
-	c client.Client,
+// ComputeLocalQueueFSUsage returns the fair-sharing usage for the workload's
+// LocalQueue using the given weight, without any API read. The persistent heap
+// comparator uses this with a cached weight so its ordering stays consistent even
+// if a LocalQueue lookup fails. See Kueue#13476.
+func (i *Info) ComputeLocalQueueFSUsage(
+	weight float64,
 	resWeights map[corev1.ResourceName]float64,
 	afsEntryPenalties *queueafs.AfsEntryPenalties,
 	afsConsumedResources *queueafs.AfsConsumedResources,
-) (float64, error) {
+) float64 {
 	lqKey := queue.KeyFromWorkload(i.Obj)
 
 	consumed := corev1.ResourceList{}
@@ -506,12 +509,22 @@ func (i *Info) CalcLocalQueueFSUsage(
 		penalty = afsEntryPenalties.Peek(lqKey)
 	}
 
+	return afs.CalculateUsage(consumed, penalty, weight, resWeights)
+}
+
+func (i *Info) CalcLocalQueueFSUsage(
+	ctx context.Context,
+	c client.Client,
+	resWeights map[corev1.ResourceName]float64,
+	afsEntryPenalties *queueafs.AfsEntryPenalties,
+	afsConsumedResources *queueafs.AfsConsumedResources,
+) (float64, error) {
 	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}
 	lqWeight, err := afs.ResolveLQWeight(ctx, c, lqObjKey)
 	if err != nil {
 		return 0, err
 	}
-	return afs.CalculateUsage(consumed, penalty, lqWeight, resWeights), nil
+	return i.ComputeLocalQueueFSUsage(lqWeight, resWeights, afsEntryPenalties, afsConsumedResources), nil
 }
 
 // IsUsingTAS returns information if the workload is using TAS

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1506,6 +1506,45 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 			ginkgo.By("Checking that the workload from lq-A is preempted despite having bigger priority")
 			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlHighA)
 		})
+
+		ginkgo.It("admits from the LocalQueue whose weight is raised through the API", framework.SlowSpec, func() {
+			// This exercises the controller update path: changing
+			// spec.fairSharing.weight reconciles the LocalQueue, which reheapifies
+			// the ClusterQueue so the next admission reflects the new weight.
+			ginkgo.By("Accumulating recent usage on lq-b")
+			wlBUsage := createWorkload("lq-b", "32")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBUsage)
+			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lqB), ">", 0)
+			util.FinishWorkloads(ctx, k8sClient, wlBUsage)
+
+			ginkgo.By("Admitting a blocker on lq-a that holds the whole cohort quota")
+			// The blocker keeps both pending workloads waiting (so no admission
+			// happens before the weight change) and gives lq-a high recent usage,
+			// so at weight 1 lq-b would be preferred.
+			wlBlocker := createWorkload("lq-a", "32")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlBlocker)
+
+			ginkgo.By("Creating two competing pending workloads, one per LocalQueue")
+			wlA := createWorkload("lq-a", "32")
+			wlB := createWorkload("lq-b", "32")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlA, wlB)
+
+			ginkgo.By("Raising lq-a's fair-sharing weight through the Kubernetes API")
+			// A large weight drives lq-a's effective usage (usage/weight) below
+			// lq-b's, so the admission order must flip to lq-a.
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lqA), lqA)).To(gomega.Succeed())
+				lqA.Spec.FairSharing.Weight = new(resource.MustParse("1000000"))
+				g.Expect(k8sClient.Update(ctx, lqA)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Releasing the quota so the scheduler picks with the new weight")
+			util.FinishWorkloads(ctx, k8sClient, wlBlocker)
+
+			ginkgo.By("Admitting lq-a's workload and keeping lq-b's pending")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlB)
+		})
 	})
 
 	ginkgo.When("Restarting the manager", func() {


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

When Admission Fair Sharing is enabled, the persistent ClusterQueue heap comparator called `CalcLocalQueueFSUsage` on every comparison, which performed a fallible LocalQueue `Get` to read the fair-sharing weight. On a transient lookup error the comparison fell back to base ordering, while a successful lookup used fair-sharing ordering, so the ordering rule could differ between comparisons for unchanged Workloads and violate the heap invariant.

This caches the LocalQueue weight per ClusterQueue, guarded by the same lock as the heap, and reads the cached weight from the comparator instead of doing an API read. The cache is seeded and kept in sync through the existing `AddLocalQueue` / `UpdateLocalQueue` / `DeleteLocalQueue` hooks; unknown or deleted LocalQueues fall back to the default weight 1.0. On a weight change, with an early return when the weight is unchanged, the heap is rebuilt in O(n) with `heap.Init`: a weight change shifts all of that LocalQueue's workloads at once relative to every other LocalQueue's workloads, so fixing entries one by one is unsafe.

Per the discussion in the issue, this keeps the change scoped to freezing the LocalQueue weights out of the comparator (correctness), and deliberately does not touch the broader reheapify strategy for performance. A debounced workqueue for the reheapify events can be explored separately if hook volume becomes a concern.

## Which issue(s) this PR fixes

Fixes #13476

## Special notes for your reviewer

Includes a deterministic regression test (`TestHeapOrderingStableOnLocalQueueLookupError`) using a client interceptor that fails every LocalQueue lookup, verified to fail against the old comparator and pass with the fix. Also adds `TestHeap_Init`, manager-level reheapify tests covering multi-workload and zero-weight (+Inf usage) transitions, and an integration test that updates `spec.fairSharing.weight` through the Kubernetes API and asserts the new admission order.

cc @YQ-Wang @apullo777 @mimowo

## Release note

```release-note
AFS: Fixed a bug where transient LocalQueue lookup errors in the heap comparator could flip the scheduling order between fair-sharing and priority-based, causing inconsistent workload admission when Admission Fair Sharing was enabled.
```