### PR TITLE
feat: Support Workload custom labels in LocalQueue admitted workload metrics

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -548,7 +548,7 @@ func (c *clusterQueue) resyncAdmittedActiveWorkloads() {
 	for wlRef, wl := range c.Workloads {
 		if workload.IsActive(wl.Obj) && workload.IsAdmitted(wl.Obj) {
 			metrics.ReportAdmittedActiveWorkloads(c.Name, 1, c.getLabelValuesFor(wlRef), c.roleTracker)
-			
+
 			qKey := queue.KeyFromWorkload(wl.Obj)
 			if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
 				lqRef := metrics.LocalQueueReference{Name: wl.Obj.Spec.QueueName, Namespace: wl.Obj.Namespace}

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -544,7 +544,6 @@ func (c *clusterQueue) reportActiveWorkloads() {
 	metrics.ReportReservingActiveWorkloads(c.Name, len(c.Workloads), clVals, c.roleTracker)
 }
 
-
 func (c *clusterQueue) reportAdmittedActiveWorkloads(wlRef workload.Reference, wl *kueue.Workload, incr int) {
 	metrics.ReportAdmittedActiveWorkloads(c.Name, incr, c.getLabelValuesFor(wlRef), c.roleTracker)
 

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -548,6 +548,12 @@ func (c *clusterQueue) resyncAdmittedActiveWorkloads() {
 	for wlRef, wl := range c.Workloads {
 		if workload.IsActive(wl.Obj) && workload.IsAdmitted(wl.Obj) {
 			metrics.ReportAdmittedActiveWorkloads(c.Name, 1, c.getLabelValuesFor(wlRef), c.roleTracker)
+			
+			qKey := queue.KeyFromWorkload(wl.Obj)
+			if _, ok := c.localQueues[qKey]; ok {
+				lqRef := metrics.LocalQueueReference{Name: wl.Obj.Spec.QueueName, Namespace: wl.Obj.Namespace}
+				metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, 1, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
+			}
 		}
 	}
 }
@@ -614,6 +620,12 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, o
 
 		wlRef := workload.Key(wi.Obj)
 		metrics.ReportAdmittedActiveWorkloads(c.Name, incr, c.getLabelValuesFor(wlRef), c.roleTracker)
+
+		qKey := queue.KeyFromWorkload(wi.Obj)
+		if _, ok := c.localQueues[qKey]; ok {
+			lqRef := metrics.LocalQueueReference{Name: wi.Obj.Spec.QueueName, Namespace: wi.Obj.Namespace}
+			metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, incr, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
+		}
 	}
 	qKey := queue.KeyFromWorkload(wi.Obj)
 	if lq, ok := c.localQueues[qKey]; ok {
@@ -633,6 +645,13 @@ func (c *clusterQueue) getLabelValuesFor(wlRef workload.Reference) []string {
 	return c.customLabels.GetFor(map[cfg.SourceKind]string{
 		cfg.SourceKindWorkload:     string(wlRef),
 		cfg.SourceKindClusterQueue: string(c.Name),
+	})
+}
+
+func (c *clusterQueue) getLQLabelValuesFor(wlRef workload.Reference, lqKey string) []string {
+	return c.customLabels.GetFor(map[cfg.SourceKind]string{
+		cfg.SourceKindWorkload:   string(wlRef),
+		cfg.SourceKindLocalQueue: lqKey,
 	})
 }
 

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -544,16 +544,21 @@ func (c *clusterQueue) reportActiveWorkloads() {
 	metrics.ReportReservingActiveWorkloads(c.Name, len(c.Workloads), clVals, c.roleTracker)
 }
 
+
+func (c *clusterQueue) reportAdmittedActiveWorkloads(wlRef workload.Reference, wl *kueue.Workload, incr int) {
+	metrics.ReportAdmittedActiveWorkloads(c.Name, incr, c.getLabelValuesFor(wlRef), c.roleTracker)
+
+	qKey := queue.KeyFromWorkload(wl)
+	if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
+		lqRef := metrics.LocalQueueReference{Name: wl.Spec.QueueName, Namespace: wl.Namespace}
+		metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, incr, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
+	}
+}
+
 func (c *clusterQueue) resyncAdmittedActiveWorkloads() {
 	for wlRef, wl := range c.Workloads {
 		if workload.IsActive(wl.Obj) && workload.IsAdmitted(wl.Obj) {
-			metrics.ReportAdmittedActiveWorkloads(c.Name, 1, c.getLabelValuesFor(wlRef), c.roleTracker)
-
-			qKey := queue.KeyFromWorkload(wl.Obj)
-			if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
-				lqRef := metrics.LocalQueueReference{Name: wl.Obj.Spec.QueueName, Namespace: wl.Obj.Namespace}
-				metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, 1, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
-			}
+			c.reportAdmittedActiveWorkloads(wlRef, wl.Obj, 1)
 		}
 	}
 }
@@ -619,13 +624,7 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, o
 		c.admittedWorkloadsCount += incr
 
 		wlRef := workload.Key(wi.Obj)
-		metrics.ReportAdmittedActiveWorkloads(c.Name, incr, c.getLabelValuesFor(wlRef), c.roleTracker)
-
-		qKey := queue.KeyFromWorkload(wi.Obj)
-		if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
-			lqRef := metrics.LocalQueueReference{Name: wi.Obj.Spec.QueueName, Namespace: wi.Obj.Namespace}
-			metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, incr, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
-		}
+		c.reportAdmittedActiveWorkloads(wlRef, wi.Obj, incr)
 	}
 	qKey := queue.KeyFromWorkload(wi.Obj)
 	if lq, ok := c.localQueues[qKey]; ok {

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -550,7 +550,7 @@ func (c *clusterQueue) resyncAdmittedActiveWorkloads() {
 			metrics.ReportAdmittedActiveWorkloads(c.Name, 1, c.getLabelValuesFor(wlRef), c.roleTracker)
 			
 			qKey := queue.KeyFromWorkload(wl.Obj)
-			if _, ok := c.localQueues[qKey]; ok {
+			if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
 				lqRef := metrics.LocalQueueReference{Name: wl.Obj.Spec.QueueName, Namespace: wl.Obj.Namespace}
 				metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, 1, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
 			}
@@ -622,7 +622,7 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, o
 		metrics.ReportAdmittedActiveWorkloads(c.Name, incr, c.getLabelValuesFor(wlRef), c.roleTracker)
 
 		qKey := queue.KeyFromWorkload(wi.Obj)
-		if _, ok := c.localQueues[qKey]; ok {
+		if lq, ok := c.localQueues[qKey]; ok && lq.shouldExposeMetrics(c.lqMetrics) {
 			lqRef := metrics.LocalQueueReference{Name: wi.Obj.Spec.QueueName, Namespace: wi.Obj.Namespace}
 			metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, incr, c.getLQLabelValuesFor(wlRef, string(qKey)), c.roleTracker)
 		}

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -81,7 +81,6 @@ func (q *LocalQueue) reportActiveWorkloads(tracker *roletracker.RoleTracker) {
 		Name:      name,
 		Namespace: namespace,
 	}
-	metrics.ReportLocalQueueAdmittedActiveWorkloads(lqRef, q.admittedWorkloads, q.customMetricLabelValues(), tracker)
 	metrics.ReportLocalQueueReservingActiveWorkloads(lqRef, q.reservingWorkloads, q.customMetricLabelValues(), tracker)
 }
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -801,6 +801,9 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			if r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, &wl) {
 				lqRef := metrics.LQRefFromWorkload(&wl)
 				lqKey := qutil.KeyFromWorkload(&wl)
+				if features.Enabled(features.CustomMetricLabels) {
+					r.customLabels.Store(config.SourceKindWorkload, string(workload.Key(&wl)), wl.Labels, wl.Annotations)
+				}
 				metrics.LocalQueueAdmittedWorkload(
 					lqRef,
 					priorityClassName,

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -801,9 +801,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			if r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, &wl) {
 				lqRef := metrics.LQRefFromWorkload(&wl)
 				lqKey := qutil.KeyFromWorkload(&wl)
-				if features.Enabled(features.CustomMetricLabels) {
-					r.customLabels.Store(config.SourceKindWorkload, string(workload.Key(&wl)), wl.Labels, wl.Annotations)
-				}
+
 				metrics.LocalQueueAdmittedWorkload(
 					lqRef,
 					priorityClassName,

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -805,7 +805,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 					lqRef,
 					priorityClassName,
 					queuedWaitTime,
-					r.customLabels.LQGet(lqKey),
+					r.customLabels.GetFor(map[config.SourceKind]string{
+						config.SourceKindLocalQueue: string(lqKey),
+						config.SourceKindWorkload:   string(workload.Key(&wl)),
+					}),
 					r.roleTracker,
 				)
 				metrics.ReportLocalQueueAdmissionChecksWaitTime(

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -561,7 +561,7 @@ The label 'underlying_cause' can have the following values:
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_workloads_total",
 			Help:      "The total number of admitted workloads per 'local_queue'",
-		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, localQueueMetricsLabels...),
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, cl.LabelNames(configapi.SourceKindLocalQueue, configapi.SourceKindWorkload)...),
 	)
 
 	AdmissionWaitTime = prometheus.NewHistogramVec(
@@ -597,7 +597,7 @@ The label 'underlying_cause' can have the following values:
 			Name:      "local_queue_admission_wait_time_seconds",
 			Help:      "The time between a workload was created or requeued until admission, per 'local_queue'",
 			Buckets:   generateExponentialBuckets(14),
-		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, localQueueMetricsLabels...),
+		}, append([]string{"name", "namespace", "priority_class", "replica_role"}, cl.LabelNames(configapi.SourceKindLocalQueue, configapi.SourceKindWorkload)...),
 	)
 
 	AdmissionChecksWaitTime = prometheus.NewHistogramVec(
@@ -791,7 +791,7 @@ The label 'reason' can have the following values:
 			Subsystem: constants.KueueName,
 			Name:      "local_queue_admitted_active_workloads",
 			Help:      "The number of admitted Workloads that are active, per 'localQueue'",
-		}, append([]string{"name", "namespace", "replica_role"}, localQueueMetricsLabels...),
+		}, append([]string{"name", "namespace", "replica_role"}, cl.LabelNames(configapi.SourceKindLocalQueue, configapi.SourceKindWorkload)...),
 	)
 	trackGaugeVec(LocalQueueAdmittedActiveWorkloads, gaugeCleanupScopeLocalQueueCache)
 
