### PR TITLE
MultiKueue: allow update on workloads in the example worker RBAC

### DIFF
--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -120,6 +120,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 - apiGroups:
   - kueue.x-k8s.io
   resources:

--- a/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
+++ b/site/static/examples/multikueue/create-multikueue-kubeconfig.sh
@@ -119,6 +119,7 @@ rules:
   - get
   - list
   - watch
+  - update
 - apiGroups:
   - kueue.x-k8s.io
   resources:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue
/area integrations

#### What this PR does / why we need it:

The example worker-cluster RBAC generated by `create-multikueue-kubeconfig.sh`
grants only `create/delete/get/list/watch` on `workloads`. However, when an
elastic workload (`ElasticJobsViaWorkloadSlices`) is scaled **down**, the
MultiKueue admission-check controller on the manager updates the **remote**
Workload on the worker cluster to propagate the new per-worker-group replica
counts (see `pkg/controller/admissionchecks/multikueue/workload.go`, the
`ScaledDown` branch that calls `remoteClient.Update` on the remote Workload).

Because the example role is missing the `update` verb on `workloads`, that
call is rejected:

```
failed to update remote workload: workloads.kueue.x-k8s.io "<name>" is
forbidden: User "system:serviceaccount:kueue-system:multikueue-sa" cannot
update resource "workloads" in API group "kueue.x-k8s.io" in the namespace
"<ns>"
```

The workload reconcile then loops on this error and the manager's quota
accounting stays out of sync with the worker (the remote copy keeps the old,
larger replica count). This PR adds `update` on `workloads` to the example
worker role so elastic scale-down propagates correctly.

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Verified on a live two-cluster (manager + worker) kind MultiKueue setup with
`ElasticJobsViaWorkloadSlices` enabled and KubeRay on the worker:

- **Before** (role without `update`): an admitted elastic `RayCluster` scaled
  from 2 → 1 workers left the remote Workload stuck at `workers-group-0=2`
  while the manager Workload was at `1`, with the controller looping on the
  Forbidden error above.
- **After** (role with `update`): the same scale-down propagated — the remote
  Workload and remote `RayCluster` moved to `1`, and the error cleared.

Scope is intentionally limited to the `workloads` `update` verb. (Separately,
the same example role also appears to be missing watch permissions for some
newer integrations — `jaxjobs`, `trainjobs`, `deployments` — needed for the
`MultiKueueCluster` to connect when those integrations are enabled; that is
out of scope here and can be addressed in a follow-up.)

AI usage disclosure: this change was developed and verified with AI assistance
(Claude Code); the RBAC gap and fix were reproduced and confirmed by the live
experiment described above.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: The example worker-cluster RBAC generated by `create-multikueue-kubeconfig.sh` now grants `update` on `workloads`, which is required to propagate scale-down of elastic workloads (`ElasticJobsViaWorkloadSlices`) to the worker cluster. Without it, scaling an elastic workload down failed with a Forbidden error and the Workload reconcile looped.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * MultiKueue now has the required permissions to update and patch Kueue workloads, improving workload management reliability.
  * This helps workload changes apply successfully across clusters in scenarios requiring either update or patch operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->