### PR TITLE
cleanup: Refactor `workload.Usage` to explicitly separate Assigned and Unassigned resources

### DIFF
--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -595,7 +595,7 @@ func (c *clusterQueue) reportWeightedShare(cohort kueue.CohortReference) {
 // and the number of admitted workloads for local queues.
 func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, op usageOp) {
 	admitted := workload.IsAdmitted(wi.Obj)
-	frUsage := wi.FlavorResourceUsage()
+	frUsage := wi.ResourceUsage().Assigned
 	for fr, q := range frUsage {
 		if op == add {
 			addUsage(c, fr, q)
@@ -683,7 +683,7 @@ func (c *clusterQueue) addLocalQueue(q *kueue.LocalQueue) error {
 	qImpl.resetFlavorsAndResources(c.resourceNode.Usage, c.AdmittedUsage)
 	for _, wl := range c.Workloads {
 		if workloadBelongsToLocalQueue(wl.Obj, q) {
-			frq := wl.FlavorResourceUsage()
+			frq := wl.ResourceUsage().Assigned
 			updateFlavorUsage(frq, qImpl.totalReserved, add)
 			qImpl.reservingWorkloads++
 			if workload.IsAdmitted(wl.Obj) {

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -109,14 +109,14 @@ func (c *ClusterQueueSnapshot) SimulateUsageRemoval(usage workload.Usage) func()
 }
 
 func (c *ClusterQueueSnapshot) AddUsage(usage workload.Usage) {
-	for fr, q := range usage.Quota {
+	for fr, q := range usage.Quota.Assigned {
 		addUsage(c, fr, q)
 	}
 	c.updateTASUsage(usage.TAS, add)
 }
 
 func (c *ClusterQueueSnapshot) RemoveUsage(usage workload.Usage) {
-	for fr, q := range usage.Quota {
+	for fr, q := range usage.Quota.Assigned {
 		removeUsage(c, fr, q)
 	}
 	c.updateTASUsage(usage.TAS, subtract)
@@ -136,7 +136,7 @@ func (c *ClusterQueueSnapshot) updateTASUsage(usage workload.TASUsage, op usageO
 }
 
 func (c *ClusterQueueSnapshot) Fits(usage workload.Usage) FitsCheck {
-	for fr, q := range usage.Quota {
+	for fr, q := range usage.Quota.Assigned {
 		if c.Available(fr).Cmp(q) < 0 {
 			return FitsCheckNoQuota
 		}

--- a/pkg/cache/scheduler/resource_test.go
+++ b/pkg/cache/scheduler/resource_test.go
@@ -402,7 +402,7 @@ func TestAvailable(t *testing.T) {
 			// add usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.ClusterQueue(cqName).AddUsage(workload.Usage{Quota: usage})
+					snapshot.ClusterQueue(cqName).AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: usage}})
 				}
 				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))
@@ -427,7 +427,7 @@ func TestAvailable(t *testing.T) {
 			// remove usage
 			{
 				for cqName, usage := range tc.usage {
-					snapshot.ClusterQueue(cqName).RemoveUsage(workload.Usage{Quota: usage})
+					snapshot.ClusterQueue(cqName).RemoveUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: usage}})
 				}
 				clusterQueues := snapshot.ClusterQueues()
 				gotAvailable := make(map[kueue.ClusterQueueReference]resources.FlavorResourceQuantities, len(clusterQueues))

--- a/pkg/scheduler/fair_sharing_iterator.go
+++ b/pkg/scheduler/fair_sharing_iterator.go
@@ -238,7 +238,7 @@ func (e *entryComparer) computeDRS(rootCohort *schdcache.CohortSnapshot, cqToEnt
 
 		wlKey := workload.Key(entry.Obj)
 		if e.requestedFRs != nil {
-			e.requestedFRs[wlKey] = usage.Quota
+			e.requestedFRs[wlKey] = usage.Quota.Assigned
 		}
 
 		// calculate DRS, with workload, for CQ.

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -674,7 +674,10 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		PodSets:            make([]PodSetAssignment, 0, len(requests)),
 		quotaCheckStrategy: a.quotaCheckStrategy,
 		Usage: workload.Usage{
-			Quota: make(resources.FlavorResourceQuantities),
+			Quota: workload.ResourceUsage{
+				Assigned:   make(resources.FlavorResourceQuantities),
+				Unassigned: make(resources.MapRequests),
+			},
 		},
 		LastState: workload.AssignmentClusterQueueState{
 			LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, 0, len(requests)),
@@ -768,7 +771,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				continue
 			}
 
-			flavors, status, considered := a.findFlavorForPodSets(ctx, log, psIDs, requests, resName, assignment.Usage.Quota)
+			flavors, status, considered := a.findFlavorForPodSets(ctx, log, psIDs, requests, resName, assignment.Usage.Quota.Assigned)
 			mergeFlavorAttemptsForResource(consideredFlavors, considered, resName, a.cq)
 			if status.IsError() || (len(flavors) == 0 && requests.Len() > 0) {
 				groupFlavors = nil
@@ -940,7 +943,7 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 			requestAmount -= oldRequest
 		}
 
-		a.Usage.Quota[fr] = a.Usage.Quota[fr].AddInt64(requestAmount)
+		a.Usage.Quota.Assigned[fr] = a.Usage.Quota.Assigned[fr].AddInt64(requestAmount)
 		flavorIdx[resource] = flvAssignment.TriedFlavorIdx
 	}
 	a.LastState.LastTriedFlavorIdx = append(a.LastState.LastTriedFlavorIdx, flavorIdx)

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -251,10 +251,10 @@ func TestAssignFlavors(t *testing.T) {
 						FlavorAssignmentAttempts: []FlavorAssignmentAttempt{{Flavor: "default", Mode: Fit}},
 					},
 				},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
 					{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
-				}},
+				}}},
 			},
 		},
 		"single flavor, fits tainted flavor": {
@@ -291,9 +291,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "tainted", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"single flavor, fits tainted flavor with toleration": {
@@ -322,9 +322,9 @@ func TestAssignFlavors(t *testing.T) {
 						{Flavor: "taint_and_toleration", Mode: Fit},
 					},
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "taint_and_toleration", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"single flavor, used resources, doesn't fit": {
@@ -363,9 +363,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"multiple resource groups, fits": {
@@ -423,10 +423,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:      resources.NewAmount(3_000),
 					{Flavor: "b_one", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, leader worker set, leader and workers request the same resources fits": {
@@ -491,9 +491,9 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						Count: 1,
 					}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(9_000),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, leader worker set, workers request GPU, leader does not request GPU, fits": {
@@ -570,11 +570,11 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						Count: 1,
 					}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(5_000),
 					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(5),
 					{Flavor: "two", Resource: "example.com/gpu"}:     resources.NewAmount(4),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, leader worker set, workers request GPU, leader does not request GPU, does not fit, without group it would fit": {
@@ -659,7 +659,7 @@ func TestAssignFlavors(t *testing.T) {
 						},
 						Count: 1,
 					}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -705,7 +705,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -762,11 +762,11 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(3_000),
 					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
 					{Flavor: "b_one", Resource: "example.com/gpu"}:   resources.NewAmount(3),
-				}},
+				}}},
 			},
 		},
 		"multiple resource groups with multiple resources, fits with different modes": {
@@ -853,11 +853,11 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(3_000),
 					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(10 * utiltesting.Mi),
 					{Flavor: "b_one", Resource: "example.com/gpu"}:   resources.NewAmount(3),
-				}},
+				}}},
 			},
 		},
 		"multiple resources in a group, doesn't fit": {
@@ -905,7 +905,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -945,9 +945,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, fits a node selector": {
@@ -1004,9 +1004,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, fits with node affinity": {
@@ -1067,10 +1067,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
 					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, node affinity fits any flavor": {
@@ -1132,9 +1132,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors with different label keys, selector only uses flavor's own keys": {
@@ -1169,9 +1169,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "label-x-a", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"labelless flavor in group with labeled flavor, workload uses labeled selector": {
@@ -1206,9 +1206,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 		},
 		"multiple flavors, doesn't fit node affinity": {
@@ -1268,7 +1268,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "NoMatchingFlavor",
 			},
 		},