@@ -1408,9 +1408,9 @@ func ReportReservingActiveWorkloads(cqName kueue.ClusterQueueReference, count in
 	ReservingActiveWorkloads.WithLabelValues(labels...).Set(float64(count))
 }
 
-func ReportLocalQueueAdmittedActiveWorkloads(lq LocalQueueReference, count int, customLabelValues []string, tracker *roletracker.RoleTracker) {
+func ReportLocalQueueAdmittedActiveWorkloads(lq LocalQueueReference, incr int, customLabelValues []string, tracker *roletracker.RoleTracker) {
 	labels := append([]string{string(lq.Name), lq.Namespace, roletracker.GetRole(tracker)}, customLabelValues...)
-	LocalQueueAdmittedActiveWorkloads.WithLabelValues(labels...).Set(float64(count))
+	LocalQueueAdmittedActiveWorkloads.WithLabelValues(labels...).Add(float64(incr))
 }
 
 func ReportLocalQueueReservingActiveWorkloads(lq LocalQueueReference, count int, customLabelValues []string, tracker *roletracker.RoleTracker) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1135,6 +1135,9 @@ func (s *Scheduler) recordWorkloadAdmissionEvents(log logr.Logger, newWorkload, 
 	shouldExposeLqMetrics := s.cache.ShouldExposeLocalQueueMetricsForWorkload(log, newWorkload)
 	if shouldExposeLqMetrics {
 		lqRef := metrics.LQRefFromWorkload(newWorkload)
+		if features.Enabled(features.CustomMetricLabels) {
+			s.customLabels.Store(config.SourceKindWorkload, string(workload.Key(newWorkload)), newWorkload.Labels, newWorkload.Annotations)
+		}
 		lqCustomLabelsValues := s.customLabels.GetFor(map[config.SourceKind]string{
 			config.SourceKindLocalQueue: string(utilqueue.KeyFromWorkload(newWorkload)),
 			config.SourceKindWorkload:   string(workload.Key(newWorkload)),

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1135,8 +1135,11 @@ func (s *Scheduler) recordWorkloadAdmissionEvents(log logr.Logger, newWorkload, 
 	shouldExposeLqMetrics := s.cache.ShouldExposeLocalQueueMetricsForWorkload(log, newWorkload)
 	if shouldExposeLqMetrics {
 		lqRef := metrics.LQRefFromWorkload(newWorkload)
-		lqCustomLabels := s.customLabels.LQGet(utilqueue.KeyFromWorkload(newWorkload))
-		metrics.LocalQueueAdmittedWorkload(lqRef, priorityClassName, waitTime, lqCustomLabels, s.roleTracker)
+		lqCustomLabelsValues := s.customLabels.GetFor(map[config.SourceKind]string{
+			config.SourceKindLocalQueue: string(utilqueue.KeyFromWorkload(newWorkload)),
+			config.SourceKindWorkload:   string(workload.Key(newWorkload)),
+		})
+		metrics.LocalQueueAdmittedWorkload(lqRef, priorityClassName, waitTime, lqCustomLabelsValues, s.roleTracker)
 	}
 
 	if len(newWorkload.Status.AdmissionChecks) > 0 {

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -1059,7 +1059,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind values")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 2, "ml-team", "kind1", "anno1")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2", "anno2")
-			
+
 			ginkgo.By("verifying LQ admitted workloads metrics includes custom_wl_kind, custom_wl_anno, and lq_label values")
 			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 2, "lq-val", "kind1", "anno1")
 			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind2", "anno2")

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -988,7 +988,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
 				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
 				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: ptr.To(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
-				{Name: "wl_anno", SourceAnnotationKey: "workload-anno", SourceKind: ptr.To(config.SourceKindWorkload)},
+				{Name: "wl_anno", SourceAnnotationKey: "workload-anno", SourceKind: ptr.To(config.SourceKindWorkload), TrackedValues: []string{"anno1", "anno2"}},
 				{Name: "lq_label", SourceLabelKey: "lq-label", SourceKind: ptr.To(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -988,6 +988,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
 				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
 				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: ptr.To(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
+				{Name: "wl_anno", SourceAnnotationKey: "workload-anno", SourceKind: ptr.To(config.SourceKindWorkload)},
+				{Name: "lq_label", SourceLabelKey: "lq-label", SourceKind: ptr.To(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -1015,22 +1017,26 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).
 				ClusterQueue(cq.Name).Obj()
+			lq.Labels = map[string]string{"lq-label": "lq-val"}
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
 			wl1 := utiltestingapi.MakeWorkload("wl1", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
 			wl2 := utiltestingapi.MakeWorkload("wl2", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl2)
 
 			wl3 := utiltestingapi.MakeWorkload("wl3", ns.Name).
 				Label("workload-kind", "kind2").
+				Annotation("workload-anno", "anno2").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl3)
@@ -1051,23 +1057,29 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind values")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 2, "ml-team", "kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 2, "ml-team", "kind1", "anno1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2", "anno2")
 			
-			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind values")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 2, "kind1")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind2")
+			ginkgo.By("verifying LQ admitted workloads metrics includes custom_wl_kind, custom_wl_anno, and lq_label values")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 2, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind2", "anno2")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 2, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind2", "anno2")
+			util.ExpectLQAdmissionWaitTimeMetric(lq, "", 2, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmissionWaitTimeMetric(lq, "", 1, "lq-val", "kind2", "anno2")
 
 			ginkgo.By("marking two workloads as finished")
 			util.FinishWorkloads(ctx, k8sClient, wl1, wl3)
 
 			ginkgo.By("verifying CQ admitted active workloads metric is updated")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1", "anno1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2", "anno2")
 
-			ginkgo.By("verifying LQ admitted active workloads metric is updated")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind2")
+			ginkgo.By("verifying LQ admitted workloads metrics are updated")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "lq-val", "kind2", "anno2")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 2, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind2", "anno2")
 		})
 
 		ginkgo.It("should update AdmittedActiveWorkloads metric when workload labels match and we change CQ labels", func() {
@@ -1081,10 +1093,12 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).
 				ClusterQueue(cq.Name).Obj()
+			lq.Labels = map[string]string{"lq-label": "lq-val"}
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
 			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
@@ -1097,7 +1111,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind=kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1", "anno1")
 
 			ginkgo.By("updating CQ team label")
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1108,8 +1122,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric updates to data-team")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "data-team", "kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "data-team", "kind1", "anno1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1", "anno1")
 		})
 
 		ginkgo.It("should update AdmittedActiveWorkloads metric when we update the labels on the workload", func() {
@@ -1123,10 +1137,12 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).
 				ClusterQueue(cq.Name).Obj()
+			lq.Labels = map[string]string{"lq-label": "lq-val"}
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
 			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
@@ -1139,12 +1155,14 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind=kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1", "anno1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2", "anno1")
 
-			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind=kind1")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind2")
+			ginkgo.By("verifying LQ admitted workloads metrics includes custom_wl_kind=kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "lq-val", "kind2", "anno1")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmissionWaitTimeMetric(lq, "", 1, "lq-val", "kind1", "anno1")
 
 			ginkgo.By("updating workload custom label value")
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1155,12 +1173,12 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric updates to kind2")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2", "anno1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1", "anno1")
 
-			ginkgo.By("verifying LQ admitted active workloads metric updates to kind2")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind2")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind1")
+			ginkgo.By("verifying LQ admitted workloads metrics updates to kind2")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind2", "anno1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "lq-val", "kind1", "anno1")
 		})
 
 		ginkgo.It("should update/decrement AdmittedActiveWorkloads metric when workload is deleted", func() {
@@ -1174,10 +1192,12 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 			lq := utiltestingapi.MakeLocalQueue("lq", ns.Name).
 				ClusterQueue(cq.Name).Obj()
+			lq.Labels = map[string]string{"lq-label": "lq-val"}
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
 			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl)
@@ -1190,19 +1210,21 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind=kind1")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1", "anno1")
 
