### PR TITLE
fix(tas): preserve leader assignment during elastic workload scale-up

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -6259,6 +6259,172 @@ func TestFindTopologyAssignments(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 			},
 		},
+		"elastic workload scale up with leader: places delta workers, preserves leader assignment": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x3").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           4,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 2, Values: []string{"x3"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		"elastic workload scale up with leader: stale leader assignment falls back to fresh placement": {
+			// Force fresh placement to differ from the workers' previous assignment:
+			// after placing the leader, x1 can hold only one worker instead of two.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("3"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x3").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("3"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"deleted-node"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x1"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           4,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x1"}},
+							{Count: 3, Values: []string{"x2"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
 		"multi-layer topology: block required; rack slices of 4; host slices of 2; TASMultiLayerTopology": {
 			// 4-level topology: block → rack → hostname
 			//              b1

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -53,6 +53,16 @@ func (s *TASFlavorSnapshot) handleElasticWorkload(
 		return elasticPlacementResult{applied: false}
 	}
 
+	// The leader's previous assignment is reused on every elastic path, so if
+	// its domain is gone the whole group needs fresh placement.
+	if leader != nil && leader.PreviousAssignment != nil {
+		if isStale, staleDomain := s.IsTopologyAssignmentStale(utiltas.InternalFrom(leader.PreviousAssignment)); isStale {
+			s.log.V(3).Info("previous TAS assignment of the leader is stale, doing fresh placement",
+				"staleDomain", staleDomain)
+			return elasticPlacementResult{applied: false}
+		}
+	}
+
 	previousCount := utiltas.CountPodsInAssignment(prevAssignment)
 
 	switch {
@@ -86,7 +96,18 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	// Previous pods consume capacity.
 	addAssumedUsage(assumedUsage, prevAssignment, &workers)
 
-	deltaAssignments, reason := s.findTopologyAssignment(ctx, deltaRequest, leader, assumedUsage, opts.simulateEmpty, "", opts.workload)
+	// The leader pod from the previous slice keeps running during scale-up, so
+	// its assignment must be preserved rather than recomputed; account for its
+	// usage so the delta placement does not oversubscribe its domain.
+	var leaderPrevAssignment *utiltas.TopologyAssignment
+	placementLeader := leader
+	if leader != nil && leader.PreviousAssignment != nil {
+		leaderPrevAssignment = utiltas.InternalFrom(leader.PreviousAssignment)
+		addAssumedUsage(assumedUsage, leaderPrevAssignment, leader)
+		placementLeader = nil
+	}
+
+	deltaAssignments, reason := s.findTopologyAssignment(ctx, deltaRequest, placementLeader, assumedUsage, opts.simulateEmpty, "", opts.workload)
 	if reason != "" {
 		result[workers.PodSet.Name] = tasPodSetAssignmentResult{FailureReason: reason}
 		return elasticPlacementResult{applied: true, assignments: result}
@@ -97,8 +118,12 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: finalAssignment}
 
 	if leader != nil {
-		result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: deltaAssignments[leader.PodSet.Name]}
-		addAssumedUsage(assumedUsage, deltaAssignments[leader.PodSet.Name], leader)
+		if leaderPrevAssignment != nil {
+			result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: leaderPrevAssignment}
+		} else {
+			result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: deltaAssignments[leader.PodSet.Name]}
+			addAssumedUsage(assumedUsage, deltaAssignments[leader.PodSet.Name], leader)
+		}
 	}
 
 	// Add only delta to avoid double-counting previous pods.

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -134,6 +134,38 @@ func countUngatedPods(pods []corev1.Pod) int {
 	return ungated
 }
 
+// podSetAssignmentByName returns the admitted pod set assignment with the given
+// name, or nil if the workload has no admission or no such assignment.
+func podSetAssignmentByName(wl *kueue.Workload, name kueue.PodSetReference) *kueue.PodSetAssignment {
+	if wl.Status.Admission == nil {
+		return nil
+	}
+	for i := range wl.Status.Admission.PodSetAssignments {
+		if wl.Status.Admission.PodSetAssignments[i].Name == name {
+			return &wl.Status.Admission.PodSetAssignments[i]
+		}
+	}
+	return nil
+}
+
+// topologyAssignmentByName returns the topology assignment of the named pod set
+// in the internal representation, failing when the pod set has no assignment yet.
+func topologyAssignmentByName(g gomega.Gomega, wl *kueue.Workload, name kueue.PodSetReference) *utiltas.TopologyAssignment {
+	psa := podSetAssignmentByName(wl, name)
+	g.Expect(psa).ShouldNot(gomega.BeNil(), "no pod set assignment for pod set %q", name)
+	g.Expect(psa.TopologyAssignment).ShouldNot(gomega.BeNil(), "no topology assignment for pod set %q", name)
+	return utiltas.InternalFrom(psa.TopologyAssignment)
+}
+
+// domainPodCounts returns the number of pods assigned to each topology domain.
+func domainPodCounts(assignment *utiltas.TopologyAssignment) map[utiltas.TopologyDomainID]int32 {
+	counts := make(map[utiltas.TopologyDomainID]int32, len(assignment.Domains))
+	for _, domain := range assignment.Domains {
+		counts[utiltas.DomainID(domain.Values)] += domain.Count
+	}
+	return counts
+}
+
 // _ is an unused variable placeholder, commonly used to ignore returned values or satisfy unused variable constraints.
 var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 	var (
@@ -6932,6 +6964,117 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					newAssignment := wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment
 					g.Expect(newAssignment.Slices).ShouldNot(gomega.BeEmpty())
 					g.Expect(originalAssignment.Slices).ShouldNot(gomega.BeEmpty())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should preserve the leader assignment when scaling up workers in a pod set group", func() {
+			var wl1 *kueue.Workload
+
+			// The group requests exactly one node's capacity (2 + 2*3 = 8 CPU), so the
+			// initial placement packs everything onto a single, fully used node. During
+			// scale-up the delta workers cannot fit there, so a (buggy) recomputation of
+			// the leader placement would necessarily move the leader to a different node.
+			ginkgo.By("create initial elastic workload with a leader and 2 workers", func() {
+				wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Annotation(constants.ElasticJobAnnotation, "true").
+					Obj()
+				wl1.Spec.PodSets = []kueue.PodSet{
+					*utiltestingapi.MakePodSet("leader", 1).
+						Request(corev1.ResourceCPU, "2").
+						UnconstrainedTopologyRequest().
+						PodSetGroup("elastic-group").
+						Image("image").
+						Obj(),
+					*utiltestingapi.MakePodSet("workers", 2).
+						Request(corev1.ResourceCPU, "3").
+						UnconstrainedTopologyRequest().
+						PodSetGroup("elastic-group").
+						Image("image").
+						Obj(),
+				}
+				util.MustCreate(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verify the workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			var originalLeaderAssignment, originalWorkersAssignment *utiltas.TopologyAssignment
+			ginkgo.By("record the leader and workers assignments", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					g.Expect(wl1.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl1.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
+					originalLeaderAssignment = topologyAssignmentByName(g, wl1, "leader")
+					originalWorkersAssignment = topologyAssignmentByName(g, wl1, "workers")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verify the group is packed onto a single node", func() {
+				// Precondition for the scenario: the leader's node is fully used, so a
+				// recomputed leader placement could never land on it again.
+				gomega.Expect(originalLeaderAssignment.Domains).Should(gomega.HaveLen(1))
+				gomega.Expect(originalWorkersAssignment.Domains).Should(gomega.HaveLen(1))
+				gomega.Expect(originalLeaderAssignment.Domains[0].Values).Should(gomega.Equal(originalWorkersAssignment.Domains[0].Values))
+			})
+
+			ginkgo.By("create pods simulating running pods", func() {
+				requests := []string{"2", "3", "3"}
+				for i := range 3 {
+					pod := testingpod.MakePod(fmt.Sprintf("pod-%d", i), ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+						Request(corev1.ResourceCPU, requests[i]).
+						Obj()
+					util.MustCreate(ctx, k8sClient, pod)
+				}
+			})
+
+			var wl2 *kueue.Workload
+			ginkgo.By("create a replacement workload slice with more workers", func() {
+				wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Annotation(constants.ElasticJobAnnotation, "true").
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(wl1))).
+					Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+					Obj()
+				wl2.Spec.PodSets = []kueue.PodSet{
+					*utiltestingapi.MakePodSet("leader", 1).
+						Request(corev1.ResourceCPU, "2").
+						UnconstrainedTopologyRequest().
+						PodSetGroup("elastic-group").
+						Image("image").
+						Obj(),
+					*utiltestingapi.MakePodSet("workers", 4).
+						Request(corev1.ResourceCPU, "3").
+						UnconstrainedTopologyRequest().
+						PodSetGroup("elastic-group").
+						Image("image").
+						Obj(),
+				}
+				util.MustCreate(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the replacement workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the leader keeps its assignment and workers keep their previous placement", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
+					g.Expect(wl2.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl2.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(2))
+					g.Expect(topologyAssignmentByName(g, wl2, "leader")).Should(gomega.BeComparableTo(originalLeaderAssignment))
+					newWorkersAssignment := topologyAssignmentByName(g, wl2, "workers")
+					g.Expect(utiltas.CountPodsInAssignment(newWorkersAssignment)).Should(gomega.Equal(int32(4)))
+					newCounts := domainPodCounts(newWorkersAssignment)
+					for _, domain := range originalWorkersAssignment.Domains {
+						g.Expect(newCounts[utiltas.DomainID(domain.Values)]).Should(
+							gomega.BeNumerically(">=", domain.Count),
+							"previous workers domain %v must be preserved", domain.Values)
+					}
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When an elastic workload (`ElasticJobsViaWorkloadSlices` + `ElasticJobsViaWorkloadSlicesWithTAS`) with a leader/workers pod set group (e.g. a RayCluster head + workers) scales up, `handleScaleUp` passed the leader to `findTopologyAssignment`, which ignores the leader's `PreviousAssignment` and computes a brand-new placement for it. The result unconditionally overwrote the leader's `TopologyAssignment` in the new workload slice. Since the assignment translates to NodeAffinity, the running leader pod could be terminated and restarted on another node, destroying cluster state and aborting running jobs. In practice the recomputed leader placement could even come out empty, tripping the internal `unexpected remainingCount` assertion in the snapshot code.

This PR fixes `handleScaleUp` to:

- preserve the leader's previous `TopologyAssignment` instead of recomputing it, and account for the leader's usage in `assumedUsage` before placing the delta workers, so the delta placement does not oversubscribe the leader's domain;
- skip the leader placement in `findTopologyAssignment` (its only effect for the leader was computing the new placement, i.e. the bug itself; elastic slices with TAS only support `Unconstrained`, so no co-location constraint is lost);
- fall back to fresh placement for the whole group when the leader's previous assignment points to a topology domain that no longer exists (mirroring the existing staleness check for the workers' assignment). The check is placed in `handleElasticWorkload` so it covers the scale-up, scale-down, and same-count paths alike.

Test coverage:

- Two new unit test cases in `TestFindTopologyAssignments`: scale-up with a leader preserving the leader assignment, and the stale-leader fallback. Both fail without the fix.
- A new integration test exercising the full path (flavorassigner → `getPreviousTopologyAssignment` → `handleScaleUp`) with a leader+workers pod set group. The scenario packs the group onto a fully-used node so that a recomputed leader placement could never coincide with the original one; the test fails on `main` with a leader-assignment diff and passes with the fix.

#### Which issue(s) this PR fixes:

Fixes #12528

#### Special notes for your reviewer:

- Scope: the issue's Impact section also mentions capacity double-subtraction on the fit path (`FindTopologyAssignmentsForWorkload` is invoked without `SimulateWorkloadRemoval` for the replaced slice while `handleScaleUp` re-adds the previous pods' usage to `assumedUsage`). That is a pre-existing problem independent of the leader reassignment fixed here: the preemption path accounts correctly, so a legitimate scale-up is still admitted through slice replacement. This PR didn't fix this problem.
- While writing the integration test I noticed the existing case "should place scaled-up workload in same topology domain as original" does not set the `kueue.x-k8s.io/elastic-job: "true"` annotation on the workloads, so it exercises fresh placement rather than the elastic delta path (and its assertions only check that the assignment is non-empty). The new test sets the annotation, matching what the jobframework reconciler propagates from the job. Fixing the existing test is left out of this PR as well.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where scaling up an elastic workload (`ElasticJobsViaWorkloadSlicesWithTAS`) with a leader/workers pod set group could overwrite the running leader pod's `TopologyAssignment` with a newly computed placement, causing the leader pod to be restarted and lose state. Kueue now preserves the leader's existing assignment and only places the newly added workers.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved elastic workload scaling for grouped leader and worker pod sets.
  * Preserved the leader’s topology assignment during worker scale-up when still valid.
  * Added fallback behavior when a leader’s previous assignment references unavailable capacity.
  * Ensured worker domain coverage is maintained during workload slice replacement and scaling.

* **Tests**
  * Added integration and table-driven coverage for elastic workload slice replacement and scale-up scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
