### PR TITLE
feat: support custom resizes for StatefulSet

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -504,7 +504,16 @@ func (r *Reconciler) syncReplicas(
 	wl *kueue.Workload,
 	replicas int32,
 ) (shouldUpdateWl bool, stopReconcile bool, err error) {
-	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
+	if replicas == 0 || len(wl.Spec.PodSets) != 1 {
+		return false, false, nil
+	}
+
+	if wl.Spec.PodSets[0].Count == replicas {
+		if len(wl.Status.ReclaimablePods) > 0 {
+			if err := workload.UpdateReclaimablePods(ctx, r.client, wl, nil); err != nil {
+				return false, false, err
+			}
+		}
 		return false, false, nil
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -244,6 +244,23 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	}
 
 	var admissionGatedByUpdated bool
+	var shouldUpdateReclaimablePods bool
+	var reclaimablePods []kueue.ReclaimablePod
+	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
+		if !workload.IsAdmitted(wl) {
+			wl.Spec.PodSets[0].Count = replicas
+			shouldUpdate = true
+		} else if replicas < wl.Spec.PodSets[0].Count {
+			shouldUpdateReclaimablePods = true
+			reclaimablePods = []kueue.ReclaimablePod{
+				{
+					Name:  wl.Spec.PodSets[0].Name,
+					Count: wl.Spec.PodSets[0].Count - replicas,
+				},
+			}
+		}
+	}
+
 	if features.Enabled(features.AdmissionGatedBy) {
 		admissionGatedByUpdated = jobframework.PropagateAdmissionGatedByAnnotation(sts, wl)
 		shouldUpdate = admissionGatedByUpdated || shouldUpdate
@@ -256,6 +273,12 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	}
 	if admissionGatedByUpdated {
 		jobframework.RecordAdmissionGatedByUpdateEvent(r.record, sts)
+	}
+
+	if shouldUpdateReclaimablePods {
+		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
+			return err
+		}
 	}
 
 	if shouldReleaseReservation {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -250,7 +250,7 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		shouldUpdate = true
 	}
 
-	wlUpdated, reclaimablePods, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
+	wlUpdated, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
 	if err != nil {
 		return err
 	}
@@ -266,12 +266,6 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 
 	if shouldUpdate {
 		if err := r.client.Update(ctx, wl); err != nil {
-			return err
-		}
-	}
-
-	if len(reclaimablePods) > 0 {
-		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
 			return err
 		}
 	}
@@ -512,40 +506,42 @@ func (r *Reconciler) syncReplicas(
 	sts *appsv1.StatefulSet,
 	wl *kueue.Workload,
 	replicas int32,
-) (shouldUpdateWl bool, reclaimablePods []kueue.ReclaimablePod, stopReconcile bool, err error) {
+) (shouldUpdateWl bool, stopReconcile bool, err error) {
 	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
-		return false, nil, false, nil
+		return false, false, nil
 	}
 
 	switch {
-	case !workload.IsAdmitted(wl):
-		// If the workload is not admitted, we can freely update its PodSet count to match the StatefulSet.
+	case !workload.HasQuotaReservation(wl):
+		// If the workload has no quota reservation, we can freely update its PodSet count to match the StatefulSet.
 		wl.Spec.PodSets[0].Count = replicas
-		return true, nil, false, nil
+		return true, false, nil
 
 	case replicas < wl.Spec.PodSets[0].Count:
 		// When scaling down an admitted workload, we record the freed pods as ReclaimablePods
 		// so Kueue can reclaim the quota before the workload finishes.
-		reclaimablePods = []kueue.ReclaimablePod{
+		reclaimablePods := []kueue.ReclaimablePod{
 			{
 				Name:  wl.Spec.PodSets[0].Name,
 				Count: wl.Spec.PodSets[0].Count - replicas,
 			},
 		}
-		return false, reclaimablePods, false, nil
+		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
+			return false, false, err
+		}
+		return false, false, nil
 
 	case replicas > wl.Spec.PodSets[0].Count:
 		// TOCTOU mitigation: A scale-up might have been allowed by the admission webhook if the workload
 		// was still in a pending state at the time of the check, but then admitted concurrently.
 		// To prevent the StatefulSet from exceeding its admitted quota, we revert its replicas to the Workload's count.
-		count := wl.Spec.PodSets[0].Count
-		sts.Spec.Replicas = &count
+		sts.Spec.Replicas = new(wl.Spec.PodSets[0].Count)
 		if err := r.client.Update(ctx, sts); err != nil {
-			return false, nil, false, err
+			return false, false, err
 		}
 		// The StatefulSet was updated, which will trigger a new reconciliation.
-		return false, nil, true, nil
+		return false, true, nil
 	}
 
-	return false, nil, false, nil
+	return false, false, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -244,7 +244,7 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	}
 
 	var admissionGatedByUpdated bool
-	wlUpdated, reclaimablePods, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
+	wlUpdated, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
 	if err != nil {
 		return err
 	}
