### PR TITLE
Graduate WorkloadPriorityClassDefaulting to Beta (v0.20)

### DIFF
--- a/keps/10765-workload-priority-class-defaulting/README.md
+++ b/keps/10765-workload-priority-class-defaulting/README.md
@@ -215,14 +215,16 @@ necessary to implement this enhancement.
 - Feature gate `WorkloadPriorityClassDefaulting` disabled by default.
 - Unit and integration tests.
 
-**Beta:**
+**Beta (v0.20):**
 - Feature gate enabled by default.
 - Address feedback from Alpha usage.
-- Re-evaluate whether defaulting should move from the Job webhook to the
-  Workload level based on user feedback and integration complexity.
+- The Job-webhook defaulting approach is retained for Beta, consistent with
+  `LocalQueueDefaulting`.
 
 **GA:**
 - Feature gate locked to true.
+- Re-evaluate whether defaulting should move from the Job webhook to the
+  Workload level based on user feedback and integration complexity.
 
 ## Alternatives
 

--- a/keps/10765-workload-priority-class-defaulting/kep.yaml
+++ b/keps/10765-workload-priority-class-defaulting/kep.yaml
@@ -13,16 +13,17 @@ approvers:
   - "@tenzen-y"
 
 # The target maturity stage in the current dev cycle for this KEP.
-stage: alpha
+stage: beta
 
 # The most recent milestone for which work toward delivery of this KEP has been
 # done. This can be the current (upcoming) milestone, if it is being actively
 # worked on.
-latest-milestone: "v0.18"
+latest-milestone: "v0.20"
 
 # The milestone at which this feature was, or is targeted to be, at each stage.
 milestone:
   alpha: "v0.18"
+  beta: "v0.20"
 
 # The following PRR answers are required at alpha release
 # List the feature gate name and the components for which it must be enabled

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -643,6 +643,7 @@ func TestDefault(t *testing.T) {
 				}
 			}
 			webhook := &JobSetWebhook{
+				client:                     cl,
 				manageJobsWithoutQueueName: false,
 				queues:                     queueManager,
 				cache:                      cqCache,

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -809,6 +809,7 @@ func TestDefault(t *testing.T) {
 				}
 			}
 			webhook := &MpiJobWebhook{
+				client:                     cl,
 				manageJobsWithoutQueueName: false,
 				queues:                     queueManager,
 				cache:                      cqCache,

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -111,6 +111,7 @@ func TestValidateDefault(t *testing.T) {
 			}
 
 			wh := &RayClusterWebhook{
+				client:                     cli,
 				manageJobsWithoutQueueName: tc.manageAll,
 				queues:                     queueManager,
 				cache:                      cqCache,

--- a/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook_test.go
@@ -111,6 +111,7 @@ func TestDefault(t *testing.T) {
 				}
 			}
 			wh := &RayJobWebhook{
+				client:                     cli,
 				manageJobsWithoutQueueName: tc.manageAll,
 				queues:                     queueManager,
 				cache:                      cqCache,

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -297,6 +297,7 @@ func TestDefault(t *testing.T) {
 			}
 
 			webhook := &TrainJobWebhook{
+				client:                     kClient,
 				manageJobsWithoutQueueName: tc.manageJobsWithoutQueueName,
 				queues:                     queueManager,
 				cache:                      cqCache,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -765,6 +765,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	WorkloadPriorityClassDefaulting: {
 		{Version: version.MustParse("0.18"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	MetricsForCohorts: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},

--- a/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class.md
+++ b/site/content/en/docs/tasks/manage/enforce_job_management/setup_default_workload_priority_class.md
@@ -6,7 +6,7 @@ description: >
   Setup a default WorkloadPriorityClass to assign a queueing priority to jobs that don't specify one.
 ---
 
-{{< feature-state state="alpha" for_version="v0.18" >}}
+{{< feature-state state="beta" for_version="v0.20" >}}
 
 This page describes how to setup a default WorkloadPriorityClass to ensure that all Kueue-managed workloads receive a consistent queueing priority,
 even if the `kueue.x-k8s.io/priority-class` label is not specified explicitly.
@@ -18,7 +18,9 @@ for workloads that do not have the `kueue.x-k8s.io/priority-class` label.
 
 To use this feature:
 
-- enable the `WorkloadPriorityClassDefaulting` feature gate in the Kueue configuration.
+- the `WorkloadPriorityClassDefaulting` feature gate is enabled by default since
+  v0.20 (Beta). On earlier versions, or if it was explicitly disabled, enable it
+  in the Kueue configuration.
   Check the [Installation](/docs/installation/#change-the-feature-gates-configuration) guide for details on feature gate configuration.
 
 - create a WorkloadPriorityClass with the name `default`:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -539,6 +539,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -539,6 +539,10 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: WorkloadRequestUseMergePatch
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
@@ -238,6 +238,8 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 	})
 
 	ginkgo.It("Should not set the default WorkloadPriorityClass label when the feature gate is disabled", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadPriorityClassDefaulting, false)
+
 		defaultWPC := utiltestingapi.MakeWorkloadPriorityClass(constants.DefaultWorkloadPriorityClassName).PriorityValue(100).Obj()
 		util.MustCreate(ctx, k8sClient, defaultWPC)
 		ginkgo.DeferCleanup(func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
Graduates the `WorkloadPriorityClassDefaulting` feature gate from Alpha to Beta
(enabled by default) in v0.20. The feature has been in Alpha since v0.18.

The Job-webhook defaulting approach is retained for Beta, consistent with
`LocalQueueDefaulting`. Per discussion in the issue, moving defaulting to the
Workload level can be revisited in a follow-up if issues surface.

Changes:
- Add the Beta versioned spec (Default: true) in `kube_features.go`, keeping the
  0.18 Alpha spec for version compatibility.
- Update the versioned feature list references (site data and compatibility
  lifecycle reference).
- Bump the KEP stage to beta and record the graduation decision.
- Update the feature-state and setup docs to reflect Beta / enabled by default.

#### Which issue(s) this PR fixes:
Fixes #13689

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
The `WorkloadPriorityClassDefaulting` feature gate is graduated to Beta and enabled by default.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload priority class defaulting graduates to Beta in version 0.20.
  * The feature is enabled by default beginning with version 0.20.
  * Job webhook defaulting remains consistent with local queue defaulting.
  * Versions 0.18 and 0.19 continue to require explicit enablement.

* **Documentation**
  * Updated setup guidance, feature lifecycle status, and versioned feature information.
  * Earlier-version and explicitly disabled-feature scenarios are now documented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->