### PR TITLE
Harden Netlify preview link verification

### DIFF
--- a/Makefile-verify.mk
+++ b/Makefile-verify.mk
@@ -294,7 +294,7 @@ verify-website-links: ## Check for broken internal links on the public website.
 	$(PROJECT_DIR)/hack/testing/linkchecker/verify.sh
 
 .PHONY: verify-website-links-preview
-verify-website-links-preview: ## Check links on a PR Netlify deploy preview; skips if no fresh same-commit preview exists.
+verify-website-links-preview: ## Check links on a PR Netlify deploy preview.
 	$(PROJECT_DIR)/hack/testing/linkchecker/verify-preview.sh
 
 .PHONY: i18n-verify

--- a/hack/testing/linkchecker/README.md
+++ b/hack/testing/linkchecker/README.md
@@ -36,27 +36,27 @@ Website changes under `site/` or `netlify.toml` trigger a Netlify deploy preview
 /test pull-kueue-verify-website-links-preview-main
 ```
 
-The presubmit is **optional and non-blocking**. It waits for a fresh same-commit Netlify preview, then runs the same link checker against:
+The presubmit is **optional**. It waits for a fresh same-commit Netlify preview, then runs the same link checker against:
 
 ```text
 https://deploy-preview-<PR>--kubernetes-sigs-kueue.netlify.app/
 ```
 
-The job skips (and passes) when:
+The job skips (and passes) when the PR does not modify `site/` or `netlify.toml`.
 
-- the PR does not modify `site/`
-- Netlify did not publish a preview
-- the preview is not ready within the bounded wait
-- GitHub API or tooling is unavailable
+The job fails when:
 
-Broken links on a resolved preview **fail** the job.
+- Netlify reports a preview failure
+- no preview is available after the bounded wait
+- the GitHub API or required tooling is unavailable
+- a resolved preview contains broken links
 
 ## CI integration
 
 | Job | Type | Dashboard |
 |-----|------|-----------|
 | `periodic-kueue-verify-website-links-main` | Daily periodic | [TestGrid](https://testgrid.k8s.io/sig-scheduling#periodic-kueue-verify-website-links-main) |
-| `pull-kueue-verify-website-links-preview-main` | Presubmit (auto-runs on `site/` changes, optional) | [TestGrid](https://testgrid.k8s.io/sig-scheduling#pull-kueue-verify-website-links-preview-main) |
+| `pull-kueue-verify-website-links-preview-main` | Presubmit (auto-runs on `site/` or `netlify.toml` changes, optional) | [TestGrid](https://testgrid.k8s.io/sig-scheduling#pull-kueue-verify-website-links-preview-main) |
 
 Prow job definitions live in [kubernetes/test-infra](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/kueue).
 
@@ -67,7 +67,7 @@ Prow job definitions live in [kubernetes/test-infra](https://github.com/kubernet
 | `LINK_CHECK_URL` | `verify.sh` | Base URL to crawl |
 | `PULL_NUMBER` | `verify-preview.sh` | PR number (set by Prow) |
 | `PULL_PULL_SHA` | `verify-preview.sh` | Head commit SHA (set by Prow) |
-| `PULL_BASE_SHA` | `verify-preview.sh` | Merge base SHA for `site/` diff detection |
+| `PULL_BASE_SHA` | `verify-preview.sh` | Base commit SHA used for merge-base diff detection under `site/` and `netlify.toml` |
 | `GH_TOKEN` | `verify-preview.sh` | Optional GitHub API token (raises rate limits) |
 | `PREVIEW_WAIT_ATTEMPTS` | `verify-preview.sh` | Poll attempts for `deploy/netlify` (default: 20) |
 | `PREVIEW_WAIT_DELAY` | `verify-preview.sh` | Seconds between polls (default: 30) |

--- a/hack/testing/linkchecker/verify-preview.sh
+++ b/hack/testing/linkchecker/verify-preview.sh
@@ -17,9 +17,8 @@
 # Runs the website link checker against a PR's Netlify deploy preview.
 #
 # The deploy/netlify commit status on the PR head SHA gates freshness; once it
-# succeeds, links are checked against the PR's deploy-preview alias. If no fresh
-# same-commit preview can be resolved, this script skips successfully; otherwise
-# the link checker runs and its result is preserved.
+# succeeds, links are checked against the PR's deploy-preview alias. A failed
+# status or an unavailable same-commit preview fails the verification.
 #
 # The resolved Netlify URL is a mutable per-PR preview alias, not an immutable
 # per-deploy URL, but the status itself is attached to the exact SHA under test.
@@ -42,54 +41,64 @@ GH_API="${GH_API:-https://api.github.com}"
 STATUS_CONTEXT="deploy/netlify"
 # Netlify site slug for the PR's deploy-preview URL (built below).
 NETLIFY_SITE="${NETLIFY_SITE:-kubernetes-sigs-kueue}"
-# Bounded wait for the preview build: 20 checks × 30s (~9.5 min), then skip.
+# Bounded wait for the preview build: 20 checks × 30s (~9.5 min), then fail.
 PREVIEW_WAIT_ATTEMPTS="${PREVIEW_WAIT_ATTEMPTS:-20}"
 PREVIEW_WAIT_DELAY="${PREVIEW_WAIT_DELAY:-30}"
 
-log()  { echo "[verify-website-links-preview] $*"; }
-skip() { log "SKIP: $*"; log "Treating as success (non-blocking link check)."; exit 0; }
+log()   { echo "[verify-website-links-preview] $*"; }
+skip()  { log "SKIP: $*"; exit 0; }
+fail()  { log "ERROR: $*"; exit 1; }
 
 # Outside a Prow presubmit (e.g. a local run) there is no PR preview to resolve.
 if [[ -z "${PULL_NUMBER}" || -z "${PULL_PULL_SHA}" ]]; then
   skip "not running in a Prow presubmit (PULL_NUMBER/PULL_PULL_SHA unset)."
 fi
 
-# If the PR does not touch site/, Netlify builds no preview (the netlify.toml
-# ignore rule), so skip instead of waiting out the timeout. If the diff can't be
-# computed, fall through and let the resolution step decide.
-if [[ -n "${PULL_BASE_SHA}" ]] && \
-   git -C "${ROOT_DIR}" diff --quiet "${PULL_BASE_SHA}" "${PULL_PULL_SHA}" -- site/ 2>/dev/null; then
-  skip "PR #${PULL_NUMBER} does not modify site/; no preview expected."
+# If the PR does not touch site/ or netlify.toml, Netlify builds no preview, so
+# skip instead of waiting out the timeout.
+if [[ -n "${PULL_BASE_SHA}" ]]; then
+  if git -C "${ROOT_DIR}" diff --quiet "${PULL_BASE_SHA}...${PULL_PULL_SHA}" -- site/ netlify.toml; then
+    skip "PR #${PULL_NUMBER} does not modify site/ or netlify.toml; no preview expected."
+  else
+    diff_status=$?
+    (( diff_status == 1 )) || \
+      fail "git diff failed with exit code ${diff_status}; cannot determine whether a preview is expected."
+  fi
 fi
 
 # A missing binary won't appear mid-loop, so short-circuit before polling.
-# Still skip (not exit 1) to keep the job non-blocking.
 for bin in curl jq; do
-  command -v "${bin}" >/dev/null 2>&1 || skip "${bin} is unavailable; cannot resolve deploy preview."
+  command -v "${bin}" >/dev/null 2>&1 || fail "${bin} is unavailable; cannot resolve deploy preview."
 done
 
-# Unauthenticated GitHub API calls are rate-limited (60/h per IP); set GH_TOKEN to
-# raise the limit. API failures are treated as skip, so rate limits never fail a PR.
+# Unauthenticated GitHub API calls are rate-limited (60/h per IP); set GH_TOKEN
+# to raise the limit.
 auth=()
 if [[ -n "${GH_TOKEN:-}" ]]; then
   auth=(-H "Authorization: Bearer ${GH_TOKEN}")
 fi
 
 preview_url=""
+warned_status_truncation=false
 for (( attempt=1; attempt<=PREVIEW_WAIT_ATTEMPTS; attempt++ )); do
   body=""
   if ! body="$(curl --connect-timeout 10 --max-time 20 -fsSL "${auth[@]+"${auth[@]}"}" \
-      "${GH_API}/repos/${REPO_OWNER}/${REPO_NAME}/commits/${PULL_PULL_SHA}/status" 2>/dev/null)"; then
+      "${GH_API}/repos/${REPO_OWNER}/${REPO_NAME}/commits/${PULL_PULL_SHA}/status?per_page=100" 2>/dev/null)"; then
     log "GitHub API call failed (attempt ${attempt}/${PREVIEW_WAIT_ATTEMPTS})."
     body=""
   fi
 
-  # Guard jq parsing: a non-JSON 200 body (curl -f does not reject it) must not
-  # fail the job. Any jq error yields "", routing to the skip path below.
+  # Guard jq parsing: a non-JSON 200 body (curl -f does not reject it) yields an
+  # empty state and is retried until the bounded wait expires.
   state=""
   if [[ -n "${body}" ]]; then
     state="$(jq -r --arg c "${STATUS_CONTEXT}" \
       'first(.statuses[]? | select(.context==$c)) | .state // empty' <<<"${body}" 2>/dev/null || true)"
+    if [[ "${warned_status_truncation}" == "false" ]] && \
+       jq -e '.total_count > (.statuses | length)' <<<"${body}" >/dev/null 2>&1; then
+      log "WARNING: GitHub returned fewer statuses than total_count; '${STATUS_CONTEXT}' may be omitted."
+      warned_status_truncation=true
+    fi
   fi
 
   case "${state}" in
@@ -100,7 +109,7 @@ for (( attempt=1; attempt<=PREVIEW_WAIT_ATTEMPTS; attempt++ )); do
       break
       ;;
     failure|error)
-      skip "Netlify deploy preview '${state}' for commit ${PULL_PULL_SHA}; nothing fresh to check."
+      fail "Netlify deploy preview '${state}' for commit ${PULL_PULL_SHA}."
       ;;
     *)
       log "preview not ready (state='${state:-none}'), attempt ${attempt}/${PREVIEW_WAIT_ATTEMPTS}."
@@ -113,7 +122,7 @@ for (( attempt=1; attempt<=PREVIEW_WAIT_ATTEMPTS; attempt++ )); do
 done
 
 if [[ -z "${preview_url}" ]]; then
-  skip "no ready same-commit deploy preview for ${PULL_PULL_SHA} after bounded wait."
+  fail "no ready same-commit deploy preview for ${PULL_PULL_SHA} after bounded wait."
 fi
 
 log "checking fresh preview for commit ${PULL_PULL_SHA}: ${preview_url}"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
Harden preview-link verification so that preview failures, timeouts, and API errors now fail the job.

context: https://github.com/kubernetes-sigs/kueue/issues/13474#issuecomment-5094031250
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Website link verification now fails (instead of passing) when required preview checks can’t be completed, including missing tooling, failed/error deploy previews, unavailable same-commit previews within the wait window, GitHub status not resolving in time, and detected broken links.
  * Verification no longer treats unexpected preview/API resolution issues as successful skips.

* **Documentation**
  * Updated the linkchecker PR presubmit description to clarify the conditions under which the check runs or is skipped, and when it fails.
  * Shortened the Make target help text for the website link preview verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->