### PR TITLE
Fix namespace matching panic for cyclic cohorts

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -192,6 +192,7 @@ func (c *Cache) newClusterQueue(log logr.Logger, cq *kueue.ClusterQueue) (*clust
 		Name:                kueue.ClusterQueueReference(cq.Name),
 		Workloads:           make(map[workload.Reference]*workload.Info),
 		WorkloadsNotReady:   sets.New[workload.Reference](),
+		NamespaceSelector:   labels.Nothing(),
 		localQueues:         make(map[queue.LocalQueueReference]*LocalQueue),
 		podsReadyTracking:   c.podsReadyTracking,
 		workloadInfoOptions: c.workloadInfoOptions,

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -2823,6 +2823,98 @@ func TestMatchingClusterQueues(t *testing.T) {
 	}
 }
 
+// TestMatchingClusterQueuesAfterFailedUpdate covers ClusterQueues that stay in the
+// hierarchy manager after updateClusterQueue returns an error, since Namespace events
+// keep matching against them.
+func TestMatchingClusterQueuesAfterFailedUpdate(t *testing.T) {
+	teamSelector := func(team string) *metav1.LabelSelector {
+		return &metav1.LabelSelector{MatchLabels: map[string]string{"team": team}}
+	}
+	addCohortCycle := func(t *testing.T, cache *Cache) {
+		t.Helper()
+		if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cycle-a").Parent("cycle-b").Obj()); err != nil {
+			t.Fatal(err)
+		}
+		if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cycle-b").Parent("cycle-a").Obj()); err == nil {
+			t.Fatal("Expected failure when cycle")
+		}
+	}
+
+	cases := map[string]struct {
+		setup       func(*testing.T, *Cache)
+		wantMatch   []map[string]string
+		wantNoMatch []map[string]string
+	}{
+		"add into cyclic cohort applies the configured selector": {
+			setup: func(t *testing.T, cache *Cache) {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				addCohortCycle(t, cache)
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					Cohort("cycle-a").
+					NamespaceSelector(teamSelector("eng")).
+					Obj()
+				if err := cache.AddClusterQueue(ctx, cq); err == nil {
+					t.Fatal("Expected failure when adding cq to cohort with cycle")
+				}
+			},
+			wantMatch:   []map[string]string{{"team": "eng"}},
+			wantNoMatch: []map[string]string{{"team": "ops"}},
+		},
+		"update into cyclic cohort applies the new selector": {
+			setup: func(t *testing.T, cache *Cache) {
+				ctx, log := utiltesting.ContextWithLog(t)
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					NamespaceSelector(teamSelector("eng")).
+					Obj()
+				if err := cache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatal(err)
+				}
+				addCohortCycle(t, cache)
+				updated := utiltestingapi.MakeClusterQueue("cq").
+					Cohort("cycle-a").
+					NamespaceSelector(teamSelector("ops")).
+					Obj()
+				if err := cache.UpdateClusterQueue(log, updated); err == nil {
+					t.Fatal("Expected failure when updating cq to cohort with cycle")
+				}
+			},
+			wantMatch:   []map[string]string{{"team": "ops"}},
+			wantNoMatch: []map[string]string{{"team": "eng"}},
+		},
+		"add with an unparsable selector matches no Namespace": {
+			setup: func(t *testing.T, cache *Cache) {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					NamespaceSelector(teamSelector("not a valid label value")).
+					Obj()
+				if err := cache.AddClusterQueue(ctx, cq); err == nil {
+					t.Fatal("Expected failure when adding cq with an unparsable selector")
+				}
+			},
+			wantNoMatch: []map[string]string{nil, {"team": "eng"}},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+			tc.setup(t, cache)
+
+			for _, nsLabels := range tc.wantMatch {
+				want := sets.New[kueue.ClusterQueueReference]("cq")
+				if diff := cmp.Diff(want, cache.MatchingClusterQueues(nsLabels)); diff != "" {
+					t.Errorf("MatchingClusterQueues(%v) returned unexpected ClusterQueues (-want,+got):\n%s", nsLabels, diff)
+				}
+			}
+			for _, nsLabels := range tc.wantNoMatch {
+				want := sets.New[kueue.ClusterQueueReference]()
+				if diff := cmp.Diff(want, cache.MatchingClusterQueues(nsLabels)); diff != "" {
+					t.Errorf("MatchingClusterQueues(%v) returned unexpected ClusterQueues (-want,+got):\n%s", nsLabels, diff)
+				}
+			}
+		})
+	}
+}
+
 // TestWaitForPodsReadyCancelled ensures that the WaitForPodsReady call does not block when the context is closed.
 func TestWaitForPodsReadyCancelled(t *testing.T) {
 	now := time.Now().Truncate(time.Second)

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -155,6 +155,12 @@ func (c *clusterQueue) updateClusterQueue(
 	admissionChecks map[kueue.AdmissionCheckReference]AdmissionCheck,
 	oldParent *cohort,
 ) error {
+	nsSelector, err := metav1.LabelSelectorAsSelector(in.Spec.NamespaceSelector)
+	if err != nil {
+		return err
+	}
+	c.NamespaceSelector = nsSelector
+
 	if c.updateQuotasAndResourceGroups(in.Spec.ResourceGroups) || oldParent != c.Parent() {
 		if oldParent != nil && oldParent != c.Parent() {
 			updateCohortTreeResourcesIfNoCycle(oldParent)
@@ -170,12 +176,6 @@ func (c *clusterQueue) updateClusterQueue(
 			updateClusterQueueResourceNode(c)
 		}
 	}
-
-	nsSelector, err := metav1.LabelSelectorAsSelector(in.Spec.NamespaceSelector)
-	if err != nil {
-		return err
-	}
-	c.NamespaceSelector = nsSelector
 
 	c.isStopped = ptr.Deref(in.Spec.StopPolicy, kueue.None) != kueue.None
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A ClusterQueue is registered in the hierarchy manager before its scheduler-cache state is populated, so a failed `updateClusterQueue` leaves it cached. `MatchingClusterQueues` then dereferences a nil `NamespaceSelector` on the next Namespace event and panics.

Two failure paths reach that state, and this PR covers both:

- A Cohort cycle makes `updateCohortTreeResources` return `ErrCohortHasCycle` before the selector is assigned. The selector is now assigned before that fallible call, so add leaves it set and update does not leave it stale.
- An unparsable selector makes `LabelSelectorAsSelector` fail. `hm.AddClusterQueue` has already run at that point, so reordering does not help. `NamespaceSelector` now defaults to `labels.Nothing()`.

`updateClusterQueue` still returns `ErrCohortHasCycle`, and all other errors, unchanged.

Updating the remaining ClusterQueue fields while the hierarchy is cyclic, cycle-safe usage and metrics, and ClusterQueue deactivation are deliberately left to #13774.

#### Which issue(s) this PR fixes:

Fixes #13553

#### Special notes for your reviewer:

This was previously a much larger change that also recovered ClusterQueue state after a cycle. Per review it has been rebased onto main and reduced to the panic fix only.

The separate ClusterQueue `Active`-condition inconsistency is tracked in #13997.

#13295 can remove its create-retry workaround after this lands. cc @amy @anahas-redhat

Validation:

- `go test ./pkg/cache/... ./pkg/controller/core/... ./pkg/scheduler/... -count=1`
- `go vet ./pkg/cache/scheduler`, `gofmt -l`, `git diff --check`
- Reverting either half of the fix fails a distinct case in `TestMatchingClusterQueuesAfterFailedUpdate`, confirmed in both directions.

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a controller panic triggered by Namespace updates after a ClusterQueue failed to initialize because its Cohort had a cycle.
```
