### PR TITLE
Allow updating tolerations for TAS ResourceFlavors

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -45,7 +45,6 @@ type TopologyReference string
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))", message="nodeLabels are immutable when topologyName is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations) && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))", message="tolerations are immutable when topologyName is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)", message="topologyName is immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that

--- a/apis/kueue/v1beta2/resourceflavor_types.go
+++ b/apis/kueue/v1beta2/resourceflavor_types.go
@@ -47,7 +47,6 @@ type TopologyReference string
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))", message="nodeLabels are immutable when topologyName is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations) && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))", message="tolerations are immutable when topologyName is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)", message="topologyName is immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -204,8 +204,6 @@ spec:
                   rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
                 - message: nodeLabels are immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
-                - message: tolerations are immutable when topologyName is set
-                  rule: '!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations) && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))'
                 - message: topologyName is immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)'
           type: object
@@ -373,8 +371,6 @@ spec:
                   rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
                 - message: nodeLabels are immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
-                - message: tolerations are immutable when topologyName is set
-                  rule: '!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations) && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))'
                 - message: topologyName is immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)'
           type: object

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -192,9 +192,6 @@ spec:
             - message: nodeLabels are immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels)
                 && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
-            - message: tolerations are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations)
-                && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))'
             - message: topologyName is immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName
                 == oldSelf.topologyName)'
@@ -373,9 +370,6 @@ spec:
             - message: nodeLabels are immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels)
                 && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
-            - message: tolerations are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (has(self.tolerations) == has(oldSelf.tolerations)
-                && (!has(self.tolerations) || self.tolerations == oldSelf.tolerations))'
             - message: topologyName is immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName
                 == oldSelf.topologyName)'

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -309,7 +309,7 @@ func (c *Cache) AddOrUpdateResourceFlavor(log logr.Logger, rf *kueue.ResourceFla
 	defer c.Unlock()
 	c.resourceFlavors[kueue.ResourceFlavorReference(rf.Name)] = rf
 	if handleTASFlavor(rf) {
-		c.tasCache.AddFlavor(rf)
+		c.tasCache.AddOrUpdateFlavor(rf)
 	}
 	return c.updateClusterQueues(log)
 }

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -84,9 +84,7 @@ func (t *tasCache) AddOrUpdateFlavor(flavor *kueue.ResourceFlavor) {
 		flavorInfo.Tolerations = tolerations
 		t.flavors[name] = flavorInfo
 		if flavorCache, ok := t.flavorCache[name]; ok {
-			flavorCache.Lock()
-			defer flavorCache.Unlock()
-			flavorCache.flavor.Tolerations = tolerations
+			flavorCache.updateTolerations(tolerations)
 		}
 		return
 	}

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -75,20 +75,29 @@ func (t *tasCache) Clone() map[kueue.ResourceFlavorReference]*TASFlavorCache {
 	return maps.Clone(t.flavorCache)
 }
 