@@ -1327,10 +1327,10 @@ func TestAssignFlavors(t *testing.T) {
 						Count: 1,
 					},
 				},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(5_000),
-				}},
+				}}},
 			},
 		},
 		"multiple specs, fits borrowing": {
@@ -1396,10 +1396,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}:    resources.NewAmount(10_000),
 					{Flavor: "default", Resource: corev1.ResourceMemory}: resources.NewAmount(5 * utiltesting.Gi),
-				}},
+				}}},
 			},
 		},
 		"not enough space to borrow": {
@@ -1442,7 +1442,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -1499,9 +1499,9 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"past min, but can preempt in ClusterQueue": {
@@ -1540,9 +1540,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"past min, but can preempt in cohort and ClusterQueue": {
@@ -1597,9 +1597,9 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"can only preempt flavors that match affinity": {
@@ -1653,9 +1653,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"each podset requires preemption on a different flavor": {
@@ -1746,10 +1746,10 @@ func TestAssignFlavors(t *testing.T) {
 						Count: 10,
 					},
 				},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:     resources.NewAmount(2_000),
 					{Flavor: "tainted", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-				}},
+				}}},
 			},
 		},
 		"resource not listed in clusterQueue": {
@@ -1773,7 +1773,7 @@ func TestAssignFlavors(t *testing.T) {
 					Status: *NewStatus("resource example.com/gpu unavailable in ClusterQueue"),
 					Count:  1,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "NoMatchingFlavor",
 			},
 		},