@@ -265,12 +265,6 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	}
 	if admissionGatedByUpdated {
 		jobframework.RecordAdmissionGatedByUpdateEvent(r.record, sts)
-	}
-
-	if len(reclaimablePods) > 0 {
-		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
-			return err
-		}
 	}
 
 	if shouldReleaseReservation {
@@ -509,40 +503,42 @@ func (r *Reconciler) syncReplicas(
 	sts *appsv1.StatefulSet,
 	wl *kueue.Workload,
 	replicas int32,
-) (shouldUpdateWl bool, reclaimablePods []kueue.ReclaimablePod, stopReconcile bool, err error) {
+) (shouldUpdateWl bool, stopReconcile bool, err error) {
 	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
-		return false, nil, false, nil
+		return false, false, nil
 	}
 
 	switch {
-	case !workload.IsAdmitted(wl):
-		// If the workload is not admitted, we can freely update its PodSet count to match the StatefulSet.
+	case !workload.HasQuotaReservation(wl):
+		// If the workload has no quota reservation, we can freely update its PodSet count to match the StatefulSet.
 		wl.Spec.PodSets[0].Count = replicas
-		return true, nil, false, nil
+		return true, false, nil
 
 	case replicas < wl.Spec.PodSets[0].Count:
 		// When scaling down an admitted workload, we record the freed pods as ReclaimablePods
 		// so Kueue can reclaim the quota before the workload finishes.
-		reclaimablePods = []kueue.ReclaimablePod{
+		reclaimablePods := []kueue.ReclaimablePod{
 			{
 				Name:  wl.Spec.PodSets[0].Name,
 				Count: wl.Spec.PodSets[0].Count - replicas,
 			},
 		}
-		return false, reclaimablePods, false, nil
+		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
+			return false, false, err
+		}
+		return false, false, nil
 
 	case replicas > wl.Spec.PodSets[0].Count:
 		// TOCTOU mitigation: A scale-up might have been allowed by the admission webhook if the workload
 		// was still in a pending state at the time of the check, but then admitted concurrently.
 		// To prevent the StatefulSet from exceeding its admitted quota, we revert its replicas to the Workload's count.
-		count := wl.Spec.PodSets[0].Count
-		sts.Spec.Replicas = &count
+		sts.Spec.Replicas = new(wl.Spec.PodSets[0].Count)
 		if err := r.client.Update(ctx, sts); err != nil {
-			return false, nil, false, err
+			return false, false, err
 		}
 		// The StatefulSet was updated, which will trigger a new reconciliation.
-		return false, nil, true, nil
+		return false, true, nil
 	}
 
-	return false, nil, false, nil
+	return false, false, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -250,6 +250,23 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		shouldUpdate = true
 	}
 
+	var shouldUpdateReclaimablePods bool
+	var reclaimablePods []kueue.ReclaimablePod
+	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
+		if !workload.IsAdmitted(wl) {
+			wl.Spec.PodSets[0].Count = replicas
+			shouldUpdate = true
+		} else if replicas < wl.Spec.PodSets[0].Count {
+			shouldUpdateReclaimablePods = true
+			reclaimablePods = []kueue.ReclaimablePod{
+				{
+					Name:  wl.Spec.PodSets[0].Name,
+					Count: wl.Spec.PodSets[0].Count - replicas,
+				},
+			}
+		}
+	}
+
 	if features.Enabled(features.AdmissionGatedBy) {
 		gateUpdated := jobframework.PropagateAdmissionGatedByAnnotation(sts, wl)
 		shouldUpdate = gateUpdated || shouldUpdate
@@ -257,6 +274,12 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 
 	if shouldUpdate {
 		if err := r.client.Update(ctx, wl); err != nil {
+			return err
+		}
+	}
+
+	if shouldUpdateReclaimablePods {
+		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -253,10 +253,11 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	var shouldUpdateReclaimablePods bool
 	var reclaimablePods []kueue.ReclaimablePod
 	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
-		if !workload.IsAdmitted(wl) {
+		switch {
+		case !workload.IsAdmitted(wl):
 			wl.Spec.PodSets[0].Count = replicas
 			shouldUpdate = true
-		} else if replicas < wl.Spec.PodSets[0].Count {
+		case replicas < wl.Spec.PodSets[0].Count:
 			shouldUpdateReclaimablePods = true
 			reclaimablePods = []kueue.ReclaimablePod{
 				{
@@ -264,6 +265,17 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 					Count: wl.Spec.PodSets[0].Count - replicas,
 				},
 			}
+		case replicas > wl.Spec.PodSets[0].Count:
+			// TOCTOU mitigation: If the workload was admitted concurrently with a scale-out,
+			// the webhook may have allowed it because the Workload was pending at the time of check.
+			// Revert the StatefulSet replicas to match the admitted workload's quota.
+			count := wl.Spec.PodSets[0].Count
+			sts.Spec.Replicas = &count
+			if err := r.client.Update(ctx, sts); err != nil {
+				return err
+			}
+			// We updated the sts, which will trigger another reconcile.
+			return nil
 		}
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -250,34 +250,14 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		shouldUpdate = true
 	}
 
-	var shouldUpdateReclaimablePods bool
-	var reclaimablePods []kueue.ReclaimablePod
-	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
-		switch {
-		case !workload.IsAdmitted(wl):
-			wl.Spec.PodSets[0].Count = replicas
-			shouldUpdate = true
-		case replicas < wl.Spec.PodSets[0].Count:
-			shouldUpdateReclaimablePods = true
-			reclaimablePods = []kueue.ReclaimablePod{
-				{
-					Name:  wl.Spec.PodSets[0].Name,
-					Count: wl.Spec.PodSets[0].Count - replicas,
-				},
-			}
-		case replicas > wl.Spec.PodSets[0].Count:
-			// TOCTOU mitigation: If the workload was admitted concurrently with a scale-out,
-			// the webhook may have allowed it because the Workload was pending at the time of check.
-			// Revert the StatefulSet replicas to match the admitted workload's quota.
-			count := wl.Spec.PodSets[0].Count
-			sts.Spec.Replicas = &count
-			if err := r.client.Update(ctx, sts); err != nil {
-				return err
-			}
-			// We updated the sts, which will trigger another reconcile.
-			return nil
-		}
+	wlUpdated, reclaimablePods, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
+	if err != nil {
+		return err
 	}
+	if stopReconcile {
+		return nil
+	}
+	shouldUpdate = shouldUpdate || wlUpdated
 
 	if features.Enabled(features.AdmissionGatedBy) {
 		gateUpdated := jobframework.PropagateAdmissionGatedByAnnotation(sts, wl)
@@ -290,7 +270,7 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		}
 	}
 
-	if shouldUpdateReclaimablePods {
+	if len(reclaimablePods) > 0 {
 		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
 			return err
 		}
@@ -521,4 +501,51 @@ func (h *podHandler) handle(obj client.Object, q workqueue.TypedRateLimitingInte
 			},
 		}, podBatchPeriod)
 	}