-func (t *tasCache) AddFlavor(flavor *kueue.ResourceFlavor) {
+func (t *tasCache) AddOrUpdateFlavor(flavor *kueue.ResourceFlavor) {
 	t.Lock()
 	defer t.Unlock()
 	name := kueue.ResourceFlavorReference(flavor.Name)
-	if _, ok := t.flavors[name]; !ok {
-		flavorInfo := flavorInformation{
-			TopologyName: *flavor.Spec.TopologyName,
-			NodeLabels:   maps.Clone(flavor.Spec.NodeLabels),
-			Tolerations:  slices.Clone(flavor.Spec.Tolerations),
-		}
+	tolerations := slices.Clone(flavor.Spec.Tolerations)
+	if flavorInfo, ok := t.flavors[name]; ok {
+		flavorInfo.Tolerations = tolerations
 		t.flavors[name] = flavorInfo
-		if tInfo, ok := t.topologies[flavorInfo.TopologyName]; ok {
-			t.flavorCache[name] = t.NewTASFlavorCache(tInfo, flavorInfo)
+		if flavorCache, ok := t.flavorCache[name]; ok {
+			flavorCache.Lock()
+			defer flavorCache.Unlock()
+			flavorCache.flavor.Tolerations = tolerations
 		}
+		return
+	}
+	flavorInfo := flavorInformation{
+		TopologyName: *flavor.Spec.TopologyName,
+		NodeLabels:   maps.Clone(flavor.Spec.NodeLabels),
+		Tolerations:  tolerations,
+	}
+	t.flavors[name] = flavorInfo
+	if tInfo, ok := t.topologies[flavorInfo.TopologyName]; ok {
+		t.flavorCache[name] = t.NewTASFlavorCache(tInfo, flavorInfo)
 	}
 }
 

--- a/pkg/cache/scheduler/tas_cache_update_test.go
+++ b/pkg/cache/scheduler/tas_cache_update_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestTASCacheUpdateFlavorTolerationsPreservesUsage(t *testing.T) {
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	topology := utiltestingapi.MakeDefaultOneLevelTopology("default")
+	tasCache.AddTopology(topology)
+
+	flavor := utiltestingapi.MakeResourceFlavor("tas-flavor").
+		NodeLabel("node-group", "tas").
+		TopologyName(topology.Name).
+		Obj()
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	const wlKey = workload.Reference("default/wl")
+	topologyRequests := []workload.TopologyDomainRequests{{
+		Values: []string{"x1"},
+		Count:  1,
+		SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+			corev1.ResourceCPU: 1,
+		}),
+	}}
+	originalFlavorCache := tasCache.Get("tas-flavor")
+	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+
+	toleration := corev1.Toleration{
+		Key:      "example.com/dedicated",
+		Operator: corev1.TolerationOpEqual,
+		Value:    "tas",
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	flavor.Spec.Tolerations = []corev1.Toleration{toleration}
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	updatedFlavorCache := tasCache.Get("tas-flavor")
+	if updatedFlavorCache != originalFlavorCache {
+		t.Fatal("TAS flavor cache was replaced while updating tolerations")
+	}
+
+	wantUsage := map[utiltas.TopologyDomainID]resources.Requests{
+		"x1": resources.NewRequestsFromMap(resources.MapRequests{
+			corev1.ResourceCPU:  1,
+			corev1.ResourcePods: 1,
+		}),
+	}
+	if diff := cmp.Diff([]corev1.Toleration{toleration}, updatedFlavorCache.flavor.Tolerations); diff != "" {
+		t.Errorf("Unexpected tolerations after update (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantUsage, updatedFlavorCache.usage, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("Unexpected usage after adding toleration (-want +got):\n%s", diff)
+	}
+	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
+		t.Error("Workload usage was removed after adding toleration")
+	}
+
+	flavor.Spec.Tolerations = nil
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	if len(updatedFlavorCache.flavor.Tolerations) != 0 {
+		t.Errorf("Expected tolerations to be empty after removal, got %v", updatedFlavorCache.flavor.Tolerations)
+	}
+	if diff := cmp.Diff(wantUsage, updatedFlavorCache.usage, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("Unexpected usage after removing toleration (-want +got):\n%s", diff)
+	}
+	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
+		t.Error("Workload usage was removed after removing toleration")
+	}
+}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -113,6 +113,12 @@ func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 	}
 }
 
