### PR TITLE
Keep ClusterQueue status accurate while terminating

### DIFF
--- a/pkg/controller/core/clusterqueue_controller.go
+++ b/pkg/controller/core/clusterqueue_controller.go
@@ -198,8 +198,15 @@ func (r *ClusterQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				if err := r.client.Update(ctx, &cqObj); err != nil {
 					return ctrl.Result{}, client.IgnoreNotFound(err)
 				}
+				// The finalizer is gone and the object will be garbage-collected, so
+				// there is no point refreshing its status (the ClusterQueue is also
+				// being removed from the cache).
+				return ctrl.Result{}, nil
 			}
-			return ctrl.Result{}, nil
+			// The finalizer is still held because workloads are reserving quota, i.e.
+			// the ClusterQueue is terminating but not yet empty. Fall through to refresh
+			// the status counters and set the Active=Terminating condition instead of
+			// returning early and leaving stale status behind.
 		}
 	}
 

--- a/pkg/controller/core/clusterqueue_controller_test.go
+++ b/pkg/controller/core/clusterqueue_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -252,36 +253,57 @@ func TestUpdateCqStatusIfChanged(t *testing.T) {
 	}
 }
 
-func TestReconcileRemovesFinalizerWithFinishedWorkloads(t *testing.T) {
-	testCases := map[string]struct {
-		cqName string
-		wlName string
+// TestClusterQueueReconcile exercises ClusterQueueReconciler.Reconcile for a
+// ClusterQueue that is being deleted, covering both the empty case (finalizer
+// removed, ClusterQueue garbage-collected) and the terminating-but-not-empty case
+// (finalizer held, status kept accurate).
+func TestClusterQueueReconcile(t *testing.T) {
+	const cqName = "cq"
+	now := time.Now()
+
+	cases := map[string]struct {
+		// workload holds quota in the ClusterQueue; whether it still reserves quota
+		// after the ClusterQueue is deleted decides if the finalizer is released.
+		workload      *kueue.Workload
+		wantDeleted   bool
+		wantActive    metav1.ConditionStatus
+		wantReason    string
+		wantReserving int32
 	}{
-		"finished workload should not block deletion": {
-			cqName: "cq",
-			wlName: "wl",
+		"finished workload does not block deletion: finalizer removed and ClusterQueue deleted": {
+			workload: utiltestingapi.MakeWorkload("wl", "").ReserveQuotaAt(&kueue.Admission{
+				ClusterQueue: cqName,
+			}, now).FinishedAt(now).Obj(),
+			wantDeleted: true,
+		},
+		"reserving workload keeps ClusterQueue terminating: status refreshed to Active=Terminating": {
+			workload: utiltestingapi.MakeWorkload("wl", "").ReserveQuotaAt(&kueue.Admission{
+				ClusterQueue: cqName,
+			}, now).Obj(),
+			wantActive:    metav1.ConditionFalse,
+			wantReason:    kueue.ClusterQueueActiveReasonTerminating,
+			wantReserving: 1,
 		},
 	}
 
-	for name, tc := range testCases {
+	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, log := utiltesting.ContextWithLog(t)
-			now := time.Now()
 
-			cq := utiltestingapi.MakeClusterQueue(tc.cqName).Obj()
+			cq := utiltestingapi.MakeClusterQueue(cqName).Generation(1).Obj()
 			cq.Finalizers = []string{kueue.ResourceInUseFinalizerName}
 
-			cl := utiltesting.NewClientBuilder().WithObjects(cq).Build()
+			cl := utiltesting.NewClientBuilder().WithObjects(cq).WithStatusSubresource(cq).Build()
 			cqCache := schdcache.New(cl)
 			qManager := qcache.NewManagerForUnitTests(cl, cqCache)
 			if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
 				t.Fatalf("Inserting clusterQueue in cache: %v", err)
 			}
+			if err := qManager.AddClusterQueue(ctx, cq); err != nil {
+				t.Fatalf("Inserting clusterQueue in manager: %v", err)
+			}
 
-			finishedWl := utiltestingapi.MakeWorkload(tc.wlName, "").ReserveQuotaAt(&kueue.Admission{
-				ClusterQueue: kueue.ClusterQueueReference(tc.cqName),
-			}, now).FinishedAt(now).Obj()
-			cqCache.AddOrUpdateWorkload(log, finishedWl)
+			cqCache.AddOrUpdateWorkload(log, tc.workload)
 
 			r := &ClusterQueueReconciler{
 				client:   cl,
@@ -294,15 +316,40 @@ func TestReconcileRemovesFinalizerWithFinishedWorkloads(t *testing.T) {
 				t.Fatalf("Failed to delete ClusterQueue: %v", err)
 			}
 
-			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: tc.cqName}})
-			if err != nil {
+			if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: cqName}}); err != nil {
 				t.Fatalf("Reconcile failed: %v", err)
 			}
 
 			got := &kueue.ClusterQueue{}
