### PR TITLE
fix: prevent int64 overflow in nominal quota metric for large quantities

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -43,7 +43,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
-	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -1170,11 +1169,6 @@ func (c *Cache) ResyncGaugeMetrics(log logr.Logger) {
 	for _, cohortName := range cohortNames {
 		c.ResyncCohortGaugeMetrics(log, cohortName)
 	}
-}
-
-func resourceFloat(formatter *resources.ResourceFormatter, name corev1.ResourceName, v int64) float64 {
-	q := formatter.ResourceQuantity(name, v)
-	return utilresource.QuantityToFloat(&q)
 }
 
 // Key is the key used to index the queue.

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -562,21 +562,21 @@ func (c *clusterQueue) reportResourceMetrics(fairSharingEnabled bool) {
 	clVals := c.GetCustomLabelValues()
 	for fr, quota := range c.resourceNode.Quotas {
 		fName, rName := string(fr.Flavor), string(fr.Resource)
-		nominal := resourceFloat(c.resourceFormatter, fr.Resource, quota.Nominal.Int64())
+		nominal := quota.Nominal.AsApproximateFloat64(fr.Resource)
 		var borrowing, lending float64
 		if quota.BorrowingLimit == nil {
 			borrowing = math.Inf(1)
 		} else {
-			borrowing = resourceFloat(c.resourceFormatter, fr.Resource, quota.BorrowingLimit.Int64())
+			borrowing = quota.BorrowingLimit.AsApproximateFloat64(fr.Resource)
 		}
 		if quota.LendingLimit == nil {
 			lending = math.Inf(1)
 		} else {
-			lending = resourceFloat(c.resourceFormatter, fr.Resource, quota.LendingLimit.Int64())
+			lending = quota.LendingLimit.AsApproximateFloat64(fr.Resource)
 		}
 		metrics.ReportClusterQueueQuotas(cohort, cqName, fName, rName, nominal, borrowing, lending, clVals, c.roleTracker)
-		metrics.ReportClusterQueueResourceReservations(cohort, cqName, fName, rName, resourceFloat(c.resourceFormatter, fr.Resource, c.resourceNode.Usage[fr].Int64()), clVals, c.roleTracker)
-		metrics.ReportClusterQueueResourceUsage(cohort, cqName, fName, rName, resourceFloat(c.resourceFormatter, fr.Resource, c.AdmittedUsage[fr].Int64()), clVals, c.roleTracker)
+		metrics.ReportClusterQueueResourceReservations(cohort, cqName, fName, rName, c.resourceNode.Usage[fr].AsApproximateFloat64(fr.Resource), clVals, c.roleTracker)
+		metrics.ReportClusterQueueResourceUsage(cohort, cqName, fName, rName, c.AdmittedUsage[fr].AsApproximateFloat64(fr.Resource), clVals, c.roleTracker)
 	}
 	if fairSharingEnabled {
 		c.reportWeightedShare(cohort)

--- a/pkg/cache/scheduler/cohort_metrics.go
+++ b/pkg/cache/scheduler/cohort_metrics.go
@@ -35,8 +35,8 @@ import (
 type cohortMetricPoint struct {
 	cohortName      kueue.CohortReference
 	flavorResource  resources.FlavorResource
-	quotaQty        int64
-	reservationsQty int64
+	quotaQty        resources.Amount
+	reservationsQty resources.Amount
 }
 
 func (c *Cache) RecordCohortMetrics(log logr.Logger, cohortName kueue.CohortReference) {
@@ -105,8 +105,8 @@ func (c *Cache) collectCohortMetricPoints(cohortName kueue.CohortReference, simu
 			points = append(points, cohortMetricPoint{
 				cohortName:      ancestor.Name,
 				flavorResource:  fr,
-				quotaQty:        ancestorSubtreeQuota[fr].Int64(),
-				reservationsQty: ancestorSubtreeReservations[fr].Int64(),
+				quotaQty:        ancestorSubtreeQuota[fr],
+				reservationsQty: ancestorSubtreeReservations[fr],
 			})
 		}
 	}
@@ -128,18 +128,18 @@ func (c *Cache) applyCohortMetricPoint(p cohortMetricPoint) {
 	flavor := p.flavorResource.Flavor
 	resource := p.flavorResource.Resource
 
-	if p.quotaQty <= 0 {
+	if p.quotaQty.CmpInt64(0) <= 0 {
 		metrics.ClearCohortSubtreeQuota(p.cohortName, flavor, resource)
 	} else {
-		metrics.ReportCohortSubtreeQuota(p.cohortName, flavor, resource, resourceFloat(c.resourceFormatter, resource, p.quotaQty), c.customLabels.CohortGet(p.cohortName), c.roleTracker)
+		metrics.ReportCohortSubtreeQuota(p.cohortName, flavor, resource, p.quotaQty.AsApproximateFloat64(resource), c.customLabels.CohortGet(p.cohortName), c.roleTracker)
 	}
 
-	if p.reservationsQty <= 0 {
+	if p.reservationsQty.CmpInt64(0) <= 0 {
 		metrics.ClearCohortSubtreeResourceReservations(p.cohortName, flavor, resource)
 	} else {
 		metrics.ReportCohortSubtreeResourceReservations(
 			p.cohortName, flavor, resource,
-			resourceFloat(c.resourceFormatter, resource, p.reservationsQty),
+			p.reservationsQty.AsApproximateFloat64(resource),
 			c.customLabels.CohortGet(p.cohortName), c.roleTracker,
 		)
 	}

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -113,12 +114,12 @@ func TestRecordCohortMetrics_Guards(t *testing.T) {
 					{
 						cohort: cohortLeft,
 						fr:     fr,
-						quota:  resourceFloat(cache.resourceFormatter, fr.Resource, cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr].Int64()),
+						quota:  cache.hm.Cohort(cohortLeft).resourceNode.SubtreeQuota[fr].AsApproximateFloat64(fr.Resource),
 					},
 					{
 						cohort: cohortRoot,
 						fr:     fr,
-						quota:  resourceFloat(cache.resourceFormatter, fr.Resource, cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr].Int64()),
+						quota:  cache.hm.Cohort(cohortRoot).resourceNode.SubtreeQuota[fr].AsApproximateFloat64(fr.Resource),
 					},
 				}
 			},
@@ -160,6 +161,26 @@ func TestRecordCohortMetrics_Guards(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyCohortMetricPointReportsUnlimitedAsInf(t *testing.T) {
+	defer kueuemetrics.InitMetricVectors(nil)
+
+	cache := New(utiltesting.NewFakeClient())
+	cohortName := kueue.CohortReference("unlimited")
+	fr := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}
+	labels := cohortQuotaMetricLabels(cohortName, fr)
+	clearCohortMetricsForTest(t, cohortName)
+
+	cache.applyCohortMetricPoint(cohortMetricPoint{
+		cohortName:      cohortName,
+		flavorResource:  fr,
+		quotaQty:        resources.Unlimited,
+		reservationsQty: resources.Unlimited,
+	})
+
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeQuota, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.CohortSubtreeResourceReservations, labels, math.Inf(1))
 }
 
 func TestRecordCohortMetrics_QuotaHierarchyLikeIntegration(t *testing.T) {

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -93,8 +93,8 @@ func (q *LocalQueue) reportResourceMetrics(cqQuotas map[resources.FlavorResource
 	lqRef := metrics.LocalQueueReference{Name: name, Namespace: namespace}
 	for fr := range cqQuotas {
 		fName, rName := string(fr.Flavor), string(fr.Resource)
-		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, resourceFloat(q.resourceFormatter, fr.Resource, q.totalReserved[fr].Int64()), q.customMetricLabelValues(), tracker)
-		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, resourceFloat(q.resourceFormatter, fr.Resource, q.admittedUsage[fr].Int64()), q.customMetricLabelValues(), tracker)
+		metrics.ReportLocalQueueResourceReservations(lqRef, fName, rName, q.totalReserved[fr].AsApproximateFloat64(fr.Resource), q.customMetricLabelValues(), tracker)
+		metrics.ReportLocalQueueResourceUsage(lqRef, fName, rName, q.admittedUsage[fr].AsApproximateFloat64(fr.Resource), q.customMetricLabelValues(), tracker)
 	}
 }
 

--- a/pkg/cache/scheduler/resource_metrics_test.go
+++ b/pkg/cache/scheduler/resource_metrics_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"math"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kueuemetrics "sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/queue"
+)
+
+func TestClusterQueueResourceMetricsReportUnlimitedAsInf(t *testing.T) {
+	defer kueuemetrics.InitMetricVectors(nil)
+
+	formatter := resources.NewResourceFormatter()
+	fr := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}
+	unlimited := resources.Unlimited
+	cq := &clusterQueue{
+		Name:              "unlimited-cq",
+		AdmittedUsage:     resources.FlavorResourceQuantities{fr: unlimited},
+		resourceFormatter: formatter,
+		customLabels:      kueuemetrics.NewCustomLabels(nil),
+		resourceNode:      NewResourceNode(),
+	}
+	cq.resourceNode.Quotas[fr] = ResourceQuota{
+		Nominal:        unlimited,
+		BorrowingLimit: &unlimited,
+		LendingLimit:   &unlimited,
+	}
+	cq.resourceNode.Usage[fr] = unlimited
+
+	cq.reportResourceMetrics(false)
+
+	labels := map[string]string{
+		"cohort":        "",
+		"cluster_queue": string(cq.Name),
+		"flavor":        string(fr.Flavor),
+		"resource":      string(fr.Resource),
+		"replica_role":  "standalone",
+	}
+	expectGaugeValue(t, kueuemetrics.ClusterQueueResourceNominalQuota, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.ClusterQueueResourceBorrowingLimit, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.ClusterQueueResourceLendingLimit, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.ClusterQueueResourceReservations, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.ClusterQueueResourceUsage, labels, math.Inf(1))
+}
+
+func TestLocalQueueResourceMetricsReportUnlimitedAsInf(t *testing.T) {
+	defer kueuemetrics.InitMetricVectors(nil)
+
+	formatter := resources.NewResourceFormatter()
+	fr := resources.FlavorResource{Flavor: "default", Resource: corev1.ResourceMemory}
+	unlimited := resources.Unlimited
+	lq := &LocalQueue{
+		key:               queue.NewLocalQueueReference("namespace", "unlimited-lq"),
+		totalReserved:     resources.FlavorResourceQuantities{fr: unlimited},
+		admittedUsage:     resources.FlavorResourceQuantities{fr: unlimited},
+		customLabels:      kueuemetrics.NewCustomLabels(nil),
+		resourceFormatter: formatter,
+	}
+
+	lq.reportResourceMetrics(map[resources.FlavorResource]ResourceQuota{fr: {}}, nil)
+
+	labels := map[string]string{
+		"name":         "unlimited-lq",
+		"namespace":    "namespace",
+		"flavor":       string(fr.Flavor),
+		"resource":     string(fr.Resource),
+		"replica_role": "standalone",
+	}
+	expectGaugeValue(t, kueuemetrics.LocalQueueResourceReservations, labels, math.Inf(1))
+	expectGaugeValue(t, kueuemetrics.LocalQueueResourceUsage, labels, math.Inf(1))
+}

