### PR TITLE
Allow updating nodeLabels for TAS ResourceFlavors

### DIFF
--- a/apis/kueue/v1beta1/resourceflavor_types.go
+++ b/apis/kueue/v1beta1/resourceflavor_types.go
@@ -44,7 +44,6 @@ type TopologyReference string
 
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))", message="nodeLabels are immutable when topologyName is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)", message="topologyName is immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that

--- a/apis/kueue/v1beta2/resourceflavor_types.go
+++ b/apis/kueue/v1beta2/resourceflavor_types.go
@@ -46,7 +46,6 @@ type TopologyReference string
 
 // ResourceFlavorSpec defines the desired state of the ResourceFlavor
 // +kubebuilder:validation:XValidation:rule="!has(self.topologyName) || self.nodeLabels.size() >= 1", message="at least one nodeLabel is required when topology is set"
-// +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))", message="nodeLabels are immutable when topologyName is set"
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)", message="topologyName is immutable when topologyName is set"
 type ResourceFlavorSpec struct {
 	// nodeLabels are labels that associate the ResourceFlavor with Nodes that

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_resourceflavors.yaml
@@ -202,8 +202,6 @@ spec:
               x-kubernetes-validations:
                 - message: at least one nodeLabel is required when topology is set
                   rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
-                - message: nodeLabels are immutable when topologyName is set
-                  rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
                 - message: topologyName is immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)'
           type: object
@@ -369,8 +367,6 @@ spec:
               x-kubernetes-validations:
                 - message: at least one nodeLabel is required when topology is set
                   rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
-                - message: nodeLabels are immutable when topologyName is set
-                  rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels) && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
                 - message: topologyName is immutable when topologyName is set
                   rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName == oldSelf.topologyName)'
           type: object

--- a/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_resourceflavors.yaml
@@ -189,9 +189,6 @@ spec:
             x-kubernetes-validations:
             - message: at least one nodeLabel is required when topology is set
               rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
-            - message: nodeLabels are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels)
-                && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
             - message: topologyName is immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName
                 == oldSelf.topologyName)'
@@ -367,9 +364,6 @@ spec:
             x-kubernetes-validations:
             - message: at least one nodeLabel is required when topology is set
               rule: '!has(self.topologyName) || self.nodeLabels.size() >= 1'
-            - message: nodeLabels are immutable when topologyName is set
-              rule: '!has(oldSelf.topologyName) || (has(self.nodeLabels) == has(oldSelf.nodeLabels)
-                && (!has(self.nodeLabels) || self.nodeLabels == oldSelf.nodeLabels))'
             - message: topologyName is immutable when topologyName is set
               rule: '!has(oldSelf.topologyName) || (has(self.topologyName) && self.topologyName
                 == oldSelf.topologyName)'

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -80,17 +80,20 @@ func (t *tasCache) AddOrUpdateFlavor(flavor *kueue.ResourceFlavor) {
 	defer t.Unlock()
 	name := kueue.ResourceFlavorReference(flavor.Name)
 	tolerations := slices.Clone(flavor.Spec.Tolerations)
+	nodeLabels := maps.Clone(flavor.Spec.NodeLabels)
 	if flavorInfo, ok := t.flavors[name]; ok {
 		flavorInfo.Tolerations = tolerations
+		flavorInfo.NodeLabels = nodeLabels
 		t.flavors[name] = flavorInfo
 		if flavorCache, ok := t.flavorCache[name]; ok {
 			flavorCache.updateTolerations(tolerations)
+			flavorCache.updateNodeLabels(nodeLabels)
 		}
 		return
 	}
 	flavorInfo := flavorInformation{
 		TopologyName: *flavor.Spec.TopologyName,
-		NodeLabels:   maps.Clone(flavor.Spec.NodeLabels),
+		NodeLabels:   nodeLabels,
 		Tolerations:  tolerations,
 	}
 	t.flavors[name] = flavorInfo

--- a/pkg/cache/scheduler/tas_cache_update_test.go
+++ b/pkg/cache/scheduler/tas_cache_update_test.go
@@ -94,3 +94,51 @@ func TestTASCacheUpdateFlavorTolerationsPreservesUsage(t *testing.T) {
 		t.Error("Workload usage was removed after removing toleration")
 	}
 }
