### PR TITLE
Update unit tests before UnadmittedWorkloadsObservability FG graduation 

### DIFF
--- a/pkg/controller/core/workload_controller_inadmissible_test.go
+++ b/pkg/controller/core/workload_controller_inadmissible_test.go
@@ -683,7 +683,7 @@ func TestReconcileInadmissible(t *testing.T) {
 		},
 		"should not write QuotaReserved condition on newly created workload": {
 			featureGates: map[featuregate.Feature]bool{
-				features.UnadmittedWorkloadsObservability: true,
+				features.UnadmittedWorkloadsObservability: false,
 			},
 			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
@@ -694,6 +694,34 @@ func TestReconcileInadmissible(t *testing.T) {
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
 				Queue("lq").
+				Obj(),
+		},
+		"should write QuotaReserved condition on newly created workload": {
+			featureGates: map[featuregate.Feature]bool{
+				features.UnadmittedWorkloadsObservability:  true,
+				features.UnadmittedWorkloadsExplicitStatus: true,
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(true).
+				Queue("lq").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadAdmitted,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadAdmittedReasonNoReservation,
+					Message: "The workload has no reservation",
+				}).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadQuotaReserved,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+					Message: "Workload is pending evaluation in the scheduling queue",
+				}).
 				Obj(),
 		},
 		"should set status QuotaReserved conditions to False with reason Suspended if quota not reserved LocalQueue StopPolicy=Hold": {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -50,6 +50,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/pkg/workload"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 )
 
@@ -1390,7 +1391,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1485,7 +1486,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1580,7 +1581,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1672,7 +1673,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1773,7 +1774,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1865,7 +1866,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{
@@ -1944,7 +1945,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "Exceeded the PodsReady timeout",
 					}).
 					Condition(metav1.Condition{
@@ -2017,7 +2018,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "At least one admission check is false",
 					}).
 					Condition(metav1.Condition{
@@ -2102,7 +2103,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The ClusterQueue is stopped",
 					}).
 					Condition(metav1.Condition{
@@ -2187,7 +2188,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The LocalQueue is stopped",
 					}).
 					Condition(metav1.Condition{
@@ -2272,7 +2273,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "Preempted",
 					}).
 					Condition(metav1.Condition{
@@ -2337,7 +2338,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					AdmissionCheck(kueue.AdmissionCheckState{
@@ -2368,7 +2369,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					AdmissionCheck(kueue.AdmissionCheckState{

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -55,6 +55,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
 
 	_ "sigs.k8s.io/kueue/pkg/controller/jobs/job"
@@ -2509,7 +2510,7 @@ func TestReconciler(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: metav1.NewTime(now),
-						Reason:             "Pending",
+						Reason:             workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message:            "Preempted to accommodate a higher priority Workload",
 					}).
 					Condition(metav1.Condition{
@@ -6325,7 +6326,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
-						Reason:  "Pending",
+						Reason:  workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message: "The workload is deactivated",
 					}).
 					Condition(metav1.Condition{

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -42,6 +42,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 var (
@@ -537,7 +538,7 @@ func TestReconciler(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
-						Reason:             "Pending",
+						Reason:             workload.UnadmittedWorkloadReasonWithFallback(kueue.WorkloadQuotaReservedReasonPendingEvaluation, kueue.WorkloadPending), //nolint:staticcheck // SA1019: fallback
 						Message:            "The workload was deactivated",
 						ObservedGeneration: 1,
 					}).

--- a/pkg/util/testing/observability.go
+++ b/pkg/util/testing/observability.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 )
 
 // AdjustConditionsForDisabledObservabilityInWorkloadController adjusts a slice of workload status conditions
@@ -139,4 +140,34 @@ func AdjustEventsForDisabledObservabilityInScheduler(events []EventRecord) {
 			}
 		}
 	}
+}
+
+// UnadmittedConditions returns the conditions if the UnadmittedWorkloadsObservability
+// feature gate is enabled, otherwise it returns nil.
+func UnadmittedConditions(conds ...metav1.Condition) []metav1.Condition {
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		return conds
+	}
+	return nil
+}
+
+// ExplicitStatusConditions returns the conditions if both UnadmittedWorkloadsObservability
+// and UnadmittedWorkloadsExplicitStatus feature gates are enabled, otherwise it returns nil.
+func ExplicitStatusConditions(conds ...metav1.Condition) []metav1.Condition {
+	if features.Enabled(features.UnadmittedWorkloadsObservability) && features.Enabled(features.UnadmittedWorkloadsExplicitStatus) {
+		return conds
+	}
+	return nil
+}
+
+// WantChangeWithObservability returns true if defaultWantChange is true or if
+// the UnadmittedWorkloadsObservability feature gate is enabled.
+func WantChangeWithObservability(defaultWantChange bool) bool {
+	return defaultWantChange || features.Enabled(features.UnadmittedWorkloadsObservability)
+}
+
+// WantChangeWithExplicitStatus returns true if defaultWantChange is true or if both
+// UnadmittedWorkloadsObservability and UnadmittedWorkloadsExplicitStatus feature gates are enabled.
+func WantChangeWithExplicitStatus(defaultWantChange bool) bool {
+	return defaultWantChange || (features.Enabled(features.UnadmittedWorkloadsObservability) && features.Enabled(features.UnadmittedWorkloadsExplicitStatus))
 }

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -28,6 +28,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
@@ -45,7 +46,15 @@ func TestSyncAdmittedCondition(t *testing.T) {
 		wantChange       bool
 		wantAdmittedTime int32
 	}{
-		"empty": {},
+		"empty": {
+			wantConditions: utiltesting.ExplicitStatusConditions(metav1.Condition{
+				Type:               kueue.WorkloadAdmitted,
+				Status:             metav1.ConditionFalse,
+				Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+				ObservedGeneration: 1,
+			}),
+			wantChange: utiltesting.WantChangeWithExplicitStatus(false),
+		},
 		"reservation no checks": {
 			conditions: []metav1.Condition{
 				{
@@ -84,12 +93,19 @@ func TestSyncAdmittedCondition(t *testing.T) {
 					Status: metav1.ConditionTrue,
 				},
 			},
-			wantConditions: []metav1.Condition{
+			wantConditions: append([]metav1.Condition{
 				{
 					Type:   kueue.WorkloadQuotaReserved,
 					Status: metav1.ConditionTrue,
 				},
+			}, utiltesting.UnadmittedConditions(metav1.Condition{
+				Type:               kueue.WorkloadAdmitted,
+				Status:             metav1.ConditionFalse,
+				Reason:             kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks,
+				ObservedGeneration: 1,
 			},
+			)...),
+			wantChange: utiltesting.WantChangeWithObservability(false),
 		},
 		"reservation, checks ready": {
 			checkStates: []kueue.AdmissionCheckState{
@@ -144,7 +160,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "NoReservation",
+					Reason:             kueue.WorkloadAdmittedReasonNoReservation,
 					ObservedGeneration: 1,
 				},
 			},
@@ -181,7 +197,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "UnsatisfiedChecks",
+					Reason:             UnadmittedWorkloadReasonWithFallback(kueue.WorkloadAdmittedReasonUnsatisfiedAdmissionChecks, "UnsatisfiedChecks"),
 					ObservedGeneration: 1,
 				},
 			},
@@ -210,7 +226,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "NoReservationUnsatisfiedChecks",
+					Reason:             UnadmittedWorkloadReasonWithFallback(kueue.WorkloadAdmittedReasonNoReservation, "NoReservationUnsatisfiedChecks"),
 					ObservedGeneration: 1,
 				},
 			},
@@ -228,7 +244,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "NoReservation",
+					Reason:             kueue.WorkloadAdmittedReasonNoReservation,
 					ObservedGeneration: 1,
 				},
 			},
