### PR TITLE
Fix flaky workload execution time metric test

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1554,10 +1554,7 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 				admission := utiltestingapi.MakeAdmission("cq").Obj()
 				util.SetQuotaReservation(ctx, k8sClient, wlKey, admission)
 				util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, wl)
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
-					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeTrue())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(clusterQueue.Name), 1)
 			})
 
 			ginkgo.By("marking workload as finished", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
#### What this PR does / why we need it:
Added a wait for the admitted-workload gauge metric instead of polling the API server directly for admission status, so that the controller has actually processed admission before the workload is marked finished.
#### Which issue(s) this PR fixes:

Fixes #13557

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved integration test coverage for workload admission metrics.
  - Added explicit validation that the active workload gauge reports one admitted workload after admission is synchronized.
  - Simplified the test’s admission verification flow to make metric behavior more deterministic and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->