--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -97,6 +97,18 @@ func (a Amount) Int64() int64 {
 	return a.value
 }
 
+// AsApproximateFloat64 returns the amount in the resource's standard unit,
+// converting milliCPU to CPU and mapping Unlimited to +Inf.
+func (a Amount) AsApproximateFloat64(name corev1.ResourceName) float64 {
+	if a.isUnlimited() {
+		return math.Inf(1)
+	}
+	if name == corev1.ResourceCPU {
+		return float64(a.value) / 1000
+	}
+	return float64(a.value)
+}
+
 // Add returns a + b, propagating Unlimited and saturating bounded overflow at
 // math.MaxInt64.
 func (a Amount) Add(b Amount) Amount {

--- a/pkg/resources/amount_test.go
+++ b/pkg/resources/amount_test.go
@@ -105,6 +105,43 @@ func TestAmountFromQuantity(t *testing.T) {
 	}
 }
 
+func TestAmountAsApproximateFloat64(t *testing.T) {
+	cases := map[string]struct {
+		resource corev1.ResourceName
+		amount   Amount
+		want     float64
+	}{
+		"bounded memory": {
+			resource: corev1.ResourceMemory,
+			amount:   NewAmount(1e18),
+			want:     1e18,
+		},
+		"bounded CPU": {
+			resource: corev1.ResourceCPU,
+			amount:   NewAmount(5_500),
+			want:     5.5,
+		},
+		"unlimited memory": {
+			resource: corev1.ResourceMemory,
+			amount:   Unlimited,
+			want:     math.Inf(1),
+		},
+		"unlimited CPU": {
+			resource: corev1.ResourceCPU,
+			amount:   Unlimited,
+			want:     math.Inf(1),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := tc.amount.AsApproximateFloat64(tc.resource); got != tc.want {
+				t.Errorf("AsApproximateFloat64(%s) = %g, want %g", tc.resource, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestAmountArithmetic pins the unlimited-propagation and saturation rules
 // that prevent cohort math from overflowing. Quota arithmetic must funnel
 // through Amount rather than raw int64 so these invariants hold globally.

--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -82,10 +82,7 @@ func QuantityToFloat(q *resource.Quantity) float64 {
 	if q == nil || q.IsZero() {
 		return 0
 	}
-	if i64, isInt := q.AsInt64(); isInt {
-		return float64(i64)
-	}
-	return float64(q.MilliValue()) / 1000
+	return q.AsApproximateFloat64()
 }
 
 // MulByFloat multiplies every element in q by f.

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -223,15 +224,27 @@ func TestQuantityToFloat(t *testing.T) {
 		},
 		"float negative exponent": {
 			q:          resource.MustParse("5.5m"),
-			wantResult: 0.006, // 1/1000 is the maximum precision, the value will be rounded
+			wantResult: 0.0055,
+		},
+		"1 exabyte": {
+			q:          resource.MustParse("1E"),
+			wantResult: 1e18,
+		},
+		"1 exbi": {
+			q:          resource.MustParse("1Ei"),
+			wantResult: float64(1) * 1024 * 1024 * 1024 * 1024 * 1024 * 1024,
+		},
+		"large binary SI": {
+			q:          resource.MustParse("8Pi"),
+			wantResult: float64(8) * 1024 * 1024 * 1024 * 1024 * 1024,
 		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := QuantityToFloat(&tc.q)
-			if got != tc.wantResult {
-				t.Errorf("Unexpected result, expecting %f got %f", tc.wantResult, got)
+			if diff := cmp.Diff(tc.wantResult, got, cmpopts.EquateApprox(1e-9, 0)); diff != "" {
+				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
_This PR was written in part with the assistance of generative AI_

## What does this PR do?

Fixes an int64 overflow in `QuantityToFloat()` that causes metrics to report silently wrong values for large resource quantities (e.g. `"1E"` memory reports ~3.876e15 instead of 1e18).

Replaces the `MilliValue()` fallback — which overflows for quantities above ~9.2 PiB — with `AsApproximateFloat64()`, and maps `Unlimited` quota amounts to `+Inf` in metric reporting, consistent with how unset borrowing/lending limits are already handled.

## Root cause

For large BinarySI quantities, `newCanonicalQuantity` round-trips through string serialization and produces an `inf.Dec`-backed `Quantity`. This makes `AsInt64()` return false, falling back to `MilliValue()` which computes `value * 1000` — overflowing int64 for anything above ~9.22e15 bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed resource metrics to report unlimited quotas/limits as `+Inf` and avoid truncation or overflow.
  * Improved float conversion accuracy for quota, reservations, and usage across cluster and local queues.
  * Standardized metric label/value handling to make dashboard readings more consistent.
* **Tests**
  * Added and updated unit tests for approximate float conversions and `+Inf` behavior, including tolerance-based assertions.
* **Observability**
  * Metrics now preserve very large resource values correctly, reducing the risk of misleading quota/usage dashboards and alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```release-note
Observability: Fixed a bug where Kueue metrics could silently report incorrect quota and usage values for very large resource quantities due to integer overflow, potentially misleading dashboards and alerts. Metrics now preserve large values correctly and report unlimited quotas as "+Inf".
```