+}
+
+// syncReplicas synchronizes the StatefulSet's replicas with its corresponding Workload's PodSet count.
+// It handles updating the Workload if not admitted, recording ReclaimablePods for scale-down,
+// and mitigating TOCTOU (Time-Of-Check to Time-Of-Use) race conditions for scale-up.
+// If it mitigates a scale-up by updating the StatefulSet, it returns stopReconcile=true.
+func (r *Reconciler) syncReplicas(
+	ctx context.Context,
+	sts *appsv1.StatefulSet,
+	wl *kueue.Workload,
+	replicas int32,
+) (shouldUpdateWl bool, reclaimablePods []kueue.ReclaimablePod, stopReconcile bool, err error) {
+	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
+		return false, nil, false, nil
+	}
+
+	switch {
+	case !workload.IsAdmitted(wl):
+		// If the workload is not admitted, we can freely update its PodSet count to match the StatefulSet.
+		wl.Spec.PodSets[0].Count = replicas
+		return true, nil, false, nil
+
+	case replicas < wl.Spec.PodSets[0].Count:
+		// When scaling down an admitted workload, we record the freed pods as ReclaimablePods
+		// so Kueue can reclaim the quota before the workload finishes.
+		reclaimablePods = []kueue.ReclaimablePod{
+			{
+				Name:  wl.Spec.PodSets[0].Name,
+				Count: wl.Spec.PodSets[0].Count - replicas,
+			},
+		}
+		return false, reclaimablePods, false, nil
+
+	case replicas > wl.Spec.PodSets[0].Count:
+		// TOCTOU mitigation: A scale-up might have been allowed by the admission webhook if the workload
+		// was still in a pending state at the time of the check, but then admitted concurrently.
+		// To prevent the StatefulSet from exceeding its admitted quota, we revert its replicas to the Workload's count.
+		count := wl.Spec.PodSets[0].Count
+		sts.Spec.Replicas = &count
+		if err := r.client.Update(ctx, sts); err != nil {
+			return false, nil, false, err
+		}
+		// The StatefulSet was updated, which will trigger a new reconciliation.
+		return false, nil, true, nil
+	}
+
+	return false, nil, false, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -247,10 +247,11 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	var shouldUpdateReclaimablePods bool
 	var reclaimablePods []kueue.ReclaimablePod
 	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
