### PR TITLE
Skip usage of ResourceSlice API when it's not available

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -79,6 +79,7 @@ import (
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption/fairsharing"
 	"sigs.k8s.io/kueue/pkg/util/cert"
+	utildra "sigs.k8s.io/kueue/pkg/util/dra"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utillogging "sigs.k8s.io/kueue/pkg/util/logging"
@@ -373,7 +374,9 @@ func main() {
 	}
 	queues := qcache.NewManager(mgr.GetClient(), cCache, requeuer, queueOptions...)
 
-	if err := setupIndexes(ctx, mgr, &cfg); err != nil {
+	resourceSliceAPIAvailable := utildra.CheckResourceSliceAPIAvailable(mgr)
+
+	if err := setupIndexes(ctx, mgr, &cfg, resourceSliceAPIAvailable); err != nil {
 		setupLog.Error(err, "Unable to setup indexes")
 		os.Exit(1)
 	}
@@ -406,12 +409,13 @@ func main() {
 	}
 
 	controllerOpts := core.SetupControllersOpts{
-		RoleTracker:            roleTracker,
-		PreemptionExpectations: preemptionExpectations,
-		CustomLabels:           customLabels,
-		DRAMapper:              draMapper,
-		DRABackedResources:     draBackedResources,
-		ResourceFormatter:      resourceFormatter,
+		RoleTracker:               roleTracker,
+		PreemptionExpectations:    preemptionExpectations,
+		CustomLabels:              customLabels,
+		DRAMapper:                 draMapper,
+		DRABackedResources:        draBackedResources,
+		ResourceFormatter:         resourceFormatter,
+		ResourceSliceAPIAvailable: resourceSliceAPIAvailable,
 	}
 	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, controllerOpts); err != nil {
 		setupLog.Error(err, "Unable to setup controllers")
@@ -447,7 +451,7 @@ func main() {
 	}
 }
 
-func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration) error {
+func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration, resourceSliceAPIAvailable bool) error {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	if err != nil {
 		return err
@@ -475,7 +479,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 		}
 	}
 
