### PR TITLE
RayJob & RayCluster: remove the write-only raycluster-podset-replica-sizes annotation

### DIFF
--- a/internal/mocks/controller/jobframework/interface.go
+++ b/internal/mocks/controller/jobframework/interface.go
@@ -384,18 +384,18 @@ func (m *MockJobWithCustomAnnotations) EXPECT() *MockJobWithCustomAnnotationsMoc
 }
 
 // GetCustomAnnotations mocks base method.
-func (m *MockJobWithCustomAnnotations) GetCustomAnnotations(ctx context.Context, c client.Client, podSets []v1beta2.PodSet) (map[string]string, error) {
+func (m *MockJobWithCustomAnnotations) GetCustomAnnotations(ctx context.Context, c client.Client) (map[string]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCustomAnnotations", ctx, c, podSets)
+	ret := m.ctrl.Call(m, "GetCustomAnnotations", ctx, c)
 	ret0, _ := ret[0].(map[string]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCustomAnnotations indicates an expected call of GetCustomAnnotations.
-func (mr *MockJobWithCustomAnnotationsMockRecorder) GetCustomAnnotations(ctx, c, podSets any) *gomock.Call {
+func (mr *MockJobWithCustomAnnotationsMockRecorder) GetCustomAnnotations(ctx, c any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomAnnotations", reflect.TypeOf((*MockJobWithCustomAnnotations)(nil).GetCustomAnnotations), ctx, c, podSets)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomAnnotations", reflect.TypeOf((*MockJobWithCustomAnnotations)(nil).GetCustomAnnotations), ctx, c)
 }
 
 // MockMultiKueueAdapter is a mock of MultiKueueAdapter interface.

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -197,14 +197,14 @@ type JobWithManagedBy interface {
 // by generic jobs when custom annotations need to be updated in the API server
 // after changes occur.
 //
-// For example, RayJob may have the "kueue.x-k8s.io/podset-replica-sizes"
-// annotation, which reflects the current replica sizes of the underlying
-// RayCluster. The job reconciler calls GetCustomAnnotations to update
-// such annotations in the API server.
+// For example, RayJob may have the "kueue.x-k8s.io/raycluster-generation"
+// annotation, which reflects the generation of the underlying RayCluster.
+// The job reconciler calls GetCustomAnnotations to update such annotations
+// in the API server.
 type JobWithCustomAnnotations interface {
 	// GetCustomAnnotations returns additional annotations
 	// that should be added to the job.
-	GetCustomAnnotations(ctx context.Context, c client.Client, podSets []kueue.PodSet) (map[string]string, error)
+	GetCustomAnnotations(ctx context.Context, c client.Client) (map[string]string, error)
 }
 
 // ElasticWorkloadNameProvider is an optional interface that provides additional

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -965,7 +965,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		}
 
 		if jobWithCustomAnnotations, ok := job.(JobWithCustomAnnotations); ok {
-			customAnnotations, err := jobWithCustomAnnotations.GetCustomAnnotations(ctx, r.client, podSets)
+			customAnnotations, err := jobWithCustomAnnotations.GetCustomAnnotations(ctx, r.client)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get custom annotations based on pod sets from job %s: %w", job.Object().GetName(), err)
 			}

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -18,7 +18,6 @@ package raycluster
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -46,11 +45,6 @@ import (
 )
 
 const (
-	// RayClusterPodsetReplicaSizesAnnotation is set on the job when autoscaling causes
-	// PodSet replica sizes to differ from the original spec. The value is a JSON
-	// array compatible with []kueue.PodSet, containing only the changed PodSets.
-	// This annotation is alpha-level enabled by the ElasticJobsViaWorkloadSlices.
-	RayClusterPodsetReplicaSizesAnnotation = "kueue.x-k8s.io/raycluster-podset-replica-sizes"
 	// RayClusterGenerationAnnotation is set on the job when autoscaling causes
 	// PodSet replica sizes to differ from the original spec. The value is the generation of
 	// the RayCluster.
@@ -400,33 +394,7 @@ func ComparePodSetCounts(podSets []kueue.PodSet, referenceCounts map[kueue.PodSe
 	return false
 }
 
-// ParsePodSetReplicaSizes parses the PodsetReplicaSizesAnnotation value into a map.
-// Returns an empty map if the annotation is absent or empty.
-func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32, error) {
-	counts := make(map[kueue.PodSetReference]int32)
-	if annotation == "" {
-		return counts, nil
-	}
-	var podSets []jobframework.PodSetReplicaSize
-	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
-	}
-	for _, ps := range podSets {
-		counts[ps.Name] = ps.Count
-	}
-	return counts, nil
-}
-
-// SerializePodSetCounts converts PodSets into a JSON byte slice of podSetReplicaSize entries.
-func SerializePodSetCounts(podSets []kueue.PodSet) ([]byte, error) {
-	sizes := make([]jobframework.PodSetReplicaSize, len(podSets))
-	for i, ps := range podSets {
-		sizes[i] = jobframework.PodSetReplicaSize{Name: ps.Name, Count: ps.Count}
-	}
-	return json.Marshal(sizes)
-}
-
-func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client.Client, jobObject client.Object, podSets []kueue.PodSet, rayClusterName string) (map[string]string, error) {
+func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client.Client, jobObject client.Object, rayClusterName string) (map[string]string, error) {
 	if workloadslicing.Enabled(jobObject) {
 		log := ctrl.LoggerFrom(ctx)
 
@@ -452,17 +420,9 @@ func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client
 			}
 		}
 
-		podSetsJSON, err := SerializePodSetCounts(podSets)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal updated podsets: %w", err)
-		}
-		annotations := map[string]string{
-			RayClusterPodsetReplicaSizesAnnotation: string(podSetsJSON),
-		}
 		if includeRayClusterGeneration {
-			annotations[RayClusterGenerationAnnotation] = rayClusterGeneration
+			return map[string]string{RayClusterGenerationAnnotation: rayClusterGeneration}, nil
 		}
-		return annotations, nil
 	}
 	return nil, nil
 }

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -18,6 +18,7 @@ package raycluster
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strconv"
@@ -45,6 +46,11 @@ import (
 )
 
 const (
+	// RayClusterPodsetReplicaSizesAnnotation is set on the job when autoscaling causes
+	// PodSet replica sizes to differ from the original spec. The value is a JSON
+	// array compatible with []kueue.PodSet, containing only the changed PodSets.
+	// This annotation is alpha-level enabled by the ElasticJobsViaWorkloadSlices.
+	RayClusterPodsetReplicaSizesAnnotation = "kueue.x-k8s.io/raycluster-podset-replica-sizes"
 	// RayClusterGenerationAnnotation is set on the job when autoscaling causes
 	// PodSet replica sizes to differ from the original spec. The value is the generation of
 	// the RayCluster.
@@ -370,6 +376,23 @@ func BuildPodSetAnnotationsPathByNameMap(rayClusterSpec *rayv1.RayClusterSpec, h
 		podSetAnnotationsPathByName[kueue.NewPodSetReference(wgs.GroupName)] = workerGroupSpecsPath.Index(i).Child("template", "metadata", "annotations")
 	}
 	return podSetAnnotationsPathByName
+}
+
+// ParsePodSetReplicaSizes parses the PodsetReplicaSizesAnnotation value into a map.
+// Returns an empty map if the annotation is absent or empty.
+func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32, error) {
+	counts := make(map[kueue.PodSetReference]int32)
+	if annotation == "" {
+		return counts, nil
+	}
+	var podSets []jobframework.PodSetReplicaSize
+	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
+	}
+	for _, ps := range podSets {
+		counts[ps.Name] = ps.Count
+	}
+	return counts, nil
 }
 
 func GetWorkloadNameExtraPart(objectMeta metav1.Object) string {

--- a/pkg/controller/jobs/raycluster/common.go
+++ b/pkg/controller/jobs/raycluster/common.go
@@ -378,23 +378,6 @@ func BuildPodSetAnnotationsPathByNameMap(rayClusterSpec *rayv1.RayClusterSpec, h
 	return podSetAnnotationsPathByName
 }
 
-// ParsePodSetReplicaSizes parses the PodsetReplicaSizesAnnotation value into a map.
-// Returns an empty map if the annotation is absent or empty.
-func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32, error) {
-	counts := make(map[kueue.PodSetReference]int32)
-	if annotation == "" {
-		return counts, nil
-	}
-	var podSets []jobframework.PodSetReplicaSize
-	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
-	}
-	for _, ps := range podSets {
-		counts[ps.Name] = ps.Count
-	}
-	return counts, nil
-}
-
 func GetWorkloadNameExtraPart(objectMeta metav1.Object) string {
 	extra := strconv.FormatInt(objectMeta.GetGeneration(), 10)
 	rayClusterGeneration := objectMeta.GetAnnotations()[RayClusterGenerationAnnotation]
@@ -415,6 +398,23 @@ func ComparePodSetCounts(podSets []kueue.PodSet, referenceCounts map[kueue.PodSe
 		}
 	}
 	return false
+}
+
+// ParsePodSetReplicaSizes parses the PodsetReplicaSizesAnnotation value into a map.
+// Returns an empty map if the annotation is absent or empty.
+func ParsePodSetReplicaSizes(annotation string) (map[kueue.PodSetReference]int32, error) {
+	counts := make(map[kueue.PodSetReference]int32)
+	if annotation == "" {
+		return counts, nil
+	}
+	var podSets []jobframework.PodSetReplicaSize
+	if err := json.Unmarshal([]byte(annotation), &podSets); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %s annotation: %w", RayClusterPodsetReplicaSizesAnnotation, err)
+	}
+	for _, ps := range podSets {
+		counts[ps.Name] = ps.Count
+	}
+	return counts, nil
 }
 
 func GetWorkloadslicingRayClusterCustomAnnotations(ctx context.Context, c client.Client, jobObject client.Object, rayClusterName string) (map[string]string, error) {

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1240,87 +1240,6 @@ func TestComparePodSetCounts(t *testing.T) {
 	}
 }
 