-		if !workload.IsAdmitted(wl) {
+		switch {
+		case !workload.IsAdmitted(wl):
 			wl.Spec.PodSets[0].Count = replicas
 			shouldUpdate = true
-		} else if replicas < wl.Spec.PodSets[0].Count {
+		case replicas < wl.Spec.PodSets[0].Count:
 			shouldUpdateReclaimablePods = true
 			reclaimablePods = []kueue.ReclaimablePod{
 				{
@@ -258,6 +259,17 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 					Count: wl.Spec.PodSets[0].Count - replicas,
 				},
 			}
+		case replicas > wl.Spec.PodSets[0].Count:
+			// TOCTOU mitigation: If the workload was admitted concurrently with a scale-out,
+			// the webhook may have allowed it because the Workload was pending at the time of check.
+			// Revert the StatefulSet replicas to match the admitted workload's quota.
+			count := wl.Spec.PodSets[0].Count
+			sts.Spec.Replicas = &count
+			if err := r.client.Update(ctx, sts); err != nil {
+				return err
+			}
+			// We updated the sts, which will trigger another reconcile.
+			return nil
 		}
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -507,7 +507,16 @@ func (r *Reconciler) syncReplicas(
 	wl *kueue.Workload,
 	replicas int32,
 ) (shouldUpdateWl bool, stopReconcile bool, err error) {
-	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
+	if replicas == 0 || len(wl.Spec.PodSets) != 1 {
+		return false, false, nil
+	}
+
+	if wl.Spec.PodSets[0].Count == replicas {
+		if len(wl.Status.ReclaimablePods) > 0 {
+			if err := workload.UpdateReclaimablePods(ctx, r.client, wl, nil); err != nil {
+				return false, false, err
+			}
+		}
 		return false, false, nil
 	}
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -244,34 +244,14 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 	}
 
 	var admissionGatedByUpdated bool
-	var shouldUpdateReclaimablePods bool
-	var reclaimablePods []kueue.ReclaimablePod
-	if replicas > 0 && len(wl.Spec.PodSets) == 1 && wl.Spec.PodSets[0].Count != replicas {
-		switch {
-		case !workload.IsAdmitted(wl):
-			wl.Spec.PodSets[0].Count = replicas
-			shouldUpdate = true
-		case replicas < wl.Spec.PodSets[0].Count:
-			shouldUpdateReclaimablePods = true
-			reclaimablePods = []kueue.ReclaimablePod{
-				{
-					Name:  wl.Spec.PodSets[0].Name,
-					Count: wl.Spec.PodSets[0].Count - replicas,
-				},
-			}
-		case replicas > wl.Spec.PodSets[0].Count:
-			// TOCTOU mitigation: If the workload was admitted concurrently with a scale-out,
-			// the webhook may have allowed it because the Workload was pending at the time of check.
-			// Revert the StatefulSet replicas to match the admitted workload's quota.
-			count := wl.Spec.PodSets[0].Count
-			sts.Spec.Replicas = &count
-			if err := r.client.Update(ctx, sts); err != nil {
-				return err
-			}
-			// We updated the sts, which will trigger another reconcile.
-			return nil
-		}
+	wlUpdated, reclaimablePods, stopReconcile, err := r.syncReplicas(ctx, sts, wl, replicas)
+	if err != nil {
+		return err
 	}
+	if stopReconcile {
+		return nil
+	}
+	shouldUpdate = shouldUpdate || wlUpdated
 
 	if features.Enabled(features.AdmissionGatedBy) {
 		admissionGatedByUpdated = jobframework.PropagateAdmissionGatedByAnnotation(sts, wl)
@@ -287,7 +267,7 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		jobframework.RecordAdmissionGatedByUpdateEvent(r.record, sts)
 	}
 
-	if shouldUpdateReclaimablePods {
+	if len(reclaimablePods) > 0 {
 		if err := workload.UpdateReclaimablePods(ctx, r.client, wl, reclaimablePods); err != nil {
 			return err
 		}
@@ -518,4 +498,51 @@ func (h *podHandler) handle(obj client.Object, q workqueue.TypedRateLimitingInte
 			},
 		}, podBatchPeriod)
 	}
+}
+
+// syncReplicas synchronizes the StatefulSet's replicas with its corresponding Workload's PodSet count.
+// It handles updating the Workload if not admitted, recording ReclaimablePods for scale-down,
+// and mitigating TOCTOU (Time-Of-Check to Time-Of-Use) race conditions for scale-up.
+// If it mitigates a scale-up by updating the StatefulSet, it returns stopReconcile=true.
+func (r *Reconciler) syncReplicas(
+	ctx context.Context,
+	sts *appsv1.StatefulSet,
+	wl *kueue.Workload,
+	replicas int32,
+) (shouldUpdateWl bool, reclaimablePods []kueue.ReclaimablePod, stopReconcile bool, err error) {
+	if replicas == 0 || len(wl.Spec.PodSets) != 1 || wl.Spec.PodSets[0].Count == replicas {
+		return false, nil, false, nil
+	}
+
+	switch {
+	case !workload.IsAdmitted(wl):
+		// If the workload is not admitted, we can freely update its PodSet count to match the StatefulSet.
+		wl.Spec.PodSets[0].Count = replicas
+		return true, nil, false, nil
+
+	case replicas < wl.Spec.PodSets[0].Count:
+		// When scaling down an admitted workload, we record the freed pods as ReclaimablePods
+		// so Kueue can reclaim the quota before the workload finishes.
+		reclaimablePods = []kueue.ReclaimablePod{
+			{
+				Name:  wl.Spec.PodSets[0].Name,
+				Count: wl.Spec.PodSets[0].Count - replicas,
+			},
+		}
+		return false, reclaimablePods, false, nil
+
+	case replicas > wl.Spec.PodSets[0].Count:
+		// TOCTOU mitigation: A scale-up might have been allowed by the admission webhook if the workload
+		// was still in a pending state at the time of the check, but then admitted concurrently.
+		// To prevent the StatefulSet from exceeding its admitted quota, we revert its replicas to the Workload's count.
+		count := wl.Spec.PodSets[0].Count
+		sts.Spec.Replicas = &count
+		if err := r.client.Update(ctx, sts); err != nil {
+			return false, nil, false, err
+		}
+		// The StatefulSet was updated, which will trigger a new reconciliation.
+		return false, nil, true, nil
+	}
+
+	return false, nil, false, nil
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -252,6 +252,10 @@ func TestReconciler(t *testing.T) {
 						Type:   kueue.WorkloadAdmitted,
 						Status: metav1.ConditionTrue,
 					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}).
 					Obj(),
 			},
 			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -267,6 +271,10 @@ func TestReconciler(t *testing.T) {
 					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
 						Status: metav1.ConditionTrue,
 					}).
 					ReclaimablePods(kueue.ReclaimablePod{
@@ -294,6 +302,10 @@ func TestReconciler(t *testing.T) {
 						Type:   kueue.WorkloadAdmitted,
 						Status: metav1.ConditionTrue,
 					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}).
 					Obj(),
 			},
 			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -309,6 +321,10 @@ func TestReconciler(t *testing.T) {
 					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
 						Status: metav1.ConditionTrue,
 					}).
 					Obj(),

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -276,6 +276,44 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"should revert StatefulSet replicas for admitted workload on scale out": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+		},
 		"shouldn't add StatefulSet to Workload owner references if replicas = 0": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -55,6 +55,7 @@ var (
 	baseCmpOpts = cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 	}
 )
 
