### PR TITLE
TAS: add TASFlavorFallback gate to allow flavor fallback on TAS recompute

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -58,6 +58,7 @@
       - [Until v0.14](#until-v014)
       - [Since v0.15](#since-v015)
     - [Re-computation of TAS assignments within the workload evaluation phase](#re-computation-of-tas-assignments-within-the-workload-evaluation-phase)
+      - [Optional flavor fallback during recomputation](#optional-flavor-fallback-during-recomputation)
   - [Two-level Topology Aware scheduling](#two-level-topology-aware-scheduling)
     - [Example](#example-1)
   - [Multi-level Topology Aware scheduling](#multi-level-topology-aware-scheduling)
@@ -1684,6 +1685,36 @@ previously evaluated Workloads. During this recomputation, the PodSet-to-Resourc
 remains sticky so that the quota calculations made earlier in the cycle remain valid.
 This behavior was introduced in 0.19.0 and guarded by the `TASRecomputeAssignmentWithinSchedulingCycle`
 feature gate (enabled by defualt as Beta). The fix is also cherry-picked to 0.17.6 and 0.18.2.
+
+##### Optional flavor fallback during recomputation
+
+The sticky recomputation described above always retries the initially nominated flavor. When a
+ClusterQueue has multiple TAS ResourceFlavors backed by disjoint node pools, a Workload whose
+topology cannot be satisfied by the nominated flavor will keep failing even if another flavor in
+the same ClusterQueue has free capacity. Under sustained load, `AllocatableResourceGeneration`
+churn also invalidates the Workload's `LastAssignment` between cycles, so the flavor-fungibility
+`LastTriedFlavorIdx` never advances and the Workload effectively pins to the first flavor for its
+lifetime (see [issue #13658](https://github.com/kubernetes-sigs/kueue/issues/13658)).
+
+The `TASFlavorFallback` feature gate (alpha, off by default; introduced in 0.20) opts a cluster
+into a different recompute behavior: the recompute inverts the `NominationMapping` semantics so
+that the flavor(s) tried in the initial pass are *excluded* rather than pinned. The flavor
+iterator then considers the remaining flavors in the ClusterQueue's resource group. This
+releases the same-cycle quota nomination on the failing flavor. The gate is scoped to the
+same-cycle recompute triggered by `TASRecomputeAssignmentWithinSchedulingCycle`; the cross-cycle
+`LastAssignment` invalidation problem is not addressed by this gate, and workloads with three or
+more ResourceFlavors will still require additional cycles (or a follow-up fix) to iterate past
+the second one because only one recompute runs per `processEntry` call.
+
+Tradeoff: breaking stickiness does not affect correctness — `fits()` is re-checked against the
+live snapshot after the recompute, and `SimulateWorkloadAdmission` reflects the flavor the
+Workload actually lands on. It does introduce mild fairness staleness: the entry ordering
+(classical `Borrows()` sort, or fair-sharing DRS tournament) is computed against each Workload's
+nomination-time flavor, so a Workload that switches flavors during recompute may have won its
+slot on slightly wrong data. The tournament self-corrects on the next `pop()` because DRS is
+recomputed against the live snapshot. Users who require the strongest fairness guarantee should
+leave the gate off; users whose Workloads pin to an under-capacity flavor and never advance
+should enable it.
 
 ### Two-level Topology Aware scheduling
 In consideration of a [Story 5](#story-5) a two-level scheduling is introduced.

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -51,6 +51,7 @@ feature-gates:
   - name: TASRespectNodeAffinityPreferred
   - name: TASHandleOverlappingFlavors
   - name: TASRecomputeAssignmentWithinSchedulingCycle
+  - name: TASFlavorFallback
   - name: TASAssignmentsEncodingByHostnamePrefix
   - name: SkipReassignmentForPodOwnedWorkloads
 disable-supported: true

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -466,6 +466,15 @@ const (
 	// Enable re-computing the assignment within the same scheduling cycle when a TAS workload doesn't fit.
 	TASRecomputeAssignmentWithinSchedulingCycle featuregate.Feature = "TASRecomputeAssignmentWithinSchedulingCycle"
 
+	// owner: @vsyal
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/13658
+	//
+	// When enabled, an in-cycle TAS recomputation (see TASRecomputeAssignmentWithinSchedulingCycle)
+	// is allowed to try a different ResourceFlavor instead of remaining pinned to the previously
+	// nominated one. This helps workloads escape a ResourceFlavor whose topology cannot satisfy
+	// placement, at the cost of releasing the earlier same-cycle quota nomination for that flavor.
+	TASFlavorFallback featuregate.Feature = "TASFlavorFallback"
+
 	// owner: @j-skiba
 	// kep: https://github.com/kubernetes-sigs/kueue/issues/10852
 	//
@@ -766,6 +775,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASRecomputeAssignmentWithinSchedulingCycle: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	TASFlavorFallback: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 
 	UnadmittedWorkloadsExplicitStatus: {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -1319,6 +1319,10 @@ func (a *FlavorAssigner) shouldRespectNominationMapping() bool {
 // shouldSkipBasedOnNominationMapping returns true if the flavor should be skipped to enforce stickiness.
 // We stick to nominated flavors from the initial attempt to avoid flavor switching during recomputation.
 //
+// When TASFlavorFallback is enabled the semantics are inverted: flavors that WERE nominated in the
+// initial pass are skipped, so the recompute tries the remaining flavors in the ClusterQueue and can
+// fall back when the previously nominated flavor's topology cannot fit the workload.
+//
 // Note: Assumes NominationMapping is complete. If a resource is not requested by a pod set in the group,
 // it returns "" which won't match fName. We rely on the upstream guarantee that at least one pod set
 // in the group requests the resource and has a nominated flavor, otherwise it would incorrectly skip.
@@ -1327,12 +1331,23 @@ func (a *FlavorAssigner) shouldSkipBasedOnNominationMapping(log logr.Logger,
 	psIDs []int,
 	resName corev1.ResourceName,
 ) bool {
+	inMapping := false
 	for _, psID := range psIDs {
 		psName := a.wl.Obj.Spec.PodSets[psID].Name
 		if fName == a.wl.NominationMapping[psName][resName] {
-			log.V(5).Info("Found flavor in the nomination mapping - cannot skip", "psName", psName, "resName", resName, "flavorName", fName)
-			return false
+			inMapping = true
+			break
 		}
+	}
+	if features.Enabled(features.TASFlavorFallback) {
+		if inMapping {
+			log.V(5).Info("TASFlavorFallback: skipping previously nominated flavor", "resName", resName, "flavorName", fName)
+		}
+		return inMapping
+	}
+	if inMapping {
+		log.V(5).Info("Found flavor in the nomination mapping - cannot skip", "resName", resName, "flavorName", fName)
+		return false
 	}
 	log.V(5).Info("Didn't find the flavor in the nomination mapping - skipping", "resName", resName, "flavorName", fName)
 	return true

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -5928,6 +5928,192 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 		},
+		"two flavors in cohort; TASFlavorFallback allows switching to second flavor; TASFlavorFallback enabled": {
+			// tas-cq-b borrows on both flavors. Both a1 and b1 nominate tas-flavor-1 / node-1;
+			// higher-priority a1 is admitted first, so b1's TAS check on tas-flavor-1 fails.
+			// With TASFlavorFallback enabled, the same-cycle recompute excludes tas-flavor-1
+			// and admits b1 on tas-flavor-2 / node-2.
+			featureGates: map[featuregate.Feature]bool{
+				features.TASRecomputeAssignmentWithinSchedulingCycle: true,
+				features.TASFlavorFallback:                           true,
+			},
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("node-1").
+					Label("tas-node", "true").
+					Label("tas-flavor", "f1").
+					Label(corev1.LabelHostname, "node-1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("8"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("node-2").
+					Label("tas-node", "true").
+					Label("tas-flavor", "f2").
+					Label(corev1.LabelHostname, "node-2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("8"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("tas-flavor-1").
+					NodeLabel("tas-flavor", "f1").
+					TopologyName("tas-single-level").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("tas-flavor-2").
+					NodeLabel("tas-flavor", "f2").
+					TopologyName("tas-single-level").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-cq-a").
+					Cohort("tas-cohort-main").
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.TryNextFlavor,
+						WhenCanPreempt: kueue.TryNextFlavor,
+						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-1").Resource(corev1.ResourceCPU, "16").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-2").Resource(corev1.ResourceCPU, "8").Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("tas-cq-b").
+					Cohort("tas-cohort-main").
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.TryNextFlavor,
+						WhenCanPreempt: kueue.TryNextFlavor,
+						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-1").Resource(corev1.ResourceCPU, "0", "8").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("tas-flavor-2").Resource(corev1.ResourceCPU, "0", "8").Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("a1", "default").
+					Queue("tas-lq-a").
+					Creation(now.Add(-time.Minute)).
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("b1", "default").
+					Queue("tas-lq-b").
+					Creation(now).
+					Priority(5).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("a1", "default").
+					Queue("tas-lq-a").
+					Creation(now.Add(-time.Minute)).
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue tas-cq-a",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("tas-cq-a").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-flavor-1", "8").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("b1", "default").
+					Queue("tas-lq-b").
+					Creation(now).
+					Priority(5).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "8").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue tas-cq-b",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("tas-cq-b").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Count(1).
+								Assignment(corev1.ResourceCPU, "tas-flavor-2", "8").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-2"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/a1": *utiltestingapi.MakeAdmission("tas-cq-a").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-flavor-1", "8").
+						Count(1).
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+				"default/b1": *utiltestingapi.MakeAdmission("tas-cq-b").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-flavor-2", "8").
+						Count(1).
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-2"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "a1", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "a1", "Admitted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "b1", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "b1", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+		},
 		"two workloads in cohort nominated to the same node; enough capacity to admit both; TASRecomputeAssignmentWithinSchedulingCycle enabled": {
 			// Both workloads nominate the same node. With recomputation enabled, the second workload (b1)
 			// recomputes and successfully lands on node-2, allowing both to be admitted.

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -447,6 +447,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASFlavorFallback
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TASReplaceNodeDueToNotReadyOverFixedTime
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -447,6 +447,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASFlavorFallback
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TASReplaceNodeDueToNotReadyOverFixedTime
   versionedSpecs:
   - default: true


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

Adds an alpha feature gate `TASFlavorFallback` (off by default) that opts a cluster into a modified same-cycle TAS recomputation. When enabled, the recompute inverts the `NominationMapping` semantics so the flavor(s) tried in the initial nomination are **excluded** instead of pinned, letting the flavor iterator fall back to another flavor in the ClusterQueue's resource group when the initial one's topology cannot fit the Workload.

Without this gate, once a Workload is nominated to a flavor whose topology cannot host its pods, the same-cycle recompute pins to that same flavor via `NominationMapping` and the Workload cannot advance to another flavor in the resource group even when the alternate has ample topological capacity. Under sustained load with `TryNextFlavor` fungibility and cross-flavor cohort borrowing, this can leave Workloads stuck for their lifetime.

The gate is scoped to the same-cycle recompute triggered by `TASRecomputeAssignmentWithinSchedulingCycle`. Cross-cycle `LastAssignment` invalidation caused by `AllocatableResourceGeneration` churn is not addressed here and remains as follow-up.

#### Which issue(s) this PR fixes:

Fixes [kubernetes-sigs/kueue#13658](https://github.com/kubernetes-sigs/kueue/issues/13658)

#### Special notes for your reviewer:

AI assistance was used to draft parts of this change and this PR description (per the Kubernetes AI Tool Usage Policy). All logic, tests, and KEP updates were reviewed by a human before submission.

- KEP-2724 is updated with a subsection describing the gate, its scope, and the fairness tradeoff (`LastState` staleness in the entry ordering / DRS tournament, which self-corrects on the next pop).
- Versioned feature-list manifests are updated (`site/data/featuregates/versioned_feature_list.yaml` and `test/compatibility_lifecycle/reference/versioned_feature_list.yaml`).
- New scheduler_tas_test case exercises the harder scenario where both flavors are borrow candidates and the iterator records `TriedFlavorIdx=-1` (last-flavor wraparound); this covers both the equal-preference-borrow and the Fit-optimal cases.
- Two known limits that could be follow-ups: (a) cross-cycle `LastAssignment` invalidation; (b) only one recompute per `processEntry`, so ClusterQueues with 3+ flavors still need additional cycles to iterate past the second.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Added an alpha `TASFlavorFallback` feature gate (off by default) that, when combined with `TASRecomputeAssignmentWithinSchedulingCycle`, allows an in-cycle TAS recomputation to fall back to another ResourceFlavor in the ClusterQueue's resource group if the initially nominated flavor's topology cannot fit the Workload.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the alpha `TASFlavorFallback` feature gate, disabled by default.
  * When enabled, topology-aware scheduling can retry with alternative resource flavors during same-cycle recomputation.
  * Previously selected flavors are released and excluded from fallback attempts, improving workload placement across available flavors.

* **Documentation**
  * Documented configuration, behavior, fairness, and correctness considerations for flavor fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->