### PR TITLE
Exempt second-pass workloads from the waitForPodsReady admission block

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -473,7 +473,12 @@ func (s *Scheduler) processEntry(
 		return
 	}
 
-	s.waitForPodsReadyIfBlocked(ctx, log, e)
+	// A second pass holds its quota reservation already, and a delayed-TAS workload is
+	// itself in WorkloadsNotReady, so the block would trip because of the very workload
+	// it is evaluating and unset that workload's own reservation.
+	if !workload.NeedsSecondPass(e.Obj) {
+		s.waitForPodsReadyIfBlocked(ctx, log, e)
+	}
 
 	// Copy ClusterName from old slice before admission (needed for MultiKueue).
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -473,12 +473,7 @@ func (s *Scheduler) processEntry(
 		return
 	}
 
-	// A second pass holds its quota reservation already, and a delayed-TAS workload is
-	// itself in WorkloadsNotReady, so the block would trip because of the very workload
-	// it is evaluating and unset that workload's own reservation.
-	if !workload.NeedsSecondPass(e.Obj) {
-		s.waitForPodsReadyIfBlocked(ctx, log, e)
-	}
+	s.waitForPodsReadyIfNeeded(ctx, log, e)
 
 	// Copy ClusterName from old slice before admission (needed for MultiKueue).
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && oldWorkloadSlice != nil {
@@ -548,10 +543,21 @@ func (s *Scheduler) issuePreemptions(ctx context.Context, log logr.Logger, e *en
 	e.markPreemptionOutcome(preempted, errors)
 }
 
-// waitForPodsReadyIfBlocked blocks admission until all currently admitted
+// waitForPodsReadyIfNeeded blocks admission until all currently admitted
 // workloads are in the PodsReady condition. Active only when WaitForPodsReady
 // is enabled with BlockAdmission=true.
-func (s *Scheduler) waitForPodsReadyIfBlocked(ctx context.Context, log logr.Logger, e *entry) {
+//
+// Workloads taking a second pass are exempt. They already hold a quota reservation and
+// consume no new quota, so the one-at-a-time sequencing the block provides for fresh
+// admissions cannot prevent anything on their behalf - the capacity is already
+// committed to them and unavailable to everyone else. Worse, such a workload is itself
+// among the admitted-but-not-ready workloads the block waits on, so blocking would trip
+// on the very workload being evaluated and unset its own reservation - and, for a
+// failed-node replacement, its admission along with it.
+func (s *Scheduler) waitForPodsReadyIfNeeded(ctx context.Context, log logr.Logger, e *entry) {
+	if workload.NeedsSecondPass(e.Obj) {
+		return
+	}
 	if s.cache.PodsReadyForAllAdmittedWorkloads(log) {
 		return
 	}

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -9768,11 +9768,16 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 	}
 }
 
-// TestSecondPassSkipsWaitForPodsReadyBlock exercises the waitForPodsReady
-// admission block against a second-pass workload. The workload holds a quota
-// reservation and its pods are not ready yet, so the block is active because
-// of the workload under test itself; the second pass must complete the
-// delayed topology assignment instead of stripping its own reservation.
+// TestSecondPassSkipsWaitForPodsReadyBlock exercises the waitForPodsReady admission
+// block against workloads taking a second pass. Such a workload already holds a quota
+// reservation and, with pods-ready tracking enabled, is itself among the
+// admitted-but-not-ready workloads the block waits on, so the block would trip on the
+// very workload it is evaluating and unset that workload's own reservation.
+//
+// The block leaves no lasting trace of its own: it unsets the reservation and, once the
+// wait ends, the admission patch re-establishes it. The workload assertions below
+// therefore document the expected end state, while the assertion that actually fails
+// without the exemption is the status patch count.
 func TestSecondPassSkipsWaitForPodsReadyBlock(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 
@@ -9795,106 +9800,176 @@ func TestSecondPassSkipsWaitForPodsReadyBlock(t *testing.T) {
 		AdmissionChecks(kueue.AdmissionCheckReference(provCheck.Name)).
 		Obj()
 	lq := utiltestingapi.MakeLocalQueue("tas-main", ns.Name).ClusterQueue(cq.Name).Obj()
-	node := testingnode.MakeNode("x1").
-		Label("tas-node", "true").
-		Label(corev1.LabelHostname, "x1").
-		StatusAllocatable(corev1.ResourceList{
-			corev1.ResourceCPU:  resource.MustParse("1"),
-			corev1.ResourcePods: resource.MustParse("10"),
-		}).
-		Ready().
+	makeNode := func(name string) corev1.Node {
+		return *testingnode.MakeNode(name).
+			Label("tas-node", "true").
+			Label(corev1.LabelHostname, name).
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("1"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj()
+	}
+	nodes := []corev1.Node{makeNode("x1"), makeNode("x2")}
+	podSet := *utiltestingapi.MakePodSet("one", 1).
+		RequiredTopologyRequest(corev1.LabelHostname).
+		Request(corev1.ResourceCPU, "1").
 		Obj()
-	wl := utiltestingapi.MakeWorkload("wl", ns.Name).
-		Queue("tas-main").
-		PodSets(*utiltestingapi.MakePodSet("one", 1).
-			RequiredTopologyRequest(corev1.LabelHostname).
-			Request(corev1.ResourceCPU, "1").
-			Obj()).
-		ReserveQuotaAt(
-			utiltestingapi.MakeAdmission("tas-main").
-				PodSets(utiltestingapi.MakePodSetAssignment("one").
-					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
-					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
-					Obj()).
+
+	testCases := map[string]struct {
+		workload *kueue.Workload
+		// verify asserts the outcome specific to the second-pass flavor under test.
+		// The shared assertions (reservation retained, exactly one status patch) are
+		// applied to every case.
+		verify func(t *testing.T, got *kueue.Workload)
+	}{
+		// A delayed topology assignment enters WorkloadsNotReady as soon as the first
+		// pass reserves quota, because the workload's pods do not exist yet.
+		"delayed topology assignment": {
+			workload: utiltestingapi.MakeWorkload("wl", ns.Name).
+				Queue("tas-main").
+				PodSets(podSet).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("tas-main").
+						PodSets(utiltestingapi.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+							DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+							Obj()).
+						Obj(),
+					now,
+				).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "prov-check",
+					State: kueue.CheckStateReady,
+				}).
 				Obj(),
-			now,
-		).
-		AdmissionCheck(kueue.AdmissionCheckState{
-			Name:  "prov-check",
-			State: kueue.CheckStateReady,
-		}).
-		Obj()
-
-	ctx, log := utiltesting.ContextWithLog(t)
-	// The block does not leave a lasting trace: it unsets the reservation and,
-	// once the wait ends, the admission patch re-establishes it. Count the
-	// status patches to catch that hidden round trip.
-	var statusPatches int
-	clientBuilder := utiltesting.NewClientBuilder().
-		WithObjects(ns.DeepCopy(), topology.DeepCopy(), rf.DeepCopy(), cq.DeepCopy(), lq.DeepCopy(), wl.DeepCopy()).
-		WithStatusSubresource(&kueue.Workload{}).
-		WithInterceptorFuncs(interceptor.Funcs{
-			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-				if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" {
-					statusPatches++
+			verify: func(t *testing.T, got *kueue.Workload) {
+				t.Helper()
+				psa := got.Status.Admission.PodSetAssignments[0]
+				if psa.TopologyAssignment == nil || psa.DelayedTopologyRequest == nil ||
+					*psa.DelayedTopologyRequest != kueue.DelayedTopologyRequestStateReady {
+					t.Errorf("expected the second pass to complete the delayed topology assignment, got assignment %v, delayed state %v",
+						psa.TopologyAssignment, psa.DelayedTopologyRequest)
 				}
-				return utiltesting.TreatSSAAsStrategicMerge(ctx, c, subResourceName, obj, patch, opts...)
 			},
+		},
+		// A failed-node replacement is already Admitted, so unsetting its reservation
+		// also clears its admission - an eviction that never goes through the eviction
+		// path.
+		"failed node replacement": {
+			workload: utiltestingapi.MakeWorkload("wl", ns.Name).
+				Queue("tas-main").
+				UnhealthyNodes("x1").
+				PodSets(podSet).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("tas-main").
+						PodSets(utiltestingapi.MakePodSetAssignment("one").
+							Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+								Obj()).
+							Obj()).
+						Obj(),
+					now,
+				).
+				AdmissionCheck(kueue.AdmissionCheckState{
+					Name:  "prov-check",
+					State: kueue.CheckStateReady,
+				}).
+				AdmittedAt(true, now).
+				Obj(),
+			verify: func(t *testing.T, got *kueue.Workload) {
+				t.Helper()
+				if !workload.IsAdmitted(got) {
+					t.Error("the admission block cleared the admission of a running workload")
+				}
+				psa := got.Status.Admission.PodSetAssignments[0]
+				if psa.TopologyAssignment == nil {
+					t.Fatal("expected the replacement to keep a topology assignment")
+				}
+				for value := range utiltas.LowestLevelValues(psa.TopologyAssignment) {
+					if value == "x1" {
+						t.Errorf("expected the replacement to move off the unhealthy node, got %v", psa.TopologyAssignment.Slices)
+					}
+				}
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			var statusPatches int
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(ns.DeepCopy(), topology.DeepCopy(), rf.DeepCopy(), cq.DeepCopy(), lq.DeepCopy(), tc.workload.DeepCopy()).
+				WithStatusSubresource(&kueue.Workload{}).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" {
+							statusPatches++
+						}
+						return utiltesting.TreatSSAAsStrategicMerge(ctx, c, subResourceName, obj, patch, opts...)
+					},
+				})
+			_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+			cl := clientBuilder.Build()
+			recorder := &utiltesting.EventRecorder{}
+			fakeClock := testingclock.NewFakeClock(now)
+			cqCache := schdcache.New(cl, schdcache.WithPodsReadyTracking(true))
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock))
+			for _, node := range nodes {
+				cqCache.TASCache().SyncNode(&node)
+			}
+			cqCache.AddOrUpdateAdmissionCheck(log, provCheck.DeepCopy())
+			cqCache.AddOrUpdateResourceFlavor(log, rf.DeepCopy())
+			cqCache.AddOrUpdateTopology(log, topology.DeepCopy())
+			if err := cqCache.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
+				t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+			}
+			if err := qManager.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
+				t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+			}
+			if err := qManager.AddLocalQueue(ctx, lq.DeepCopy()); err != nil {
+				t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+			}
+			// Contributes the reserved usage and, with pods-ready tracking on, places
+			// the workload in its ClusterQueue's WorkloadsNotReady set.
+			cqCache.AddOrUpdateWorkload(log, tc.workload.DeepCopy())
+			if !qManager.QueueSecondPassIfNeeded(ctx, tc.workload, 0) {
+				t.Fatal("expected the workload to be queued for a second pass")
+			}
+			fakeClock.Step(time.Second)
+
+			scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
+			wg := sync.WaitGroup{}
+			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+				func() { wg.Add(1) },
+				func() { wg.Done() },
+			))
+
+			ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+			defer cancel()
+			go cqCache.CleanUpOnContext(ctx)
+			go qManager.CleanUpOnContext(ctx)
+
+			scheduler.schedule(ctx)
+			wg.Wait()
+
+			var got kueue.Workload
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(tc.workload), &got); err != nil {
+				t.Fatalf("Getting workload: %v", err)
+			}
+			if !workload.HasQuotaReservation(&got) {
+				t.Fatal("the admission block stripped the second-pass workload's own quota reservation")
+			}
+			if got.Status.Admission == nil {
+				t.Fatal("the admission block cleared the second-pass workload's admission")
+			}
+			tc.verify(t, &got)
+			if statusPatches != 1 {
+				t.Errorf("got %d workload status patches, want 1: an extra patch means the admission block stripped and re-established the workload's own reservation", statusPatches)
+			}
 		})