+func (c *TASFlavorCache) updateTolerations(tolerations []corev1.Toleration) {
+	c.Lock()
+	defer c.Unlock()
+	c.flavor.Tolerations = tolerations
+}
+
 func (c *TASFlavorCache) NodeLabels() map[string]string {
 	return c.flavor.NodeLabels
 }

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -182,6 +182,13 @@ func (r *rfReconciler) Delete(event event.TypedDeleteEvent[*kueue.ResourceFlavor
 func (r *rfReconciler) Update(event event.TypedUpdateEvent[*kueue.ResourceFlavor]) bool {
 	switch {
 	case ptr.Equal(event.ObjectOld.Spec.TopologyName, event.ObjectNew.Spec.TopologyName):
+		if event.ObjectNew.Spec.TopologyName != nil &&
+			!equality.Semantic.DeepEqual(event.ObjectOld.Spec.Tolerations, event.ObjectNew.Spec.Tolerations) {
+			log := r.logger().WithValues("flavor", event.ObjectNew.Name)
+			log.V(2).Info("TAS ResourceFlavor tolerations updated")
+			r.cache.AddOrUpdateResourceFlavor(log, event.ObjectNew)
+			return true
+		}
 		return false
 	case event.ObjectOld.Spec.TopologyName == nil:
 		return true

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -275,11 +275,11 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should not allow to update tolerations", func() {
+		ginkgo.It("should allow to update tolerations", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
 			tasFlavor.Spec.Tolerations = []corev1.Toleration{
 				{Key: "key1", Value: "value", Effect: corev1.TaintEffectNoSchedule, Operator: corev1.TolerationOpEqual}}
-			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("should not allow to update nodeLabels", func() {
@@ -296,6 +296,131 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				"foo": "bar",
 			}
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+		})
+	})
+
+	ginkgo.When("Updating TAS ResourceFlavor tolerations", func() {
+		var (
+			node         *corev1.Node
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		taint := corev1.Taint{
+			Key:    "example.com/dedicated",
+			Value:  "tas",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+		toleration := corev1.Toleration{
+			Key:      taint.Key,
+			Operator: corev1.TolerationOpEqual,
+			Value:    taint.Value,
+			Effect:   taint.Effect,
+		}
+
+		ginkgo.BeforeEach(func() {
+			node = testingnode.MakeNode("x1").
+				Label("node-group", "tas").
+				Label(corev1.LabelHostname, "x1").
+				Taints(taint).
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj()
+			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*node})
+
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName(topology.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "3").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
+		})
+
+		ginkgo.It("should apply updates, requeue pending workloads, and preserve admitted usage", func() {
+			makeWorkload := func(name, cpu string, podTolerations ...corev1.Toleration) *kueue.Workload {
+				podSet := utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, cpu)
+				for _, podToleration := range podTolerations {
+					podSet.Toleration(podToleration)
+				}
+				return utiltestingapi.MakeWorkload(name, ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(*podSet.Obj()).
+					Obj()
+			}
+			updateTolerations := func(tolerations ...corev1.Toleration) {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updatedFlavor kueue.ResourceFlavor
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), &updatedFlavor)).To(gomega.Succeed())
+					updatedFlavor.Spec.Tolerations = tolerations
+					g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}
+
+			ginkgo.By("creating a workload that cannot tolerate the node taint", func() {
+				wl1 := makeWorkload("wl1", "1")
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+
+				ginkgo.By("adding the toleration and verifying the pending workload is retried")
+				updateTolerations(toleration)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+
+				ginkgo.By("creating a capacity probe with its own toleration")
+				capacityProbe := makeWorkload("capacity-probe", "2", toleration)
+				util.MustCreate(ctx, k8sClient, capacityProbe)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, capacityProbe)
+
+				ginkgo.By("removing the flavor toleration without losing admitted usage")
+				metrics.AdmissionAttemptsTotal.Reset()
+				updateTolerations()
+				util.ExpectPendingAdmissionAttempts(1, ">=")
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, capacityProbe)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, capacityProbe, true)
+
+				ginkgo.By("verifying future workloads no longer tolerate the taint")
+				wl2 := makeWorkload("wl2", "1")
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+
+				ginkgo.By("restoring the toleration and verifying the workload is retried")
+				updateTolerations(toleration)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+
+				ginkgo.By("verifying both admitted workloads still account for the full node capacity")
+				wl3 := makeWorkload("wl3", "1")
+				util.MustCreate(ctx, k8sClient, wl3)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl3)
+			})
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/area tas

#### What this PR does / why we need it:

Allows updating `spec.tolerations` on ResourceFlavors that reference a Topology.

The TAS ResourceFlavor controller applies the updated tolerations to the existing flavor cache before retrying inadmissible workloads. The cache is updated in place so that topology usage and per-Workload usage remain accounted for across both toleration additions and removals.

This is intentionally limited to tolerations. `spec.nodeLabels` and `spec.topologyName` remain immutable for TAS ResourceFlavors.

#### Which issue(s) this PR fixes:

Part of #3733

#### Special notes for your reviewer:

Validation performed:

- `go test ./pkg/cache/... ./pkg/controller/tas/... -count=1`
- `go test -race ./pkg/cache/scheduler ./pkg/controller/tas -count=1`
- focused TAS integration tests for API mutability, requeueing, and usage preservation
- full TAS integration suite: 107 specs passed
- `go test ./apis/... -count=1`
- `go vet` for the changed API, cache, controller, and integration packages
- Helm and Kustomize rendering verification

AI tool usage disclosure: I used an AI coding tool to help investigate the update paths, implement the change, and prepare tests and documentation. I reviewed the resulting code and ran the validations listed above.

#### Does this PR introduce a user-facing change?

```release-note
ResourceFlavor `spec.tolerations` can now be updated when `spec.topologyName` is set.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology-aware ResourceFlavor tolerations can now be updated after creation.
* **Bug Fixes**
  * Updating tolerations now correctly refreshes scheduling behavior while preserving already-accounted workload usage.
  * Workloads are re-evaluated when tolerations are added or removed, matching the latest ResourceFlavor settings.
* **Validation**
  * Removed the CRD restriction that blocked toleration updates when topology name is set.
  * Kept existing immutability/consistency rules for topology name and node labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->