@@ -202,6 +203,76 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(gvk, "sts", "sts-uid").
 					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
 					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Obj(),
+			},
+		},
+		"should update PodSet count for pending workload on scale up": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Obj(),
+			},
+		},
+		"should update ReclaimablePods for admitted workload on scale down": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					ReclaimablePods(kueue.ReclaimablePod{
+						Name:  "main",
+						Count: 2,
+					}).
 					Obj(),
 			},
 		},
@@ -724,7 +795,7 @@ func TestReconciler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
-			clientBuilder := utiltesting.NewClientBuilder()
+			clientBuilder := utiltesting.NewClientBuilder().WithStatusSubresource(&kueue.Workload{})
 			indexer := utiltesting.AsIndexer(clientBuilder)
 			err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName)
 			if err != nil {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -49,6 +49,7 @@ var (
 	baseCmpOpts = cmp.Options{
 		cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+		cmpopts.IgnoreFields(metav1.Condition{}, "LastTransitionTime"),
 	}
 )
 
@@ -183,6 +184,76 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(gvk, "sts", "sts-uid").
 					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
 					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Obj(),
+			},
+		},
+		"should update PodSet count for pending workload on scale up": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Obj(),
+			},
+		},
+		"should update ReclaimablePods for admitted workload on scale down": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 5).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					ReclaimablePods(kueue.ReclaimablePod{
+						Name:  "main",
+						Count: 2,
+					}).
 					Obj(),
 			},
 		},
@@ -528,7 +599,7 @@ func TestReconciler(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			ctx, _ := utiltesting.ContextWithLog(t)
-			clientBuilder := utiltesting.NewClientBuilder()
+			clientBuilder := utiltesting.NewClientBuilder().WithStatusSubresource(&kueue.Workload{})
 			indexer := utiltesting.AsIndexer(clientBuilder)
 			err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName)
 			if err != nil {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -257,6 +257,44 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 		},
