### PR TITLE
feat(tas): implement `required` topology support for elastic scale-up

### DIFF
--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -86,6 +86,43 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	// Previous pods consume capacity.
 	addAssumedUsage(assumedUsage, prevAssignment, &workers)
 
+	if isRequired(workers.PodSet.TopologyRequest) {
+		currAssignment := prevAssignment
+
+		for i := range deltaCount {
+			iterRequest := workers
+			iterRequest.Count = 1
+			iterRequest.PreviousAssignment = nil
+
+			requiredDomain := s.findScaleUpDomain(&iterRequest, currAssignment)
+
+			iterLeader := leader
+			if i > 0 {
+				iterLeader = nil // Only process leader in the first iteration
+			}
+
+			deltaAssignments, reason := s.findTopologyAssignment(ctx, iterRequest, iterLeader, assumedUsage, opts.simulateEmpty, requiredDomain, opts.workload)
+			if reason != "" {
+				result[workers.PodSet.Name] = tasPodSetAssignmentResult{FailureReason: reason}
+				return elasticPlacementResult{applied: true, assignments: result}
+			}
+
+			deltaAssignment := deltaAssignments[workers.PodSet.Name]
+			currAssignment = s.mergeTopologyAssignments(deltaAssignment, currAssignment)
+
+			if iterLeader != nil {
+				result[iterLeader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: deltaAssignments[iterLeader.PodSet.Name]}
+				addAssumedUsage(assumedUsage, deltaAssignments[iterLeader.PodSet.Name], iterLeader)
+			}
+
+			// Add only the 1-pod delta to avoid double-counting.
+			addAssumedUsage(assumedUsage, deltaAssignment, &iterRequest)
+		}
+
+		result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: currAssignment}
+		return elasticPlacementResult{applied: true, assignments: result}
+	}
+
 	deltaAssignments, reason := s.findTopologyAssignment(ctx, deltaRequest, leader, assumedUsage, opts.simulateEmpty, "", opts.workload)
 	if reason != "" {
 		result[workers.PodSet.Name] = tasPodSetAssignmentResult{FailureReason: reason}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -927,6 +927,64 @@ func (s *TASFlavorSnapshot) findIncompleteSliceDomain(tr *TASPodSetRequests, ta 
 	return ""
 }
 
+// findScaleUpDomain finds the bounding domain for scaling up an elastic workload by 1 pod.
+// It first attempts to find a leaf domain that has an incomplete slice, to ensure slices
+// are packed correctly. If no incomplete slices exist, it falls back to the top-level
+// Required topology domain, enforcing the strict scale-up boundary.
+func (s *TASFlavorSnapshot) findScaleUpDomain(tr *TASPodSetRequests, ta *utiltas.TopologyAssignment) utiltas.TopologyDomainID {
+	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(tr.PodSet.TopologyRequest)
+	if reason != "" {
+		return ""
+	}
+
+	if slicesRequested(tr.PodSet.TopologyRequest) {
+		topologyKey := s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel())
+		sliceLevelIdx, found := s.resolveLevelIdx(topologyKey)
+		if found {
+			nodeLevel := len(s.levelKeys) - 1
+			domainToUsage := make(map[utiltas.TopologyDomainID]int32)
+			for _, domainFromAssignment := range ta.Domains {
+				domain, ok := s.domainsPerLevel[nodeLevel][utiltas.DomainID(domainFromAssignment.Values)]
+				if !ok {
+					continue
+				}
+				for i := nodeLevel; i > sliceLevelIdx; i-- {
+					domain = domain.parent
+				}
+				domainToUsage[domain.id] += domainFromAssignment.Count
+			}
+
+			for domainID, count := range domainToUsage {
+				if count%sliceSize != 0 {
+					return domainID
+				}
+			}
+		}
+	}
+
+	if !isRequired(tr.PodSet.TopologyRequest) {
+		return ""
+	}
+
+	levelIdx := slices.Index(s.levelKeys, *tr.PodSet.TopologyRequest.Required)
+	if levelIdx == -1 {
+		return ""
+	}
+	nodeLevel := len(s.levelKeys) - 1
+	domainValues := ta.Domains[0].Values
+	if len(domainValues) == 0 {
+		return ""
+	}
+	domain, found := s.domainsPerLevel[nodeLevel][utiltas.DomainID(domainValues)]
+	if !found {
+		return ""
+	}
+	for i := nodeLevel; i > levelIdx; i-- {
+		domain = domain.parent
+	}
+	return domain.id
+}
+
 // Algorithm overview:
 // Phase 1:
 //

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -242,9 +242,9 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 		return validationErrs, nil
 	}
 
