### PR TITLE
stop watcher goroutines from outliving their owner

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -124,6 +124,7 @@ type remoteClient struct {
 	watchEndedCh chan<- event.GenericEvent
 	cqUpdateCh   chan<- event.TypedGenericEvent[kueue.ClusterQueueReference]
 	watchCancel  func()
+	watchers     sync.WaitGroup
 	config       *clientConfig
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
@@ -418,9 +419,23 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	}
 
 	return func() {
+		rc.watchers.Add(1)
 		go func() {
+			defer rc.watchers.Done()
 			log.V(2).Info("Starting watch")
-			for r := range newWatcher.ResultChan() {
+			resultCh := newWatcher.ResultChan()
+		watching:
+			for {
+				var r watch.Event
+				select {
+				case <-ctx.Done():
+					break watching
+				case ev, ok := <-resultCh:
+					if !ok {
+						break watching
+					}
+					r = ev
+				}
 				switch r.Type {
 				case watch.Bookmark:
 					// Bookmark events are periodic signals from the API server to
@@ -564,19 +579,26 @@ func (rc *remoteClient) setClient(c SelectivelyCachingClient) {
 	rc.client = c
 }
 
+// StopWatchers cancels the watch context and blocks until every watcher goroutine returned.
 func (rc *remoteClient) StopWatchers() {
 	rc.mu.Lock()
-	defer rc.mu.Unlock()
 	if rc.watchCancel != nil {
 		rc.watchCancel()
 		rc.watchCancel = nil
 	}
+	rc.mu.Unlock()
+
+	// Not under rc.mu: watcher goroutines take it themselves via getClient.
+	rc.watchers.Wait()
 }
 
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
-		rc.wlUpdateCh <- event.GenericEvent{Object: localWl}
+		select {
+		case rc.wlUpdateCh <- event.GenericEvent{Object: localWl}:
+		case <-ctx.Done():
+		}
 	} else if !apierrors.IsNotFound(err) {
 		ctrl.LoggerFrom(ctx).Error(err, "reading local workload")
 	}
@@ -585,7 +607,10 @@ func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.Name
 func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 	cluster := &kueue.MultiKueueCluster{}
 	if err := rc.localClient.Get(ctx, types.NamespacedName{Name: rc.clusterName}, cluster); err == nil {
-		rc.watchEndedCh <- event.GenericEvent{Object: cluster}
+		select {
+		case rc.watchEndedCh <- event.GenericEvent{Object: cluster}:
+		case <-ctx.Done():
+		}
 	} else {
 		ctrl.LoggerFrom(ctx).Error(err, "sending watch ended event")
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -423,45 +423,9 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	return func() {
 		rc.runWatcher(func() {
 			log.V(2).Info("Starting watch")
-			resultCh := newWatcher.ResultChan()
-		watching:
-			for {
-				select {
-				case <-ctx.Done():
-					break watching
-				case r, ok := <-resultCh:
-					if !ok {
-						break watching
-					}
-					switch r.Type {
-					case watch.Bookmark:
-						// Bookmark events are periodic signals from the API server to
-						// keep the connection alive. They carry no meaningful payload
-						// and can be safely ignored.
-						log.V(5).Info("Watch bookmark received")
-					case watch.Error:
-						switch s := r.Object.(type) {
-						case *metav1.Status:
-							log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
-						default:
-							log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
-						}
-					default:
-						wlKeys, err := w.WorkloadKeysFor(r.Object)
-						if err != nil {
-							log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
-						} else {
-							for _, wlKey := range wlKeys {
-								rc.queueWorkloadEvent(ctx, wlKey)
-							}
-						}
-					}
-				}
-			}
+			rc.consumeWatch(ctx, log, newWatcher, w)
 			log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
-			// If the context is not yet Done , queue a reconcile to attempt reconnection
 			if ctx.Err() == nil {
-				// reconnect if this is the first watch failing.
 				if wasConnected := rc.connState.markDisconnected(rc.clock.Now()); wasConnected {
 					log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
 					rc.queueWatchEndedEvent(ctx)
@@ -469,6 +433,48 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 			}
 		})
 	}, nil
+}
+
+// consumeWatch dispatches events until the watch ends or ctx is cancelled. Cancelling does
+// not close the result channel, so the ctx arm is what lets StopWatchers join this goroutine.
+func (rc *remoteClient) consumeWatch(ctx context.Context, log logr.Logger, watcher watch.Interface, w jobframework.MultiKueueWatcher) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+			rc.handleWatchEvent(ctx, log, r, w)
+		}
+	}
+}
+
+func (rc *remoteClient) handleWatchEvent(ctx context.Context, log logr.Logger, r watch.Event, w jobframework.MultiKueueWatcher) {
+	switch r.Type {
+	case watch.Bookmark:
+		// Bookmark events are periodic signals from the API server to
+		// keep the connection alive. They carry no meaningful payload
+		// and can be safely ignored.
+		log.V(5).Info("Watch bookmark received")
+	case watch.Error:
+		switch s := r.Object.(type) {
+		case *metav1.Status:
+			log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+		default:
+			log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
+		}
+	default:
+		wlKeys, err := w.WorkloadKeysFor(r.Object)
+		if err != nil {
+			log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
+			return
+		}
+		for _, wlKey := range wlKeys {
+			rc.queueWorkloadEvent(ctx, wlKey)
+		}
+	}
 }
 
 func (rc *remoteClient) startQueueWatchers(ctx context.Context) error {
@@ -546,10 +552,7 @@ func (rc *remoteClient) queueEventsForLQ(ctx context.Context, remoteLQ *kueue.Lo
 		return
 	}
 
-	select {
-	case rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}:
-	case <-ctx.Done():
-	}
+	rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}
 }
 
 func (rc *remoteClient) getFailedConnAttempts() uint {
@@ -616,10 +619,7 @@ func (rc *remoteClient) StopWatchers() {
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
-		select {
-		case rc.wlUpdateCh <- event.GenericEvent{Object: localWl}:
-		case <-ctx.Done():
-		}
+		rc.wlUpdateCh <- event.GenericEvent{Object: localWl}
 	} else if !apierrors.IsNotFound(err) {
 		ctrl.LoggerFrom(ctx).Error(err, "reading local workload")
 	}
@@ -628,10 +628,7 @@ func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.Name
 func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 	cluster := &kueue.MultiKueueCluster{}
 	if err := rc.localClient.Get(ctx, types.NamespacedName{Name: rc.clusterName}, cluster); err == nil {
-		select {
-		case rc.watchEndedCh <- event.GenericEvent{Object: cluster}:
-		case <-ctx.Done():
-		}
+		rc.watchEndedCh <- event.GenericEvent{Object: cluster}
 	} else {
 		ctrl.LoggerFrom(ctx).Error(err, "sending watch ended event")
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -307,7 +307,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		}
 	}
 
