### PR TITLE
fix(Flake): pull-kueue-test-fuzz-main failed on PR #13556

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -115,7 +115,8 @@ test: gotestsum ## Run tests. Set UNIT_TOTAL_SHARDS and UNIT_SHARD_INDEX to run 
 	GORACE="log_path=$(ARTIFACTS)/race$(OPTIONAL_SHARD_SUFFIX)" TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) $(GOTESTSUM) --junitfile $(ARTIFACTS)/junit$(OPTIONAL_SHARD_SUFFIX).xml -- $(GOFLAGS) $(GO_TEST_FLAGS) $(UNIT_TEST_PACKAGES) -coverpkg=$(GO_TEST_TARGET)/... -coverprofile $(ARTIFACTS)/cover$(OPTIONAL_SHARD_SUFFIX).out
 
 # Time budget for fuzzing each individual fuzz target.
-FUZZTIME ?= 5s
+# TODO: Change back to 5s when golang/go#75804 is fixed in Go 1.27
+FUZZTIME ?= 1000x
 
 .PHONY: test-fuzz
 test-fuzz: ## Run all fuzz tests with fuzzing enabled, FUZZTIME per target.

--- a/pkg/util/tas/tas_assignment_fuzz_test.go
+++ b/pkg/util/tas/tas_assignment_fuzz_test.go
@@ -152,6 +152,11 @@ func FuzzTopologyAssignmentCompactionRoundTrip(f *testing.F) {
 	f.Add(uint8(1), true, append([]byte{1}, bytes.Repeat([]byte{'-'}, maxFuzzHostnameLength)...))
 
 	f.Fuzz(func(t *testing.T, levelCount uint8, lowestLevelIsHostname bool, input []byte) {
+		// Limit input size to prevent fuzzer timeout
+		if len(input) > 512 {
+			input = input[:512]
+		}
+
 		want := topologyAssignmentFromFuzzInput(levelCount, lowestLevelIsHostname, input)
 		encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(want)
 		verifyTopologyAssignmentJSONRoundTrip(t, want, encoded)

--- a/pkg/util/tas/tas_assignment_fuzz_test.go
+++ b/pkg/util/tas/tas_assignment_fuzz_test.go
@@ -152,11 +152,6 @@ func FuzzTopologyAssignmentCompactionRoundTrip(f *testing.F) {
 	f.Add(uint8(1), true, append([]byte{1}, bytes.Repeat([]byte{'-'}, maxFuzzHostnameLength)...))
 
 	f.Fuzz(func(t *testing.T, levelCount uint8, lowestLevelIsHostname bool, input []byte) {
-		// Limit input size to prevent fuzzer timeout
-		if len(input) > 8192 {
-			input = input[:8192]
-		}
-
 		want := topologyAssignmentFromFuzzInput(levelCount, lowestLevelIsHostname, input)
 		encoded := compactTopologyAssignmentEncodingWithHostnamePrefixRuns(want)
 		verifyTopologyAssignmentJSONRoundTrip(t, want, encoded)

--- a/pkg/util/tas/tas_assignment_fuzz_test.go
+++ b/pkg/util/tas/tas_assignment_fuzz_test.go
@@ -153,8 +153,8 @@ func FuzzTopologyAssignmentCompactionRoundTrip(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, levelCount uint8, lowestLevelIsHostname bool, input []byte) {
 		// Limit input size to prevent fuzzer timeout
-		if len(input) > 512 {
-			input = input[:512]
+		if len(input) > 8192 {
+			input = input[:8192]
 		}
 
 		want := topologyAssignmentFromFuzzInput(levelCount, lowestLevelIsHostname, input)


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test
/kind flake
/area tas
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #13558 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved fuzz testing stability by capping oversized fuzz inputs to prevent timeouts while keeping the existing round-trip validation intact.
  - Updated the default per-fuzz-target budget to run longer during fuzz testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->