### PR TITLE
promote MultiKueueKubeConfigPathValidation to beta

### DIFF
--- a/keps/693-multikueue/README.md
+++ b/keps/693-multikueue/README.md
@@ -159,7 +159,7 @@ deployments with very high job throughput (above 1M jobs per day).
   files from the controller pod's filesystem (e.g. the projected service account
   token). This is mitigated by:
   * Gating safe path validation behind the `MultiKueueKubeConfigPathValidation` feature
-    gate (Alpha, default disabled). When the gate is on, only
+    gate (Beta, default enabled). When the gate is on, only
     paths under the hardcoded prefix `/etc/multikueue/kubeconfigs/` are
     accepted. When disabled, the controller falls back to the legacy
     behavior of allowing any path.

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -642,6 +642,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	MultiKueueKubeConfigPathValidation: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/concepts/multikueue.md
+++ b/site/content/en/docs/concepts/multikueue.md
@@ -212,13 +212,15 @@ MultiKueueCluster supports three sources for cluster credentials:
 | `Secret` | ✅ Production | Kubeconfig stored in a Kubernetes Secret. |
 | `Path` | ⚠️ Development only | File path on the controller pod's filesystem. |
 
-**`locationType=Path` validation is available as an alpha feature.**
-The `MultiKueueKubeConfigPathValidation` feature gate (disabled by default)
-restricts kubeconfig file paths to the hardcoded prefix
-`/etc/multikueue/kubeconfigs/`. When enabled, the controller rejects paths
-containing `..`, relative paths, and symlinks that resolve outside the prefix.
-To enable this validation, set the feature gate:
-`--feature-gates=MultiKueueKubeConfigPathValidation=true`.
+**`locationType=Path` validation is available as a beta feature, enabled by default.**
+The `MultiKueueKubeConfigPathValidation` feature gate restricts kubeconfig file
+paths to the hardcoded prefix `/etc/multikueue/kubeconfigs/`. When enabled, the
+controller rejects paths containing `..`, relative paths, and symlinks that
+resolve outside the prefix.
+To disable this validation, set the feature gate:
+`--feature-gates=MultiKueueKubeConfigPathValidation=false`.
+Disabling this restores the legacy behavior of allowing any file path, which can
+expose sensitive files on the controller's filesystem to be read as a kubeconfig.
 
 For production deployments, use `ClusterProfile` or `Secret` instead of `Path`.
 

--- a/site/content/en/docs/tasks/manage/setup_multikueue.md
+++ b/site/content/en/docs/tasks/manage/setup_multikueue.md
@@ -84,14 +84,14 @@ For the next example, having the `worker1` cluster Kubeconfig stored in a file c
 
 Check the [worker](#multikueue-specific-kubeconfig) section for details on Kubeconfig generation.
 
-### (Optional) Enable `locationType=Path` for kubeconfig files
+### `locationType=Path` for kubeconfig files
 
 {{% alert title="Security Notice" color="warning" %}}
-`locationType=Path` path validation is an **alpha feature** (disabled by default).
+`locationType=Path` is intended for development use.
 In production, use `locationType=Secret` or `ClusterProfile` instead.
 {{% /alert %}}
 
-The `MultiKueueKubeConfigPathValidation` feature gate (alpha, disabled by default)
+The `MultiKueueKubeConfigPathValidation` feature gate (beta, enabled by default)
 restricts kubeconfig file paths to the hardcoded prefix
 `/etc/multikueue/kubeconfigs/`. When enabled, the controller will:
 
@@ -99,11 +99,14 @@ restricts kubeconfig file paths to the hardcoded prefix
 - Reject paths containing `..` segments after cleaning.
 - Resolve symlinks and reject any path that resolves outside the prefix.
 
-To enable this validation, set the feature gate:
+To disable this validation, set the feature gate:
 
+```bash
+--feature-gates=MultiKueueKubeConfigPathValidation=false
 ```
---feature-gates=MultiKueueKubeConfigPathValidation=true
-```
+
+Disabling this restores the legacy behavior of allowing any file path, which can
+expose sensitive files on the controller's filesystem to be read as a kubeconfig.
 
 To use a path-based kubeconfig, mount the file into the controller pod under
 `/etc/multikueue/kubeconfigs/` and reference it in the `MultiKueueCluster`:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -227,6 +227,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueManagerQuotaAutomation
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -227,6 +227,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: MultiKueueManagerQuotaAutomation
   versionedSpecs:
   - default: false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
promote MultiKueueKubeConfigPathValidation to beta
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13704 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
promote MultiKueueKubeConfigPathValidation to beta
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Promoted MultiKueue kubeconfig path validation to Beta.
  * Enabled path validation by default starting in version 0.20.
  * Added the option to disable validation through the feature gate.

* **Documentation**
  * Updated setup and concept documentation to reflect the Beta status, default enablement, and configuration guidance.
  * Documented that disabling validation restores unrestricted file-path access, which may expose sensitive files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->