### PR TITLE
Narrow ResourceSlice notification to DRA-backed ClusterQueues

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -300,6 +300,34 @@ func (c *Cache) ActiveClusterQueues() sets.Set[kueue.ClusterQueueReference] {
 	return cqs
 }
 
+// ClusterQueuesForResources returns the names of ClusterQueues whose
+// ResourceGroups cover any of the given resource names.
+func (c *Cache) ClusterQueuesForResources(resourceNames sets.Set[corev1.ResourceName]) sets.Set[kueue.ClusterQueueReference] {
+	if resourceNames.Len() == 0 {
+		return nil
+	}
+	c.RLock()
+	defer c.RUnlock()
+	result := sets.New[kueue.ClusterQueueReference]()
+	for _, cq := range c.hm.ClusterQueues() {
+		if coversAnyResource(cq.ResourceGroups, resourceNames) {
+			result.Insert(cq.Name)
+		}
+	}
+	return result
+}
+
+func coversAnyResource(rgs []ResourceGroup, resourceNames sets.Set[corev1.ResourceName]) bool {
+	for _, rg := range rgs {
+		for name := range resourceNames {
+			if rg.CoveredResources.Has(name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (c *Cache) TASCache() *tasCache {
 	return &c.tasCache
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -2713,6 +2713,83 @@ func TestClusterQueuesUsingFlavor(t *testing.T) {
 	}
 }
 
+func TestClusterQueuesForResources(t *testing.T) {
+	defaultRf := utiltestingapi.MakeResourceFlavor("default").Obj()
+	gpuCq := utiltestingapi.MakeClusterQueue("gpu-cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource("gpu.nvidia.com/mig-1g.10gb", "10").Obj()).
+		Obj()
+	cpuCq := utiltestingapi.MakeClusterQueue("cpu-cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource("cpu", "100").Obj()).
+		Obj()
+	multiCq := utiltestingapi.MakeClusterQueue("multi-cq").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").Resource("cpu", "50").Resource("gpu.nvidia.com/mig-1g.10gb", "5").Obj()).
+		Obj()
+	emptyCq := utiltestingapi.MakeClusterQueue("empty-cq").Obj()
+
+	tests := []struct {
+		name          string
+		clusterQueues []*kueue.ClusterQueue
+		resourceNames []corev1.ResourceName
+		wantCQNames   []kueue.ClusterQueueReference
+	}{
+		{
+			name:          "matches CQ covering the resource",
+			clusterQueues: []*kueue.ClusterQueue{gpuCq, cpuCq},
+			resourceNames: []corev1.ResourceName{"gpu.nvidia.com/mig-1g.10gb"},
+			wantCQNames:   []kueue.ClusterQueueReference{"gpu-cq"},
+		},
+		{
+			name:          "no match returns empty",
+			clusterQueues: []*kueue.ClusterQueue{cpuCq},
+			resourceNames: []corev1.ResourceName{"gpu.nvidia.com/mig-1g.10gb"},
+		},
+		{
+			name:          "matches multiple CQs covering the resource",
+			clusterQueues: []*kueue.ClusterQueue{gpuCq, cpuCq, multiCq},
+			resourceNames: []corev1.ResourceName{"gpu.nvidia.com/mig-1g.10gb"},
+			wantCQNames:   []kueue.ClusterQueueReference{"gpu-cq", "multi-cq"},
+		},
+		{
+			name:          "matches on any of the requested resources",
+			clusterQueues: []*kueue.ClusterQueue{gpuCq, cpuCq},
+			resourceNames: []corev1.ResourceName{"gpu.nvidia.com/mig-1g.10gb", "cpu"},
+			wantCQNames:   []kueue.ClusterQueueReference{"gpu-cq", "cpu-cq"},
+		},
+		{
+			name:          "empty resource names returns empty",
+			clusterQueues: []*kueue.ClusterQueue{gpuCq},
+			resourceNames: []corev1.ResourceName{},
+		},
+		{
+			name:          "CQ with no resource groups is not matched",
+			clusterQueues: []*kueue.ClusterQueue{emptyCq},
+			resourceNames: []corev1.ResourceName{"cpu"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache := New(utiltesting.NewFakeClient())
+			cache.AddOrUpdateResourceFlavor(log, defaultRf)
+
+			for _, cq := range tc.clusterQueues {
+				if err := cache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("failed to add clusterQueue %s: %v", cq.Name, err)
+				}
+			}
+
+			got := cache.ClusterQueuesForResources(sets.New(tc.resourceNames...))
+			wantCQs := sets.New(tc.wantCQNames...)
+			if diff := cmp.Diff(wantCQs, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("ClusterQueuesForResources mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestMatchingClusterQueues(t *testing.T) {
 	clusterQueues := []*kueue.ClusterQueue{
 		utiltestingapi.MakeClusterQueue("matching1").

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -123,7 +123,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	}
 
 	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) || features.Enabled(features.KueueDRAIntegrationConsumableCapacity) {
-		rsRec := NewResourceSliceReconciler(qManager, cfg, opts.RoleTracker)
+		rsRec := NewResourceSliceReconciler(qManager, cc, cfg, opts.RoleTracker)
 		if err := rsRec.SetupWithManager(mgr, cfg); err != nil {
 			return "ResourceSlice", err
 		}

--- a/pkg/controller/core/resourceslice_controller.go
+++ b/pkg/controller/core/resourceslice_controller.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,43 +33,59 @@ import (
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
 type ResourceSliceReconciler struct {
-	qManager    *qcache.Manager
-	drivers     sets.Set[string]
-	roleTracker *roletracker.RoleTracker
+	qManager       *qcache.Manager
+	cache          *schdcache.Cache
+	drivers        sets.Set[string]
+	quotaResources sets.Set[corev1.ResourceName]
+	roleTracker    *roletracker.RoleTracker
 }
 
 var _ reconcile.Reconciler = (*ResourceSliceReconciler)(nil)
 
-func NewResourceSliceReconciler(qManager *qcache.Manager, cfg *configapi.Configuration, roleTracker *roletracker.RoleTracker) *ResourceSliceReconciler {
+func NewResourceSliceReconciler(qManager *qcache.Manager, cache *schdcache.Cache, cfg *configapi.Configuration, roleTracker *roletracker.RoleTracker) *ResourceSliceReconciler {
 	drivers := sets.New[string]()
+	quotaResources := sets.New[corev1.ResourceName]()
+
 	if cfg.Resources != nil {
 		for _, m := range cfg.Resources.DeviceClassMappings {
 			for _, s := range m.Sources {
-				if s.Counter != nil {
-					drivers.Insert(s.Counter.Driver)
-				}
-				if s.Capacity != nil {
-					drivers.Insert(s.Capacity.Driver)
+				if driver := sourceDriver(s); driver != "" {
+					drivers.Insert(driver)
+					quotaResources.Insert(m.Name)
 				}
 			}
 		}
 	}
 	return &ResourceSliceReconciler{
-		qManager:    qManager,
-		drivers:     drivers,
-		roleTracker: roleTracker,
+		qManager:       qManager,
+		cache:          cache,
+		drivers:        drivers,
+		quotaResources: quotaResources,
+		roleTracker:    roleTracker,
 	}
+}
+
+func sourceDriver(s configapi.DeviceClassSourceConfig) string {
+	if s.Counter != nil {
+		return s.Counter.Driver
+	}
+	if s.Capacity != nil {
+		return s.Capacity.Driver
+	}
+	return ""
 }
 
 func (r *ResourceSliceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(3).Info("Reconcile ResourceSlice", "resourceSlice", req.NamespacedName)
-	cqNames := sets.New(r.qManager.GetClusterQueueNames()...)
-	qcache.NotifyRetryInadmissible(r.qManager, cqNames)
+	if cqNames := r.cache.ClusterQueuesForResources(r.quotaResources); cqNames.Len() > 0 {
+		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
+	}
 	return ctrl.Result{}, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The ResourceSlice reconciler notifies all ClusterQueues on every ResourceSlice change, even CQs that have no DRA-backed resources. This causes unnecessary inadmissible workload requeue churn at scale. This PR narrows the notification to only ClusterQueues whose ResourceGroups cover quota resources derived from DeviceClassMappings.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
AI was used in the development of this PR, but all changes manually reviewed and validated.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Narrowed ResourceSlice change notifications to only ClusterQueues covering DRA-mapped resources, reducing unnecessary inadmissible workload requeue churn.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Improvements**
  - Enhanced resource update handling for partitionable devices and consumable capacity.
  - Resource change notifications now target only cluster queues that match the resource coverage derived from configured device-class mappings, reducing unnecessary scheduling retries.
  - Added a cache-based lookup to resolve matching cluster queues from one or more requested resource names, including “any-of” behavior and correct empty/no-match handling.

- **Reliability**
  - Added unit tests covering resource-to-cluster-queue matching, including cases where cluster queues have no resource groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->