@@ -1805,9 +1805,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
-				}},
+				}}},
 			},
 			wantRepMode: Fit,
 		},
@@ -1841,10 +1841,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(1_000),
 					{Flavor: "default", Resource: "example.com/gpu"}:  resources.NewAmount(0),
-				}},
+				}}},
 			},
 			wantRepMode: Fit,
 		},
@@ -1879,10 +1879,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 3,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(3),
 					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(3_000),
-				}},
+				}}},
 			},
 			wantRepMode: Fit,
 		},
@@ -1918,7 +1918,7 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 3,
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -1958,10 +1958,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 3,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(3),
 					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(3_000),
-				}},
+				}}},
 			},
 			wantRepMode: Fit,
 		},
@@ -1998,10 +1998,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 5,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "default", Resource: corev1.ResourcePods}: resources.NewAmount(5),
 					{Flavor: "default", Resource: corev1.ResourceCPU}:  resources.NewAmount(5_000),
-				}},
+				}}},
 			},
 			wantRepMode: Fit,
 			featureGates: map[featuregate.Feature]bool{
@@ -2051,10 +2051,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"preempt before try next flavor; using WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -2101,10 +2101,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"preempt try next flavor": {
@@ -2150,10 +2150,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: "cpu"}:  resources.NewAmount(9_000),
 					{Flavor: "two", Resource: "pods"}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"borrow try next flavor, found the first flavor": {
@@ -2210,10 +2210,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"borrow try next flavor, found the second flavor": {
@@ -2265,10 +2265,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
 					{Flavor: "two", Resource: corev1.ResourcePods}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"borrow before try next flavor": {
@@ -2318,10 +2318,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: "cpu"}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: "pods"}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=MayStopSearch": {
@@ -2386,9 +2386,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -2453,9 +2453,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, no borrowingLimit; WhenCanBorrow=MayStopSearch": {
@@ -2520,9 +2520,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, no borrowingLimit; WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -2587,9 +2587,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=TryNextFlavor": {
@@ -2642,9 +2642,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one; WhenCanBorrow=TryNextFlavor,WhenCanPreempt=MayStopSearch": {
@@ -2697,9 +2697,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed, but borrowingLimit exceeds the quota available in the cohort": {
@@ -2733,7 +2733,7 @@ func TestAssignFlavors(t *testing.T) {
 			},
 			wantRepMode: NoFit,
 			wantAssignment: Assignment{
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				PodSets: []PodSetAssignment{
 					{
 						Name:   kueue.DefaultPodSetName,
@@ -2806,10 +2806,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
 					{Flavor: "two", Resource: corev1.ResourcePods}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"lend try next flavor, found the first flavor": {
@@ -2867,10 +2867,10 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"cannot preempt in cohort (oracle returns None) for the first flavor, tries the second flavor (which fits)": {
@@ -2935,9 +2935,9 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"cannot preempt in cohort (oracle returns None) for the first flavor, tries the second flavor (which fits); using deprecated WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -3002,9 +3002,9 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
-				}},
+				}}},
 			},
 		},
 		"quota exhausted, but can preempt in cohort and ClusterQueue": {
@@ -3060,10 +3060,10 @@ func TestAssignFlavors(t *testing.T) {
 					Count: 1,
 				}},
 				Borrowing: 1,
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}:  resources.NewAmount(9_000),
 					{Flavor: "one", Resource: corev1.ResourcePods}: resources.NewAmount(1),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Any": {
