### PR TITLE
Cleanup: follow up for PR #13651

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -234,12 +234,6 @@ const (
 	// Enables reclaimable pods counting towards quota.
 	ReclaimablePods featuregate.Feature = "ReclaimablePods"
 
-	// owner: @yaroslva-serdiuk
-	//
-	// issue: https://github.com/kubernetes-sigs/kueue/issues/7597
-	// Do not remove job-name label from Workload PodTemplate object.
-	PropagateBatchJobLabelsToWorkload featuregate.Feature = "PropagateBatchJobLabelsToWorkload"
-
 	// owner: @hdp617
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/693-multikueue
 	//
@@ -646,9 +640,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
-	PropagateBatchJobLabelsToWorkload: {
-	  {Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Deprecated},
-  },
 	MultiKueueClusterProfile: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -646,10 +646,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
-	// PropagateBatchJobLabelsToWorkload is enabled from 0.13.10 and 0.14.5.
-	PropagateBatchJobLabelsToWorkload: {
-		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
-	},
 	MultiKueueClusterProfile: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -646,6 +646,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	ReclaimablePods: {
 		{Version: version.MustParse("0.15"), Default: true, PreRelease: featuregate.Beta},
 	},
+	PropagateBatchJobLabelsToWorkload: {
+	  {Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Deprecated},
+  },
 	MultiKueueClusterProfile: {
 		{Version: version.MustParse("0.15"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -210,6 +210,11 @@
   to: "0.19"
 - feature: PropagateBatchJobLabelsToWorkload
   default: true
+  stage: Beta
+  from: "0.15"
+  to: "0.20"
+- feature: PropagateBatchJobLabelsToWorkload
+  default: true
   stage: GA
   from: "0.17"
-  to: "0.19"
+  to: "0.20"

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -212,7 +212,7 @@
   default: true
   stage: Beta
   from: "0.15"
-  to: "0.20"
+  to: "0.16"
 - feature: PropagateBatchJobLabelsToWorkload
   default: true
   stage: GA

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -208,9 +208,8 @@
   stage: Deprecated
   from: "0.17"
   to: "0.19"
-- name: PropagateBatchJobLabelsToWorkload
-  versionedSpecs:
-  - default: true
-    lockToDefault: true
-    preRelease: GA
-    version: "0.17"
+- feature: PropagateBatchJobLabelsToWorkload
+  default: true
+  stage: GA
+  from: "0.17"
+  to: "0.19"

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -281,12 +281,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.6"
-- name: PropagateBatchJobLabelsToWorkload
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.19"
 - name: QuotaCheckStrategy
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -283,10 +283,10 @@
     version: "0.6"
 - name: PropagateBatchJobLabelsToWorkload
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
-    version: "0.15"
+    preRelease: Deprecated
+    version: "0.19"
 - name: QuotaCheckStrategy
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -281,12 +281,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.6"
-- name: PropagateBatchJobLabelsToWorkload
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Deprecated
-    version: "0.19"
 - name: QuotaCheckStrategy
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -283,10 +283,10 @@
     version: "0.6"
 - name: PropagateBatchJobLabelsToWorkload
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
-    version: "0.15"
+    preRelease: Deprecated
+    version: "0.19"
 - name: QuotaCheckStrategy
   versionedSpecs:
   - default: false


### PR DESCRIPTION

#### What type of PR is this?


Add one of the following kinds:

/kind cleanup


#### What this PR does / why we need it:

This is a follow-up to PR #13651 that removes deprecated feature gate `PropagateBatchJobLabelsToWorkload` marked for removal.

- Removes `PropagateBatchJobLabelsToWorkload` feature gate (marked for removal in 0.19)

PropagateBatchJobLabelsToWorkload is old feature gate, so cleaning them up is valuable.


#### Which issue(s) this PR fixes:

part of #13697 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Feature Lifecycle**
  * Updated lifecycle information for `PropagateBatchJobLabelsToWorkload` across supported versions.
  * The feature is now deprecated and disabled by default starting in version 0.19.
  * Historical Beta and GA availability is documented for applicable versions to improve compatibility reviews and upgrade planning.
  * Existing workloads relying on this behavior should verify their configuration before upgrading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->