### PR TITLE
Document supported FairSharing preemptionStrategies combinations

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -626,6 +626,10 @@ type FairSharing struct {
 	//   This strategy doesn't depend on the share usage of the workload being preempted.
 	//   As a result, the strategy chooses to preempt workloads with the lowest priority and
 	//   newest start time first.
+	// Only the following lists are supported:
+	// ["LessThanOrEqualToFinalShare"], ["LessThanInitialShare"],
+	// and ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
+	// Any other combination or ordering fails configuration validation.
 	// The default strategy is ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
 	PreemptionStrategies []PreemptionStrategy `json:"preemptionStrategies,omitempty"`
 }

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -626,9 +626,12 @@ type FairSharing struct {
 	//   This strategy doesn't depend on the share usage of the workload being preempted.
 	//   As a result, the strategy chooses to preempt workloads with the lowest priority and
 	//   newest start time first.
+	//
 	// Only the following lists are supported:
-	// ["LessThanOrEqualToFinalShare"], ["LessThanInitialShare"],
-	// and ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
+	// - ["LessThanOrEqualToFinalShare"]
+	// - ["LessThanInitialShare"]
+	// - ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
+	//
 	// Any other combination or ordering fails configuration validation.
 	// The default strategy is ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
 	PreemptionStrategies []PreemptionStrategy `json:"preemptionStrategies,omitempty"`

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -752,9 +752,12 @@ type FairSharing struct {
 	//   This strategy doesn't depend on the share usage of the workload being preempted.
 	//   As a result, the strategy chooses to preempt workloads with the lowest priority and
 	//   newest start time first.
+	//
 	// Only the following lists are supported:
-	// ["LessThanOrEqualToFinalShare"], ["LessThanInitialShare"],
-	// and ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
+	// - ["LessThanOrEqualToFinalShare"]
+	// - ["LessThanInitialShare"]
+	// - ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
+	//
 	// Any other combination or ordering fails configuration validation.
 	PreemptionStrategies []PreemptionStrategy `json:"preemptionStrategies"`
 }

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -752,6 +752,10 @@ type FairSharing struct {
 	//   This strategy doesn't depend on the share usage of the workload being preempted.
 	//   As a result, the strategy chooses to preempt workloads with the lowest priority and
 	//   newest start time first.
+	// Only the following lists are supported:
+	// ["LessThanOrEqualToFinalShare"], ["LessThanInitialShare"],
+	// and ["LessThanOrEqualToFinalShare", "LessThanInitialShare"].
+	// Any other combination or ordering fails configuration validation.
 	PreemptionStrategies []PreemptionStrategy `json:"preemptionStrategies"`
 }
 

--- a/site/content/en/docs/concepts/preemption.md
+++ b/site/content/en/docs/concepts/preemption.md
@@ -180,6 +180,16 @@ The values you can put in the `preemptionStrategies` list are:
   As a result, the strategy chooses to first preempt workloads with the lowest priority and
   newest start time within the target ClusterQueue.
 
+Kueue only supports the following `preemptionStrategies` lists:
+
+- `[LessThanOrEqualToFinalShare]`
+- `[LessThanInitialShare]`
+- `[LessThanOrEqualToFinalShare, LessThanInitialShare]`
+
+Any other combination or ordering, such as
+`[LessThanInitialShare, LessThanOrEqualToFinalShare]`, fails configuration
+validation and Kueue does not start.
+
 ### Algorithm overview
 
 The initial step of the algorithm is to identify the [Workloads that are candidate for preemption](#candidates),

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -661,13 +661,16 @@ as high as possible.</li>
 with the incoming workload is strictly less than the share of the preemptee CQ.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
-newest start time first.
-Only the following lists are supported:
-[&quot;LessThanOrEqualToFinalShare&quot;], [&quot;LessThanInitialShare&quot;],
-and [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].
-Any other combination or ordering fails configuration validation.
-The default strategy is [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].</li>
+newest start time first.</li>
 </ul>
+<p>Only the following lists are supported:</p>
+<ul>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;]</li>
+<li>[&quot;LessThanInitialShare&quot;]</li>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;]</li>
+</ul>
+<p>Any other combination or ordering fails configuration validation.
+The default strategy is [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -662,6 +662,10 @@ with the incoming workload is strictly less than the share of the preemptee CQ.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
 newest start time first.
+Only the following lists are supported:
+[&quot;LessThanOrEqualToFinalShare&quot;], [&quot;LessThanInitialShare&quot;],
+and [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].
+Any other combination or ordering fails configuration validation.
 The default strategy is [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].</li>
 </ul>
 </td>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -871,12 +871,15 @@ as high as possible.</li>
 with the incoming workload is strictly less than the share of the preemptee CQ.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
-newest start time first.
-Only the following lists are supported:
-[&quot;LessThanOrEqualToFinalShare&quot;], [&quot;LessThanInitialShare&quot;],
-and [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].
-Any other combination or ordering fails configuration validation.</li>
+newest start time first.</li>
 </ul>
+<p>Only the following lists are supported:</p>
+<ul>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;]</li>
+<li>[&quot;LessThanInitialShare&quot;]</li>
+<li>[&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;]</li>
+</ul>
+<p>Any other combination or ordering fails configuration validation.</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -871,7 +871,11 @@ as high as possible.</li>
 with the incoming workload is strictly less than the share of the preemptee CQ.
 This strategy doesn't depend on the share usage of the workload being preempted.
 As a result, the strategy chooses to preempt workloads with the lowest priority and
-newest start time first.</li>
+newest start time first.
+Only the following lists are supported:
+[&quot;LessThanOrEqualToFinalShare&quot;], [&quot;LessThanInitialShare&quot;],
+and [&quot;LessThanOrEqualToFinalShare&quot;, &quot;LessThanInitialShare&quot;].
+Any other combination or ordering fails configuration validation.</li>
 </ul>
 </td>
 </tr>


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

## Why

The docs list the two `preemptionStrategies` values but do not say which lists are accepted. The validation in `pkg/config/validation.go` only accepts three lists, and the order matters.
Design discussion: https://github.com/kubernetes-sigs/kueue/pull/2070#discussion_r1592955834

## What

State the three supported lists in the preemption concept page and in the config API comments for v1beta1 and v1beta2. Regenerate the reference docs with `make generate-apiref`.

#### Which issue(s) this PR fixes:

Fixes #13623

#### Special notes for your reviewer:

The issue also suggests supporting all combinations as an alternative. This PR only documents the current behavior.

This PR was prepared with AI assistance (Claude Code). I reviewed and verified all changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Clarified the three supported Fair Sharing preemption strategy configurations.
- Documented that unsupported combinations or orderings fail configuration validation and prevent Kueue from starting.
- Updated configuration references and concepts documentation for both supported API versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->