@@ -3121,9 +3121,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Any; using deprecated WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -3181,9 +3181,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Never": {
@@ -3240,9 +3240,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"when borrowing while preemption is needed for flavor one, fair sharing enabled, reclaimWithinCohort=Never; using deprecated WhenCanBorrow=MayStopSearch,WhenCanPreempt=MayStopSearch": {
@@ -3299,9 +3299,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}: resources.NewAmount(12_000),
-				}},
+				}}},
 			},
 		},
 		"workload slice preemption fits in the original workload resource flavor": {
@@ -3364,10 +3364,10 @@ func TestAssignFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "two", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
 					{Flavor: "two", Resource: corev1.ResourceMemory}: resources.NewAmount(0),
-				}},
+				}}},
 			},
 		},
 		"workload slice preemption does not fit in the original workload resource flavor": {
@@ -3434,7 +3434,7 @@ func TestAssignFlavors(t *testing.T) {
 						},
 					},
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "ExceedsMaxQuota",
 			},
 		},
@@ -3484,10 +3484,10 @@ func TestAssignFlavors(t *testing.T) {
 						},
 					},
 				},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "tas-a", Resource: corev1.ResourceCPU}:    resources.NewAmount(1_000),
 					{Flavor: "tas-b", Resource: corev1.ResourceMemory}: resources.NewAmount(utiltesting.Mi),
-				}},
+				}}},
 			},
 		},
 		"multi-podset, one fits and another fails, fitting podset attempts skipped in resolveNoFitReason": {
@@ -3569,9 +3569,9 @@ func TestAssignFlavors(t *testing.T) {
 					},
 				},
 				Usage: workload.Usage{
-					Quota: resources.FlavorResourceQuantities{
+					Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 						{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(1000),
-					},
+					}},
 				},
 			},
 		},
@@ -3625,7 +3625,7 @@ func TestAssignFlavors(t *testing.T) {
 					t.Fatalf("Failed to create CQ snapshot")
 				}
 				if tc.clusterQueueUsage != nil {
-					clusterQueue.AddUsage(workload.Usage{Quota: tc.clusterQueueUsage})
+					clusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.clusterQueueUsage}})
 				}
 
 				if tc.secondaryClusterQueue != nil {
@@ -3633,7 +3633,7 @@ func TestAssignFlavors(t *testing.T) {
 					if secondaryClusterQueue == nil {
 						t.Fatalf("Failed to create secondary CQ snapshot")
 					}
-					secondaryClusterQueue.AddUsage(workload.Usage{Quota: tc.secondaryClusterQueueUsage})
+					secondaryClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.secondaryClusterQueueUsage}})
 				}
 
 				flvAssigner := New(
@@ -3834,10 +3834,10 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 			otherClusterQueue := snapshot.ClusterQueue("other-clusterqueue")
-			otherClusterQueue.AddUsage(workload.Usage{Quota: tc.otherClusterQueueUsage})
+			otherClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.otherClusterQueueUsage}})
 
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
-			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
+			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
 			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
 			assignment := flvAssigner.Assign(ctx, nil)
@@ -3902,9 +3902,9 @@ func TestDeletedFlavors(t *testing.T) {
 					},
 					Count: 1,
 				}},
-				Usage: workload.Usage{Quota: resources.FlavorResourceQuantities{
+				Usage: workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
 					{Flavor: "flavor", Resource: corev1.ResourceCPU}: resources.NewAmount(3_000),
-				}},
+				}}},
 			},
 		},
 		"flavor not found": {
@@ -3936,7 +3936,7 @@ func TestDeletedFlavors(t *testing.T) {
 						},
 					},
 				}},
-				Usage:       workload.Usage{Quota: resources.FlavorResourceQuantities{}},
+				Usage:       workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{}}},
 				NoFitReason: "NoMatchingFlavor",
 			},
 		},
@@ -4171,10 +4171,10 @@ func TestHierarchical(t *testing.T) {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
 			otherClusterQueue := snapshot.ClusterQueue("other-clusterqueue")
-			otherClusterQueue.AddUsage(workload.Usage{Quota: tc.otherClusterQueueUsage})
+			otherClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.otherClusterQueueUsage}})
 
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
-			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
+			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
 			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
 			assignment := flvAssigner.Assign(ctx, nil)