-	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
+	var watchCancel context.CancelFunc
+	watchCtx, watchCancel = context.WithCancel(watchCtx)
+	rc.setWatchCancel(watchCancel)
 
 	builder := newClientWithWatch
 	if rc.builderOverride != nil {
@@ -419,43 +421,39 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	}
 
 	return func() {
-		rc.watchers.Add(1)
-		go func() {
-			defer rc.watchers.Done()
+		rc.runWatcher(func() {
 			log.V(2).Info("Starting watch")
 			resultCh := newWatcher.ResultChan()
 		watching:
 			for {
-				var r watch.Event
 				select {
 				case <-ctx.Done():
 					break watching
-				case ev, ok := <-resultCh:
+				case r, ok := <-resultCh:
 					if !ok {
 						break watching
 					}
-					r = ev
-				}
-				switch r.Type {
-				case watch.Bookmark:
-					// Bookmark events are periodic signals from the API server to
-					// keep the connection alive. They carry no meaningful payload
-					// and can be safely ignored.
-					log.V(5).Info("Watch bookmark received")
-				case watch.Error:
-					switch s := r.Object.(type) {
-					case *metav1.Status:
-						log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+					switch r.Type {
+					case watch.Bookmark:
+						// Bookmark events are periodic signals from the API server to
+						// keep the connection alive. They carry no meaningful payload
+						// and can be safely ignored.
+						log.V(5).Info("Watch bookmark received")
+					case watch.Error:
+						switch s := r.Object.(type) {
+						case *metav1.Status:
+							log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+						default:
+							log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
+						}
 					default:
-						log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
-					}
-				default:
-					wlKeys, err := w.WorkloadKeysFor(r.Object)
-					if err != nil {
-						log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
-					} else {
-						for _, wlKey := range wlKeys {
-							rc.queueWorkloadEvent(ctx, wlKey)
+						wlKeys, err := w.WorkloadKeysFor(r.Object)
+						if err != nil {
+							log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
+						} else {
+							for _, wlKey := range wlKeys {
+								rc.queueWorkloadEvent(ctx, wlKey)
+							}
 						}
 					}
 				}
@@ -469,7 +467,7 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 					rc.queueWatchEndedEvent(ctx)
 				}
 			}
-		}()
+		})
 	}, nil
 }
 
