### PR TITLE
docs: say that deviceClassMappings needs a controller restart

### DIFF
--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -85,6 +85,19 @@ resources:
     - gpu-h100.example.com
 ```
 
+{{% alert title="Note" color="primary" %}}
+Kueue reads the Configuration once, at manager startup. If you change
+`deviceClassMappings` on a running cluster, restart the controller so the new
+mapping takes effect:
+
+```shell
+kubectl rollout restart deployment/kueue-controller-manager -n kueue-system
+```
+
+Until then the manager keeps using the mapping it loaded at startup, so device
+requests referencing a newly mapped `DeviceClass` are not counted against quota.
+{{% /alert %}}
+
 ### 2. Add the DRA resource to your ClusterQueue
 
 Include the logical resource name from `deviceClassMappings` in the

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -94,8 +94,10 @@ mapping takes effect:
 kubectl rollout restart deployment/kueue-controller-manager -n kueue-system
 ```
 
-Until then the manager keeps using the mapping it loaded at startup, so device
-requests referencing a newly mapped `DeviceClass` are not counted against quota.
+Until then the manager keeps using the mapping it loaded at startup. A Workload
+whose claim references a `DeviceClass` that mapping does not contain is rejected
+rather than admitted uncounted: Kueue unsets its quota reservation and marks it
+inadmissible, with `DeviceClass <name> is not mapped in DRA configuration`.
 {{% /alert %}}
 
 ### 2. Add the DRA resource to your ClusterQueue

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -98,8 +98,7 @@ Until then the manager keeps using the mapping it loaded at startup. A Workload
 whose claim references a `DeviceClass` that mapping does not contain is not
 admitted, rather than admitted without quota accounting: Kueue unsets its quota
 reservation and marks the Workload inadmissible, with `DeviceClass <name> is not
-mapped in DRA configuration`. It becomes admissible once the controller restarts
-with the mapping in place.
+mapped in DRA configuration`.
 {{% /alert %}}
 
 ### 2. Add the DRA resource to your ClusterQueue

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -95,9 +95,11 @@ kubectl rollout restart deployment/kueue-controller-manager -n kueue-system
 ```
 
 Until then the manager keeps using the mapping it loaded at startup. A Workload
-whose claim references a `DeviceClass` that mapping does not contain is rejected
-rather than admitted uncounted: Kueue unsets its quota reservation and marks it
-inadmissible, with `DeviceClass <name> is not mapped in DRA configuration`.
+whose claim references a `DeviceClass` that mapping does not contain is not
+admitted, rather than admitted without quota accounting: Kueue unsets its quota
+reservation and marks the Workload inadmissible, with `DeviceClass <name> is not
+mapped in DRA configuration`. It becomes admissible once the controller restarts
+with the mapping in place.
 {{% /alert %}}
 
 ### 2. Add the DRA resource to your ClusterQueue

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -97,8 +97,8 @@ kubectl rollout restart deployment/kueue-controller-manager -n kueue-system
 Until then the manager keeps using the mapping it loaded at startup. A Workload
 whose claim references a `DeviceClass` that mapping does not contain is not
 admitted, rather than admitted without quota accounting: Kueue unsets its quota
-reservation and marks the Workload inadmissible, with `DeviceClass <name> is not
-mapped in DRA configuration`.
+reservation and marks the Workload inadmissible, with `DeviceClass <class> is not
+mapped in DRA configuration for podset <podset>`.
 {{% /alert %}}
 
 ### 2. Add the DRA resource to your ClusterQueue


### PR DESCRIPTION
The ResourceClaimTemplate path on [Set Up Dynamic Resource Allocation](https://kueue.sigs.k8s.io/docs/tasks/manage/setup_dra/) tells the reader to add a `deviceClassMappings` entry to the Kueue Configuration, then moves straight on to the ClusterQueue. It never says the manager reads that Configuration once, at startup.

`config.Load(scheme, configFile)` runs in `cmd/kueue/main.go` before the manager starts, and nothing reloads the file afterwards: the only watcher in that path is `certwatcher`, for the metrics certificate. So editing the `kueue-manager-config` ConfigMap on a running cluster changes nothing until the controller restarts.

Followed exactly, the current steps leave the reader with a mapped `DeviceClass` that the running manager still does not know about. I hit it on a live cluster while adding a second mapping alongside an existing one.

The note goes at the end of "1. Configure deviceClassMappings", before the ClusterQueue step, so it is read at the point the edit is made.

### Related text already on the site

[Change the feature gates configuration](https://kueue.sigs.k8s.io/docs/getting-started/installation/) already says the deployment must be restarted after a ConfigMap change. That is the same underlying fact, but it sits on the installation page in a feature-gate context, and a reader following the DRA setup guide has no reason to be there. Happy to make this a cross-reference instead of a standalone note if you would rather keep the statement in one place.

The note as written also applies to the counter-based and capacity-based paths further down the page, since both configure `deviceClassMappings` too. It is phrased generally for that reason, but I have left it under the first path rather than restructuring the page.

### On the wording

Two corrections, both made against the code rather than intuition, and one claim withdrawn:

- The first version said such requests "are not counted against quota". That reads as the Workload running while its device goes unaccounted, which is the more alarming reading and is not what happens. `mapper.Lookup` returns not-found, `GetResourceRequestsForResourceClaimTemplates` raises a `field.NotFound`, and `workload_controller.go` unsets the quota reservation.
- The second said the Workload is "rejected". That carries a finality the code does not have. "Requeued" would be wrong in the other direction: `SetRequeuedCondition` is called with status `false`, so the Workload is held out rather than put back. It now says "not admitted".
- A third version added "It becomes admissible once the controller restarts with the mapping in place." I removed it: I could not establish that from the code, and `backoffWaitingTimeExpired` returns false whenever `Requeued` is false, with both requeue paths gating on it (`cluster_queue.go:414`, `inadmissible_workloads.go:184`). Whether a successful reconcile after the restart clears the condition, I did not trace. If someone knows the answer, it would be worth a sentence, but I would rather leave it out than guess in an operator-facing page.

Only `site/content/en/docs/` is touched. Happy to apply the same note to the `v0.19` snapshot if you would like it there too.

/kind documentation
/area dra

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that device class mappings are loaded when the controller starts.
  * Added guidance to restart the controller after updating mappings.
  * Documented how workloads using unmapped device classes are handled, including rejection and an explanatory inadmissibility status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->