@@ -5615,14 +5615,14 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			}
 			cqSnapshot := snapshot.ClusterQueue(kueue.ClusterQueueReference(testCQ.Name))
 			if len(tc.cqUsage) > 0 {
-				cqSnapshot.AddUsage(workload.Usage{Quota: tc.cqUsage})
+				cqSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.cqUsage}})
 			}
 			for siblingName, usage := range tc.siblingCQUsage {
 				siblingSnapshot := snapshot.ClusterQueue(siblingName)
 				if siblingSnapshot == nil {
 					t.Fatalf("Sibling ClusterQueue %s not found in snapshot", siblingName)
 				}
-				siblingSnapshot.AddUsage(workload.Usage{Quota: usage})
+				siblingSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: usage}})
 			}
 
 			assigner := New(

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -145,8 +145,10 @@ func (p *Preemptor) GetTargets(ctx context.Context, wl workload.Info, assignment
 		tasRequests:       tasRequests,
 		frsNeedPreemption: flavorResourcesNeedPreemption(assignment),
 		workloadUsage: workload.Usage{
-			Quota: assignment.TotalRequestsFor(log, &wl),
-			TAS:   wl.TASUsage(),
+			Quota: workload.ResourceUsage{
+				Assigned: assignment.TotalRequestsFor(log, &wl),
+			},
+			TAS: wl.TASUsage(),
 		},
 	})
 }
@@ -284,7 +286,7 @@ func (p *Preemptor) classicalPreemptions(preemptionCtx *preemptionCtx) []*Target
 		Wl:                preemptionCtx.preemptor.Obj,
 		Cq:                preemptionCtx.preemptorCQ,
 		FrsNeedPreemption: preemptionCtx.frsNeedPreemption,
-		Requests:          preemptionCtx.workloadUsage.Quota,
+		Requests:          preemptionCtx.workloadUsage.Quota.Assigned,
 		WorkloadOrdering:  p.workloadOrdering,
 	}
 	candidatesGenerator := classical.NewCandidateIterator(hierarchicalReclaimCtx, p.enabledAfs, preemptionCtx.frsNeedPreemption, preemptionCtx.snapshot, p.clock, preemptioncommon.CandidatesOrdering)
