### PR TITLE
docs: reorganize community tabs into Join Us and User Showcase

### DIFF
--- a/site/content/en/community/_index.md
+++ b/site/content/en/community/_index.md
@@ -7,56 +7,27 @@ menu:
     weight: 30
 ---
 
+<!-- 1. JOIN US & COMMUNITY OVERVIEW -->
+<div class="text-center mb-5">
+  <h2 class="fw-bold text-primary mb-2">Join the Kueue Community</h2>
+  <p class="lead text-muted mx-auto" style="max-width: 750px;">
+    Kueue is a Kubernetes SIG Apps subproject developed by the community. We welcome users, contributors, and maintainers of all skill levels!
+  </p>
+</div>
 
-<!-- 1. CORE PILLARS (compelling content at first glance) -->
-<div class="row g-3 mb-5">
-  
-  <!-- Adopters Card -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
-        <div class="text-info mb-2">
-          <i class="fas fa-users fa-lg"></i>
-        </div>
-        <h5 class="fw-bold text-primary mb-2">Adopters Showcase</h5>
-        <p class="text-muted small mb-3 flex-grow-1">
-          Explore the list of organizations running Kueue in production for large-scale AI/ML and batch workloads.
-        </p>
-        <a href="adopters/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
-          View Adopters ➔
-        </a>
-      </div>
-    </div>
-  </div>
-
-  <!-- Talks Card -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
-        <div class="text-info mb-2">
-          <i class="fas fa-video fa-lg"></i>
-        </div>
-        <h5 class="fw-bold text-primary mb-2">Talks & Case Studies</h5>
-        <p class="text-muted small mb-3 flex-grow-1">
-          Watch KubeCon talks, keynotes, and technical demos, and read curated engineering case studies from Kueue adopters.
-        </p>
-        <a href="talks_and_presentations/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
-          Watch & Read ➔
-        </a>
-      </div>
-    </div>
-  </div>
+<!-- 2. COMMUNITY CHANNELS & CONTRIBUTOR ZONE -->
+<div class="row g-4 mb-5">
 
   <!-- Contribute Card -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
         <div class="text-info mb-2">
-          <i class="fas fa-tools fa-lg"></i>
+          <i class="fas fa-tools fa-2x"></i>
         </div>
-        <h5 class="fw-bold text-primary mb-2">Contributor Zone</h5>
+        <h4 class="fw-bold text-primary mb-2">Contributor Zone</h4>
         <p class="text-muted small mb-3 flex-grow-1">
-          Ready to help shape the future of batch scheduling? Read our guide on how to set up your dev environment and submit your first PR.
+          Ready to help shape the future of batch scheduling? Read our guide on how to set up your dev environment, run tests, and submit your first PR.
         </p>
         <a href="contribution_guidelines/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
           How to Contribute ➔
@@ -65,28 +36,30 @@ menu:
     </div>
   </div>
 
-</div>
-
-<!-- 2. AUTOMATED MEDIUM FEED -->
-<div class="mb-5 border-top pt-4">
-  <div class="text-center mb-3">
-    <h4 class="fw-bold text-primary mb-1">Latest from Medium</h4>
-    <p class="text-muted small">Deep-dives, tutorials, and community articles.</p>
+  <!-- Community Syncs & Discussion -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-users fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">Working Group Batch</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          Kueue is built under WG Batch. Participate in our bi-weekly community meetings, present ideas, or bring your questions to open discussion.
+        </p>
+        <a href="https://github.com/kubernetes/community/tree/master/wg-batch" target="_blank" rel="noopener" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          WG Batch Details ➔
+        </a>
+      </div>
+    </div>
   </div>
-  
-  {{< medium-feed >}}
-  
-  <p class="text-end small mt-3 mb-0">
-    <a href="https://medium.com/tag/kueue" target="_blank" rel="noopener" class="text-info text-decoration-none fw-semibold">
-      View all Kueue articles on Medium <i class="fas fa-external-link-alt ms-1 small"></i>
-    </a>
-  </p>
+
 </div>
 