-	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) || features.Enabled(features.KueueDRAIntegrationConsumableCapacity) {
+	if resourceSliceAPIAvailable {
 		if err := core.SetupResourceSliceIndexer(ctx, mgr.GetFieldIndexer()); err != nil {
 			return fmt.Errorf("could not setup ResourceSlice indexer: %w", err)
 		}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -19,7 +19,10 @@ package core
 import (
 	"time"
 
+	resourcev1 "k8s.io/api/resource/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -41,12 +44,13 @@ const (
 
 // SetupControllersOpts holds optional dependencies for SetupControllers.
 type SetupControllersOpts struct {
-	RoleTracker            *roletracker.RoleTracker
-	PreemptionExpectations *expectations.Store
-	CustomLabels           *metrics.CustomLabels
-	DRAMapper              *dra.ResourceMapper
-	DRABackedResources     *dra.ExtendedResourceCache
-	ResourceFormatter      *resources.ResourceFormatter
+	RoleTracker               *roletracker.RoleTracker
+	PreemptionExpectations    *expectations.Store
+	CustomLabels              *metrics.CustomLabels
+	DRAMapper                 *dra.ResourceMapper
+	DRABackedResources        *dra.ExtendedResourceCache
+	ResourceFormatter         *resources.ResourceFormatter
+	ResourceSliceAPIAvailable bool
 }
 
 // SetupControllers sets up the core controllers. It returns the name of the
@@ -113,6 +117,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		WithDRAMapper(opts.DRAMapper),
 		WithDRABackedResources(opts.DRABackedResources),
 		WithResourceFormatter(opts.ResourceFormatter),
+		WithResourceSliceAPIAvailable(opts.ResourceSliceAPIAvailable),
 	)
 	if features.Enabled(features.KueueDRAIntegration) {
 		qManager.SetDRAReconcileChannel(workloadRec.GetDRAReconcileChannel())
@@ -122,7 +127,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		return "Workload", err
 	}
 
-	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) || features.Enabled(features.KueueDRAIntegrationConsumableCapacity) {
+	if opts.ResourceSliceAPIAvailable {
 		rsRec := NewResourceSliceReconciler(qManager, cc, cfg, opts.RoleTracker)
 		if err := rsRec.SetupWithManager(mgr, cfg); err != nil {
 			return "ResourceSlice", err
@@ -163,4 +168,16 @@ func workloadRetention(cfg *configapi.ObjectRetentionPolicies) *workloadRetentio
 	return &workloadRetentionConfig{
 		afterFinished: &cfg.Workloads.AfterFinished.Duration,
 	}
+}
+
+// ServerSupportsResourceSlice checks if the server supports the ResourceSlice API (resource.k8s.io/v1).
+func ServerSupportsResourceSlice(mgr manager.Manager) error {
+	gvk, err := apiutil.GVKForObject(&resourcev1.ResourceSlice{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+	if _, err = mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -252,6 +252,16 @@ func WithDRABackedResources(value *dra.ExtendedResourceCache) Option {
 	}
 }
 
+// WithResourceSliceAPIAvailable indicates whether the ResourceSlice API
+// (resource.k8s.io/v1) is available on the cluster. When false, the
+// KueueDRAIntegrationPartitionableDevices and KueueDRAIntegrationConsumableCapacity
+// code paths are skipped to avoid reconciliation errors on clusters without ResourceSlice API.
+func WithResourceSliceAPIAvailable(value bool) Option {
+	return func(r *WorkloadReconciler) {
+		r.resourceSliceAPIAvailable = value
+	}
+}
+
 // WithResourceFormatter sets the formatter used for resource quantities written by the controller.
 func WithResourceFormatter(value *resources.ResourceFormatter) Option {
 	return func(r *WorkloadReconciler) {
@@ -265,23 +275,24 @@ type WorkloadUpdateWatcher interface {
 
 // WorkloadReconciler reconciles a Workload object
 type WorkloadReconciler struct {
-	logName                string
-	queues                 *qcache.Manager
-	cache                  *schdcache.Cache
-	client                 client.Client
-	watchers               []WorkloadUpdateWatcher
-	waitForPodsReady       *waitForPodsReadyConfig
-	recorder               events.EventRecorder
-	clock                  clock.Clock
-	workloadRetention      *workloadRetentionConfig
-	draReconcileChannel    chan event.TypedGenericEvent[*kueue.Workload]
-	draMapper              *dra.ResourceMapper
-	draBackedResources     *dra.ExtendedResourceCache
-	admissionFSConfig      *config.AdmissionFairSharing
-	roleTracker            *roletracker.RoleTracker
-	preemptionExpectations *expectations.Store
-	customLabels           *metrics.CustomLabels
-	resourceFormatter      *resources.ResourceFormatter
+	logName                   string
+	queues                    *qcache.Manager
+	cache                     *schdcache.Cache
+	client                    client.Client
+	watchers                  []WorkloadUpdateWatcher
+	waitForPodsReady          *waitForPodsReadyConfig
+	recorder                  events.EventRecorder
+	clock                     clock.Clock
+	workloadRetention         *workloadRetentionConfig
+	draReconcileChannel       chan event.TypedGenericEvent[*kueue.Workload]
+	draMapper                 *dra.ResourceMapper
+	draBackedResources        *dra.ExtendedResourceCache
+	resourceSliceAPIAvailable bool
+	admissionFSConfig         *config.AdmissionFairSharing
+	roleTracker               *roletracker.RoleTracker
+	preemptionExpectations    *expectations.Store
+	customLabels              *metrics.CustomLabels
+	resourceFormatter         *resources.ResourceFormatter
 }
 
 var _ reconcile.Reconciler = (*WorkloadReconciler)(nil)
@@ -515,7 +526,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		draResources = mergeDRAResources(draResources, extendedResources)
 
 		// Process counter-based resources for partitionable devices
-		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
+		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && r.resourceSliceAPIAvailable {
 			counterResources, counterFieldErrs := dra.GetCounterResourcesForWorkload(ctx, r.client, sliceCache, r.draMapper, &wl)
 			if len(counterFieldErrs) > 0 {
 				err := counterFieldErrs.ToAggregate()
@@ -540,7 +551,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 
 		// Process capacity-based resources for consumable capacity devices
-		if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) {
+		if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && r.resourceSliceAPIAvailable {
 			ccResources, done, result, ccErr := r.handleDRAConsumableCapacity(ctx, &wl, sliceCache, draResources)
 			if done {
 				return result, ccErr

--- a/pkg/util/dra/dra.go
+++ b/pkg/util/dra/dra.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+// checkResourceSliceAPIAvailable returns true when at least one of the ResourceSlice-dependent
+// feature gates is enabled and the ResourceSlice API (resource.k8s.io/v1) is available
+// on the cluster.
+func CheckResourceSliceAPIAvailable(mgr ctrl.Manager) bool {
+	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) || features.Enabled(features.KueueDRAIntegrationConsumableCapacity) {
+		if err := core.ServerSupportsResourceSlice(mgr); err != nil {
+			ctrl.Log.V(0).Info("ResourceSlice API not available, skipping DRA partitionable and consumable capacity features", "reason", err)
+		} else {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/dra/dra_test.go
+++ b/pkg/util/dra/dra_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"net/http"
+	"testing"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+var resourceSliceGVK = resourcev1.SchemeGroupVersion.WithKind("ResourceSlice")
+
+func TestCheckResourceSliceAPIAvailable(t *testing.T) {
+	cases := map[string]struct {
+		partitionableDevicesFeatureGate bool
+		consumableCapacityFeatureGate   bool
+		ResourceSliceAvailable          bool
+		want                            bool
+	}{
+		"no feature gates enabled": {
+			partitionableDevicesFeatureGate: false,
+			consumableCapacityFeatureGate:   false,
+			ResourceSliceAvailable:          true,
+			want:                            false,
+		},
+		"KueueDRAIntegrationPartitionableDevices enabled, API available": {
+			partitionableDevicesFeatureGate: true,
+			consumableCapacityFeatureGate:   false,
+			ResourceSliceAvailable:          true,
+			want:                            true,
+		},
+		"KueueDRAIntegrationConsumableCapacity enabled, API available": {
+			partitionableDevicesFeatureGate: false,
+			consumableCapacityFeatureGate:   true,
+			ResourceSliceAvailable:          true,
+			want:                            true,
+		},
+		"both feature gates enabled, API available": {
+			partitionableDevicesFeatureGate: true,
+			consumableCapacityFeatureGate:   true,
+			ResourceSliceAvailable:          true,
+			want:                            true,
+		},
+		"KueueDRAIntegrationPartitionableDevices enabled, API unavailable": {
+			partitionableDevicesFeatureGate: true,
+			consumableCapacityFeatureGate:   false,
+			ResourceSliceAvailable:          false,
+			want:                            false,
+		},
+		"KueueDRAIntegrationConsumableCapacity enabled, API unavailable": {
+			partitionableDevicesFeatureGate: false,
+			consumableCapacityFeatureGate:   true,
+			ResourceSliceAvailable:          false,
+			want:                            false,
+		},
+		"both feature gates enabled, API unavailable": {
+			partitionableDevicesFeatureGate: true,
+			consumableCapacityFeatureGate:   true,
+			ResourceSliceAvailable:          false,
+			want:                            false,
+		},
+	}
+	k8sClient := utiltesting.NewClientBuilder().Build()
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationPartitionableDevices, tc.partitionableDevicesFeatureGate)
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationConsumableCapacity, tc.consumableCapacityFeatureGate)
+
+			mgr, err := ctrlmgr.New(&rest.Config{}, ctrlmgr.Options{
+				Scheme: k8sClient.Scheme(),
+				NewClient: func(*rest.Config, client.Options) (client.Client, error) {
+					return k8sClient, nil
+				},
+				MapperProvider: func(*rest.Config, *http.Client) (apimeta.RESTMapper, error) {
+					mapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{resourceSliceGVK.GroupVersion()})
+					if tc.ResourceSliceAvailable {
+						mapper.Add(resourceSliceGVK, apimeta.RESTScopeRoot)
+					}
+					return mapper, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			got := CheckResourceSliceAPIAvailable(mgr)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -147,10 +147,11 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			cCache,
 			controllersCfg,
 			core.SetupControllersOpts{
-				PreemptionExpectations: preemptionExpectations,
-				DRAMapper:              draMapper,
-				DRABackedResources:     draBackedResources,
-				ResourceFormatter:      resourceFormatter,
+				PreemptionExpectations:    preemptionExpectations,
+				DRAMapper:                 draMapper,
+				DRABackedResources:        draBackedResources,
+				ResourceFormatter:         resourceFormatter,
+				ResourceSliceAPIAvailable: true,
 			},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)


### PR DESCRIPTION

#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The Feature Gate `KueueDRAIntegrationPartitionableDevices` is enabled by default and if Resources API is not available in the cluster, the kueue-controller-manager would crashloop. This commit fixes the issue by adding checks that skip the `KueueDRAIntegrationPartitionableDevices` and `KueueDRAIntegrationConsumableCapacity` path if resource API is not available.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13600

#### Special notes for your reviewer:
This PR was developed with the assistance of Claude.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fixed a startup crash when `KueueDRAIntegrationPartitionableDevices` or `KueueDRAIntegrationConsumableCapacity` feature gates are enabled but the ResourceSlice API (`resource.k8s.io/v1`) is not available on the cluster.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with clusters that do not support the Kubernetes ResourceSlice API.
  * ResourceSlice-dependent workload processing and controller features now activate only when the API is available and relevant DRA features are enabled.
  * Added validation and test coverage for ResourceSlice API detection across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->