### PR TITLE
Restore TAS usage after ResourceFlavor recreation

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -382,11 +382,11 @@ func (c *clusterQueue) isTASViolated() bool {
 // UpdateWithFlavors updates a ClusterQueue based on the passed ResourceFlavors set.
 // Exported only for testing.
 func (c *clusterQueue) UpdateWithFlavors(log logr.Logger, flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
-	c.updateFlavorMetadata(flavors)
+	c.updateFlavorMetadata(log, flavors)
 	c.updateQueueStatus(log)
 }
 
-func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
+func (c *clusterQueue) updateFlavorMetadata(log logr.Logger, flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
 	oldTASFlavors := c.tasFlavors
 	c.missingFlavors = nil
 	c.tasFlavors = nil
@@ -395,6 +395,13 @@ func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorRefe
 		for _, fName := range rg.Flavors {
 			if flv, exist := flavors[fName]; exist {
 				if flv.Spec.TopologyName != nil {
+					// A TAS flavor which was not tracked before may come with a freshly created,
+					// empty TAS flavor cache (e.g., the ResourceFlavor was deleted and re-created),
+					// so force a resync to account the usage of admitted workloads again.
+					if _, tracked := oldTASFlavors[fName]; !tracked {
+						log.V(3).Info("TAS flavor was not previously tracked, marking TAS cache as not synced", "flavor", fName)
+						c.isTASSynced = false
+					}
 					if c.tasFlavors == nil {
 						c.tasFlavors = make(map[kueue.ResourceFlavorReference]kueue.TopologyReference, 1)
 					}
@@ -403,15 +410,6 @@ func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorRefe
 			} else {
 				c.missingFlavors = append(c.missingFlavors, fName)
 			}
-		}
-	}
-	// A TAS flavor which was not tracked before may come with a freshly created,
-	// empty TAS flavor cache (e.g., the ResourceFlavor was deleted and re-created),
-	// so force a resync to account the usage of admitted workloads again.
-	for fName := range c.tasFlavors {
-		if _, tracked := oldTASFlavors[fName]; !tracked {
-			c.isTASSynced = false
-			break
 		}
 	}
 }

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -275,7 +275,11 @@ func (c *clusterQueue) updateQueueStatus(log logr.Logger) {
 // ensureTASIsSynced makes sure all TAS workloads are accounted (TAS cache is synced),
 // if TAS cache is initialized.
 func (c *clusterQueue) ensureTASIsSynced(log logr.Logger) {
-	if !features.Enabled(features.TopologyAwareScheduling) || len(c.tasFlavors) == 0 {
+	if !features.Enabled(features.TopologyAwareScheduling) {
+		return
+	}
+	if len(c.tasFlavors) == 0 {
+		c.isTASSynced = false
 		return
 	}
 	if !c.isTASInitialized() {

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -387,6 +387,7 @@ func (c *clusterQueue) UpdateWithFlavors(log logr.Logger, flavors map[kueue.Reso
 }
 
 func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor) {
+	oldTASFlavors := c.tasFlavors
 	c.missingFlavors = nil
 	c.tasFlavors = nil
 	for i := range c.ResourceGroups {
@@ -402,6 +403,15 @@ func (c *clusterQueue) updateFlavorMetadata(flavors map[kueue.ResourceFlavorRefe
 			} else {
 				c.missingFlavors = append(c.missingFlavors, fName)
 			}
+		}
+	}
+	// A TAS flavor which was not tracked before may come with a freshly created,
+	// empty TAS flavor cache (e.g., the ResourceFlavor was deleted and re-created),
+	// so force a resync to account the usage of admitted workloads again.
+	for fName := range c.tasFlavors {
+		if _, tracked := oldTASFlavors[fName]; !tracked {
+			c.isTASSynced = false
+			break
 		}
 	}
 }

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -5800,6 +5800,81 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 			})
+
+			ginkgo.It("should respect TAS usage of admitted workloads after one of multiple TAS RFs is deleted and re-created", framework.SlowSpec, func() {
+				var wl1, wl2 *kueue.Workload
+				ginkgo.By("creating wl1 which consumes the entire GPU TAS capacity", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 2).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).Request(gpuResName, "2").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify wl1 is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+				})
+
+				ginkgo.By("remove GPU TAS RF finalizers to allow deletion", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedFlavor kueue.ResourceFlavor
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasGPUFlavor), &updatedFlavor)).To(gomega.Succeed())
+						updatedFlavor.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("delete GPU TAS RF", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, tasGPUFlavor, true)
+				})
+
+				ginkgo.By("await for the CQ to become inactive", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedCq kueue.ClusterQueue
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
+						g.Expect(updatedCq.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+							{
+								Type:    kueue.ClusterQueueActive,
+								Status:  metav1.ConditionFalse,
+								Reason:  "FlavorNotFound",
+								Message: `Can't admit new workloads: references missing ResourceFlavor(s): tas-gpu-flavor.`,
+							},
+						}, util.IgnoreConditionTimestampsAndObservedGeneration))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("recreate the GPU TAS RF and wait for the queue to become active", func() {
+					tasGPUFlavor = utiltestingapi.MakeResourceFlavor("tas-gpu-flavor").
+						NodeLabel(corev1.LabelInstanceTypeStable, "gpu-node").
+						TopologyName("default").
+						Obj()
+					util.MustCreate(ctx, k8sClient, tasGPUFlavor)
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				})
+
+				ginkgo.By("create wl2 which requires GPU capacity still used by wl1", func() {
+					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 1).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).Request(gpuResName, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl2)
+				})
+
+				ginkgo.By("verify wl2 is not admitted as wl1 still uses the entire GPU TAS capacity", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("finish wl1 to release the GPU TAS capacity", func() {
+					util.FinishWorkloads(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify wl2 gets admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+				})
+			})
 		})
 
 		// Two TAS ResourceFlavors share the same physical nodes (same NodeLabel)

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -1115,6 +1115,80 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				})
 			})
 
