### PR TITLE
fix stale LocalQueue status usage after ClusterQueue deletion

### DIFF
--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -199,7 +199,7 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var cq kueue.ClusterQueue
 	if err := r.client.Get(ctx, client.ObjectKey{Name: string(queueObj.Spec.ClusterQueue)}, &cq); err != nil {
 		if apierrors.IsNotFound(err) {
-			err = r.UpdateStatusIfChanged(ctx, &queueObj, metav1.ConditionFalse, "ClusterQueueDoesNotExist", clusterQueueIsInactiveMsg)
+			err = r.updateStatusIfChanged(ctx, &queueObj, &schdcache.LocalQueueUsageStats{}, metav1.ConditionFalse, "ClusterQueueDoesNotExist", clusterQueueIsInactiveMsg)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -646,6 +646,16 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
+	return r.updateStatusIfChanged(ctx, queue, nil, conditionStatus, reason, msg)
+}
+
+func (r *LocalQueueReconciler) updateStatusIfChanged(
+	ctx context.Context,
+	queue *kueue.LocalQueue,
+	usage *schdcache.LocalQueueUsageStats,
+	conditionStatus metav1.ConditionStatus,
+	reason, msg string,
+) error {
 	log := r.logger()
 	oldStatus := queue.Status.DeepCopy()
 	var (
@@ -659,10 +669,13 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 			return err
 		}
 	}
-	stats, err := r.cache.LocalQueueUsage(queue)
-	if err != nil {
-		log.Error(err, failedUpdateLqStatusMsg)
-		return err
+	stats := usage
+	if stats == nil {
+		stats, err = r.cache.LocalQueueUsage(queue)
+		if err != nil {
+			log.Error(err, failedUpdateLqStatusMsg)
+			return err
+		}
 	}
 	queue.Status.PendingWorkloads = pendingWls
 	queue.Status.ReservingWorkloads = int32(stats.ReservingWorkloads)

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -56,6 +56,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 	clock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
 	cases := map[string]struct {
 		clusterQueue             *kueue.ClusterQueue
+		deleteClusterQueue       bool
 		localQueue               *kueue.LocalQueue
 		wantLocalQueue           *kueue.LocalQueue
 		wantError                error
@@ -130,6 +131,37 @@ func TestLocalQueueReconcile(t *testing.T) {
 					kueue.LocalQueueActive,
 					metav1.ConditionFalse,
 					clusterQueueIsInactiveReason,
+					clusterQueueIsInactiveMsg,
+					1,
+				).
+				Obj(),
+			wantError: nil,
+		},
+		"cluster queue deleted while its scheduler cache entry is still present": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).
+				Obj(),
+			deleteClusterQueue: true,
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Obj(),
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("test-queue").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("test-cluster-queue", "rf", now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Condition(
+					kueue.LocalQueueActive,
+					metav1.ConditionFalse,
+					"ClusterQueueDoesNotExist",
 					clusterQueueIsInactiveMsg,
 					1,
 				).
@@ -894,6 +926,11 @@ func TestLocalQueueReconcile(t *testing.T) {
 				t.Fatalf("Unexpected error: %v", err)
 			}
 			_ = qManager.AddLocalQueue(ctxWithLogger, tc.localQueue)
+			if tc.deleteClusterQueue {
+				if err := cl.Delete(ctxWithLogger, tc.clusterQueue); err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			}
 			if tc.initialConsumedResources.Resources != nil {
 				lqKey := utilqueue.Key(tc.localQueue)
 				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug 
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
A `LocalQueue` can be left permanently reporting quota usage against a `ClusterQueue` that no longer exists.

`LocalQueue.status` is assembled from two sources of truth that are updated independently:

- the `Active` condition comes from a live API read of the `ClusterQueue` (`NotFound` → `ClusterQueueDoesNotExist`);
- `reservingWorkloads`, `admittedWorkloads`, `flavorsReservation`, and `flavorsUsage` come from the scheduler cache, whose entry is torn down asynchronously by `ClusterQueueReconciler.Delete`.

When a `LocalQueue` reconcile lands between those two events, it writes a self-contradicting status  `Active=False/ClusterQueueDoesNotExist` alongside non-zero reserved and admitted quota.

This does not self-correct. The `ClusterQueue` delete event has already been consumed, and the follow-up reconcile triggered by the status write recomputes the same stale values, so the API server no-ops the identical write, emits no watch event, and the reconcile chain terminates on the wrong value. The status stays wrong until some unrelated event (workload churn, a `LocalQueue` edit) happens to trigger another reconcile. For an idle queue that may never happen.

Since `LocalQueue.status` is read by `kubectl`, KueueViz, and the visibility endpoints, this misreports cluster capacity to operators.

Fix: in the `ClusterQueue`-not-found branch, supply zeroed usage directly rather than querying a cache that may not have caught up. We have just observed the `ClusterQueue` to be gone, so the quota consumed against it is necessarily zero. The reconcile now converges in a single pass and produces the same result regardless of cleanup ordering.

This changes no policy `Cache.LocalQueueUsage` already returns zeroed stats for an absent `ClusterQueue`; the fix makes that outcome deterministic instead of timing-dependent.

`PendingWorkloads` is deliberately not zeroed: it measures queue depth rather than quota consumed against the `ClusterQueue`, and workloads waiting in an orphaned `LocalQueue` genuinely are still pending.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related #13526 

#### Special notes for your reviewer:

I reproduced it deterministically, with no concurrency, against the exact tree the failing CI job tested (`release-0.19` @ `4591b09a` + PR #13515 head `afb94dab`, from the run's `started.json`). The "racy" state is a static condition, `ClusterQueue` absent from the API client, still present in the scheduler cache, and given that state the reconciler always produces the wrong status. Timing only decides which input it sees.

During investigation I also ran the opposite ordering, with the cache already cleaned, which passes isolating cache staleness as the sole cause. That control is not included as a test, since it passes with or without the fix and so guards nothing.

PR #13515, whose CI run surfaced the flake, touches only fair-sharing and queue-cache code nothing in the `LocalQueue` controller, `LocalQueueUsage`, or `DeleteClusterQueue`. The defect is pre-existing on both `main` and `release-0.19`.


Verification performed:
- The new unit case fails against the unfixed tree with the same diff shape CI reported, and passes with the fix, it detects the defect rather than tolerating it.

I noticed couple of things when also statically reading the code and I am not sure if they are intended (so I would appreciate any correction)

1. `UpdateStatusIfChanged` compares `queue.Status.DeepCopy()` (a `*LocalQueueStatus`) against `queue.Status` (a value). `equality.Semantic.DeepEqual` returns `false` for mismatched types, so the "if changed" guard never fires and a status write is issued on every reconcile?

2. `UpdateStatusIfChanged` is exported but has no callers outside its own file.

Disclosure: this change was developed with AI assistance (Claude Code). The investigation, the change, and the verification were reviewed by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Observability: Fixed a bug where a LocalQueue could continue reporting stale admitted/reserving workload counts and resource usage after its referenced ClusterQueue was deleted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LocalQueue status updates when usage statistics are already available.
  * Correctly marks a LocalQueue as inactive when its associated ClusterQueue has been deleted.

* **Tests**
  * Added coverage for reconciliation with stale scheduler-cache entries and running workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->