### PR TITLE
Automated cherry pick of #13629: Skip usage of ResourceSlice API when it's not available

### DIFF
--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -77,6 +77,7 @@ import (
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/scheduler/preemption/fairsharing"
 	"sigs.k8s.io/kueue/pkg/util/cert"
+	utildra "sigs.k8s.io/kueue/pkg/util/dra"
 	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
 	utillogging "sigs.k8s.io/kueue/pkg/util/logging"
@@ -351,7 +352,9 @@ func main() {
 	}
 	queues := qcache.NewManager(mgr.GetClient(), cCache, requeuer, queueOptions...)
 
-	if err := setupIndexes(ctx, mgr, &cfg); err != nil {
+	resourceSliceAPIAvailable := utildra.CheckResourceSliceAPIAvailable(mgr)
+
+	if err := setupIndexes(ctx, mgr, &cfg, resourceSliceAPIAvailable); err != nil {
 		setupLog.Error(err, "Unable to setup indexes")
 		os.Exit(1)
 	}
@@ -384,11 +387,12 @@ func main() {
 	}
 
 	controllerOpts := core.SetupControllersOpts{
-		RoleTracker:            roleTracker,
-		PreemptionExpectations: preemptionExpectations,
-		CustomLabels:           customLabels,
-		DRAMapper:              draMapper,
-		DRABackedResources:     draBackedResources,
+		RoleTracker:               roleTracker,
+		PreemptionExpectations:    preemptionExpectations,
+		CustomLabels:              customLabels,
+		DRAMapper:                 draMapper,
+		DRABackedResources:        draBackedResources,
+		ResourceSliceAPIAvailable: resourceSliceAPIAvailable,
 	}
 	if err := setupControllers(ctx, mgr, cCache, queues, &cfg, serverVersionFetcher, controllerOpts); err != nil {
 		setupLog.Error(err, "Unable to setup controllers")
@@ -424,7 +428,7 @@ func main() {
 	}
 }
 
-func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration) error {
+func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configuration, resourceSliceAPIAvailable bool) error {
 	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
 	if err != nil {
 		return err
@@ -452,7 +456,7 @@ func setupIndexes(ctx context.Context, mgr ctrl.Manager, cfg *configapi.Configur
 		}
 	}
 
-	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
+	if resourceSliceAPIAvailable {
 		if err := core.SetupResourceSliceIndexer(ctx, mgr.GetFieldIndexer()); err != nil {
 			return fmt.Errorf("could not setup ResourceSlice indexer: %w", err)
 		}

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -19,7 +19,10 @@ package core
 import (
 	"time"
 
+	resourcev1 "k8s.io/api/resource/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -40,11 +43,12 @@ const (
 
 // SetupControllersOpts holds optional dependencies for SetupControllers.
 type SetupControllersOpts struct {
-	RoleTracker            *roletracker.RoleTracker
-	PreemptionExpectations *expectations.Store
-	CustomLabels           *metrics.CustomLabels
-	DRAMapper              *dra.ResourceMapper
-	DRABackedResources     *dra.ExtendedResourceCache
+	RoleTracker               *roletracker.RoleTracker
+	PreemptionExpectations    *expectations.Store
+	CustomLabels              *metrics.CustomLabels
+	DRAMapper                 *dra.ResourceMapper
+	DRABackedResources        *dra.ExtendedResourceCache
+	ResourceSliceAPIAvailable bool
 }
 
 // SetupControllers sets up the core controllers. It returns the name of the
@@ -119,7 +123,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 		return "Workload", err
 	}
 
-	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
+	if opts.ResourceSliceAPIAvailable {
 		rsRec := NewResourceSliceReconciler(qManager, cfg, opts.RoleTracker)
 		if err := rsRec.SetupWithManager(mgr, cfg); err != nil {
 			return "ResourceSlice", err
@@ -160,4 +164,16 @@ func workloadRetention(cfg *configapi.ObjectRetentionPolicies) *workloadRetentio
 	return &workloadRetentionConfig{
 		afterFinished: &cfg.Workloads.AfterFinished.Duration,
 	}
+}
+
+// ServerSupportsResourceSlice checks if the server supports the ResourceSlice API (resource.k8s.io/v1).
+func ServerSupportsResourceSlice(mgr manager.Manager) error {
+	gvk, err := apiutil.GVKForObject(&resourcev1.ResourceSlice{}, mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+	if _, err = mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version); err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/util/dra/dra.go
+++ b/pkg/util/dra/dra.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/kueue/pkg/controller/core"
+	"sigs.k8s.io/kueue/pkg/features"
+)
+
+// checkResourceSliceAPIAvailable returns true when a ResourceSlice-dependent
+// feature gate is enabled and the ResourceSlice API (resource.k8s.io/v1) is available
+// on the cluster.
+func CheckResourceSliceAPIAvailable(mgr ctrl.Manager) bool {
+	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) {
+		if err := core.ServerSupportsResourceSlice(mgr); err != nil {
+			ctrl.Log.V(0).Info("ResourceSlice API not available, skipping DRA partitionable feature", "reason", err)
+		} else {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/dra/dra_test.go
+++ b/pkg/util/dra/dra_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dra
+
+import (
+	"net/http"
+	"testing"
+
+	resourcev1 "k8s.io/api/resource/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+)
+
+var resourceSliceGVK = resourcev1.SchemeGroupVersion.WithKind("ResourceSlice")
+
+func TestCheckResourceSliceAPIAvailable(t *testing.T) {
+	cases := map[string]struct {
+		partitionableDevicesFeatureGate bool
+		ResourceSliceAvailable          bool
+		want                            bool
+	}{
+		"no feature gates enabled": {
+			partitionableDevicesFeatureGate: false,
+			ResourceSliceAvailable:          true,
+			want:                            false,
+		},
+		"KueueDRAIntegrationPartitionableDevices enabled, API available": {
+			partitionableDevicesFeatureGate: true,
+			ResourceSliceAvailable:          true,
+			want:                            true,
+		},
+		"KueueDRAIntegrationPartitionableDevices enabled, API unavailable": {
+			partitionableDevicesFeatureGate: true,
+			ResourceSliceAvailable:          false,
+			want:                            false,
+		},
+	}
+	k8sClient := utiltesting.NewClientBuilder().Build()
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegrationPartitionableDevices, tc.partitionableDevicesFeatureGate)
+
+			mgr, err := ctrlmgr.New(&rest.Config{}, ctrlmgr.Options{
+				Scheme: k8sClient.Scheme(),
+				NewClient: func(*rest.Config, client.Options) (client.Client, error) {
+					return k8sClient, nil
+				},
+				MapperProvider: func(*rest.Config, *http.Client) (apimeta.RESTMapper, error) {
+					mapper := apimeta.NewDefaultRESTMapper([]schema.GroupVersion{resourceSliceGVK.GroupVersion()})
+					if tc.ResourceSliceAvailable {
+						mapper.Add(resourceSliceGVK, apimeta.RESTScopeRoot)
+					}
+					return mapper, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("failed to create manager: %v", err)
+			}
+
+			got := CheckResourceSliceAPIAvailable(mgr)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/integration/singlecluster/controller/dra/suite_test.go
+++ b/test/integration/singlecluster/controller/dra/suite_test.go
@@ -135,7 +135,7 @@ func managerSetup(modifyConfig func(*config.Configuration)) framework.ManagerSet
 			queues,
 			cCache,
 			controllersCfg,
-			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper, DRABackedResources: dra.NewExtendedResourceCache()},
+			core.SetupControllersOpts{PreemptionExpectations: preemptionExpectations, DRAMapper: draMapper, DRABackedResources: dra.NewExtendedResourceCache(), ResourceSliceAPIAvailable: true},
 		)
 		gomega.Expect(err).ToNot(gomega.HaveOccurred(), "controller", failedCtrl)
 


### PR DESCRIPTION
Cherry pick of #13629 on release-0.18.

#13629: Skip usage of ResourceSlice API when it's not available

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

/area release

```release-note
DRA: Fixed a startup crash when KueueDRAIntegrationPartitionableDevices feature gate is enabled but the ResourceSlice API (resource.k8s.io/v1) is not available on the cluster.
```