-	_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
-	cl := clientBuilder.Build()
-	recorder := &utiltesting.EventRecorder{}
-	fakeClock := testingclock.NewFakeClock(now)
-	cqCache := schdcache.New(cl, schdcache.WithPodsReadyTracking(true))
-	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock))
-	cqCache.TASCache().SyncNode(node)
-	cqCache.AddOrUpdateAdmissionCheck(log, provCheck.DeepCopy())
-	cqCache.AddOrUpdateResourceFlavor(log, rf.DeepCopy())
-	cqCache.AddOrUpdateTopology(log, topology.DeepCopy())
-	if err := cqCache.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
-		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
-	}
-	if err := qManager.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
-		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
-	}
-	if err := qManager.AddLocalQueue(ctx, lq.DeepCopy()); err != nil {
-		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
-	}
-	// Contributes the reserved usage and, with pods-ready tracking on, places
-	// the workload in its ClusterQueue's WorkloadsNotReady set.
-	cqCache.AddOrUpdateWorkload(log, wl.DeepCopy())
-	if !qManager.QueueSecondPassIfNeeded(ctx, wl, 0) {
-		t.Fatal("expected the workload to be queued for a second pass")
-	}
-	fakeClock.Step(time.Second)
-
-	scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
-	wg := sync.WaitGroup{}
-	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
-		func() { wg.Add(1) },
-		func() { wg.Done() },
-	))
-
-	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
-	defer cancel()
-	go cqCache.CleanUpOnContext(ctx)
-	go qManager.CleanUpOnContext(ctx)
-
-	scheduler.schedule(ctx)
-	wg.Wait()
-
-	var got kueue.Workload
-	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
-		t.Fatalf("Getting workload: %v", err)
-	}
-	if !workload.HasQuotaReservation(&got) {
-		t.Fatal("the admission block stripped the second-pass workload's own quota reservation")
-	}
-	psa := got.Status.Admission.PodSetAssignments[0]
-	if psa.TopologyAssignment == nil || psa.DelayedTopologyRequest == nil || *psa.DelayedTopologyRequest != kueue.DelayedTopologyRequestStateReady {
-		t.Fatalf("expected the second pass to complete the delayed topology assignment, got assignment %v, delayed state %v", psa.TopologyAssignment, psa.DelayedTopologyRequest)
-	}
-	if statusPatches != 1 {
-		t.Errorf("got %d workload status patches, want 1: an extra patch means the admission block stripped and re-established the workload's own reservation", statusPatches)
 	}
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -9767,3 +9767,134 @@ func TestScheduleForTASWhenWorkloadModifiedConcurrently(t *testing.T) {
 		}
 	}
 }