@@ -548,7 +546,10 @@ func (rc *remoteClient) queueEventsForLQ(ctx context.Context, remoteLQ *kueue.Lo
 		return
 	}
 
-	rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}
+	select {
+	case rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}:
+	case <-ctx.Done():
+	}
 }
 
 func (rc *remoteClient) getFailedConnAttempts() uint {
@@ -577,6 +578,26 @@ func (rc *remoteClient) setClient(c SelectivelyCachingClient) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.client = c
+}
+
+// setWatchCancel stores the cancel func of the watch context the next watchers will observe.
+// A non-nil value is what marks the client as accepting new watchers, see runWatcher.
+func (rc *remoteClient) setWatchCancel(cancel context.CancelFunc) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.watchCancel = cancel
+}
+
+// runWatcher starts fn as a tracked watcher goroutine, unless the watchers were already
+// stopped. Registering under rc.mu makes it mutually exclusive with StopWatchers, so a
+// watcher can never begin after StopWatchers has decided what to wait for.
+func (rc *remoteClient) runWatcher(fn func()) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.watchCancel == nil {
+		return
+	}
+	rc.watchers.Go(fn)
 }
 
 // StopWatchers cancels the watch context and blocks until every watcher goroutine returned.

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -864,6 +864,7 @@ func TestReconnectBackoff(t *testing.T) {
 			rc.clock = fc
 			rc.builderOverride = reconciler.builderOverride
 			reconciler.remoteClients["worker1"] = rc
+			t.Cleanup(rc.StopWatchers)
 
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}}
 
@@ -1446,6 +1447,11 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileAccessProvider{}, nil, recorder)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
+	t.Cleanup(func() {
+		for _, rc := range reconciler.remoteClients {
+			rc.StopWatchers()
+		}
+	})
 
 	slowDone := make(chan struct{})
 	go func() {
@@ -1683,61 +1689,5 @@ func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
 	case <-stopped:
 	case <-time.After(30 * time.Second):
 		t.Fatal("StopWatchers did not return: the watcher goroutine was never joined")
-	}
-}
-
-func TestQueueEventSendsUnblockOnCancel(t *testing.T) {
-	baseCtx, _ := utiltesting.ContextWithLog(t)
-
-	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl1", Namespace: "ns1"}}
-	lq := &kueue.LocalQueue{
-		ObjectMeta: metav1.ObjectMeta{Name: "lq1", Namespace: "ns1"},
-		Spec:       kueue.LocalQueueSpec{ClusterQueue: "cq1"},
-	}
-	cluster := &kueue.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: "worker1"}}
-
-	cases := map[string]func(ctx context.Context, rc *remoteClient){
-		"queueWorkloadEvent on wlUpdateCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueWorkloadEvent(ctx, types.NamespacedName{Namespace: "ns1", Name: "wl1"})
-		},
-		"queueWatchEndedEvent on watchEndedCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueWatchEndedEvent(ctx)
-		},
-		"queueEventsForLQ on cqUpdateCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueEventsForLQ(ctx, lq)
-		},
-	}
-
-	for name, send := range cases {
-		t.Run(name, func(t *testing.T) {
-			rc := &remoteClient{
-				clusterName:  "worker1",
-				localClient:  getClientBuilder(baseCtx).WithObjects(wl, lq, cluster).Build(),
-				wlUpdateCh:   make(chan event.GenericEvent),
-				watchEndedCh: make(chan event.GenericEvent),
-				cqUpdateCh:   make(chan event.TypedGenericEvent[kueue.ClusterQueueReference]),
-				clock:        clock.RealClock{},
-			}
-
-			ctx, cancel := context.WithCancel(baseCtx)
-			returned := make(chan struct{})
-			go func() {
-				send(ctx, rc)
-				close(returned)
-			}()
-
-			select {
-			case <-returned:
-				t.Fatal("send returned before cancellation; it never blocked on the channel")
-			case <-time.After(100 * time.Millisecond):
-			}
-
-			cancel()
-			select {
-			case <-returned:
-			case <-time.After(30 * time.Second):
-				t.Fatal("send did not unblock on cancellation")
-			}
-		})
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -694,6 +694,12 @@ func TestUpdateConfig(t *testing.T) {
 			}
 			reconciler.builderOverride = fakeClientBuilder(ctx)
 
+			t.Cleanup(func() {
+				for _, rc := range reconciler.remoteClients {
+					rc.StopWatchers()
+				}
+			})
+
 			features.SetFeatureGateDuringTest(t, features.MultiKueueKubeConfigPathValidation, tc.multiKueueSafePathFeatureGate)
 
 			if tc.overrideKubeConfigPrefix {

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1650,3 +1650,94 @@ func TestRemoteClientConcurrentSetConfigAndReaders(t *testing.T) {
 		_ = remoteCl.List(ctx, &kueue.LocalQueueList{}) // clusterqueue.go-style read
 	})
 }