-			err = cl.Get(ctx, types.NamespacedName{Name: tc.cqName}, got)
-			if !apierrors.IsNotFound(err) {
-				t.Fatalf("Expected ClusterQueue to be deleted after finalizer removal, but got: %v", err)
+			err := cl.Get(ctx, types.NamespacedName{Name: cqName}, got)
+
+			if tc.wantDeleted {
+				if !apierrors.IsNotFound(err) {
+					t.Fatalf("Expected ClusterQueue to be deleted after finalizer removal, but got: %v", err)
+				}
+				return
+			}
+
+			// The ClusterQueue is terminating but not empty, so the finalizer is held
+			// and the object still exists.
+			if err != nil {
+				t.Fatalf("Terminating ClusterQueue should still exist while the finalizer is held: %v", err)
+			}
+
+			// Regression guard: before the fix, Reconcile returned early in the
+			// finalizer-held deletion branch and never refreshed status, leaving the
+			// Active condition and workload counters frozen at their pre-deletion values.
+			// The fix falls through to updateCqStatusIfChanged so the terminating
+			// ClusterQueue reports accurate status.
+			active := apimeta.FindStatusCondition(got.Status.Conditions, kueue.ClusterQueueActive)
+			if active == nil {
+				t.Fatalf("Active condition not set: status was not refreshed while the CQ was terminating")
+			}
+			if active.Status != tc.wantActive || active.Reason != tc.wantReason {
+				t.Errorf("Active condition = %s/%q, want %s/%q", active.Status, active.Reason, tc.wantActive, tc.wantReason)
+			}
+			if got.Status.ReservingWorkloads != tc.wantReserving {
+				t.Errorf("ReservingWorkloads = %d, want %d", got.Status.ReservingWorkloads, tc.wantReserving)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -1069,7 +1069,9 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 			ginkgo.By("Delete clusterQueue")
 			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq)).To(gomega.Succeed())
 			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusTerminating)
-			util.ExpectLQByStatusMetric(lq, metav1.ConditionTrue)
+			// The ClusterQueue is now terminating (Active=False), so its LocalQueue is
+			// no longer active either (it mirrors the ClusterQueue's Active condition).
+			util.ExpectLQByStatusMetric(lq, metav1.ConditionFalse)
 			var newCQ kueue.ClusterQueue
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &newCQ)).To(gomega.Succeed())
@@ -1080,6 +1082,66 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 			util.FinishWorkloads(ctx, k8sClient, wl)
 
 			ginkgo.By("The clusterQueue will be deleted")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, false)
