### PR TITLE
Don't prefer a flavor with no preemption candidates over one that fits

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -493,6 +493,15 @@ func isPreferred(a, b granularMode, fungibilityConfig kueue.FlavorFungibility) b
 		return true
 	}
 
+	// A flavor without preemption candidates cannot be admitted in this
+	// scheduling attempt. Rank it below viable modes before applying the
+	// configured fungibility preference, while retaining noFit as the worst mode.
+	aHasNoCandidates := a.preemptionMode == noPreemptionCandidates
+	bHasNoCandidates := b.preemptionMode == noPreemptionCandidates
+	if aHasNoCandidates != bHasNoCandidates {
+		return !aHasNoCandidates
+	}
+
 	borrowingOverPreemption := func() bool {
 		if a.preemptionMode != b.preemptionMode {
 			return a.preemptionMode > b.preemptionMode

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4065,6 +4065,13 @@ func TestLastAssignmentOutdated(t *testing.T) {
 // each cohort get 4 units of CPU in a different flavor.
 func TestHierarchical(t *testing.T) {
 	type rfMap = map[corev1.ResourceName]kueue.ResourceFlavorReference
+	defaultTestClusterQueueFlavors := func() []kueue.FlavorQuotas {
+		return []kueue.FlavorQuotas{
+			*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+		}
+	}
 	cases := map[string]struct {
 		workloadRequests        *utiltestingapi.PodSetWrapper
 		testClusterQueueFlavors []kueue.FlavorQuotas
@@ -4076,7 +4083,8 @@ func TestHierarchical(t *testing.T) {
 		wantAssigment           rfMap
 	}{
 		"Select the top flavor": {
-			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			workloadRequests:        utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: defaultTestClusterQueueFlavors(),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
@@ -4087,14 +4095,15 @@ func TestHierarchical(t *testing.T) {
 			wantAssigment: rfMap{corev1.ResourceCPU: "three"},
 		},
 		"Select the first flavor which fits": {
-			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			workloadRequests:        utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: defaultTestClusterQueueFlavors(),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
 		},
-		"Select deeper flavor that fits when shallower flavor has no preemption candidates": {
+		"Select deeper-borrowing flavor that fits when shallower-borrowing flavor has no preemption candidates": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
 			testClusterQueueFlavors: []kueue.FlavorQuotas{
 				*utiltestingapi.MakeFlavorQuotas("one").
@@ -4129,14 +4138,6 @@ func TestHierarchical(t *testing.T) {
 				"two":   utiltestingapi.MakeResourceFlavor("two").Obj(),
 				"three": utiltestingapi.MakeResourceFlavor("three").Obj(),
 			}
-			testClusterQueueFlavors := tc.testClusterQueueFlavors
-			if testClusterQueueFlavors == nil {
-				testClusterQueueFlavors = []kueue.FlavorQuotas{
-					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
-				}
-			}
 			cohorts := []*kueue.Cohort{
 				utiltestingapi.MakeCohort("three").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("three").
@@ -4159,7 +4160,7 @@ func TestHierarchical(t *testing.T) {
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				}).
-				ResourceGroup(testClusterQueueFlavors...).
+				ResourceGroup(tc.testClusterQueueFlavors...).
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).Obj()
@@ -4285,7 +4286,7 @@ func TestIsPreferred(t *testing.T) {
 			},
 			wantPreferred: false,
 		},
-		"explicit PreemptionOverBorrowing prefers fit over shallower no-candidate flavor": {
+		"explicit PreemptionOverBorrowing prefers fit over shallower-borrowing no-candidate flavor": {
 			a: granularMode{preemptionMode: fit, borrowingLevel: 2},
 			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
 			config: kueue.FlavorFungibility{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4066,12 +4066,14 @@ func TestLastAssignmentOutdated(t *testing.T) {
 func TestHierarchical(t *testing.T) {
 	type rfMap = map[corev1.ResourceName]kueue.ResourceFlavorReference
 	cases := map[string]struct {
-		workloadRequests       *utiltestingapi.PodSetWrapper
-		testClusterQueueUsage  resources.FlavorResourceQuantities
-		otherClusterQueueUsage resources.FlavorResourceQuantities
-		flavorFungibility      *kueue.FlavorFungibility
-		wantMode               FlavorAssignmentMode
-		wantAssigment          rfMap
+		workloadRequests        *utiltestingapi.PodSetWrapper
+		testClusterQueueFlavors []kueue.FlavorQuotas
+		testClusterQueueUsage   resources.FlavorResourceQuantities
+		otherClusterQueueUsage  resources.FlavorResourceQuantities
+		flavorFungibility       *kueue.FlavorFungibility
+		simulationResult        map[resources.FlavorResource]simulationResultForFlavor
+		wantMode                FlavorAssignmentMode
+		wantAssigment           rfMap
 	}{
 		"Select the top flavor": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
@@ -4092,6 +4094,32 @@ func TestHierarchical(t *testing.T) {
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
 		},
+		"Select deeper flavor that fits when shallower flavor has no preemption candidates": {
+			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: []kueue.FlavorQuotas{
+				*utiltestingapi.MakeFlavorQuotas("one").
+					ResourceQuotaWrapper(corev1.ResourceCPU).
+					NominalQuota("4").
+					BorrowingLimit("0").
+					Append().
+					Obj(),
+				*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+			},
+			testClusterQueueUsage: resources.FlavorResourceQuantities{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
+			},
+			flavorFungibility: &kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 1},
+			},
+			wantMode:      Fit,
+			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -4100,6 +4128,14 @@ func TestHierarchical(t *testing.T) {
 				"one":   utiltestingapi.MakeResourceFlavor("one").Obj(),
 				"two":   utiltestingapi.MakeResourceFlavor("two").Obj(),
 				"three": utiltestingapi.MakeResourceFlavor("three").Obj(),
+			}
+			testClusterQueueFlavors := tc.testClusterQueueFlavors
+			if testClusterQueueFlavors == nil {
+				testClusterQueueFlavors = []kueue.FlavorQuotas{
+					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+				}
 			}
 			cohorts := []*kueue.Cohort{
 				utiltestingapi.MakeCohort("three").
@@ -4123,11 +4159,7 @@ func TestHierarchical(t *testing.T) {
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				}).
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
-				).
+				ResourceGroup(testClusterQueueFlavors...).
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).Obj()
@@ -4176,7 +4208,7 @@ func TestHierarchical(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
 			assignment := flvAssigner.Assign(ctx, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -4240,6 +4272,52 @@ func TestIsPreferred(t *testing.T) {
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
 				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: false,
+		},
+		"explicit PreemptionOverBorrowing rejects no-candidate flavor before borrowing comparison": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b: granularMode{preemptionMode: fit, borrowingLevel: 2},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: false,
+		},
+		"explicit PreemptionOverBorrowing prefers fit over shallower no-candidate flavor": {
+			a: granularMode{preemptionMode: fit, borrowingLevel: 2},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: true,
+		},
+		"no-candidate flavor remains preferable to no-fit flavor": {
+			a:             granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b:             granularMode{preemptionMode: noFit, borrowingLevel: 0},
+			wantPreferred: true,
+		},
+		"no-fit flavor remains worse than no-candidate flavor": {
+			a:             granularMode{preemptionMode: noFit, borrowingLevel: 0},
+			b:             granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			wantPreferred: false,
+		},
+		"no-candidate flavors retain borrowing preference": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 2},
+			config: kueue.FlavorFungibility{
+				Preference: makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: true,
+		},
+		"no-candidate flavors retain borrowing preference in reverse": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 2},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				Preference: makePref(kueue.PreemptionOverBorrowing),
 			},
 			wantPreferred: false,
 		},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6217,6 +6217,131 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "high-pob", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
 			},
 		},
+		//     nopc-root (spot: 5)
+		//         |
+		//     nopc-mid
+		//      /      \
+		// nopc-cq    nopc-sibling (on-demand: 5, idle)
+		//
+		// The on-demand flavor of nopc-cq is exhausted and cannot borrow, and
+		// preemption finds no candidates because the admitted workload has the same
+		// priority. The idle sibling keeps on-demand sourceable one level higher than
+		// spot, so under PreemptionOverBorrowing the shallower borrowing level must not
+		// let the unschedulable on-demand flavor outrank spot, which fits.
+		"PreemptionOverBorrowing preference: skip first flavor that has no preemption candidates": {
+			cohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("nopc-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).Obj(),
+				*utiltestingapi.MakeCohort("nopc-mid").Parent("nopc-root").Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("nopc-cq").
+					Cohort("nopc-mid").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+					}).
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.TryNextFlavor,
+						WhenCanPreempt: kueue.TryNextFlavor,
+						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("5").BorrowingLimit("0").Append().
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+					).Obj(),
+				*utiltestingapi.MakeClusterQueue("nopc-sibling").
+					Cohort("nopc-mid").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+					).Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("nopc-queue", "default").ClusterQueue("nopc-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("nopc-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("pending-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("nopc-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("pending-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue nopc-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("nopc-cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+									Assignment(corev1.ResourceCPU, "spot", "5000m").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"default/admitted-nopc": *utiltestingapi.MakeAdmission("nopc-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+						Obj()).
+					Obj(),
+				"default/pending-nopc": *utiltestingapi.MakeAdmission("nopc-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "5000m").
+						Obj()).
+					Obj(),
+			},
+		},
 		"BorrowingOverPreemption preference: borrow in second flavor instead of preempting in first": {
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("bop-cq").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6228,7 +6228,7 @@ func TestSchedule(t *testing.T) {
 		// priority. The idle sibling keeps on-demand sourceable one level higher than
 		// spot, so under PreemptionOverBorrowing the shallower borrowing level must not
 		// let the unschedulable on-demand flavor outrank spot, which fits.
-		"PreemptionOverBorrowing preference: skip first flavor that has no preemption candidates": {
+		"PreemptionOverBorrowing preference: select fitting second flavor over first flavor with no preemption candidates": {
 			cohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("nopc-root").
 					ResourceGroup(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

With `flavorFungibility.preference: PreemptionOverBorrowing`, `isPreferred` compares `borrowingLevel` before `preemptionMode`. That lets a flavor whose preemption simulation found no candidates outrank a later flavor that fits, purely because its quota is sourceable at a shallower level in the cohort tree.

The first flavor cannot admit the workload in that scheduling attempt, and the fitting flavor loses the comparison because borrowing depth is considered first, so the workload stays pending indefinitely while quota sits idle. Every cycle repeats the same decision.

This PR ranks `noPreemptionCandidates` below all viable modes before applying the configured preference, keeping `noFit` as the worst mode.

The change only affects `PreemptionOverBorrowing`. The default preference and `BorrowingOverPreemption` already compare `preemptionMode` first, so they are unaffected.

#### Which issue(s) this PR fixes:

Fixes #13607

#### Special notes for your reviewer:

/cc @amy

Tests are added at three levels, and all of them fail without the fix:

- `TestIsPreferred` covers the new ordering directly, including that `noPreemptionCandidates` still beats `noFit` and that borrowing level still breaks ties between two such flavors.
- A `TestHierarchical` case pins the first flavor to `NoCandidates` at borrowing level 1 through a fake oracle, while exercising the flavor assigner’s real selection path against a fitting second flavor.
- A `TestSchedule` case reproduces the issue end to end and asserts the workload is admitted into the second flavor. It needs a two-level cohort: with a flat cohort both flavors land at the same borrowing level, the existing tie-break on `preemptionMode` fires, and the bug does not appear.

The middle case may look redundant next to the end-to-end one, but it guards against a specific kind of drift. `TestSchedule` derives its borrowing levels from the real oracle and real cohort-height math, so if a future change moved the first flavor to the same level as the second, the levels would tie, the pre-existing tie-break would select the fitting flavor, and the test would keep passing without exercising this bug at all. Pinning the oracle result keeps one test anchored to the ordering itself. Happy to drop it if you would rather not carry the extra layer.

One thing worth flagging, which I left out of scope. The docs and the KEP describe `PreemptionOverBorrowing` over a binary borrow key:

`(Fit, NoBorrow)` > `(Preempt, NoBorrow)` > `(Fit, Borrow)` > `(Preempt, Borrow)`

The implementation compares the full `borrowingLevel` depth first, so in a hierarchical cohort `(preempt, level 1)` still outranks `(fit, level 2)` even when preemption candidates do exist. That is not starvation, since preemption makes progress, so I kept this PR narrow. Happy to follow up if you would like the graded comparison reconciled with the documented ordering.

AI assistance was used to help implement and review this change. The author reviewed and tested the resulting code and takes responsibility for it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a ClusterQueue with `flavorFungibility.preference: PreemptionOverBorrowing` could leave workloads pending indefinitely. A flavor that required preemption but had no preemption candidates could outrank a later flavor that fits, purely because its quota was sourceable at a shallower borrowing level in the cohort tree.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved flavor selection when the preferred flavor has no eligible preemption candidates.
  - The scheduler now skips unavailable flavors and can select a viable fallback flavor.
  - Preserved existing handling for flavors that cannot fit workloads.
- **Tests**
  - Added coverage for borrowing and preemption preferences, hierarchical flavor selection, and fallback scheduling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