-			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind=kind1")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
+			ginkgo.By("verifying LQ admitted workloads metrics includes custom_wl_kind=kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind1", "anno1")
 
 			ginkgo.By("deleting workload")
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
 
 			ginkgo.By("verifying CQ admitted active workloads metric is updated/decremented")
-			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1")
+			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1", "anno1")
 
-			ginkgo.By("verifying LQ admitted active workloads metric is updated/decremented")
-			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind1")
+			ginkgo.By("verifying LQ admitted workloads metrics are updated/decremented")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "lq-val", "kind1", "anno1")
+			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind1", "anno1")
 		})
 	})
 })

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -983,6 +983,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 		ginkgo.BeforeEach(func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
 				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
@@ -1052,6 +1053,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind values")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 2, "ml-team", "kind1")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2")
+			
+			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind values")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 2, "kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind2")
 
 			ginkgo.By("marking two workloads as finished")
 			util.FinishWorkloads(ctx, k8sClient, wl1, wl3)
@@ -1059,6 +1064,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying CQ admitted active workloads metric is updated")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2")
+
+			ginkgo.By("verifying LQ admitted active workloads metric is updated")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind2")
 		})
 
 		ginkgo.It("should update AdmittedActiveWorkloads metric when workload labels match and we change CQ labels", func() {
@@ -1133,6 +1142,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind2")
 
+			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind=kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind2")
+
 			ginkgo.By("updating workload custom label value")
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
@@ -1144,6 +1157,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying CQ admitted active workloads metric updates to kind2")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind2")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1")
+
+			ginkgo.By("verifying LQ admitted active workloads metric updates to kind2")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind2")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind1")
 		})
 
 		ginkgo.It("should update/decrement AdmittedActiveWorkloads metric when workload is deleted", func() {
@@ -1175,11 +1192,17 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			ginkgo.By("verifying CQ admitted active workloads metric includes custom_team_cq=ml-team and custom_wl_kind=kind1")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 1, "ml-team", "kind1")
 
+			ginkgo.By("verifying LQ admitted active workloads metric includes custom_wl_kind=kind1")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 1, "kind1")
+
 			ginkgo.By("deleting workload")
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
 
 			ginkgo.By("verifying CQ admitted active workloads metric is updated/decremented")
 			util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(cq.Name), 0, "ml-team", "kind1")
