### PR TITLE
Requeue pending workloads when a non-TAS ResourceFlavor nodeTaints change

### DIFF
--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
@@ -173,7 +174,16 @@ func (r *ResourceFlavorReconciler) Update(e event.TypedUpdateEvent[*kueue.Resour
 		return true
 	}
 
-	if cqNames := r.cache.AddOrUpdateResourceFlavor(log, e.ObjectNew.DeepCopy()); len(cqNames) > 0 {
+	cqNames := r.cache.AddOrUpdateResourceFlavor(log, e.ObjectNew.DeepCopy())
+	// AddOrUpdateResourceFlavor only reports ClusterQueues that transitioned
+	// from pending to active. Editing nodeTaints keeps the ClusterQueues active
+	// but changes which workloads the flavor can admit, so the workloads left
+	// inadmissible by a since-removed taint would otherwise never be retried.
+	// Retry the inadmissible workloads in the ClusterQueues that use this flavor.
+	if !equality.Semantic.DeepEqual(e.ObjectOld.Spec.NodeTaints, e.ObjectNew.Spec.NodeTaints) {
+		cqNames.Insert(r.cache.ClusterQueuesUsingFlavor(kueue.ResourceFlavorReference(e.ObjectNew.Name))...)
+	}
+	if len(cqNames) > 0 {
 		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return false

--- a/test/integration/singlecluster/scheduler/scheduler_nodetaints_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_nodetaints_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Scheduler non-TAS ResourceFlavor nodeTaints", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	taint := corev1.Taint{
+		Key:    "example.com/dedicated",
+		Value:  "reserved",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "nodetaints-")
+
+		flavor = utiltestingapi.MakeResourceFlavor("tainted-flavor").
+			Taint(taint).
+			Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+				Resource(corev1.ResourceCPU, "5").
+				Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	makeWorkload := func(name, cpu string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, cpu).
+			Obj()
+	}
+
+	removeNodeTaints := func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			var updatedFlavor kueue.ResourceFlavor
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(flavor), &updatedFlavor)).To(gomega.Succeed())
+			updatedFlavor.Spec.NodeTaints = nil
+			g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	// The second workload's shape is the only difference between the scenarios:
+	// a differently-shaped one proves the scheduler cache saw the flavor update,
+	// while an identically-shaped one additionally exercises the
+	// scheduling-equivalence-hash freeze that would otherwise block resubmissions.
+	ginkgo.DescribeTable("should retry pending workloads after nodeTaints are removed",
+		func(secondWorkloadCPU string) {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("removing the flavor nodeTaints", removeNodeTaints)
+
+			ginkgo.By("verifying a workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", secondWorkloadCPU)
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+		},
+		ginkgo.Entry("with a differently-shaped new workload", "500m"),
+		ginkgo.Entry("with an identically-shaped new workload", "1"),
+	)
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Removing or editing the `nodeTaints` of a **non-TAS** ResourceFlavor does not retry workloads that were left inadmissible by the taint. A workload rejected for an untolerated flavor taint stays `Pending` indefinitely after the taint is removed, until some unrelated event happens to trigger a retry.

Root cause: the core ResourceFlavor controller's `Update` calls `AddOrUpdateResourceFlavor`, which via `updateClusterQueues` only returns the ClusterQueues that transitioned from `pending` to `active`. Editing `nodeTaints` keeps the ClusterQueues `active`, so the returned set is empty and `NotifyRetryInadmissible` is never called.

The TAS-side fix (#13647) sidesteps this through the separate TAS ResourceFlavor controller, but non-TAS flavors have no such controller and are only handled by the core controller, so they remained exposed.

This PR makes the core ResourceFlavor controller, when a flavor's `nodeTaints` change, also retry the inadmissible workloads in the ClusterQueues that use that flavor (via the existing `Cache.ClusterQueuesUsingFlavor`). This is intentionally narrow: it fires only on a `nodeTaints` change and targets only the ClusterQueues that reference the flavor. It also harmlessly covers TAS flavors — `NotifyRetryInadmissible` is idempotent, so the overlap with #13647 is safe.

Reproduced with two integration specs (both fail without the fix, pass with it):
- A pending workload is never retried after the taint is removed — while a differently-shaped workload created after the update **is** admitted, proving the scheduler cache saw the update and only the requeue was missing.
- An identically-shaped workload submitted after the removal is also frozen by scheduling-equivalence hashing, so resubmitting the same job does not help either.

Verification: the two new specs, `./pkg/controller/core/...` unit tests, the existing TAS `nodeTaints` integration specs (interaction with #13647), and the full `test/integration/singlecluster/scheduler` suite all pass.

#### Which issue(s) this PR fixes:

Related to #3733 (this addresses the non-TAS `nodeTaints` requeue gap surfaced there; the issue tracks additional ResourceFlavor/Topology mutability work and remains open).

#### Special notes for your reviewer:

There is a narrow-vs-wide design choice here and I went with the narrow one:

- **Narrow (this PR):** fix it in the core ResourceFlavor controller, gated on a `nodeTaints` change, scoped to `ClusterQueuesUsingFlavor`.
- **Wide alternative:** change `updateClusterQueues` (pkg/cache/scheduler/cache.go) so a flavor update that changes matching semantics returns already-active ClusterQueues too. This is the deepest fix but has a much larger blast radius — `updateClusterQueues` has several callers and the `pending -> active` gate exists to avoid over-requeuing — so I did not take it. Happy to switch if you prefer the wider approach.

The same requeue gap likely applies to `nodeLabels` for non-TAS flavors, but I kept this PR scoped to `nodeTaints` (the reproduced case). `nodeLabels` mutability has additional matching-set semantics and is better handled separately.

AI disclosure: I used an AI assistant to help investigate the code paths, write the reproduction, and draft this change. I reviewed all changed lines and verified the behavior with the tests listed above.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where editing the `nodeTaints` of a non-TAS ResourceFlavor did not retry workloads that had been made inadmissible by the taint, leaving them pending until an unrelated event triggered a retry.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workloads blocked by ResourceFlavor node taints are now retried automatically when those taints are removed or changed.
  * Previously pending workloads can be admitted without requiring another workload or configuration change to trigger scheduling.
  * New workloads are scheduled promptly after node taints are updated.
  * Scheduling now consistently retries affected workloads across all applicable queues and supports different workload request shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->