### PR TITLE
Prototype AFS entry-penalty accounting at QuotaReserved

### DIFF
--- a/keps/4136-admission-fair-sharing/README.md
+++ b/keps/4136-admission-fair-sharing/README.md
@@ -7,6 +7,7 @@
   - [Non-Goals](#non-goals)
 - [Proposal](#proposal)
   - [Entry penalty](#entry-penalty)
+  - [Accounting anchor](#accounting-anchor)
   - [User Stories (Optional)](#user-stories-optional)
     - [Story 1](#story-1)
     - [Story 2](#story-2)
@@ -206,12 +207,34 @@ usageSamplingInterval: 5mins
 Here, all Jobs submitted by Tenant B  within the next 5min get scheduled.
 Even if Tenant B submitted a job that consumed 1000 CPUs, consecutive jobs would still be prioritized because of the delay in updating the status.
 
-Hence, since v0.13 Kueue adds an entry penalty to FairSharingStatus every time it admits a Workload. The penalty should be calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
+Hence, since v0.13 Kueue charges an entry penalty when the scheduler assumes a Workload into the cache, which is the point at which it commits to reserving quota. The penalty is held in memory and is rolled back if the admission patch fails; it reaches FairSharingStatus only once it is consolidated, as described in [Accounting anchor](#accounting-anchor). A Workload that already holds a reservation is not charged again on a second scheduling pass. The penalty should be calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
 
 `A = 1 - 0.5 ^ (sampling/half_life_decay)`. 
 
-This an equivalent of a job's usage that has been admitted `samplingInterval` ago. The value of penalty is an arbitrary decision for now.
+This is the equivalent of the usage of a job that was admitted `samplingInterval` ago. The value of penalty is an arbitrary decision for now.
 After we collect customers' feedback, we'll consider introducing an API that allows to configure it.
+
+### Accounting anchor
+
+The usage tracked above is quota-based, so it is accounted from the point a Workload holds quota rather than from the point it starts running. `QuotaReserved` is the accounting start, which gives the following semantics for each transition:
+
+| Transition | Effect on AFS accounting |
+|---|---|
+| `Pending -> QuotaReserved` | Consolidate the LocalQueue's pending entry penalties into its consumed usage and clear them, when the ClusterQueue admits on usage. A Workload deactivated or finished in the same status update does not trigger it, and the penalties simply stay pending until the LocalQueue's next consolidation. |
+| `Pending -> Admitted` | The same. A ClusterQueue without AdmissionChecks reaches both conditions in one status update. |
+| `QuotaReserved -> Admitted` | Nothing, the cost having been accounted when quota was reserved. |
+| `QuotaReserved -> Pending` | Nothing, matching `Admitted -> Pending`. A consolidated cost stays in the decaying usage; a penalty still pending counts toward the LocalQueue's usage undecayed until a consolidation folds it in. |
+| `QuotaReserved -> deleted / deactivated` | Nothing, matching `Admitted -> deleted / deactivated`. |
+
+Two consequences are worth stating explicitly, because they are observable.
+
+First, `current_usage` in the decay formula is the LocalQueue's quota-reserving usage, which includes Workloads still waiting on their AdmissionChecks. The sampled usage and the consolidation must be anchored at the same stage. Were the usage admitted-gated while penalties are consolidated at quota reservation, a check-gated Workload's cost would decay out of the average while it still holds quota, and a tenant able to lengthen its own checks, with a slow ProvisioningRequest for instance, could keep its usage understated. Over-counting a tenant's own usage is self-correcting; under-counting is not, so the two must not be allowed to drift apart.
+
+Second, a Workload that reserves quota and is evicted before being admitted still leaves its consolidated cost behind. This is deliberate: it is what stops a submit-and-evict churn loop from being free. The guarantee is scoped to the LocalQueue's lifetime: deleting the LocalQueue discards its consumed usage and its pending penalties together.
+
+An entry penalty and the consumed usage it will be folded into are two halves of one LocalQueue record, updated together. A reader that fetches the record once, as the admission-ordering path does, therefore never sees the same penalty counted in both halves, nor misses it in both.
+
+Consolidation folds the LocalQueue's whole pending bucket rather than a per-Workload figure, so it cannot disagree with what was pushed and leave a residue behind. The bucket is not attributed per Workload, though, which bounds what can be said about any single one: a rollback arriving after its penalty was already consolidated is floored at zero rather than refunded, and may instead consume another Workload's pending penalty. Both errors are bounded by one entry penalty, land on the same LocalQueue, and decay within a half-life. A Workload also pays the penalty for its full request even when only part of it is admitted, since the penalty is priced at `A * requested_resource` when the Workload is assumed.
 
 ### User Stories (Optional)
 #### Story 1

--- a/pkg/cache/queue/afs/entry_penalties.go
+++ b/pkg/cache/queue/afs/entry_penalties.go
@@ -15,75 +15,90 @@
 package afs
 
 import (
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 
-	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/resource"
 )
 
-type AfsEntryPenalties struct {
-	penalties *utilmaps.SyncMap[utilqueue.LocalQueueReference, corev1.ResourceList]
-}
-
-func NewPenaltyMap() *AfsEntryPenalties {
-	return &AfsEntryPenalties{
-		penalties: utilmaps.NewSyncMap[utilqueue.LocalQueueReference, corev1.ResourceList](0),
-	}
-}
-
-func (m *AfsEntryPenalties) Push(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
-	m.penalties.Update(lqKey, func(existing corev1.ResourceList, _ bool) corev1.ResourceList {
-		return resource.MergeResourceListKeepSum(existing, penalty)
+// PushPenalty records an entry penalty for a LocalQueue. The penalty counts toward
+// the LocalQueue's fair-sharing usage until a settlement consolidates it into the
+// consumed history.
+//
+// now is used only when the push creates the entry, so that the first sampling tick
+// measures elapsed time from the push rather than from the zero time. An entry
+// created here carries StatusAccounted=false, which makes the LocalQueue reconciler
+// merge the persisted status into it exactly once.
+func (a *AfsUsageLedger) PushPenalty(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList, now time.Time) {
+	a.resources.Update(lqKey, func(entry UsageLedgerEntry, found bool) UsageLedgerEntry {
+		if !found {
+			entry.LastUpdate = now
+		}
+		entry.PendingPenalty = resource.MergeResourceListKeepSum(entry.PendingPenalty, penalty)
+		return entry
 	})
 }
 
-func (m *AfsEntryPenalties) Sub(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList) {
+// SubPenalty removes a penalty that was pushed but will never be settled, i.e. the
+// scheduler rolled an assumed Workload back after a failed admission patch.
+//
+// It stamps LastUpdate on creation for the same reason PushPenalty does: the rolled
+// back Workload's LocalQueue may have been deleted in the meantime, and resurrecting
+// its entry with a zero timestamp would make the next decay elapse from the zero time.
+func (a *AfsUsageLedger) SubPenalty(lqKey utilqueue.LocalQueueReference, penalty corev1.ResourceList, now time.Time) {
 	negated := make(corev1.ResourceList, len(penalty))
 	for k, v := range penalty {
 		q := v.DeepCopy()
 		q.Neg()
 		negated[k] = q
 	}
-	m.penalties.UpdateOrDelete(lqKey, func(existing corev1.ResourceList) (corev1.ResourceList, bool) {
-		merged := resource.MergeResourceListKeepSum(existing, negated)
-		// Sub recomputes the amount at settlement time rather than recording it at
-		// push time, so it can exceed what was pushed (e.g. after a restart loses the
-		// in-memory penalties). Clamp at zero: a mismatch must not become a permanent
-		// usage discount for the LocalQueue.
-		for k, v := range merged {
-			if v.Sign() < 0 {
-				v.Set(0)
-				merged[k] = v
-			}
+	a.resources.Update(lqKey, func(entry UsageLedgerEntry, found bool) UsageLedgerEntry {
+		if !found {
+			entry.LastUpdate = now
 		}
-		return merged, canClearPenalty(merged)
+		entry.PendingPenalty = clampNegativeToZero(resource.MergeResourceListKeepSum(entry.PendingPenalty, negated))
+		return entry
 	})
 }
 
-func canClearPenalty(penalty corev1.ResourceList) bool {
-	for _, v := range penalty {
-		if !v.IsZero() {
-			return false
+// clampNegativeToZero floors each resource at zero. A rollback can outrun the
+// settlement that already consolidated the penalty; a negative bucket would be a
+// lasting usage discount for the LocalQueue — the exploitable direction, whereas
+// over-counting only penalizes the queue itself.
+func clampNegativeToZero(penalty corev1.ResourceList) corev1.ResourceList {
+	for k, v := range penalty {
+		if v.Sign() < 0 {
+			q := v.DeepCopy()
+			q.Set(0)
+			penalty[k] = q
 		}
 	}
-	return true
-}
-
-func (m *AfsEntryPenalties) Peek(lqKey utilqueue.LocalQueueReference) corev1.ResourceList {
-	penalty, found := m.penalties.Get(lqKey)
-	if !found {
-		return corev1.ResourceList{}
-	}
-
 	return penalty
 }
 
-func (m *AfsEntryPenalties) HasPendingFor(lqKey utilqueue.LocalQueueReference) bool {
-	_, found := m.penalties.Get(lqKey)
-	return found
+// PeekPenalty returns the penalties awaiting settlement for a LocalQueue.
+func (a *AfsUsageLedger) PeekPenalty(lqKey utilqueue.LocalQueueReference) corev1.ResourceList {
+	entry, found := a.resources.Get(lqKey)
+	if !found {
+		return corev1.ResourceList{}
+	}
+	return entry.PendingPenalty
 }
 
-func (m *AfsEntryPenalties) Delete(lqKey utilqueue.LocalQueueReference) {
-	m.penalties.Delete(lqKey)
+// HasPendingPenalty reports whether any penalty is awaiting settlement. It tests the
+// amounts rather than the presence of an entry, which now outlives every penalty, and
+// rather than the presence of a key, which a fully subtracted penalty leaves behind.
+func (a *AfsUsageLedger) HasPendingPenalty(lqKey utilqueue.LocalQueueReference) bool {
+	entry, found := a.resources.Get(lqKey)
+	if !found {
+		return false
+	}
+	for _, q := range entry.PendingPenalty {
+		if !q.IsZero() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/cache/queue/afs/entry_penalties_test.go
+++ b/pkg/cache/queue/afs/entry_penalties_test.go
@@ -16,6 +16,7 @@ package afs
 
 import (
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -23,71 +24,128 @@ import (
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
-func TestSub(t *testing.T) {
-	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+func TestSubPenaltyClampsAtZero(t *testing.T) {
+	lqKey := utilqueue.LocalQueueReference("ns/lq")
+	now := time.Now()
 
 	cases := map[string]struct {
-		push        corev1.ResourceList
-		sub         corev1.ResourceList
-		wantPending bool
-		wantPenalty corev1.ResourceList
+		pushes  []corev1.ResourceList
+		sub     corev1.ResourceList
+		wantHas bool
+		// wantMilli is asserted per resource name when wantHas is true.
+		wantMilli map[corev1.ResourceName]int64
 	}{
-		"subtracting the pushed amount clears the entry": {
-			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
-			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
-			wantPending: false,
-			wantPenalty: corev1.ResourceList{},
+		"exact subtraction leaves nothing pending": {
+			pushes:  []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("2")}},
+			sub:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			wantHas: false,
 		},
 		"partial subtraction keeps the remainder": {
-			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
-			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
-			wantPending: true,
-			wantPenalty: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+			pushes:    []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("3")}},
+			sub:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			wantHas:   true,
+			wantMilli: map[corev1.ResourceName]int64{corev1.ResourceCPU: 1_000},
 		},
-		"subtracting more than pushed clamps at zero and clears the entry": {
-			push:        corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
-			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
-			wantPending: false,
-			wantPenalty: corev1.ResourceList{},
+		"over-subtraction clamps to zero": {
+			pushes:  []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("2")}},
+			sub:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5")},
+			wantHas: false,
 		},
-		"subtracting without a prior push does not leave a negative entry": {
-			sub:         corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
-			wantPending: false,
-			wantPenalty: corev1.ResourceList{},
+		"over-subtraction on one resource does not drain another": {
+			pushes: []corev1.ResourceList{{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
+			}},
+			sub:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("5")},
+			wantHas:   true,
+			wantMilli: map[corev1.ResourceName]int64{corev1.ResourceCPU: 0, corev1.ResourceMemory: 4 * 1024 * 1024 * 1024 * 1000},
+		},
+		"subtraction without a prior push leaves no negative residue": {
+			sub:     corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			wantHas: false,
 		},
 		"clamping applies per resource": {
-			push: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")},
+			pushes: []corev1.ResourceList{{corev1.ResourceCPU: resource.MustParse("4")}},
 			sub: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
-			wantPending: true,
-			wantPenalty: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
-				corev1.ResourceMemory: resource.MustParse("0"),
-			},
+			wantHas:   true,
+			wantMilli: map[corev1.ResourceName]int64{corev1.ResourceCPU: 3_000, corev1.ResourceMemory: 0},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			m := NewPenaltyMap()
-			if tc.push != nil {
-				m.Push(lqKey, tc.push.DeepCopy())
+			penalties := NewAfsUsageLedger()
+			for _, p := range tc.pushes {
+				penalties.PushPenalty(lqKey, p, now)
 			}
-			m.Sub(lqKey, tc.sub.DeepCopy())
 
-			if got := m.HasPendingFor(lqKey); got != tc.wantPending {
-				t.Errorf("HasPendingFor() = %v, want %v", got, tc.wantPending)
+			penalties.SubPenalty(lqKey, tc.sub, now)
+
+			if got := penalties.HasPendingPenalty(lqKey); got != tc.wantHas {
+				t.Fatalf("HasPendingPenalty() = %t, want %t (peek: %v)", got, tc.wantHas, penalties.PeekPenalty(lqKey))
 			}
-			got := m.Peek(lqKey)
-			if len(got) != len(tc.wantPenalty) {
-				t.Fatalf("Peek() = %v, want %v", got, tc.wantPenalty)
-			}
-			for name, want := range tc.wantPenalty {
-				if v, ok := got[name]; !ok || v.Cmp(want) != 0 {
-					t.Errorf("Peek()[%s] = %s, want %s", name, v.String(), want.String())
+			for resName, wantMilli := range tc.wantMilli {
+				got := penalties.PeekPenalty(lqKey)[resName]
+				if got.MilliValue() != wantMilli {
+					t.Errorf("unexpected %s penalty: want %dm, got %dm", resName, wantMilli, got.MilliValue())
 				}
 			}
 		})
+	}
+}
+
+// A push may be the first writer for a LocalQueue. It must stamp LastUpdate, or the
+// LocalQueue reconciler would merge the persisted status onto a zero timestamp and the
+// first decay would elapse from the zero time and wash the history away.
+func TestPushPenaltySeedsLastUpdateOnlyWhenCreating(t *testing.T) {
+	lqKey := utilqueue.LocalQueueReference("ns/lq")
+	created := time.Now()
+	penalty := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}
+
+	ledger := NewAfsUsageLedger()
+	ledger.PushPenalty(lqKey, penalty, created)
+
+	entry, found := ledger.Get(lqKey)
+	if !found {
+		t.Fatal("expected the push to create an entry")
+	}
+	if !entry.LastUpdate.Equal(created) {
+		t.Errorf("LastUpdate = %v, want %v", entry.LastUpdate, created)
+	}
+	if entry.StatusAccounted {
+		t.Error("expected StatusAccounted to stay false so the persisted status is still merged")
+	}
+
+	ledger.PushPenalty(lqKey, penalty, created.Add(time.Hour))
+	entry, _ = ledger.Get(lqKey)
+	if !entry.LastUpdate.Equal(created) {
+		t.Errorf("a later push moved LastUpdate to %v, want it left at %v", entry.LastUpdate, created)
+	}
+	if got := entry.PendingPenalty[corev1.ResourceCPU]; got.MilliValue() != 2_000 {
+		t.Errorf("pending CPU = %dm, want 2000m", got.MilliValue())
+	}
+}
+
+// A rollback can be the first writer for a LocalQueue when the queue was deleted while
+// the admission patch was in flight. Resurrecting its entry with a zero LastUpdate would
+// make the next decay elapse from year 1 and wash away the seeded history (#12783).
+func TestSubPenaltySeedsLastUpdateOnCreate(t *testing.T) {
+	lqKey := utilqueue.LocalQueueReference("ns/lq")
+	now := time.Now()
+
+	ledger := NewAfsUsageLedger()
+	ledger.SubPenalty(lqKey, corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}, now)
+
+	entry, found := ledger.Get(lqKey)
+	if !found {
+		t.Fatal("expected the rollback to leave an entry")
+	}
+	if entry.LastUpdate.IsZero() {
+		t.Error("LastUpdate is the zero time; the next decay would elapse from year 1")
+	}
+	if !entry.LastUpdate.Equal(now) {
+		t.Errorf("LastUpdate = %v, want %v", entry.LastUpdate, now)
 	}
 }

--- a/pkg/cache/queue/afs/usage_ledger.go
+++ b/pkg/cache/queue/afs/usage_ledger.go
@@ -25,33 +25,40 @@ import (
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 )
 
-// ConsumedResourcesEntry stores the consumed resources for a LocalQueue with timestamp.
+// UsageLedgerEntry holds everything a LocalQueue's fair-sharing usage is computed from:
+// the decayed history in Resources, and the entry penalties in PendingPenalty that no
+// settlement has consolidated into it yet. The two live in one entry so a single Update
+// moves a penalty from one to the other and a single Get observes a consistent pair,
+// which is what keeps a reader from seeing the same penalty counted in both.
+//
 // StatusAccounted records whether the LocalQueue's persisted fair-sharing status has
 // been folded into this entry: once history is merged, the entry's existence alone no
 // longer tells whether that happened, so it must be tracked explicitly. Every writer
-// must carry the flag forward (use Update), or the history would be merged repeatedly.
-type ConsumedResourcesEntry struct {
+// must carry it, and PendingPenalty, forward (use Update), or history is merged twice
+// or a pending penalty is silently dropped.
+type UsageLedgerEntry struct {
 	Resources       corev1.ResourceList
+	PendingPenalty  corev1.ResourceList
 	LastUpdate      time.Time
 	StatusAccounted bool
 }
 
-// AfsConsumedResources manages the fair sharing consumed resources cache
-type AfsConsumedResources struct {
-	resources *utilmaps.SyncMap[utilqueue.LocalQueueReference, ConsumedResourcesEntry]
+// AfsUsageLedger is the per-LocalQueue fair-sharing accounting cache.
+type AfsUsageLedger struct {
+	resources *utilmaps.SyncMap[utilqueue.LocalQueueReference, UsageLedgerEntry]
 }
 
-// NewAfsConsumedResources creates a new AfsConsumedResources cache
-func NewAfsConsumedResources() *AfsConsumedResources {
-	return &AfsConsumedResources{
-		resources: utilmaps.NewSyncMap[utilqueue.LocalQueueReference, ConsumedResourcesEntry](0),
+// NewAfsUsageLedger creates an empty ledger.
+func NewAfsUsageLedger() *AfsUsageLedger {
+	return &AfsUsageLedger{
+		resources: utilmaps.NewSyncMap[utilqueue.LocalQueueReference, UsageLedgerEntry](0),
 	}
 }
 
 // Set unconditionally replaces the entry for a LocalQueue, resetting
 // StatusAccounted. Controllers should use Update instead.
-func (a *AfsConsumedResources) Set(lqKey utilqueue.LocalQueueReference, resources corev1.ResourceList, lastUpdate time.Time) {
-	a.resources.Add(lqKey, ConsumedResourcesEntry{
+func (a *AfsUsageLedger) Set(lqKey utilqueue.LocalQueueReference, resources corev1.ResourceList, lastUpdate time.Time) {
+	a.resources.Add(lqKey, UsageLedgerEntry{
 		Resources:  resources,
 		LastUpdate: lastUpdate,
 	})
@@ -63,16 +70,18 @@ func (a *AfsConsumedResources) Set(lqKey utilqueue.LocalQueueReference, resource
 // it must not call back into the scheduler cache (lock ordering).
 // All controller writers should go through Update so concurrent read-modify-writes
 // cannot overwrite each other and StatusAccounted is preserved by construction.
-func (a *AfsConsumedResources) Update(lqKey utilqueue.LocalQueueReference, fn func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry) ConsumedResourcesEntry {
+func (a *AfsUsageLedger) Update(lqKey utilqueue.LocalQueueReference, fn func(entry UsageLedgerEntry, found bool) UsageLedgerEntry) UsageLedgerEntry {
 	return a.resources.Update(lqKey, fn)
 }
 
-// Get retrieves the consumed resources for a LocalQueue
-func (a *AfsConsumedResources) Get(lqKey utilqueue.LocalQueueReference) (ConsumedResourcesEntry, bool) {
+// Get retrieves a LocalQueue's whole ledger entry, both the consumed history and
+// any penalty still pending, as one consistent pair.
+func (a *AfsUsageLedger) Get(lqKey utilqueue.LocalQueueReference) (UsageLedgerEntry, bool) {
 	return a.resources.Get(lqKey)
 }
 
-// Delete removes the consumed resources entry for a LocalQueue
-func (a *AfsConsumedResources) Delete(lqKey utilqueue.LocalQueueReference) {
+// Delete drops a LocalQueue's entry, discarding its consumed history and any
+// pending penalty together.
+func (a *AfsUsageLedger) Delete(lqKey utilqueue.LocalQueueReference) {
 	a.resources.Delete(lqKey)
 }

--- a/pkg/cache/queue/afs/usage_ledger_test.go
+++ b/pkg/cache/queue/afs/usage_ledger_test.go
@@ -35,41 +35,41 @@ func TestUpdate(t *testing.T) {
 	seeded := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}
 	settled := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
 
-	seedFn := func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry {
+	seedFn := func(entry UsageLedgerEntry, found bool) UsageLedgerEntry {
 		if !found {
-			return ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true}
+			return UsageLedgerEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true}
 		}
 		return entry
 	}
-	writerFn := func(entry ConsumedResourcesEntry, found bool) ConsumedResourcesEntry {
-		return ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: entry.StatusAccounted}
+	writerFn := func(entry UsageLedgerEntry, found bool) UsageLedgerEntry {
+		return UsageLedgerEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: entry.StatusAccounted}
 	}
 
 	cases := map[string]struct {
-		existing  *ConsumedResourcesEntry
-		fn        func(ConsumedResourcesEntry, bool) ConsumedResourcesEntry
-		wantEntry ConsumedResourcesEntry
+		existing  *UsageLedgerEntry
+		fn        func(UsageLedgerEntry, bool) UsageLedgerEntry
+		wantEntry UsageLedgerEntry
 	}{
 		"passes found=false and a zero entry when absent, stores the result": {
 			fn:        seedFn,
-			wantEntry: ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
+			wantEntry: UsageLedgerEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
 		},
 		"passes the current entry when present": {
-			existing:  &ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime},
+			existing:  &UsageLedgerEntry{Resources: settled, LastUpdate: settleTime},
 			fn:        seedFn,
-			wantEntry: ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime},
+			wantEntry: UsageLedgerEntry{Resources: settled, LastUpdate: settleTime},
 		},
 		"a writer-style update preserves StatusAccounted": {
-			existing:  &ConsumedResourcesEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
+			existing:  &UsageLedgerEntry{Resources: seeded, LastUpdate: seedTime, StatusAccounted: true},
 			fn:        writerFn,
-			wantEntry: ConsumedResourcesEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: true},
+			wantEntry: UsageLedgerEntry{Resources: settled, LastUpdate: settleTime, StatusAccounted: true},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			consumed := NewAfsConsumedResources()
+			consumed := NewAfsUsageLedger()
 			if tc.existing != nil {
-				consumed.Update(lqKey, func(ConsumedResourcesEntry, bool) ConsumedResourcesEntry { return *tc.existing })
+				consumed.Update(lqKey, func(UsageLedgerEntry, bool) UsageLedgerEntry { return *tc.existing })
 			}
 
 			got := consumed.Update(lqKey, tc.fn)

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -47,7 +47,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/heap"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
-	"sigs.k8s.io/kueue/pkg/util/resource"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -200,7 +199,7 @@ type ClusterQueue struct {
 
 	AdmissionScope *kueue.AdmissionScope
 
-	afsEntryPenalties         *queueafs.AfsEntryPenalties
+	afsUsageLedger            *queueafs.AfsUsageLedger
 	localQueuesInClusterQueue map[utilqueue.LocalQueueReference]bool
 
 	sw *stickyWorkload
@@ -245,10 +244,9 @@ func workloadKey(i *workload.Info) workload.Reference {
 type clusterQueueOption func(*clusterQueueOptions)
 
 type clusterQueueOptions struct {
-	fsResWeights         map[corev1.ResourceName]float64
-	enableAdmissionFs    bool
-	afsEntryPenalties    *queueafs.AfsEntryPenalties
-	afsConsumedResources *queueafs.AfsConsumedResources
+	fsResWeights      map[corev1.ResourceName]float64
+	enableAdmissionFs bool
+	afsUsageLedger    *queueafs.AfsUsageLedger
 }
 
 func withFSResWeights(weights map[corev1.ResourceName]float64) clusterQueueOption {
@@ -263,15 +261,9 @@ func withEnableAdmissionFs(enable bool) clusterQueueOption {
 	}
 }
 
-func withAfsEntryPenalties(penalties *queueafs.AfsEntryPenalties) clusterQueueOption {
+func withAfsUsageLedger(consumed *queueafs.AfsUsageLedger) clusterQueueOption {
 	return func(o *clusterQueueOptions) {
-		o.afsEntryPenalties = penalties
-	}
-}
-
-func withAfsConsumedResources(consumed *queueafs.AfsConsumedResources) clusterQueueOption {
-	return func(o *clusterQueueOptions) {
-		o.afsConsumedResources = consumed
+		o.afsUsageLedger = consumed
 	}
 }
 
@@ -282,8 +274,7 @@ func newClusterQueue(
 	cl *metrics.CustomLabels,
 	wo workload.Ordering,
 	afsConfig *configapi.AdmissionFairSharing,
-	afsEntryPenalties *queueafs.AfsEntryPenalties,
-	afsConsumedResources *queueafs.AfsConsumedResources,
+	afsUsageLedger *queueafs.AfsUsageLedger,
 ) (*ClusterQueue, error) {
 	enableAdmissionFs, fsResWeights := afs.ResourceWeights(cq.Spec.AdmissionScope, afsConfig)
 	cqImpl := newClusterQueueImpl(
@@ -294,8 +285,7 @@ func newClusterQueue(
 		realClock,
 		withFSResWeights(fsResWeights),
 		withEnableAdmissionFs(enableAdmissionFs),
-		withAfsEntryPenalties(afsEntryPenalties),
-		withAfsConsumedResources(afsConsumedResources),
+		withAfsUsageLedger(afsUsageLedger),
 	)
 	err := cqImpl.Update(cq)
 	if err != nil {
@@ -312,7 +302,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 	sw := stickyWorkload{}
 	// The heap comparator reads the sticky workload live on every comparison;
 	// this is safe because sticky writes and heap operations both hold rwm.
-	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsEntryPenalties, options.afsConsumedResources, sw.matches)
+	compareFunc := queueOrderingFunc(ctx, client, wo, options.fsResWeights, options.enableAdmissionFs, options.afsUsageLedger, sw.matches)
 	// Derive lessFunc from compareFunc for the heap.
 	lessFunc := func(a, b *workload.Info) bool { return compareFunc(a, b) < 0 }
 	// Snapshot sorts without the lock, so it captures the sticky workload once
@@ -320,7 +310,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 	snapshotSort := buildSnapshotSort(
 		ctx, wo, &sw, client,
 		options.enableAdmissionFs, options.fsResWeights,
-		options.afsEntryPenalties, options.afsConsumedResources,
+		options.afsUsageLedger,
 	)
 	return &ClusterQueue{
 		customLabels:                 cl,
@@ -336,7 +326,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		snapshotSort:                 snapshotSort,
 		rwm:                          sync.RWMutex{},
 		clock:                        clock,
-		afsEntryPenalties:            options.afsEntryPenalties,
+		afsUsageLedger:               options.afsUsageLedger,
 		localQueuesInClusterQueue:    make(map[utilqueue.LocalQueueReference]bool),
 		sw:                           &sw,
 		pendingResourcesTotal:        make(map[corev1.ResourceName]int64),
@@ -897,13 +887,12 @@ func (c *ClusterQueue) rebuildAll() {
 }
 
 func (c *ClusterQueue) hasPendingPenalties() bool {
-	if c.afsEntryPenalties == nil {
+	if c.afsUsageLedger == nil {
 		return false
 	}
 
 	for lqKey := range c.localQueuesInClusterQueue {
-		lqPenalty := c.afsEntryPenalties.Peek(lqKey)
-		if !resource.IsZero(lqPenalty) {
+		if c.afsUsageLedger.HasPendingPenalty(lqKey) {
 			return true
 		}
 	}
@@ -961,8 +950,7 @@ func buildSnapshotSort(
 	cl client.Client,
 	enableAdmissionFs bool,
 	fsResWeights map[corev1.ResourceName]float64,
-	afsEntryPenalties *queueafs.AfsEntryPenalties,
-	afsConsumedResources *queueafs.AfsConsumedResources,
+	afsUsageLedger *queueafs.AfsUsageLedger,
 ) func(elements []*workload.Info) {
 	log := ctrl.LoggerFrom(ctx)
 	if !enableAdmissionFs {
@@ -995,13 +983,11 @@ func buildSnapshotSort(
 				continue
 			}
 			var consumed, penalty corev1.ResourceList
-			if afsConsumedResources != nil {
-				if entry, found := afsConsumedResources.Get(lqKey); found {
+			if afsUsageLedger != nil {
+				if entry, found := afsUsageLedger.Get(lqKey); found {
 					consumed = entry.Resources.DeepCopy()
+					penalty = entry.PendingPenalty.DeepCopy()
 				}
-			}
-			if afsEntryPenalties != nil {
-				penalty = afsEntryPenalties.Peek(lqKey).DeepCopy()
 			}
 			lqWeight, ok := getLQWeight(lqKey)
 			if !ok {
@@ -1151,8 +1137,7 @@ func queueOrderingFunc(
 	wo workload.Ordering,
 	fsResWeights map[corev1.ResourceName]float64,
 	enableAdmissionFs bool,
-	afsEntryPenalties *queueafs.AfsEntryPenalties,
-	afsConsumedResources *queueafs.AfsConsumedResources,
+	afsUsageLedger *queueafs.AfsUsageLedger,
 	stickyMatches func(workload.Reference) bool,
 ) func(a, b *workload.Info) int {
 	log := ctrl.LoggerFrom(ctx)
@@ -1161,8 +1146,8 @@ func queueOrderingFunc(
 		return baseCmp
 	}
 	return func(a, b *workload.Info) int {
-		lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
-		lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsEntryPenalties, afsConsumedResources)
+		lqAUsage, errA := a.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsUsageLedger)
+		lqBUsage, errB := b.CalcLocalQueueFSUsage(ctx, cl, fsResWeights, afsUsageLedger)
 		switch {
 		case errA != nil:
 			log.V(2).Error(errA, "Error determining LocalQueue usage")

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -438,9 +438,9 @@ func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 			},
 		}).
 		Build()
-	afsConsumedResources := queueafs.NewAfsConsumedResources()
-	afsConsumedResources.Set("default/higher-usage", corev1.ResourceList{resourceGPU: resource.MustParse("20")}, now)
-	afsConsumedResources.Set("default/lower-usage", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
+	afsUsageLedger := queueafs.NewAfsUsageLedger()
+	afsUsageLedger.Set("default/higher-usage", corev1.ResourceList{resourceGPU: resource.MustParse("20")}, now)
+	afsUsageLedger.Set("default/lower-usage", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
 
 	cq, err := newClusterQueue(
 		ctx,
@@ -449,8 +449,7 @@ func TestSnapshotFallsBackToBaseOrderingOnLocalQueueLookupError(t *testing.T) {
 		nil,
 		defaultOrdering,
 		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1}},
-		nil,
-		afsConsumedResources,
+		afsUsageLedger,
 	)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
@@ -492,17 +491,16 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 			FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).Obj(),
 	)
 
-	afsConsumedResources := queueafs.NewAfsConsumedResources()
-	afsConsumedResources.Set("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
-	afsConsumedResources.Set("default/lq2", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
+	afsUsageLedger := queueafs.NewAfsUsageLedger()
+	afsUsageLedger.Set("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
+	afsUsageLedger.Set("default/lq2", corev1.ResourceList{resourceGPU: resource.MustParse("5")}, now)
 
-	penaltyMap := queueafs.NewPenaltyMap()
 	ctx, _ := utiltesting.ContextWithLog(t)
 	cq, err := newClusterQueue(ctx, builder.Build(),
 		utiltestingapi.MakeClusterQueue("cq").AdmissionMode(kueue.UsageBasedAdmissionFairSharing).Obj(),
 		nil, defaultOrdering,
 		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1.0}},
-		penaltyMap, afsConsumedResources)
+		afsUsageLedger)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
 	}
@@ -524,8 +522,8 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				penaltyMap.Push("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")})
-				penaltyMap.Sub("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")})
+				afsUsageLedger.PushPenalty("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")}, now)
+				afsUsageLedger.SubPenalty("default/lq1", corev1.ResourceList{resourceGPU: resource.MustParse("100")}, now)
 			}
 		}
 	}()
@@ -550,9 +548,9 @@ func TestSnapshotStableWithConcurrentFSUpdates(t *testing.T) {
 func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	ctx, _ := utiltesting.ContextWithLog(t)
-	afsConsumedResources := queueafs.NewAfsConsumedResources()
-	afsConsumedResources.Set("default/existing", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
-	afsConsumedResources.Set("default/missing", corev1.ResourceList{resourceGPU: resource.MustParse("15")}, now)
+	afsUsageLedger := queueafs.NewAfsUsageLedger()
+	afsUsageLedger.Set("default/existing", corev1.ResourceList{resourceGPU: resource.MustParse("10")}, now)
+	afsUsageLedger.Set("default/missing", corev1.ResourceList{resourceGPU: resource.MustParse("15")}, now)
 
 	cq, err := newClusterQueue(
 		ctx,
@@ -563,8 +561,7 @@ func TestSnapshotUsesDefaultWeightForMissingLocalQueue(t *testing.T) {
 		nil,
 		defaultOrdering,
 		&config.AdmissionFairSharing{ResourceWeights: map[corev1.ResourceName]float64{resourceGPU: 1}},
-		nil,
-		afsConsumedResources,
+		afsUsageLedger,
 	)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
@@ -601,7 +598,7 @@ func TestSnapshotConcurrentWithRequeueNoDataRace(t *testing.T) {
 			},
 		}, nil,
 		defaultOrdering,
-		nil, nil, nil)
+		nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
 	}
@@ -660,7 +657,7 @@ func TestSnapshotConsistentUnderConcurrentStickyChange(t *testing.T) {
 			},
 		}, nil,
 		defaultOrdering,
-		nil, nil, nil)
+		nil, nil)
 	if err != nil {
 		t.Fatalf("failed to create ClusterQueue: %v", err)
 	}
@@ -1342,7 +1339,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 					},
 				}, nil,
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
-				nil, nil, nil)
+				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 			info := workload.NewInfo(wl)
 			info.LastAssignment = tc.lastAssignment
@@ -1377,7 +1374,7 @@ func TestFIFOClusterQueue(t *testing.T) {
 		}, nil,
 		workload.Ordering{
 			PodsReadyRequeuingTimestamp: config.EvictionTimestamp,
-		}, nil, nil, nil)
+		}, nil, nil)
 	if err != nil {
 		t.Fatalf("Failed creating ClusterQueue %v", err)
 	}
@@ -1534,7 +1531,7 @@ func TestStrictFIFO(t *testing.T) {
 					},
 				}, nil,
 				*tt.workloadOrdering,
-				nil, nil, nil)
+				nil, nil)
 			if err != nil {
 				t.Fatalf("Failed creating ClusterQueue %v", err)
 			}
@@ -1578,7 +1575,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 					},
 				}, nil,
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
-				nil, nil, nil)
+				nil, nil)
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).Obj()
 			if ok := cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), reason, ""); !ok {
 				t.Error("failed to requeue nonexistent workload")
@@ -1750,12 +1747,12 @@ func TestFsAdmission(t *testing.T) {
 			}
 			client := builder.Build()
 
-			afsConsumedResources := queueafs.NewAfsConsumedResources()
+			afsUsageLedger := queueafs.NewAfsUsageLedger()
 			for lqKey, consumedResources := range tc.initConsumedResources {
-				afsConsumedResources.Set(utilqueue.LocalQueueReference(lqKey), consumedResources, time.Now())
+				afsUsageLedger.Set(utilqueue.LocalQueueReference(lqKey), consumedResources, time.Now())
 			}
 
-			cq, _ := newClusterQueue(t.Context(), client, tc.cq, nil, defaultOrdering, tc.afsConfig, nil, afsConsumedResources)
+			cq, _ := newClusterQueue(t.Context(), client, tc.cq, nil, defaultOrdering, tc.afsConfig, afsUsageLedger)
 			for _, wl := range tc.wls {
 				cq.PushOrUpdate(workload.NewInfo(&wl))
 			}
@@ -1969,7 +1966,7 @@ func TestRequeueHashTriggerByReason(t *testing.T) {
 					},
 				}, nil,
 				workload.Ordering{PodsReadyRequeuingTimestamp: config.EvictionTimestamp},
-				nil, nil, nil)
+				nil, nil)
 
 			wl := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 				Request(corev1.ResourceCPU, "1").Obj()

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -178,8 +178,7 @@ type Manager struct {
 	admissionFairSharingConfig *config.AdmissionFairSharing
 	secondPassQueue            *secondPassQueue
 
-	AfsEntryPenalties      *queueafs.AfsEntryPenalties
-	AfsConsumedResources   *queueafs.AfsConsumedResources
+	AfsUsageLedger         *queueafs.AfsUsageLedger
 	workloadUpdateWatchers []WorkloadUpdateWatcher
 
 	draReconcileChannel chan<- event.TypedGenericEvent[*kueue.Workload]
@@ -220,8 +219,7 @@ func NewManager(client client.Client, checker StatusChecker, requeuer inadmissib
 
 		topologyUpdateWatchers: make([]TopologyUpdateWatcher, 0),
 		secondPassQueue:        newSecondPassQueue(),
-		AfsEntryPenalties:      queueafs.NewPenaltyMap(),
-		AfsConsumedResources:   queueafs.NewAfsConsumedResources(),
+		AfsUsageLedger:         queueafs.NewAfsUsageLedger(),
 		requeuer:               requeuer,
 		resourceFormatter:      resources.NewResourceFormatter(),
 	}
@@ -329,13 +327,11 @@ func (m *Manager) AddClusterQueue(ctx context.Context, cq *kueue.ClusterQueue) e
 		return errClusterQueueAlreadyExists
 	}
 
-	var afsEntryPenalties *queueafs.AfsEntryPenalties
-	var afsConsumedResources *queueafs.AfsConsumedResources
+	var afsUsageLedger *queueafs.AfsUsageLedger
 	if afs.Enabled(m.admissionFairSharingConfig) {
-		afsEntryPenalties = m.AfsEntryPenalties
-		afsConsumedResources = m.AfsConsumedResources
+		afsUsageLedger = m.AfsUsageLedger
 	}
-	cqImpl, err := newClusterQueue(ctx, m.client, cq, m.customLabels, m.workloadOrdering, m.admissionFairSharingConfig, afsEntryPenalties, afsConsumedResources)
+	cqImpl, err := newClusterQueue(ctx, m.client, cq, m.customLabels, m.workloadOrdering, m.admissionFairSharingConfig, afsUsageLedger)
 	if err != nil {
 		return err
 	}

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -628,7 +628,10 @@ func (c *clusterQueue) updateWorkloadUsage(log logr.Logger, wi *workload.Info, o
 	}
 	qKey := queue.KeyFromWorkload(wi.Obj)
 	if lq, ok := c.localQueues[qKey]; ok {
-		updateFlavorUsage(frUsage, lq.totalReserved, op)
+		// totalReserved takes the LocalQueue lock because GetReservedUsage reads it
+		// without the cache lock; the counters below are only read under the cache
+		// lock, so they need none until one gains a cache-lock-free reader.
+		lq.updateTotalReserved(frUsage, op)
 		lq.reservingWorkloads += op.asSignedOne()
 		if admitted {
 			lq.updateAdmittedUsage(frUsage, op)
@@ -702,7 +705,7 @@ func (c *clusterQueue) addLocalQueue(q *kueue.LocalQueue) error {
 	for _, wl := range c.Workloads {
 		if workloadBelongsToLocalQueue(wl.Obj, q) {
 			frq := wl.ResourceUsage().Assigned
-			updateFlavorUsage(frq, qImpl.totalReserved, add)
+			qImpl.updateTotalReserved(frq, add)
 			qImpl.reservingWorkloads++
 			if workload.IsAdmitted(wl.Obj) {
 				qImpl.updateAdmittedUsage(frq, add)

--- a/pkg/cache/scheduler/localqueue.go
+++ b/pkg/cache/scheduler/localqueue.go
@@ -46,10 +46,13 @@ func (q *LocalQueue) customMetricLabelValues() []string {
 	return q.customLabels.LQGet(q.key)
 }
 
-func (q *LocalQueue) GetAdmittedUsage() corev1.ResourceList {
+// GetReservedUsage returns usage for all quota-reserving workloads, including
+// those still waiting on admission checks — the source matching AFS's
+// QuotaReserved accounting anchor, unlike admitted-gated usage.
+func (q *LocalQueue) GetReservedUsage() corev1.ResourceList {
 	q.RLock()
 	defer q.RUnlock()
-	return q.admittedUsage.FlattenFlavors().ToResourceList(q.resourceFormatter)
+	return q.totalReserved.FlattenFlavors().ToResourceList(q.resourceFormatter)
 }
 
 func (q *LocalQueue) GetLabels() map[string]string {
@@ -70,6 +73,12 @@ func (q *LocalQueue) updateAdmittedUsage(usage resources.FlavorResourceQuantitie
 	q.Lock()
 	defer q.Unlock()
 	updateFlavorUsage(usage, q.admittedUsage, op)
+}
+
+func (q *LocalQueue) updateTotalReserved(usage resources.FlavorResourceQuantities, op usageOp) {
+	q.Lock()
+	defer q.Unlock()
+	updateFlavorUsage(usage, q.totalReserved, op)
 }
 
 func (q *LocalQueue) reportActiveWorkloads(tracker *roletracker.RoleTracker) {

--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -141,21 +141,14 @@ func (s *Snapshot) Log(log logr.Logger) {
 }
 
 type snapshotOption struct {
-	afsEntryPenalties    *queueafs.AfsEntryPenalties
-	afsConsumedResources *queueafs.AfsConsumedResources
+	afsUsageLedger *queueafs.AfsUsageLedger
 }
 
 type SnapshotOption func(*snapshotOption)
 
-func WithAfsEntryPenalties(penalties *queueafs.AfsEntryPenalties) SnapshotOption {
+func WithAfsUsageLedger(consumedResources *queueafs.AfsUsageLedger) SnapshotOption {
 	return func(o *snapshotOption) {
-		o.afsEntryPenalties = penalties
-	}
-}
-
-func WithAfsConsumedResources(consumedResources *queueafs.AfsConsumedResources) SnapshotOption {
-	return func(o *snapshotOption) {
-		o.afsConsumedResources = consumedResources
+		o.afsUsageLedger = consumedResources
 	}
 }
 
@@ -228,7 +221,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 		if snap.InactiveClusterQueueSets.Has(cq.Name) {
 			continue
 		}
-		cqSnapshot, err := c.snapshotClusterQueue(ctx, cq, opts.afsEntryPenalties, opts.afsConsumedResources)
+		cqSnapshot, err := c.snapshotClusterQueue(ctx, cq, opts.afsUsageLedger)
 		if err != nil {
 			return nil, err
 		}
@@ -289,8 +282,7 @@ func skipInactiveCQReason(cq *clusterQueue) inactiveCQReason {
 func (c *Cache) snapshotClusterQueue(
 	ctx context.Context,
 	cq *clusterQueue,
-	afsEntryPenalties *queueafs.AfsEntryPenalties,
-	afsConsumedResources *queueafs.AfsConsumedResources,
+	afsUsageLedger *queueafs.AfsUsageLedger,
 ) (*ClusterQueueSnapshot, error) {
 	log := log.FromContext(ctx)
 	cc := &ClusterQueueSnapshot{
@@ -323,7 +315,7 @@ func (c *Cache) snapshotClusterQueue(
 			return cc, nil
 		}
 		for key, wl := range cc.Workloads {
-			usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights, afsEntryPenalties, afsConsumedResources)
+			usage, err := wl.CalcLocalQueueFSUsage(ctx, c.client, resourceWeights, afsUsageLedger)
 			if err != nil {
 				return nil, fmt.Errorf("failed to calculate LocalQueue FS usage for LocalQueue %v", client.ObjectKey{Namespace: wl.Obj.Namespace, Name: string(wl.Obj.Spec.QueueName)})
 			}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -220,7 +220,7 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// before this reconcile. Without this, self-triggered status
 		// updates cause sub-millisecond reconciles where the decay math
 		// truncates CPU consumed resources to zero.
-		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; hadCache && sinceLastUpdate < interval && !r.queues.AfsEntryPenalties.HasPendingFor(lqKey) {
+		if interval := r.admissionFSConfig.UsageSamplingInterval.Duration; hadCache && sinceLastUpdate < interval && !r.queues.AfsUsageLedger.HasPendingPenalty(lqKey) {
 			return ctrl.Result{RequeueAfter: interval - sinceLastUpdate}, nil
 		}
 		if err := r.reconcileConsumedUsage(ctx, &queueObj); err != nil {
@@ -266,8 +266,7 @@ func (r *LocalQueueReconciler) Delete(e event.TypedDeleteEvent[*kueue.LocalQueue
 	}
 	if afs.Enabled(r.admissionFSConfig) {
 		lqKey := utilqueue.Key(e.Object)
-		r.queues.AfsConsumedResources.Delete(lqKey)
-		r.queues.AfsEntryPenalties.Delete(lqKey)
+		r.queues.AfsUsageLedger.Delete(lqKey)
 	}
 
 	if features.Enabled(features.CustomMetricLabels) {
@@ -338,7 +337,7 @@ func (r *LocalQueueReconciler) Update(e event.TypedUpdateEvent[*kueue.LocalQueue
 	return true
 }
 
-func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadCache bool, entry queueafs.ConsumedResourcesEntry) {
+func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadCache bool, entry queueafs.UsageLedgerEntry) {
 	if lq.Status.FairSharing == nil {
 		lq.Status.FairSharing = &kueue.LocalQueueFairSharingStatus{}
 	}
@@ -369,14 +368,15 @@ func (r *LocalQueueReconciler) initializeAfsIfNeeded(lq *kueue.LocalQueue) (hadC
 	if hasStatus {
 		seeded = lq.Status.FairSharing.AdmissionFairSharingStatus.ConsumedResources.DeepCopy()
 	}
-	entry = r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+	entry = r.queues.AfsUsageLedger.Update(lqKey, func(old queueafs.UsageLedgerEntry, found bool) queueafs.UsageLedgerEntry {
 		hadCache = found
 		switch {
 		case !found:
-			return queueafs.ConsumedResourcesEntry{Resources: seeded, LastUpdate: now, StatusAccounted: true}
+			return queueafs.UsageLedgerEntry{Resources: seeded, LastUpdate: now, StatusAccounted: true}
 		case !old.StatusAccounted:
-			return queueafs.ConsumedResourcesEntry{
+			return queueafs.UsageLedgerEntry{
 				Resources:       utilresource.MergeResourceListKeepSum(old.Resources, seeded),
+				PendingPenalty:  old.PendingPenalty,
 				LastUpdate:      old.LastUpdate,
 				StatusAccounted: true,
 			}
@@ -399,14 +399,14 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 			log.V(2).Info("Failed to reset LocalQueue status", "namespace", lq.Namespace, "name", lq.Name, "error", err)
 			return err
 		}
-		r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
-			return queueafs.ConsumedResourcesEntry{Resources: corev1.ResourceList{}, LastUpdate: now, StatusAccounted: old.StatusAccounted || !found}
+		r.queues.AfsUsageLedger.Update(lqKey, func(old queueafs.UsageLedgerEntry, found bool) queueafs.UsageLedgerEntry {
+			return queueafs.UsageLedgerEntry{Resources: corev1.ResourceList{}, PendingPenalty: old.PendingPenalty, LastUpdate: now, StatusAccounted: old.StatusAccounted || !found}
 		})
 		log.V(2).Info("Reset AFS consumed resources cache", "namespace", lq.Namespace, "name", lq.Name)
 		return nil
 	}
 
-	entry, _ := r.queues.AfsConsumedResources.Get(lqKey)
+	entry, _ := r.queues.AfsUsageLedger.Get(lqKey)
 
 	cacheLq, err := r.cache.GetCacheLocalQueue(lq.Spec.ClusterQueue, lqKey)
 	if err != nil {
@@ -436,9 +436,9 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 	// land between the Get above and this write (the status update is an API call),
 	// and its folded penalty must not be overwritten. The persisted status may lag
 	// the stored value by one interval in that case; the next tick converges it.
-	stored := r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+	stored := r.queues.AfsUsageLedger.Update(lqKey, func(old queueafs.UsageLedgerEntry, found bool) queueafs.UsageLedgerEntry {
 		if !found {
-			return queueafs.ConsumedResourcesEntry{Resources: newConsumed, LastUpdate: now, StatusAccounted: true}
+			return queueafs.UsageLedgerEntry{Resources: newConsumed, LastUpdate: now, StatusAccounted: true}
 		}
 		// Clamp elapsed and keep the stored timestamp monotonic; see the
 		// canonical note above.
@@ -447,8 +447,9 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 		if old.LastUpdate.After(now) {
 			storedLastUpdate = old.LastUpdate
 		}
-		return queueafs.ConsumedResourcesEntry{
+		return queueafs.UsageLedgerEntry{
 			Resources:       afs.CalculateDecayedConsumed(old.Resources, newUsage, elapsed, halfLifeTime),
+			PendingPenalty:  old.PendingPenalty,
 			LastUpdate:      storedLastUpdate,
 			StatusAccounted: old.StatusAccounted,
 		}
@@ -457,7 +458,10 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 	return nil
 }
 
-func (r *LocalQueueReconciler) reportAfsUsage(lq *kueue.LocalQueue, consumedResources corev1.ResourceList) {
+// reportAfsUsage takes both halves of the usage from the caller so a caller holding a
+// whole entry can report a consistent pair; looking the second half up here would
+// reintroduce the split read the single-entry ledger exists to prevent.
+func (r *LocalQueueReconciler) reportAfsUsage(lq *kueue.LocalQueue, consumedResources, penalty corev1.ResourceList) {
 	if !afs.Enabled(r.admissionFSConfig) {
 		return
 	}
@@ -465,7 +469,6 @@ func (r *LocalQueueReconciler) reportAfsUsage(lq *kueue.LocalQueue, consumedReso
 		return
 	}
 	lqKey := utilqueue.Key(lq)
-	penalty := r.queues.AfsEntryPenalties.Peek(lqKey)
 	metrics.ReportLocalQueueAdmissionFairSharingUsage(
 		localQueueReferenceFromLocalQueue(lq),
 		lq.Spec.ClusterQueue,
@@ -481,7 +484,7 @@ func (r *LocalQueueReconciler) updateAdmissionFsStatus(ctx context.Context, lq *
 	if err := r.client.Status().Update(ctx, lq); err != nil {
 		return err
 	}
-	r.reportAfsUsage(lq, consumedResources)
+	r.reportAfsUsage(lq, consumedResources, r.queues.AfsUsageLedger.PeekPenalty(utilqueue.Key(lq)))
 	return nil
 }
 
@@ -514,8 +517,8 @@ func (r *LocalQueueReconciler) resyncLocalQueueGaugeMetrics(lq *kueue.LocalQueue
 	if !r.lqMetrics.ShouldExposeLocalQueueMetrics(lq.GetLabels()) {
 		return
 	}
-	if entry, found := r.queues.AfsConsumedResources.Get(lqKey); found {
-		r.reportAfsUsage(lq, entry.Resources)
+	if entry, found := r.queues.AfsUsageLedger.Get(lqKey); found {
+		r.reportAfsUsage(lq, entry.Resources, entry.PendingPenalty)
 	}
 	condition := meta.FindStatusCondition(lq.Status.Conditions, kueue.LocalQueueActive)
 	if condition == nil {

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -414,7 +414,10 @@ func (r *LocalQueueReconciler) reconcileConsumedUsage(ctx context.Context, lq *k
 	}
 
 	oldUsage := entry.Resources
-	newUsage := cacheLq.GetAdmittedUsage()
+	// Reserved-gated: sampling and settlement must read the same admission stage,
+	// else a check-gated workload's settled cost decays out while it holds quota.
+	// See updateAfsConsumedUsage (workload_controller.go).
+	newUsage := cacheLq.GetReservedUsage()
 	// A concurrent settlement can stamp an entry's LastUpdate later than now.
 	// A negative elapsed would drive the decay alpha outside [0, 1] and inflate
 	// consumed usage, so every elapsed derived from a stored LastUpdate is

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -63,9 +63,9 @@ func TestLocalQueueReconcile(t *testing.T) {
 		afsConfig                *config.AdmissionFairSharing
 		runningWls               []kueue.Workload
 		wantRequeueAfter         *time.Duration
-		initialConsumedResources queueafs.ConsumedResourcesEntry
+		initialConsumedResources queueafs.UsageLedgerEntry
 		pendingEntryPenalty      corev1.ResourceList
-		wantConsumedResources    *queueafs.ConsumedResourcesEntry
+		wantConsumedResources    *queueafs.UsageLedgerEntry
 	}{
 		"local queue with Hold StopPolicy": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
@@ -179,7 +179,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -217,7 +217,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -246,10 +246,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+			wantConsumedResources: &queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
+				// The tick samples usage; only a settlement consolidates, so the
+				// penalty must still be pending afterwards.
+				PendingPenalty: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 				// Monotonic: the stored timestamp keeps the later value.
 				LastUpdate:      now.Add(5 * time.Minute),
 				StatusAccounted: true,
@@ -274,7 +277,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -322,7 +325,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 					resourceGPU:        resource.MustParse("16"),
@@ -384,7 +387,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -432,7 +435,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -470,7 +473,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					resourceGPU: resource.MustParse("8"),
 				},
@@ -518,7 +521,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					resourceGPU: resource.MustParse("8"),
 				},
@@ -570,7 +573,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("8"),
 				},
@@ -752,7 +755,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("2"),
 				},
@@ -785,7 +788,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+			wantConsumedResources: &queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("7"),
 				},
@@ -820,7 +823,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("2"),
 				},
@@ -853,7 +856,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantConsumedResources: &queueafs.ConsumedResourcesEntry{
+			wantConsumedResources: &queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("3"),
 				},
@@ -876,7 +879,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Weight: new(resource.MustParse("1")),
 				}).
 				Obj(),
-			initialConsumedResources: queueafs.ConsumedResourcesEntry{
+			initialConsumedResources: queueafs.UsageLedgerEntry{
 				Resources: corev1.ResourceList{
 					corev1.ResourceCPU: resource.MustParse("500m"),
 				},
@@ -933,14 +936,14 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 			if tc.initialConsumedResources.Resources != nil {
 				lqKey := utilqueue.Key(tc.localQueue)
-				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
+				qManager.AfsUsageLedger.Update(lqKey, func(queueafs.UsageLedgerEntry, bool) queueafs.UsageLedgerEntry {
 					return tc.initialConsumedResources
 				})
 			}
 			if tc.pendingEntryPenalty != nil {
 				// A pending entry penalty bypasses the sampling-interval guard so
 				// the tick runs even when the cached LastUpdate is not yet stale.
-				qManager.AfsEntryPenalties.Push(utilqueue.Key(tc.localQueue), tc.pendingEntryPenalty)
+				qManager.AfsUsageLedger.PushPenalty(utilqueue.Key(tc.localQueue), tc.pendingEntryPenalty, clock.Now())
 			}
 			reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 				WithClock(clock),
@@ -982,12 +985,15 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 
 			if tc.wantConsumedResources != nil {
-				gotEntry, found := qManager.AfsConsumedResources.Get(utilqueue.Key(tc.localQueue))
+				gotEntry, found := qManager.AfsUsageLedger.Get(utilqueue.Key(tc.localQueue))
 				if !found {
-					t.Fatal("expected an AfsConsumedResources entry after reconcile")
+					t.Fatal("expected an AfsUsageLedger entry after reconcile")
 				}
 				if diff := cmp.Diff(tc.wantConsumedResources.Resources, gotEntry.Resources, cmpopts.EquateEmpty()); diff != "" {
 					t.Errorf("unexpected consumed resources in cache entry (-want,+got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tc.wantConsumedResources.PendingPenalty, gotEntry.PendingPenalty, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("unexpected pending entry penalty in cache entry (-want,+got):\n%s", diff)
 				}
 				if !gotEntry.LastUpdate.Equal(tc.wantConsumedResources.LastUpdate) {
 					t.Errorf("unexpected cache entry LastUpdate: want %v, got %v", tc.wantConsumedResources.LastUpdate, gotEntry.LastUpdate)
@@ -1050,14 +1056,14 @@ func TestLocalQueueReconcileReportsAdmissionFairSharingUsageMetric(t *testing.T)
 	if err := qManager.AddLocalQueue(ctx, localQueue); err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	qManager.AfsConsumedResources.Set(lqKey, corev1.ResourceList{
+	qManager.AfsUsageLedger.Set(lqKey, corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("8"),
 		resourceGPU:        resource.MustParse("4"),
 	}, now.Add(-5*time.Minute))
-	qManager.AfsEntryPenalties.Push(lqKey, corev1.ResourceList{
+	qManager.AfsUsageLedger.PushPenalty(lqKey, corev1.ResourceList{
 		corev1.ResourceCPU: resource.MustParse("1"),
 		resourceGPU:        resource.MustParse("1"),
-	})
+	}, now)
 
 	reconciler := NewLocalQueueReconciler(cl, qManager, cqCache,
 		WithClock(clock),

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1451,13 +1451,13 @@ func (r *WorkloadReconciler) Generic(e event.TypedGenericEvent[*kueue.Workload])
 
 func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.Workload) {
 	if features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsParent(wl) {
-		// A parent copies its reservation from an admitted variant and shares that
-		// variant's LocalQueue, so it never pushed a penalty of its own; settling
-		// here would fold the variant's penalty in a second time.
+		// A parent copies its reservation from an admitted variant rather than being
+		// scheduled, so it never pushed a penalty of its own. Settling for it would
+		// consolidate its LocalQueue's pending penalties on a transition that reserved
+		// no quota, ahead of the variant that actually did.
 		return
 	}
 	lqKey := qutil.KeyFromWorkload(wl)
-	penalty := afs.CalculateEntryPenalty(workload.NewInfo(wl).SumTotalRequests(r.resourceFormatter), r.admissionFSConfig)
 	now := r.clock.Now()
 
 	cacheLq, err := r.cache.GetCacheLocalQueue(wl.Status.Admission.ClusterQueue, lqKey)
@@ -1466,14 +1466,14 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 		return
 	}
 	// Read live usage before taking the entry lock: the scheduler snapshot reads
-	// AfsConsumedResources while holding the scheduler-cache lock, so the Update
+	// AfsUsageLedger while holding the scheduler-cache lock, so the Update
 	// closure must not call back into the cache.
 	// Reserved-gated to match the QuotaReserved anchor: an admitted-gated read would
 	// omit a check-gated workload whose penalty settles here, so the EMA would decay
 	// its cost away while it still holds quota.
 	newUsage := cacheLq.GetReservedUsage()
 
-	updated := r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
+	updated := r.queues.AfsUsageLedger.Update(lqKey, func(old queueafs.UsageLedgerEntry, found bool) queueafs.UsageLedgerEntry {
 		lastUpdate := old.LastUpdate
 		if !found {
 			lastUpdate = now
@@ -1487,16 +1487,18 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 			storedLastUpdate = lastUpdate
 		}
 		newConsumed := afs.CalculateDecayedConsumed(old.Resources, newUsage, elapsed, r.admissionFSConfig.UsageHalfLifeTime.Seconds())
-		return queueafs.ConsumedResourcesEntry{
-			Resources:       resource.MergeResourceListKeepSum(newConsumed, penalty),
+		// Consolidate whatever is pending and clear it in the same write, so no
+		// reader can observe a penalty in both halves of the entry. Folding the
+		// bucket rather than a per-Workload figure also means the settled amount
+		// cannot disagree with the pushed one and leave a residue behind.
+		return queueafs.UsageLedgerEntry{
+			Resources:       resource.MergeResourceListKeepSum(newConsumed, old.PendingPenalty),
 			LastUpdate:      storedLastUpdate,
 			StatusAccounted: old.StatusAccounted,
 		}
 	})
-	r.queues.AfsEntryPenalties.Sub(lqKey, penalty)
-	log.V(3).Info("Entry penalty subtracted from localQueue", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "penalty", penalty, "remaining", r.queues.AfsEntryPenalties.Peek(lqKey))
 
-	log.V(2).Info("Updated AFS consumed usage", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "consumed", updated.Resources)
+	log.V(2).Info("Consolidated AFS entry penalties into consumed usage", "localQueue", klog.KRef(wl.Namespace, string(wl.Spec.QueueName)), "consumed", updated.Resources)
 }
 
 func (r *WorkloadReconciler) notifyWatchers(oldWl, newWl *kueue.Workload) {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -1426,13 +1426,16 @@ func (r *WorkloadReconciler) Update(e event.TypedUpdateEvent[*kueue.Workload]) b
 		// and are not supposed to actually change anything.
 		r.cache.AddOrUpdateWorkload(log, wlCopy)
 	}
-	// The AFS entry penalty must be settled on every transition into Admitted
-	// (#12539). It is settled outside the switch so that no transition into
-	// Admitted is missed, and after it so that the cache already accounts for
-	// the workload usage read by updateAfsConsumedUsage. Deactivation wins
-	// over admission: a workload deactivated in the same event was removed
-	// from the cache by the first case and must not be charged.
-	if active && status == workload.StatusAdmitted && prevStatus != workload.StatusAdmitted &&
+	// The AFS entry penalty must be settled on the transition into holding a
+	// quota reservation, not at Admitted: usage is quota-based. Gating on
+	// Admitted stranded a check-gated workload's penalty until its checks
+	// passed, and never settled it at all if they never did. It is settled
+	// outside the switch so that no transition into QuotaReserved is missed,
+	// and after it so that the cache already accounts for the workload usage
+	// read by updateAfsConsumedUsage. Deactivation wins over admission: a
+	// workload deactivated in the same event was removed from the cache by the
+	// first case and must not be charged.
+	if active && workload.HasQuotaReservation(e.ObjectNew) && !workload.HasQuotaReservation(e.ObjectOld) &&
 		afs.Enabled(r.admissionFSConfig) &&
 		r.cache.ClusterQueueUsesAdmissionFairSharing(wlCopy.Status.Admission.ClusterQueue) {
 		r.updateAfsConsumedUsage(log, wlCopy)
@@ -1447,6 +1450,12 @@ func (r *WorkloadReconciler) Generic(e event.TypedGenericEvent[*kueue.Workload])
 }
 
 func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.Workload) {
+	if features.Enabled(features.ConcurrentAdmission) && concurrentadmission.IsParent(wl) {
+		// A parent copies its reservation from an admitted variant and shares that
+		// variant's LocalQueue, so it never pushed a penalty of its own; settling
+		// here would fold the variant's penalty in a second time.
+		return
+	}
 	lqKey := qutil.KeyFromWorkload(wl)
 	penalty := afs.CalculateEntryPenalty(workload.NewInfo(wl).SumTotalRequests(r.resourceFormatter), r.admissionFSConfig)
 	now := r.clock.Now()
@@ -1459,7 +1468,10 @@ func (r *WorkloadReconciler) updateAfsConsumedUsage(log logr.Logger, wl *kueue.W
 	// Read live usage before taking the entry lock: the scheduler snapshot reads
 	// AfsConsumedResources while holding the scheduler-cache lock, so the Update
 	// closure must not call back into the cache.
-	newUsage := cacheLq.GetAdmittedUsage()
+	// Reserved-gated to match the QuotaReserved anchor: an admitted-gated read would
+	// omit a check-gated workload whose penalty settles here, so the EMA would decay
+	// its cost away while it still holds quota.
+	newUsage := cacheLq.GetReservedUsage()
 
 	updated := r.queues.AfsConsumedResources.Update(lqKey, func(old queueafs.ConsumedResourcesEntry, found bool) queueafs.ConsumedResourcesEntry {
 		lastUpdate := old.LastUpdate

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -545,7 +545,11 @@ func TestUpdateRemovesStaleQueueEntryForOnHoldWorkload(t *testing.T) {
 	}
 }
 
-func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
+// TestUpdateSettlesAfsEntryPenaltyOnce pins the transition the settlement is
+// anchored on: the workload gaining a quota reservation, and only the first
+// event that does so. TestUpdateSettlesEntryPenaltyAtQuotaReserved covers why
+// the anchor is the reservation rather than admission.
+func TestUpdateSettlesAfsEntryPenaltyOnce(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
 
@@ -583,19 +587,19 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 		newWl       *kueue.Workload
 		wantSettled bool
 	}{
-		"Pending to Admitted settles the entry penalty": {
-			oldWl:       pending,
-			newWl:       admitted,
-			wantSettled: true,
-		},
-		"QuotaReserved to Admitted settles the entry penalty": {
-			oldWl:       quotaReserved,
-			newWl:       admitted,
-			wantSettled: true,
-		},
-		"Pending to QuotaReserved does not settle the entry penalty": {
+		"Pending to QuotaReserved settles the entry penalty": {
 			oldWl:       pending,
 			newWl:       quotaReserved,
+			wantSettled: true,
+		},
+		"Pending to Admitted settles the entry penalty in the same event": {
+			oldWl:       pending,
+			newWl:       admitted,
+			wantSettled: true,
+		},
+		"QuotaReserved to Admitted does not settle the entry penalty again": {
+			oldWl:       quotaReserved,
+			newWl:       admitted,
 			wantSettled: false,
 		},
 		"Admitted to Admitted does not settle the entry penalty again": {
@@ -604,7 +608,7 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 			wantSettled: false,
 		},
 		"deactivation in the same event does not settle the entry penalty": {
-			oldWl:       quotaReserved,
+			oldWl:       pending,
 			newWl:       deactivatedAdmitted,
 			wantSettled: false,
 		},
@@ -2381,6 +2385,220 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			}
 			if gotEntry.StatusAccounted != tc.wantStatusAccounted {
 				t.Errorf("unexpected StatusAccounted: want %t, got %t", tc.wantStatusAccounted, gotEntry.StatusAccounted)
+			}
+		})
+	}
+}
+
+func TestUpdateSettlesEntryPenaltyAtQuotaReserved(t *testing.T) {
+	// This test drives the full reconciler.Update path, whose settle branch is
+	// gated on afs.Enabled (which reads the AdmissionFairSharing feature gate);
+	// pin it so the test does not depend on the process-global default.
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	// With halfLifeTime == samplingInterval the pushed penalty for the 4 CPU
+	// workload is 2 CPU.
+	pushedPenalty := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+
+	baseWl := func() *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			Queue("lq").
+			Request(corev1.ResourceCPU, "4")
+	}
+
+	cases := map[string]struct {
+		usageBasedCQ bool
+		// admitted also syncs the Admitted condition on the new workload,
+		// modelling the no-checks path where QuotaReserved and Admitted
+		// arrive in the same status update.
+		admitted bool
+		// parentVariant models a ConcurrentAdmission parent, which reaches
+		// QuotaReserved by copying an admitted variant's admission rather than
+		// through the scheduler, so it never pushed a penalty of its own.
+		parentVariant bool
+
+		wantSettled bool
+	}{
+		"settles when quota is reserved before admission (AdmissionCheck path)": {
+			usageBasedCQ: true,
+			wantSettled:  true,
+		},
+		"settles on the combined reservation and admission update (no-checks path)": {
+			usageBasedCQ: true,
+			admitted:     true,
+			wantSettled:  true,
+		},
+		"does not settle for a ClusterQueue without usage-based admission": {
+			wantSettled: false,
+		},
+		"does not settle for a ConcurrentAdmission parent": {
+			usageBasedCQ:  true,
+			admitted:      true,
+			parentVariant: true,
+			wantSettled:   false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if tc.parentVariant {
+				features.SetFeatureGateDuringTest(t, features.ConcurrentAdmission, true)
+			}
+			fakeClock := testingclock.NewFakeClock(now)
+			cl := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cl)
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, &utiltesting.EventRecorder{}, WithAdmissionFairSharing(afsConfig))
+			reconciler.clock = fakeClock
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cqWrapper := utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue)
+			if tc.usageBasedCQ {
+				cqWrapper = cqWrapper.AdmissionMode(kueue.UsageBasedAdmissionFairSharing)
+			}
+			setupClusterQueue(ctx, t, cl, qManager, cqCache, cqWrapper.Obj(), false)
+			lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+			setupLocalQueue(ctx, t, cl, qManager, lq, false)
+			if err := cqCache.AddLocalQueue(lq); err != nil {
+				t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+			}
+
+			lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+			qManager.AfsEntryPenalties.Push(lqKey, pushedPenalty)
+
+			wl := func() *utiltestingapi.WorkloadWrapper {
+				if tc.parentVariant {
+					return baseWl().ParentVariant()
+				}
+				return baseWl()
+			}
+
+			oldWl := wl().Obj()
+			newWl := wl().ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).Obj(), now).Obj()
+			if tc.admitted {
+				newWl = wl().
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).Obj(), now).
+					AdmittedAt(true, now).
+					Obj()
+			}
+
+			if got := reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+				ObjectOld: oldWl,
+				ObjectNew: newWl,
+			}); !got {
+				t.Fatalf("Update() = %v, want true", got)
+			}
+
+			hasPending := qManager.AfsEntryPenalties.HasPendingFor(lqKey)
+			entry, settled := qManager.AfsConsumedResources.Get(lqKey)
+			if tc.wantSettled {
+				if hasPending {
+					t.Errorf("expected the entry penalty to be settled, still pending: %v", qManager.AfsEntryPenalties.Peek(lqKey))
+				}
+				if !settled {
+					t.Fatal("expected an AfsConsumedResources entry after settlement")
+				}
+				gotCPU := entry.Resources[corev1.ResourceCPU]
+				if gotCPU.MilliValue() != 2_000 {
+					t.Errorf("unexpected consumed CPU: want 2000m, got %dm", gotCPU.MilliValue())
+				}
+			} else {
+				if !hasPending {
+					t.Error("expected the entry penalty to remain pending")
+				}
+				if settled {
+					t.Errorf("expected no AfsConsumedResources entry, got %v", entry.Resources)
+				}
+			}
+		})
+	}
+}
+
+// TestUpdateSettlesUsingReservedUsage pins the usage source settlement reads: both
+// cases reserve the same quota and must settle to the same consumed value. An
+// admitted-gated read would fold in nothing for the check-gated case, so its cost
+// would decay away while it still holds quota.
+func TestUpdateSettlesUsingReservedUsage(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	// The consumed entry is seeded one half-life in the past, making the decay
+	// weight alpha = 1 - 0.5^1 = 0.5 so that the live usage reaches the result.
+	// On a fresh entry elapsed is 0 and alpha multiplies the usage away, so the
+	// seed is what lets this test tell the two usage sources apart.
+	// consumed = 0*(1-alpha) + 4 CPU*alpha + penalty(4 CPU) = 2 + 2 = 4 CPU.
+	const wantConsumedCPUMilli = int64(4_000)
+
+	cases := map[string]struct {
+		admitted bool
+	}{
+		"quota reserved, still waiting on AdmissionChecks": {},
+		"quota reserved and already admitted":              {admitted: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			fakeClock := testingclock.NewFakeClock(now)
+			cl := utiltesting.NewClientBuilder().Build()
+			cqCache := schdcache.New(cl)
+			qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+			reconciler := NewWorkloadReconciler(cl, qManager, cqCache, &utiltesting.EventRecorder{}, WithAdmissionFairSharing(afsConfig))
+			reconciler.clock = fakeClock
+
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cq := utiltestingapi.MakeClusterQueue("cq").
+				Active(metav1.ConditionTrue).
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				Obj()
+			setupClusterQueue(ctx, t, cl, qManager, cqCache, cq, false)
+			lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+			setupLocalQueue(ctx, t, cl, qManager, lq, false)
+			if err := cqCache.AddLocalQueue(lq); err != nil {
+				t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+			}
+
+			lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
+			qManager.AfsConsumedResources.Update(lqKey, func(_ queueafs.ConsumedResourcesEntry, _ bool) queueafs.ConsumedResourcesEntry {
+				return queueafs.ConsumedResourcesEntry{
+					Resources:       corev1.ResourceList{},
+					LastUpdate:      now.Add(-afsConfig.UsageHalfLifeTime.Duration),
+					StatusAccounted: true,
+				}
+			})
+
+			admission := utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).
+				Obj()
+			oldWl := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Request(corev1.ResourceCPU, "4").Obj()
+			newWlWrapper := utiltestingapi.MakeWorkload("wl", "ns").
+				Queue("lq").
+				Request(corev1.ResourceCPU, "4").
+				ReserveQuotaAt(admission, now)
+			if tc.admitted {
+				newWlWrapper = newWlWrapper.AdmittedAt(true, now)
+			}
+
+			if got := reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
+				ObjectOld: oldWl,
+				ObjectNew: newWlWrapper.Obj(),
+			}); !got {
+				t.Fatalf("Update() = %v, want true", got)
+			}
+
+			entry, found := qManager.AfsConsumedResources.Get(lqKey)
+			if !found {
+				t.Fatal("expected an AfsConsumedResources entry after settlement")
+			}
+			gotCPU := entry.Resources[corev1.ResourceCPU]
+			if gotCPU.MilliValue() != wantConsumedCPUMilli {
+				t.Errorf("unexpected consumed CPU: want %dm, got %dm", wantConsumedCPUMilli, gotCPU.MilliValue())
 			}
 		})
 	}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -643,15 +643,15 @@ func TestUpdateSettlesAfsEntryPenaltyOnce(t *testing.T) {
 			if len(seeded) == 0 {
 				t.Fatal("the seeded penalty is empty, so the settlement would subtract nothing and every case would pass")
 			}
-			qManager.AfsEntryPenalties.Push(lqKey, seeded)
+			qManager.AfsUsageLedger.PushPenalty(lqKey, seeded, now)
 
 			reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
 				ObjectOld: tc.oldWl.DeepCopy(),
 				ObjectNew: tc.newWl.DeepCopy(),
 			})
 
-			if hasPending := qManager.AfsEntryPenalties.HasPendingFor(lqKey); hasPending == tc.wantSettled {
-				t.Errorf("HasPendingFor() = %v, want settled = %v", hasPending, tc.wantSettled)
+			if hasPending := qManager.AfsUsageLedger.HasPendingPenalty(lqKey); hasPending == tc.wantSettled {
+				t.Errorf("HasPendingPenalty() = %v, want settled = %v", hasPending, tc.wantSettled)
 			}
 		})
 	}
@@ -2294,10 +2294,13 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 	}
 
-	// With halfLifeTime == samplingInterval the entry penalty is half of the
-	// request, so the 4 CPU workload settles a 2 CPU penalty.
+	// Settlement consolidates whatever the scheduler pushed, so each case pushes
+	// 2 CPU rather than relying on the settled amount being recomputed.
+	pushedPenalty := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+
 	cases := map[string]struct {
-		initialEntry        *queueafs.ConsumedResourcesEntry
+		initialEntry        *queueafs.UsageLedgerEntry
+		noPendingPenalty    bool
 		wantCPUMilli        int64
 		wantStatusAccounted bool
 		// wantLastUpdate defaults to now when zero.
@@ -2310,7 +2313,7 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			wantStatusAccounted: false,
 		},
 		"folds into an existing entry and preserves StatusAccounted": {
-			initialEntry: &queueafs.ConsumedResourcesEntry{
+			initialEntry: &queueafs.UsageLedgerEntry{
 				Resources:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
 				LastUpdate:      now,
 				StatusAccounted: true,
@@ -2324,7 +2327,7 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			// usage is kept verbatim and only the 2 CPU penalty folds in (8+2=10),
 			// instead of the negative-elapsed path inflating it. The stored
 			// timestamp stays monotonic at the later value rather than rewinding.
-			initialEntry: &queueafs.ConsumedResourcesEntry{
+			initialEntry: &queueafs.UsageLedgerEntry{
 				Resources:       corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
 				LastUpdate:      now.Add(5 * time.Minute),
 				StatusAccounted: true,
@@ -2332,6 +2335,16 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 			wantCPUMilli:        10_000,
 			wantStatusAccounted: true,
 			wantLastUpdate:      now.Add(5 * time.Minute),
+		},
+		"charges nothing when no penalty is pending": {
+			// Settlement consolidates the pending bucket rather than recomputing a
+			// per-Workload figure, so a reservation the scheduler never pushed for
+			// (a ConcurrentAdmission parent, a restart that dropped the push) is
+			// not charged a penalty it never incurred.
+			noPendingPenalty:    true,
+			initialEntry:        &queueafs.UsageLedgerEntry{Resources: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}, LastUpdate: now, StatusAccounted: true},
+			wantCPUMilli:        8_000,
+			wantStatusAccounted: true,
 		},
 	}
 	for name, tc := range cases {
@@ -2361,16 +2374,19 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 
 			lqKey := utilqueue.KeyFromWorkload(wl)
 			if tc.initialEntry != nil {
-				qManager.AfsConsumedResources.Update(lqKey, func(queueafs.ConsumedResourcesEntry, bool) queueafs.ConsumedResourcesEntry {
+				qManager.AfsUsageLedger.Update(lqKey, func(queueafs.UsageLedgerEntry, bool) queueafs.UsageLedgerEntry {
 					return *tc.initialEntry
 				})
+			}
+			if !tc.noPendingPenalty {
+				qManager.AfsUsageLedger.PushPenalty(lqKey, pushedPenalty, now)
 			}
 
 			reconciler.updateAfsConsumedUsage(log, wl)
 
-			gotEntry, found := qManager.AfsConsumedResources.Get(lqKey)
+			gotEntry, found := qManager.AfsUsageLedger.Get(lqKey)
 			if !found {
-				t.Fatal("expected an AfsConsumedResources entry after settlement")
+				t.Fatal("expected an AfsUsageLedger entry after settlement")
 			}
 			gotCPU := gotEntry.Resources[corev1.ResourceCPU]
 			if gotCPU.MilliValue() != tc.wantCPUMilli {
@@ -2387,6 +2403,56 @@ func TestUpdateAfsConsumedUsage(t *testing.T) {
 				t.Errorf("unexpected StatusAccounted: want %t, got %t", tc.wantStatusAccounted, gotEntry.StatusAccounted)
 			}
 		})
+	}
+}
+
+// TestUpdateAfsConsumedUsageFoldsAPenaltyOnce is the regression guard for the reason
+// consolidation and the pending bucket share one record: consolidation must both fold
+// and clear, so a second reservation on the same LocalQueue cannot re-charge a penalty
+// that was already consolidated.
+func TestUpdateAfsConsumedUsageFoldsAPenaltyOnce(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	afsConfig := &configapi.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+	}
+
+	fakeClock := testingclock.NewFakeClock(now)
+	cl := utiltesting.NewClientBuilder().Build()
+	cqCache := schdcache.New(cl)
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+	reconciler := NewWorkloadReconciler(cl, qManager, cqCache, &utiltesting.EventRecorder{}, WithAdmissionFairSharing(afsConfig))
+	reconciler.clock = fakeClock
+
+	ctx, log := utiltesting.ContextWithLog(t)
+	setupClusterQueue(ctx, t, cl, qManager, cqCache, utiltestingapi.MakeClusterQueue("cq").Active(metav1.ConditionTrue).Obj(), false)
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	setupLocalQueue(ctx, t, cl, qManager, lq, false)
+	if err := cqCache.AddLocalQueue(lq); err != nil {
+		t.Fatalf("couldn't add the local queue to the scheduler cache: %v", err)
+	}
+
+	wl := utiltestingapi.MakeWorkload("wl", "ns").
+		Queue("lq").
+		Request(corev1.ResourceCPU, "4").
+		SimpleReserveQuota("cq", "rf", now).
+		AdmittedAt(true, now).
+		Obj()
+	lqKey := utilqueue.KeyFromWorkload(wl)
+	qManager.AfsUsageLedger.PushPenalty(lqKey, corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}, now)
+
+	reconciler.updateAfsConsumedUsage(log, wl)
+	reconciler.updateAfsConsumedUsage(log, wl)
+
+	entry, found := qManager.AfsUsageLedger.Get(lqKey)
+	if !found {
+		t.Fatal("expected an AfsUsageLedger entry after settlement")
+	}
+	if gotCPU := entry.Resources[corev1.ResourceCPU]; gotCPU.MilliValue() != 2_000 {
+		t.Errorf("the penalty was consolidated more than once: want 2000m consumed CPU, got %dm", gotCPU.MilliValue())
+	}
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
+		t.Errorf("expected the bucket to stay clear, still pending: %v", entry.PendingPenalty)
 	}
 }
 
@@ -2468,7 +2534,7 @@ func TestUpdateSettlesEntryPenaltyAtQuotaReserved(t *testing.T) {
 			}
 
 			lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
-			qManager.AfsEntryPenalties.Push(lqKey, pushedPenalty)
+			qManager.AfsUsageLedger.PushPenalty(lqKey, pushedPenalty, now)
 
 			wl := func() *utiltestingapi.WorkloadWrapper {
 				if tc.parentVariant {
@@ -2493,16 +2559,16 @@ func TestUpdateSettlesEntryPenaltyAtQuotaReserved(t *testing.T) {
 				t.Fatalf("Update() = %v, want true", got)
 			}
 
-			hasPending := qManager.AfsEntryPenalties.HasPendingFor(lqKey)
-			entry, settled := qManager.AfsConsumedResources.Get(lqKey)
+			hasPending := qManager.AfsUsageLedger.HasPendingPenalty(lqKey)
+			entry, found := qManager.AfsUsageLedger.Get(lqKey)
+			if !found {
+				t.Fatal("expected an AfsUsageLedger entry, the push creates one")
+			}
+			gotCPU := entry.Resources[corev1.ResourceCPU]
 			if tc.wantSettled {
 				if hasPending {
-					t.Errorf("expected the entry penalty to be settled, still pending: %v", qManager.AfsEntryPenalties.Peek(lqKey))
+					t.Errorf("expected the entry penalty to be settled, still pending: %v", entry.PendingPenalty)
 				}
-				if !settled {
-					t.Fatal("expected an AfsConsumedResources entry after settlement")
-				}
-				gotCPU := entry.Resources[corev1.ResourceCPU]
 				if gotCPU.MilliValue() != 2_000 {
 					t.Errorf("unexpected consumed CPU: want 2000m, got %dm", gotCPU.MilliValue())
 				}
@@ -2510,8 +2576,8 @@ func TestUpdateSettlesEntryPenaltyAtQuotaReserved(t *testing.T) {
 				if !hasPending {
 					t.Error("expected the entry penalty to remain pending")
 				}
-				if settled {
-					t.Errorf("expected no AfsConsumedResources entry, got %v", entry.Resources)
+				if !gotCPU.IsZero() {
+					t.Errorf("expected nothing consolidated into consumed usage, got %v", entry.Resources)
 				}
 			}
 		})
@@ -2533,9 +2599,10 @@ func TestUpdateSettlesUsingReservedUsage(t *testing.T) {
 	// The consumed entry is seeded one half-life in the past, making the decay
 	// weight alpha = 1 - 0.5^1 = 0.5 so that the live usage reaches the result.
 	// On a fresh entry elapsed is 0 and alpha multiplies the usage away, so the
-	// seed is what lets this test tell the two usage sources apart.
-	// consumed = 0*(1-alpha) + 4 CPU*alpha + penalty(4 CPU) = 2 + 2 = 4 CPU.
-	const wantConsumedCPUMilli = int64(4_000)
+	// seed is what lets this test tell the two usage sources apart. No penalty is
+	// pending, so the whole result comes from the usage source:
+	// consumed = 0*(1-alpha) + 4 CPU*alpha = 2 CPU.
+	const wantConsumedCPUMilli = int64(2_000)
 
 	cases := map[string]struct {
 		admitted bool
@@ -2565,8 +2632,8 @@ func TestUpdateSettlesUsingReservedUsage(t *testing.T) {
 			}
 
 			lqKey := utilqueue.NewLocalQueueReference("ns", "lq")
-			qManager.AfsConsumedResources.Update(lqKey, func(_ queueafs.ConsumedResourcesEntry, _ bool) queueafs.ConsumedResourcesEntry {
-				return queueafs.ConsumedResourcesEntry{
+			qManager.AfsUsageLedger.Update(lqKey, func(_ queueafs.UsageLedgerEntry, _ bool) queueafs.UsageLedgerEntry {
+				return queueafs.UsageLedgerEntry{
 					Resources:       corev1.ResourceList{},
 					LastUpdate:      now.Add(-afsConfig.UsageHalfLifeTime.Duration),
 					StatusAccounted: true,
@@ -2592,9 +2659,9 @@ func TestUpdateSettlesUsingReservedUsage(t *testing.T) {
 				t.Fatalf("Update() = %v, want true", got)
 			}
 
-			entry, found := qManager.AfsConsumedResources.Get(lqKey)
+			entry, found := qManager.AfsUsageLedger.Get(lqKey)
 			if !found {
-				t.Fatal("expected an AfsConsumedResources entry after settlement")
+				t.Fatal("expected an AfsUsageLedger entry after settlement")
 			}
 			gotCPU := entry.Resources[corev1.ResourceCPU]
 			if gotCPU.MilliValue() != wantConsumedCPUMilli {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -327,8 +327,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	// 2. Take a snapshot of the cache.
 	var snapshotOpts []schdcache.SnapshotOption
 	if afs.Enabled(s.admissionFairSharing) {
-		snapshotOpts = append(snapshotOpts, schdcache.WithAfsEntryPenalties(s.queues.AfsEntryPenalties))
-		snapshotOpts = append(snapshotOpts, schdcache.WithAfsConsumedResources(s.queues.AfsConsumedResources))
+		snapshotOpts = append(snapshotOpts, schdcache.WithAfsUsageLedger(s.queues.AfsUsageLedger))
 	}
 	phaseStartTime := s.clock.Now()
 	snapshot, err := s.cache.Snapshot(ctx, snapshotOpts...)
@@ -1282,10 +1281,10 @@ func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {
 
 	switch op {
 	case add:
-		s.queues.AfsEntryPenalties.Push(lqKey, penalty)
+		s.queues.AfsUsageLedger.PushPenalty(lqKey, penalty, s.clock.Now())
 		log.V(3).Info("Entry penalty added to localQueue", "localQueue", lqObjRef, "penalty", penalty)
 	case subtract:
-		s.queues.AfsEntryPenalties.Sub(lqKey, penalty)
+		s.queues.AfsUsageLedger.SubPenalty(lqKey, penalty, s.clock.Now())
 		log.V(3).Info("Entry penalty subtracted from localQueue", "localQueue", lqObjRef, "penalty", penalty)
 	}
 }

--- a/pkg/scheduler/scheduler_afs_secondpass_test.go
+++ b/pkg/scheduler/scheduler_afs_secondpass_test.go
@@ -185,8 +185,8 @@ func TestSecondPassDoesNotRepushEntryPenalty(t *testing.T) {
 	}
 
 	lqKey := utilqueue.NewLocalQueueReference("default", "lq")
-	if qManager.AfsEntryPenalties.HasPendingFor(lqKey) {
+	if qManager.AfsUsageLedger.HasPendingPenalty(lqKey) {
 		t.Errorf("second pass pushed a duplicate entry penalty for an already-reserved workload; bucket = %v, want empty",
-			qManager.AfsEntryPenalties.Peek(lqKey))
+			qManager.AfsUsageLedger.PeekPenalty(lqKey))
 	}
 }

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -884,7 +884,7 @@ func TestScheduleForAFS(t *testing.T) {
 					}
 					for lqName, resources := range tc.initialUsage {
 						lqKey := utilqueue.LocalQueueReference(fmt.Sprintf("default/%s", lqName))
-						qManager.AfsConsumedResources.Set(lqKey, resources, fakeClock.Now())
+						qManager.AfsUsageLedger.Set(lqKey, resources, fakeClock.Now())
 					}
 					for _, rf := range resourceFlavors {
 						cqCache.AddOrUpdateResourceFlavor(log, rf)

--- a/pkg/util/maps/maps_test.go
+++ b/pkg/util/maps/maps_test.go
@@ -384,7 +384,7 @@ func TestUpdateConcurrent(t *testing.T) {
 
 // TestUpdateOrDeleteConcurrentWithPush verifies that UpdateOrDelete eliminates
 // the TOCTOU between checking canClearPenalty and calling Delete in the
-// original AfsEntryPenalties.Sub implementation
+// original entry-penalty Sub implementation
 // (https://github.com/kubernetes-sigs/kueue/issues/12546).
 func TestUpdateOrDeleteConcurrentWithPush(t *testing.T) {
 	const key = "default/lq1"

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -488,22 +488,19 @@ func (i *Info) CalcLocalQueueFSUsage(
 	ctx context.Context,
 	c client.Client,
 	resWeights map[corev1.ResourceName]float64,
-	afsEntryPenalties *queueafs.AfsEntryPenalties,
-	afsConsumedResources *queueafs.AfsConsumedResources,
+	afsUsageLedger *queueafs.AfsUsageLedger,
 ) (float64, error) {
 	lqKey := queue.KeyFromWorkload(i.Obj)
 
+	// One Get: consumed and the pending penalty come from the same entry, so a
+	// settlement in flight can never be observed in both.
 	consumed := corev1.ResourceList{}
-	if afsConsumedResources != nil {
-		entry, found := afsConsumedResources.Get(lqKey)
-		if found {
-			consumed = entry.Resources
-		}
-	}
-
 	penalty := corev1.ResourceList{}
-	if afsEntryPenalties != nil {
-		penalty = afsEntryPenalties.Peek(lqKey)
+	if afsUsageLedger != nil {
+		if entry, found := afsUsageLedger.Get(lqKey); found {
+			consumed = entry.Resources
+			penalty = entry.PendingPenalty
+		}
 	}
 
 	lqObjKey := client.ObjectKey{Namespace: i.Obj.Namespace, Name: string(i.Obj.Spec.QueueName)}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3346,12 +3346,12 @@ func TestCalcLocalQueueFSUsage(t *testing.T) {
 
 			resWeights := map[corev1.ResourceName]float64{corev1.ResourceCPU: 5.0}
 
-			afsConsumed := queueafs.NewAfsConsumedResources()
+			afsConsumed := queueafs.NewAfsUsageLedger()
 			afsConsumed.Set(utilqueue.KeyFromWorkload(wl), corev1.ResourceList{
 				corev1.ResourceCPU: resource.MustParse("10"),
 			}, time.Now())
 
-			usage, err := info.CalcLocalQueueFSUsage(ctx, cl, resWeights, nil, afsConsumed)
+			usage, err := info.CalcLocalQueueFSUsage(ctx, cl, resWeights, afsConsumed)
 
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)

--- a/site/content/en/docs/concepts/admission_fair_sharing.md
+++ b/site/content/en/docs/concepts/admission_fair_sharing.md
@@ -33,9 +33,11 @@ When multiple workloads compete for resources within a ClusterQueue:
 Entry Penalty is available since Kueue v0.13.0.
 {{% /alert %}}
 
-To prevent exploitation where tenants could submit many workloads quickly before usage statistics are updated, Kueue applies an entry penalty to each admitted workload. This penalty is immediately added to the LocalQueue's usage statistics. This ensures that even if a tenant submits multiple workloads rapidly, subsequent workloads will be properly prioritized based on the updated usage including the penalty.
+To prevent exploitation where tenants could submit many workloads quickly before usage statistics are updated, Kueue applies an entry penalty when it selects a workload for quota reservation. The penalty counts toward the LocalQueue usage used to order admissions immediately, and is folded into the reported `consumedResources` once the quota reservation is observed. This ensures that even if a tenant submits multiple workloads rapidly, subsequent workloads will be properly prioritized based on the updated usage including the penalty.
 
-For example, if Tenant A has low historical usage and Tenant B has high usage, but Tenant B submits 100 workloads simultaneously, without the entry penalty all 100 workloads might be admitted before the usage statistics update. With the entry penalty, each admitted workload immediately increases Tenant B's usage statistics, so subsequent workloads from Tenant B will be properly deprioritized in favor of workloads from Tenant A.
+For example, if Tenant A has low historical usage and Tenant B has high usage, but Tenant B submits 100 workloads simultaneously, without the entry penalty all 100 workloads might be admitted before the usage statistics update. With the entry penalty, each workload that reserves quota immediately increases Tenant B's usage statistics, so subsequent workloads from Tenant B will be properly deprioritized in favor of workloads from Tenant A.
+
+Usage is counted from the moment a workload reserves quota rather than from the moment it is admitted, so a workload still waiting on its AdmissionChecks already counts toward its LocalQueue's usage.
 
 ## Configuration
 

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1142,7 +1142,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 			ginkgo.By("Verifying no entry penalty exists after workload admission")
 			gomega.Eventually(func(g gomega.Gomega) {
-				penalty := qManager.AfsEntryPenalties.HasPendingFor(lqAKey)
+				penalty := qManager.AfsUsageLedger.HasPendingPenalty(lqAKey)
 				g.Expect(penalty).To(gomega.BeFalse(), "entry penalty should be absent for lq-a")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1155,7 +1155,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 
 			ginkgo.By("Verifying no entry penalty exists after second admission")
 			gomega.Eventually(func(g gomega.Gomega) {
-				penalty := qManager.AfsEntryPenalties.HasPendingFor(lqAKey)
+				penalty := qManager.AfsUsageLedger.HasPendingPenalty(lqAKey)
 				g.Expect(penalty).To(gomega.BeFalse(), "entry penalty should be absent for lq-a")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -1424,16 +1424,14 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 					ctx,
 					k8sClient,
 					nil,
-					qManager.AfsEntryPenalties,
-					qManager.AfsConsumedResources,
+					qManager.AfsUsageLedger,
 				)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				lqBUsage, err := wlLowBInfo.CalcLocalQueueFSUsage(
 					ctx,
 					k8sClient,
 					nil,
-					qManager.AfsEntryPenalties,
-					qManager.AfsConsumedResources,
+					qManager.AfsUsageLedger,
 				)
 				g.Expect(err).NotTo(gomega.HaveOccurred())
 				g.Expect(lqAUsage).To(gomega.BeNumerically(">", lqBUsage),
@@ -1622,7 +1620,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 
 			ginkgo.By("Verifying the entry penalty settles once QuotaReserved is observed")
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(),
+				g.Expect(qManager.AfsUsageLedger.HasPendingPenalty(lqKey)).To(gomega.BeFalse(),
 					"entry penalty should be settled at quota reservation, not at admission")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1635,7 +1633,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 
 			ginkgo.By("Verifying no penalty appears or remains after admission")
 			gomega.Consistently(func(g gomega.Gomega) {
-				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(),
+				g.Expect(qManager.AfsUsageLedger.HasPendingPenalty(lqKey)).To(gomega.BeFalse(),
 					"the QuotaReserved -> Admitted transition should be transparent to AFS accounting")
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -1161,65 +1161,6 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 		})
 	})
 
-	ginkgo.When("Using AdmissionFairSharing with AdmissionChecks", ginkgo.Label("feature:admissionfairsharing"), func() {
-		var (
-			check *kueue.AdmissionCheck
-			cq    *kueue.ClusterQueue
-			lq    *kueue.LocalQueue
-		)
-
-		ginkgo.BeforeEach(func() {
-			check = utiltestingapi.MakeAdmissionCheck("check1").ControllerName("ctrl").Obj()
-			util.MustCreate(ctx, k8sClient, check)
-			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
-
-			cq = utiltestingapi.MakeClusterQueue("cq-with-check").
-				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "8").Obj()).
-				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
-				AdmissionChecks(kueue.AdmissionCheckReference(check.Name)).
-				Obj()
-			util.MustCreate(ctx, k8sClient, cq)
-
-			lq = utiltestingapi.MakeLocalQueue("lq-a", ns.Name).
-				FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
-				ClusterQueue(cq.Name).Obj()
-			lqs = append(lqs, lq)
-			util.MustCreate(ctx, k8sClient, lq)
-		})
-
-		ginkgo.AfterEach(func() {
-			// Delete in dependency order so the in-use finalizers can be
-			// removed: workloads -> ClusterQueue -> AdmissionCheck.
-			for _, wl := range wls {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
-			}
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, check, true)
-		})
-
-		ginkgo.It("should subtract the entry penalty when the workload is admitted via an AdmissionCheck", func() {
-			lqKey := utilqueue.NewLocalQueueReference(ns.Name, kueue.LocalQueueName(lq.Name))
-
-			ginkgo.By("Creating a workload which reserves quota and waits for the admission check")
-			wl := createWorkload("lq-a", "4")
-			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
-
-			ginkgo.By("Verifying the entry penalty is pending while the workload is in QuotaReserved")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeTrue(), "entry penalty should be pending for lq-a")
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Marking the admission check Ready so the workload transitions from QuotaReserved to Admitted")
-			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
-			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
-
-			ginkgo.By("Verifying the entry penalty is subtracted after admission")
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(), "entry penalty should be subtracted for lq-a after admission via admission check")
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-	})
-
 	ginkgo.When("Preemption is enabled in fairsharing and there are large values of quota and weights", func() {
 		var (
 			cqA *kueue.ClusterQueue
@@ -1631,6 +1572,75 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing", "featur
 				g.Expect(cpu.Cmp(resource.MustParse("0"))).To(gomega.BeNumerically(">", 0),
 					"ConsumedResources CPU should remain > 0, got %v", cpu.String())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("Workloads pass through AdmissionChecks", func() {
+		var (
+			check *kueue.AdmissionCheck
+			cq    *kueue.ClusterQueue
+			lq    *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			check = utiltestingapi.MakeAdmissionCheck("afs-check").ControllerName("test-controller").Obj()
+			util.MustCreate(ctx, k8sClient, check)
+			util.SetAdmissionCheckActive(ctx, k8sClient, check, metav1.ConditionTrue)
+
+			cq = utiltestingapi.MakeClusterQueue("cq-ac").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).Resource(corev1.ResourceCPU, "16").Obj()).
+				AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+				AdmissionChecks(kueue.AdmissionCheckReference(check.Name)).
+				Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			cqs = append(cqs, cq)
+
+			lq = utiltestingapi.MakeLocalQueue("lq-ac", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, lq)
+			lqs = append(lqs, lq)
+		})
+
+		ginkgo.AfterEach(func() {
+			// The check's in-use finalizer is only released once no
+			// ClusterQueue references it, and the ClusterQueue only goes
+			// away after its workloads, so delete in dependency order while
+			// the manager still runs; the enclosing AfterEach re-deleting
+			// these objects is a no-op.
+			for _, wl := range wls {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, wl, true)
+			}
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, check, true)
+		})
+
+		ginkgo.It("should settle the entry penalty when quota is reserved, before the checks complete", func() {
+			lqKey := utilqueue.NewLocalQueueReference(ns.Name, kueue.LocalQueueName(lq.Name))
+
+			ginkgo.By("Creating a workload that reserves quota and waits on the admission check")
+			wl := createWorkload("lq-ac", "4")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl)
+
+			ginkgo.By("Verifying the entry penalty settles once QuotaReserved is observed")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(),
+					"entry penalty should be settled at quota reservation, not at admission")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying the reserved usage is visible in fair-sharing usage before admission")
+			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lq), ">", 0)
+
+			ginkgo.By("Completing the admission check so the workload gets admitted")
+			util.SetWorkloadsAdmissionCheck(ctx, k8sClient, wl, kueue.AdmissionCheckReference(check.Name), kueue.CheckStateReady, true)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+
+			ginkgo.By("Verifying no penalty appears or remains after admission")
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(qManager.AfsEntryPenalties.HasPendingFor(lqKey)).To(gomega.BeFalse(),
+					"the QuotaReserved -> Admitted transition should be transparent to AFS accounting")
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying the usage remains accounted after admission")
+			util.ExpectLocalQueueFairSharingUsageToBe(ctx, k8sClient, client.ObjectKeyFromObject(lq), ">", 0)
 		})
 	})
 })

--- a/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
+++ b/test/integration/singlecluster/scheduler/quotacheckstrategy/quota_check_strategy_test.go
@@ -128,7 +128,7 @@ var _ = ginkgo.Describe("Quota check strategy", ginkgo.Ordered, ginkgo.ContinueO
 			ginkgo.By("Verifying the entry penalty does not include the undeclared resource")
 			lqKey := utilqueue.NewLocalQueueReference(ns.Name, kueue.LocalQueueName(lq.Name))
 			gomega.Eventually(func(g gomega.Gomega) {
-				penalty := qManager.AfsEntryPenalties.Peek(lqKey)
+				penalty := qManager.AfsUsageLedger.PeekPenalty(lqKey)
 				g.Expect(penalty).NotTo(gomega.HaveKey(corev1.ResourceName("example.com/gpu")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it:

This draft implements the two concerns identified in https://github.com/kubernetes-sigs/kueue/pull/12786#issuecomment-5050956487 together so we can evaluate whether they should land as one change or be split:

1. account AFS entry penalties at `QuotaReserved`;
2. prevent entry penalties from leaking.

It also implements the same-lock requirement attached to (1): pending penalties and consumed usage now live in one per-LocalQueue ledger, so settlement is one atomic update rather than a move across two independently locked maps.

The code is kept in separate commits for the accounting anchor, push-side guards, ledger consolidation, KEP update, and user-facing docs, so the pieces can still be split without rewriting them:

**(1) QuotaReserved accounting**

- The existing `Pending -> QuotaReserved|Admitted` path now settles as soon as quota is reserved. Once that reservation transition has been observed, `QuotaReserved -> Admitted` is transparent to AFS.
- Sampling and settlement both use reserved-gated usage. Moving only the settlement would let a check-gated Workload's cost decay while it still holds quota.
- `ConcurrentAdmission` parents are excluded because they copy a variant's reservation and do not push a penalty of their own.
- Leaving `QuotaReserved` does not refund an already consolidated cost; it remains in the decaying usage history.

**(2) Leak prevention**

- Re-assuming an already-reserved second-pass Workload does not push again.
- Pushes are gated on `UsageBasedAdmissionFairSharing`, matching settlement.
- Rollback subtraction is clamped at zero, preventing a negative usage discount.

**(3) Same-lock consolidation**

- Consumed usage and pending penalties now form one `AfsUsageLedger` entry. One `Update` atomically consolidates the LocalQueue's entire pending penalty into consumed usage and clears the pending bucket; one `Get` observes a consistent pair.
- Settlement uses the amount that was actually pushed instead of recomputing a per-Workload penalty. This removes double counting and push/settle residue from partial admission and `IgnoreUndeclaredResources`.
- A partially admitted Workload is therefore charged for its full requested resources, matching `penalty = A * requested_resource`, rather than only the admitted portion.

Per-Workload penalty records and a level-triggered sweep remain out of scope; together they are the structural follow-up for missed observations and exact rollback attribution.

#### Questions for reviewers:

1. Is reserved-gated usage the intended operator-visible meaning of AFS `consumedResources`?
2. Because settlement consolidates only what is actually pending, a reservation for which the scheduler never pushed a penalty is not charged. Is that the intended behavior?
3. #12787 asks for a bound on penalties from Workloads that reserve quota and leave before admission. Anchoring at `QuotaReserved` moves those costs into decaying usage, so repeated churn converges rather than accumulating indefinitely. Is that the intended semantics, and is it enough to close the issue? A missed reservation observation can still strand an undecaying pending penalty.

AI assistance was used for parts of the implementation and analysis; I reviewed and validated the changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #12539.
Fixes #13495.

Relates to #12787.

This prototype supersedes #12786, which fixes #12539 under the current `Admitted` anchor.

Historical context: #12783, whose related flake was fixed by #12891. 
The same-lock consolidation implements the atomicity requested in the #12783 discussion.

This PR also updates KEP-4136.

#### Special notes for your reviewer:

Coverage includes:

- quota-reservation settlement with and without AdmissionChecks;
- `ConcurrentAdmission` parent exclusion;
- predicate and real-scheduler second-pass coverage;
- reserved-gated settlement and sampling;
- push/settle gate symmetry and zero-clamped rollback;
- atomic fold-and-clear and LocalQueue ledger initialization;
- focused race-enabled unit and integration tests.

Integration with `--race`: fairsharing 42/42, core controllers 72/72, and quota-check-strategy 3/3, with no race reports.

The operator-visible behavior change is that Workloads waiting on AdmissionChecks now count as usage once they reserve quota. This affects admission ordering and cross-LocalQueue preemption victim ordering.

`consumedResources` and `kueue_local_queue_admission_fair_sharing_usage` also move to reserved-gated usage for every LocalQueue, including those whose ClusterQueue is not using `UsageBasedAdmissionFairSharing`, because the sampling tick is gated only by the global AFS configuration.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AdmissionFairSharing now accounts LocalQueue usage from quota reservation and consolidates pending entry penalties into consumed usage atomically.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fair-sharing usage now begins when workloads reserve quota, including those waiting on AdmissionChecks.
  * Entry penalties are settled when reservations are observed, with accounting preserved through workload transitions.
  * Reserved usage includes all quota-reserving workloads, not only admitted workloads.

* **Bug Fixes**
  * Improved penalty accumulation, rollback handling, resource clamping, and one-time settlement.
  * Preserved accounting history through eviction, deactivation, and LocalQueue deletion.

* **Documentation**
  * Added guidance on accounting anchors, usage sampling, settlement, rollback, and resource charging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->