### PR TITLE
Requeue pending workloads when a non-TAS ResourceFlavor tolerations or nodeLabels change

### DIFF
--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -176,17 +176,31 @@ func (r *ResourceFlavorReconciler) Update(e event.TypedUpdateEvent[*kueue.Resour
 
 	cqNames := r.cache.AddOrUpdateResourceFlavor(log, e.ObjectNew.DeepCopy())
 	// AddOrUpdateResourceFlavor only reports ClusterQueues that transitioned
-	// from pending to active. Editing nodeTaints keeps the ClusterQueues active
-	// but changes which workloads the flavor can admit, so the workloads left
-	// inadmissible by a since-removed taint would otherwise never be retried.
+	// from pending to active. Editing the spec fields the flavor assigner
+	// consults (nodeTaints, tolerations, nodeLabels) keeps the ClusterQueues
+	// active but changes which workloads the flavor can admit, so the workloads
+	// left inadmissible by the previous spec would otherwise never be retried.
 	// Retry the inadmissible workloads in the ClusterQueues that use this flavor.
-	if !equality.Semantic.DeepEqual(e.ObjectOld.Spec.NodeTaints, e.ObjectNew.Spec.NodeTaints) {
+	if flavorSchedulingFieldsChanged(e.ObjectOld, e.ObjectNew) {
+		log.V(3).Info("ResourceFlavor scheduling-relevant fields changed",
+			"oldNodeTaints", e.ObjectOld.Spec.NodeTaints, "newNodeTaints", e.ObjectNew.Spec.NodeTaints,
+			"oldTolerations", e.ObjectOld.Spec.Tolerations, "newTolerations", e.ObjectNew.Spec.Tolerations,
+			"oldNodeLabels", e.ObjectOld.Spec.NodeLabels, "newNodeLabels", e.ObjectNew.Spec.NodeLabels)
 		cqNames.Insert(r.cache.ClusterQueuesUsingFlavor(kueue.ResourceFlavorReference(e.ObjectNew.Name))...)
 	}
 	if len(cqNames) > 0 {
 		qcache.NotifyRetryInadmissible(r.qManager, cqNames)
 	}
 	return false
+}
+
+// flavorSchedulingFieldsChanged reports whether any of the ResourceFlavor spec
+// fields the flavor assigner consults when matching workloads to the flavor
+// (nodeTaints, tolerations, nodeLabels) changed.
+func flavorSchedulingFieldsChanged(oldRF, newRF *kueue.ResourceFlavor) bool {
+	return !equality.Semantic.DeepEqual(oldRF.Spec.NodeTaints, newRF.Spec.NodeTaints) ||
+		!equality.Semantic.DeepEqual(oldRF.Spec.Tolerations, newRF.Spec.Tolerations) ||
+		!equality.Semantic.DeepEqual(oldRF.Spec.NodeLabels, newRF.Spec.NodeLabels)
 }
 
 func (r *ResourceFlavorReconciler) Generic(e event.TypedGenericEvent[*kueue.ResourceFlavor]) bool {

--- a/test/integration/singlecluster/scheduler/scheduler_rf_spec_fields_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_rf_spec_fields_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe("Scheduler non-TAS ResourceFlavor tolerations", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	taint := corev1.Taint{
+		Key:    "example.com/dedicated",
+		Value:  "reserved",
+		Effect: corev1.TaintEffectNoSchedule,
+	}
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rf-tolerations-")
+
+		flavor = utiltestingapi.MakeResourceFlavor("tolerations-flavor").
+			Taint(taint).
+			Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+				Resource(corev1.ResourceCPU, "5").
+				Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	makeWorkload := func(name, cpu string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, cpu).
+			Obj()
+	}
+
+	addFlavorToleration := func() {
+		gomega.Eventually(func(g gomega.Gomega) {
+			var updatedFlavor kueue.ResourceFlavor
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(flavor), &updatedFlavor)).To(gomega.Succeed())
+			updatedFlavor.Spec.Tolerations = []corev1.Toleration{{
+				Key:      taint.Key,
+				Operator: corev1.TolerationOpEqual,
+				Value:    taint.Value,
+				Effect:   taint.Effect,
+			}}
+			g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	// The second workload's shape is the only difference between the scenarios:
+	// a differently-shaped one proves the scheduler cache saw the flavor update,
+	// while an identically-shaped one additionally exercises the
+	// scheduling-equivalence-hash freeze that would otherwise block resubmissions.
+	ginkgo.DescribeTable("should retry pending workloads after the flavor tolerates its own taint",
+		func(secondWorkloadCPU string) {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload that cannot tolerate the flavor nodeTaints", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("adding a matching toleration to the flavor spec", addFlavorToleration)
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verifying a workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", secondWorkloadCPU)
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+		},
+		ginkgo.Entry("with a differently-shaped new workload", "500m"),
+		ginkgo.Entry("with an identically-shaped new workload", "1"),
+	)
+})
+
+var _ = ginkgo.Describe("Scheduler non-TAS ResourceFlavor nodeLabels", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		flavor       *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	const zoneKey = "example.com/zone"
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "rf-nodelabels-")
+
+		flavor = utiltestingapi.MakeResourceFlavor("nodelabels-flavor").
+			NodeLabel(zoneKey, "zone-a").
+			Obj()
+		util.MustCreate(ctx, k8sClient, flavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavor.Name).
+				Resource(corev1.ResourceCPU, "5").
+				Obj()).
+			Obj()
+		util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, flavor, true)
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	makeWorkload := func(name, cpu string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, cpu).
+			NodeSelector(map[string]string{zoneKey: "zone-b"}).
+			Obj()
+	}
+
+	setFlavorZone := func(zone string) {
+		gomega.Eventually(func(g gomega.Gomega) {
+			var updatedFlavor kueue.ResourceFlavor
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(flavor), &updatedFlavor)).To(gomega.Succeed())
+			updatedFlavor.Spec.NodeLabels = map[string]string{zoneKey: zone}
+			g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	}
+
+	// The second workload's shape is the only difference between the scenarios:
+	// a differently-shaped one proves the scheduler cache saw the flavor update,
+	// while an identically-shaped one additionally exercises the
+	// scheduling-equivalence-hash freeze that would otherwise block resubmissions.
+	ginkgo.DescribeTable("should retry pending workloads after nodeLabels match their nodeSelector",
+		func(secondWorkloadCPU string) {
+			wl1 := makeWorkload("wl1", "1")
+			ginkgo.By("creating a workload whose nodeSelector does not match the flavor nodeLabels", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("updating the flavor nodeLabels to match the workload nodeSelector", func() {
+				setFlavorZone("zone-b")
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verifying a workload created after the update is admitted", func() {
+				wl2 := makeWorkload("wl2", secondWorkloadCPU)
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+		},
+		ginkgo.Entry("with a differently-shaped new workload", "500m"),
+		ginkgo.Entry("with an identically-shaped new workload", "1"),
+	)
+})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Editing the `tolerations` or `nodeLabels` of a **non-TAS** ResourceFlavor does not retry workloads that were left inadmissible by the previous spec. A workload rejected for an untolerated flavor taint (or a nodeSelector that did not match the flavor's `nodeLabels`) stays `Pending` indefinitely after the flavor is updated to accept it, until some unrelated event happens to trigger a retry.

This is the same root cause as #13670, which fixed the gap for `nodeTaints`: the core ResourceFlavor controller's `Update` only calls `NotifyRetryInadmissible` for ClusterQueues using the flavor when `spec.nodeTaints` changed. However, the flavor assigner consults three spec fields when deciding whether a workload can use the flavor — `nodeTaints`, `tolerations` (appended to the pod's own tolerations), and `nodeLabels` (matched against the podset's nodeSelector/affinity). Changing any of the three changes which workloads the flavor can admit; only one of them triggered the retry.

#13670 already flagged the `nodeLabels` half of this as a likely follow-up ("The same requeue gap likely applies to `nodeLabels` for non-TAS flavors"). This PR completes the field set by extracting a `flavorSchedulingFieldsChanged` helper that compares all three scheduling-relevant fields.

Note on `nodeLabels` scope: unlike the TAS `nodeLabels` mutability discussion in #3733, non-TAS flavors keep no per-domain topology usage, and ClusterQueue quota usage is recorded at admission and never recomputed from node matching — so retrying pending workloads on a `nodeLabels` change involves no state migration for already-admitted workloads. This PR only adds the missing retry; it does not change any admission semantics.

Reproduced with four integration specs (2 fields x 2 second-workload shapes; all red without the fix, green with it), following the pattern of the #13670 specs:
- A pending workload is never retried after the flavor update — while a differently-shaped workload created after the update **is** admitted, proving the scheduler cache saw the update and only the requeue was missing.
- An identically-shaped workload submitted after the update is also frozen by scheduling-equivalence hashing, so resubmitting the same job does not help either.

Verification: the four new specs, `./pkg/controller/core/...` unit tests, the existing non-TAS `nodeTaints` integration specs (regression for #13670), and the full `test/integration/singlecluster/scheduler` suite (109/109) all pass.

#### Which issue(s) this PR fixes:

Related to #3733 (this addresses the non-TAS `tolerations`/`nodeLabels` requeue gap, completing the field set started by #13647/#13670; the issue tracks additional ResourceFlavor/Topology mutability work and remains open).

#### Special notes for your reviewer:

The fix intentionally keeps the shape of #13670: gated on a scheduling-relevant spec change, scoped to `ClusterQueuesUsingFlavor`, and idempotent for TAS flavors (safe overlap with the TAS-side controllers from #13622/#13647).

AI disclosure: I used an AI assistant to help investigate the code paths, write the reproduction, and draft this change. I reviewed all changed lines and verified the behavior with the tests listed above.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where editing the `tolerations` or `nodeLabels` of a non-TAS ResourceFlavor did not retry workloads that had been left inadmissible by the previous spec, leaving them pending until an unrelated event triggered a retry.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending workloads are now retried when a ResourceFlavor’s taints, tolerations, or node labels change.
  * Workloads can be admitted after an updated ResourceFlavor provides matching scheduling requirements.
  * Subsequent workloads are handled correctly after ResourceFlavor scheduling updates.

* **Tests**
  * Added coverage for retries involving matching taint tolerations and node labels.
  * Added scenarios covering subsequent workloads with both matching and different configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->