### PR TITLE
Requeue pending workloads when TAS ResourceFlavor nodeTaints are updated

### DIFF
--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -183,9 +183,10 @@ func (r *rfReconciler) Update(event event.TypedUpdateEvent[*kueue.ResourceFlavor
 	switch {
 	case ptr.Equal(event.ObjectOld.Spec.TopologyName, event.ObjectNew.Spec.TopologyName):
 		if event.ObjectNew.Spec.TopologyName != nil &&
-			!equality.Semantic.DeepEqual(event.ObjectOld.Spec.Tolerations, event.ObjectNew.Spec.Tolerations) {
+			(!equality.Semantic.DeepEqual(event.ObjectOld.Spec.Tolerations, event.ObjectNew.Spec.Tolerations) ||
+				!equality.Semantic.DeepEqual(event.ObjectOld.Spec.NodeTaints, event.ObjectNew.Spec.NodeTaints)) {
 			log := r.logger().WithValues("flavor", event.ObjectNew.Name)
-			log.V(2).Info("TAS ResourceFlavor tolerations updated")
+			log.V(2).Info("TAS ResourceFlavor tolerations or nodeTaints updated")
 			r.cache.AddOrUpdateResourceFlavor(log, event.ObjectNew)
 			return true
 		}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -535,6 +535,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				util.MustCreate(ctx, k8sClient, wl2)
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
 			})
+
+			ginkgo.By("verifying the pending workload is also retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
 		})
 	})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -424,6 +424,120 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		})
 	})
 
+	ginkgo.When("Updating TAS ResourceFlavor nodeTaints", func() {
+		var (
+			node         *corev1.Node
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		taint := corev1.Taint{
+			Key:    "example.com/dedicated",
+			Value:  "tas",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+
+		ginkgo.BeforeEach(func() {
+			node = testingnode.MakeNode("x1").
+				Label("node-group", "tas").
+				Label(corev1.LabelHostname, "x1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj()
+			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*node})
+
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName(topology.Name).
+				Taint(taint).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "3").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
+		})
+
+		makeWorkload := func(name, cpu string) *kueue.Workload {
+			return utiltestingapi.MakeWorkload(name, ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, cpu).
+					Obj()).
+				Obj()
+		}
+		removeNodeTaints := func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedFlavor kueue.ResourceFlavor
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), &updatedFlavor)).To(gomega.Succeed())
+				updatedFlavor.Spec.NodeTaints = nil
+				g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.It("should requeue pending workloads when nodeTaints are removed", func() {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("removing the flavor nodeTaints", removeNodeTaints)
+
+			ginkgo.By("verifying a differently-shaped workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", "500m")
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+		})
+
+		ginkgo.It("should schedule workloads created after nodeTaints are removed", func() {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("removing the flavor nodeTaints", removeNodeTaints)
+
+			ginkgo.By("verifying an identically-shaped workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", "1")
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+		})
+	})
+
 	ginkgo.When("non-TAS pod exists", func() {
 		var (
 			nodes        []corev1.Node


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

`spec.nodeTaints` is already mutable on TAS ResourceFlavors (#9427), but updating it currently has no effect on workloads that were already deemed inadmissible:

- The TAS ResourceFlavor controller's update predicate only reacts to `tolerations` changes, so the inadmissible-workloads requeue never fires for nodeTaints-only updates.
- The core ResourceFlavor controller only requeues inadmissible workloads when a ClusterQueue flips from pending to active, which does not happen here.

As a result, a workload rejected with `untolerated taint ... in flavor ...` stays Pending indefinitely after the admin removes the taint from the flavor. With `SchedulingEquivalenceHashing` enabled (default since 0.18) the impact is broader: newly created workloads with the same shape are parked immediately without a single scheduling attempt, because the equivalence-hash bulk-move map is only cleared by the inadmissible-workloads requeue — which never fires in this scenario. Resubmitting the job does not help.

This PR extends the TAS ResourceFlavor controller's update predicate to also detect `nodeTaints` changes, reusing the sync-cache-then-requeue path introduced for tolerations in #13622. Unlike tolerations, nodeTaints are not stored in the TAS flavor cache, so admitted usage is unaffected.

#### Which issue(s) this PR fixes:

Part of #3733

#### Special notes for your reviewer:

Both added integration specs fail on main (they time out waiting for admission) and pass with this change:

- a workload pending due to an untolerated flavor taint is requeued and admitted after the nodeTaints are removed
- an identically-shaped workload created after the removal is scheduled (covers the `SchedulingEquivalenceHashing` interaction)

Validation performed:

- `go test ./pkg/controller/tas/... ./pkg/cache/... -count=1`
- `go test -race ./pkg/controller/tas -count=1`
- focused TAS integration specs for nodeTaints and tolerations updates
- full TAS integration suite: 109 specs passed
- `go vet` for the changed packages

AI tool usage disclosure: I used an AI coding tool to help investigate the requeue paths, reproduce the issue, and prepare the fix and tests. I reviewed the resulting code and ran the validations listed above.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where updating `spec.nodeTaints` on a ResourceFlavor with `spec.topologyName` set did not retry inadmissible workloads, leaving them Pending until an unrelated event triggered a requeue.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource flavor updates now also detect semantic changes to node taints (not just tolerations), refreshing cached scheduling information when topology remains the same.
  * Workloads that were blocked due to flavor node taints are retried and admitted promptly after node taints are removed.
  * Newly created workloads are admitted immediately once updated flavor taints no longer prevent scheduling.

* **Tests**
  * Extended integration coverage to validate node-taint removal causes pending workloads to be retried and admitted, alongside newly created workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->