-<!-- 3. COMPACT CONNECT FOOTER -->
+<!-- 3. CONNECT FOOTER -->
 <div class="border-top pt-4">
   <div class="text-center mb-4">
-    <h4 class="fw-bold text-primary mb-1">Connect with the Community</h4>
+    <h4 class="fw-bold text-primary mb-1">Connect with Us</h4>
     <p class="text-muted small">Get help, join discussions, and stay updated.</p>
   </div>
   

--- a/site/content/en/community/_index.md
+++ b/site/content/en/community/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Kueue Community"
-linkTitle: "Community"
+title: "Join Us"
+linkTitle: "Join Us"
 weight: 30
 menu:
   main:

--- a/site/content/en/community/showcase/_index.md
+++ b/site/content/en/community/showcase/_index.md
@@ -26,7 +26,7 @@ menu:
         </div>
         <h4 class="fw-bold text-primary mb-2">Adopters Directory</h4>
         <p class="text-muted small mb-3 flex-grow-1">
-          Explore companies and institutions officially adopting Kueue to manage multi-tenant Kubernetes batch clusters.
+          Explore the list of organizations running Kueue in production for large-scale AI/ML and batch workloads.
         </p>
         <a href="../adopters/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
           View Official Adopters ➔
@@ -42,7 +42,7 @@ menu:
         <div class="text-info mb-2">
           <i class="fas fa-file-alt fa-2x"></i>
         </div>
-        <h4 class="fw-bold text-primary mb-2">Case Studies & Keynotes</h4>
+        <h4 class="fw-bold text-primary mb-2">Case Studies & Talks</h4>
         <p class="text-muted small mb-3 flex-grow-1">
           Watch KubeCon presentations, technical demos, and engineering blogs highlighting real-world Kueue deployment stories.
         </p>

--- a/site/content/en/community/showcase/_index.md
+++ b/site/content/en/community/showcase/_index.md
@@ -1,0 +1,71 @@
+---
+title: "User Showcase"
+linkTitle: "User Showcase"
+weight: 31
+menu:
+  main:
+    weight: 31
+---
+
+<!-- USER SHOWCASE HEADER -->
+<div class="text-center mb-5">
+  <h2 class="fw-bold text-primary mb-2">User Showcase & Case Studies</h2>
+  <p class="lead text-muted mx-auto" style="max-width: 750px;">
+    Discover how leading organizations run Kueue in production for large-scale AI/ML, batch processing, and high-performance workloads.
+  </p>
+</div>
+
+<!-- 1. SHOWCASE PILLARS -->
+<div class="row g-4 mb-5">
+  <!-- Official Adopters -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-building fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">Adopters Directory</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          Explore companies and institutions officially adopting Kueue to manage multi-tenant Kubernetes batch clusters.
+        </p>
+        <a href="../adopters/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          View Official Adopters ➔
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Talks & Case Studies -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-file-alt fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">Case Studies & Keynotes</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          Watch KubeCon presentations, technical demos, and engineering blogs highlighting real-world Kueue deployment stories.
+        </p>
+        <a href="../talks_and_presentations/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          Explore Presentations & Articles ➔
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 2. AUTOMATED MEDIUM & BLOG FEED -->
+<div class="mb-5 border-top pt-4">
+  <div class="text-center mb-3">
+    <h4 class="fw-bold text-primary mb-1">Latest Engineering Case Studies & Blogs</h4>
+    <p class="text-muted small">Blog posts, deep-dives, and technical tutorials from Kueue adopters.</p>
+  </div>
+  
+  {{< medium-feed >}}
+  
+  <p class="text-end small mt-3 mb-0">
+    <a href="https://medium.com/tag/kueue" target="_blank" rel="noopener" class="text-info text-decoration-none fw-semibold">
+      View all Kueue case studies on Medium <i class="fas fa-external-link-alt ms-1 small"></i>
+    </a>
+  </p>
+</div>

--- a/site/content/zh-CN/community/_index.md
+++ b/site/content/zh-CN/community/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Kueue 社区"
-linkTitle: "社区"
+title: "加入我们"
+linkTitle: "加入我们"
 weight: 30
 menu:
   main:

