### PR TITLE
feat: support Topology-Aware Scheduling (TAS) for Elastic Jobs (`preferred` mode)

### DIFF
--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -242,9 +242,9 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 		return validationErrs, nil
 	}
 
-	// Reject elastic jobs with required/preferred topology (only unconstrained is supported).
-	// TODO: Support for required/preferred modes will be added in a future release.
-	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
+	// Reject elastic jobs with required/preferred topology if TAS integration is disabled.
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) &&
+		!features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
 			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 				"required topology is not supported with elastic jobs")}, nil

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -242,16 +242,18 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 		return validationErrs, nil
 	}
 
-	// Reject elastic jobs with required/preferred topology if TAS integration is disabled.
-	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) &&
-		!features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
+		// Required topology is never supported with elastic jobs.
 		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
 			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 				"required topology is not supported with elastic jobs")}, nil
 		}
-		if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
-			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
-				"preferred topology is not supported with elastic jobs")}, nil
+		// Preferred topology is supported only if TAS integration is enabled.
+		if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+			if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
+				return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
+					"preferred topology is not supported with elastic jobs")}, nil
+			}
 		}
 	}
 

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -243,12 +243,12 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 	}
 
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
-		// Required topology is never supported with elastic jobs.
+		// Required topology is not supported with elastic jobs.
 		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
 			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 				"required topology is not supported with elastic jobs")}, nil
 		}
-		// Preferred topology is supported only if TAS integration is enabled.
+		// Preferred topology requires the ElasticJobsViaWorkloadSlicesWithTAS feature gate.
 		if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 			if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
 				return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -448,12 +448,13 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "elastic job with required topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			name: "elastic job with required topology is rejected even when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
 			job: testingutil.MakeJob("job", "default").
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			wantValidationErrs: nil,
+			wantValidationErrs: field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
+				"required topology is not supported with elastic jobs")},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:             true,
 				features.ElasticJobsViaWorkloadSlices:        true,

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -448,6 +448,32 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "elastic job with required topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			job: testingutil.MakeJob("job", "default").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		{
+			name: "elastic job with preferred topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			job: testingutil.MakeJob("job", "default").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, "cloud.com/block").
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		{
 			name: "elastic job with unconstrained topology is accepted",
 			job: testingutil.MakeJob("job", "default").
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).

