### PR TITLE
Measure perf runner workload latency from creation time

### DIFF
--- a/test/performance/scheduler/runner/recorder/recorder.go
+++ b/test/performance/scheduler/runner/recorder/recorder.go
@@ -90,20 +90,42 @@ type WLEvent struct {
 	types.NamespacedName
 	UID       types.UID
 	ClassName string
-	Admitted  bool
-	Evicted   bool
-	Finished  bool
+	// CreationTime is the Workload's creation timestamp. It is the baseline for
+	// latency measurements, so that a Workload observed for the first time after
+	// it was created is not credited with a shorter wait than it actually had.
+	CreationTime time.Time
+	Admitted     bool
+	Evicted      bool
+	Finished     bool
 }
 
 type WLState struct {
 	ID int
 	types.NamespacedName
-	ClassName        string
-	FirstEventTime   time.Time
+	ClassName string
+	// FirstEventTime is when the recorder first observed the Workload. It is not
+	// used for latency measurements; see baselineTime.
+	FirstEventTime time.Time
+	// CreationTime is the Workload's creation timestamp, carried over from the
+	// first observed event.
+	CreationTime     time.Time
 	TimeToAdmitMs    int64
 	TimeToFinishedMs int64
 	EvictionCount    int32
 	LastEvent        *WLEvent
+}
+
+// baselineTime returns the instant from which admission and finish latencies are
+// measured. The Workload's creation timestamp is preferred, since the recorder may
+// start after - or receive a delayed event for - a Workload that was created, and
+// possibly already admitted, earlier. Measuring from the first observed event in
+// that case reports a near-zero latency and drags the reported averages down.
+// FirstEventTime is used as a fallback when the creation timestamp is unavailable.
+func (wls *WLState) baselineTime() time.Time {
+	if !wls.CreationTime.IsZero() {
+		return wls.CreationTime
+	}
+	return wls.FirstEventTime
 }
 
 var WLStateCsvHeader = []string{
@@ -190,13 +212,14 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 			NamespacedName: ev.NamespacedName,
 			ClassName:      ev.ClassName,
 			FirstEventTime: ev.Time,
+			CreationTime:   ev.CreationTime,
 			LastEvent:      &WLEvent{},
 		}
 		r.Store.WL[ev.UID] = state
 	}
 
 	if ev.Admitted && !state.LastEvent.Admitted {
-		state.TimeToAdmitMs = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+		state.TimeToAdmitMs = ev.Time.Sub(state.baselineTime()).Milliseconds()
 	}
 
 	if ev.Evicted && !state.LastEvent.Evicted {
@@ -204,7 +227,7 @@ func (r *Recorder) recordWLEvent(ev *WLEvent) {
 	}
 
 	if ev.Finished && !state.LastEvent.Finished {
-		state.TimeToFinishedMs = ev.Time.Sub(state.FirstEventTime).Milliseconds()
+		state.TimeToFinishedMs = ev.Time.Sub(state.baselineTime()).Milliseconds()
 	}
 
 	state.LastEvent = ev
@@ -457,11 +480,12 @@ func (r *Recorder) RecordWorkloadState(wl *kueue.Workload) {
 			Namespace: wl.Namespace,
 			Name:      wl.Name,
 		},
-		UID:       wl.UID,
-		ClassName: wl.Labels[generator.ClassLabel],
-		Admitted:  workload.IsAdmitted(wl),
-		Evicted:   workloadevict.IsEvicted(wl),
-		Finished:  workloadfinish.IsFinished(wl),
+		UID:          wl.UID,
+		ClassName:    wl.Labels[generator.ClassLabel],
+		CreationTime: wl.CreationTimestamp.Time,
+		Admitted:     workload.IsAdmitted(wl),
+		Evicted:      workloadevict.IsEvicted(wl),
+		Finished:     workloadfinish.IsFinished(wl),
 	}
 	select {
 	case r.wlEvChan <- ev:

--- a/test/performance/scheduler/runner/recorder/recorder_test.go
+++ b/test/performance/scheduler/runner/recorder/recorder_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recorder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestRecordWLEventLatencies(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	uid := types.UID("wl-uid")
+
+	newEvent := func(offset time.Duration, admitted, finished bool) *WLEvent {
+		return &WLEvent{
+			Time:           created.Add(offset),
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
+			UID:            uid,
+			ClassName:      "large",
+			CreationTime:   created,
+			Admitted:       admitted,
+			Finished:       finished,
+		}
+	}
+
+	cases := map[string]struct {
+		events               []*WLEvent
+		wantTimeToAdmitMs    int64
+		wantTimeToFinishedMs int64
+	}{
+		"first observed already admitted: latency measured from creation, not from first observation": {
+			// The recorder starts (or receives its first event) 30s after the
+			// Workload was created and admitted. Measuring from the first observed
+			// event would report 0ms.
+			events:            []*WLEvent{newEvent(30*time.Second, true, false)},
+			wantTimeToAdmitMs: 30_000,
+		},
+		"first observed before admission: latency still measured from creation": {
+			// Even when admission is observed live, the Workload waited from its
+			// creation, not from the moment the recorder first saw it.
+			events: []*WLEvent{
+				newEvent(10*time.Second, false, false),
+				newEvent(25*time.Second, true, false),
+			},
+			wantTimeToAdmitMs: 25_000,
+		},
+		"admission and finish are both measured from creation": {
+			events: []*WLEvent{
+				newEvent(5*time.Second, false, false),
+				newEvent(20*time.Second, true, false),
+				newEvent(50*time.Second, true, true),
+			},
+			wantTimeToAdmitMs:    20_000,
+			wantTimeToFinishedMs: 50_000,
+		},
+		"admission time is recorded once and not refreshed by later events": {
+			events: []*WLEvent{
+				newEvent(15*time.Second, true, false),
+				newEvent(40*time.Second, true, false),
+			},
+			wantTimeToAdmitMs: 15_000,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := New(time.Minute)
+			for _, ev := range tc.events {
+				r.recordWLEvent(ev)
+			}
+
+			got, ok := r.Store.WL[uid]
+			if !ok {
+				t.Fatalf("no WLState recorded for uid %q", uid)
+			}
+			if diff := cmp.Diff(tc.wantTimeToAdmitMs, got.TimeToAdmitMs); diff != "" {
+				t.Errorf("unexpected TimeToAdmitMs (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantTimeToFinishedMs, got.TimeToFinishedMs); diff != "" {
+				t.Errorf("unexpected TimeToFinishedMs (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestRecordWLEventFallsBackToFirstEventTime(t *testing.T) {
+	// Workloads without a creation timestamp (for example, if the field is not
+	// populated) must still produce a usable measurement rather than a negative
+	// or wildly large one.
+	first := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	uid := types.UID("wl-uid")
+
+	r := New(time.Minute)
+	r.recordWLEvent(&WLEvent{
+		Time:           first,
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
+		UID:            uid,
+	})
+	r.recordWLEvent(&WLEvent{
+		Time:           first.Add(12 * time.Second),
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
+		UID:            uid,
+		Admitted:       true,
+	})
+
+	got := r.Store.WL[uid]
+	if diff := cmp.Diff(int64(12_000), got.TimeToAdmitMs); diff != "" {
+		t.Errorf("unexpected TimeToAdmitMs (-want +got):\n%s", diff)
+	}
+}
+
+func TestRecordWLEventCountsEvictions(t *testing.T) {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	uid := types.UID("wl-uid")
+
+	r := New(time.Minute)
+	events := []struct {
+		offset  time.Duration
+		evicted bool
+	}{
+		{0, false},
+		{time.Second, true},
+		{2 * time.Second, true},  // still evicted, must not double count
+		{3 * time.Second, false}, // requeued
+		{4 * time.Second, true},  // evicted again
+	}
+	for _, e := range events {
+		r.recordWLEvent(&WLEvent{
+			Time:           created.Add(e.offset),
+			NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
+			UID:            uid,
+			CreationTime:   created,
+			Evicted:        e.evicted,
+		})
+	}
+
+	if diff := cmp.Diff(int32(2), r.Store.WL[uid].EvictionCount); diff != "" {
+		t.Errorf("unexpected EvictionCount (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The performance scheduler runner measured admission and finish latency from the first event the recorder observed for a Workload, rather than from the Workload's creation.

In `recordWLEvent`, a newly seen Workload gets `FirstEventTime: ev.Time` and a zero-valued `LastEvent`. If the Workload is already admitted when first observed, the `ev.Admitted && !state.LastEvent.Admitted` branch fires on that same event and computes `ev.Time.Sub(ev.Time)` — reporting 0ms. More generally, any Workload first observed after its creation is credited with a shorter wait than it actually had, which drags `averageTimeToAdmissionMs` down.

This carries the Workload's creation timestamp on the recorded event and measures both admission and finish latency from it, falling back to the first observed event when the timestamp is unavailable.

The issue reports admission latency specifically; `TimeToFinishedMs` is computed from the same baseline and had the same problem, so it is fixed here too. Happy to split that out if you'd prefer the PR scoped strictly to the reported symptom.

**Which issue(s) this PR fixes**:

Fixes #11870

**Special notes for your reviewer**:

The recorder package had no unit tests. This adds coverage for the latency
baseline, the fallback path, and eviction counting. Against the previous
behaviour the new tests fail as follows, which matches the symptom in the
issue (920/4000 workloads reporting < 1000ms):

```
--- FAIL: TestRecordWLEventLatencies/first_observed_already_admitted
    unexpected TimeToAdmitMs (-want +got):
      int64(
    - 	30000,
    + 	0,
      )
```

Disclosure: this change was prepared with the assistance of an AI coding agent. The analysis, the fix, and the tests were reviewed against the source before submitting.

**Does this PR introduce a user-facing change?**

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workload latency measurements by using the workload creation time when available.
  - Preserved accurate latency tracking when creation timestamps are unavailable.
  - Prevented repeated eviction observations from being counted multiple times.

- **Tests**
  - Added coverage for latency calculations, fallback timing behavior, and eviction counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->