--- a/site/content/zh-CN/community/_index.md
+++ b/site/content/zh-CN/community/_index.md
@@ -7,56 +7,27 @@ menu:
     weight: 30
 ---
 
+<!-- 1. 加入我们与社区概述 -->
+<div class="text-center mb-5">
+  <h2 class="fw-bold text-primary mb-2">加入 Kueue 社区</h2>
+  <p class="lead text-muted mx-auto" style="max-width: 750px;">
+    Kueue 是由社区共同开发的 Kubernetes SIG Apps 子项目。我们欢迎各种技能水平的用户、贡献者和维护者加入！
+  </p>
+</div>
 
-<!-- 1. 核心支柱卡片 (三栏布局) -->
-<div class="row g-3 mb-5">
-  
-  <!-- 采用者展示卡片 -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
-        <div class="text-info mb-2">
-          <i class="fas fa-users fa-lg"></i>
-        </div>
-        <h5 class="fw-bold text-primary mb-2">采用者展示</h5>
-        <p class="text-muted small mb-3 flex-grow-1">
-          探索在生产运行环境中部署 Kueue 以管理大规模 AI/ML 和批处理工作负载的组织列表。
-        </p>
-        <a href="adopters/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
-          查看采用者 ➔
-        </a>
-      </div>
-    </div>
-  </div>
-
-  <!-- 演讲与案例卡片 -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
-        <div class="text-info mb-2">
-          <i class="fas fa-video fa-lg"></i>
-        </div>
-        <h5 class="fw-bold text-primary mb-2">演讲与案例研究</h5>
-        <p class="text-muted small mb-3 flex-grow-1">
-          观看 KubeCon 演讲、主题演讲和技术演示，并阅读 Kueue 采用者精心撰写的工程案例研究。
-        </p>
-        <a href="talks_and_presentations/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
-          观看与阅读 ➔
-        </a>
-      </div>
-    </div>
-  </div>
+<!-- 2. 社区频道与贡献者专区 -->
+<div class="row g-4 mb-5">
 
   <!-- 贡献者专区卡片 -->
-  <div class="col-md-4">
-    <div class="card h-100 feature-card bg-light border-0 rounded-3">
-      <div class="card-body p-3 d-flex flex-column">
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
         <div class="text-info mb-2">
-          <i class="fas fa-tools fa-lg"></i>
+          <i class="fas fa-tools fa-2x"></i>
         </div>
-        <h5 class="fw-bold text-primary mb-2">贡献者专区</h5>
+        <h4 class="fw-bold text-primary mb-2">贡献者专区</h4>
         <p class="text-muted small mb-3 flex-grow-1">
-          准备好帮助塑造批处理调度的未来了吗？阅读我们的指南，了解如何设置开发环境并提交您的第一个 PR。
+          准备好帮助塑造批处理调度的未来了吗？阅读我们的指南，了解如何设置开发环境、运行测试并提交您的第一个 PR。
         </p>
         <a href="contribution_guidelines/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
           如何参与贡献 ➔
@@ -65,22 +36,24 @@ menu:
     </div>
   </div>
 
-</div>
-
-<!-- 2. 自动集成的 MEDIUM 博客动态 -->
-<div class="mb-5 border-top pt-4">
-  <div class="text-center mb-3">
-    <h4 class="fw-bold text-primary mb-1">Medium 最新动态</h4>
-    <p class="text-muted small">深度剖析、教程和社区文章。</p>
+  <!-- 社区例会与讨论 -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-users fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">批处理工作组 (WG Batch)</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          Kueue 是在 WG Batch 下构建的。欢迎参加我们的双周社区例会，提出创意或参与公开讨论。
+        </p>
+        <a href="https://github.com/kubernetes/community/tree/master/wg-batch" target="_blank" rel="noopener" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          了解 WG Batch 详情 ➔
+        </a>
+      </div>
+    </div>
   </div>
