### PR TITLE
[release-0.19] Requeue pending workloads when TAS ResourceFlavor nodeTaints are updated

### DIFF
--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -182,6 +182,13 @@ func (r *rfReconciler) Delete(event event.TypedDeleteEvent[*kueue.ResourceFlavor
 func (r *rfReconciler) Update(event event.TypedUpdateEvent[*kueue.ResourceFlavor]) bool {
 	switch {
 	case ptr.Equal(event.ObjectOld.Spec.TopologyName, event.ObjectNew.Spec.TopologyName):
+		if event.ObjectNew.Spec.TopologyName != nil &&
+			!equality.Semantic.DeepEqual(event.ObjectOld.Spec.NodeTaints, event.ObjectNew.Spec.NodeTaints) {
+			log := r.logger().WithValues("flavor", event.ObjectNew.Name)
+			log.V(2).Info("TAS ResourceFlavor nodeTaints updated")
+			r.cache.AddOrUpdateResourceFlavor(log, event.ObjectNew)
+			return true
+		}
 		return false
 	case event.ObjectOld.Spec.TopologyName == nil:
 		return true

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -410,6 +410,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				util.MustCreate(ctx, k8sClient, wl2)
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
 			})
+
+			ginkgo.By("verifying the pending workload is also retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
 		})
 	})
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -299,6 +299,120 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		})
 	})
 
+	ginkgo.When("Updating TAS ResourceFlavor nodeTaints", func() {
+		var (
+			node         *corev1.Node
+			topology     *kueue.Topology
+			tasFlavor    *kueue.ResourceFlavor
+			clusterQueue *kueue.ClusterQueue
+			localQueue   *kueue.LocalQueue
+		)
+
+		taint := corev1.Taint{
+			Key:    "example.com/dedicated",
+			Value:  "tas",
+			Effect: corev1.TaintEffectNoSchedule,
+		}
+
+		ginkgo.BeforeEach(func() {
+			node = testingnode.MakeNode("x1").
+				Label("node-group", "tas").
+				Label(corev1.LabelHostname, "x1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj()
+			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*node})
+
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName(topology.Name).
+				Taint(taint).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "3").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+				ClusterQueue(clusterQueue.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, node, true)
+		})
+
+		makeWorkload := func(name, cpu string) *kueue.Workload {
+			return utiltestingapi.MakeWorkload(name, ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, cpu).
+					Obj()).
+				Obj()
+		}
+		removeNodeTaints := func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedFlavor kueue.ResourceFlavor
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), &updatedFlavor)).To(gomega.Succeed())
+				updatedFlavor.Spec.NodeTaints = nil
+				g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.It("should requeue pending workloads when nodeTaints are removed", func() {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("removing the flavor nodeTaints", removeNodeTaints)
+
+			ginkgo.By("verifying a differently-shaped workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", "500m")
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+		})
+
+		ginkgo.It("should schedule workloads created after nodeTaints are removed", func() {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("removing the flavor nodeTaints", removeNodeTaints)
+
+			ginkgo.By("verifying an identically-shaped workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", "1")
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+		})
+	})
+
 	ginkgo.When("non-TAS pod exists", func() {
 		var (
 			nodes        []corev1.Node


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Manual cherry-pick of #13647 (commit 0474733f8) onto `release-0.19`.

Updating `spec.nodeTaints` on a TAS ResourceFlavor (mutable since #9427) does not requeue inadmissible workloads: they stay Pending indefinitely after the taints are removed, and with `SchedulingEquivalenceHashing` (default on in this release) identically-shaped new workloads are also parked without a scheduling attempt.

Differences from the main change, as discussed in https://github.com/kubernetes-sigs/kueue/pull/13647#issuecomment-5126783489:

- The update predicate detects only `nodeTaints` changes (this branch does not have the tolerations mutability from #13622, so the tolerations condition is not applicable).
- Only the nodeTaints integration specs are cherry-picked (the tolerations specs belong to #13622).

No TAS cache changes are involved: on this branch `tasCache.AddFlavor` skips existing flavors, so the predicate's `AddOrUpdateResourceFlavor` call only refreshes the generic flavor map read by the flavor assigner; admitted usage is unaffected.

#### Which issue(s) this PR fixes:

Part of #3733

#### Special notes for your reviewer:

Verified on this branch: both added integration specs fail without the controller change (time out waiting for admission) and pass with it.

AI tool usage disclosure: I used an AI coding tool to help adapt and verify the backport; I reviewed the result myself.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where updating `spec.nodeTaints` on a ResourceFlavor with `spec.topologyName` set did not retry inadmissible workloads, leaving them Pending until an unrelated event triggered a requeue.
```
