### PR TITLE
fix(jobframework): fallback to annotation for prebuilt workload names exceeding 63 chars

### DIFF
--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -190,12 +191,19 @@ func PrebuiltWorkloadNameFor(obj client.Object) string {
 		if name := obj.GetAnnotations()[controllerconstants.PrebuiltWorkloadAnnotation]; name != "" {
 			return name
 		}
+		return obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]
 	}
-	return obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]
+	if name := obj.GetLabels()[controllerconstants.PrebuiltWorkloadLabel]; name != "" {
+		return name
+	}
+	if name := obj.GetAnnotations()[controllerconstants.PrebuiltWorkloadAnnotation]; len(name) > validation.LabelValueMaxLength {
+		return name
+	}
+	return ""
 }
 
 func SetPrebuiltWorkloadName(obj client.Object, workloadName string) {
-	if features.Enabled(features.WorkloadIdentifierAnnotations) {
+	if features.Enabled(features.WorkloadIdentifierAnnotations) || len(workloadName) > validation.LabelValueMaxLength {
 		annotations := obj.GetAnnotations()
 		if annotations == nil {
 			annotations = make(map[string]string, 1)

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -154,7 +154,7 @@ func ValidateAnnotationAsCRDName(obj client.Object, crdNameAnnotation string) fi
 
 func ValidatePrebuiltWorkloadName(obj client.Object) field.ErrorList {
 	prebuiltAnnotation := obj.GetAnnotations()[constants.PrebuiltWorkloadAnnotation]
-	if features.Enabled(features.WorkloadIdentifierAnnotations) && prebuiltAnnotation != "" {
+	if (features.Enabled(features.WorkloadIdentifierAnnotations) || len(prebuiltAnnotation) > validation.LabelValueMaxLength) && prebuiltAnnotation != "" {
 		return ValidateAnnotationAsCRDName(obj, constants.PrebuiltWorkloadAnnotation)
 	}
 	return ValidateLabelAsCRDName(obj, constants.PrebuiltWorkloadLabel)
@@ -291,7 +291,7 @@ func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {
 
 func GetPrebuiltWorkloadPath(obj client.Object) *field.Path {
 	prebuiltWorkloadAnnotation := obj.GetAnnotations()[constants.PrebuiltWorkloadAnnotation]
-	if features.Enabled(features.WorkloadIdentifierAnnotations) && prebuiltWorkloadAnnotation != "" {
+	if (features.Enabled(features.WorkloadIdentifierAnnotations) || len(prebuiltWorkloadAnnotation) > validation.LabelValueMaxLength) && prebuiltWorkloadAnnotation != "" {
 		return prebuiltWorkloadAnnotationPath
 	}
 	return prebuiltWorkloadLabelPath

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -374,6 +374,11 @@ func TestValidateJobOnUpdate(t *testing.T) {
 			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-new").Suspend(true).Obj(),
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: true},
 		},
+		"prebuilt workload annotation valid for long names > 63 chars when WorkloadIdentifierAnnotations disabled": {
+			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-that-is-very-long-and-exceeds-the-63-character-label-limit-value").Suspend(true).Obj(),
+			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-that-is-very-long-and-exceeds-the-63-character-label-limit-value").Suspend(true).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+		},
 		"prebuilt workload annotation update not suspended, WorkloadIdentifierAnnotations enabled": {
 			oldJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name").Suspend(false).Obj(),
 			newJob:       utiltestingjob.MakeJob("test-job", "ns1").PrebuiltWorkloadAnnotation("workload-name-new").Suspend(false).Obj(),


### PR DESCRIPTION
Fixes #10098

**Summary**
Automatically fall back to `PrebuiltWorkloadAnnotation` (`kueue.x-k8s.io/prebuilt-workload-name`) when prebuilt workload names exceed 63 characters (`validation.LabelValueMaxLength`), avoiding Kubernetes label value length validation failures on MultiKueue and LWS integrations.

**Root Cause & Fix**
- `pkg/controller/jobframework/utils.go`: Update `SetPrebuiltWorkloadName` to check if `len(workloadName) > 63` and set `PrebuiltWorkloadAnnotation` instead of `PrebuiltWorkloadLabel`. Update `PrebuiltWorkloadNameFor` to fall back to `PrebuiltWorkloadAnnotation` if present.
- `pkg/controller/jobframework/validation.go`: Update `ValidatePrebuiltWorkloadName` to validate `PrebuiltWorkloadAnnotation` as a DNS1123 subdomain when present.
- `pkg/controller/jobframework/validation_test.go`: Add test case verifying long workload names (> 63 chars) pass validation using annotations.

**Validation**
go test ./pkg/controller/jobframework -count=1

```release-note
MultiKueue & LeaderWorkerSet: Fixed a bug that prevented workloads from using PrebuiltWorkloads whose names exceeded the 63-character label limit when "WorkloadIdentifierAnnotations" was disabled. Kueue falls back to annotations for these Workloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed prebuilt workload identifier handling for names that exceed the 63-character label limit.
  - Updated retrieval logic to prefer the annotation when annotation-based identifiers are enabled and fall back appropriately.
  - Improved validation and field targeting so long, unchanged workload identifiers remain valid during job updates.
  - Ensured writing identifiers uses annotations when needed for over-limit names, otherwise continues using labels.
- **Tests**
  - Added coverage to prevent regressions when updating jobs with long prebuilt workload identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->