--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -28,9 +28,9 @@ import (
 // Sentinel errors for TAS request building, so callers/tests can identify the
 // failure with errors.Is instead of matching on the message text.
 var (
-
-	ErrNoTASCacheInformation                = errors.New("workload requires Topology, but there is no TAS cache information")
-	ErrNoTASFlavorAssigned                  = errors.New("no TAS flavor assigned")
+	ErrElasticRequiredTopologyNotSupported = errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices")
+	ErrNoTASCacheInformation               = errors.New("workload requires Topology, but there is no TAS cache information")
+	ErrNoTASFlavorAssigned                 = errors.New("no TAS flavor assigned")
 )
 
 // MultipleTASFlavorsAssignedError indicates that a PodSet ended up with more

--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -28,8 +28,7 @@ import (
 // Sentinel errors for TAS request building, so callers/tests can identify the
 // failure with errors.Is instead of matching on the message text.
 var (
-	ErrElasticRequiredTopologyNotSupported  = errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices")
-	ErrElasticPreferredTopologyNotSupported = errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices")
+
 	ErrNoTASCacheInformation                = errors.New("workload requires Topology, but there is no TAS cache information")
 	ErrNoTASFlavorAssigned                  = errors.New("no TAS flavor assigned")
 )

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4376,7 +4376,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		workload   workload.Info
 		wantErr    error
 	}{
-		"required topology is rejected with ElasticJobsViaWorkloadSlices": {
+		"required topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4416,9 +4416,9 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticRequiredTopologyNotSupported,
+			wantErr: nil,
 		},
-		"preferred topology is rejected with ElasticJobsViaWorkloadSlices": {
+		"preferred topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4458,9 +4458,9 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticPreferredTopologyNotSupported,
+			wantErr: nil,
 		},
-		"preferred topology is rejected for new elastic workload": {
+		"preferred topology is accepted for new elastic workload": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4489,7 +4489,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticPreferredTopologyNotSupported,
+			wantErr: nil,
 		},
 		"unconstrained topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4389,6 +4389,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
+				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4376,7 +4376,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		workload   workload.Info
 		wantErr    error
 	}{
-		"required topology is accepted with ElasticJobsViaWorkloadSlices": {
+		"required topology is rejected even with ElasticJobsViaWorkloadSlicesWithTAS enabled": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4389,7 +4389,6 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
-				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
@@ -4416,7 +4415,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: nil,
+			wantErr: ErrElasticRequiredTopologyNotSupported,
 		},
 		"preferred topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -58,6 +58,10 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			var previousAssignment *kueue.TopologyAssignment
 
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
+					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
+					continue
+				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -57,16 +57,7 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 
 			var previousAssignment *kueue.TopologyAssignment
 
-			// Only unconstrained topology is supported with elastic workload slices.
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
-				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
-					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
-					continue
-				}
-				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Preferred != nil {
-					a.psError(psAssignment, ErrElasticPreferredTopologyNotSupported)
-					continue
-				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -7336,6 +7336,84 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("should admit elastic workload with preferred topology and scale up", func() {
+			var wl1 *kueue.Workload
+
+			ginkgo.By("create initial workload with 2 pods using preferred topology at block level", func() {
+				wl1 = utiltestingapi.MakeWorkload("wl-preferred", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Obj()
+				wl1.Spec.PodSets[0] = *utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+					Request(corev1.ResourceCPU, "1").
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Image("image").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verify the workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			var originalAssignment *kueue.TopologyAssignment
+			ginkgo.By("verify admission and record the topology assignment", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					g.Expect(wl1.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl1.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				originalAssignment = wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment
+			})
+
+			ginkgo.By("verify the original assignment has slices", func() {
+				gomega.Expect(originalAssignment).ShouldNot(gomega.BeNil())
+				gomega.Expect(originalAssignment.Slices).ShouldNot(gomega.BeEmpty())
+			})
+
+			ginkgo.By("create pods simulating running pods", func() {
+				for i := range 2 {
+					pod := testingpod.MakePod(fmt.Sprintf("pod-preferred-%d", i), ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+						Request(corev1.ResourceCPU, "1").
+						Obj()
+					util.MustCreate(ctx, k8sClient, pod)
+				}
+			})
+
+			var wl2 *kueue.Workload
+			ginkgo.By("create a replacement workload slice with more pods (scale up)", func() {
+				wl2 = utiltestingapi.MakeWorkload("wl-preferred-replacement", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(wl1))).
+					Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+					Obj()
+				wl2.Spec.PodSets[0] = *utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
+					Request(corev1.ResourceCPU, "1").
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Image("image").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the replacement workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the replacement workload has topology assignment", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
+					g.Expect(wl2.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl2.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					newAssignment := wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment
+					g.Expect(newAssignment.Slices).ShouldNot(gomega.BeEmpty())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 
 	ginkgo.When("Multi-layer topology constraints", func() {

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -7411,6 +7411,39 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 					newAssignment := wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment
 					g.Expect(newAssignment.Slices).ShouldNot(gomega.BeEmpty())
+					g.Expect(assignedPodCount(newAssignment)).Should(gomega.Equal(int32(4)))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			var wl3 *kueue.Workload
+			ginkgo.By("create a replacement workload slice with fewer pods (scale down)", func() {
+				wl3 = utiltestingapi.MakeWorkload("wl-preferred-scaledown", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(wl2))).
+					Annotation(kueue.WorkloadSliceNameAnnotation, wl2.Name).
+					Obj()
+				wl3.Spec.PodSets[0] = *utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+					Request(corev1.ResourceCPU, "1").
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Image("image").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl3)
+			})
+
+			ginkgo.By("verify the scale-down workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl3)
+			})
+
+			ginkgo.By("verify the scale-down workload has correct topology assignment", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl3), wl3)).To(gomega.Succeed())
+					g.Expect(wl3.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl3.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(wl3.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					downAssignment := wl3.Status.Admission.PodSetAssignments[0].TopologyAssignment
+					g.Expect(downAssignment.Slices).ShouldNot(gomega.BeEmpty())
+					g.Expect(assignedPodCount(downAssignment)).Should(gomega.Equal(int32(2)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR adds support for **preferred** Topology-Aware Scheduling (TAS) for Elastic Jobs. 

Currently, the Kueue job webhook explicitly rejects all TAS topology annotations for elastic workloads. This change allows the `kueue.x-k8s.io/podset-preferred-topology` annotation to be used on elastic workloads when the `ElasticJobsViaWorkloadSlicesWithTAS` feature gate is enabled. 

The underlying TAS scheduling mechanism gracefully handles the `preferred` topology assignment during elastic scale-ups (using `mergeTopologyAssignments` with a greedy fallback) and scale-downs (using `TruncateAssignment`), so the core addition is relaxing the webhook constraints and allowing the preferred assignments to proceed natively.

**Note:** The `required` topology mode remains explicitly rejected for elastic jobs. Implementing `required` topology for elastic scale-up requires strict guarantees to avoid spanning domains when scaling, which will be tackled in a follow-up PR using a node-hot-swap style iterative algorithm.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to #13640

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Enabled `preferred` Topology-Aware Scheduling (TAS) for Elastic Jobs via the `kueue.x-k8s.io/podset-preferred-topology` annotation when the `ElasticJobsViaWorkloadSlicesWithTAS` feature is enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elastic workloads can now request preferred topology when TAS workload-slice support is enabled.
  * Preferred-topology assignments are supported during elastic workload replacement, scaling up, and scaling down.

* **Bug Fixes**
  * Required topology requests for elastic workloads continue to be rejected.
  * Improved topology validation and admission behavior for elastic workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->