### PR TITLE
TAS Scheduler PodSetSliceSize API validation

### DIFF
--- a/apis/kueue/v1beta1/workload_types.go
+++ b/apis/kueue/v1beta1/workload_types.go
@@ -148,6 +148,7 @@ type PodSetTopologyRequest struct {
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 }
 

--- a/apis/kueue/v1beta2/workload_types.go
+++ b/apis/kueue/v1beta2/workload_types.go
@@ -232,6 +232,7 @@ type PodSetTopologyRequest struct {
 	// in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
 	//
 	// +optional
+	// +kubebuilder:validation:Minimum=1
 	PodSetSliceSize *int32 `json:"podSetSliceSize,omitempty"`
 
 	// podsetSliceRequiredTopologyConstraints defines all layers of slice

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_workloads.yaml
@@ -8307,6 +8307,7 @@ spec:
                               Kueue finds a requested topology domain on a level defined
                               in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                             format: int32
+                            minimum: 1
                             type: integer
                           preferred:
                             description: |-
@@ -17211,6 +17212,7 @@ spec:
                               Kueue finds a requested topology domain on a level defined
                               in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                             format: int32
+                            minimum: 1
                             type: integer
                           podsetSliceRequiredTopologyConstraints:
                             description: |-

--- a/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_workloads.yaml
@@ -8758,6 +8758,7 @@ spec:
                             Kueue finds a requested topology domain on a level defined
                             in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                           format: int32
+                          minimum: 1
                           type: integer
                         preferred:
                           description: |-
@@ -18198,6 +18199,7 @@ spec:
                             Kueue finds a requested topology domain on a level defined
                             in `kueue.x-k8s.io/podset-slice-required-topology` annotation.
                           format: int32
+                          minimum: 1
                           type: integer
                         podsetSliceRequiredTopologyConstraints:
                           description: |-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/area tas

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

This PR adds API-level validation for Workload PodSetTopologyRequest PodSetSliceSize so invalid value 0 is rejected at admission time.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:
This is an API validation hardening change only.
Existing valid workloads are unaffected.
Workloads with PodSetSliceSize: 0 will now be rejected by CRD validation.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Workload PodSetTopologyRequest PodSetSliceSize is now validated to be at least 1. Creating or updating workloads with PodSetSliceSize set to 0 is rejected by API validation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation to require pod set slice sizes to be at least 1.
  * Updated workload CRD schema validation to reject zero or negative topology-related integer values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->