### PR TITLE
test: fixing topology ssignment preservation test coverage gap

### DIFF
--- a/test/e2e/tas/baseline/job_test.go
+++ b/test/e2e/tas/baseline/job_test.go
@@ -380,6 +380,24 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for Job", ginkgo.Label(util.Sha
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
+			var scaledWorkload *kueue.Workload
+			ginkgo.By("verify the scaled workload has two assigned domains", func() {
+				scaledWorkload = util.ExpectNewWorkloadSlice(
+					ctx,
+					k8sClient,
+					createdWorkload,
+				)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(scaledWorkload), scaledWorkload)).Should(gomega.Succeed())
+					g.Expect(scaledWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(scaledWorkload.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(tas.TotalDomainCount(
+						scaledWorkload.Status.Admission.PodSetAssignments[0].TopologyAssignment,
+					)).Should(gomega.Equal(int(scaledParallelism)))
+				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.By("verify both job pods are ready", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/kind feature
/kind flake
/area tas
/area testing


#### What this PR does / why we need it:
The test is missing the verification of the scaled workload's topology assignment so I am adding that in this PR

#### Which issue(s) this PR fixes:

Fixes #13537

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for elastic job scale-up behavior.
  * Verified that workload admission topology reflects the updated parallelism after scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->