-	// Reject elastic jobs with required/preferred topology (only unconstrained is supported).
-	// TODO: Support for required/preferred modes will be added in a future release.
-	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
+	// Reject elastic jobs with required/preferred topology if TAS integration is disabled.
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) &&
+		!features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
 		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
 			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 				"required topology is not supported with elastic jobs")}, nil

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -242,16 +242,18 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 		return validationErrs, nil
 	}
 
-	// Reject elastic jobs with required/preferred topology if TAS integration is disabled.
-	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) &&
-		!features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
+		// Required topology is never supported with elastic jobs.
 		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
 			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
 				"required topology is not supported with elastic jobs")}, nil
 		}
-		if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
-			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
-				"preferred topology is not supported with elastic jobs")}, nil
+		// Preferred topology is supported only if TAS integration is enabled.
+		if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+			if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
+				return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
+					"preferred topology is not supported with elastic jobs")}, nil
+			}
 		}
 	}
 

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -243,13 +243,12 @@ func (w *JobWebhook) validateTopologyRequest(ctx context.Context, job *Job) (fie
 	}
 
 	if features.Enabled(features.ElasticJobsViaWorkloadSlices) && workloadslicing.Enabled(job.Object()) {
-		// Required topology is never supported with elastic jobs.
-		if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
-			return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
-				"required topology is not supported with elastic jobs")}, nil
-		}
-		// Preferred topology is supported only if TAS integration is enabled.
+		// TAS topology annotations are only supported with elastic jobs if the TAS integration feature gate is enabled.
 		if !features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+			if _, hasRequired := job.Spec.Template.Annotations[kueue.PodSetRequiredTopologyAnnotation]; hasRequired {
+				return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
+					"required topology is not supported with elastic jobs")}, nil
+			}
 			if _, hasPreferred := job.Spec.Template.Annotations[kueue.PodSetPreferredTopologyAnnotation]; hasPreferred {
 				return field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetPreferredTopologyAnnotation),
 					"preferred topology is not supported with elastic jobs")}, nil

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -448,12 +448,13 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "elastic job with required topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			name: "elastic job with required topology is rejected even when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
 			job: testingutil.MakeJob("job", "default").
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			wantValidationErrs: nil,
+			wantValidationErrs: field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
+				"required topology is not supported with elastic jobs")},
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:             true,
 				features.ElasticJobsViaWorkloadSlices:        true,

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -448,13 +448,12 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
-			name: "elastic job with required topology is rejected even when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			name: "elastic job with required topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
 			job: testingutil.MakeJob("job", "default").
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				Obj(),
-			wantValidationErrs: field.ErrorList{field.Forbidden(replicaMetaPath.Child("annotations", kueue.PodSetRequiredTopologyAnnotation),
-				"required topology is not supported with elastic jobs")},
+			wantValidationErrs: nil,
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:             true,
 				features.ElasticJobsViaWorkloadSlices:        true,

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -448,6 +448,32 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "elastic job with required topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			job: testingutil.MakeJob("job", "default").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		{
+			name: "elastic job with preferred topology is accepted when ElasticJobsViaWorkloadSlicesWithTAS is enabled",
+			job: testingutil.MakeJob("job", "default").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				PodAnnotation(kueue.PodSetPreferredTopologyAnnotation, "cloud.com/block").
+				Obj(),
+			wantValidationErrs: nil,
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:             true,
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		{
 			name: "elastic job with unconstrained topology is accepted",
 			job: testingutil.MakeJob("job", "default").
 				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).

