### PR TITLE
docs: correct TAS ResourceFlavor spec mutability description

### DIFF
--- a/site/content/en/docs/concepts/topology.md
+++ b/site/content/en/docs/concepts/topology.md
@@ -80,8 +80,9 @@ When a ResourceFlavor references a Topology:
 
 - **At least one nodeLabel is required**: The ResourceFlavor must have at least
   one entry in `.spec.nodeLabels`.
-- **Spec becomes immutable**: Once a ResourceFlavor has a `topologyName` set,
-  the entire `.spec` field cannot be modified.
+- **Restricted mutability**: Once a ResourceFlavor has a `topologyName` set,
+  the `.spec.nodeLabels` and `.spec.topologyName` fields cannot be modified.
+  The `.spec.nodeTaints` and `.spec.tolerations` fields can still be updated.
 
 ## What's next?
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

The Topology concepts page still states that once a ResourceFlavor has `topologyName` set, the entire `.spec` field cannot be modified. This has been outdated since:

- #9427 made `spec.nodeTaints` mutable
- #13622 made `spec.tolerations` mutable

This PR updates the wording to list exactly which fields remain immutable (`nodeLabels`, `topologyName`) and which can be updated (`nodeTaints`, `tolerations`).

Note: the versioned snapshots (`site/content/en/v0.18`, `site/content/en/v0.19`) carry the same sentence, which is also inaccurate for those releases (`nodeTaints` is mutable there via #9427, `tolerations` is not). I left them untouched to keep this minimal — happy to adjust them here or in a follow-up if preferred.

#### Which issue(s) this PR fixes:

Part of #3733

#### Special notes for your reviewer:

AI tool usage disclosure: I used an AI coding tool to help locate the outdated wording and prepare this change; I reviewed the result myself.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified mutability rules when a ResourceFlavor references a Topology.
  * Documented that node labels and topology name cannot be changed, while node taints and tolerations remain editable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->