+
+// TestSecondPassSkipsWaitForPodsReadyBlock exercises the waitForPodsReady
+// admission block against a second-pass workload. The workload holds a quota
+// reservation and its pods are not ready yet, so the block is active because
+// of the workload under test itself; the second pass must complete the
+// delayed topology assignment instead of stripping its own reservation.
+func TestSecondPassSkipsWaitForPodsReadyBlock(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+
+	ns := utiltesting.MakeNamespaceWrapper(metav1.NamespaceDefault).Obj()
+	topology := utiltestingapi.MakeDefaultOneLevelTopology("tas-single-level")
+	rf := utiltestingapi.MakeResourceFlavor("tas-default").
+		NodeLabel("tas-node", "true").
+		TopologyName(topology.Name).
+		Obj()
+	provCheck := utiltestingapi.MakeAdmissionCheck("prov-check").
+		ControllerName(kueue.ProvisioningRequestControllerName).
+		Condition(metav1.Condition{
+			Type:   kueue.AdmissionCheckActive,
+			Status: metav1.ConditionTrue,
+		}).
+		Obj()
+	cq := utiltestingapi.MakeClusterQueue("tas-main").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+			Resource(corev1.ResourceCPU, "50").Obj()).
+		AdmissionChecks(kueue.AdmissionCheckReference(provCheck.Name)).
+		Obj()
+	lq := utiltestingapi.MakeLocalQueue("tas-main", ns.Name).ClusterQueue(cq.Name).Obj()
+	node := testingnode.MakeNode("x1").
+		Label("tas-node", "true").
+		Label(corev1.LabelHostname, "x1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).
+		Ready().
+		Obj()
+	wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+		Queue("tas-main").
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("tas-main").
+				PodSets(utiltestingapi.MakePodSetAssignment("one").
+					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+					Obj()).
+				Obj(),
+			now,
+		).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:  "prov-check",
+			State: kueue.CheckStateReady,
+		}).
+		Obj()
+
+	ctx, log := utiltesting.ContextWithLog(t)
+	// The block does not leave a lasting trace: it unsets the reservation and,
+	// once the wait ends, the admission patch re-establishes it. Count the
+	// status patches to catch that hidden round trip.
+	var statusPatches int
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithObjects(ns.DeepCopy(), topology.DeepCopy(), rf.DeepCopy(), cq.DeepCopy(), lq.DeepCopy(), wl.DeepCopy()).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if _, ok := obj.(*kueue.Workload); ok && subResourceName == "status" {
+					statusPatches++
+				}
+				return utiltesting.TreatSSAAsStrategicMerge(ctx, c, subResourceName, obj, patch, opts...)
+			},
+		})
+	_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+	cl := clientBuilder.Build()
+	recorder := &utiltesting.EventRecorder{}
+	fakeClock := testingclock.NewFakeClock(now)
+	cqCache := schdcache.New(cl, schdcache.WithPodsReadyTracking(true))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock))
+	cqCache.TASCache().SyncNode(node)
+	cqCache.AddOrUpdateAdmissionCheck(log, provCheck.DeepCopy())
+	cqCache.AddOrUpdateResourceFlavor(log, rf.DeepCopy())
+	cqCache.AddOrUpdateTopology(log, topology.DeepCopy())
+	if err := cqCache.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in cache: %v", cq.Name, err)
+	}
+	if err := qManager.AddClusterQueue(ctx, cq.DeepCopy()); err != nil {
+		t.Fatalf("Inserting clusterQueue %s in manager: %v", cq.Name, err)
+	}
+	if err := qManager.AddLocalQueue(ctx, lq.DeepCopy()); err != nil {
+		t.Fatalf("Inserting queue %s/%s in manager: %v", lq.Namespace, lq.Name, err)
+	}
+	// Contributes the reserved usage and, with pods-ready tracking on, places
+	// the workload in its ClusterQueue's WorkloadsNotReady set.
+	cqCache.AddOrUpdateWorkload(log, wl.DeepCopy())
+	if !qManager.QueueSecondPassIfNeeded(ctx, wl, 0) {
+		t.Fatal("expected the workload to be queued for a second pass")
+	}
+	fakeClock.Step(time.Second)
+
+	scheduler := New(qManager, cqCache, cl, recorder, WithClock(t, fakeClock), WithPreemptionExpectations(preemptexpectations.New()))
+	wg := sync.WaitGroup{}
+	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+		func() { wg.Add(1) },
+		func() { wg.Done() },
+	))
+
+	ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+	defer cancel()
+	go cqCache.CleanUpOnContext(ctx)
+	go qManager.CleanUpOnContext(ctx)
+
+	scheduler.schedule(ctx)
+	wg.Wait()
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
+		t.Fatalf("Getting workload: %v", err)
+	}
+	if !workload.HasQuotaReservation(&got) {
+		t.Fatal("the admission block stripped the second-pass workload's own quota reservation")
+	}
+	psa := got.Status.Admission.PodSetAssignments[0]
+	if psa.TopologyAssignment == nil || psa.DelayedTopologyRequest == nil || *psa.DelayedTopologyRequest != kueue.DelayedTopologyRequestStateReady {
+		t.Fatalf("expected the second pass to complete the delayed topology assignment, got assignment %v, delayed state %v", psa.TopologyAssignment, psa.DelayedTopologyRequest)
+	}
+	if statusPatches != 1 {
+		t.Errorf("got %d workload status patches, want 1: an extra patch means the admission block stripped and re-established the workload's own reservation", statusPatches)
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

A workload taking a second pass already holds a quota reservation and returns only to complete a delayed topology assignment or replace a failed node.

With `waitForPodsReady.blockAdmission` enabled, the workload can trigger the block against itself and unset its existing reservation. When replacing a failed node, the workload is already `Admitted`, so this also clears the admission of a running workload.

This PR exempts second pass workloads from the block. They request no new quota, so the sequencing used for fresh admissions does not apply to them.

The bug exists on `main` independently of `FairSharingDeepAdmission`. It was found while validating #13496 and split out for separate review and backporting.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13684

#### Special notes for your reviewer:

The guard now lives in `waitForPodsReadyIfNeeded`, leaving `processEntry` unchanged apart from the helper rename.

Unit tests cover both delayed topology assignment and replacement of a failed node. No integration suite currently enables both TAS and pods ready admission blocking. I have coverage working locally and can add it here or send it as a follow up.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fixed an issue where workloads taking a second pass to complete a delayed topology assignment or replace a failed node could lose their existing quota reservation when `waitForPodsReady.blockAdmission` was enabled. Replacing a failed node could also clear the admission of a running workload.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workloads requiring a second admission pass no longer become unnecessarily blocked by the PodsReady check.
  * Delayed topology assignments now complete correctly while preserving quota reservations and avoiding unnecessary status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->