### PR TITLE
fix(jobframework): only match/delete Workloads controlled by the reconciled job

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -1177,16 +1178,37 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 	return nil
 }
 
+// isControlledByJob reports whether owner is a controller owner reference
+// that identifies the job by Kind, APIVersion and name. The owner-reference
+// index (indexer.WorkloadOwnerIndexFunc) matches all owner references with
+// the job's GroupVersionKind, including non-controller ones, so callers
+// must verify the controller reference explicitly: workloads merely
+// referencing the job, or controlled by another object - even one with the
+// same name but a different GroupVersionKind - must be left to their owners
+// and to the garbage collector.
+func isControlledByJob(owner *metav1.OwnerReference, gvk schema.GroupVersionKind, name string) bool {
+	return owner != nil &&
+		owner.Kind == gvk.Kind &&
+		owner.APIVersion == gvk.GroupVersion().String() &&
+		owner.Name == name
+}
+
 func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob) (match *kueue.Workload, toDelete []*kueue.Workload, err error) {
 	object := job.Object()
+	gvk := job.GVK()
 
 	workloads := &kueue.WorkloadList{}
-	if err := c.List(ctx, workloads, client.InNamespace(object.GetNamespace()), OwnerReferenceIndexFieldMatcher(job.GVK(), object.GetName())); err != nil {
+	if err := c.List(ctx, workloads, client.InNamespace(object.GetNamespace()), OwnerReferenceIndexFieldMatcher(gvk, object.GetName())); err != nil {
 		return nil, nil, err
 	}
 
+	log := ctrl.LoggerFrom(ctx)
 	for i := range workloads.Items {
 		w := &workloads.Items[i]
+		if owner := metav1.GetControllerOfNoCopy(w); !isControlledByJob(owner, gvk, object.GetName()) {
+			log.V(2).Info("Skipping workload not controlled by the job", "workload", klog.KObj(w))
+			continue
+		}
 		isEquivalent, err := EquivalentToWorkload(ctx, c, job, w)
 		if err != nil {
 			return nil, nil, err
@@ -1275,10 +1297,14 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 	return runningPodSets
 }
 
-// EquivalentToWorkload checks if the job corresponds to the workload
+// EquivalentToWorkload checks if the job corresponds to the workload.
+// A workload is never equivalent when it is not controlled by this job:
+// neither when it has no controller owner reference, nor when its
+// controller is another object - even one with the same name but a
+// different GroupVersionKind.
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
-	if owner.Name != job.Object().GetName() {
+	if !isControlledByJob(owner, job.GVK(), job.Object().GetName()) {
 		return false, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -1384,14 +1385,20 @@ func priorityStateEqual(wl *kueue.Workload, ref *kueue.PriorityClassRef, priorit
 
 func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob) (match *kueue.Workload, toDelete []*kueue.Workload, err error) {
 	object := job.Object()
+	gvk := job.GVK()
 
 	workloads := &kueue.WorkloadList{}
-	if err := c.List(ctx, workloads, client.InNamespace(object.GetNamespace()), OwnerReferenceIndexFieldMatcher(job.GVK(), object.GetName())); err != nil {
+	if err := c.List(ctx, workloads, client.InNamespace(object.GetNamespace()), OwnerReferenceIndexFieldMatcher(gvk, object.GetName())); err != nil {
 		return nil, nil, err
 	}
 
+	log := ctrl.LoggerFrom(ctx)
 	for i := range workloads.Items {
 		w := &workloads.Items[i]
+		if owner := metav1.GetControllerOfNoCopy(w); !ownerMatchesJob(owner, gvk, object.GetName()) {
+			log.V(2).Info("Skipping workload not controlled by the job", "workload", klog.KObj(w))
+			continue
+		}
 		isEquivalent, err := EquivalentToWorkload(ctx, c, job, w)
 		if err != nil {
 			return nil, nil, err
@@ -1404,6 +1411,14 @@ func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob)
 	}
 
 	return match, toDelete, nil
+}
+
+// ownerMatchesJob reports whether owner identifies the job by Kind, APIVersion and name.
+func ownerMatchesJob(owner *metav1.OwnerReference, gvk schema.GroupVersionKind, name string) bool {
+	return owner != nil &&
+		owner.Kind == gvk.Kind &&
+		owner.APIVersion == gvk.GroupVersion().String() &&
+		owner.Name == name
 }
 
 func EnsurePrebuiltWorkloadOwnership(ctx context.Context, c client.Client, wl *kueue.Workload, object client.Object) error {
@@ -1488,13 +1503,13 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 	return runningPodSets
 }
 
-// EquivalentToWorkload checks if the job corresponds to the workload
+// EquivalentToWorkload checks if the job corresponds to the workload.
 func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, wl *kueue.Workload) (bool, error) {
 	owner := metav1.GetControllerOf(wl)
 	// A Workload without a controller owner reference cannot belong to this job.
 	// The owner index that selects candidates matches any owner reference, not only
 	// controller ones, so wl may reach here with no controller owner.
-	if owner == nil || owner.Name != job.Object().GetName() {
+	if owner == nil || !ownerMatchesJob(owner, job.GVK(), job.Object().GetName()) {
 		return false, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
@@ -579,6 +581,370 @@ func TestReconcileGenericJobWithCustomWorkloadActivation(t *testing.T) {
 			}
 			if *updated.Spec.Active != tc.expectedActive {
 				t.Fatalf("Workload.Spec.Active = %t, want %t", *updated.Spec.Active, tc.expectedActive)
+			}
+		})
+	}
+}
+
+func TestFindMatchingWorkloads(t *testing.T) {
+	const (
+		testJobName = "test-job"
+		testNS      = metav1.NamespaceDefault
+		testJobUID  = "test-job-uid"
+	)
+	testGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+	basePodSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("main", 1).Obj(),
+	}
+	baseJob := testingjob.MakeJob(testJobName, testNS).UID(testJobUID).Obj()
+
+	baseWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).PodSets(basePodSets...)
+	}
+
+	testCases := map[string]struct {
+		featureGates map[featuregate.Feature]bool
+		workloads    []*kueue.Workload
+		wantMatch    string
+		wantToDelete []string
+	}{
+		"workload with only a non-controller owner reference is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-plain").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+		},
+		"workload controlled by another object is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-controlled").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+			},
+		},
+		"workload controlled by a same-named object of a different kind is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-same-name").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), testJobName, "some-config-uid").
+					Obj(),
+			},
+		},
+		"foreign workload with different pod sets is neither matched nor deleted": {
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("foreign-diff-pods", testNS).
+					PodSets(*utiltestingapi.MakePodSet("main", 2).Obj()).
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+			},
+		},
+		"owned workload with different pod sets is collected for deletion": {
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("owned-diff-pods", testNS).
+					PodSets(*utiltestingapi.MakePodSet("main", 2).Obj()).
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantToDelete: []string{"owned-diff-pods"},
+		},
+		"workload controlled by the job with a stale UID is collected for deletion": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workloads: []*kueue.Workload{
+				baseWl("stale-uid").
+					ControllerReference(testGVK, testJobName, "old-uid").
+					Obj(),
+			},
+			wantToDelete: []string{"stale-uid"},
+		},
+		"equivalent workload controlled by the job is matched": {
+			workloads: []*kueue.Workload{
+				baseWl("owned").
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantMatch: "owned",
+		},
+		"foreign workloads are ignored while the owned workload is matched": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-plain").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+				baseWl("foreign-controlled").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+				baseWl("owned").
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantMatch: "owned",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			mockctrl := gomock.NewController(t)
+
+			mgj := mocks.NewMockGenericJob(mockctrl)
+			mgj.EXPECT().Object().Return(baseJob).AnyTimes()
+			mgj.EXPECT().GVK().Return(testGVK).AnyTimes()
+			mgj.EXPECT().IsSuspended().Return(true).AnyTimes()
+			mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(basePodSets, nil).AnyTimes()
+
+			objs := make([]client.Object, 0, len(tc.workloads))
+			for _, wl := range tc.workloads {
+				objs = append(objs, wl)
+			}
+			cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+				WithObjects(objs...).
+				WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(testGVK), indexer.WorkloadOwnerIndexFunc(testGVK)).
+				Build()
+
+			match, toDelete, err := FindMatchingWorkloads(ctx, cl, mgj)
+			if err != nil {
+				t.Fatalf("FindMatchingWorkloads returned error: %v", err)
+			}
+
+			gotMatch := ""
+			if match != nil {
+				gotMatch = match.Name
+			}
+			if gotMatch != tc.wantMatch {
+				t.Errorf("match = %q, want %q", gotMatch, tc.wantMatch)
+			}
+
+			gotToDelete := make([]string, 0, len(toDelete))
+			for _, wl := range toDelete {
+				gotToDelete = append(gotToDelete, wl.Name)
+			}
+			slices.Sort(gotToDelete)
+			wantToDelete := slices.Clone(tc.wantToDelete)
+			slices.Sort(wantToDelete)
+			if diff := cmp.Diff(wantToDelete, gotToDelete, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("toDelete mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestEquivalentToWorkload covers the ownership checks of
+// EquivalentToWorkload with concrete job GVK and Workload examples: a
+// Workload is equivalent only when it is controlled by an owner reference
+// whose Kind, APIVersion and Name all match the job (and whose UID matches
+// when FinishOrphanedWorkloads is enabled). Each test case provides a fully
+// constructed job and Workload.
+func TestEquivalentToWorkload(t *testing.T) {
+	const (
+		testJobName = "test-job"
+		testNS      = metav1.NamespaceDefault
+		testJobUID  = "test-job-uid"
+	)
+	testGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+	configMapGVK := corev1.SchemeGroupVersion.WithKind("ConfigMap")
+
+	baseJob := func() *job.Job {
+		return (*job.Job)(testingjob.MakeJob(testJobName, testNS).UID(testJobUID).Obj())
+	}
+
+	partiallyAdmittedJob := func(suspended bool) *job.Job {
+		return (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+			UID(testJobUID).
+			Parallelism(2).
+			SetAnnotation(job.JobMinParallelismAnnotation, "1").
+			Suspend(suspended).
+			Obj())
+	}
+
+	execTimeJob := (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+		UID(testJobUID).
+		Label(constants.MaxExecTimeSecondsLabel, "60").
+		Obj())
+
+	invalidTASJob := (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+		UID(testJobUID).
+		PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "not-a-bool").
+		Obj())
+
+	// podSetsFor builds the Workload pod sets matching the pod sets reported
+	// by the given Job, including the TAS pod index label, as
+	// TopologyAwareScheduling is enabled by default.
+	podSetsFor := func(j *job.Job, count int) *utiltestingapi.PodSetWrapper {
+		return utiltestingapi.MakePodSet(kueue.DefaultPodSetName, count).
+			PodSpec(j.Spec.Template.Spec).
+			PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation))
+	}
+
+	baseWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).
+			PodSets(*podSetsFor(baseJob(), 1).Obj())
+	}
+
+	admittedWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return baseWl(name).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+				kueue.PodSetAssignment{Name: kueue.DefaultPodSetName},
+			).Obj(), time.Now().Truncate(time.Hour)).
+			AdmittedAt(true, time.Now().Truncate(time.Hour))
+	}
+
+	partiallyAdmittedWl := func(name string, j *job.Job) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).
+			PodSets(*podSetsFor(j, 2).SetMinimumCount(1).Obj()).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+				kueue.PodSetAssignment{Name: kueue.DefaultPodSetName, Count: ptr.To[int32](1)},
+			).Obj(), time.Now().Truncate(time.Hour)).
+			AdmittedAt(true, time.Now().Truncate(time.Hour))
+	}
+
+	testCases := map[string]struct {
+		featureGates map[featuregate.Feature]bool
+		job          GenericJob
+		wl           *kueue.Workload
+		want         bool
+		wantErr      bool
+	}{
+		"no controller owner reference (previously panicked)": {
+			job: baseJob(),
+			wl: baseWl("plain-owner").
+				OwnerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"without any owner references": {
+			job:  baseJob(),
+			wl:   baseWl("no-owners").Obj(),
+			want: false,
+		},
+		"matching UID when FinishOrphanedWorkloads is enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			job:          baseJob(),
+			wl: baseWl("owned-matching-uid").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"stale UID is ignored when FinishOrphanedWorkloads is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
+			job:          baseJob(),
+			wl: baseWl("owned-stale-uid-gate-off").
+				ControllerReference(testGVK, testJobName, "old-uid").
+				Obj(),
+			want: true,
+		},
+		"suspended job falls back to spec comparison for an admitted workload": {
+			job: partiallyAdmittedJob(true),
+			wl: partiallyAdmittedWl("owned-admitted-partial", partiallyAdmittedJob(true)).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"running job does not fall back to spec comparison for an admitted workload": {
+			job: partiallyAdmittedJob(false),
+			wl: partiallyAdmittedWl("owned-admitted-partial-running", partiallyAdmittedJob(false)).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"controller with a different kind but the same name": {
+			job: baseJob(),
+			wl: baseWl("configmap-controlled").
+				OwnerReference(testGVK, testJobName, testJobUID).
+				ControllerReference(configMapGVK, testJobName, "some-config-uid").
+				Obj(),
+			want: false,
+		},
+		"controller with a different apiVersion": {
+			job: baseJob(),
+			wl: baseWl("old-api").
+				ControllerReference(schema.GroupVersion{Group: "batch", Version: "v1beta1"}.WithKind("Job"), testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"controller with the same GVK but a different name": {
+			job: baseJob(),
+			wl: baseWl("other-job").
+				ControllerReference(testGVK, "other-job", "other-uid").
+				Obj(),
+			want: false,
+		},
+		"matching controller with a stale UID (FinishOrphanedWorkloads)": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			job:          baseJob(),
+			wl: baseWl("stale-uid").
+				ControllerReference(testGVK, testJobName, "old-uid").
+				Obj(),
+			want: false,
+		},
+		"matching controller and pod sets": {
+			job: baseJob(),
+			wl: baseWl("owned").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"matching controller but different pod sets": {
+			job: baseJob(),
+			wl: utiltestingapi.MakeWorkload("owned-diff-pods", testNS).
+				PodSets(*podSetsFor(baseJob(), 2).Obj()).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"matching controller but different maximum execution time": {
+			job: execTimeJob,
+			wl: baseWl("owned-diff-exec-time").
+				MaximumExecutionTimeSeconds(30).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"admitted workload with matching running pod sets": {
+			job: baseJob(),
+			wl: admittedWl("owned-admitted").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"admitted workload with different pod sets and a suspended job": {
+			job: baseJob(),
+			wl: admittedWl("owned-admitted-diff").
+				PodSets(*podSetsFor(baseJob(), 2).Obj()).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"error reading job pod sets is propagated": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			job:          invalidTASJob,
+			wl: baseWl("owned").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			wantErr: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).Build()
+
+			got, err := EquivalentToWorkload(ctx, cl, tc.job, tc.wl)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("EquivalentToWorkload expected error, got nil (result %t)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EquivalentToWorkload returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("EquivalentToWorkload = %t, want %t", got, tc.want)
 			}
 		})
 	}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
@@ -874,7 +876,11 @@ func TestReconcileGenericJob(t *testing.T) {
 					Obj(),
 			},
 		},
-		"non-controller owner reference matching the job name is not equivalent and gets updated in place": {
+		// A Workload that merely references the job (non-controller owner
+		// reference) is not matched and is not updated in place: it is left
+		// to its owner and to the garbage collector, while a new owned
+		// Workload is created.
+		"non-controller owner reference matching the job name is ignored and a new workload is created": {
 			req:     baseReq,
 			job:     baseJob.DeepCopy(),
 			podSets: basePodSets,
@@ -890,13 +896,14 @@ func TestReconcileGenericJob(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("job-test-job-1", metav1.NamespaceDefault).
-					ResourceVersion("2").
+					ResourceVersion("1").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					OwnerReference(testGVK, testJobName, testJobName).
 					Queue(testLocalQueueName).
-					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+					PodSets(*utiltestingapi.MakePodSet("old", 2).Obj()).
 					Priority(0).
 					Obj(),
+				*baseWl.Clone().Name("job-test-job-ce737").Obj(),
 			},
 		},
 		"workload with no owner references at all is not matched and a new workload is created": {
@@ -1107,6 +1114,395 @@ func TestReconcileGenericJobWithCustomWorkloadActivation(t *testing.T) {
 			}
 			if *updated.Spec.Active != tc.expectedActive {
 				t.Fatalf("Workload.Spec.Active = %t, want %t", *updated.Spec.Active, tc.expectedActive)
+			}
+		})
+	}
+}
+
+func TestFindMatchingWorkloads(t *testing.T) {
+	const (
+		testJobName = "test-job"
+		testNS      = metav1.NamespaceDefault
+		testJobUID  = "test-job-uid"
+	)
+	testGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+	basePodSets := []kueue.PodSet{
+		*utiltestingapi.MakePodSet("main", 1).Obj(),
+	}
+	baseJob := testingjob.MakeJob(testJobName, testNS).UID(testJobUID).Obj()
+
+	baseWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).PodSets(basePodSets...)
+	}
+
+	testCases := map[string]struct {
+		featureGates map[featuregate.Feature]bool
+		workloads    []*kueue.Workload
+		wantMatch    string
+		wantToDelete []string
+	}{
+		"workload with only a non-controller owner reference is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-plain").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+		},
+		"workload controlled by another object is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-controlled").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+			},
+		},
+		"workload controlled by a same-named object of a different kind is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-same-name").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), testJobName, "some-config-uid").
+					Obj(),
+			},
+		},
+		"foreign workload with different pod sets is neither matched nor deleted": {
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("foreign-diff-pods", testNS).
+					PodSets(*utiltestingapi.MakePodSet("main", 2).Obj()).
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+			},
+		},
+		"owned workload with different pod sets is collected for deletion": {
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("owned-diff-pods", testNS).
+					PodSets(*utiltestingapi.MakePodSet("main", 2).Obj()).
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantToDelete: []string{"owned-diff-pods"},
+		},
+		"workload controlled by the job with a stale UID is collected for deletion": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			workloads: []*kueue.Workload{
+				baseWl("stale-uid").
+					ControllerReference(testGVK, testJobName, "old-uid").
+					Obj(),
+			},
+			wantToDelete: []string{"stale-uid"},
+		},
+		"equivalent workload controlled by the job is matched": {
+			workloads: []*kueue.Workload{
+				baseWl("owned").
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantMatch: "owned",
+		},
+		"equivalent workload slice controlled by the job is matched": {
+			workloads: []*kueue.Workload{
+				baseWl("owned-slice").
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "owned-slice").
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantMatch: "owned-slice",
+		},
+		"workload slice with only a non-controller owner reference is ignored": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-slice").
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "foreign-slice").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+		},
+		"foreign workloads are ignored while the owned workload is matched": {
+			workloads: []*kueue.Workload{
+				baseWl("foreign-plain").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+				baseWl("foreign-controlled").
+					OwnerReference(testGVK, testJobName, testJobUID).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("ConfigMap"), "some-config", "some-config-uid").
+					Obj(),
+				baseWl("owned").
+					ControllerReference(testGVK, testJobName, testJobUID).
+					Obj(),
+			},
+			wantMatch: "owned",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			mockctrl := gomock.NewController(t)
+
+			mockedJob := mocks.NewMockGenericJob(mockctrl)
+			mockedJob.EXPECT().Object().Return(baseJob).AnyTimes()
+			mockedJob.EXPECT().GVK().Return(testGVK).AnyTimes()
+			mockedJob.EXPECT().IsSuspended().Return(true).AnyTimes()
+			mockedJob.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(basePodSets, nil).AnyTimes()
+
+			objs := make([]client.Object, 0, len(tc.workloads))
+			for _, wl := range tc.workloads {
+				objs = append(objs, wl)
+			}
+			cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+				WithObjects(objs...).
+				WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(testGVK), indexer.WorkloadOwnerIndexFunc(testGVK)).
+				Build()
+
+			match, toDelete, err := FindMatchingWorkloads(ctx, cl, mockedJob)
+			if err != nil {
+				t.Fatalf("FindMatchingWorkloads returned error: %v", err)
+			}
+
+			gotMatch := ""
+			if match != nil {
+				gotMatch = match.Name
+			}
+			if gotMatch != tc.wantMatch {
+				t.Errorf("match = %q, want %q", gotMatch, tc.wantMatch)
+			}
+
+			gotToDelete := make([]string, 0, len(toDelete))
+			for _, wl := range toDelete {
+				gotToDelete = append(gotToDelete, wl.Name)
+			}
+			slices.Sort(gotToDelete)
+			wantToDelete := slices.Clone(tc.wantToDelete)
+			slices.Sort(wantToDelete)
+			if diff := cmp.Diff(wantToDelete, gotToDelete, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("toDelete mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestEquivalentToWorkload covers the ownership checks of
+// EquivalentToWorkload with concrete job GVK and Workload examples: a
+// Workload is equivalent only when it is controlled by an owner reference
+// whose Kind, APIVersion and Name all match the job (and whose UID matches
+// when FinishOrphanedWorkloads is enabled). Each test case provides a fully
+// constructed job and Workload.
+func TestEquivalentToWorkload(t *testing.T) {
+	const (
+		testJobName = "test-job"
+		testNS      = metav1.NamespaceDefault
+		testJobUID  = "test-job-uid"
+	)
+	testGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+	configMapGVK := corev1.SchemeGroupVersion.WithKind("ConfigMap")
+
+	baseJob := func() *job.Job {
+		return (*job.Job)(testingjob.MakeJob(testJobName, testNS).UID(testJobUID).Obj())
+	}
+
+	partiallyAdmittedJob := func(suspended bool) *job.Job {
+		return (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+			UID(testJobUID).
+			Parallelism(2).
+			SetAnnotation(job.JobMinParallelismAnnotation, "1").
+			Suspend(suspended).
+			Obj())
+	}
+
+	execTimeJob := (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+		UID(testJobUID).
+		Label(constants.MaxExecTimeSecondsLabel, "60").
+		Obj())
+
+	invalidTASJob := (*job.Job)(testingjob.MakeJob(testJobName, testNS).
+		UID(testJobUID).
+		PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "not-a-bool").
+		Obj())
+
+	// podSetsFor builds the Workload pod sets matching the pod sets reported
+	// by the given Job, including the TAS pod index label, as
+	// TopologyAwareScheduling is enabled by default.
+	podSetsFor := func(j *job.Job, count int) *utiltestingapi.PodSetWrapper {
+		return utiltestingapi.MakePodSet(kueue.DefaultPodSetName, count).
+			PodSpec(j.Spec.Template.Spec).
+			PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation))
+	}
+
+	baseWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).
+			PodSets(*podSetsFor(baseJob(), 1).Obj())
+	}
+
+	admittedWl := func(name string) *utiltestingapi.WorkloadWrapper {
+		return baseWl(name).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+				kueue.PodSetAssignment{Name: kueue.DefaultPodSetName},
+			).Obj(), time.Now().Truncate(time.Hour)).
+			AdmittedAt(true, time.Now().Truncate(time.Hour))
+	}
+
+	partiallyAdmittedWl := func(name string, j *job.Job) *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload(name, testNS).
+			PodSets(*podSetsFor(j, 2).SetMinimumCount(1).Obj()).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(
+				kueue.PodSetAssignment{Name: kueue.DefaultPodSetName, Count: ptr.To[int32](1)},
+			).Obj(), time.Now().Truncate(time.Hour)).
+			AdmittedAt(true, time.Now().Truncate(time.Hour))
+	}
+
+	testCases := map[string]struct {
+		featureGates map[featuregate.Feature]bool
+		job          GenericJob
+		wl           *kueue.Workload
+		want         bool
+		wantErr      bool
+	}{
+		"no controller owner reference (previously panicked)": {
+			job: baseJob(),
+			wl: baseWl("plain-owner").
+				OwnerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"without any owner references": {
+			job:  baseJob(),
+			wl:   baseWl("no-owners").Obj(),
+			want: false,
+		},
+		"matching UID when FinishOrphanedWorkloads is enabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			job:          baseJob(),
+			wl: baseWl("owned-matching-uid").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"stale UID is ignored when FinishOrphanedWorkloads is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: false},
+			job:          baseJob(),
+			wl: baseWl("owned-stale-uid-gate-off").
+				ControllerReference(testGVK, testJobName, "old-uid").
+				Obj(),
+			want: true,
+		},
+		"suspended job falls back to spec comparison for an admitted workload": {
+			job: partiallyAdmittedJob(true),
+			wl: partiallyAdmittedWl("owned-admitted-partial", partiallyAdmittedJob(true)).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		// Partially admitted (1 running pod of parallelism 2): the running
+		// pod sets don't match the job's, and the spec-comparison fallback
+		// applies only to suspended jobs - so for a running job this
+		// workload is intentionally not equivalent: the reconciler stops
+		// the job and deletes the workload; a matching one is constructed
+		// on the next sync.
+		"running job does not fall back to spec comparison for an admitted workload": {
+			job: partiallyAdmittedJob(false),
+			wl: partiallyAdmittedWl("owned-admitted-partial-running", partiallyAdmittedJob(false)).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"controller with a different kind but the same name": {
+			job: baseJob(),
+			wl: baseWl("configmap-controlled").
+				OwnerReference(testGVK, testJobName, testJobUID).
+				ControllerReference(configMapGVK, testJobName, "some-config-uid").
+				Obj(),
+			want: false,
+		},
+		"controller with a different apiVersion": {
+			job: baseJob(),
+			wl: baseWl("old-api").
+				ControllerReference(schema.GroupVersion{Group: "batch", Version: "v1beta1"}.WithKind("Job"), testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"controller with the same GVK but a different name": {
+			job: baseJob(),
+			wl: baseWl("other-job").
+				ControllerReference(testGVK, "other-job", "other-uid").
+				Obj(),
+			want: false,
+		},
+		"matching controller with a stale UID (FinishOrphanedWorkloads)": {
+			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
+			job:          baseJob(),
+			wl: baseWl("stale-uid").
+				ControllerReference(testGVK, testJobName, "old-uid").
+				Obj(),
+			want: false,
+		},
+		"matching controller and pod sets": {
+			job: baseJob(),
+			wl: baseWl("owned").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"matching controller but different pod sets": {
+			job: baseJob(),
+			wl: utiltestingapi.MakeWorkload("owned-diff-pods", testNS).
+				PodSets(*podSetsFor(baseJob(), 2).Obj()).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"matching controller but different maximum execution time": {
+			job: execTimeJob,
+			wl: baseWl("owned-diff-exec-time").
+				MaximumExecutionTimeSeconds(30).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"admitted workload with matching running pod sets": {
+			job: baseJob(),
+			wl: admittedWl("owned-admitted").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: true,
+		},
+		"admitted workload with different pod sets and a suspended job": {
+			job: baseJob(),
+			wl: admittedWl("owned-admitted-diff").
+				PodSets(*podSetsFor(baseJob(), 2).Obj()).
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			want: false,
+		},
+		"error reading job pod sets is propagated": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+			job:          invalidTASJob,
+			wl: baseWl("owned").
+				ControllerReference(testGVK, testJobName, testJobUID).
+				Obj(),
+			wantErr: true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).Build()
+
+			got, err := EquivalentToWorkload(ctx, cl, tc.job, tc.wl)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("EquivalentToWorkload expected error, got nil (result %t)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EquivalentToWorkload returned error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("EquivalentToWorkload = %t, want %t", got, tc.want)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -688,6 +688,128 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		})
 	})
 
+	ginkgo.It("should not get stuck when a workload with a non-controller owner reference exists", func() {
+		job := testingjob.MakeJob(jobName, ns.Name).
+			Queue("main").
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		// A workload whose only owner reference points to the job, but is NOT
+		// a controller reference (e.g. a hand-made manifest or a GitOps
+		// round-trip that dropped the controller flag).
+		foreignPlain := utiltestingapi.MakeWorkload("foreign-plain", ns.Name).
+			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+				Containers(job.Spec.Template.Spec.Containers[0]).
+				Obj()).
+			OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), job.Name, string(job.UID)).
+			Obj()
+		util.MustCreate(ctx, k8sClient, foreignPlain)
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+		ginkgo.By("checking kueue creates its own workload for the job", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(metav1.IsControlledBy(createdWorkload, job)).To(gomega.BeTrue(), "The new Workload should be owned by the Job")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admitting the workload, the job should unsuspend", func() {
+			admission := utiltestingapi.MakeAdmission("cq", kueue.NewPodSetReference(job.Spec.Template.Spec.Containers[0].Name)).Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the foreign workload is neither matched, adopted nor deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				createdWl := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foreignPlain), &createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.DeletionTimestamp).To(gomega.BeNil(), "foreign Workload should not be deleted")
+				g.Expect(createdWl.OwnerReferences).To(gomega.Equal(foreignPlain.OwnerReferences), "foreign Workload owner references should be untouched")
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("should neither hijack nor delete workloads controlled by another object", func() {
+		job := testingjob.MakeJob(jobName, ns.Name).
+			Queue("main").
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		ginkgo.By("waiting for the job to be suspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Workloads with a plain owner reference to the served job plus a
+		// controller reference to another object (a third-party controller
+		// pattern). Distinct pod set counts make a spec hijack observable.
+		mkForeignControlled := func(name string, count int) *kueue.Workload {
+			wl := utiltestingapi.MakeWorkload(name, ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, count).
+					Containers(job.Spec.Template.Spec.Containers[0]).
+					Obj()).
+				Obj()
+			wl.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       job.Name,
+					UID:        job.UID,
+				},
+				{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+					Name:       "some-config",
+					UID:        types.UID("some-config-uid"),
+					Controller: new(true),
+				},
+			}
+			return wl
+		}
+		foreignA := mkForeignControlled("foreign-a", 2)
+		foreignB := mkForeignControlled("foreign-b", 3)
+		util.MustCreate(ctx, k8sClient, foreignA)
+		util.MustCreate(ctx, k8sClient, foreignB)
+
+		// The job controller owns only controller-owned workloads, so creating
+		// the foreign workloads does not enqueue a reconcile by itself; nudge
+		// the job to force one.
+		ginkgo.By("triggering a job reconcile", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				if createdJob.Annotations == nil {
+					createdJob.Annotations = map[string]string{}
+				}
+				createdJob.Annotations["test.kueue.x-k8s.io/nudge"] = "1"
+				g.Expect(k8sClient.Update(ctx, &createdJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the foreign workloads are neither hijacked nor deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, foreign := range []*kueue.Workload{foreignA, foreignB} {
+					createdWl := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foreign), &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.DeletionTimestamp).To(gomega.BeNil(), "foreign Workload should not be deleted")
+					g.Expect(createdWl.OwnerReferences).To(gomega.Equal(foreign.OwnerReferences), "foreign Workload owner references should be untouched")
+					g.Expect(createdWl.Spec.PodSets).To(gomega.Equal(foreign.Spec.PodSets), "foreign Workload spec should be untouched")
+					g.Expect(createdWl.Spec.QueueName).To(gomega.BeEmpty(), "foreign Workload should not be adopted into a queue")
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("WorkloadIdentifierAnnotations feature gate is disabled", func() {
 		ginkgo.BeforeEach(func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadIdentifierAnnotations, false)

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -127,17 +127,21 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 		job := testingjob.MakeJob(jobName, ns.Name).Suspend(true).Parallelism(3).Completions(3).Obj()
 		util.MustCreate(ctx, k8sClient, job)
 
-		ginkgo.By("verifying the reconcile ran to completion: it adopts the crafted Workload and rewrites its PodSet count to the job's parallelism")
-		// A suspended job with a single non-matching Workload has that Workload's
-		// spec rewritten to match the job (reconciler.go updateWorkloadToMatchJob).
-		// Without the guard, FindMatchingWorkloads panics on the crafted Workload
-		// before reaching this point, so the count stays at its original value.
+		ginkgo.By("verifying the reconcile does not crash and does not hijack the crafted Workload")
 		craftedKey := types.NamespacedName{Name: craftedWl.Name, Namespace: ns.Name}
 		updatedWl := &kueue.Workload{}
-		gomega.Eventually(func(g gomega.Gomega) {
+		gomega.Consistently(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, craftedKey, updatedWl)).Should(gomega.Succeed())
 			g.Expect(updatedWl.Spec.PodSets).ShouldNot(gomega.BeEmpty())
-			g.Expect(updatedWl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(3)))
+			g.Expect(updatedWl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(1)))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+		ginkgo.By("checking kueue creates its own workload for the job")
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+			g.Expect(metav1.IsControlledBy(createdWorkload, job)).To(gomega.BeTrue(), "The new Workload should be owned by the Job")
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
@@ -821,6 +825,128 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 					g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+	})
+
+	ginkgo.It("should not get stuck when a workload with a non-controller owner reference exists", func() {
+		job := testingjob.MakeJob(jobName, ns.Name).
+			Queue("main").
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		// A workload whose only owner reference points to the job, but is NOT
+		// a controller reference (e.g. a hand-made manifest or a GitOps
+		// round-trip that dropped the controller flag).
+		foreignPlain := utiltestingapi.MakeWorkload("foreign-plain", ns.Name).
+			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+				Containers(job.Spec.Template.Spec.Containers[0]).
+				Obj()).
+			OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), job.Name, string(job.UID)).
+			Obj()
+		util.MustCreate(ctx, k8sClient, foreignPlain)
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: ns.Name}
+		ginkgo.By("checking kueue creates its own workload for the job", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+				g.Expect(metav1.IsControlledBy(createdWorkload, job)).To(gomega.BeTrue(), "The new Workload should be owned by the Job")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("admitting the workload, the job should unsuspend", func() {
+			admission := utiltestingapi.MakeAdmission("cq", kueue.NewPodSetReference(job.Spec.Template.Spec.Containers[0].Name)).Obj()
+			util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+			util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, true)).To(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the foreign workload is neither matched, adopted nor deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				createdWl := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foreignPlain), &createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.DeletionTimestamp).To(gomega.BeNil(), "foreign Workload should not be deleted")
+				g.Expect(createdWl.OwnerReferences).To(gomega.Equal(foreignPlain.OwnerReferences), "foreign Workload owner references should be untouched")
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("should neither hijack nor delete workloads controlled by another object", func() {
+		job := testingjob.MakeJob(jobName, ns.Name).
+			Queue("main").
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		ginkgo.By("waiting for the job to be suspended", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Workloads with a plain owner reference to the served job plus a
+		// controller reference to another object (a third-party controller
+		// pattern). Distinct pod set counts make a spec hijack observable.
+		mkForeignControlled := func(name string, count int) *kueue.Workload {
+			wl := utiltestingapi.MakeWorkload(name, ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, count).
+					Containers(job.Spec.Template.Spec.Containers[0]).
+					Obj()).
+				Obj()
+			wl.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: batchv1.SchemeGroupVersion.String(),
+					Kind:       "Job",
+					Name:       job.Name,
+					UID:        job.UID,
+				},
+				{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+					Name:       "some-config",
+					UID:        types.UID("some-config-uid"),
+					Controller: new(true),
+				},
+			}
+			return wl
+		}
+		foreignA := mkForeignControlled("foreign-a", 2)
+		foreignB := mkForeignControlled("foreign-b", 3)
+		util.MustCreate(ctx, k8sClient, foreignA)
+		util.MustCreate(ctx, k8sClient, foreignB)
+
+		// The job controller owns only controller-owned workloads, so creating
+		// the foreign workloads does not enqueue a reconcile by itself; nudge
+		// the job to force one.
+		ginkgo.By("triggering a job reconcile", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				if createdJob.Annotations == nil {
+					createdJob.Annotations = map[string]string{}
+				}
+				createdJob.Annotations["test.kueue.x-k8s.io/nudge"] = "1"
+				g.Expect(k8sClient.Update(ctx, &createdJob)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the foreign workloads are neither hijacked nor deleted", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, foreign := range []*kueue.Workload{foreignA, foreignB} {
+					createdWl := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(foreign), &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.DeletionTimestamp).To(gomega.BeNil(), "foreign Workload should not be deleted")
+					g.Expect(createdWl.OwnerReferences).To(gomega.Equal(foreign.OwnerReferences), "foreign Workload owner references should be untouched")
+					g.Expect(createdWl.Spec.PodSets).To(gomega.Equal(foreign.Spec.PodSets), "foreign Workload spec should be untouched")
+					g.Expect(createdWl.Spec.QueueName).To(gomega.BeEmpty(), "foreign Workload should not be adopted into a queue")
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
Fixes #13572

What this PR does:

`FindMatchingWorkloads` lists Workloads through the owner-reference field index, which matches *all* ownerReferences with the job's GVK — including non-controller ones. The reconciler then treated every listed Workload as its own, which caused:

- a nil pointer dereference in `EquivalentToWorkload` for Workloads without a controller reference (permanent reconcile error-loop for the affected job),
- deletion of Workloads controlled by other objects (`toDelete` path),
- spec hijack of suspended-job foreign Workloads (`toUpdate` path).

Changes:

- `FindMatchingWorkloads` now skips (with a V(2) log) any listed Workload that is not controlled by this job, before the equivalency check. The UID is intentionally **not** compared here, so the existing stale-UID cleanup (via `FinishOrphanedWorkloads`) keeps working.
- `EquivalentToWorkload` gets a nil guard for the controller owner reference as defense-in-depth (it is exported and also called from the prebuilt path).

Controller-less Workloads that merely reference the job are left to their owners and to the garbage collector; pod group Workloads (controller-less by design) are unaffected because the pod group path uses its own equivalency check.

Tests:

- Unit: `TestFindMatchingWorkloads` — non-controller ownerRef ignored; foreign-controlled ignored; stale-UID still collected for deletion; normal match; mixed. Without the fix the first case panics.
- Integration (`test/integration/singlecluster/controller/jobs/job`): job no longer gets stuck with a foreign plain-ownerRef Workload present; foreign-controlled Workloads are neither hijacked nor deleted. Both specs fail without the fix, pass with it.

```release-note
JobFramework: Fix a nil pointer dereference and unauthorized deletion/modification of foreign Workloads in the job framework: FindMatchingWorkloads now only considers Workloads controlled by the reconciled job. Workloads with non-controller ownerReferences to a served job previously caused a permanent reconcile error-loop for that job, and Workloads controlled by other objects could be deleted or have their spec overwritten by kueue.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Jobs now only select, reconcile, and clean up workloads explicitly controller-owned by the job.
  - Workloads with missing or conflicting controller owner references are no longer adopted or queued for deletion.
  - Ownership equivalence now requires matching controller ownership, with behavior aligned to orphan-handling settings.

- **Tests**
  - Added unit tests for workload matching, deletion selection, and ownership equivalence.
  - Added integration tests confirming foreign workloads are neither modified, deleted, nor adopted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->