@@ -626,7 +628,7 @@ func cqIsBorrowing(cq *schdcache.ClusterQueueSnapshot, frsNeedPreemption sets.Se
 // requestable resources and simulated usage of the ClusterQueue and its cohort,
 // if it belongs to one.
 func workloadFits(preemptionCtx *preemptionCtx, allowBorrowing bool) bool {
-	for fr, v := range preemptionCtx.workloadUsage.Quota {
+	for fr, v := range preemptionCtx.workloadUsage.Quota.Assigned {
 		if !allowBorrowing && preemptionCtx.preemptorCQ.BorrowingWith(fr, v) {
 			return false
 		}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -56,7 +56,11 @@ func (p *PreemptionOracle) SimulatePreemption(
 		preemptorCQ:       p.snapshot.ClusterQueue(wl.ClusterQueue),
 		snapshot:          p.snapshot,
 		frsNeedPreemption: sets.New(fr),
-		workloadUsage:     workload.Usage{Quota: resources.FlavorResourceQuantities{fr: quantity}},
+		workloadUsage: workload.Usage{
+			Quota: workload.ResourceUsage{
+				Assigned: resources.FlavorResourceQuantities{fr: quantity},
+			},
+		},
 	})
 
 	if len(candidates) == 0 {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -609,7 +609,7 @@ type entry struct {
 }
 
 func (e *entry) assignmentUsage(log logr.Logger) workload.Usage {
-	return netUsage(log, e, e.assignment.Usage.Quota)
+	return netUsage(log, e, e.assignment.Usage.Quota.Assigned)
 }
 
 func (e *entry) readResourceToFlavorMapping() workload.PodSetResourcesToFlavors {
@@ -717,17 +717,17 @@ func netUsage(log logr.Logger, e *entry, netQuota resources.FlavorResourceQuanti
 		result.TAS = e.assignment.ComputeTASNetUsage(log, e.clusterQueueSnapshot, &e.Info, e.Obj.Status.Admission)
 	}
 	if !workload.HasQuotaReservation(e.Obj) {
-		result.Quota = netQuota
+		result.Quota.Assigned = netQuota
 	}
 	return result
 }
 
 func quotaResourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) resources.FlavorResourceQuantities {
 	if e.assignment.RepresentativeMode() != flavorassigner.Preempt {
-		return e.assignment.Usage.Quota
+		return e.assignment.Usage.Quota.Assigned
 	}
 	reservedUsage := make(resources.FlavorResourceQuantities)
-	for fr, usage := range e.assignment.Usage.Quota {
+	for fr, usage := range e.assignment.Usage.Quota.Assigned {
 		cqQuota := cq.QuotaFor(fr)
 		if e.assignment.Borrowing > 0 {
 			if cqQuota.BorrowingLimit == nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8398,7 +8398,7 @@ func TestResourcesToReserve(t *testing.T) {
 					},
 				},
 				Borrowing: tc.borrowing,
-				Usage:     workload.Usage{Quota: tc.assignmentUsage},
+				Usage:     workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.assignmentUsage}},
 			}
 			e := &entry{assignment: assignment, Info: *workload.NewInfo(
 				&kueue.Workload{},
@@ -8434,7 +8434,7 @@ func TestResourcesToReserve(t *testing.T) {
 			cqSnapshot := snapshot.ClusterQueue("cq")
 
 			got := resourcesToReserve(logr.Discard(), e, cqSnapshot)
-			if !reflect.DeepEqual(tc.wantReserved, got.Quota) {
+			if !reflect.DeepEqual(tc.wantReserved, got.Quota.Assigned) {
 				t.Errorf("%s failed\n: Want reservedMem: %v, got: %v", tc.name, tc.wantReserved, got)
 			}
 		})

--- a/pkg/workload/usage.go
+++ b/pkg/workload/usage.go
@@ -24,7 +24,13 @@ import (
 type TASFlavorUsage []TopologyDomainRequests
 type TASUsage map[kueue.ResourceFlavorReference]TASFlavorUsage
 
+// ResourceUsage contains both the assigned resources and the overall requests.
+type ResourceUsage struct {
+	Assigned   resources.FlavorResourceQuantities
+	Unassigned resources.MapRequests
+}
+
 type Usage struct {
-	Quota resources.FlavorResourceQuantities
+	Quota ResourceUsage
 	TAS   TASUsage
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -410,27 +410,35 @@ func (i *Info) CanBePartiallyAdmitted() bool {
 // quota and TAS usage.
 func (i *Info) Usage() Usage {
 	return Usage{
-		Quota: i.FlavorResourceUsage(),
+		Quota: i.ResourceUsage(),
 		TAS:   i.TASUsage(),
 	}
 }
 
-// FlavorResourceUsage returns the total resource usage for the workload,
-// per flavor (if assigned, otherwise flavor shows as empty string), per resource.
-func (i *Info) FlavorResourceUsage() resources.FlavorResourceQuantities {
-	total := make(resources.FlavorResourceQuantities)
+// ResourceUsage returns the total resource usage for the workload,
+// separating assigned flavors and unassigned requests.
+func (i *Info) ResourceUsage() ResourceUsage {
+	ru := ResourceUsage{
+		Assigned:   make(resources.FlavorResourceQuantities),
+		Unassigned: make(resources.MapRequests),
+	}
 	if i == nil {
-		return total
+		return ru
 	}
 	for _, psReqs := range i.TotalRequests {
 		if psReqs.Requests != nil {
 			psReqs.Requests.ForEach(func(res corev1.ResourceName, q int64) {
 				flv := psReqs.Flavors[res]
-				total[resources.FlavorResource{Flavor: flv, Resource: res}] = total[resources.FlavorResource{Flavor: flv, Resource: res}].AddInt64(q)
+				if flv == "" {
+					ru.Unassigned[res] += q
+				} else {
+					fr := resources.FlavorResource{Flavor: flv, Resource: res}
+					ru.Assigned[fr] = ru.Assigned[fr].AddInt64(q)
+				}
 			})
 		}
 	}
-	return total
+	return ru
 }
 
 func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string) corev1.ResourceList {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1272,13 +1272,16 @@ func TestAssignmentClusterQueueState(t *testing.T) {
 	}
 }
 
-func TestFlavorResourceUsage(t *testing.T) {
+func TestResourceUsage(t *testing.T) {
 	cases := map[string]struct {
 		info *Info
-		want resources.FlavorResourceQuantities
+		want ResourceUsage
 	}{
 		"nil": {
-			want: resources.FlavorResourceQuantities{},
+			want: ResourceUsage{
+				Assigned:   resources.FlavorResourceQuantities{},
+				Unassigned: resources.MapRequests{},
+			},
 		},
 		"one podset, no flavors": {
 			info: &Info{
@@ -1289,9 +1292,12 @@ func TestFlavorResourceUsage(t *testing.T) {
 					}),
 				}},
 			},
-			want: resources.FlavorResourceQuantities{
-				{Flavor: "", Resource: "cpu"}:             resources.NewAmount(1_000),
-				{Flavor: "", Resource: "example.com/gpu"}: resources.NewAmount(3),
+			want: ResourceUsage{
+				Assigned: resources.FlavorResourceQuantities{},
+				Unassigned: resources.MapRequests{
+					"cpu":             1_000,
+					"example.com/gpu": 3,
+				},
 			},
 		},
 		"one podset, multiple flavors": {
@@ -1307,9 +1313,12 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				}},
 			},
-			want: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "cpu"}:         resources.NewAmount(1_000),
-				{Flavor: "gpu", Resource: "example.com/gpu"}: resources.NewAmount(3),
+			want: ResourceUsage{
+				Assigned: resources.FlavorResourceQuantities{
+					{Flavor: "default", Resource: "cpu"}:         resources.NewAmount(1_000),
+					{Flavor: "gpu", Resource: "example.com/gpu"}: resources.NewAmount(3),
+				},
+				Unassigned: resources.MapRequests{},
 			},
 		},
 		"multiple podsets, multiple flavors": {
@@ -1345,17 +1354,20 @@ func TestFlavorResourceUsage(t *testing.T) {
 					},
 				},
 			},
-			want: resources.FlavorResourceQuantities{
-				{Flavor: "default", Resource: "cpu"}:             resources.NewAmount(3_000),
-				{Flavor: "default", Resource: "memory"}:          resources.NewAmount(2 * utiltesting.Gi),
-				{Flavor: "model_a", Resource: "example.com/gpu"}: resources.NewAmount(3),
-				{Flavor: "model_b", Resource: "example.com/gpu"}: resources.NewAmount(1),
+			want: ResourceUsage{
+				Assigned: resources.FlavorResourceQuantities{
+					{Flavor: "default", Resource: "cpu"}:             resources.NewAmount(3_000),
+					{Flavor: "default", Resource: "memory"}:          resources.NewAmount(2 * utiltesting.Gi),
+					{Flavor: "model_a", Resource: "example.com/gpu"}: resources.NewAmount(3),
+					{Flavor: "model_b", Resource: "example.com/gpu"}: resources.NewAmount(1),
+				},
+				Unassigned: resources.MapRequests{},
 			},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.info.FlavorResourceUsage()
+			got := tc.info.ResourceUsage()
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("info.ResourceUsage() returned (-want,+got):\n%s", diff)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR refactors `workload.Usage` to explicitly separate `Assigned` and `Unassigned` resource requests into dedicated fields within a new `ResourceUsage` struct. 

Previously, `Quota` grouped all requested resources into a single map (`resources.FlavorResourceQuantities`), relying on an empty string (`""`) for the `Flavor` field to represent unassigned resources. This was error-prone and required callers to loop through keys to check `Flavor == ""` to isolate unassigned quantities. 

By splitting this into `.Assigned` (for admitted flavors) and `.Unassigned` (for pending requests), we establish stronger type safety and clarity across the `scheduler`, `preemption`, `cache`, and `flavorassigner` components.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4545

#### Special notes for your reviewer:
All test fixtures and method calls (such as `workload.Info.ResourceUsage()`) across the scheduler and cache layers have been migrated to the new struct format. 

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved scheduling accuracy by distinguishing resources assigned to flavors from resources that remain unassigned.
  - Updated quota tracking to consistently account for assigned resources during reservations, admissions, capacity checks, fairness decisions, and preemption.
  - Improved workload usage reporting to include both flavor-assigned quantities and unassigned resource requests.
  - Preserved existing topology-aware scheduling behavior while making resource accounting more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->