### PR TITLE
docs: clarify behavior for missing WorkloadPriorityClass references

### DIFF
--- a/site/content/en/docs/concepts/workload_priority_class.md
+++ b/site/content/en/docs/concepts/workload_priority_class.md
@@ -77,6 +77,14 @@ spec:
 ...
 ```
 
+## Referencing a WorkloadPriorityClass
+
+The `WorkloadPriorityClass` referenced by the `kueue.x-k8s.io/priority-class` label must exist in the cluster.
+
+If the label explicitly references a nonexistent `WorkloadPriorityClass`, Kueue cannot resolve the workload priority and does not fall back to the Pod `PriorityClass`, the global default `PriorityClass`, or the default priority value. As a result, the corresponding `Workload` cannot be created or updated until the reference is corrected or the referenced `WorkloadPriorityClass` is created.
+
+This differs from omitting the `kueue.x-k8s.io/priority-class` label. When the label is omitted, Kueue determines the workload priority from the applicable Pod `PriorityClass`, the global default `PriorityClass`, or the default priority value. When the alpha `WorkloadPriorityClassDefaulting` feature is enabled and a `WorkloadPriorityClass` named `default` exists, an omitted label is first defaulted to that class; see [Setup default WorkloadPriorityClass](/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class).
+
 ## The relationship between pod's priority and workload's priority
 
 When creating a `Workload` for a given job, Kueue considers the following scenarios:


### PR DESCRIPTION
Related to #3439 (implementation discussed in #6688).

The WorkloadPriorityClass concept page documents how to reference a WorkloadPriorityClass with the `kueue.x-k8s.io/priority-class` label, but it does not say what happens when the label references a class that does not exist.

On current `main`, `ExtractPriority` looks up the referenced WorkloadPriorityClass and returns the lookup error when it is not found, without falling back to a Pod `PriorityClass` or the default priority. The error propagates before `client.Create`, so the Workload is not created (the same applies on update). This PR documents that behavior and how it differs from omitting the label.

This is documentation-only and does not close #3439, which tracks adding a user-facing Warning event for this case. When that event lands the section can be updated to mention it.

/kind documentation

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for referencing a `WorkloadPriorityClass`.
  - Clarified that if the label references a class that doesn’t exist, workload priority can’t be resolved, blocking corresponding Workload creation or updates.
  - Documented fallback behavior when the label is omitted, including Pod/global/default priority sources and optional defaulting when the alpha feature is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->