+
+func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	fw := watch.NewFake()
+	t.Cleanup(fw.Stop)
+
+	rc := newTestClient(ctx, []byte("placeholder"), nil, nil)
+	rc.client = NewNeverCachingClient(getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
+		Watch: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+			return fw, nil
+		},
+	}).Build())
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	rc.setWatchCancel(cancel)
+
+	startWatcher, err := rc.establishWatcher(watchCtx, "Workload", &workloadKueueWatcher{})
+	if err != nil {
+		t.Fatalf("unexpected error establishing the watcher: %v", err)
+	}
+	startWatcher()
+
+	stopped := make(chan struct{})
+	go func() {
+		rc.StopWatchers()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		t.Fatal("StopWatchers did not return: the watcher goroutine was never joined")
+	}
+}
+
+func TestQueueEventSendsUnblockOnCancel(t *testing.T) {
+	baseCtx, _ := utiltesting.ContextWithLog(t)
+
+	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl1", Namespace: "ns1"}}
+	lq := &kueue.LocalQueue{
+		ObjectMeta: metav1.ObjectMeta{Name: "lq1", Namespace: "ns1"},
+		Spec:       kueue.LocalQueueSpec{ClusterQueue: "cq1"},
+	}
+	cluster := &kueue.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: "worker1"}}
+
+	cases := map[string]func(ctx context.Context, rc *remoteClient){
+		"queueWorkloadEvent on wlUpdateCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueWorkloadEvent(ctx, types.NamespacedName{Namespace: "ns1", Name: "wl1"})
+		},
+		"queueWatchEndedEvent on watchEndedCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueWatchEndedEvent(ctx)
+		},
+		"queueEventsForLQ on cqUpdateCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueEventsForLQ(ctx, lq)
+		},
+	}
+
+	for name, send := range cases {
+		t.Run(name, func(t *testing.T) {
+			rc := &remoteClient{
+				clusterName:  "worker1",
+				localClient:  getClientBuilder(baseCtx).WithObjects(wl, lq, cluster).Build(),
+				wlUpdateCh:   make(chan event.GenericEvent),
+				watchEndedCh: make(chan event.GenericEvent),
+				cqUpdateCh:   make(chan event.TypedGenericEvent[kueue.ClusterQueueReference]),
+				clock:        clock.RealClock{},
+			}
+
+			ctx, cancel := context.WithCancel(baseCtx)
+			returned := make(chan struct{})
+			go func() {
+				send(ctx, rc)
+				close(returned)
+			}()
+
+			select {
+			case <-returned:
+				t.Fatal("send returned before cancellation; it never blocked on the channel")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			cancel()
+			select {
+			case <-returned:
+			case <-time.After(30 * time.Second):
+				t.Fatal("send did not unblock on cancellation")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug 
/kind flake 
/area multikueue

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
The multikueue unit-test package fails intermittently under -race as a package-level FAIL that no individual test explains. The cause is a watcher goroutine that outlives the test that started it and logs through that test's logger.

`establishWatcher` spawns a goroutine that logs as its very first statement, and again after
its loop ends:

```go
return func() {
    go func() {
        log.V(2).Info("Starting watch")
        for r := range newWatcher.ResultChan() {
            ...
        }
        log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
```
`log` comes from `ctrl.LoggerFrom(ctx)`, which under test is a `testr` logger bound to
`*testing.T`. A watcher still running after its test returns calls `t.Log()` while `tRunner`
is writing to the same `testing.common` during teardown. The racing memory is Go's own
struct, which is why no Kueue-side test owns the failure.

This is an excerpt from the local logs
```
WARNING: DATA RACE
Read at 0x00c000cfc953 by goroutine 765:
  testing.(*common).destination()                       testing/testing.go:1064
  github.com/go-logr/logr/testr.logInfo()               testr/testr.go:101
  multikueue.(*remoteClient).establishWatcher.func1.1() multikueuecluster.go:422

Previous write at 0x00c000cfc953 by goroutine 451:
  testing.tRunner.func1()                               testing/testing.go:2023

Goroutine 765 (running) created at:
  multikueue.(*remoteClient).establishWatcher.func1()   multikueuecluster.go:421
  multikueue.(*remoteClient).updateConfigAndRefreshWatchers()
  multikueue.(*clustersReconciler).setRemoteClientConfig()
  multikueue.(*clustersReconciler).Reconcile()
  multikueue.TestUpdateConfig.func2()                   multikueuecluster_test.go:718
Goroutine 451 (finished)
```


There are two independent defects here, and **neither fix works without the other**.

**1. `StopWatchers` could not stop anything (`multikueuecluster.go`).**

It cancelled the watch context and returned. Cancellation is a request, not a join — and worse,
the watch loop never observed it, because cancelling the context does not close
`newWatcher.ResultChan()`. A watcher could therefore ignore cancellation indefinitely.

- The loop now selects on `ctx.Done()` alongside the result channel.
- `remoteClient` gains a `sync.WaitGroup`; the starter closure registers before spawning, so a
  concurrent `StopWatchers` never sees a zero counter while a goroutine is coming up.
- `StopWatchers` joins the group after cancelling, outside `rc.mu` — watcher goroutines take
  that lock themselves via `getClient`, so joining under it would deadlock.
- The two channel sends reachable from a watcher (`queueWorkloadEvent`, `queueWatchEndedEvent`)
  now yield to cancellation instead of blocking forever. This is required, not tidying:
  `updateConfigAndRefreshWatchers` calls `StopWatchers` while its caller holds
  `updateConfigLock`, so a watcher blocked sending on `watchEndedCh` would wait on a reconcile
  that is itself waiting on the join.

The resulting ordering is what closes the race: cancel → loop exits → the trailing
`"Watch ended"` log runs → deferred `Done()` → `Wait()` returns. Every log the goroutine emits
now completes before `StopWatchers` returns.

**2. `TestUpdateConfig` never stopped anything (`multikueuecluster_test.go`).**

The subtest builds a reconciler, calls `Reconcile`, which starts the watchers and returns.
It never calls `StopWatchers`, and `utiltesting.ContextWithLog` hands back no cancel func, so
nothing tears the watchers down. A `t.Cleanup` now joins every remote client the subtest
created. `TestRemoteClientGC` already used `defer rc.StopWatchers()`; this brings
`TestUpdateConfig` in line.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #13290 

#### Special notes for your reviewer:

I reproduced at the exact commit the failing CI run built,
`d2a131a954b7ff703df5e87ec32902e3cedb00f9`, taken from that run's `clone-log.txt`. The tree was
materialised with `git archive` and verified by content hash against a fresh archive of the same
commit (identical SHA-256 manifest); `go mod verify` passes against that commit's
own `go.sum`.

few things I tried while testing this:
- Adding only the `WaitGroup` and the join deadlocked the unit suite, three watcher
  goroutines sat in `chan receive` for nine minutes until the package timed out. The
  `WaitGroup` did not cause that; it exposed goroutines that were already ignoring
  cancellation, unnoticed because nothing joined them. Hence the context-aware loop.
- Fixing only the controller side still raced, on the first iteration of a fresh
  validation run. A join nothing calls changes nothing. Hence the test cleanup.
  

One last thing: the reproduction ran on linux/arm6, not on amd64.

Disclosure: this change was developed with AI assistance (Claude Code). The investigation, the change, and the verification were reviewed by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
MultiKueue: Fixed an issue where remote-cluster watcher goroutines could continue running after a worker cluster was removed, disconnected, or reconfigured.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for remote watchers.
  * Prevented blocked event delivery when watch contexts are canceled or channels close.
  * Ensured watcher processes finish cleanly during shutdown, improving resource cleanup and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->