+			ginkgo.It("should respect TAS usage of admitted workloads after the TAS RF is deleted and re-created", framework.SlowSpec, func() {
+				var wl1, wl2 *kueue.Workload
+				ginkgo.By("creating wl1 which consumes the entire TAS capacity", func() {
+					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 4).
+						PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify wl1 is admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectAdmittedWorkloadsTotalMetric(clusterQueue, "", 1)
+				})
+
+				ginkgo.By("remove TAS RF finalizers to allow deletion", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedFlavor kueue.ResourceFlavor
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), &updatedFlavor)).To(gomega.Succeed())
+						updatedFlavor.Finalizers = nil
+						g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("delete TAS RF", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				})
+
+				ginkgo.By("await for the CQ to become inactive", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updatedCq kueue.ClusterQueue
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCq)).To(gomega.Succeed())
+						g.Expect(updatedCq.Status.Conditions).Should(gomega.BeComparableTo([]metav1.Condition{
+							{
+								Type:    kueue.ClusterQueueActive,
+								Status:  metav1.ConditionFalse,
+								Reason:  "FlavorNotFound",
+								Message: `Can't admit new workloads: references missing ResourceFlavor(s): tas-flavor.`,
+							},
+						}, util.IgnoreConditionTimestampsAndObservedGeneration))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("recreate the ResourceFlavor and wait for the queue to become active", func() {
+					tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+						NodeLabel("node-group", "tas").
+						TopologyName("default").Obj()
+					util.MustCreate(ctx, k8sClient, tasFlavor)
+					util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+				})
+
+				ginkgo.By("create wl2 which requires capacity still used by wl1", func() {
+					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
+						Queue(kueue.LocalQueueName(localQueue.Name)).PodSets(*utiltestingapi.MakePodSet("worker", 1).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).Request(corev1.ResourceCPU, "1").Obj()
+					util.MustCreate(ctx, k8sClient, wl2)
+				})
+
+				ginkgo.By("verify wl2 is not admitted as wl1 still uses the entire TAS capacity", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+					util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				})
+
+				ginkgo.By("finish wl1 to release the TAS capacity", func() {
+					util.FinishWorkloads(ctx, k8sClient, wl1)
+				})
+
+				ginkgo.By("verify wl2 gets admitted", func() {
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+				})
+			})
+
 			ginkgo.It("should not leak TAS domains if a workload is deleted while the topology is uninitialized (#12545)", func() {
 				var wl1, wl2 *kueue.Workload
 				ginkgo.By("creating a workload which requires block and can fit", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Deleting a TAS ResourceFlavor removes its `TASFlavorCache`, including the topology usage of admitted workloads. Recreating the ResourceFlavor builds a fresh empty cache, so admitted workload usage must be replayed before the ClusterQueue can safely admit more workloads.

The stale usage can occur in two configurations:

1. If the ClusterQueue has a single TAS flavor, deleting it temporarily leaves the queue with no TAS flavors. `ensureTASIsSynced` previously left `isTASSynced` set to `true`.
2. If the ClusterQueue has multiple TAS flavors, deleting one leaves the others initialized, so the ClusterQueue-level `isTASSynced` flag can remain `true` even after the deleted flavor is recreated with an empty cache.

In both cases, the stale synchronization flag skips replaying admitted workloads and can admit a new workload against topology capacity that is already fully used.

This change marks TAS usage as unsynchronized when the ClusterQueue temporarily has no TAS flavors and when a TAS flavor appears that was not tracked by the previous flavor metadata. The existing synchronization path then replays admitted workload usage into the available TAS caches.

The integration coverage verifies both single-flavor and multi-flavor ClusterQueues:

1. Admit a workload that consumes all relevant TAS capacity.
2. Delete and recreate the referenced ResourceFlavor.
3. Verify that a second workload remains pending while the first workload holds the capacity.
4. Verify that the second workload is admitted after the first workload finishes.

AI tools were used to assist with code investigation, reproduction, test development, and drafting this change. I reviewed the implementation and verified the behavior with the tests listed below.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The multi-flavor scenario was identified while extending validation after the initial PR submission. In that scenario, a CPU TAS flavor remains initialized while a GPU TAS flavor is deleted and recreated. Before the additional synchronization guard, a workload consuming all 4 GPU was followed by another admitted workload assigned 1 GPU in the same topology domain.

The failure was reproduced twice before the fix. Applying, reverting, and restoring the additional guard produced fail/pass/fail/pass results.

Verified with:

```text
go test ./test/integration/singlecluster/tas/ -count=1 -ginkgo.focus="should respect TAS usage of admitted workloads after the TAS RF is deleted and re-created"
go test ./test/integration/singlecluster/tas/ -count=1 -ginkgo.focus="should respect TAS usage of admitted workloads after one of multiple TAS RFs is deleted and re-created"
go test ./test/integration/singlecluster/tas/ -count=1
go test ./pkg/cache/... ./pkg/scheduler/... -count=1
go vet ./pkg/cache/... ./pkg/scheduler/... ./test/integration/singlecluster/tas/...
```

The full TAS integration suite passed all 106 specs.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where resource accounting was incorrect after a ResourceFlavor was deleted and recreated, including ClusterQueues with multiple TAS flavors, allowing workloads to be admitted against topology capacity already used by other admitted workloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale TAS sync state when Topology-Aware Scheduling is turned off.
  * Improved TAS usage accounting so newly discovered TAS flavors and post-deletion/recreation scenarios correctly reflect capacity, keeping workloads pending until resources are actually released.
* **Tests**
  * Added integration coverage for TAS ResourceFlavor deletion and re-creation (single and multiple flavors) to verify correct workload admission and waiting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->