### PR TITLE
Avoid duplicate second-pass queueing when workload is already prequeued

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -975,6 +975,9 @@ func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload
 	log := ctrl.LoggerFrom(ctx)
 	wlKey := workload.Key(w)
 	if workload.NeedsSecondPass(w) {
+		if m.secondPassQueue.prequeued.Has(wlKey) {
+			return false
+		}
 		iteration++
 		delay := m.secondPassQueue.nextDelay(iteration)
 		log.V(3).Info("Workload pre-queued for second pass (with backoff)", "workload", wlKey, "delay", delay)

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -975,13 +975,12 @@ func (m *Manager) QueueSecondPassIfNeeded(ctx context.Context, w *kueue.Workload
 	log := ctrl.LoggerFrom(ctx)
 	wlKey := workload.Key(w)
 	if workload.NeedsSecondPass(w) {
-		if m.secondPassQueue.prequeued.Has(wlKey) {
+		if !m.secondPassQueue.prequeueIfAbsent(w) {
 			return false
 		}
 		iteration++
 		delay := m.secondPassQueue.nextDelay(iteration)
 		log.V(3).Info("Workload pre-queued for second pass (with backoff)", "workload", wlKey, "delay", delay)
-		m.secondPassQueue.prequeue(w)
 		m.clock.AfterFunc(delay, func() {
 			m.queueSecondPass(ctx, w, iteration)
 		})

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2090,10 +2090,11 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 	baseWorkloadNotNeedingSecondPass := baseWorkloadBuilder.Clone()
 
 	cases := map[string]struct {
-		workloads      []*kueue.Workload
-		updateWorkload *kueue.Workload
-		passTime       time.Duration
-		wantReady      sets.Set[workload.Reference]
+		workloads        []*kueue.Workload
+		updateWorkload   *kueue.Workload
+		wantUpdateQueued *bool
+		passTime         time.Duration
+		wantReady        sets.Set[workload.Reference]
 	}{
 		"single queued workload checked immediately": {
 			workloads: []*kueue.Workload{
@@ -2115,8 +2116,9 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			updateWorkload: baseWorkloadNeedingSecondPass.Clone().
 				EvictedAt(now).
 				Obj(),
-			passTime:  time.Second,
-			wantReady: nil,
+			wantUpdateQueued: new(false),
+			passTime:         time.Second,
+			wantReady:        nil,
 		},
 		"two queued workloads, one evicted before second pass": {
 			workloads: []*kueue.Workload{
@@ -2127,8 +2129,18 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 				Name("first").
 				EvictedAt(now).
 				Obj(),
-			passTime:  time.Second,
-			wantReady: sets.New(workload.NewReference("default", "second")),
+			wantUpdateQueued: new(false),
+			passTime:         time.Second,
+			wantReady:        sets.New(workload.NewReference("default", "second")),
+		},
+		"one workload gets queued twice, don't queue if already in present in queue": {
+			workloads: []*kueue.Workload{
+				baseWorkloadNeedingSecondPass.Clone().Obj(),
+			},
+			updateWorkload:   baseWorkloadNeedingSecondPass.Clone().Obj(),
+			wantUpdateQueued: new(false),
+			passTime:         time.Second,
+			wantReady:        sets.New(workload.Key(baseWorkloadNeedingSecondPass.Obj())),
 		},
 	}
 
@@ -2148,7 +2160,10 @@ func TestQueueSecondPassIfNeeded(t *testing.T) {
 			}
 
 			if tc.updateWorkload != nil {
-				manager.QueueSecondPassIfNeeded(ctx, tc.updateWorkload, 1)
+				got := manager.QueueSecondPassIfNeeded(ctx, tc.updateWorkload, 1)
+				if tc.wantUpdateQueued != nil && got != *tc.wantUpdateQueued {
+					t.Errorf("Unexpected return from QueueSecondPassIfNeeded for updateWorkload: want %v, got %v", *tc.wantUpdateQueued, got)
+				}
 			}
 
 			fakeClock.Step(tc.passTime)

--- a/pkg/cache/queue/second_pass_queue.go
+++ b/pkg/cache/queue/second_pass_queue.go
@@ -62,11 +62,16 @@ func (q *secondPassQueue) takeAllReady() []workload.Info {
 	return result
 }
 
-func (q *secondPassQueue) prequeue(obj *kueue.Workload) {
+func (q *secondPassQueue) prequeueIfAbsent(obj *kueue.Workload) bool {
 	q.Lock()
 	defer q.Unlock()
 
-	q.prequeued.Insert(workload.Key(obj))
+	key := workload.Key(obj)
+	if q.prequeued.Has(key) {
+		return false
+	}
+	q.prequeued.Insert(key)
+	return true
 }
 
 func (q *secondPassQueue) queue(w *workload.Info) bool {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Prevents re-queuing workloads for a second pass of scheduling if the workload is already present in the `secondPassQueue.prequeued` set.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for your reviewer:

https://github.com/kubernetes-sigs/kueue/pull/13063#discussion_r3702929769

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed an issue in queue management where workloads requiring a second pass of scheduling could be pre-queued multiple times concurrently, causing duplicate backoff timer callbacks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate scheduling of workloads already queued for second-pass processing.
  * Ensured evicted workloads and repeated queue attempts are not requeued.
  * Preserved expected readiness behavior for valid second-pass processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->