-  
-  {{< medium-feed >}}
-  
-  <p class="text-end small mt-3 mb-0">
-    <a href="https://medium.com/tag/kueue" target="_blank" rel="noopener" class="text-info text-decoration-none fw-semibold">
-      在 Medium 上查看所有 Kueue 文章 <i class="fas fa-external-link-alt ms-1 small"></i>
-    </a>
-  </p>
+
 </div>
 
 <!-- 3. 社区联系页脚 -->

--- a/site/content/zh-CN/community/showcase/_index.md
+++ b/site/content/zh-CN/community/showcase/_index.md
@@ -1,0 +1,71 @@
+---
+title: "用户展示"
+linkTitle: "用户展示"
+weight: 31
+menu:
+  main:
+    weight: 31
+---
+
+<!-- USER SHOWCASE HEADER -->
+<div class="text-center mb-5">
+  <h2 class="fw-bold text-primary mb-2">用户展示与案例研究</h2>
+  <p class="lead text-muted mx-auto" style="max-width: 750px;">
+    探索各大组织如何在生产环境中运行 Kueue，以管理大规模 AI/ML、批处理和高性能工作负载。
+  </p>
+</div>
+
+<!-- 1. SHOWCASE PILLARS -->
+<div class="row g-4 mb-5">
+  <!-- Official Adopters -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-building fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">采用者目录</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          探索正式采用 Kueue 管理多租户 Kubernetes 批处理集群的公司和机构。
+        </p>
+        <a href="../adopters/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          查看官方采用者 ➔
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <!-- Talks & Case Studies -->
+  <div class="col-md-6">
+    <div class="card h-100 feature-card bg-light border-0 rounded-3 p-3">
+      <div class="card-body d-flex flex-column">
+        <div class="text-info mb-2">
+          <i class="fas fa-file-alt fa-2x"></i>
+        </div>
+        <h4 class="fw-bold text-primary mb-2">案例研究与主题演讲</h4>
+        <p class="text-muted small mb-3 flex-grow-1">
+          观看 KubeCon 演示、技术演示和工程博客，突出实际的 Kueue 部署故事。
+        </p>
+        <a href="../talks_and_presentations/" class="btn btn-sm btn-outline-info mt-auto align-self-start fw-semibold">
+          探索演讲与文章 ➔
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 2. AUTOMATED MEDIUM & BLOG FEED -->
+<div class="mb-5 border-top pt-4">
+  <div class="text-center mb-3">
+    <h4 class="fw-bold text-primary mb-1">最新工程案例研究与博客</h4>
+    <p class="text-muted small">来自 Kueue 采用者的博客文章、深度剖析和技术教程。</p>
+  </div>
+  
+  {{< medium-feed >}}
+  
+  <p class="text-end small mt-3 mb-0">
+    <a href="https://medium.com/tag/kueue" target="_blank" rel="noopener" class="text-info text-decoration-none fw-semibold">
+      在 Medium 上查看所有案例研究 <i class="fas fa-external-link-alt ms-1 small"></i>
+    </a>
+  </p>
+</div>


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**
This PR reorganizes the single Community documentation tab into two top-level navbar tabs:
1. **Join Us** (`weight: 30`): Focuses on connecting with the community (Slack, mailing list, community syncs) and the contributor zone.
2. **User Showcase** (`weight: 31`): Features official adopters directory, talks, case studies, and engineering blog posts.

Includes both English (`content/en/`) and Chinese (`content/zh-CN/`) site translations.

Fixes #13365

**Which issue(s) this PR fixes**:
Fixes #13365

**Special notes for your reviewer**:
None.

**Does this PR introduce a user-facing change?**
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a community showcase landing page with a two-column directory of adopters and case studies, plus a “latest engineering” feed and external Medium link.
  * Added updated community entry pages to encourage joining via “Contributor Zone” and “Working Group Batch” cards, including Chinese versions.

* **Documentation**
  * Updated community navigation/section labels from “Kueue Community/Community” to “Join Us” in English and Chinese.
  * Refreshed community landing page content to match the new “Join the Kueue Community” overview and card layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->