+		})
+
+		ginkgo.It("Should keep the status counters and Active condition accurate while terminating", func() {
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusActive)
+
+			ginkgo.By("Admitting a workload that consumes the whole quota")
+			admittedWl := utiltestingapi.MakeWorkload("admitted", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(resourceGPU, "5").
+				Obj()
+			util.MustCreate(ctx, k8sClient, admittedWl)
+			admittedKey := client.ObjectKeyFromObject(admittedWl)
+			podSetAssignment := utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(
+				resourceGPU,
+				kueue.ResourceFlavorReference(flavor.Name),
+			).Obj()
+			cqAdmission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).PodSets(podSetAssignment).Obj()
+			util.SetQuotaReservation(ctx, k8sClient, admittedKey, cqAdmission)
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, admittedWl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
+
+			ginkgo.By("Creating a second workload that stays pending (quota is exhausted)")
+			pendingWl := utiltestingapi.MakeWorkload("pending", ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(resourceGPU, "5").
+				Obj()
+			util.MustCreate(ctx, k8sClient, pendingWl)
+
+			ginkgo.By("The ClusterQueue reports one admitted and one pending workload while active")
+			createdCQ := &kueue.ClusterQueue{}
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdCQ)).To(gomega.Succeed())
+				g.Expect(createdCQ.Status.AdmittedWorkloads).To(gomega.Equal(int32(1)))
+				g.Expect(createdCQ.Status.ReservingWorkloads).To(gomega.Equal(int32(1)))
+				g.Expect(createdCQ.Status.PendingWorkloads).To(gomega.Equal(int32(1)))
+				g.Expect(createdCQ.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.ClusterQueueActive, "Ready"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Deleting the ClusterQueue - the resource-in-use finalizer keeps it while a workload reserves quota")
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, cq)).To(gomega.Succeed())
+			util.ExpectClusterQueueStatusMetric(cq, metrics.CQStatusTerminating)
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdCQ)).To(gomega.Succeed())
+				g.Expect(createdCQ.GetFinalizers()).Should(gomega.Equal([]string{kueue.ResourceInUseFinalizerName}))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Deleting the pending workload while the ClusterQueue is terminating")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, pendingWl, true)
+
+			ginkgo.By("The terminating ClusterQueue keeps its status accurate: Active=Terminating and pendingWorkloads back to 0")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), createdCQ)).To(gomega.Succeed())
+				g.Expect(createdCQ.Status.Conditions).To(utiltesting.HaveConditionStatusFalseAndReason(kueue.ClusterQueueActive, kueue.ClusterQueueActiveReasonTerminating))
+				g.Expect(createdCQ.Status.PendingWorkloads).To(gomega.Equal(int32(0)))
+				g.Expect(createdCQ.Status.ReservingWorkloads).To(gomega.Equal(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing the admitted workload lets the ClusterQueue be deleted")
+			util.FinishWorkloads(ctx, k8sClient, admittedWl)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, false)
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

While a ClusterQueue is terminating — it has a deletionTimestamp but is still retained by the `kueue.x-k8s.io/resource-in-use` finalizer because workloads are still reserving quota — its reconcile returned early in the finalizer-held deletion branch and never refreshed status. status.pendingWorkloads, status.admittedWorkloads, and status.reservingWorkloads froze at their pre-deletion values, and the Active condition was never set to Terminating. A stuck-deleting ClusterQueue therefore reported inaccurate counters — for example, pendingWorkloads stays at its pre-deletion value after the queued workloads are removed — which is misleading for operators debugging the stuck deletion.

This PR returns early only once the finalizer has actually been removed (the CQ is empty and about to be garbage-collected, where refreshing status is pointless and racy against removal from the cache). While the finalizer is still held, it falls through to the existing updateCqStatusIfChanged path so the terminating ClusterQueue keeps reporting accurate counters and an Active=Terminating condition. Behavior when the CQ becomes empty (finalizer removed, object deleted) is unchanged.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes  https://github.com/kubernetes-sigs/kueue/issues/13676

#### Special notes for your reviewer:

 - Root cause: the unconditional early return in the finalizer-held deletion branch of ClusterQueueReconciler.Reconcile skipped updateCqStatusIfChanged (the only writer of these counters and of the Active condition).
 - Tests: added a unit test (TestReconcileRefreshesStatusWhileTerminating) and an integration test ("Should keep the status counters and Active condition accurate while terminating"). Both fail without the fix and pass with it.
  - Manually verified on kind: a terminating ClusterQueue that reported stale pending=5 / Active=Ready on v0.19.0 was corrected to pending=0 / Active=Terminating after the fix; the empty→finalizer-removal→delete path is unaffected.
  - AI assistance disclosure (per the Kubernetes AI Tool Usage Policy): prepared with the help of an AI coding assistant. The author reviewed, tested, and validated all changes.


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ClusterQueue: Fixed a bug where a terminating ClusterQueue (one with a deletion timestamp still retained by the resource-in-use finalizer because workloads are reserving quota) stopped updating `status.pendingWorkloads`, `status.admittedWorkloads`, and `status.reservingWorkloads` and never set its `Active` condition to `Terminating`, leaving stale status. Kueue now keeps the status of a terminating ClusterQueue accurate.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - ClusterQueues now refresh status while terminating if workloads still reserve quota.
  - Terminating ClusterQueues correctly report inactive status and accurate workload counts.
  - LocalQueues are marked inactive when their ClusterQueue is being deleted.
  - ClusterQueue deletion now completes after reservations and pending workloads are cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->