+
+			ginkgo.By("verifying LQ admitted active workloads metric is updated/decremented")
+			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "kind1")
 		})
 	})
 })

--- a/test/util/metrics.go
+++ b/test/util/metrics.go
@@ -280,9 +280,10 @@ func expectCounterMetric(metric *prometheus.CounterVec, count int, lvs ...string
 	expectCounterMetricWithTimeout(metric, count, Timeout, lvs...)
 }
 
-func ExpectLQAdmissionWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string, count int) {
+func ExpectLQAdmissionWaitTimeMetric(lq *kueue.LocalQueue, priorityClass string, count int, customLabels ...string) {
 	ginkgo.GinkgoHelper()
-	expectHistogramMetric(metrics.LocalQueueAdmissionWaitTime, gomega.Equal(count), lq.Name, lq.Namespace, priorityClass, roletracker.RoleStandalone)
+	lvs := append([]string{lq.Name, lq.Namespace, priorityClass, roletracker.RoleStandalone}, customLabels...)
+	expectHistogramMetric(metrics.LocalQueueAdmissionWaitTime, gomega.Equal(count), lvs...)
 }
 
 func ExpectClusterQueueStatusMetric(cq *kueue.ClusterQueue, status metrics.ClusterQueueStatus, customLabelValues ...string) {
@@ -389,6 +390,12 @@ func ExpectAdmittedActiveWorkloadsGaugeMetric(clusterQueue kueue.ClusterQueueRef
 	ginkgo.GinkgoHelper()
 	lvs := append([]string{string(clusterQueue), roletracker.RoleStandalone}, customLabels...)
 	expectGaugeMetric(metrics.AdmittedActiveWorkloads, lvs, gomega.Equal(count))
+}
+
+func ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq *kueue.LocalQueue, count float64, customLabels ...string) {
+	ginkgo.GinkgoHelper()
+	lvs := append([]string{lq.Name, lq.Namespace, roletracker.RoleStandalone}, customLabels...)
+	expectGaugeMetric(metrics.LocalQueueAdmittedActiveWorkloads, lvs, gomega.Equal(count))
 }
 
 func ExpectCohortSubtreeAdmittedActiveWorkloadsGaugeMetric(cohortName kueue.CohortReference, count float64) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area testing
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Adds support for `SourceKindWorkload` custom metric labels on LocalQueue admitted workload metrics (`local_queue_admitted_active_workloads`, `local_queue_admitted_workloads_total`, `local_queue_admission_wait_time_seconds`).

Previously, these LQ metrics only included custom labels sourced from `LocalQueue` objects. With this change, workload-sourced labels (configured via `CustomMetricLabels` with `sourceKind: Workload`) are now also included, matching the behavior already available on ClusterQueue metrics.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13587 

#### Special notes for your reviewer:
The `LocalQueueMetrics` feature gate is enabled in the relevant integration tests to cover the new behavior.
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support Workload custom labels in LocalQueue admitted workload metrics when CustomMetricLabels feature gate is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local queue and cluster queue admission metrics can now include custom label dimensions derived from workloads and local queues when enabled.
  - Admitted-active workload metrics are emitted consistently for cluster queues and applicable local queues with local-queue-specific labels.

- **Bug Fixes**
  - Corrected admitted-active workload gauge updates to accumulate increments and decrements properly.

- **Tests**
  - Expanded coverage for custom-labeled admission, admitted-active workloads, totals, and wait times across workload and label lifecycle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->