### PR TITLE
[release-0.18] ElasticJobsViaWorkloadSlices: finish a replaced slice as WorkloadSliceReplaced

### DIFF
--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -317,9 +317,12 @@ func normalizeActiveSlices(
 		if wl == selectedWorkload || wl == latestWithQuotaReservation {
 			continue
 		}
-		log.V(2).Info("Finishing out-of-sync workload slice", "workload", workload.Key(wl))
-		if err := workload.Finish(ctx, clnt, wl, kueue.WorkloadFinishedReasonOutOfSync,
-			"The workload slice is out of sync with its parent job", clk); err != nil {
+		reason, message := kueue.WorkloadFinishedReasonOutOfSync, "The workload slice is out of sync with its parent job"
+		if _, replaced := replacements[workload.Key(wl)]; replaced {
+			reason, message = kueue.WorkloadSliceReplaced, "Replaced to accommodate a new workload slice"
+		}
+		log.V(2).Info("Finishing workload slice", "workload", workload.Key(wl), "reason", reason)
+		if err := workload.Finish(ctx, clnt, wl, reason, message, clk); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -945,7 +945,7 @@ func TestEnsureWorkloadSlices(t *testing.T) {
 						Obj()).
 					WithInterceptorFuncs(interceptor.Funcs{
 						SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-							return assertStatusConditionPatch(t, subResourceName, obj, testJobObject.Name+"-1", kueue.WorkloadFinished, kueue.WorkloadFinishedReasonOutOfSync)
+							return assertStatusConditionPatch(t, subResourceName, obj, testJobObject.Name+"-1", kueue.WorkloadFinished, kueue.WorkloadSliceReplaced)
 						},
 					}).
 					Build(),

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -2147,6 +2147,111 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 	})
 
+	ginkgo.It("Should keep a replaced elastic-job slice's worker objects when normalizeActiveSlices finishes it", func() {
+		manager := managerTestCluster
+		worker1 := worker1TestCluster
+
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+
+		job := testingjob.MakeJob("job", managerNs.Name).
+			Parallelism(1).
+			Completions(2).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Obj()
+		util.MustCreate(manager.ctx, manager.client, job)
+
+		// sliceKey refreshes the job and returns the current slice's workload key.
+		// Elastic slice names embed the job generation, so scaling up yields a new key.
+		sliceKey := func() types.NamespacedName {
+			ginkgo.GinkgoHelper()
+			gomega.Expect(manager.client.Get(manager.ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+			return types.NamespacedName{Name: jobframework.GetWorkloadNameForOwnerWithGVKAndGeneration(job.Name, job.UID, jobGVK, job.GetGeneration()), Namespace: job.Namespace}
+		}
+
+		ginkgo.By("observe: the old workload slice is created in the manager cluster")
+		oldWorkloadKey := sliceKey()
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		// This suite does not run a scheduler, so the steps a scheduler would perform
+		// (reserving quota to admit a slice) are emulated with SetQuotaReservation.
+		ginkgo.By("emulate the scheduler reserving quota for the old slice on the manager cluster", func() {
+			util.SetQuotaReservation(manager.ctx, manager.client, oldWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+		})
+
+		ginkgo.By("emulate the scheduler reserving quota for the old slice on the worker1 cluster, and observe it is dispatched there", func() {
+			util.SetQuotaReservation(worker1.ctx, worker1.client, oldWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(worker1.client.Get(worker1.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+				g.Expect(worker1.client.Get(worker1.ctx, client.ObjectKeyFromObject(job), &batchv1.Job{})).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("scale-up the job so a replacement slice is created", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(manager.client.Get(manager.ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+				job.Spec.Parallelism = new(int32(2))
+				g.Expect(manager.client.Update(manager.ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the replacement slice is created in the manager cluster")
+		newWorkloadKey := sliceKey()
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(manager.client.Get(manager.ctx, newWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("observe: both the old and the replacement slice exist in the manager cluster", func() {
+			list := &kueue.WorkloadList{}
+			gomega.Expect(manager.client.List(manager.ctx, list, client.InNamespace(job.Namespace))).To(gomega.Succeed())
+			gomega.Expect(list.Items).To(gomega.HaveLen(2))
+		})
+
+		ginkgo.By("emulate the scheduler admitting the replacement slice (clusterName + quota reservation), but leave the old slice for normalizeActiveSlices to finish", func() {
+			oldWorkload := &kueue.Workload{}
+			gomega.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, oldWorkload)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				newWorkload := &kueue.Workload{}
+				g.Expect(manager.client.Get(manager.ctx, newWorkloadKey, newWorkload)).To(gomega.Succeed())
+				newWorkload.Status.ClusterName = oldWorkload.Status.ClusterName
+				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey,
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
+		})
+
+		ginkgo.By("observe: normalizeActiveSlices finishes the old slice with reason WorkloadSliceReplaced (not OutOfSync)", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				oldWorkload := &kueue.Workload{}
+				g.Expect(manager.client.Get(manager.ctx, oldWorkloadKey, oldWorkload)).To(gomega.Succeed())
+				finished := apimeta.FindStatusCondition(oldWorkload.Status.Conditions, kueue.WorkloadFinished)
+				g.Expect(finished).NotTo(gomega.BeNil())
+				g.Expect(finished.Status).To(gomega.Equal(metav1.ConditionTrue))
+				g.Expect(finished.Reason).To(gomega.Equal(kueue.WorkloadSliceReplaced))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("observe: the replaced slice's worker1 objects are kept during the handover (not deleted by MultiKueue)", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(worker1.client.Get(worker1.ctx, oldWorkloadKey, &kueue.Workload{})).To(gomega.Succeed())
+				remoteJob := &batchv1.Job{}
+				g.Expect(worker1.client.Get(worker1.ctx, client.ObjectKeyFromObject(job), remoteJob)).To(gomega.Succeed())
+			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should redo the admission process once the workload loses Admission in the worker cluster", func() {
 		job := testingjob.MakeJob("job", managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).


### PR DESCRIPTION
Cherry-pick of #13489 onto `release-0.18`.

#### What this PR does / why we need it:

`normalizeActiveSlices` now finishes a slice whose replacement is taking over with reason `WorkloadSliceReplaced` (matching the scheduler), so the MultiKueue elastic guard keeps the replaced slice's remote objects during the handover. Previously it finished such slices as `OutOfSync`, which is not recognized by the guard, so MultiKueue could delete the replaced slice's running remote objects mid-handover. Slices with no replacement keep the `OutOfSync` reason.

Includes a deterministic MultiKueue integration test (the suite runs no scheduler, so `normalizeActiveSlices` is the finisher) and a unit-test update.

#### Notes for reviewer

- The core fix was adapted to `release-0.18`, which predates the `workload` → `workloadfinish` package split, so it calls `workload.Finish` rather than `workloadfinish.Finish`. Everything else matches the merged change.
- Verified on `release-0.18`: `go vet` and `gofmt` clean, `pkg/workloadslicing` unit tests pass, and the new MultiKueue integration test passes (and fails deterministically when the one-line fix is reverted).
- This backport was prepared with AI assistance (Claude Code); the author reviewed and verified all changes.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where scaling an elastic job managed through workload slices could delete the running remote objects of the replaced slice mid-handover, disrupting the job's pods. The replaced slice is now finished with reason `WorkloadSliceReplaced`, matching the scheduler, so its remote objects are kept during the handover.
```
