### PR TITLE
DRA: skip AdminAccess device requests in DRA quota counting

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -237,8 +237,8 @@ a simple device class named `gpu.example.com`. This will be the way to enforce q
 
 ### Non-Goals
 
-- Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta, default enabled in K8s 1.35)
-  is not included in Kueue's alpha. See [Risks and Mitigations](#risks-and-mitigations) for the
+- Quota-aware handling of DRAPrioritizedLists (beta, default enabled in K8s 1.35)
+  is not included. See [Risks and Mitigations](#risks-and-mitigations) for the
   planned approach.
 - Support for DRA features like DRADeviceTaints is not included.
 - Multi-host partitionable devices (e.g., NVLink fabrics spanning multiple nodes) are not
@@ -309,8 +309,9 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
 - This design does not work with Kueue's Topology Aware Scheduling feature and will be addressed in future work.
 - DRA resource preprocessing is not scoped by ResourceFlavor node constraints. Counter
   charges and device matching are computed globally before flavor assignment.
-- Quota-aware handling of DRAAdminAccess and DRAPrioritizedLists (beta in K8s 1.35) is deferred
-  to beta graduation. DRADeviceTaints is not supported in alpha.
+- AdminAccess requests are skipped in quota counting (zero charge) since they provide
+  shared read-only access to already-allocated devices. DRAPrioritizedLists support is
+  deferred. DRADeviceTaints is not supported.
 - **Single-node partitionable devices (e.g., MIG) are supported** via counter-based
   quota. See [Partitionable Devices](#partitionable-devices). Multi-host partitionable
   devices are not supported.
@@ -356,16 +357,14 @@ unlimited GPU consumption outside Kueue's control. The `KueueDRARejectWorkloadsW
 (default: enabled, Beta) mitigates this by rejecting DRA workloads when the DRA feature is off.
 See [Workload Rejection When DRA Is Disabled](#workload-rejection-when-dra-is-disabled).
 
-With DRAAdminAccess and DRAPrioritizedLists (both beta, default enabled in K8s 1.35), there is a
-risk that effective tallying of resources will not be available until after allocation of these
-resources by kube-scheduler. Support for these is deferred to Beta but the mitigation approach
+With DRAPrioritizedLists (beta, default enabled in K8s 1.35), there is a risk that effective
+tallying of resources will not be available until after allocation. The mitigation approach
 is documented here:
 1. For DRAPrioritizedLists: all the mentioned device classes in the request will be counted against the quota
-2. For DRAAdminAccess: This feature can only be enabled in admin namespace, therefore it should be skipped for being
-   counted against ClusterQuota. This is a different stance than Kubernetes ResourceQuota because kubernetes
-   ResourceQuota is namespace scoped. As a result, admin users can account for quota independent of user workloads.
-   On the contrary, with Kueue, since quota is part of ClusterQuota a cluster scoped object, admin workloads using
-   devices in admin namespace if counted against quota, will eat up quota meant for user workloads.
+2. AdminAccess requests are skipped in quota counting. This feature can only be enabled in
+   admin namespaces (gated by the `resource.kubernetes.io/admin-access` label), and provides
+   shared read-only access to already-allocated devices. Charging quota would double-count the
+   device. This matches the Kubernetes scheduler which excludes AdminAccess from `allocatedDevices`.
 3. For ResourceClaims with allocation mode `All`: worst-case scenario of the max number of devices that could be
    allocated to a single claim will be used against quota.
 4. For Extended Resources: if a DeviceClass is created or updated between Kueue admitting a

--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -96,7 +96,7 @@ func determineCapacityForPodSet(
 		}
 
 		for reqIdx, req := range spec.Devices.Requests {
-			if req.Exactly == nil {
+			if req.Exactly == nil || isAdminAccessRequest(req.Exactly) {
 				continue
 			}
 			deviceClass := corev1.ResourceName(req.Exactly.DeviceClassName)

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -51,10 +51,14 @@ type celDeviceRequest struct {
 	selectors       []resourcev1.DeviceSelector
 }
 
+func isAdminAccessRequest(req *resourcev1.ExactDeviceRequest) bool {
+	return req.AdminAccess != nil && *req.AdminAccess
+}
+
 // countDevicesPerClass returns a resources.Requests representing the
 // total number of devices requested for each DeviceClass inside the provided
 // ResourceClaimSpec. Returns field errors for unsupported request features
-// (FirstAvailable, AdminAccess, AllocationMode All).
+// (FirstAvailable, AllocationMode All). AdminAccess requests are skipped (zero quota).
 func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, field.ErrorList) {
 	out := resources.CreateEmpty()
 	if claimSpec == nil {
@@ -87,9 +91,8 @@ func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Re
 		}
 
 		switch {
-		case req.Exactly.AdminAccess != nil && *req.Exactly.AdminAccess:
-			allErrs = append(allErrs, field.Invalid(devicesRequestsPath.Index(i).Child("exactly", "adminAccess"), nil, "AdminAccess is not supported"))
-			return nil, allErrs
+		case isAdminAccessRequest(req.Exactly):
+			continue
 		case req.Exactly.AllocationMode == resourcev1.DeviceAllocationModeAll:
 			allErrs = append(
 				allErrs,

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -553,7 +553,7 @@ func Test_GetResourceRequests(t *testing.T) {
 			},
 		},
 		{
-			name: "AdminAccess returns error",
+			name: "AdminAccess request is skipped with zero quota",
 			extraObjects: []runtime.Object{
 				utiltesting.MakeResourceClaimTemplate("claim-tmpl-admin", "ns1").
 					DeviceRequest("req", "test-deviceclass-1", 1).
@@ -566,12 +566,47 @@ func Test_GetResourceRequests(t *testing.T) {
 				}
 			},
 			lookup: defaultLookup,
-			wantErr: field.ErrorList{
-				field.Invalid(
-					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("devices", "requests").Index(0).Child("exactly", "adminAccess"),
-					"",
-					"",
-				),
+		},
+		{
+			name: "Mixed AdminAccess and normal requests counts only normal",
+			extraObjects: []runtime.Object{
+				&resourcev1.ResourceClaimTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "claim-tmpl-mixed", Namespace: "ns1"},
+					Spec: resourcev1.ResourceClaimTemplateSpec{
+						Spec: resourcev1.ResourceClaimSpec{
+							Devices: resourcev1.DeviceClaim{
+								Requests: []resourcev1.DeviceRequest{
+									{
+										Name: "normal-req",
+										Exactly: &resourcev1.ExactDeviceRequest{
+											DeviceClassName: "test-deviceclass-1",
+											AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+											Count:           2,
+										},
+									},
+									{
+										Name: "admin-req",
+										Exactly: &resourcev1.ExactDeviceRequest{
+											DeviceClassName: "test-deviceclass-1",
+											AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+											Count:           1,
+											AdminAccess:     new(true),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			modifyWL: func(w *kueue.Workload) {
+				w.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+					{Name: "req-mixed", ResourceClaimTemplateName: new("claim-tmpl-mixed")},
+				}
+			},
+			lookup: defaultLookup,
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {"res-1": resource.MustParse("2")},
 			},
 		},
 		{

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -68,7 +68,7 @@ func GetCounterResourcesForWorkload(
 			}
 
 			for reqIdx, req := range spec.Devices.Requests {
-				if req.Exactly == nil {
+				if req.Exactly == nil || isAdminAccessRequest(req.Exactly) {
 					continue
 				}
 				deviceClass := corev1.ResourceName(req.Exactly.DeviceClassName)

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -667,7 +667,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("Should reject workload with AdminAccess", func() {
+		ginkgo.It("Should admit workload with AdminAccess and zero quota charge", func() {
 			ginkgo.By("Adding admin-access label to namespace")
 			var namespace corev1.Namespace
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: ns.Name}, &namespace)).To(gomega.Succeed())
@@ -699,19 +699,15 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			ginkgo.By("Verifying workload is marked as inadmissible")
+			ginkgo.By("Verifying workload is admitted with no DRA resource usage")
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
-				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
-
-				g.Expect(updatedWl.Status.Conditions).To(gomega.ContainElement(gomega.And(
-					gomega.HaveField("Type", kueue.WorkloadQuotaReserved),
-					gomega.HaveField("Status", metav1.ConditionFalse),
-					gomega.HaveField("Reason", kueue.WorkloadInadmissible),
-					gomega.HaveField("Message", gomega.ContainSubstring("AdminAccess is not supported")),
-				)))
-			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(updatedWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+				g.Expect(updatedWl.Status.Admission.PodSetAssignments[0].ResourceUsage).NotTo(gomega.HaveKey(corev1.ResourceName("foo")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("Should admit workload with device config", func() {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area dra
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
AdminAccess provides shared read-only access to already-allocated devices. Charging quota would double-count the device (once for the real owner, once for the monitor). This matches the Kubernetes scheduler behavior which explicitly excludes AdminAccess from allocatedDevices.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Workloads with AdminAccess device requests are now admitted with zero quota charge instead of being rejected. AdminAccess provides shared read-only access to already-allocated devices.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added DRA AdminAccess handling that is skipped from quota accounting (zero charge).

* **Bug Fixes**
  * Updated capacity, workload, and resource usage calculations to ignore AdminAccess requests and prevent double-counting.
  * Adjusted validation behavior so AdminAccess no longer triggers quota accounting errors.

* **Documentation**
  * Clarified alpha semantics and constraints: AdminAccess is zero-charged, prioritized lists are deferred, and device taints remain unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->