### PR TITLE
 Move ResourceGroup helpers to resource.go

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -44,6 +44,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -310,22 +311,11 @@ func (c *Cache) ClusterQueuesForResources(resourceNames sets.Set[corev1.Resource
 	defer c.RUnlock()
 	result := sets.New[kueue.ClusterQueueReference]()
 	for _, cq := range c.hm.ClusterQueues() {
-		if coversAnyResource(cq.ResourceGroups, resourceNames) {
+		if resourcegroups.CoversAnyResource(cq.ResourceGroups, resourceNames) {
 			result.Insert(cq.Name)
 		}
 	}
 	return result
-}
-
-func coversAnyResource(rgs []ResourceGroup, resourceNames sets.Set[corev1.ResourceName]) bool {
-	for _, rg := range rgs {
-		for name := range resourceNames {
-			if rg.CoveredResources.Has(name) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (c *Cache) TASCache() *tasCache {
@@ -1073,7 +1063,7 @@ func handleTASFlavor(rf *kueue.ResourceFlavor) bool {
 	return features.Enabled(features.TopologyAwareScheduling) && rf.Spec.TopologyName != nil
 }
 
-func (c *Cache) filterLocalQueueUsage(orig resources.FlavorResourceQuantities, resourceGroups []ResourceGroup) []kueue.LocalQueueFlavorUsage {
+func (c *Cache) filterLocalQueueUsage(orig resources.FlavorResourceQuantities, resourceGroups []resourcegroups.ResourceGroup) []kueue.LocalQueueFlavorUsage {
 	qFlvUsages := make([]kueue.LocalQueueFlavorUsage, 0, len(orig))
 	for _, rg := range resourceGroups {
 		for _, fName := range rg.Flavors {

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/api"
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
 	"sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -55,7 +56,7 @@ var (
 // holds admitted workloads.
 type clusterQueue struct {
 	Name              kueue.ClusterQueueReference
-	ResourceGroups    []ResourceGroup
+	ResourceGroups    []resourcegroups.ResourceGroup
 	Workloads         map[workload.Reference]*workload.Info
 	WorkloadsNotReady sets.Set[workload.Reference]
 	NamespaceSelector labels.Selector
@@ -216,10 +217,10 @@ func (c *clusterQueue) ConcurrentAdmissionEnabled() bool {
 	return c.ConcurrentAdmissionPolicy != nil
 }
 
-func createdResourceGroups(kueueRgs []kueue.ResourceGroup) []ResourceGroup {
-	rgs := make([]ResourceGroup, len(kueueRgs))
+func createdResourceGroups(kueueRgs []kueue.ResourceGroup) []resourcegroups.ResourceGroup {
+	rgs := make([]resourcegroups.ResourceGroup, len(kueueRgs))
 	for i, kueueRg := range kueueRgs {
-		rgs[i] = ResourceGroup{
+		rgs[i] = resourcegroups.ResourceGroup{
 			CoveredResources: sets.New(kueueRg.CoveredResources...),
 			Flavors:          make([]kueue.ResourceFlavorReference, 0, len(kueueRg.Flavors)),
 		}
@@ -439,7 +440,7 @@ func (c *clusterQueue) updateWithAdmissionChecks(log logr.Logger, checks map[kue
 				// - cannot use multiple MultiKueue AdmissionChecks on the same ClusterQueue
 				// - cannot use specify MultiKueue AdmissionCheck per flavor
 				multiKueueAdmissionChecks.Insert(acName)
-				if !flavors.Equal(AllFlavors(c.ResourceGroups)) {
+				if !flavors.Equal(resourcegroups.AllFlavors(c.ResourceGroups)) {
 					perFlavorMultiKueueChecks = append(perFlavorMultiKueueChecks, acName)
 				}
 			}

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -51,7 +52,7 @@ const (
 
 type ClusterQueueSnapshot struct {
 	Name                      kueue.ClusterQueueReference
-	ResourceGroups            []ResourceGroup
+	ResourceGroups            []resourcegroups.ResourceGroup
 	Workloads                 map[workload.Reference]*workload.Info
 	WorkloadsNotReady         sets.Set[workload.Reference]
 	NamespaceSelector         labels.Selector
@@ -81,13 +82,8 @@ type ClusterQueueSnapshot struct {
 
 // RGByResource returns the ResourceGroup which contains capacity
 // for the resource, or nil if the CQ doesn't provide this resource.
-func (c *ClusterQueueSnapshot) RGByResource(resource corev1.ResourceName) *ResourceGroup {
-	for i := range c.ResourceGroups {
-		if c.ResourceGroups[i].CoveredResources.Has(resource) {
-			return &c.ResourceGroups[i]
-		}
-	}
-	return nil
+func (c *ClusterQueueSnapshot) RGByResource(resource corev1.ResourceName) *resourcegroups.ResourceGroup {
+	return resourcegroups.RGByResource(c.ResourceGroups, resource)
 }
 
 // SimulateUsageAddition modifies the snapshot by adding usage, and

--- a/pkg/cache/scheduler/resource.go
+++ b/pkg/cache/scheduler/resource.go
@@ -17,26 +17,11 @@ limitations under the License.
 package scheduler
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/resources"
-	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 )
-
-type ResourceGroup struct {
-	CoveredResources sets.Set[corev1.ResourceName]
-	Flavors          []kueue.ResourceFlavorReference
-}
-
-func (rg *ResourceGroup) Clone() ResourceGroup {
-	return ResourceGroup{
-		CoveredResources: rg.CoveredResources.Clone(),
-		Flavors:          rg.Flavors,
-	}
-}
 
 type ResourceQuota struct {
 	Nominal        resources.Amount
@@ -82,14 +67,4 @@ func createResourceQuotas(kueueRgs []kueue.ResourceGroup) map[resources.FlavorRe
 		}
 	}
 	return quotas
-}
-
-func AllFlavors(rgs []ResourceGroup) sets.Set[kueue.ResourceFlavorReference] {
-	return utilslices.Reduce(
-		rgs,
-		func(acc sets.Set[kueue.ResourceFlavorReference], rg ResourceGroup) sets.Set[kueue.ResourceFlavorReference] {
-			return acc.Insert(rg.Flavors...)
-		},
-		sets.New[kueue.ResourceFlavorReference](),
-	)
 }

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	afs "sigs.k8s.io/kueue/pkg/util/admissionfairsharing"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -294,7 +295,7 @@ func (c *Cache) snapshotClusterQueue(
 	log := log.FromContext(ctx)
 	cc := &ClusterQueueSnapshot{
 		Name:                          cq.Name,
-		ResourceGroups:                make([]ResourceGroup, len(cq.ResourceGroups)),
+		ResourceGroups:                make([]resourcegroups.ResourceGroup, len(cq.ResourceGroups)),
 		FlavorFungibility:             cq.FlavorFungibility,
 		FairWeight:                    cq.FairWeight,
 		AllocatableResourceGeneration: cq.AllocatableResourceGeneration,

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -31,6 +31,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -238,7 +239,7 @@ func TestSnapshot(t *testing.T) {
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
-								ResourceGroups: []ResourceGroup{
+								ResourceGroups: []resourcegroups.ResourceGroup{
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"demand", "spot"},
@@ -278,7 +279,7 @@ func TestSnapshot(t *testing.T) {
 							"b": {
 								Name:                          "b",
 								AllocatableResourceGeneration: 1,
-								ResourceGroups: []ResourceGroup{
+								ResourceGroups: []resourcegroups.ResourceGroup{
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"spot"},
@@ -340,7 +341,7 @@ func TestSnapshot(t *testing.T) {
 							"c": {
 								Name:                          "c",
 								AllocatableResourceGeneration: 1,
-								ResourceGroups: []ResourceGroup{
+								ResourceGroups: []resourcegroups.ResourceGroup{
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"default"},
@@ -498,7 +499,7 @@ func TestSnapshot(t *testing.T) {
 							"a": {
 								Name:                          "a",
 								AllocatableResourceGeneration: 2,
-								ResourceGroups: []ResourceGroup{
+								ResourceGroups: []resourcegroups.ResourceGroup{
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
@@ -559,7 +560,7 @@ func TestSnapshot(t *testing.T) {
 							"b": {
 								Name:                          "b",
 								AllocatableResourceGeneration: 1,
-								ResourceGroups: []ResourceGroup{
+								ResourceGroups: []resourcegroups.ResourceGroup{
 									{
 										CoveredResources: sets.New(corev1.ResourceCPU),
 										Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
@@ -640,7 +641,7 @@ func TestSnapshot(t *testing.T) {
 						"cq": {
 							Name:                          "cq",
 							AllocatableResourceGeneration: 2,
-							ResourceGroups: []ResourceGroup{
+							ResourceGroups: []resourcegroups.ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
 									Flavors:          []kueue.ResourceFlavorReference{"arm", "x86"},
@@ -720,7 +721,7 @@ func TestSnapshot(t *testing.T) {
 						"cq-nocycle": {
 							Name:                          "cq-nocycle",
 							AllocatableResourceGeneration: 2,
-							ResourceGroups: []ResourceGroup{
+							ResourceGroups: []resourcegroups.ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
 									Flavors:          []kueue.ResourceFlavorReference{"arm"},
@@ -817,7 +818,7 @@ func TestSnapshot(t *testing.T) {
 						"tas-cq": {
 							Name:                          "tas-cq",
 							AllocatableResourceGeneration: 2,
-							ResourceGroups: []ResourceGroup{
+							ResourceGroups: []resourcegroups.ResourceGroup{
 								{
 									CoveredResources: sets.New(corev1.ResourceCPU),
 									Flavors:          []kueue.ResourceFlavorReference{"tas-flavor"},

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -44,6 +44,7 @@ import (
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/orderedgroups"
 	"sigs.k8s.io/kueue/pkg/util/podset"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -1120,7 +1121,7 @@ func (a *FlavorAssigner) checkFlavorForPodSets(
 	flavorName kueue.ResourceFlavorReference,
 	psIDs []int,
 	podSets []*kueue.PodSet,
-	rg *schdcache.ResourceGroup,
+	rg *resourcegroups.ResourceGroup,
 ) *Status {
 	status := NewStatus()
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -29,6 +29,7 @@ import (
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -161,7 +162,7 @@ func onlyTASFlavor(
 	return nil, &MultipleTASFlavorsAssignedError{Flavors: sets.List(flavors)}
 }
 
-func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor, rg *schdcache.ResourceGroup) *string {
+func checkPodSetAndFlavorMatchForTAS(cq *schdcache.ClusterQueueSnapshot, ps *kueue.PodSet, flavor *kueue.ResourceFlavor, rg *resourcegroups.ResourceGroup) *string {
 	if isTASRequested(ps, cq) {
 		if isTASImplied(ps, cq) {
 			// If this is a TAS-only CQ, then we don't need to check the flavor because

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -55,6 +55,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/routine"
 	"sigs.k8s.io/kueue/pkg/util/wait"
@@ -1186,14 +1187,6 @@ const (
 	subtract
 )
 
-func allCoveredResources(resourceGroups []schdcache.ResourceGroup) sets.Set[corev1.ResourceName] {
-	covered := sets.New[corev1.ResourceName]()
-	for _, rg := range resourceGroups {
-		covered = covered.Union(rg.CoveredResources)
-	}
-	return covered
-}
-
 // filterByNames returns a new ResourceList containing only resources whose names
 // are in the allowed set.
 func filterByNames(requests corev1.ResourceList, allowed sets.Set[corev1.ResourceName]) corev1.ResourceList {
@@ -1211,7 +1204,7 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 	lqObjRef := klog.KRef(e.Obj.Namespace, string(e.Obj.Spec.QueueName))
 	totalRequests := e.SumTotalRequests(s.resourceFormatter)
 	if flavorassigner.IgnoreUndeclaredResources(s.quotaCheckStrategy) {
-		totalRequests = filterByNames(totalRequests, allCoveredResources(e.clusterQueueSnapshot.ResourceGroups))
+		totalRequests = filterByNames(totalRequests, resourcegroups.AllCoveredResources(e.clusterQueueSnapshot.ResourceGroups))
 	}
 	penalty := afs.CalculateEntryPenalty(totalRequests, s.admissionFairSharing)
 

--- a/pkg/util/resourcegroups/resourcegroups.go
+++ b/pkg/util/resourcegroups/resourcegroups.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcegroups
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
+)
+
+type ResourceGroup struct {
+	CoveredResources sets.Set[corev1.ResourceName]
+	Flavors          []kueue.ResourceFlavorReference
+}
+
+func (rg *ResourceGroup) Clone() ResourceGroup {
+	return ResourceGroup{
+		CoveredResources: rg.CoveredResources.Clone(),
+		Flavors:          rg.Flavors,
+	}
+}
+
+// CoversAnyResource reports whether any ResourceGroup in rgs covers
+// at least one of the given resource names.
+func CoversAnyResource(rgs []ResourceGroup, resourceNames sets.Set[corev1.ResourceName]) bool {
+	for _, rg := range rgs {
+		for name := range resourceNames {
+			if rg.CoveredResources.Has(name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// AllCoveredResources returns the union of CoveredResources across all ResourceGroups.
+func AllCoveredResources(rgs []ResourceGroup) sets.Set[corev1.ResourceName] {
+	covered := sets.New[corev1.ResourceName]()
+	for _, rg := range rgs {
+		covered = covered.Union(rg.CoveredResources)
+	}
+	return covered
+}
+
+// RGByResource returns the ResourceGroup that covers the given resource, or nil.
+func RGByResource(rgs []ResourceGroup, resource corev1.ResourceName) *ResourceGroup {
+	for i := range rgs {
+		if rgs[i].CoveredResources.Has(resource) {
+			return &rgs[i]
+		}
+	}
+	return nil
+}
+
+func AllFlavors(rgs []ResourceGroup) sets.Set[kueue.ResourceFlavorReference] {
+	return utilslices.Reduce(
+		rgs,
+		func(acc sets.Set[kueue.ResourceFlavorReference], rg ResourceGroup) sets.Set[kueue.ResourceFlavorReference] {
+			return acc.Insert(rg.Flavors...)
+		},
+		sets.New[kueue.ResourceFlavorReference](),
+	)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area dra
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Addresses https://github.com/kubernetes-sigs/kueue/pull/13639#discussion_r3680005564

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated resource-group matching and covered-resource calculations into shared utilities for consistent behavior across the scheduler.
  * Updated resource-group lookups and flavor aggregation to preserve prior matching/filtering semantics.
  * Improved consistency in admission fair-sharing penalty computation by using the unified covered-resource set.
* **Tests**
  * Updated scheduler snapshot tests to reflect the unified resource-group representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->