+
+func TestTASCacheUpdateFlavorNodeLabelsPreservesUsage(t *testing.T) {
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	topology := utiltestingapi.MakeDefaultOneLevelTopology("default")
+	tasCache.AddTopology(topology)
+
+	flavor := utiltestingapi.MakeResourceFlavor("tas-flavor").
+		NodeLabel("node-group", "tas").
+		TopologyName(topology.Name).
+		Obj()
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	const wlKey = workload.Reference("default/wl")
+	topologyRequests := []workload.TopologyDomainRequests{{
+		Values: []string{"x1"},
+		Count:  1,
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU: 1,
+		}),
+	}}
+	originalFlavorCache := tasCache.Get("tas-flavor")
+	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+
+	updatedNodeLabels := map[string]string{"node-group": "other"}
+	flavor.Spec.NodeLabels = updatedNodeLabels
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	updatedFlavorCache := tasCache.Get("tas-flavor")
+	if updatedFlavorCache != originalFlavorCache {
+		t.Fatal("TAS flavor cache was replaced while updating nodeLabels")
+	}
+
+	wantUsage := map[utiltas.TopologyDomainID]resources.Requests{
+		"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU:  1,
+			corev1.ResourcePods: 1,
+		}),
+	}
+	if diff := cmp.Diff(updatedNodeLabels, updatedFlavorCache.flavor.NodeLabels); diff != "" {
+		t.Errorf("Unexpected nodeLabels after update (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantUsage, updatedFlavorCache.usage, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("Unexpected usage after updating nodeLabels (-want +got):\n%s", diff)
+	}
+	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
+		t.Error("Workload usage was removed after updating nodeLabels")
+	}
+}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -119,6 +119,12 @@ func (c *TASFlavorCache) updateTolerations(tolerations []corev1.Toleration) {
 	c.flavor.Tolerations = tolerations
 }
 
+func (c *TASFlavorCache) updateNodeLabels(nodeLabels map[string]string) {
+	c.Lock()
+	defer c.Unlock()
+	c.flavor.NodeLabels = nodeLabels
+}
+
 func (c *TASFlavorCache) NodeLabels() map[string]string {
 	return c.flavor.NodeLabels
 }

