### PR TITLE
Reduce website link checker attempts

### DIFF
--- a/hack/testing/linkchecker/verify.sh
+++ b/hack/testing/linkchecker/verify.sh
@@ -30,7 +30,7 @@ echo "Building linkchecker Docker image..."
 "${DOCKER}" build --load -f "${SOURCE_DIR}/Dockerfile" -t linkchecker "${SOURCE_DIR}"
 
 echo "Running linkchecker against ${LINK_CHECK_URL} ..."
-"${ROOT_DIR}/hack/testing/retry.sh" --attempts 5 --delay 5 --stream -- \
+"${ROOT_DIR}/hack/testing/retry.sh" --attempts 2 --delay 5 --stream -- \
     "${DOCKER}" run --rm linkchecker --no-warnings --ignore-url='^mailto:' --ignore-url='^tel:' "${LINK_CHECK_URL}"
 
 echo "Link check completed successfully"


### PR DESCRIPTION

#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:
If `pull-kueue-verify-website-links-preview-main` fails, it retries 5 times taking ~50 min. 
Reduced to 2.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated link verification checks to retry up to two times when needed.
  * Preserved existing delays, URL handling, and ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->