@@ -248,7 +264,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "NoReservation",
+					Reason:             kueue.WorkloadAdmittedReasonNoReservation,
 					ObservedGeneration: 1,
 				},
 			},
@@ -286,7 +302,7 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
-					Reason:             "PendingDelayedTopologyRequests",
+					Reason:             kueue.WorkloadAdmittedReasonPendingDelayedTopologyRequests,
 					ObservedGeneration: 1,
 				},
 				{
@@ -332,10 +348,11 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				{
 					Type:               kueue.WorkloadAdmitted,
 					Status:             metav1.ConditionFalse,
+					Reason:             UnadmittedWorkloadReasonWithFallback(kueue.WorkloadAdmittedReasonPendingDelayedTopologyRequests, ""),
 					ObservedGeneration: 1,
 				},
 			},
-			wantChange: false,
+			wantChange: utiltesting.WantChangeWithObservability(false),
 		},
 		"reservation, checks not ready with observability": {
 			featureGates: map[featuregate.Feature]bool{features.UnadmittedWorkloadsObservability: true},
@@ -466,24 +483,20 @@ func TestSyncAdmittedCondition(t *testing.T) {
 			},
 			wantChange: true,
 		},
-		"no reservation, no condition initially with observability (explicit status initialization disabled)": {
-			featureGates: map[featuregate.Feature]bool{features.UnadmittedWorkloadsObservability: true},
+		"no reservation, no condition initially": {
 			checkStates: []kueue.AdmissionCheckState{
 				{
 					Name:  "check1",
 					State: kueue.CheckStatePending,
 				},
 			},
-			wantChange: false,
-		},
-		"no reservation, no condition initially (explicit status initialization disabled)": {
-			checkStates: []kueue.AdmissionCheckState{
-				{
-					Name:  "check1",
-					State: kueue.CheckStatePending,
-				},
-			},
-			wantChange: false,
+			wantConditions: utiltesting.ExplicitStatusConditions(metav1.Condition{
+				Type:               kueue.WorkloadAdmitted,
+				Status:             metav1.ConditionFalse,
+				Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+				ObservedGeneration: 1,
+			}),
+			wantChange: utiltesting.WantChangeWithExplicitStatus(false),
 		},
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/area testing

#### What this PR does / why we need it:

Prep PR before enabling `UnadmittedWorkloadsObservability` FG by default.

- added helper functions in pkg/util/testing/observability.go
- use fallback reason function in remaining tests
- add extra test case to pkg/controller/core/workload_controller_inadmissible_test.go

#### Which issue(s) this PR fixes:
Part of #10852 

#### Special notes for your reviewer:

PR created as advised here https://github.com/kubernetes-sigs/kueue/pull/13063/changes#r3683535259

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload status reporting across observability and explicit-status configurations.
  * Newly created unadmitted workloads now accurately reflect pending evaluation and quota reservation state.
  * Preserved compatibility with legacy pending-status reasons when explicit status is unavailable.
  * Improved status handling for delayed-topology and no-reservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->