### PR TITLE
MPIJob: skip nil replica specs in orderedReplicaTypes

### DIFF
--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -230,10 +230,10 @@ func SetupIndexes(ctx context.Context, indexer client.FieldIndexer) error {
 
 func orderedReplicaTypes(jobSpec *kfmpi.MPIJobSpec) []kfmpi.MPIReplicaType {
 	var result []kfmpi.MPIReplicaType
-	if _, ok := jobSpec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher]; ok {
+	if spec, ok := jobSpec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher]; ok && spec != nil {
 		result = append(result, kfmpi.MPIReplicaTypeLauncher)
 	}
-	if _, ok := jobSpec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker]; ok {
+	if spec, ok := jobSpec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker]; ok && spec != nil {
 		result = append(result, kfmpi.MPIReplicaTypeWorker)
 	}
 	return result

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -325,6 +325,19 @@ func TestPodSets(t *testing.T) {
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
+		"nil launcher replica spec is skipped": {
+			job: func() *MPIJob {
+				job := (*MPIJob)(jobTemplate.Clone().Obj())
+				job.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = nil
+				return job
+			}(),
+			wantPodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
+					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
+					Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -372,9 +372,10 @@ func TestRestorePodSetsInfo(t *testing.T) {
 	baseJob := testingmpijob.MakeMPIJob("mpijob", "ns").GenericLauncherAndWorker()
 
 	testCases := map[string]struct {
-		job         *MPIJob
-		podSetsInfo []podset.PodSetInfo
-		wantChanged bool
+		job             *MPIJob
+		podSetsInfo     []podset.PodSetInfo
+		wantChanged     bool
+		wantRestoredFor kfmpi.MPIReplicaType
 	}{
 		"more podSetsInfo than replica types is a no-op": {
 			job:         (*MPIJob)(baseJob.Clone().Obj()),
@@ -394,12 +395,107 @@ func TestRestorePodSetsInfo(t *testing.T) {
 			},
 			wantChanged: true,
 		},
+		"nil launcher replica spec restores only the worker": {
+			job: func() *MPIJob {
+				job := (*MPIJob)(baseJob.Clone().Obj())
+				job.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = nil
+				return job
+			}(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged:     true,
+			wantRestoredFor: kfmpi.MPIReplicaTypeWorker,
+		},
+		"nil worker replica spec restores only the launcher": {
+			job: func() *MPIJob {
+				job := (*MPIJob)(baseJob.Clone().Obj())
+				job.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker] = nil
+				return job
+			}(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"restored": "true"}},
+			},
+			wantChanged:     true,
+			wantRestoredFor: kfmpi.MPIReplicaTypeLauncher,
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			if gotChanged := tc.job.RestorePodSetsInfo(t.Context(), tc.podSetsInfo); gotChanged != tc.wantChanged {
 				t.Errorf("RestorePodSetsInfo() = %v, want %v", gotChanged, tc.wantChanged)
+			}
+			if tc.wantRestoredFor != "" {
+				gotNodeSelector := tc.job.Spec.MPIReplicaSpecs[tc.wantRestoredFor].Template.Spec.NodeSelector
+				if diff := cmp.Diff(map[string]string{"restored": "true"}, gotNodeSelector); diff != "" {
+					t.Errorf("NodeSelector for %s mismatch (-want +got):\n%s", tc.wantRestoredFor, diff)
+				}
+			}
+		})
+	}
+}
+
+func TestRunWithPodSetsInfo(t *testing.T) {
+	baseJob := testingmpijob.MakeMPIJob("mpijob", "ns").GenericLauncherAndWorker()
+
+	testCases := map[string]struct {
+		job            *MPIJob
+		podSetsInfo    []podset.PodSetInfo
+		wantErr        bool
+		wantAssignedTo kfmpi.MPIReplicaType
+	}{
+		"mismatched length returns an error": {
+			job:         (*MPIJob)(baseJob.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{{}},
+			wantErr:     true,
+		},
+		"matching length runs the job": {
+			job: (*MPIJob)(baseJob.Clone().Obj()),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"assigned": "true"}},
+				{NodeSelector: map[string]string{"assigned": "true"}},
+			},
+			wantErr: false,
+		},
+		"nil launcher replica spec only assigns the worker": {
+			job: func() *MPIJob {
+				job := (*MPIJob)(baseJob.Clone().Obj())
+				job.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = nil
+				return job
+			}(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"assigned": "true"}},
+			},
+			wantErr:        false,
+			wantAssignedTo: kfmpi.MPIReplicaTypeWorker,
+		},
+		"nil worker replica spec only assigns the launcher": {
+			job: func() *MPIJob {
+				job := (*MPIJob)(baseJob.Clone().Obj())
+				job.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker] = nil
+				return job
+			}(),
+			podSetsInfo: []podset.PodSetInfo{
+				{NodeSelector: map[string]string{"assigned": "true"}},
+			},
+			wantErr:        false,
+			wantAssignedTo: kfmpi.MPIReplicaTypeLauncher,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			err := tc.job.RunWithPodSetsInfo(ctx, nil, tc.podSetsInfo)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Errorf("RunWithPodSetsInfo() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if tc.wantAssignedTo != "" {
+				gotNodeSelector := tc.job.Spec.MPIReplicaSpecs[tc.wantAssignedTo].Template.Spec.NodeSelector
+				if diff := cmp.Diff(map[string]string{"assigned": "true"}, gotNodeSelector); diff != "" {
+					t.Errorf("NodeSelector for %s mismatch (-want +got):\n%s", tc.wantAssignedTo, diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
What type of PR is this?

/kind bug

Motivation:
kubernetes-sigs/kueue issue 12564 reported that orderedReplicaTypes()
in pkg/controller/jobs/mpijob/mpijob_controller.go only checks for map
key presence in MPIJobSpec.MPIReplicaSpecs, not whether the value is
non-nil. If the map contains a key (e.g. Launcher) whose *ReplicaSpec
value is nil, PodSets() later dereferences
MPIReplicaSpecs[mpiReplicaType].Template on that nil pointer and
panics.

A maintainer investigated and found this is not reachable through a
real cluster: the MPIJob CRD's mpiReplicaSpecs.additionalProperties
schema does not set `nullable: true`, so the Kubernetes API server's
structural-schema pruning strips null map values before any object
reaches Kueue's webhook. Because net/http recovers per-request handler
panics, this also does not crash the controller process even if it
were reached; failurePolicy: Fail on the webhook would just reject the
request. So this is not an exploitable production DoS or a webhook
crash today. The maintainer nonetheless suggested the nil check below
as reasonable defense-in-depth, since MPIReplicaSpecs is also built
programmatically elsewhere (tests, other Go callers) without going
through API server validation.

Approach:
Add a `spec != nil` check alongside the existing map-key check in
orderedReplicaTypes(), matching the fix suggested in the issue. Both
callers that trust orderedReplicaTypes() output to index
MPIReplicaSpecs (PodSets() and, transitively via the same helper,
RunWithPodSetsInfo()/RestorePodSetsInfo()) are protected since a
replica type with a nil spec is now excluded from the returned slice.

Validation:
- go build ./...
- go test ./pkg/controller/jobs/mpijob/...  (all pass, including a new
  "nil launcher replica spec is skipped" case added to TestPodSets)
- go vet ./pkg/controller/jobs/mpijob/...
- gofmt -l on both changed files (no output)
- Confirmed the new test reproduces the exact panic from the issue:
  temporarily reverting only the orderedReplicaTypes() change and
  rerunning the new test panics with a nil pointer dereference at
  mpijob_controller.go:119, the line cited in the issue; restoring the
  fix makes it pass.

kubernetes-sigs/kueue issue 12564

```release-note
MPIJob: Hardened `orderedReplicaTypes` against a nil `ReplicaSpec` value in `mpiReplicaSpecs`, avoiding a nil pointer dereference if such an object is ever constructed. Kubernetes API server schema pruning already prevents this from being reached through normal cluster usage.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MPI job handling by ignoring missing launcher or worker replica specifications.
  * Prevented invalid replica configurations from producing unnecessary pod sets.
  * Ensured pod-set restoration and assignment target only valid replicas.

* **Tests**
  * Added coverage for missing launcher and worker specifications.
  * Added validation for pod-set assignment mismatches and valid assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->