### PR TITLE
MultiKueue: allow update/patch on rayclusters in the example worker RBAC

### DIFF
--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -242,6 +242,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - ray.io
   resources:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue
/area integrations

#### What this PR does / why we need it:

The Ray MultiKueue adapter now propagates manager-driven elastic RayCluster
worker-group replica changes to the worker cluster: when an
`ElasticJobsViaWorkloadSlices` RayCluster is scaled on the management cluster,
`syncElastic` (`pkg/controller/jobs/ray/ray_multikueue_adapter.go`) issues a
`Patch` against the remote RayCluster on the admitting worker cluster.

However, the worker-side ServiceAccount created by the documented
`create-multikueue-kubeconfig.sh` only grants
`create,delete,get,list,watch` on `ray.io/rayclusters` — no `update`/`patch`.
So on any scoped-RBAC MultiKueue worker set up by following the docs, that sync
`Patch` is rejected:

```
rayclusters.ray.io "<name>" is forbidden: User
"system:serviceaccount:kueue-system:multikueue-sa" cannot patch resource
"rayclusters" in API group "ray.io"
```

and the remote RayCluster is never resized. This PR adds `update` and `patch`
to the `rayclusters` rule in the example script so the documented worker RBAC
matches what the adapter needs. `rayjobs`/`rayservices` keep their create-once
verbs, since their worker replicas live on a child RayCluster that has no
representation on the manager.

Reproduced locally on kind: with the current script the scale `Patch` returns
`403 Forbidden`; after adding `update,patch` the identical `Patch` succeeds and
the worker RayCluster's `workerGroupSpecs[].replicas` updates.

#### Which issue(s) this PR fixes:

None. This closes an RBAC gap in the example worker RBAC left by the elastic
RayCluster MultiKueue sync feature added in #12885.

#### Special notes for your reviewer:

The Kueue controller-manager's own ClusterRole
(`charts/kueue/templates/rbac/role.yaml`) already has `update`/`patch` on
`rayclusters` and is unaffected — that is a different identity from the
MultiKueue worker ServiceAccount, which is defined only in this example script.

AI disclosure: per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance),
this change was developed with the assistance of an AI coding tool. All code was
authored, reviewed, and tested by the submitter.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: The example `create-multikueue-kubeconfig.sh` now grants `update` and `patch` on `ray.io/rayclusters` to the MultiKueue worker ServiceAccount. Without this, elastic RayCluster worker-group replica changes made on the management cluster (via the `ElasticJobsViaWorkloadSlices` feature gate) were rejected on the worker cluster with a 403 Forbidden and never propagated.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated access permissions to support updating and patching Ray clusters when using the Multikueue kubeconfig creation script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->