--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -28,9 +28,9 @@ import (
 // Sentinel errors for TAS request building, so callers/tests can identify the
 // failure with errors.Is instead of matching on the message text.
 var (
-
-	ErrNoTASCacheInformation                = errors.New("workload requires Topology, but there is no TAS cache information")
-	ErrNoTASFlavorAssigned                  = errors.New("no TAS flavor assigned")
+	ErrElasticRequiredTopologyNotSupported = errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices")
+	ErrNoTASCacheInformation               = errors.New("workload requires Topology, but there is no TAS cache information")
+	ErrNoTASFlavorAssigned                 = errors.New("no TAS flavor assigned")
 )
 
 // MultipleTASFlavorsAssignedError indicates that a PodSet ended up with more

--- a/pkg/scheduler/flavorassigner/errors.go
+++ b/pkg/scheduler/flavorassigner/errors.go
@@ -28,8 +28,7 @@ import (
 // Sentinel errors for TAS request building, so callers/tests can identify the
 // failure with errors.Is instead of matching on the message text.
 var (
-	ErrElasticRequiredTopologyNotSupported  = errors.New("required topology is not supported with ElasticJobsViaWorkloadSlices")
-	ErrElasticPreferredTopologyNotSupported = errors.New("preferred topology is not supported with ElasticJobsViaWorkloadSlices")
+
 	ErrNoTASCacheInformation                = errors.New("workload requires Topology, but there is no TAS cache information")
 	ErrNoTASFlavorAssigned                  = errors.New("no TAS flavor assigned")
 )

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4376,7 +4376,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		workload   workload.Info
 		wantErr    error
 	}{
-		"required topology is rejected with ElasticJobsViaWorkloadSlices": {
+		"required topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4416,9 +4416,9 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticRequiredTopologyNotSupported,
+			wantErr: nil,
 		},
-		"preferred topology is rejected with ElasticJobsViaWorkloadSlices": {
+		"preferred topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4458,9 +4458,9 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticPreferredTopologyNotSupported,
+			wantErr: nil,
 		},
-		"preferred topology is rejected for new elastic workload": {
+		"preferred topology is accepted for new elastic workload": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4489,7 +4489,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticPreferredTopologyNotSupported,
+			wantErr: nil,
 		},
 		"unconstrained topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4376,7 +4376,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		workload   workload.Info
 		wantErr    error
 	}{
-		"required topology is accepted with ElasticJobsViaWorkloadSlices": {
+		"required topology is rejected even with ElasticJobsViaWorkloadSlicesWithTAS enabled": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4389,7 +4389,6 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
-				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
@@ -4416,7 +4415,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: nil,
+			wantErr: ErrElasticRequiredTopologyNotSupported,
 		},
 		"preferred topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4376,7 +4376,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 		workload   workload.Info
 		wantErr    error
 	}{
-		"required topology is rejected even with ElasticJobsViaWorkloadSlicesWithTAS enabled": {
+		"required topology is accepted with ElasticJobsViaWorkloadSlicesWithTAS enabled": {
 			cq: schdcache.ClusterQueueSnapshot{
 				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": tasFlavor},
 			},
@@ -4389,6 +4389,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					Count:  2,
 					Status: *NewStatus(),
 				}},
+				representativeMode: new(Fit),
 				replaceWorkloadSlice: workload.NewInfo(&kueue.Workload{
 					Status: kueue.WorkloadStatus{
 						Admission: &kueue.Admission{
@@ -4415,7 +4416,7 @@ func TestWorkloadsTopologyRequests_ElasticJobsValidation(t *testing.T) {
 					},
 				},
 			}),
-			wantErr: ErrElasticRequiredTopologyNotSupported,
+			wantErr: nil,
 		},
 		"preferred topology is accepted with ElasticJobsViaWorkloadSlices": {
 			cq: schdcache.ClusterQueueSnapshot{

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -58,10 +58,6 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			var previousAssignment *kueue.TopologyAssignment
 
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
-				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
-					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
-					continue
-				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -58,6 +58,10 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 			var previousAssignment *kueue.TopologyAssignment
 
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
+				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
+					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
+					continue
+				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
 

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -57,16 +57,7 @@ func (a *Assignment) WorkloadsTopologyRequests(log logr.Logger, wl *workload.Inf
 
 			var previousAssignment *kueue.TopologyAssignment
 
-			// Only unconstrained topology is supported with elastic workload slices.
 			if workload.IsElasticWorkload(wl.Obj) && features.Enabled(features.ElasticJobsViaWorkloadSlicesWithTAS) {
-				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Required != nil {
-					a.psError(psAssignment, ErrElasticRequiredTopologyNotSupported)
-					continue
-				}
-				if podSet.TopologyRequest != nil && podSet.TopologyRequest.Preferred != nil {
-					a.psError(psAssignment, ErrElasticPreferredTopologyNotSupported)
-					continue
-				}
 				previousAssignment = getPreviousTopologyAssignment(a.replaceWorkloadSlice, podSet.Name)
 			}
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -7336,6 +7336,84 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+
+		ginkgo.It("should admit elastic workload with preferred topology and scale up", func() {
+			var wl1 *kueue.Workload
+
+			ginkgo.By("create initial workload with 2 pods using preferred topology at block level", func() {
+				wl1 = utiltestingapi.MakeWorkload("wl-preferred", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Obj()
+				wl1.Spec.PodSets[0] = *utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+					Request(corev1.ResourceCPU, "1").
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Image("image").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("verify the workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			var originalAssignment *kueue.TopologyAssignment
+			ginkgo.By("verify admission and record the topology assignment", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), wl1)).To(gomega.Succeed())
+					g.Expect(wl1.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl1.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				originalAssignment = wl1.Status.Admission.PodSetAssignments[0].TopologyAssignment
+			})
+
+			ginkgo.By("verify the original assignment has slices", func() {
+				gomega.Expect(originalAssignment).ShouldNot(gomega.BeNil())
+				gomega.Expect(originalAssignment.Slices).ShouldNot(gomega.BeEmpty())
+			})
+
+			ginkgo.By("create pods simulating running pods", func() {
+				for i := range 2 {
+					pod := testingpod.MakePod(fmt.Sprintf("pod-preferred-%d", i), ns.Name).
+						Annotation(kueue.WorkloadAnnotation, wl1.Name).
+						Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+						Request(corev1.ResourceCPU, "1").
+						Obj()
+					util.MustCreate(ctx, k8sClient, pod)
+				}
+			})
+
+			var wl2 *kueue.Workload
+			ginkgo.By("create a replacement workload slice with more pods (scale up)", func() {
+				wl2 = utiltestingapi.MakeWorkload("wl-preferred-replacement", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, string(workload.Key(wl1))).
+					Annotation(kueue.WorkloadSliceNameAnnotation, wl1.Name).
+					Obj()
+				wl2.Spec.PodSets[0] = *utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
+					Request(corev1.ResourceCPU, "1").
+					PreferredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
+					Image("image").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the replacement workload is admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			ginkgo.By("verify the replacement workload has topology assignment", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), wl2)).To(gomega.Succeed())
+					g.Expect(wl2.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(wl2.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
+					g.Expect(wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment).ShouldNot(gomega.BeNil())
+
+					newAssignment := wl2.Status.Admission.PodSetAssignments[0].TopologyAssignment
+					g.Expect(newAssignment.Slices).ShouldNot(gomega.BeEmpty())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 
 	ginkgo.When("Multi-layer topology constraints", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area tas

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR introduces `required` topology support for Elastic Jobs with Topology-Aware Scheduling (TAS).

As discussed in #13640, scaling up with a `required` topology is delicate because we must guarantee that new pods land in the exact same topology domain as the original pods without spanning across domains or fragmenting slices.

To achieve this, this PR adopts the iterative `+1 pod` algorithm (similar to the node-hot-swap logic used in `findReplacementAssignment`). During a scale-up of a `required` elastic job, the assignment is built incrementally by finding a bounding domain (either an incomplete slice leaf or the top-level required domain) for the existing assignment, and placing 1 pod at a time. This guarantees strict boundary adherence and optimal slice packing with an $O(N)$ linear time complexity that is perfectly acceptable for typical scale-up magnitudes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13640 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Support `required` topology requests for elastic jobs when `TopologyAwareScheduling` and `ElasticJobsViaWorkloadSlicesWithTAS` are enabled.
```
