### PR TITLE
KEP-2941: firstAvailable quota via the maximum count among alternatives

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -73,6 +73,14 @@ tags, and then generate with `hack/update-toc.sh`.
     - [Validation](#validation-1)
   - [Architecture Details](#architecture-details)
     - [Queue Manager Extensions](#queue-manager-extensions)
+  - [Prioritized List Quota](#prioritized-list-quota)
+    - [Accounting rule](#accounting-rule)
+    - [Safety argument](#safety-argument)
+    - [Scope](#scope)
+    - [Coordination with feasibility](#coordination-with-feasibility)
+    - [Relationship with Kubernetes ResourceQuota](#relationship-with-kubernetes-resourcequota)
+    - [Feature gate lifecycle, version skew, and observability](#feature-gate-lifecycle-version-skew-and-observability)
+    - [Tradeoffs](#tradeoffs)
   - [Integration with Admission Fair Sharing](#integration-with-admission-fair-sharing)
   - [MultiKueue Integration](#multikueue-integration)
   - [Test Plan](#test-plan)
@@ -87,13 +95,16 @@ tags, and then generate with `hack/update-toc.sh`.
       - [KueueDRAIntegrationExtendedResource (v0.18)](#kueuedraintegrationextendedresource-v018)
       - [KueueDRAIntegrationPartitionableDevices (v0.18)](#kueuedraintegrationpartitionabledevices-v018)
       - [KueueDRAIntegrationConsumableCapacity (v0.19)](#kueuedraintegrationconsumablecapacity-v019)
+      - [KueueDRAIntegrationPrioritizedList (v0.20)](#kueuedraintegrationprioritizedlist-v020)
     - [Beta](#beta)
       - [KueueDRAIntegration (v0.18)](#kueuedraintegration-v018)
       - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource)
       - [KueueDRAIntegrationPartitionableDevices](#kueuedraintegrationpartitionabledevices)
       - [KueueDRAIntegrationConsumableCapacity](#kueuedraintegrationconsumablecapacity)
+      - [KueueDRAIntegrationPrioritizedList](#kueuedraintegrationprioritizedlist)
     - [GA](#ga)
       - [KueueDRAIntegration](#kueuedraintegration)
+      - [KueueDRAIntegrationPrioritizedList](#kueuedraintegrationprioritizedlist-1)
       - [KueueDRAIntegrationExtendedResource](#kueuedraintegrationextendedresource-1)
       - [KueueDRAIntegrationPartitionableDevices](#kueuedraintegrationpartitionabledevices-1)
 - [Implementation History](#implementation-history)
@@ -234,12 +245,14 @@ a simple device class named `gpu.example.com`. This will be the way to enforce q
   instead of device count quota for MIG profiles).
 - Admins can enforce capacity-based quota for devices that allow software-level sharing
   (e.g., GPU memory and compute cores quota for time-sliced or fractional GPU devices).
+- Admins can enforce quota for prioritized-list (`firstAvailable`) requests over count-based
+  DeviceClass mappings, charging the component-wise maximum over the alternatives.
 
 ### Non-Goals
 
-- Quota-aware handling of DRAPrioritizedLists (beta, default enabled in K8s 1.35)
-  is not included. See [Risks and Mitigations](#risks-and-mitigations) for the
-  planned approach.
+- Counter-backed or capacity-backed `firstAvailable` (`DRAPrioritizedList`) alternatives are
+  out of scope for the initial Alpha. Count-based prioritized-list quota is supported; see
+  [Prioritized List Quota](#prioritized-list-quota).
 - Support for DRA features like DRADeviceTaints is not included.
 - Multi-host partitionable devices (e.g., NVLink fabrics spanning multiple nodes) are not
   supported.
@@ -267,6 +280,9 @@ scheduling. This includes:
    `capacity` source type on `deviceClassMappings` (requires Kubernetes
    `DRAConsumableCapacity` feature gate, beta in K8s 1.36). Kueue charges the workload's
    `capacity.requests` rounded per the device's `RequestPolicy`.
+8. Supporting count-based quota accounting for `firstAvailable` (prioritized alternative) requests
+   through a component-wise envelope after DeviceClass-to-logical-resource mapping, behind
+   `KueueDRAIntegrationPrioritizedList` (requires Kubernetes `DRAPrioritizedList`, stable in K8s 1.36).
 
 More details are documented in [Design Details](#design-details)
 
@@ -310,8 +326,11 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
 - DRA resource preprocessing is not scoped by ResourceFlavor node constraints. Counter
   charges and device matching are computed globally before flavor assignment.
 - AdminAccess requests are skipped in quota counting (zero charge) since they provide
-  shared read-only access to already-allocated devices. DRAPrioritizedLists support is
-  deferred. DRADeviceTaints is not supported.
+  shared read-only access to already-allocated devices. DRADeviceTaints is not supported.
+- Count-based `firstAvailable` (`DRAPrioritizedList`) quota is supported behind the
+  `KueueDRAIntegrationPrioritizedList` feature gate; see
+  [Prioritized List Quota](#prioritized-list-quota). Counter-backed and capacity-backed
+  alternatives remain unsupported.
 - **Single-node partitionable devices (e.g., MIG) are supported** via counter-based
   quota. See [Partitionable Devices](#partitionable-devices). Multi-host partitionable
   devices are not supported.
@@ -357,10 +376,14 @@ unlimited GPU consumption outside Kueue's control. The `KueueDRARejectWorkloadsW
 (default: enabled, Beta) mitigates this by rejecting DRA workloads when the DRA feature is off.
 See [Workload Rejection When DRA Is Disabled](#workload-rejection-when-dra-is-disabled).
 
-With DRAPrioritizedLists (beta, default enabled in K8s 1.35), there is a risk that effective
-tallying of resources will not be available until after allocation. The mitigation approach
-is documented here:
-1. For DRAPrioritizedLists: all the mentioned device classes in the request will be counted against the quota
+With `DRAPrioritizedList` (stable in K8s 1.36), there is a risk that the effective resource
+tally is not available until kube-scheduler allocates. The mitigation for each case is
+documented here:
+1. For `DRAPrioritizedList`: for count-based mappings, Kueue charges the component-wise maximum
+   over the alternatives after DeviceClass-to-logical-resource mapping, which is a per-resource
+   upper bound on any single realized allocation (see [Prioritized List Quota](#prioritized-list-quota)).
+   Counter-backed and capacity-backed alternatives are rejected until their accounting paths can
+   produce per-alternative charge vectors.
 2. AdminAccess requests are skipped in quota counting. This feature can only be enabled in
    admin namespaces (gated by the `resource.kubernetes.io/admin-access` label), and provides
    shared read-only access to already-allocated devices. Charging quota would double-count the
@@ -414,6 +437,12 @@ Feature gates controlling DRA support in Kueue:
   that allow multiple allocations. Enables the `capacity` source type on
   `deviceClassMappings` entries. Requires `KueueDRAIntegration`. Also requires the
   Kubernetes `DRAConsumableCapacity` feature gate (beta in K8s 1.36).
+- `KueueDRAIntegrationPrioritizedList` (Alpha, default off): gates count-based quota accounting
+  for `firstAvailable` (prioritized alternative) requests via the component-wise-max envelope.
+  Requires `KueueDRAIntegration`; the manager fails validation at startup if this gate is enabled
+  while `KueueDRAIntegration` is off. On Kubernetes 1.34 and 1.35 the upstream `DRAPrioritizedList`
+  gate must be enabled; the Kubernetes feature is Stable in 1.36. Counter-backed and capacity-backed
+  alternatives are rejected.
 - `KueueDRARejectWorkloadsWhenDRADisabled` (Beta, default on since v0.18): rejects workloads
   that use DRA resources (ResourceClaimTemplates or ResourceClaims) when `KueueDRAIntegration`
   is disabled. Without this gate, DRA workloads submitted while `KueueDRAIntegration` is off
@@ -1428,7 +1457,9 @@ device's `Capacity` field and the workload's `capacity.requests` on `ExactDevice
 
 Only `ExactDeviceRequest` with `count` is supported. `FirstAvailable` subrequests with
 `capacity.requests` are not supported, consistent with the existing exclusion for
-partitionable devices.
+partitionable devices. Count-based `firstAvailable` quota (see
+[Prioritized List Quota](#prioritized-list-quota)) therefore rejects any alternative whose
+DeviceClass mapping configures a capacity source.
 
 #### ResourceSlice Structure
 
@@ -1719,6 +1750,138 @@ Processing Flow:
 
 This architecture separates concerns between DRA processing (controller) and queue management (scheduler), enabling robust error handling and retry logic for DRA-specific operations.
 
+### Prioritized List Quota
+
+This section is gated behind the `KueueDRAIntegrationPrioritizedList` Kueue feature gate (Alpha,
+default off). It adds quota accounting for prioritized-list requests, expressed with the
+`firstAvailable` field of a `DeviceRequest` (the Kubernetes `DRAPrioritizedList` feature, GA in
+1.36). A `firstAvailable` request lists ordered alternatives; kube-scheduler selects exactly one at
+allocation time, which is not known when Kueue reserves quota. With the gate off, such requests
+remain rejected as before.
+
+#### Accounting rule
+
+For a top-level `firstAvailable` request `q` with alternatives `A_q`, Kueue resolves each
+subrequest's DeviceClass to its logical quota resource through `deviceClassMappings` and forms a
+non-negative charge vector `charge(q, a)` per alternative `a`. The request is charged the
+component-wise maximum:
+
+```text
+envelope(q)[r] = max over a in A_q of charge(q, a)[r]
+```
+
+The per-Pod DRA charge is the existing `Exactly` charges plus the sum, over all `firstAvailable`
+requests, of `envelope(q)`. PodSet scaling is unchanged: the per-Pod charge is multiplied by the
+effective PodSet count by the existing workload-request calculation.
+
+Device-count sums use saturating `int64` arithmetic (`utilmath.SaturatingAdd`, as in
+`countDevicesPerClass`), so no envelope or per-request sum wraps negative. Charges that map to the
+same logical resource are then combined as `resource.Quantity` before being converted back to
+`int64`. That conversion must clamp an out-of-range quantity rather than call `Value()` directly,
+using the `SafeValue` helper added for the counter and capacity paths; the prioritized-list path
+must not introduce a new unclamped conversion. This overflow window is a pre-existing property of
+the shared count path (several DeviceClasses mapping to one logical resource near `MaxInt64`); the
+component-wise maximum keeps the envelope itself bounded, and tests cover multiple `firstAvailable`
+requests, `Exactly` plus `firstAvailable` on one resource, and PodSet scaling near `MaxInt64`.
+
+The maximum is taken after DeviceClass-to-logical-resource mapping. Two DeviceClasses may
+intentionally map to one logical resource (for example an H100 and an A100 class both mapping to a
+`gpu` resource); taking the maximum per DeviceClass and then summing the mapped classes would
+overcharge in that case.
+
+#### Safety argument
+
+kube-scheduler selects exactly one subrequest from each `firstAvailable`, so for every logical
+resource `r` the selected alternative's charge is at most `envelope(q)[r]`. Summing over all
+top-level requests, the realized charge cannot exceed the admitted envelope. This holds only if
+every alternative resolves to a complete, non-negative charge vector; unmapped, unsupported, or
+unknown forms are rejected rather than charged.
+
+#### Scope
+
+Supported: `ResourceClaimTemplate` references; `ExactCount` subrequests; count-based
+`deviceClassMappings` (no `sources`); request-selector CEL compilation.
+
+Rejected: direct `ResourceClaim` references; `All` and unknown allocation modes; unmapped
+DeviceClasses; and any alternative whose DeviceClass mapping configures a counter or capacity
+`source`. Source-backed alternatives are excluded because the counter and consumable-capacity
+accounting paths process only `Exactly` requests today; they can be added later by charging each
+alternative through its source path and taking the component-wise maximum of the resulting vectors.
+
+CEL selectors in every subrequest are compiled and syntax-checked. The `Exactly`
+device-cardinality check against ResourceSlices is not reused, because it would require every
+alternative to be satisfiable while only one has to be; the initial scope compiles CEL but skips
+that cardinality check for `firstAvailable`. Skipping it does not affect quota safety, since the
+envelope depends only on the declared counts; it can, however, let an unschedulable workload hold
+the envelope reservation. `WaitForPodsReady`, when enabled, eventually releases that reservation.
+It is a liveness and utilization safety net, not a premise of the quota upper bound; admission-time
+feasibility may reduce such cases in the future.
+
+#### Coordination with feasibility
+
+This quota accounting is independently safe: the envelope is a conservative upper bound and does
+not depend on any feasibility check. Two related efforts inform admission accuracy and are linked
+here but do not block this KEP: the TAS+DRA work
+([#10548](https://github.com/kubernetes-sigs/kueue/issues/10548)), and the broader admission-time
+scheduling-feasibility umbrella
+([#12422](https://github.com/kubernetes-sigs/kueue/issues/12422)), which passes the full claim spec
+to `structured.Allocator`.
+
+Two properties must be distinguished:
+
+- Static support: whether Kueue can correctly account for a request shape. Unsupported shapes (for
+  example a source-backed alternative in the initial scope) are permanent errors, rejected as
+  inadmissible.
+- Dynamic feasibility: whether the current cluster state can schedule a supported claim. A
+  supported-but-infeasible claim is retryable rather than a permanent error. Kueue has no
+  ResourceSlice informer today, so it is re-evaluated on ClusterQueue events, the same recovery
+  path and the same limitation the CEL selector check above carries: a workload that became
+  schedulable is not noticed until such an event, and one that never becomes schedulable holds its
+  reservation until `WaitForPodsReady` evicts it. Event-driven requeuing on ResourceSlice changes
+  is already an Alpha graduation criterion, and it covers this path as well.
+
+The quota and feasibility paths must apply equivalent static-support validation, preferably through
+a shared helper, so a claim is never accepted by one and rejected by the other. A feasibility
+result of "infeasible" must not be surfaced as "unsupported".
+
+#### Relationship with Kubernetes ResourceQuota
+
+This is a Kueue-specific quota policy and does not change Kubernetes `ResourceQuota`. Core
+`ResourceQuota` (KEP-4816) requires quota for each `DeviceSubRequest` under every `FirstAvailable`,
+keyed per DeviceClass. Kueue's envelope keeps every logical resource an alternative maps to and
+only collapses to a maximum where an administrator has deliberately mapped several DeviceClasses to
+one Kueue logical resource. Namespace `ResourceQuota` and Kueue `ClusterQueue` quota may both apply
+to the same workload; this design does not let a user use `firstAvailable` to bypass namespace
+`ResourceQuota`.
+
+#### Feature gate lifecycle, version skew, and observability
+
+- Rollback: the gate is Alpha, default off. Disabling it returns a new `firstAvailable` workload to
+  the current rejection. An already-admitted workload keeps the `resourceUsage` recorded in its
+  status, so a controller restart or downgrade does not lose admitted accounting and no envelope is
+  recomputed for it.
+- Version skew: the gate requires `KueueDRAIntegration`. On Kubernetes 1.34 and 1.35 the upstream
+  `DRAPrioritizedList` gate must be enabled; it is Stable in 1.36. If the API does not offer
+  `firstAvailable`, no envelope is charged and the request is handled as today.
+- MultiKueue: the envelope is computed on the management cluster from the ResourceClaimTemplate
+  spec, and admitted `resourceUsage` is synchronized to workers unchanged, so a worker does not
+  recompute a different charge. Full cross-version manager/worker behavior is out of scope for the
+  initial Alpha and is a Beta consideration.
+- Observability: the envelope appears in
+  `Workload.status.admission.podSetAssignments[].resourceUsage`; a debug log records each
+  alternative's charge vector and the resulting envelope, and a rejection names the alternative,
+  DeviceClass, or source that is unsupported. A metric or event is evaluated before Beta.
+
+#### Tradeoffs
+
+For alternatives that map to disjoint logical resources, the envelope reserves every dimension even
+though only one alternative runs. This is conservative rather than unsafe, but it affects admission
+eligibility, cohort borrowing, preemption, Admission Fair Sharing usage, workload ordering, and
+utilization, and is called out here as an explicit policy tradeoff. Shrinking the reservation to
+the realized alternative after allocation is out of scope for this design; it would need a separate
+mechanism to observe the generated ResourceClaims and update admitted usage, cache, fair-sharing,
+borrowing, and preemption state.
+
 ### Integration with Admission Fair Sharing
 
 DRA logical resources participate in Admission Fair Sharing (AFS) when both DRA and AFS are enabled.
@@ -1841,6 +2004,13 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
   resolved to a DeviceClass with capacity sources is marked inadmissible
 - Capacity device-count skip: device-count charge skipped when capacity sources
   are configured for the DeviceClass (prevents double-counting)
+- Prioritized list quota: `firstAvailable` envelope charge with two DeviceClasses mapped to one
+  logical resource (max, not sum), disjoint alternatives (both reserved), multiple top-level
+  `firstAvailable` requests summed, mixed `Exactly` and `firstAvailable`, PodSet count greater
+  than one, and saturation as summed counts approach `MaxInt64`
+- Prioritized list rejection: unmapped alternative, `All` and unknown allocation modes, a
+  counter-backed or capacity-backed alternative, and the feature gate disabled all marked
+  inadmissible
 
 #### E2E Test
 
@@ -1850,6 +2020,10 @@ driver publishes `SharedCounters` yet
 ([kubernetes-sigs/dra-example-driver#150](https://github.com/kubernetes-sigs/dra-example-driver/pull/150)
 tracks adding this). This follows the same pattern as upstream K8s integration tests in
 `test/integration/dra/`.
+
+For prioritized lists, an e2e test submits `firstAvailable` workloads where different Pods can
+select different alternatives, and verifies each PodSet's admitted envelope stays an upper bound on
+the realized allocation.
 
 ### Graduation Criteria
 
@@ -1889,6 +2063,15 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
   selectors, summed into one quota resource)
 - reuses the existing ResourceSlice controller from partitionable devices; capacity
   source drivers are added to the watched driver set at startup
+- integration and e2e tests
+
+##### KueueDRAIntegrationPrioritizedList (v0.20)
+
+- count-based `firstAvailable` quota via the component-wise-max envelope, computed after
+  DeviceClass-to-logical-resource mapping
+- rejection of counter-backed and capacity-backed alternatives, and of `All`, unknown allocation
+  modes, and unmapped DeviceClasses
+- alignment with the feasibility path on the supported-versus-rejected predicate
 - integration and e2e tests
 
 #### Beta
@@ -1935,6 +2118,15 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - re-evaluate surfacing the rounded charge vs raw request in a workload condition or
   event for operator visibility
 
+##### KueueDRAIntegrationPrioritizedList
+
+- gate default remains off, or a documented rationale to enable it by default
+- quota and feasibility paths agree on the supported-versus-rejected predicate, with tests
+- no known quota under-accounting, including the aggregation-boundary overflow cases
+- upgrade and downgrade behavior verified
+- E2E stability for the count-based case
+- decision on whether source-backed alternatives are a Beta prerequisite
+
 #### GA
 
 ##### KueueDRAIntegration
@@ -1942,10 +2134,18 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - the feature gate in stable
 - TAS + DRA integration and testing
 - re-evaluate support for AdminAccess requests
-- re-evaluate support for FirstAvailable device selection
 - re-evaluate support for AllocationMode All
 - re-evaluate closing the admission-scheduling timing gap via scheduler-library
   integration
+
+##### KueueDRAIntegrationPrioritizedList
+
+- the feature gate in stable, with a lock-to-default or removal plan
+- production adoption feedback
+- final decision on counter-backed and capacity-backed alternatives, reusing the existing source
+  paths rather than a separate implementation
+- final decision on post-allocation reconciliation
+- version-skew and MultiKueue behavior validated
 
 ##### KueueDRAIntegrationExtendedResource
 
@@ -1985,6 +2185,9 @@ tracks adding this). This follows the same pattern as upstream K8s integration t
 - Consumable capacity design: July 2026 by @sohankunkerkar — added KEP-5075 integration
   for software-level device sharing
 - Promoted KueueDRAIntegrationPartitionableDevices to Beta: July 2026 by @PannagaRao
+- Prioritized-list (`firstAvailable`) quota design: July 2026 by @thc1006 — component-wise-max
+  envelope for count-based `DRAPrioritizedList` requests
+  (see [#13599](https://github.com/kubernetes-sigs/kueue/issues/13599))
 
 **Key Design Evolution:**
 - **Original Design**: Standalone DynamicResourceAllocationConfig CRD with runtime ambiguity resolution

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -367,8 +367,8 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
   count path included) registers no driver and is not requeued on ResourceSlice changes;
   such workloads are re-evaluated only when the ClusterQueue is notified through other events
   such as quota changes. Extending event-driven requeuing to cover these paths is an Alpha
-  graduation criterion. `WaitForPodsReady` serves as the safety net for cases where the
-  validation state diverges from actual device availability at scheduling time.
+  graduation criterion. `WaitForPodsReady`, when enabled, serves as the safety net for cases where
+  the validation state diverges from actual device availability at scheduling time.
 
 ### Risks and Mitigations
 
@@ -1800,7 +1800,16 @@ not fit has to be reported rather than silently truncated, which is what makes t
 possible. Nothing currently stops an administrator from naming a logical resource `cpu`, where an
 unconditional `SafeValue` would read `8` as 8 milliCPU. The component-wise maximum keeps the
 envelope itself bounded, and tests cover multiple `firstAvailable` requests, `Exactly` plus
-`firstAvailable` on one resource, and PodSet scaling at the representable boundary.
+`firstAvailable` on one resource, and PodSet scaling past the representable range.
+
+The same check is needed wherever these quantities are summed, not only within a Pod. Two PodSets
+can each have a representable total for a logical resource while the sum across PodSets does not
+fit in an `int64`.
+
+There is currently no way to report any of this. `totalRequestsFromPodSets` returns
+`[]PodSetResources` and no error, and `NewInfo` and `Info.Update` do not return errors either. The
+implementation will need to add an error path, so that the workload can be marked inadmissible
+instead of saturating.
 
 The maximum is taken after DeviceClass-to-logical-resource mapping. Two DeviceClasses may
 intentionally map to one logical resource (for example an H100 and an A100 class both mapping to a
@@ -1813,7 +1822,10 @@ kube-scheduler selects exactly one subrequest from each `firstAvailable`, so for
 resource `r` the selected alternative's charge is at most `envelope(q)[r]`. Summing over all
 top-level requests, the realized charge cannot exceed the admitted envelope. This holds only if
 every alternative resolves to a complete, non-negative charge vector; unmapped, unsupported, or
-unknown forms are rejected rather than charged.
+unknown forms are rejected rather than charged. This only covers the request forms that exist in
+the Kubernetes API version Kueue is compiled against. A classifier written over the Go types cannot
+see a field that was added in a later Kubernetes minor release, so bumping the API dependency will
+require reviewing any new fields that affect the charge.
 
 The bound rests on two further assumptions. First, the `ResourceClaimSpec` Kueue charges is the one
 later used to create the generated `ResourceClaim`. A `ResourceClaimTemplate` spec is immutable in
@@ -1875,7 +1887,7 @@ Two properties must be distinguished:
   requeue in the first place; once quota is reserved, kube-scheduler owns dynamic feasibility and
   retries the Pending Pod on ResourceClaim, DeviceClass, ResourceSlice, and node events. A workload
   still waiting on quota is requeued on the next ClusterQueue event, and an admitted one whose Pod
-  never becomes schedulable holds its reservation until `WaitForPodsReady`, where it is configured,
+  never becomes schedulable holds its reservation until `WaitForPodsReady`, when enabled,
   evicts it. Extending the controller to count-only mappings, or reaching feasibility through the
   scheduler library, is a graduation criterion rather than something the current controller covers.
 
@@ -1919,7 +1931,10 @@ to the same workload; this design does not let a user use `firstAvailable` to by
   check rejects a local workload whose claim templates carry `firstAvailable` before any remote
   Workload or Job is created, so the existing rejected-check path deactivates the workload and
   releases its reservation instead of dispatching an envelope the worker would not reproduce. A
-  template that cannot be read yet stays retryable rather than becoming a rejection.
+  template that cannot be read yet stays retryable rather than becoming a rejection. The check
+  looks up the template by name, so it has the same limitation as the envelope itself. If the
+  template is deleted and recreated in between, the check will not see the `firstAvailable` request
+  it is meant to reject.
 - Observability: the enforced portion of the envelope appears in
   `Workload.status.admission.podSetAssignments[].resourceUsage`; under `IgnoreUndeclared` an omitted
   logical resource appears in neither that usage nor ClusterQueue quota, borrowing, or preemption;
@@ -2062,14 +2077,15 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
 - Prioritized list quota: `firstAvailable` envelope charge with two DeviceClasses mapped to one
   logical resource (max, not sum), disjoint alternatives (both reserved), multiple top-level
   `firstAvailable` requests summed, mixed `Exactly` and `firstAvailable`, PodSet count greater
-  than one, and a total at the representable boundary rejected rather than saturated
+  than one, and a total that exceeds the representable range rejected rather than saturated
 - Prioritized list rejection: unmapped alternative, `All` and unknown allocation modes, a
   counter-backed or capacity-backed alternative, and the feature gate disabled all marked
   inadmissible
-- Prioritized list representability: a per-Pod sum, a merge with an ordinary resource sharing the
-  same key, and a PodSet multiplication that cannot be represented as `int64` each mark the workload
-  inadmissible rather than clamping, and a scaled request is recomputed from the per-Pod envelope
-  rather than divided out of an aggregate
+- Prioritized list representability: a per-Pod sum, a merge with an ordinary resource that shares
+  the same key, a PodSet multiplication, and a sum across two PodSets that each fit on their own,
+  none of which can be represented as `int64`. Each of these marks the workload inadmissible instead
+  of clamping. Scaling a PodSet down stays exact, because only an aggregate that is exactly the
+  per-Pod value times the count is admitted in the first place
 - Prioritized list with a logical resource named `cpu`: the charge round-trips through the
   milli-unit convention rather than being read as absolute units
 - Prioritized list under MultiKueue: the admission check rejects before any remote Workload or Job
@@ -2253,8 +2269,7 @@ the realized allocation.
 - Consumable capacity design: July 2026 by @sohankunkerkar — added KEP-5075 integration
   for software-level device sharing
 - Promoted KueueDRAIntegrationPartitionableDevices to Beta: July 2026 by @PannagaRao
-- Prioritized-list (`firstAvailable`) quota design: July 2026 by @thc1006 — component-wise-max
-  envelope for count-based `DRAPrioritizedList` requests
+- Prioritized-list (`firstAvailable`) quota design: July 2026 by @thc1006
   (see [#13599](https://github.com/kubernetes-sigs/kueue/issues/13599))
 
 **Key Design Evolution:**

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -440,9 +440,10 @@ Feature gates controlling DRA support in Kueue:
 - `KueueDRAIntegrationPrioritizedList` (Alpha, default off): gates count-based quota accounting
   for `firstAvailable` (prioritized alternative) requests via the component-wise-max envelope.
   Requires `KueueDRAIntegration`; the manager fails validation at startup if this gate is enabled
-  while `KueueDRAIntegration` is off. On Kubernetes 1.34 and 1.35 the upstream `DRAPrioritizedList`
-  gate must be enabled; the Kubernetes feature is Stable in 1.36. Counter-backed and capacity-backed
-  alternatives are rejected.
+  while `KueueDRAIntegration` is off. The upstream `DRAPrioritizedList` gate has been Beta and on by
+  default since Kubernetes 1.34 and GA since 1.36, and it locks to enabled in 1.37, so the
+  requirement on a cluster is that the gate has not been turned off rather than that an admin turns
+  it on. Counter-backed and capacity-backed alternatives are rejected.
 - `KueueDRARejectWorkloadsWhenDRADisabled` (Beta, default on since v0.18): rejects workloads
   that use DRA resources (ResourceClaimTemplates or ResourceClaims) when `KueueDRAIntegration`
   is disabled. Without this gate, DRA workloads submitted while `KueueDRAIntegration` is off
@@ -1755,16 +1756,18 @@ This architecture separates concerns between DRA processing (controller) and que
 This section is gated behind the `KueueDRAIntegrationPrioritizedList` Kueue feature gate (Alpha,
 default off). It adds quota accounting for prioritized-list requests, expressed with the
 `firstAvailable` field of a `DeviceRequest` (the Kubernetes `DRAPrioritizedList` feature, GA in
-1.36). A `firstAvailable` request lists ordered alternatives; kube-scheduler selects exactly one at
-allocation time, which is not known when Kueue reserves quota. With the gate off, such requests
-remain rejected as before.
+1.36). A `firstAvailable` request lists ordered alternatives, at most eight of them
+(`FirstAvailableDeviceRequestMaxSize`); kube-scheduler selects exactly one at allocation time, which
+is not known when Kueue reserves quota. With the gate off, such requests remain rejected as
+before.
 
 #### Accounting rule
 
 For a top-level `firstAvailable` request `q` with alternatives `A_q`, Kueue resolves each
 subrequest's DeviceClass to its logical quota resource through `deviceClassMappings` and forms a
-non-negative charge vector `charge(q, a)` per alternative `a`. The request is charged the
-component-wise maximum:
+non-negative charge vector `charge(q, a)` per alternative `a`. `DeviceSubRequest` has no
+`adminAccess` field, so admin access cannot appear on an alternative and its zero-charge rule stays
+confined to `Exactly` requests. The request is charged the component-wise maximum:
 
 ```text
 envelope(q)[r] = max over a in A_q of charge(q, a)[r]
@@ -1822,9 +1825,11 @@ feasibility may reduce such cases in the future.
 
 #### Coordination with feasibility
 
-This quota accounting is independently safe: the envelope is a conservative upper bound and does
-not depend on any feasibility check. Two related efforts inform admission accuracy and are linked
-here but do not block this KEP: the TAS+DRA work
+This quota accounting is independently safe. Whichever alternative kube-scheduler picks, that
+alternative's charge is at most the envelope, so reserving the envelope cannot under-charge the
+allocation that follows. The argument never needs to predict the choice, so it does not rest on
+ResourceSlice inspection or on any node-level fit check. Two related efforts inform admission
+accuracy and are linked here but do not block this KEP: the TAS+DRA work
 ([#10548](https://github.com/kubernetes-sigs/kueue/issues/10548)), and the broader admission-time
 scheduling-feasibility umbrella
 ([#12422](https://github.com/kubernetes-sigs/kueue/issues/12422)), which passes the full claim spec
@@ -2138,7 +2143,9 @@ the realized allocation.
 
 - gate default remains off, or a documented rationale to enable it by default
 - quota and feasibility paths agree on the supported-versus-rejected predicate, with tests
-- no known quota under-accounting, including the aggregation-boundary overflow cases
+- no known quota under-accounting at the aggregation boundaries: the per-Pod sum across requests,
+  the PodSet-count multiplication, and the `resource.Quantity` to `int64` conversion where several
+  DeviceClasses map to one logical resource
 - upgrade and downgrade behavior verified
 - E2E stability for the count-based case
 - decision on whether source-backed alternatives are a Beta prerequisite
@@ -2500,4 +2507,5 @@ between partitioning schemes on the same counter set. This is a partitionable de
 concern: it lives on `DeviceCounterConsumption` and only applies to devices sharing a
 counter set. Consumable capacity devices that use `Device.Capacity` without
 `consumesCounters` are not affected. Kueue would handle compatibility groups as part
-of the counter source path.
+of the counter source path. Counter-backed alternatives are rejected in this Alpha, so
+compatibility groups do not interact with prioritized-list quota.

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1878,9 +1878,10 @@ to the same workload; this design does not let a user use `firstAvailable` to by
   the current rejection. An already-admitted workload keeps the `resourceUsage` recorded in its
   status, so a controller restart or downgrade does not lose admitted accounting and no envelope is
   recomputed for it.
-- Version skew: the gate requires `KueueDRAIntegration`. On Kubernetes 1.34 and 1.35 the upstream
-  `DRAPrioritizedList` gate must be enabled; it is Stable in 1.36. If the API does not offer
-  `firstAvailable`, no envelope is charged and the request is handled as today.
+- Version skew: the gate requires `KueueDRAIntegration`, and it requires that a cluster has not
+  disabled the upstream `DRAPrioritizedList` gate, which has been Beta and on by default since
+  Kubernetes 1.34 and GA since 1.36. If the API does not offer `firstAvailable`, no envelope is
+  charged and the request is handled as today.
 - MultiKueue: `firstAvailable` is out of scope for the initial Alpha. MultiKueue resolves
   ResourceClaimTemplates against cluster-local objects, and the DRA end-to-end test depends on that:
   it gives the manager and both workers a template of the same name with different device counts,

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1841,6 +1841,30 @@ the Kubernetes API version Kueue is compiled against. A classifier written over 
 see a field that was added in a later Kubernetes minor release, so bumping the API dependency will
 require reviewing any new fields that affect the charge.
 
+The subrequest fields Kueue can see today, and how the classifier treats each one:
+
+| Field | Treatment |
+| --- | --- |
+| `deviceClassName` | maps to the logical resource; an unmapped class is rejected |
+| `allocationMode` | only an effective `ExactCount` is charged |
+| `count` | the charge itself |
+| `selectors` | compiled, and otherwise not part of the charge |
+| `tolerations` | feasibility only, and not part of the charge |
+
+The API specifies the defaults, so the classifier reads effective values: an omitted
+`allocationMode` is `ExactCount`, and an omitted `count` under that mode is one. The same type
+states that clients must refuse to handle requests with unknown modes, which is what the rejection
+above does. Claim-level `constraints` and `config` do not change the device count, and `pkg/dra`
+does not read them.
+
+Kubernetes 1.37 adds `capacity` and `derivedAttributes` to `DeviceSubRequest`. Kueue is compiled
+against 1.36, where the type ends at `tolerations`, so a 1.36 build talking to a 1.37 apiserver
+decodes a subrequest without either field and cannot reject an alternative that uses them. The
+envelope still charges the declared count, which is what a count-based mapping produces in any
+case, but deciding whether that is the right charge for a capacity request is what the
+capacity-backed rejection exists to do. Raising the dependency to 1.37 and classifying both fields
+is a prerequisite for this gate leaving Alpha.
+
 The bound rests on two further assumptions. First, the `ResourceClaimSpec` Kueue charges is the one
 later used to create the generated `ResourceClaim`. A `ResourceClaimTemplate` spec is immutable in
 place, but deleting and recreating one under the same name can change the spec between charging

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -361,12 +361,14 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
   time on a best-effort basis. Workloads with CEL selectors that match fewer devices than requested are rejected
   to prevent quota leaks. This validation uses the upstream DRA CEL compiler from [`k8s.io/dynamic-resource-allocation/cel`](https://github.com/kubernetes/dynamic-resource-allocation/tree/master/cel).
   On the other hand, devices can be allocated between Kueue's check and scheduling, and new ResourceSlices published after
-  validation can make previously-unsatisfiable workloads satisfiable. Kueue does not
-  currently have a ResourceSlice informer. Inadmissible workloads are only re-evaluated
-  when the ClusterQueue is notified through other events such as quota changes. Adding
-  event-driven requeuing on ResourceSlice changes is an Alpha graduation criterion.
-  `WaitForPodsReady` serves as the safety net for cases where the validation state
-  diverges from actual device availability at scheduling time.
+  validation can make previously-unsatisfiable workloads satisfiable. Kueue has a
+  `ResourceSliceReconciler`, but it registers watched drivers only from source-backed
+  `deviceClassMappings` (their `sources`), so a mapping with no sources (this CEL-validated
+  count path included) registers no driver and is not requeued on ResourceSlice changes;
+  such workloads are re-evaluated only when the ClusterQueue is notified through other events
+  such as quota changes. Extending event-driven requeuing to cover these paths is an Alpha
+  graduation criterion. `WaitForPodsReady` serves as the safety net for cases where the
+  validation state diverges from actual device availability at scheduling time.
 
 ### Risks and Mitigations
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -429,9 +429,9 @@ released.
 Feature gates controlling DRA support in Kueue:
 - `KueueDRAIntegration` (Beta, default on since v0.18): gates ResourceClaimTemplate-based
   DRA quota accounting. Uses `deviceClassMappings` for DeviceClass-to-quota-resource mapping.
-- `KueueDRAIntegrationExtendedResource` (Alpha): gates extended resources support, including
+- `KueueDRAIntegrationExtendedResource` (Beta, default on since v0.19): gates extended resources support, including
   DeviceClass auto-discovery via `extendedResourceName`. Requires `KueueDRAIntegration`.
-- `KueueDRAIntegrationPartitionableDevices` (Alpha): gates counter-based quota for
+- `KueueDRAIntegrationPartitionableDevices` (Beta, default on since v0.19): gates counter-based quota for
   partitionable devices. Enables the `counter` source type on `deviceClassMappings` entries.
   Requires `KueueDRAIntegration`. Also requires the Kubernetes `DRAPartitionableDevices`
   feature gate (beta in K8s 1.36).
@@ -1805,6 +1805,16 @@ top-level requests, the realized charge cannot exceed the admitted envelope. Thi
 every alternative resolves to a complete, non-negative charge vector; unmapped, unsupported, or
 unknown forms are rejected rather than charged.
 
+The bound rests on two further assumptions. First, the `ResourceClaimSpec` Kueue charges is the one
+later used to create the generated `ResourceClaim`. A `ResourceClaimTemplate` spec is immutable in
+place, but deleting and recreating one under the same name can change the spec between charging
+(while the workload is `Pending`) and claim generation, so the running claim could differ from the
+charged envelope. This gap is shared by all Kueue DRA charging, including the existing `Exactly`
+path, rather than introduced here, and warrants a separate prerequisite issue on binding the charge
+to the generated claim's spec. Second, the bound covers the logical resources the target
+`ClusterQueue` manages; `quotaCheckStrategy: IgnoreUndeclared` deliberately omits undeclared
+dimensions from enforcement, so an alternative that resolves to an omitted resource is not charged.
+
 #### Scope
 
 Supported: `ResourceClaimTemplate` references; `ExactCount` subrequests; count-based
@@ -1849,11 +1859,13 @@ Two properties must be distinguished:
   ResourceSlice controller, but it builds its driver set from the `sources` of each device class
   mapping and filters slice events on that set, so a count-only mapping registers no driver and its
   slice changes trigger no requeue. The initial Alpha also reserves quota without running the
-  cardinality or allocator checks, so it never produces a supported-but-infeasible result to
-  requeue in the first place. A workload that becomes schedulable is noticed on the next
-  ClusterQueue event, and one that never does holds its reservation until `WaitForPodsReady` evicts
-  it. Extending the controller to count-only mappings, or reaching feasibility through the
-  scheduler library, is a graduation criterion rather than something the current controller covers.
+  cardinality or allocator checks, so Kueue never produces a supported-but-infeasible result to
+  requeue in the first place; once quota is reserved, kube-scheduler owns dynamic feasibility and
+  retries the Pending Pod on ResourceClaim, DeviceClass, ResourceSlice, and node events. A workload
+  still waiting on quota is requeued on the next ClusterQueue event, and an admitted one whose Pod
+  never becomes schedulable holds its reservation until `WaitForPodsReady` evicts it. Extending the
+  controller to count-only mappings, or reaching feasibility through the scheduler library, is a
+  graduation criterion rather than something the current controller covers.
 
 The quota and feasibility paths MUST consume the same static-support classification, from one
 helper, so a claim is never accepted by one and rejected by the other. Splitting the two invites
@@ -1935,7 +1947,7 @@ is more valuable than CPU time for fair sharing purposes.
 
 ### MultiKueue Integration
 
-DRA workloads are supported with MultiKueue through the existing workload synchronization mechanism. ResourceClaimTemplates must be deployed on worker clusters by users; they are not automatically synced.
+DRA workloads are supported with MultiKueue through the existing workload synchronization mechanism. ResourceClaimTemplates must be deployed on worker clusters by users; they are not automatically synced. Count-based `firstAvailable` requests are excluded while `KueueDRAIntegrationPrioritizedList` is Alpha; they remain rejected (fail-closed) rather than dispatched, so a manager and worker cannot charge different envelopes for the same workload.
 
 ### Test Plan
 
@@ -2095,7 +2107,8 @@ the realized allocation.
   DeviceClass-to-logical-resource mapping
 - rejection of counter-backed and capacity-backed alternatives, and of `All`, unknown allocation
   modes, and unmapped DeviceClasses
-- alignment with the feasibility path on the supported-versus-rejected predicate
+- a shared static-support classifier that the quota path consumes, with table-driven tests freezing
+  the supported-versus-rejected contract (agreement with the feasibility path is a Beta criterion)
 - integration and e2e tests
 
 #### Beta

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1772,7 +1772,10 @@ envelope(q)[r] = max over a in A_q of charge(q, a)[r]
 
 The per-Pod DRA charge is the existing `Exactly` charges plus the sum, over all `firstAvailable`
 requests, of `envelope(q)`. PodSet scaling is unchanged: the per-Pod charge is multiplied by the
-effective PodSet count by the existing workload-request calculation.
+effective PodSet count by the existing workload-request calculation. With
+`ElasticJobsViaWorkloadSlices`, each slice carries its own PodSet count, so each computes its
+envelope independently and multiplies the same per-Pod envelope by its own count; nothing is shared
+between the slices of one Job.
 
 Device-count sums use saturating `int64` arithmetic (`utilmath.SaturatingAdd`, as in
 `countDevicesPerClass`), so no envelope or per-request sum wraps negative. Charges that map to the
@@ -1829,28 +1832,38 @@ to `structured.Allocator`.
 
 Two properties must be distinguished:
 
-- Static support: whether Kueue can correctly account for a request shape. Unsupported shapes (for
-  example a source-backed alternative in the initial scope) are permanent errors, rejected as
-  inadmissible.
+- Static support: whether Kueue can correctly account for a request shape. Unsupported shapes are
+  permanent errors, rejected as inadmissible. Where one alternative carries a counter or capacity
+  source, the whole request is rejected rather than that alternative skipped: the envelope is a
+  maximum over every alternative, so dropping one of them stops bounding the allocation the
+  scheduler may still choose.
 - Dynamic feasibility: whether the current cluster state can schedule a supported claim. A
-  supported-but-infeasible claim is retryable rather than a permanent error. Kueue has no
-  ResourceSlice informer today, so it is re-evaluated on ClusterQueue events, the same recovery
-  path and the same limitation the CEL selector check above carries: a workload that became
-  schedulable is not noticed until such an event, and one that never becomes schedulable holds its
-  reservation until `WaitForPodsReady` evicts it. Event-driven requeuing on ResourceSlice changes
-  is already an Alpha graduation criterion, and it covers this path as well.
+  supported-but-infeasible claim is retryable rather than a permanent error. Kueue has a
+  ResourceSlice controller, but it builds its driver set from the `sources` of each device class
+  mapping and filters slice events on that set, so a count-only mapping registers no driver and its
+  slice changes trigger no requeue. The initial Alpha also reserves quota without running the
+  cardinality or allocator checks, so it never produces a supported-but-infeasible result to
+  requeue in the first place. A workload that becomes schedulable is noticed on the next
+  ClusterQueue event, and one that never does holds its reservation until `WaitForPodsReady` evicts
+  it. Extending the controller to count-only mappings, or reaching feasibility through the
+  scheduler library, is a graduation criterion rather than something the current controller covers.
 
-The quota and feasibility paths must apply equivalent static-support validation, preferably through
-a shared helper, so a claim is never accepted by one and rejected by the other. A feasibility
-result of "infeasible" must not be surfaced as "unsupported".
+The quota and feasibility paths MUST consume the same static-support classification, from one
+helper, so a claim is never accepted by one and rejected by the other. Splitting the two invites
+the failures that are hardest to notice: a shape the quota path charges and the feasibility path
+refuses forever, a shape the feasibility path admits and the quota path never charges, or a new API
+field that only one of them learns to reject. A feasibility result of "infeasible" must not be
+surfaced as "unsupported", and a failed object read or slice listing is neither.
 
 #### Relationship with Kubernetes ResourceQuota
 
 This is a Kueue-specific quota policy and does not change Kubernetes `ResourceQuota`. Core
-`ResourceQuota` (KEP-4816) requires quota for each `DeviceSubRequest` under every `FirstAvailable`,
-keyed per DeviceClass. Kueue's envelope keeps every logical resource an alternative maps to and
-only collapses to a maximum where an administrator has deliberately mapped several DeviceClasses to
-one Kueue logical resource. Namespace `ResourceQuota` and Kueue `ClusterQueue` quota may both apply
+`ResourceQuota` (KEP-4816) takes, within each top-level `FirstAvailable`, the largest device count
+among the alternatives that name a given DeviceClass, and adds those per-class maxima across
+top-level requests; it does not sum the alternatives of one request. Kueue applies the same
+per-request maximum, but after mapping DeviceClasses into logical resources, so a mapping that
+sends several DeviceClasses to one logical resource collapses charges that core `ResourceQuota`
+keeps apart. Namespace `ResourceQuota` and Kueue `ClusterQueue` quota may both apply
 to the same workload; this design does not let a user use `firstAvailable` to bypass namespace
 `ResourceQuota`.
 
@@ -1863,10 +1876,13 @@ to the same workload; this design does not let a user use `firstAvailable` to by
 - Version skew: the gate requires `KueueDRAIntegration`. On Kubernetes 1.34 and 1.35 the upstream
   `DRAPrioritizedList` gate must be enabled; it is Stable in 1.36. If the API does not offer
   `firstAvailable`, no envelope is charged and the request is handled as today.
-- MultiKueue: the envelope is computed on the management cluster from the ResourceClaimTemplate
-  spec, and admitted `resourceUsage` is synchronized to workers unchanged, so a worker does not
-  recompute a different charge. Full cross-version manager/worker behavior is out of scope for the
-  initial Alpha and is a Beta consideration.
+- MultiKueue: `firstAvailable` is out of scope for the initial Alpha. MultiKueue resolves
+  ResourceClaimTemplates against cluster-local objects, and the DRA end-to-end test depends on that:
+  it gives the manager and both workers a template of the same name with different device counts,
+  and asserts the admitted usage on the worker matches the worker's own template rather than the
+  manager's. A manager and a worker can therefore select different alternatives, or map the same
+  DeviceClass differently, and arrive at different envelopes. Deciding which side is authoritative,
+  and covering a template or mapping mismatch, is Beta work.
 - Observability: the envelope appears in
   `Workload.status.admission.podSetAssignments[].resourceUsage`; a debug log records each
   alternative's charge vector and the resulting envelope, and a rejection names the alternative,

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -443,9 +443,9 @@ Feature gates controlling DRA support in Kueue:
   for `firstAvailable` (prioritized alternative) requests via the component-wise-max envelope.
   Requires `KueueDRAIntegration`; the manager fails validation at startup if this gate is enabled
   while `KueueDRAIntegration` is off. The upstream `DRAPrioritizedList` gate has been Beta and on by
-  default since Kubernetes 1.34 and GA since 1.36, and it locks to enabled in 1.37, so the
-  requirement on a cluster is that the gate has not been turned off rather than that an admin turns
-  it on. Counter-backed and capacity-backed alternatives are rejected.
+  default since Kubernetes 1.34 and GA since 1.36, and upstream plans to lock it to enabled in 1.37,
+  so the requirement on a cluster is that the gate has not been turned off rather than that an admin
+  turns it on. Counter-backed and capacity-backed alternatives are rejected.
 - `KueueDRARejectWorkloadsWhenDRADisabled` (Beta, default on since v0.18): rejects workloads
   that use DRA resources (ResourceClaimTemplates or ResourceClaims) when `KueueDRAIntegration`
   is disabled. Without this gate, DRA workloads submitted while `KueueDRAIntegration` is off
@@ -1782,15 +1782,25 @@ effective PodSet count by the existing workload-request calculation. With
 envelope independently and multiplies the same per-Pod envelope by its own count; nothing is shared
 between the slices of one Job.
 
-Device-count sums use saturating `int64` arithmetic (`utilmath.SaturatingAdd`, as in
-`countDevicesPerClass`), so no envelope or per-request sum wraps negative. Charges that map to the
-same logical resource are then combined as `resource.Quantity` before being converted back to
-`int64`. That conversion must clamp an out-of-range quantity rather than call `Value()` directly,
-using the `SafeValue` helper added for the counter and capacity paths; the prioritized-list path
-must not introduce a new unclamped conversion. This overflow window is a pre-existing property of
-the shared count path (several DeviceClasses mapping to one logical resource near `MaxInt64`); the
-component-wise maximum keeps the envelope itself bounded, and tests cover multiple `firstAvailable`
-requests, `Exactly` plus `firstAvailable` on one resource, and PodSet scaling near `MaxInt64`.
+Saturating arithmetic stops a sum from wrapping, but a saturated sum no longer stands for the value
+it replaced, so it cannot carry the bound: clamping to `MaxInt64` reports less than the total it
+came from. The merge into `resources.Requests` is weaker still, since `MapRequests.Add` uses plain
+`+` and can wrap negative where a DRA logical resource shares a key with an ordinary Pod resource. A
+charge that cannot be represented exactly as `int64` therefore makes the workload inadmissible
+rather than being clamped and admitted, at each step that can produce one: the per-Pod sum across
+requests, the merge with ordinary resources, and the PodSet-count multiplication. Nor is a saturated
+aggregate divided to recover a smaller request: `PodSetResources` scaling divides by the old count
+and multiplies by the new, so partial admission, `ReclaimablePods`, and workload-slice replacement
+recompute from the per-Pod envelope instead.
+
+Converting a combined `resource.Quantity` back to `int64` follows the unit convention in
+`resources.ResourceValue`, milli-units for `cpu` and absolute units otherwise. That helper calls
+`Value()` for everything but `cpu`, so following it is not on its own enough: a quantity that does
+not fit has to be reported rather than silently truncated, which is what makes the rejection above
+possible. Nothing currently stops an administrator from naming a logical resource `cpu`, where an
+unconditional `SafeValue` would read `8` as 8 milliCPU. The component-wise maximum keeps the
+envelope itself bounded, and tests cover multiple `firstAvailable` requests, `Exactly` plus
+`firstAvailable` on one resource, and PodSet scaling at the representable boundary.
 
 The maximum is taken after DeviceClass-to-logical-resource mapping. Two DeviceClasses may
 intentionally map to one logical resource (for example an H100 and an A100 class both mapping to a
@@ -1810,10 +1820,12 @@ later used to create the generated `ResourceClaim`. A `ResourceClaimTemplate` sp
 place, but deleting and recreating one under the same name can change the spec between charging
 (while the workload is `Pending`) and claim generation, so the running claim could differ from the
 charged envelope. This gap is shared by all Kueue DRA charging, including the existing `Exactly`
-path, rather than introduced here, and warrants a separate prerequisite issue on binding the charge
-to the generated claim's spec. Second, the bound covers the logical resources the target
-`ClusterQueue` manages; `quotaCheckStrategy: IgnoreUndeclared` deliberately omits undeclared
-dimensions from enforcement, so an alternative that resolves to an omitted resource is not charged.
+path, rather than introduced here. It is a known limitation tracked in
+[#13842](https://github.com/kubernetes-sigs/kueue/issues/13842), and the bound above is stated for a
+fixed `ResourceClaimSpec` rather than made conditional on that issue landing first. Second, the
+bound covers the logical resources the target `ClusterQueue` manages; `quotaCheckStrategy:
+IgnoreUndeclared` deliberately omits undeclared dimensions from enforcement, so an alternative that
+resolves to an omitted resource is not charged.
 
 #### Scope
 
@@ -1863,15 +1875,16 @@ Two properties must be distinguished:
   requeue in the first place; once quota is reserved, kube-scheduler owns dynamic feasibility and
   retries the Pending Pod on ResourceClaim, DeviceClass, ResourceSlice, and node events. A workload
   still waiting on quota is requeued on the next ClusterQueue event, and an admitted one whose Pod
-  never becomes schedulable holds its reservation until `WaitForPodsReady` evicts it. Extending the
-  controller to count-only mappings, or reaching feasibility through the scheduler library, is a
-  graduation criterion rather than something the current controller covers.
+  never becomes schedulable holds its reservation until `WaitForPodsReady`, where it is configured,
+  evicts it. Extending the controller to count-only mappings, or reaching feasibility through the
+  scheduler library, is a graduation criterion rather than something the current controller covers.
 
-The quota and feasibility paths MUST consume the same static-support classification, from one
-helper, so a claim is never accepted by one and rejected by the other. Splitting the two invites
-the failures that are hardest to notice: a shape the quota path charges and the feasibility path
-refuses forever, a shape the feasibility path admits and the quota path never charges, or a new API
-field that only one of them learns to reject. A feasibility result of "infeasible" must not be
+The quota path MUST consume the static-support classification from a single helper, and any
+admission-time feasibility path MUST consume that same helper once one exists, so a claim is never
+accepted by one and rejected by the other. Splitting the two invites the failures that are hardest
+to notice: a shape the quota path charges and the feasibility path refuses forever, a shape the
+feasibility path admits and the quota path never charges, or a new API field that only one of them
+learns to reject. A feasibility result of "infeasible" must not be
 surfaced as "unsupported", and a failed object read or slice listing is neither.
 
 #### Relationship with Kubernetes ResourceQuota
@@ -1902,11 +1915,17 @@ to the same workload; this design does not let a user use `firstAvailable` to by
   and asserts the admitted usage on the worker matches the worker's own template rather than the
   manager's. A manager and a worker can therefore select different alternatives, or map the same
   DeviceClass differently, and arrive at different envelopes. Deciding which side is authoritative,
-  and covering a template or mapping mismatch, is Beta work.
-- Observability: the envelope appears in
-  `Workload.status.admission.podSetAssignments[].resourceUsage`; a debug log records each
-  alternative's charge vector and the resulting envelope, and a rejection names the alternative,
-  DeviceClass, or source that is unsupported. A metric or event is evaluated before Beta.
+  and covering a template or mapping mismatch, is Beta work. Until then the MultiKueue admission
+  check rejects a local workload whose claim templates carry `firstAvailable` before any remote
+  Workload or Job is created, so the existing rejected-check path deactivates the workload and
+  releases its reservation instead of dispatching an envelope the worker would not reproduce. A
+  template that cannot be read yet stays retryable rather than becoming a rejection.
+- Observability: the enforced portion of the envelope appears in
+  `Workload.status.admission.podSetAssignments[].resourceUsage`; under `IgnoreUndeclared` an omitted
+  logical resource appears in neither that usage nor ClusterQueue quota, borrowing, or preemption;
+  a debug log records each alternative's charge vector and the resulting envelope, and a rejection
+  names the alternative, DeviceClass, or source that is unsupported. A metric or event is evaluated
+  before Beta.
 
 #### Tradeoffs
 
@@ -2043,10 +2062,20 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
 - Prioritized list quota: `firstAvailable` envelope charge with two DeviceClasses mapped to one
   logical resource (max, not sum), disjoint alternatives (both reserved), multiple top-level
   `firstAvailable` requests summed, mixed `Exactly` and `firstAvailable`, PodSet count greater
-  than one, and saturation as summed counts approach `MaxInt64`
+  than one, and a total at the representable boundary rejected rather than saturated
 - Prioritized list rejection: unmapped alternative, `All` and unknown allocation modes, a
   counter-backed or capacity-backed alternative, and the feature gate disabled all marked
   inadmissible
+- Prioritized list representability: a per-Pod sum, a merge with an ordinary resource sharing the
+  same key, and a PodSet multiplication that cannot be represented as `int64` each mark the workload
+  inadmissible rather than clamping, and a scaled request is recomputed from the per-Pod envelope
+  rather than divided out of an aggregate
+- Prioritized list with a logical resource named `cpu`: the charge round-trips through the
+  milli-unit convention rather than being read as absolute units
+- Prioritized list under MultiKueue: the admission check rejects before any remote Workload or Job
+  exists, and a transient template read error is retried instead of rejected
+- Prioritized list under `quotaCheckStrategy: IgnoreUndeclared`: an alternative resolving to an
+  undeclared logical resource is left out of enforcement and out of reported usage
 
 #### E2E Test
 
@@ -2160,8 +2189,8 @@ the realized allocation.
 - gate default remains off, or a documented rationale to enable it by default
 - quota and feasibility paths agree on the supported-versus-rejected predicate, with tests
 - no known quota under-accounting at the aggregation boundaries: the per-Pod sum across requests,
-  the PodSet-count multiplication, and the `resource.Quantity` to `int64` conversion where several
-  DeviceClasses map to one logical resource
+  the merge with an ordinary resource sharing the same key, the PodSet-count multiplication, and the
+  `resource.Quantity` to `int64` conversion where several DeviceClasses map to one logical resource
 - upgrade and downgrade behavior verified
 - E2E stability for the count-based case
 - decision on whether source-backed alternatives are a Beta prerequisite

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1850,6 +1850,7 @@ The subrequest fields Kueue can see today, and how the classifier treats each on
 | `count` | the charge itself |
 | `selectors` | compiled, and otherwise not part of the charge |
 | `tolerations` | feasibility only, and not part of the charge |
+| `capacity` | rejected, for the same reason a capacity-backed mapping is: the count path does not charge a consumable-capacity request |
 
 The API specifies the defaults, so the classifier reads effective values: an omitted
 `allocationMode` is `ExactCount`, and an omitted `count` under that mode is one. The same type
@@ -1857,13 +1858,11 @@ states that clients must refuse to handle requests with unknown modes, which is 
 above does. Claim-level `constraints` and `config` do not change the device count, and `pkg/dra`
 does not read them.
 
-Kubernetes 1.37 adds `capacity` and `derivedAttributes` to `DeviceSubRequest`. Kueue is compiled
-against 1.36, where the type ends at `tolerations`, so a 1.36 build talking to a 1.37 apiserver
-decodes a subrequest without either field and cannot reject an alternative that uses them. The
-envelope still charges the declared count, which is what a count-based mapping produces in any
-case, but deciding whether that is the right charge for a capacity request is what the
-capacity-backed rejection exists to do. Raising the dependency to 1.37 and classifying both fields
-is a prerequisite for this gate leaving Alpha.
+Kubernetes 1.37 adds `derivedAttributes` to `DeviceSubRequest`. Kueue is compiled against 1.36,
+where the type ends at `capacity`, so a 1.36 build talking to a 1.37 apiserver decodes a subrequest
+without that field and cannot reject an alternative that uses it. The envelope still charges the
+declared count, which is what a count-based mapping produces in any case. Raising the dependency to
+1.37 and classifying the field is a prerequisite for this gate leaving Alpha.
 
 The bound rests on two further assumptions. First, the `ResourceClaimSpec` Kueue charges is the one
 later used to create the generated `ResourceClaim`. A `ResourceClaimTemplate` spec is immutable in
@@ -1883,8 +1882,8 @@ Supported: `ResourceClaimTemplate` references; `ExactCount` subrequests; count-b
 `deviceClassMappings` (no `sources`); request-selector CEL compilation.
 
 Rejected: direct `ResourceClaim` references; `All` and unknown allocation modes; unmapped
-DeviceClasses; and any alternative whose DeviceClass mapping configures a counter or capacity
-`source`. Source-backed alternatives are excluded because the counter and consumable-capacity
+DeviceClasses; any alternative that sets `capacity` on the subrequest; and any alternative whose
+DeviceClass mapping configures a counter or capacity `source`. Source-backed alternatives are excluded because the counter and consumable-capacity
 accounting paths process only `Exactly` requests today; they can be added later by charging each
 alternative through its source path and taking the component-wise maximum of the resulting vectors.
 
@@ -1946,7 +1945,7 @@ surfaced as "unsupported", and a failed object read or slice listing is neither.
 #### Relationship with Kubernetes ResourceQuota
 
 This is a Kueue-specific quota policy and does not change Kubernetes `ResourceQuota`. Core
-`ResourceQuota` (KEP-4816) takes, within each top-level `FirstAvailable`, the largest device count
+`ResourceQuota` (KEP-4816) takes, within each top-level `firstAvailable`, the largest device count
 among the alternatives that name a given DeviceClass, and adds those per-class maxima across
 top-level requests; it does not sum the alternatives of one request. Kueue applies the same
 per-request maximum, but after mapping DeviceClasses into logical resources, so a mapping that
@@ -2253,14 +2252,15 @@ the realized allocation.
 
 ##### KueueDRAIntegrationPrioritizedList
 
-- gate default remains off, or a documented rationale to enable it by default
+- feature gate enabled by default
 - quota and feasibility paths agree on the supported-versus-rejected predicate, with tests
 - no known quota under-accounting at the aggregation boundaries: the per-Pod sum across requests,
   the merge with an ordinary resource sharing the same key, the PodSet-count multiplication, and the
   `resource.Quantity` to `int64` conversion where several DeviceClasses map to one logical resource
 - upgrade and downgrade behavior verified
 - E2E stability for the count-based case
-- decision on whether source-backed alternatives are a Beta prerequisite
+- re-evaluate source-backed alternatives, charging each through its source path and taking the
+  component-wise maximum of the resulting vectors
 
 #### GA
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -2255,8 +2255,9 @@ the realized allocation.
 - feature gate enabled by default
 - quota and feasibility paths agree on the supported-versus-rejected predicate, with tests
 - no known quota under-accounting at the aggregation boundaries: the per-Pod sum across requests,
-  the merge with an ordinary resource sharing the same key, the PodSet-count multiplication, and the
-  `resource.Quantity` to `int64` conversion where several DeviceClasses map to one logical resource
+  the merge with an ordinary resource sharing the same key, the PodSet-count multiplication, the
+  sum across PodSets, and the `resource.Quantity` to `int64` conversion where several DeviceClasses
+  map to one logical resource
 - upgrade and downgrade behavior verified
 - E2E stability for the count-based case
 - re-evaluate source-backed alternatives, charging each through its source path and taking the

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -385,7 +385,9 @@ documented here:
    over the alternatives after DeviceClass-to-logical-resource mapping, which is a per-resource
    upper bound on any single realized allocation (see [Prioritized List Quota](#prioritized-list-quota)).
    Counter-backed and capacity-backed alternatives are rejected until their accounting paths can
-   produce per-alternative charge vectors.
+   produce per-alternative charge vectors, as are alternatives using allocation mode `All` or a
+   mode Kueue does not recognise. The worst-case `All` charge in item 3 applies to a whole-claim
+   `All` request, not to an alternative.
 2. AdminAccess requests are skipped in quota counting. This feature can only be enabled in
    admin namespaces (gated by the `resource.kubernetes.io/admin-access` label), and provides
    shared read-only access to already-allocated devices. Charging quota would double-count the
@@ -1809,12 +1811,24 @@ fit in an `int64`.
 There is currently no way to report any of this. `totalRequestsFromPodSets` returns
 `[]PodSetResources` and no error, and `NewInfo` and `Info.Update` do not return errors either. The
 implementation will need to add an error path, so that the workload can be marked inadmissible
-instead of saturating.
+instead of saturating. Until that exists, the Alpha bound holds for charges the shared path can
+represent, which is the condition the existing `Exactly` charges already depend on.
 
 The maximum is taken after DeviceClass-to-logical-resource mapping. Two DeviceClasses may
 intentionally map to one logical resource (for example an H100 and an A100 class both mapping to a
 `gpu` resource); taking the maximum per DeviceClass and then summing the mapped classes would
 overcharge in that case.
+
+The envelope is a bound in resource space, and it does not record which ResourceFlavor an
+alternative would have used. When two alternatives map to different logical resources, Kueue
+assigns a flavor to each one, and `podset.FromAssignment` copies the node labels of every assigned
+flavor into the same PodSet. `podSetAssignments[].flavors` is a map, so when two of those flavors
+set the same label key, the value that survives depends on map iteration order. This is not
+specific to prioritized lists, since any PodSet assigned two such flavors behaves the same way, but
+a prioritized list makes it easy to reach: the alternatives are mutually exclusive, and a user is
+likely to expect a fallback rather than the labels of both branches. For Alpha, the logical
+resources used by prioritized-list alternatives are expected to use flavors whose node labels do
+not conflict. DRA flavors normally carry none.
 
 #### Safety argument
 
@@ -1858,6 +1872,12 @@ envelope depends only on the declared counts; it can, however, let an unschedula
 the envelope reservation. `WaitForPodsReady`, when enabled, eventually releases that reservation.
 It is a liveness and utilization safety net, not a premise of the quota upper bound; admission-time
 feasibility may reduce such cases in the future.
+
+The compiler that check uses is shared with the `Exactly` path, and Kueue builds its cache with an
+empty `dracel.Features`. The apiserver compiles the same selectors with the consumable capacity and
+list attribute features available, so a selector it accepted can fail to compile in Kueue. That is
+not introduced here, but a classifier that compiles every alternative will hit it more often, so
+the two environments should be aligned before this scope is implemented.
 
 #### Coordination with feasibility
 
@@ -1981,7 +2001,8 @@ is more valuable than CPU time for fair sharing purposes.
 
 ### MultiKueue Integration
 
-DRA workloads are supported with MultiKueue through the existing workload synchronization mechanism. ResourceClaimTemplates must be deployed on worker clusters by users; they are not automatically synced. Count-based `firstAvailable` requests are excluded while `KueueDRAIntegrationPrioritizedList` is Alpha; they remain rejected (fail-closed) rather than dispatched, so a manager and worker cannot charge different envelopes for the same workload.
+DRA workloads are supported with MultiKueue through the existing workload synchronization mechanism. ResourceClaimTemplates must be deployed on worker clusters by users; they are not automatically synced. Count-based `firstAvailable` requests are excluded while `KueueDRAIntegrationPrioritizedList` is Alpha; they remain rejected (fail-closed) rather than dispatched, so a manager and worker cannot charge different envelopes for the same workload for a fixed template identity. The check looks the template up by name, so it
+carries the limitation described in the prioritized-list section.
 
 ### Test Plan
 
@@ -2088,6 +2109,9 @@ using mock ResourceClaimTemplates and DeviceClasses to simulate DRA workloads. K
   per-Pod value times the count is admitted in the first place
 - Prioritized list with a logical resource named `cpu`: the charge round-trips through the
   milli-unit convention rather than being read as absolute units
+- Prioritized list flavors: disjoint alternatives whose logical resources resolve to flavors
+  without node labels, and to flavors whose node labels do not share a key, produce the PodSet
+  node selector the alternatives imply
 - Prioritized list under MultiKueue: the admission check rejects before any remote Workload or Job
   exists, and a transient template read error is retried instead of rejected
 - Prioritized list under `quotaCheckStrategy: IgnoreUndeclared`: an alternative resolving to an
@@ -2154,6 +2178,9 @@ the realized allocation.
   modes, and unmapped DeviceClasses
 - a shared static-support classifier that the quota path consumes, with table-driven tests freezing
   the supported-versus-rejected contract (agreement with the feasibility path is a Beta criterion)
+- an envelope that cannot be represented exactly makes the workload permanently inadmissible
+  instead of being saturated. The same check at the shared aggregation boundaries, which every DRA
+  charge already passes through, is a Beta criterion
 - integration and e2e tests
 
 #### Beta

--- a/keps/2941-DRA/kep.yaml
+++ b/keps/2941-DRA/kep.yaml
@@ -17,6 +17,7 @@ see-also:
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5004-dra-extended-resource"
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4815-dra-partitionable-devices"
   - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/5075-dra-consumable-capacity"
+  - "https://github.com/kubernetes/enhancements/tree/master/keps/sig-scheduling/4816-dra-prioritized-list"
 replaces:
   - "https://github.com/kubernetes-sigs/kueue/pull/3071"
 
@@ -26,7 +27,7 @@ stage: beta
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.19"
+latest-milestone: "v0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
@@ -41,6 +42,7 @@ feature-gates:
   - name: KueueDRAIntegrationExtendedResource
   - name: KueueDRAIntegrationPartitionableDevices
   - name: KueueDRAIntegrationConsumableCapacity
+  - name: KueueDRAIntegrationPrioritizedList
   - name: KueueDRARejectWorkloadsWhenDRADisabled
 disable-supported: true
 


### PR DESCRIPTION
#### What type of PR is this?

/kind kep
/area dra

#### What this PR does / why we need it?

Defines device-count quota accounting for DRA `firstAvailable` requests in KEP-2941, behind the Alpha, default-off `KueueDRAIntegrationPrioritizedList` gate.

For each top-level `firstAvailable` request, Alpha requires all alternatives to use source-less mappings to the same logical resource. Kueue charges the maximum count among those alternatives; that charge is the request's envelope. kube-scheduler selects exactly one alternative, so the envelope is an upper bound on whichever it selects. Independent requests remain additive, and PodSet scaling is unchanged. The combinations Alpha rejects are listed in the KEP's support matrix.

The amendment covers the accounting rule, the Alpha support matrix, exactness, the integration requirements the gate depends on, tests and graduation criteria. The shared DRA fixes and their regression coverage are tracked with the implementation PR, #14130, which is held until #14154 merges.

Part of #13599. #13842 tracks the reservation-to-claim identity gap the KEP lists as a limitation.

#### Useful notes for your reviewer

The `capacity` treatment (charged by device count under a source-less mapping) was confirmed in review. The fixed-template identity boundary (#13842) stays listed as a limitation, inherited from the `Exactly` path. The implementation PR carries the accounting core; the remaining Alpha criteria follow as separate PRs, and the KEP targets v0.21 for the Alpha.

_Disclosure: I used an AI coding assistant to help with the analysis and drafting of this update. I reviewed and verified the design, the code paths, and the KEP wording myself._

#### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added count-based quota support for DRA prioritized-list (`firstAvailable`) requests behind a feature gate.
  * Alternatives are accounted for using the maximum required charge across components.
  * Unsupported allocation modes and incompatible resource configurations are rejected.

* **Documentation**
  * Added guidance on safety, feasibility, quotas, lifecycle behavior, observability, trade-offs, testing, and graduation criteria.
  * Updated feature-gate milestones and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->