--- a/pkg/controller/tas/resource_flavor.go
+++ b/pkg/controller/tas/resource_flavor.go
@@ -184,9 +184,10 @@ func (r *rfReconciler) Update(event event.TypedUpdateEvent[*kueue.ResourceFlavor
 	case ptr.Equal(event.ObjectOld.Spec.TopologyName, event.ObjectNew.Spec.TopologyName):
 		if event.ObjectNew.Spec.TopologyName != nil &&
 			(!equality.Semantic.DeepEqual(event.ObjectOld.Spec.Tolerations, event.ObjectNew.Spec.Tolerations) ||
-				!equality.Semantic.DeepEqual(event.ObjectOld.Spec.NodeTaints, event.ObjectNew.Spec.NodeTaints)) {
+				!equality.Semantic.DeepEqual(event.ObjectOld.Spec.NodeTaints, event.ObjectNew.Spec.NodeTaints) ||
+				!equality.Semantic.DeepEqual(event.ObjectOld.Spec.NodeLabels, event.ObjectNew.Spec.NodeLabels)) {
 			log := r.logger().WithValues("flavor", event.ObjectNew.Name)
-			log.V(2).Info("TAS ResourceFlavor tolerations or nodeTaints updated")
+			log.V(2).Info("TAS ResourceFlavor tolerations, nodeTaints or nodeLabels updated")
 			r.cache.AddOrUpdateResourceFlavor(log, event.ObjectNew)
 			return true
 		}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -282,20 +282,20 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should not allow to update nodeLabels", func() {
+		ginkgo.It("should allow to update nodeLabels", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
 			tasFlavor.Spec.NodeLabels = map[string]string{
 				"tas-node": "true",
 			}
-			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("should not allow to delete one of the nodeLabels", func() {
+		ginkgo.It("should allow to remove one of the nodeLabels", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
 			tasFlavor.Spec.NodeLabels = map[string]string{
 				"foo": "bar",
 			}
-			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
+			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.Succeed())
 		})
 	})
 
@@ -538,6 +538,205 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 			ginkgo.By("verifying the pending workload is also retried and admitted", func() {
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+		})
+	})
+
+	ginkgo.When("Updating TAS ResourceFlavor nodeLabels", func() {
+		var (
+			nodes       []corev1.Node
+			topology    *kueue.Topology
+			tasFlavorA  *kueue.ResourceFlavor
+			tasFlavorB  *kueue.ResourceFlavor
+			cqA         *kueue.ClusterQueue
+			cqB         *kueue.ClusterQueue
+			localQueueA *kueue.LocalQueue
+			localQueueB *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			nodes = []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("node-group", "tas-a").
+					Label("region", "all").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("node-group", "tas-b").
+					Label("region", "all").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavorA = utiltestingapi.MakeResourceFlavor("tas-flavor-a").
+				NodeLabel("node-group", "tas-a").
+				TopologyName(topology.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavorA)
+
+			tasFlavorB = utiltestingapi.MakeResourceFlavor("tas-flavor-b").
+				NodeLabel("node-group", "tas-b").
+				TopologyName(topology.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavorB)
+
+			cqA = utiltestingapi.MakeClusterQueue("cluster-queue-a").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavorA.Name).
+					Resource(corev1.ResourceCPU, "4").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cqA)
+
+			cqB = utiltestingapi.MakeClusterQueue("cluster-queue-b").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavorB.Name).
+					Resource(corev1.ResourceCPU, "5").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cqB)
+
+			localQueueA = utiltestingapi.MakeLocalQueue("local-queue-a", ns.Name).
+				ClusterQueue(cqA.Name).
+				Obj()
+			localQueueB = utiltestingapi.MakeLocalQueue("local-queue-b", ns.Name).
+				ClusterQueue(cqB.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueueA, localQueueB)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueueA)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueueB)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cqA, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cqB, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavorA, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavorB, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for i := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+			}
+		})
+
+		makeWorkload := func(name string, lq *kueue.LocalQueue, cpu string) *kueue.Workload {
+			podSet := utiltestingapi.MakePodSet("worker", 1).
+				RequiredTopologyRequest(corev1.LabelHostname).
+				Request(corev1.ResourceCPU, cpu)
+			return utiltestingapi.MakeWorkload(name, ns.Name).
+				Queue(kueue.LocalQueueName(lq.Name)).
+				PodSets(*podSet.Obj()).
+				Obj()
+		}
+
+		updateNodeLabels := func(flavor *kueue.ResourceFlavor, nodeLabels map[string]string) {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedFlavor kueue.ResourceFlavor
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(flavor), &updatedFlavor)).To(gomega.Succeed())
+				updatedFlavor.Spec.NodeLabels = nodeLabels
+				g.Expect(k8sClient.Update(ctx, &updatedFlavor)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		expectAdmittedOnNode := func(wl *kueue.Workload, hostname string) {
+			expected := utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+				Levels:  []string{corev1.LabelHostname},
+				Domains: []utiltas.TopologyDomainAssignment{{Count: 1, Values: []string{hostname}}},
+			})
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+				g.Expect(updated.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(updated.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+				g.Expect(updated.Status.Admission.PodSetAssignments[0].TopologyAssignment).To(gomega.BeComparableTo(expected))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}
+
+		ginkgo.It("should requeue pending workloads and preserve admitted usage and assignments", func() {
+			wl1 := makeWorkload("wl1", localQueueA, "1")
+			ginkgo.By("admitting a workload on the original node set", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+				expectAdmittedOnNode(wl1, "x1")
+			})
+
+			wl2 := makeWorkload("wl2", localQueueA, "2")
+			ginkgo.By("creating a workload that does not fit on the original node set", func() {
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("pointing the flavor nodeLabels at the other node group", func() {
+				updateNodeLabels(tasFlavorA, map[string]string{"node-group": "tas-b"})
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted on the new node set", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+				expectAdmittedOnNode(wl2, "x2")
+			})
+
+			ginkgo.By("verifying the admitted workload keeps its assignment and reservation", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+				expectAdmittedOnNode(wl1, "x1")
+			})
+
+			ginkgo.By("verifying capacity of out-of-scope nodes is no longer admissible", func() {
+				// x2 is fully used by wl2 and x1 is out of the flavor's scope, so
+				// its remaining physical capacity must not admit new workloads.
+				wl3 := makeWorkload("wl3", localQueueA, "1")
+				util.MustCreate(ctx, k8sClient, wl3)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl3)
+			})
+		})
+
+		ginkgo.It("should not double-count usage of a workload admitted on an overlapping flavor", func() {
+			wlA := makeWorkload("wl-a", localQueueA, "1")
+			ginkgo.By("admitting a workload via flavor A on its node", func() {
+				util.MustCreate(ctx, k8sClient, wlA)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA)
+				expectAdmittedOnNode(wlA, "x1")
+			})
+
+			wlB1 := makeWorkload("wl-b1", localQueueB, "2")
+			ginkgo.By("filling flavor B's original node", func() {
+				util.MustCreate(ctx, k8sClient, wlB1)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlB1)
+				expectAdmittedOnNode(wlB1, "x2")
+			})
+
+			ginkgo.By("extending flavor B to also cover flavor A's node", func() {
+				updateNodeLabels(tasFlavorB, map[string]string{"region": "all"})
+			})
+
+			wlB2 := makeWorkload("wl-b2", localQueueB, "1")
+			ginkgo.By("verifying the capacity left by flavor A's workload is admissible exactly once", func() {
+				// x1 has 1 CPU free (2 minus wl-a's 1). If wl-a's usage were
+				// double-counted after the extension, x1 would appear full and
+				// wl-b2 would stay pending.
+				util.MustCreate(ctx, k8sClient, wlB2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlB2)
+				expectAdmittedOnNode(wlB2, "x1")
+			})
+
+			wlB3 := makeWorkload("wl-b3", localQueueB, "1")
+			ginkgo.By("verifying flavor A's usage still counts against the shared node", func() {
+				// Both nodes are now full (x1: wl-a + wl-b2, x2: wl-b1). If
+				// wl-a's usage were invisible to flavor B, x1 would appear to
+				// have capacity left and wl-b3 would be admitted.
+				util.MustCreate(ctx, k8sClient, wlB3)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wlB3)
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change
/area tas

#### What this PR does / why we need it:

Allows updating `spec.nodeLabels` of a TAS ResourceFlavor (one with `topologyName` set). Previously the field was immutable, so retargeting a TAS flavor to a different set of nodes required deleting and recreating the flavor.

This continues the field-by-field mutability work from #13622 (tolerations) and #13647/#13670 (nodeTaints requeue), following the semantics discussed and agreed in #3733:

1. **Admitted workloads keep their ClusterQueue quota reservation.** Quota usage is recorded at admission and is not recomputed from node matching, matching the regular-quota behavior.
2. **The flavor cache updates `nodeLabels` in place**, preserving the per-domain `usage`/`wlUsage` (same pattern as `updateTolerations` from #13622). Each scheduling cycle the snapshot rebuilds the topology tree from the nodes matching the *current* labels; preserved usage rows for domains that fell out of scope are skipped via the existing skip path for deleted/NotReady nodes — no new state migration.
3. **Admitted workloads are not evicted** and their `TopologyAssignment` stays authoritative.
4. **Pending workloads are requeued** after the change (the TAS ResourceFlavor controller update predicate now also fires on `nodeLabels` changes, syncing the cache before retrying inadmissible workloads, which also clears the scheduling-equivalence freeze).
5. **No double-counting across overlapping flavors**: a workload admitted on flavor A is counted exactly once after flavor B's `nodeLabels` are extended to also cover A's nodes.

Verification (red → green):

- Two new integration specs, both failing without the implementation at the predicted steps and passing with it:
  - retargeting the flavor requeues the pending workload onto the new node set, keeps the admitted workload's assignment and reservation, and makes out-of-scope capacity inadmissible;
  - after extending an overlapping flavor, the capacity left by another flavor's admitted workload is admissible exactly once (covers the double-counting concern raised in #3733).
- A new unit test asserting the flavor cache object is preserved across the update and `usage`/`wlUsage` are intact.
- Full TAS integration suite passes (111/111), plus `./pkg/cache/scheduler/...`, `./pkg/controller/tas/...`, and `./apis/...` unit tests.

#### Which issue(s) this PR fixes:

Related to #3733 (implements the `nodeLabels` step of the ResourceFlavor mutability work; the issue tracks the remaining fields and remains open).

#### Special notes for your reviewer:

The change deliberately mirrors #13622's shape: CEL rule removal in both API versions, in-place cache update encapsulated in a `TASFlavorCache` method that owns the lock, and the controller predicate extension. The two previously-negative immutability specs are flipped to positive, as #13622 did for tolerations.

AI disclosure: I used an AI assistant to help investigate the code paths, write the tests, and draft this change. I reviewed all changed lines and verified the behavior with the tests listed above.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Allowed updating `spec.nodeLabels` of a ResourceFlavor with `topologyName` set. Admitted workloads keep their quota reservation and topology assignment, pending workloads are requeued against the new node set, and usage of workloads admitted on overlapping flavors is counted exactly once.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ResourceFlavor node labels can now be updated after creation.
  - TAS scheduling caches refresh node-label changes while preserving existing resource usage and workload assignments.
  - Pending workloads are requeued when label updates affect scheduling capacity.

- **Bug Fixes**
  - Improved handling of updated or removed labels across multiple flavors and ClusterQueues.
  - Prevented double-counting shared workload usage with overlapping flavors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->