-func TestParsePodSetReplicaSizes(t *testing.T) {
-	testCases := map[string]struct {
-		annotation string
-		wantCounts map[kueue.PodSetReference]int32
-		wantErr    bool
-	}{
-		"empty annotation": {
-			annotation: "",
-			wantCounts: map[kueue.PodSetReference]int32{},
-		},
-		"valid annotation": {
-			annotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
-			wantCounts: map[kueue.PodSetReference]int32{
-				"head":   1,
-				"worker": 3,
-			},
-		},
-		"single podset": {
-			annotation: `[{"name":"head","count":1}]`,
-			wantCounts: map[kueue.PodSetReference]int32{
-				"head": 1,
-			},
-		},
-		"invalid json": {
-			annotation: `invalid`,
-			wantErr:    true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got, err := ParsePodSetReplicaSizes(tc.annotation)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
-			}
-			if !tc.wantErr {
-				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
-					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
-				}
-			}
-		})
-	}
-}
-
-func TestSerializePodSetCounts(t *testing.T) {
-	testCases := map[string]struct {
-		podSets  []kueue.PodSet
-		wantJSON string
-	}{
-		"single podset": {
-			podSets: []kueue.PodSet{
-				{Name: "head", Count: 1},
-			},
-			wantJSON: `[{"name":"head","count":1}]`,
-		},
-		"multiple podsets": {
-			podSets: []kueue.PodSet{
-				{Name: "head", Count: 1},
-				{Name: "worker", Count: 5},
-			},
-			wantJSON: `[{"name":"head","count":1},{"name":"worker","count":5}]`,
-		},
-		"empty podsets": {
-			podSets:  []kueue.PodSet{},
-			wantJSON: `[]`,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got, err := SerializePodSetCounts(tc.podSets)
-			if err != nil {
-				t.Fatalf("SerializePodSetCounts() unexpected error: %v", err)
-			}
-			if string(got) != tc.wantJSON {
-				t.Errorf("SerializePodSetCounts() = %s, want %s", string(got), tc.wantJSON)
-			}
-		})
-	}
-}
-
 func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 	testCases := map[string]struct {
 		annotations      map[string]string
@@ -1354,8 +1273,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			registerRayType:  true,
 			createRayCluster: true,
 			wantAnnotation: map[string]string{
-				RayClusterGenerationAnnotation:         "0",
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+				RayClusterGenerationAnnotation: "0",
 			},
 		},
 		"standalone raycluster does not track its own generation": {
@@ -1370,14 +1288,11 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			registerRayType:  true,
 			createRayCluster: true,
 			standalone:       true,
-			wantAnnotation: map[string]string{
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
-			},
+			wantAnnotation:   nil,
 		},
 		"returns annotations even when counts match existing annotation": {
 			annotations: map[string]string{
-				workloadslicing.EnabledAnnotationKey:   workloadslicing.EnabledAnnotationValue,
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+				workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
 			},
 			podSets: []kueue.PodSet{
 				{Name: "head", Count: 1},
@@ -1387,14 +1302,12 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			registerRayType:  true,
 			createRayCluster: true,
 			wantAnnotation: map[string]string{
-				RayClusterGenerationAnnotation:         "0",
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+				RayClusterGenerationAnnotation: "0",
 			},
 		},
 		"updated when counts differ": {
 			annotations: map[string]string{
-				workloadslicing.EnabledAnnotationKey:   workloadslicing.EnabledAnnotationValue,
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+				workloadslicing.EnabledAnnotationKey: workloadslicing.EnabledAnnotationValue,
 			},
 			podSets: []kueue.PodSet{
 				{Name: "head", Count: 1},
@@ -1404,8 +1317,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			registerRayType:  true,
 			createRayCluster: true,
 			wantAnnotation: map[string]string{
-				RayClusterGenerationAnnotation:         "0",
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":5}]`,
+				RayClusterGenerationAnnotation: "0",
 			},
 		},
 		"raycluster not found returns annotations with empty generation": {
@@ -1419,8 +1331,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			rayClusterName:  "nonexistent-raycluster",
 			registerRayType: true,
 			wantAnnotation: map[string]string{
-				RayClusterGenerationAnnotation:         "",
-				RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+				RayClusterGenerationAnnotation: "",
 			},
 		},
 		"other get error returns error": {
@@ -1470,7 +1381,7 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 				jobObject = &corev1.ConfigMap{ObjectMeta: *obj}
 			}
 
-			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.podSets, tc.rayClusterName)
+			got, err := GetWorkloadslicingRayClusterCustomAnnotations(t.Context(), c, jobObject, tc.rayClusterName)
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("GetWorkloadslicingCustomAnnotations() expected error but got nil")

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1397,3 +1397,47 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePodSetReplicaSizes(t *testing.T) {
+	testCases := map[string]struct {
+		annotation string
+		wantCounts map[kueue.PodSetReference]int32
+		wantErr    bool
+	}{
+		"empty annotation": {
+			annotation: "",
+			wantCounts: map[kueue.PodSetReference]int32{},
+		},
+		"valid annotation": {
+			annotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+			wantCounts: map[kueue.PodSetReference]int32{
+				"head":   1,
+				"worker": 3,
+			},
+		},
+		"single podset": {
+			annotation: `[{"name":"head","count":1}]`,
+			wantCounts: map[kueue.PodSetReference]int32{
+				"head": 1,
+			},
+		},
+		"invalid json": {
+			annotation: `invalid`,
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParsePodSetReplicaSizes(tc.annotation)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr {
+				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
+					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -1240,6 +1240,50 @@ func TestComparePodSetCounts(t *testing.T) {
 	}
 }
 
+func TestParsePodSetReplicaSizes(t *testing.T) {
+	testCases := map[string]struct {
+		annotation string
+		wantCounts map[kueue.PodSetReference]int32
+		wantErr    bool
+	}{
+		"empty annotation": {
+			annotation: "",
+			wantCounts: map[kueue.PodSetReference]int32{},
+		},
+		"valid annotation": {
+			annotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
+			wantCounts: map[kueue.PodSetReference]int32{
+				"head":   1,
+				"worker": 3,
+			},
+		},
+		"single podset": {
+			annotation: `[{"name":"head","count":1}]`,
+			wantCounts: map[kueue.PodSetReference]int32{
+				"head": 1,
+			},
+		},
+		"invalid json": {
+			annotation: `invalid`,
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := ParsePodSetReplicaSizes(tc.annotation)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr {
+				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
+					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 	testCases := map[string]struct {
 		annotations      map[string]string
@@ -1393,50 +1437,6 @@ func TestGetWorkloadslicingCustomAnnotations(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.wantAnnotation, got); diff != "" {
 				t.Errorf("GetWorkloadslicingCustomAnnotations() mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestParsePodSetReplicaSizes(t *testing.T) {
-	testCases := map[string]struct {
-		annotation string
-		wantCounts map[kueue.PodSetReference]int32
-		wantErr    bool
-	}{
-		"empty annotation": {
-			annotation: "",
-			wantCounts: map[kueue.PodSetReference]int32{},
-		},
-		"valid annotation": {
-			annotation: `[{"name":"head","count":1},{"name":"worker","count":3}]`,
-			wantCounts: map[kueue.PodSetReference]int32{
-				"head":   1,
-				"worker": 3,
-			},
-		},
-		"single podset": {
-			annotation: `[{"name":"head","count":1}]`,
-			wantCounts: map[kueue.PodSetReference]int32{
-				"head": 1,
-			},
-		},
-		"invalid json": {
-			annotation: `invalid`,
-			wantErr:    true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			got, err := ParsePodSetReplicaSizes(tc.annotation)
-			if (err != nil) != tc.wantErr {
-				t.Fatalf("ParsePodSetReplicaSizes() error = %v, wantErr %v", err, tc.wantErr)
-			}
-			if !tc.wantErr {
-				if diff := cmp.Diff(tc.wantCounts, got); diff != "" {
-					t.Errorf("ParsePodSetReplicaSizes() mismatch (-want +got):\n%s", diff)
-				}
 			}
 		})
 	}

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -227,8 +227,8 @@ func (j *RayJob) PodsReady(ctx context.Context, _ client.Client) bool {
 	return j.Status.RayClusterStatus.State == rayv1.Ready
 }
 
-func (j *RayJob) GetCustomAnnotations(ctx context.Context, c client.Client, podSets []kueue.PodSet) (map[string]string, error) {
-	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), podSets, j.Status.RayClusterName)
+func (j *RayJob) GetCustomAnnotations(ctx context.Context, c client.Client, _ []kueue.PodSet) (map[string]string, error) {
+	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), j.Status.RayClusterName)
 }
 
 func (j *RayJob) GetWorkloadNameExtraPart() string {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -227,7 +227,7 @@ func (j *RayJob) PodsReady(ctx context.Context, _ client.Client) bool {
 	return j.Status.RayClusterStatus.State == rayv1.Ready
 }
 
-func (j *RayJob) GetCustomAnnotations(ctx context.Context, c client.Client, _ []kueue.PodSet) (map[string]string, error) {
+func (j *RayJob) GetCustomAnnotations(ctx context.Context, c client.Client) (map[string]string, error) {
 	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), j.Status.RayClusterName)
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1082,15 +1082,13 @@ func TestGetCustomAnnotations(t *testing.T) {
 				WithWorkerGroups(workerGroup("group1", 5)).
 				Obj(),
 			wantCustomAnnotation: map[string]string{
-				raycluster.RayClusterGenerationAnnotation:         "0",
-				raycluster.RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"group1","count":5}]`,
+				raycluster.RayClusterGenerationAnnotation: "0",
 			},
 			wantGroupCount: 5,
 		},
 		"skip patch when annotation already matches": {
 			rayJob: testingrayutil.MakeJob("rayjob", "ns").
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-				Annotation(raycluster.RayClusterPodsetReplicaSizesAnnotation, `[{"name":"head","count":1},{"name":"group1","count":5}]`).
 				WithHeadGroupSpec(headSpec).
 				WithWorkerGroups(workerGroup("group1", 1)).
 				WithEnableAutoscaling(new(true)).
@@ -1099,15 +1097,13 @@ func TestGetCustomAnnotations(t *testing.T) {
 				WithWorkerGroups(workerGroup("group1", 5)).
 				Obj(),
 			wantCustomAnnotation: map[string]string{
-				raycluster.RayClusterGenerationAnnotation:         "0",
-				raycluster.RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"group1","count":5}]`,
+				raycluster.RayClusterGenerationAnnotation: "0",
 			},
 			wantGroupCount: 5,
 		},
 		"annotation updated after scale-down": {
 			rayJob: testingrayutil.MakeJob("rayjob", "ns").
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-				Annotation(raycluster.RayClusterPodsetReplicaSizesAnnotation, `[{"name":"head","count":1},{"name":"group1","count":6}]`).
 				WithHeadGroupSpec(headSpec).
 				WithWorkerGroups(workerGroup("group1", 4)).
 				WithEnableAutoscaling(new(true)).
@@ -1116,15 +1112,13 @@ func TestGetCustomAnnotations(t *testing.T) {
 				WithWorkerGroups(workerGroup("group1", 4)).
 				Obj(),
 			wantCustomAnnotation: map[string]string{
-				raycluster.RayClusterGenerationAnnotation:         "0",
-				raycluster.RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"group1","count":4}]`,
+				raycluster.RayClusterGenerationAnnotation: "0",
 			},
 			wantGroupCount: 4,
 		},
 		"annotation updated when podset count differs from annotation length": {
 			rayJob: testingrayutil.MakeJob("rayjob", "ns").
 				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-				Annotation(raycluster.RayClusterPodsetReplicaSizesAnnotation, `[{"name":"group1","count":5}]`).
 				WithHeadGroupSpec(headSpec).
 				WithWorkerGroups(workerGroup("group1", 1)).
 				WithEnableAutoscaling(new(true)).
@@ -1133,8 +1127,7 @@ func TestGetCustomAnnotations(t *testing.T) {
 				WithWorkerGroups(workerGroup("group1", 5)).
 				Obj(),
 			wantCustomAnnotation: map[string]string{
-				raycluster.RayClusterGenerationAnnotation:         "0",
-				raycluster.RayClusterPodsetReplicaSizesAnnotation: `[{"name":"head","count":1},{"name":"group1","count":5}]`,
+				raycluster.RayClusterGenerationAnnotation: "0",
 			},
 			wantGroupCount: 5,
 		},

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1160,7 +1160,7 @@ func TestGetCustomAnnotations(t *testing.T) {
 			}
 
 			// Verify GetCustomAnnotations returns the expected annotations
-			gotAnnotations, err := job.GetCustomAnnotations(ctx, fakeClient, podSets)
+			gotAnnotations, err := job.GetCustomAnnotations(ctx, fakeClient)
 			if err != nil {
 				t.Fatalf("unexpected error from GetCustomAnnotations: %v", err)
 			}

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -231,8 +231,8 @@ func (j *RayService) PodsReady(ctx context.Context, _ client.Client) bool {
 	return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayServiceReady))
 }
 
-func (j *RayService) GetCustomAnnotations(ctx context.Context, c client.Client, podSets []kueue.PodSet) (map[string]string, error) {
-	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), podSets, j.Status.ActiveServiceStatus.RayClusterName)
+func (j *RayService) GetCustomAnnotations(ctx context.Context, c client.Client, _ []kueue.PodSet) (map[string]string, error) {
+	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), j.Status.ActiveServiceStatus.RayClusterName)
 }
 
 func (j *RayService) GetWorkloadNameExtraPart() string {

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -231,7 +231,7 @@ func (j *RayService) PodsReady(ctx context.Context, _ client.Client) bool {
 	return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayServiceReady))
 }
 
-func (j *RayService) GetCustomAnnotations(ctx context.Context, c client.Client, _ []kueue.PodSet) (map[string]string, error) {
+func (j *RayService) GetCustomAnnotations(ctx context.Context, c client.Client) (map[string]string, error) {
 	return raycluster.GetWorkloadslicingRayClusterCustomAnnotations(ctx, c, j.Object(), j.Status.ActiveServiceStatus.RayClusterName)
 }
 

--- a/test/e2e/singlecluster/extended/kuberay_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_test.go
@@ -18,7 +18,6 @@ package extended
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -52,24 +51,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/util"
 )
-
-// parsePodSetReplicaCount parses the PodsetReplicaSizesAnnotation JSON and
-// returns the count for the given group name.
-func parsePodSetReplicaCount(annotationValue, groupName string) (int32, error) {
-	var podSets []struct {
-		Name  string `json:"name"`
-		Count int32  `json:"count"`
-	}
-	if err := json.Unmarshal([]byte(annotationValue), &podSets); err != nil {
-		return 0, fmt.Errorf("failed to parse annotation: %w", err)
-	}
-	for _, ps := range podSets {
-		if ps.Name == groupName {
-			return ps.Count, nil
-		}
-	}
-	return 0, fmt.Errorf("group %q not found in annotation", groupName)
-}
 
 // findContainer returns the container with the given name, or nil if absent.
 func findContainer(containers []corev1.Container, name string) *corev1.Container {
@@ -601,19 +582,6 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), "Did not scale up to 5 worker pods")
 		})
 
-		ginkgo.By("Checking podset-replica-sizes annotation is set on the RayJob after second scale-up", func() {
-			createdRayJob := &rayv1.RayJob{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
-				g.Expect(createdRayJob.Annotations).To(gomega.HaveKey(workloadraycluster.RayClusterPodsetReplicaSizesAnnotation),
-					"Expected podset-replica-sizes annotation on RayJob after second scale-up")
-				count, err := parsePodSetReplicaCount(createdRayJob.Annotations[workloadraycluster.RayClusterPodsetReplicaSizesAnnotation], "workers-group-0")
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(count).To(gomega.Equal(int32(5)),
-					"Expected workers-group-0 count = 5 after second scale-up")
-			}, util.LongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("podset-replica-sizes annotation not updated after second scale-up", createdRayJob))
-		})
-
 		ginkgo.By("Waiting for at least 3 total workloads due to multiple scale-ups", func() {
 			// Use >= 3 since multiple scale-up events should create additional workload slices.
 			workloadList := &kueue.WorkloadList{}
@@ -621,19 +589,6 @@ print([ray.get(my_task.remote(i, 1)) for i in range(20)])`,
 				g.Expect(k8sClient.List(ctx, workloadList, client.InNamespace(ns.Name))).To(gomega.Succeed())
 				g.Expect(len(workloadList.Items)).To(gomega.BeNumerically(">=", 3), "Expected at least 3 workloads due to multiple scale-ups")
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsgObjList("Did not observe >=3 workloads from multiple scale-ups", workloadList))
-		})
-
-		ginkgo.By("Checking podset-replica-sizes annotation updated after scaling down", func() {
-			createdRayJob := &rayv1.RayJob{}
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rayJob), createdRayJob)).To(gomega.Succeed())
-				g.Expect(createdRayJob.Annotations).To(gomega.HaveKey(workloadraycluster.RayClusterPodsetReplicaSizesAnnotation),
-					"Expected podset-replica-sizes annotation on RayJob after scaling down")
-				count, err := parsePodSetReplicaCount(createdRayJob.Annotations[workloadraycluster.RayClusterPodsetReplicaSizesAnnotation], "workers-group-0")
-				g.Expect(err).NotTo(gomega.HaveOccurred())
-				g.Expect(count).To(gomega.Equal(int32(1)),
-					"Expected workers-group-0 count = 1 after scaling down")
-			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed(), util.AssertMsg("podset-replica-sizes annotation not updated after scaling down", createdRayJob))
 		})
 
 		ginkgo.By("Waiting for the RayJob to finish", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

Stops writing the internal `kueue.x-k8s.io/raycluster-podset-replica-sizes`
annotation and removes the dead helpers that only fed it.

This annotation was introduced (#9726, #9958) as the scale-detection mechanism for
elastic Ray autoscaling. #9960 ("Generate elastic workload name based on raycluster
generation") superseded it: the elastic workload name is now derived from the separate
`kueue.x-k8s.io/raycluster-generation` annotation via `GetWorkloadNameExtraPart`. After
that change the annotation was left orphaned — it was still written by
`GetWorkloadslicingRayClusterCustomAnnotations`, but **no controller code read it**.

This PR removes:
- the write of the annotation in `GetWorkloadslicingRayClusterCustomAnnotations`,
- the now-dead `SerializePodSetCounts` helper,
- the `podSets` parameter of `GetCustomAnnotations` /
  `GetWorkloadslicingRayClusterCustomAnnotations` that only existed to feed the write, and
- the e2e/unit assertions that solely verified the write.

It intentionally **keeps** the `RayClusterPodsetReplicaSizesAnnotation` constant and the
`ParsePodSetReplicaSizes` parser (with its unit test). The MultiKueue worker-side Ray
autoscaling work (#13435) reuses `ParsePodSetReplicaSizes` to parse the per-worker-group
replica sizes reflected onto the manager cluster, so deleting it here would only force
that PR to re-add it. Keeping it decouples the two PRs — either can merge first.

The functional `raycluster-generation` annotation and its read/write path are unchanged.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

- Scope is a pure removal of a dead write path — no behavioral change, since nothing
  reads the annotation.
- On this branch `ParsePodSetReplicaSizes` has no production caller yet (only its unit
  test exercises it); its production consumer lands in #13435. It is exported and
  test-covered, so it is not flagged as unused.
- One e2e coverage consideration: in the `rayjob-multi-scaleup` test, the deleted
  "annotation updated after scaling down" assertion was the only step that verified the
  cluster idle-scales-down back to 1 worker (it did so indirectly, via the now-removed
  annotation value). Scale-**up** coverage is fully retained through the direct
  worker-pod-count assertions (`HaveLen(5)`) and workload-count checks. I kept this PR to
  a pure removal rather than adding a new direct pod-count scale-down assertion, both to
  avoid scope creep and because idle scale-down timing is racy in e2e (see the existing
  comment near the autoscaler idle scale-down). Happy to add a direct `HaveLen(1)`
  scale-down assertion in a follow-up if you'd prefer to keep that behavioral coverage.

This PR was prepared with the assistance of an AI tool (Claude Code); all changes were
reviewed by the author.

#### Does this PR introduce a user-facing change?

```release-note
RayJob, RayCluster, RayService: Kueue no longer writes the internal, write-only `kueue.x-k8s.io/raycluster-podset-replica-sizes` annotation on Ray workloads. It was superseded by the `kueue.x-k8s.io/raycluster-generation` annotation and was not read by any controller code.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Workload-slicing annotations now include only the RayCluster generation when applicable.
  * Pod-set replica-size annotations are no longer generated or validated.
  * Standalone RayCluster workloads no longer receive custom annotations.
  * RayJob and RayService annotation handling has been simplified.
* **Tests**
  * Updated unit and end-to-end coverage to reflect the revised annotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->