+		"should revert StatefulSet replicas for admitted workload on scale out": {
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(5).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Replicas(3).
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					PodSets(*utiltestingapi.MakePodSet("main", 3).Obj()).
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
+		},
 		"shouldn't add StatefulSet to Workload owner references if replicas = 0": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -233,6 +233,10 @@ func TestReconciler(t *testing.T) {
 						Type:   kueue.WorkloadAdmitted,
 						Status: metav1.ConditionTrue,
 					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}).
 					Obj(),
 			},
 			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -248,6 +252,10 @@ func TestReconciler(t *testing.T) {
 					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
 						Status: metav1.ConditionTrue,
 					}).
 					ReclaimablePods(kueue.ReclaimablePod{
@@ -275,6 +283,10 @@ func TestReconciler(t *testing.T) {
 						Type:   kueue.WorkloadAdmitted,
 						Status: metav1.ConditionTrue,
 					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}).
 					Obj(),
 			},
 			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -290,6 +302,10 @@ func TestReconciler(t *testing.T) {
 					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
 						Status: metav1.ConditionTrue,
 					}).
 					Obj(),

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -208,7 +208,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 			wlExists := wl != nil
 
 			if newReplicas != 0 && oldReplicas != 0 {
-				if wlExists && workload.IsAdmitted(wl) && newReplicas > oldReplicas {
+				if wlExists && workload.HasQuotaReservation(wl) && newReplicas > oldReplicas {
 					allErrs = append(allErrs, field.Forbidden(replicasPath, "scale-out is not supported for admitted workloads"))
 				}
 			}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -200,7 +200,7 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 			wlExists := err == nil
 
 			if newReplicas != 0 && oldReplicas != 0 {
-				if wlExists && workload.IsAdmitted(&wl) && newReplicas > oldReplicas {
+				if wlExists && workload.HasQuotaReservation(&wl) && newReplicas > oldReplicas {
 					allErrs = append(allErrs, field.Forbidden(replicasPath, "scale-out is not supported for admitted workloads"))
 				}
 			}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -200,28 +200,27 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		oldReplicas := ptr.Deref(oldStatefulSet.Spec.Replicas, 1)
 		newReplicas := ptr.Deref(newStatefulSet.Spec.Replicas, 1)
 
-		// Allow only scale down to zero and scale up from zero.
-		// TODO(#3279): Support custom resizes later
-		if newReplicas != 0 && oldReplicas != 0 {
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-				newStatefulSet.Spec.Replicas,
-				oldStatefulSet.Spec.Replicas,
-				replicasPath,
-			)...)
-		}
+		if newReplicas != oldReplicas {
+			_, wl, err := findWorkload(ctx, wh.client, (*appsv1.StatefulSet)(oldStatefulSet))
+			if err != nil {
+				return nil, err
+			}
+			wlExists := wl != nil
 
-		if oldReplicas == 0 && newReplicas > 0 {
-			if newStatefulSet.Status.Replicas > 0 {
-				// Block if pods are still terminating
-				allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
-			} else {
-				// Block if workload is still being deleted (exists without OnHold).
-				// If the workload is on hold, it is intentionally kept alive during
-				// scale-to-zero and will be re-admitted on scale-up.
-				_, wl, err := findWorkload(ctx, wh.client, (*appsv1.StatefulSet)(oldStatefulSet))
-				if err != nil {
-					return nil, err
-				} else if wl != nil && !workload.IsOnHold(wl) {
+			if newReplicas != 0 && oldReplicas != 0 {
+				if wlExists && workload.IsAdmitted(wl) && newReplicas > oldReplicas {
+					allErrs = append(allErrs, field.Forbidden(replicasPath, "scale-out is not supported for admitted workloads"))
+				}
+			}
+
+			if oldReplicas == 0 && newReplicas > 0 {
+				if newStatefulSet.Status.Replicas > 0 {
+					// Block if pods are still terminating
+					allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
+				} else if wlExists && !workload.IsOnHold(wl) {
+					// Block if workload is still being deleted (exists without OnHold).
+					// If the workload is on hold, it is intentionally kept alive during
+					// scale-to-zero and will be re-admitted on scale-up.
 					allErrs = append(allErrs, field.Forbidden(replicasPath, "workload from previous scale-down is still being deleted"))
 				}
 			}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -187,33 +187,32 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		oldReplicas := ptr.Deref(oldStatefulSet.Spec.Replicas, 1)
 		newReplicas := ptr.Deref(newStatefulSet.Spec.Replicas, 1)
 
-		// Allow only scale down to zero and scale up from zero.
-		// TODO(#3279): Support custom resizes later
-		if newReplicas != 0 && oldReplicas != 0 {
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-				newStatefulSet.Spec.Replicas,
-				oldStatefulSet.Spec.Replicas,
-				replicasPath,
-			)...)
-		}
+		if newReplicas != oldReplicas {
+			wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
+			if err != nil {
+				return nil, err
+			}
+			var wl kueue.Workload
+			err = wh.client.Get(ctx, client.ObjectKey{Namespace: oldSTSObj.GetNamespace(), Name: wlName}, &wl)
+			if client.IgnoreNotFound(err) != nil {
+				return nil, err
+			}
+			wlExists := err == nil
 
-		if oldReplicas == 0 && newReplicas > 0 {
-			if newStatefulSet.Status.Replicas > 0 {
-				// Block if pods are still terminating
-				allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
-			} else {
-				// Block if workload is still being deleted (exists without OnHold).
-				// If the workload is on hold, it is intentionally kept alive during
-				// scale-to-zero and will be re-admitted on scale-up.
-				wlName, err := findWorkloadName(ctx, wh.client, oldSTSObj)
-				if err != nil {
-					return nil, err
+			if newReplicas != 0 && oldReplicas != 0 {
+				if wlExists && workload.IsAdmitted(&wl) && newReplicas > oldReplicas {
+					allErrs = append(allErrs, field.Forbidden(replicasPath, "scale-out is not supported for admitted workloads"))
 				}
-				var wl kueue.Workload
-				err = wh.client.Get(ctx, client.ObjectKey{Namespace: oldSTSObj.GetNamespace(), Name: wlName}, &wl)
-				if client.IgnoreNotFound(err) != nil {
-					return nil, err
-				} else if err == nil && !workload.IsOnHold(&wl) {
+			}
+
+			if oldReplicas == 0 && newReplicas > 0 {
+				if newStatefulSet.Status.Replicas > 0 {
+					// Block if pods are still terminating
+					allErrs = append(allErrs, field.Forbidden(replicasPath, "scaling down is still in progress"))
+				} else if wlExists && !workload.IsOnHold(&wl) {
+					// Block if workload is still being deleted (exists without OnHold).
+					// If the workload is on hold, it is intentionally kept alive during
+					// scale-to-zero and will be re-admitted on scale-up.
 					allErrs = append(allErrs, field.Forbidden(replicasPath, "workload from previous scale-down is still being deleted"))
 				}
 			}

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -722,6 +722,10 @@ func TestValidateUpdate(t *testing.T) {
 						Type:   kueue.WorkloadAdmitted,
 						Status: metav1.ConditionTrue,
 					}).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}).
 					Obj(),
 			},
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").

--- a/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
@@ -703,7 +704,26 @@ func TestValidateUpdate(t *testing.T) {
 				},
 			}.ToAggregate(),
 		},
-		"change in replicas (scale up)": {
+		"change in replicas (scale up) for pending workload": {
+			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Replicas(3).
+				Obj(),
+			newObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
+				Queue("test-queue").
+				Replicas(4).
+				Obj(),
+		},
+		"change in replicas (scale up) for admitted workload is blocked": {
+			objs: []runtime.Object{
+				utiltestingapi.MakeWorkload(GetWorkloadName("", "test-sts"), "test-ns").
+					Admission(utiltestingapi.MakeAdmission("cluster-queue").Obj()).
+					Condition(metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Obj(),
+			},
 			oldObj: testingstatefulset.MakeStatefulSet("test-sts", "test-ns").
 				Queue("test-queue").
 				Replicas(3).
@@ -714,7 +734,7 @@ func TestValidateUpdate(t *testing.T) {
 				Obj(),
 			wantErr: field.ErrorList{
 				&field.Error{
-					Type:  field.ErrorTypeInvalid,
+					Type:  field.ErrorTypeForbidden,
 					Field: replicasPath.String(),
 				},
 			}.ToAggregate(),

--- a/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
@@ -153,6 +153,83 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should update the workload PodSet count when a StatefulSet is scaled before admission", func() {
+		ginkgo.By("Creating a StatefulSet with replicas=1 pointing to a non-existent queue (stays pending)")
+		sts := testingstatefulset.MakeStatefulSet("test-sts-preadmit", ns.Name).
+			Queue("non-existent-lq").
+			Replicas(1).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		util.MustCreate(ctx, k8sClient, sts)
+
+		createdSTS := &appsv1.StatefulSet{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
+			g.Expect(createdSTS.UID).ShouldNot(gomega.BeEmpty())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		wlName := statefulset.GetWorkloadName(createdSTS.UID, createdSTS.Name)
+		wl := &kueue.Workload{}
+		ginkgo.By("Waiting for the workload to be created with PodSet count=1")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wlName, Namespace: ns.Name}, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Spec.PodSets).Should(gomega.HaveLen(1))
+			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(1)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Scaling the StatefulSet to replicas=3 before admission")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
+			createdSTS.Spec.Replicas = ptr.To[int32](3)
+			g.Expect(k8sClient.Update(ctx, createdSTS)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying the workload PodSet count is updated to 3")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wlName, Namespace: ns.Name}, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Spec.PodSets).Should(gomega.HaveLen(1))
+			g.Expect(wl.Spec.PodSets[0].Count).Should(gomega.Equal(int32(3)))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should set ReclaimablePods on the workload when an admitted StatefulSet is scaled down", func() {
+		ginkgo.By("Creating a StatefulSet with replicas=3")
+		sts := testingstatefulset.MakeStatefulSet("test-sts-scaledown", ns.Name).
+			Queue("lq").
+			Replicas(3).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		util.MustCreate(ctx, k8sClient, sts)
+
+		createdSTS := &appsv1.StatefulSet{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
+			g.Expect(createdSTS.UID).ShouldNot(gomega.BeEmpty())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		wlName := statefulset.GetWorkloadName(createdSTS.UID, createdSTS.Name)
+		wl := &kueue.Workload{}
+		ginkgo.By("Waiting for the workload to be admitted")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wlName, Namespace: ns.Name}, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Scaling the StatefulSet down to replicas=1")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
+			createdSTS.Spec.Replicas = ptr.To[int32](1)
+			g.Expect(k8sClient.Update(ctx, createdSTS)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying the workload has ReclaimablePods with count=2 (3-1)")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wlName, Namespace: ns.Name}, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Status.ReclaimablePods).Should(gomega.HaveLen(1))
+			g.Expect(wl.Status.ReclaimablePods[0].Count).Should(gomega.Equal(int32(2)))
+		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should set the workload OnHold when StatefulSet scales to zero and clear it on scale-up", func() {
 		ginkgo.By("Creating a StatefulSet with replicas=1")
 		sts := testingstatefulset.MakeStatefulSet("test-sts", ns.Name).

--- a/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -17,11 +17,16 @@ limitations under the License.
 package jobs
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -29,6 +34,7 @@ import (
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingstatefulset "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -86,6 +92,46 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 							gomega.BeEmpty(),
 							"Queue name should not be injected to pod template labels",
 						)
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("The StatefulSet is admitted", func() {
+			ginkgo.It("Should reject scale out", func() {
+				sts := testingstatefulset.MakeStatefulSet("sts", ns.Name).Replicas(1).Queue("user-queue").Obj()
+				util.MustCreate(ctx, k8sClient, sts)
+
+				// Create the corresponding workload and admit it
+				wlName := statefulset.GetWorkloadName(sts.UID, sts.Name)
+				wl := utiltestingapi.MakeWorkload(wlName, ns.Name).
+					Queue("user-queue").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+				util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), utiltestingapi.MakeAdmission("cluster-queue").Obj())
+
+				// Attempt to scale out, wrapping in Eventually because the webhook's cache might be stale
+				gomega.Eventually(func() error {
+					createdStatefulSet := &appsv1.StatefulSet{}
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdStatefulSet)
+					if err != nil {
+						return err
+					}
+					if *createdStatefulSet.Spec.Replicas == 3 {
+						// Revert if it succeeded due to stale cache
+						createdStatefulSet.Spec.Replicas = ptr.To[int32](1)
+						_ = k8sClient.Update(ctx, createdStatefulSet)
+						return errors.New("update succeeded but should have been rejected")
+					}
+					createdStatefulSet.Spec.Replicas = ptr.To[int32](3)
+					err = k8sClient.Update(ctx, createdStatefulSet)
+					if err == nil {
+						return errors.New("update succeeded but should have been rejected")
+					}
+					if !strings.Contains(err.Error(), "scale-out is not supported") {
+						return err
+					}
+					return nil
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package jobs
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -30,6 +35,7 @@ import (
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingstatefulset "sigs.k8s.io/kueue/pkg/util/testingjobs/statefulset"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -152,6 +158,46 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 				patch := client.MergeFrom(terminatingChild.DeepCopy())
 				terminatingChild.Finalizers = nil
 				gomega.Expect(k8sClient.Patch(ctx, &terminatingChild, patch)).To(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("The StatefulSet is admitted", func() {
+			ginkgo.It("Should reject scale out", func() {
+				sts := testingstatefulset.MakeStatefulSet("sts", ns.Name).Replicas(1).Queue("user-queue").Obj()
+				util.MustCreate(ctx, k8sClient, sts)
+
+				// Create the corresponding workload and admit it
+				wlName := statefulset.GetWorkloadName(sts.UID, sts.Name)
+				wl := utiltestingapi.MakeWorkload(wlName, ns.Name).
+					Queue("user-queue").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+				util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), utiltestingapi.MakeAdmission("cluster-queue").Obj())
+
+				// Attempt to scale out, wrapping in Eventually because the webhook's cache might be stale
+				gomega.Eventually(func() error {
+					createdStatefulSet := &appsv1.StatefulSet{}
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdStatefulSet)
+					if err != nil {
+						return err
+					}
+					if *createdStatefulSet.Spec.Replicas == 3 {
+						// Revert if it succeeded due to stale cache
+						createdStatefulSet.Spec.Replicas = ptr.To[int32](1)
+						_ = k8sClient.Update(ctx, createdStatefulSet)
+						return errors.New("update succeeded but should have been rejected")
+					}
+					createdStatefulSet.Spec.Replicas = ptr.To[int32](3)
+					err = k8sClient.Update(ctx, createdStatefulSet)
+					if err == nil {
+						return errors.New("update succeeded but should have been rejected")
+					}
+					if !strings.Contains(err.Error(), "scale-out is not supported") {
+						return err
+					}
+					return nil
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
 	})

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -82,6 +83,8 @@ func managerSetup(setup func(ctrl.Manager, ...jobframework.Option) error, opts .
 		opts = append(opts, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 
 		err := setup(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = webhooks.Setup(mgr, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		integrationManager.EnableIntegration(job.FrameworkName)
 	}

--- a/test/integration/singlecluster/webhook/jobs/suite_test.go
+++ b/test/integration/singlecluster/webhook/jobs/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
 	"sigs.k8s.io/kueue/test/util"
 )
@@ -81,6 +82,8 @@ func managerSetup(setup func(ctrl.Manager, ...jobframework.Option) error, opts .
 		opts = append(opts, jobframework.WithIntegrationManager(integrationManager), jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 
 		err := setup(mgr, opts...)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		_, err = webhooks.Setup(mgr, nil)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		integrationManager.EnableIntegration(job.FrameworkName)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature 
/area integrations
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR enables dynamic scaling (custom resizes) for StatefulSet workloads. 

Changes include:
- **Webhook Updates:** Removes the blanket restriction on all non-zero to non-zero `replicas` changes. It now allows custom resizes, but actively blocks scale-out operations (increasing replicas) for *already admitted* workloads, since Kueue currently does not support dynamic quota increases for admitted jobs.
- **Reconciler Updates:** Syncs replica changes back to the Workload:
  - For **pending workloads**, it directly updates `wl.Spec.PodSets[0].Count` so the workload retains its queue position with the updated quota request.
  - For **admitted workloads (scale-in)**, it computes the unused quota and triggers `UpdateReclaimablePods` to release it back to the queue for other workloads to use.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13641 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add support for dynamic custom resizing for StatefulSet workloads (scale-in and scale-out).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StatefulSet scaling reconciliation for admitted workloads.
  * Scale-downs now track reclaimed pods while preserving admitted workload replica counts.
  * Pending workloads can scale up and update their requested pod counts.
  * Scale-outs beyond admitted capacity are blocked or safely reverted.
  * Improved validation for scaling from zero while pods terminate or a prior workload remains active.

* **Tests**
  * Expanded coverage for pending and admitted scaling, rollback behavior, reclaimed pods, and webhook validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->