### PR TITLE
Cherry-pick [release-0.19] cleanup: eliminate concrete uses of MapRequests outside pkg/resources

### DIFF
--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -476,7 +476,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 5000}),
+									Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 5000}),
 									Count:    1,
 									Flavors:  map[corev1.ResourceName]kueue.ResourceFlavorReference{corev1.ResourceCPU: "default"},
 								},
@@ -920,7 +920,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+									Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",
@@ -933,7 +933,7 @@ func TestCacheClusterQueueOperations(t *testing.T) {
 							TotalRequests: []workload.PodSetResources{
 								{
 									Name:     kueue.DefaultPodSetName,
-									Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+									Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
 									Count:    1,
 									Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 										corev1.ResourceCPU: "f1",

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -201,14 +201,14 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 			c.usage[domainID].Sub(tr.TotalRequests())
 			c.usage[domainID].Sub(
 				resources.NewRequestsFromMap(
-					resources.MapRequests{corev1.ResourcePods: int64(tr.Count)},
+					map[corev1.ResourceName]int64{corev1.ResourcePods: int64(tr.Count)},
 				),
 			)
 		} else {
 			c.usage[domainID].Add(tr.TotalRequests())
 			c.usage[domainID].Add(
 				resources.NewRequestsFromMap(
-					resources.MapRequests{corev1.ResourcePods: int64(tr.Count)},
+					map[corev1.ResourceName]int64{corev1.ResourcePods: int64(tr.Count)},
 				),
 			)
 		}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -329,7 +329,7 @@ func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, us
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
 	u := usage.Clone()
-	u.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: int64(count)}))
+	u.Add(resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourcePods: int64(count)}))
 	if op == add {
 		s.addTASUsage(domainID, u)
 	} else {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -46,22 +46,22 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 			leaves: func() leafDomainByID {
 				return leafDomainByID{
 					"domain2": &leafDomain{
-						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    1000,
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
 						}),
-						tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
+						tasUsage: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 1 * 1024 * 1024 * 1024, // 1 GiB
 							corev1.ResourceCPU:    500,
 						}),
 					},
 					"domain1": &leafDomain{
-						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
 							corev1.ResourceCPU:    2000,
 							"nvidia.com/gpu":      1,
 						}),
-						tasUsage: resources.NewRequestsFromMap(resources.MapRequests{
+						tasUsage: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    500,
 							"nvidia.com/gpu":      1,
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
@@ -75,7 +75,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 			leaves: func() leafDomainByID {
 				return leafDomainByID{
 					"domain1": &leafDomain{
-						freeCapacity: resources.NewRequestsFromMap(resources.MapRequests{
+						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1000,
 						}),
 						// tasUsage is left nil, as there is no TAS workload
@@ -793,7 +793,7 @@ func TestCountPodsInAssignment(t *testing.T) {
 }
 
 func TestComputeAssumedUsageFromAssignment(t *testing.T) {
-	singlePodRequests := resources.NewRequestsFromMap(resources.MapRequests{
+	singlePodRequests := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 		corev1.ResourceCPU:    1000,
 		corev1.ResourceMemory: 1024,
 	})
@@ -817,7 +817,7 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 				},
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 1024,
 					corev1.ResourcePods:   1,
@@ -833,12 +833,12 @@ func TestComputeAssumedUsageFromAssignment(t *testing.T) {
 				},
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    2000,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
 				}),
-				"node-b": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-b": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    3000,
 					corev1.ResourceMemory: 3072,
 					corev1.ResourcePods:   3,
@@ -866,7 +866,7 @@ func TestAddAssumedUsage(t *testing.T) {
 	}{
 		"includes pod count for existing and new domains": {
 			assumedUsage: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:  1000,
 					corev1.ResourcePods: 1,
 				}),
@@ -879,18 +879,18 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+				SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    500,
 					corev1.ResourceMemory: 2048,
 				}),
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    1500,
 					corev1.ResourceMemory: 2048,
 					corev1.ResourcePods:   2,
 				}),
-				"node-b": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-b": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    1000,
 					corev1.ResourceMemory: 4096,
 					corev1.ResourcePods:   2,
@@ -906,13 +906,13 @@ func TestAddAssumedUsage(t *testing.T) {
 				},
 			},
 			tasRequests: &TASPodSetRequests{
-				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+				SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    250,
 					corev1.ResourceMemory: 512,
 				}),
 			},
 			want: map[tas.TopologyDomainID]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:    750,
 					corev1.ResourceMemory: 1536,
 					corev1.ResourcePods:   3,
@@ -1068,7 +1068,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			flavorUsage := workload.TASFlavorUsage{
 				{
 					Values: []string{"node-a"},
-					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 5000,
 					}),
 					Count: 1,
@@ -1079,7 +1079,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
 
 			// Add TAS usage of 4 CPU (4000m), leaving 4 CPU (8000m - 4000m = 4000m) remaining
-			usage := resources.NewRequestsFromMap(resources.MapRequests{
+			usage := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 				corev1.ResourceCPU: 4000,
 			})
 			snapshot.updateTASUsage(domainID, usage, add, 1)

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -45,14 +45,14 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  2,
-						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 2,
 						}),
 					},
 				})
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:  4,
 					corev1.ResourcePods: 2,
 				}),
@@ -66,7 +66,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1,
 						}),
 					},
@@ -76,18 +76,18 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain2"},
 						Count:  2,
-						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 3,
 						}),
 					},
 				})
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
 				}),
-				"domain2": resources.NewRequestsFromMap(resources.MapRequests{
+				"domain2": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:  6,
 					corev1.ResourcePods: 2,
 				}),
@@ -100,7 +100,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 					{
 						Values: []string{"domain1"},
 						Count:  1,
-						SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1,
 						}),
 					},
@@ -108,7 +108,7 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 				cache.removeUsage(logr, wlKey)
 			},
 			wantUsage: map[utiltas.TopologyDomainID]resources.Requests{
-				"domain1": resources.NewRequestsFromMap(resources.MapRequests{
+				"domain1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:  0,
 					corev1.ResourcePods: 0,
 				}),

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -65,7 +65,7 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
 	}
 
 	log.V(5).Info("Adding non-TAS pod to the cache")
-	requests := resources.NewMapRequestsFromPodSpec(&pod.Spec)
+	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
 	n.podUsage[key] = podUsageValue{
 		node:  pod.Spec.NodeName,
 		usage: requests,

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -94,7 +94,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				makePod("pod2", "ns", "node-a", "2"),
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 3000, corev1.ResourcePods: 2}),
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 3000, corev1.ResourcePods: 2}),
 			},
 		},
 		"pod moves between nodes cleans up source node": {
@@ -103,7 +103,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.NodeName = "node-b"
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-b": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
+				"node-b": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
 			},
 		},
 		"pod resize on same node updates usage to new requests": {
@@ -112,7 +112,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("4")
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 4000, corev1.ResourcePods: 1}),
 			},
 		},
 		"resize one of two pods on same node updates only that pod's contribution": {
@@ -124,7 +124,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 				pods[0].Spec.Containers[0].Resources.Requests[corev1.ResourceCPU] = resource.MustParse("3")
 			},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 5000, corev1.ResourcePods: 2}),
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 5000, corev1.ResourcePods: 2}),
 			},
 		},
 		"terminated pod removes usage": {
@@ -143,7 +143,7 @@ func TestNonTasUsageCacheIncrementalUpdates(t *testing.T) {
 			},
 			podsDelete: []client.ObjectKey{{Namespace: "ns", Name: "pod1"}},
 			wantNodeUsage: map[string]resources.Requests{
-				"node-a": resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1}),
+				"node-a": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1}),
 			},
 		},
 		"removing last pod cleans up node entry": {

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -209,7 +209,7 @@ func GetResourceRequestsForResourceClaimTemplates(
 				return nil, allErrs
 			}
 
-			for dc, qty := range resources.ToMapRequests(deviceCounts) {
+			for dc, qty := range deviceCounts.Iter() {
 				logical, found := mapper.Lookup(dc)
 				if !found {
 					allErrs = append(allErrs, field.NotFound(

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -48,16 +48,16 @@ func CreateEmpty() Requests {
 	return MapRequests{}
 }
 
-// NewRequestsFromMap creates a Requests instance from a MapRequests map based on feature gates.
-func NewRequestsFromMap(m MapRequests) Requests {
+// NewRequestsFromMap creates a Requests instance from a map based on feature gates.
+func NewRequestsFromMap(m map[corev1.ResourceName]int64) Requests {
 	if len(m) == 0 {
-		return nil
+		return CreateEmpty()
 	}
 	if features.Enabled(features.VectorizedResourceRequests) {
-		sr := toSliceRequests(m)
+		sr := toSliceRequests(MapRequests(m))
 		return &sr
 	}
-	return m
+	return MapRequests(m)
 }
 
 // NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
@@ -78,8 +78,25 @@ func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	return NewRequestsFromResourceList(rl)
 }
 
-// ToMapRequests converts any Requests instance into a MapRequests map.
-func ToMapRequests(r Requests) MapRequests {
+// NewRequestsFromResourceListRetainZero creates a Requests instance from a corev1.ResourceList,
+// ensuring that explicitly zero-valued resources are retained.
+func NewRequestsFromResourceListRetainZero(rl corev1.ResourceList) Requests {
+	// For now, returning MapRequests ensures zeroes are retained regardless of feature gates.
+	return NewMapRequests(rl)
+}
+
+// NewRequestsFromPodSpecRetainZero creates a Requests instance from a PodSpec,
+// ensuring that explicitly zero-valued resources are retained.
+func NewRequestsFromPodSpecRetainZero(podSpec *corev1.PodSpec) Requests {
+	if podSpec == nil {
+		return CreateEmpty()
+	}
+	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
+	return NewRequestsFromResourceListRetainZero(rl)
+}
+
+// ToMap converts any Requests instance into a MapRequests map.
+func ToMap(r Requests) map[corev1.ResourceName]int64 {
 	if isEmpty(r) {
 		return nil
 	}

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package resources
 
 import (
+	"iter"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -34,6 +36,7 @@ type Requests interface {
 	GetValue(name corev1.ResourceName) int64
 	Set(name corev1.ResourceName, val int64)
 	ForEach(fn func(name corev1.ResourceName, val int64))
+	Iter() iter.Seq2[corev1.ResourceName, int64]
 	Len() int
 	IsEmpty() bool
 	// FloorToZero replaces negative resource values with zero.

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"iter"
 	"maps"
 	"math"
 
@@ -151,7 +152,7 @@ func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(r) == 0 || isEmpty(other) {
 		return nil
 	}
-	otherMap := ToMapRequests(other)
+	otherMap := ToMap(other)
 	var result []corev1.ResourceName
 	for name, value := range r {
 		if otherValue, found := otherMap[name]; found && value > otherValue {
@@ -219,4 +220,14 @@ func CountInWithLimitingResource(requests Requests, capacity Requests) (int32, c
 		}
 	})
 	return ptr.Deref(result, 0), limitingResource
+}
+
+func (r MapRequests) Iter() iter.Seq2[corev1.ResourceName, int64] {
+	return func(yield func(corev1.ResourceName, int64) bool) {
+		for k, v := range r {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
 }

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -532,14 +532,14 @@ func TestLazyRequests(t *testing.T) {
 				t.Errorf("expected cachedCreated=%t, got cached=%v", tc.wantCachedCreated, lazy.cached)
 			}
 
-			gotResult := ToMapRequests(lazy.Get())
+			gotResult := MapRequests(ToMap(lazy.Get()))
 			wantResult := tc.wantResult
 			if diff := cmp.Diff(wantResult, gotResult); diff != "" {
 				t.Errorf("unexpected Get() result, diff (-want +got):\n%s", diff)
 			}
 
 			if base != nil {
-				if diff := cmp.Diff(ToMapRequests(originalBase), ToMapRequests(base)); diff != "" {
+				if diff := cmp.Diff(MapRequests(ToMap(originalBase)), MapRequests(ToMap(base))); diff != "" {
 					t.Errorf("base map was mutated! diff (-want +got):\n%s", diff)
 				}
 			}
@@ -593,7 +593,7 @@ func TestFloorToZero(t *testing.T) {
 				r = &SliceRequests{}
 			}
 			r.FloorToZero()
-			got := ToMapRequests(r)
+			got := MapRequests(ToMap(r))
 			want := tc.want
 			if len(want) == 0 {
 				want = nil
@@ -765,7 +765,7 @@ func TestMapRequestsClone(t *testing.T) {
 	})
 }
 
-func TestToMapRequests(t *testing.T) {
+func TestToMap(t *testing.T) {
 	cases := map[string]struct {
 		req  Requests
 		want MapRequests
@@ -801,9 +801,9 @@ func TestToMapRequests(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := ToMapRequests(tc.req)
+			got := MapRequests(ToMap(tc.req))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ToMapRequests mismatch (-want +got):\n%s", diff)
+				t.Errorf("ToMap mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -45,12 +45,15 @@ func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 	return json.Marshal(temp)
 }
 
-func (frq FlavorResourceQuantities) FlattenFlavors() MapRequests {
-	result := MapRequests{}
+func (frq FlavorResourceQuantities) FlattenFlavors() Requests {
+	if len(frq) == 0 {
+		return CreateEmpty()
+	}
+	result := map[corev1.ResourceName]int64{}
 	for key, val := range frq {
 		result[key.Resource] += val.Int64()
 	}
-	return result
+	return NewRequestsFromMap(result)
 }
 
 // Clone returns a shallow copy of the map.

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"cmp"
 	"hash/fnv"
+	"iter"
 	"math"
 	"slices"
 	"strings"
@@ -104,8 +105,8 @@ func ResourceListToSliceRequests(rl corev1.ResourceList) SliceRequests {
 	return sr
 }
 
-// ToMapRequests converts a SliceRequests back to a MapRequests map.
-func (sr *SliceRequests) ToMapRequests() MapRequests {
+// ToMap converts a SliceRequests back to a MapRequests map.
+func (sr *SliceRequests) ToMap() map[corev1.ResourceName]int64 {
 	if sr.IsEmpty() {
 		return nil
 	}
@@ -394,5 +395,18 @@ func (sr *SliceRequests) FloorToZero() {
 	}
 	for i := range *sr {
 		(*sr)[i].value = max((*sr)[i].value, 0)
+	}
+}
+
+func (r *SliceRequests) Iter() iter.Seq2[corev1.ResourceName, int64] {
+	return func(yield func(corev1.ResourceName, int64) bool) {
+		if r == nil {
+			return
+		}
+		for _, req := range *r {
+			if !yield(req.name, req.value) {
+				return
+			}
+		}
 	}
 }

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -109,12 +109,12 @@ func checkRequestsEquivalence(t *testing.T, opName string, mapRes Requests, slic
 		if m, ok := mapRes.(MapRequests); ok {
 			mapM = normalizeMap(m)
 		} else if s, ok := mapRes.(*SliceRequests); ok {
-			mapM = normalizeMap(s.ToMapRequests())
+			mapM = normalizeMap(MapRequests(s.ToMap()))
 		}
 	}
 	if sliceRes != nil {
 		if s, ok := sliceRes.(*SliceRequests); ok {
-			sliceM = normalizeMap(s.ToMapRequests())
+			sliceM = normalizeMap(MapRequests(s.ToMap()))
 		} else if m, ok := sliceRes.(MapRequests); ok {
 			sliceM = normalizeMap(m)
 		}

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -77,17 +77,17 @@ func TestSliceRequests_Conversion(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			sr := toSliceRequests(tc.input)
-			got := sr.ToMapRequests()
+			got := MapRequests(sr.ToMap())
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ToMapRequests mismatch (-want +got):\n%s", diff)
+				t.Errorf("ToMap mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
 
-	t.Run("nil_receiver_ToMapRequests", func(t *testing.T) {
+	t.Run("nil_receiver_ToMap", func(t *testing.T) {
 		var nilSR *SliceRequests
-		if got := nilSR.ToMapRequests(); got != nil {
-			t.Errorf("expected nil for nil receiver ToMapRequests, got %v", got)
+		if got := MapRequests(nilSR.ToMap()); got != nil {
+			t.Errorf("expected nil for nil receiver ToMap, got %v", got)
 		}
 	})
 }
@@ -125,7 +125,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 
 		base.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
-		if diff := cmp.Diff(want, base.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(base.ToMap())); diff != "" {
 			t.Errorf("mismatch with sufficient capacity (-want +got):\n%s", diff)
 		}
 	})
@@ -136,7 +136,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 
 		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("mismatch with insufficient capacity (-want +got):\n%s", diff)
 		}
 	})
@@ -145,7 +145,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048})
 		sr.mergeWithInPlace(*sr, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 2000, corev1.ResourceMemory: 4096}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("mismatch on self merge (-want +got):\n%s", diff)
 		}
 	})
@@ -155,7 +155,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a - b })
 		want := MapRequests{corev1.ResourceCPU: 0, corev1.ResourceMemory: 2048}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("mismatch on zero drop merge (-want +got):\n%s", diff)
 		}
 	})
@@ -165,7 +165,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		other := *NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("mismatch on empty receiver merge (-want +got):\n%s", diff)
 		}
 	})
@@ -175,7 +175,7 @@ func TestSliceRequests_MergeWithInPlace(t *testing.T) {
 		var other SliceRequests
 		sr.mergeWithInPlace(other, func(a, b int64) int64 { return a + b })
 		want := MapRequests{corev1.ResourceCPU: 1000}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("mismatch on empty operand merge (-want +got):\n%s", diff)
 		}
 	})
@@ -191,7 +191,7 @@ func TestSliceRequests_ResourceList(t *testing.T) {
 		corev1.ResourceCPU:    2000,
 		corev1.ResourceMemory: 4 * 1024 * 1024 * 1024,
 	}
-	if diff := cmp.Diff(wantMap, sr.ToMapRequests()); diff != "" {
+	if diff := cmp.Diff(wantMap, MapRequests(sr.ToMap())); diff != "" {
 		t.Errorf("ResourceListToSliceRequests mismatch (-want +got):\n%s", diff)
 	}
 
@@ -242,7 +242,7 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 			} else {
 				sr.Sub(opSr)
 			}
-			if diff := cmp.Diff(tc.want, sr.ToMapRequests()); diff != "" {
+			if diff := cmp.Diff(tc.want, MapRequests(sr.ToMap())); diff != "" {
 				t.Errorf("mismatch after %s (-want +got):\n%s", tc.op, diff)
 			}
 		})
@@ -261,13 +261,13 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 		sr := NewSliceRequests(MapRequests{corev1.ResourceCPU: 1000})
 		sr.Add(MapRequests{corev1.ResourceMemory: 2048})
 		want := MapRequests{corev1.ResourceCPU: 1000, corev1.ResourceMemory: 2048}
-		if diff := cmp.Diff(want, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(want, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("Add MapRequests mismatch (-want +got):\n%s", diff)
 		}
 
 		sr.Sub(MapRequests{corev1.ResourceCPU: 500})
 		wantSub := MapRequests{corev1.ResourceCPU: 500, corev1.ResourceMemory: 2048}
-		if diff := cmp.Diff(wantSub, sr.ToMapRequests()); diff != "" {
+		if diff := cmp.Diff(wantSub, MapRequests(sr.ToMap())); diff != "" {
 			t.Errorf("Sub MapRequests mismatch (-want +got):\n%s", diff)
 		}
 	})
@@ -362,7 +362,7 @@ func TestSliceRequests_ScaledUp(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.ScaledUp(tc.factor)
-			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
+			if diff := cmp.Diff(ToMap(tc.want), ToMap(got)); diff != "" {
 				t.Errorf("ScaledUp mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -387,7 +387,7 @@ func TestSliceRequests_Clone(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.Clone()
-			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
+			if diff := cmp.Diff(ToMap(tc.want), ToMap(got)); diff != "" {
 				t.Errorf("Clone mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -521,7 +521,7 @@ func TestSliceRequests_Set(t *testing.T) {
 			for _, s := range tc.sets {
 				tc.req.Set(s.name, s.val)
 			}
-			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+			if diff := cmp.Diff(tc.want, MapRequests(tc.req.ToMap())); diff != "" {
 				t.Errorf("Set mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -549,7 +549,7 @@ func TestSliceRequests_ScaledDown(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got := tc.req.ScaledDown(tc.factor)
-			if diff := cmp.Diff(ToMapRequests(tc.want), ToMapRequests(got)); diff != "" {
+			if diff := cmp.Diff(ToMap(tc.want), ToMap(got)); diff != "" {
 				t.Errorf("ScaledDown mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -576,7 +576,7 @@ func TestSliceRequests_Divide(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.req.Divide(tc.divisor)
-			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+			if diff := cmp.Diff(tc.want, MapRequests(tc.req.ToMap())); diff != "" {
 				t.Errorf("Divide mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -608,7 +608,7 @@ func TestSliceRequests_Mul(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			tc.req.Mul(tc.factor)
-			if diff := cmp.Diff(tc.want, tc.req.ToMapRequests()); diff != "" {
+			if diff := cmp.Diff(tc.want, MapRequests(tc.req.ToMap())); diff != "" {
 				t.Errorf("Mul mismatch (-want +got):\n%s", diff)
 			}
 		})

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -690,7 +690,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			if podSet.Requests != nil {
 				podSet.Requests.Set(corev1.ResourcePods, int64(podSet.Count))
 			} else {
-				podSet.Requests = resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: int64(podSet.Count)})
+				podSet.Requests = resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourcePods: int64(podSet.Count)})
 			}
 		}
 
@@ -749,7 +749,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			maps.Copy(groupFlavors, ips.podSetAssignment.Flavors)
 		}
 		var groupStatus Status
-		for resName, quantity := range resources.ToMapRequests(requests) {
+		for resName, quantity := range requests.Iter() {
 			// Skip zero-quantity requests for resources not defined in the ClusterQueue (#8079) or
 			// If quotaCheckStrategy is IgnoreUndeclared, skip resources not declared in the ClusterQueue.
 			if a.cq.RGByResource(resName) == nil {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3328,7 +3328,7 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
 						}),
@@ -3394,7 +3394,7 @@ func TestAssignFlavors(t *testing.T) {
 				TotalRequests: []workload.PodSetResources{
 					{
 						Name: "main",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    2000,
 							corev1.ResourceMemory: 10 * utiltesting.Mi,
 						}),

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -70,7 +70,7 @@ func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *
 		if resNames := resources.NewRequestsFromResourceList(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewRequestsFromResourceList(containerRange.Min).GreaterKeys(resources.NewMapRequests(cMin)); len(resNames) > 0 {
+		if resNames := resources.NewRequestsFromResourceList(containerRange.Min).GreaterKeys(resources.NewRequestsFromResourceListRetainZero(cMin)); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}
@@ -83,11 +83,11 @@ func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) field.Err
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.InitContainers, path.Child("initContainers"))...)
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.Containers, path.Child("containers"))...)
 	if podRange, found := s[corev1.LimitTypePod]; found {
-		total := resources.NewMapRequestsFromPodSpec(ps)
+		total := resources.NewRequestsFromPodSpecRetainZero(ps)
 		if resNames := total.GreaterKeysRL(podRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewMapRequests(podRange.Min).GreaterKeys(total); len(resNames) > 0 {
+		if resNames := resources.NewRequestsFromResourceList(podRange.Min).GreaterKeys(total); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	testingutil "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
@@ -149,6 +150,7 @@ func TestValidatePodSpec(t *testing.T) {
 	}
 	cases := map[string]struct {
 		summary Summary
+		podSpec *corev1.PodSpec
 		want    field.ErrorList
 	}{
 		"empty": {
@@ -269,10 +271,55 @@ func TestValidatePodSpec(t *testing.T) {
 					Obj(),
 			),
 		},
+		"container under with explicit zero": {
+			summary: Summarize(*testingutil.MakeLimitRange("", "").
+				WithType(corev1.LimitTypeContainer).
+				WithValue("Min", "example.com/mainContainerGpu", "3").
+				Obj()),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					*testingutil.MakeContainer().
+						WithResourceReq("example.com/mainContainerGpu", "0").
+						Obj(),
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(
+					podSpecPath.Child("containers").Index(0),
+					[]corev1.ResourceName{"example.com/mainContainerGpu"},
+					RequestsMustNotBeBelowLimitRangeMinMessage,
+				),
+			},
+		},
+		"pod under with explicit zero": {
+			summary: Summarize(*testingutil.MakeLimitRange("", "").
+				WithType(corev1.LimitTypePod).
+				WithValue("Min", corev1.ResourceCPU, "6").
+				Obj()),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					*testingutil.MakeContainer().
+						WithResourceReq(corev1.ResourceCPU, "0").
+						Obj(),
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(
+					podSpecPath,
+					[]corev1.ResourceName{corev1.ResourceCPU},
+					RequestsMustNotBeBelowLimitRangeMinMessage,
+				),
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			result := tc.summary.ValidatePodSpec(podSpec, podSpecPath)
+			features.SetFeatureGateDuringTest(t, features.VectorizedResourceRequests, true)
+			ps := tc.podSpec
+			if ps == nil {
+				ps = podSpec
+			}
+			result := tc.summary.ValidatePodSpec(ps, podSpecPath)
 			if diff := cmp.Diff(tc.want, result); diff != "" {
 				t.Errorf("Unexpected result (-want,+got):\n%s", diff)
 			}

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -561,7 +561,7 @@ func ComputeUsagePerDomain(ta *TopologyAssignment, singlePodRequests resources.R
 	for _, domain := range ta.Domains {
 		domainID := DomainID(domain.Values)
 		domainUsage := singlePodRequests.ScaledUp(int64(domain.Count))
-		domainUsage.Add(resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourcePods: int64(domain.Count)}))
+		domainUsage.Add(resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourcePods: int64(domain.Count)}))
 		usage[domainID] = domainUsage
 	}
 	return usage

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -376,7 +376,7 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 			"name":            ps.Name,
 			"spec":            utilpod.SpecShape(&ps.Template.Spec),
 			"count":           effectiveCount,
-			"requests":        resources.ToMapRequests(effectiveRequests),
+			"requests":        resources.ToMap(effectiveRequests),
 			"minCount":        ps.MinCount,
 			"topologyRequest": ps.TopologyRequest,
 		})

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -152,7 +152,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						}),
@@ -174,7 +174,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    0,
 							corev1.ResourceMemory: 2 * 512 * 1024,
 						}),
@@ -202,7 +202,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 512 * 1024,
 						}),
@@ -230,7 +230,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 512 * 1024,
 						}),
@@ -253,7 +253,7 @@ func TestNewInfo(t *testing.T) {
 					{
 						Name:  kueue.DefaultPodSetName,
 						Count: 2147483647,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 9223372036854775807,
 						}),
 					},
@@ -303,7 +303,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "driver",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						}),
@@ -314,7 +314,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "workers",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    15,
 							corev1.ResourceMemory: 3 * 1024 * 1024,
 							"ex.com/gpu":          3,
@@ -361,7 +361,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceMemory:     "tas",
 							"example.com/logical-gpu": "quota",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:        2000,
 							corev1.ResourceMemory:     2 * 1024 * 1024 * 1024,
 							"example.com/logical-gpu": 2,
@@ -371,7 +371,7 @@ func TestNewInfo(t *testing.T) {
 							Levels: []string{corev1.LabelHostname},
 							DomainRequests: []TopologyDomainRequests{{
 								Values: []string{"node-a"},
-								SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{
+								SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 									corev1.ResourceCPU:           1000,
 									corev1.ResourceMemory:        1024 * 1024 * 1024,
 									"example.com/gpu":            1,
@@ -416,7 +416,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
 						}),
@@ -457,7 +457,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    5 * 10,
 							corev1.ResourceMemory: 5 * 10 * 1024,
 						}),
@@ -500,7 +500,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    2 * 10,
 							corev1.ResourceMemory: 2 * 10 * 1024,
 						}),
@@ -541,7 +541,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    0,
 							corev1.ResourceMemory: 0,
 						}),
@@ -576,7 +576,7 @@ func TestNewInfo(t *testing.T) {
 							corev1.ResourceCPU:    "f1",
 							corev1.ResourceMemory: "f1",
 						},
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    3 * 10,
 							corev1.ResourceMemory: 3 * 10 * 1024,
 						}),
@@ -596,7 +596,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: kueue.DefaultPodSetName,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    10,
 							corev1.ResourceMemory: 512 * 1024,
 						}),
@@ -675,7 +675,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "a",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 20 * 1024,
 							corev1.ResourceName("example.com/credits"):            35,
@@ -684,7 +684,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "b",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 4 * 1000,
 							corev1.ResourceName("example.com/accelerator-memory"): 80 * 1024,
 							corev1.ResourceName("example.com/credits"):            200,
@@ -694,7 +694,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "c",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceName("nvidia.com/vgpu"):            2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 20,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 1024,
@@ -703,7 +703,7 @@ func TestNewInfo(t *testing.T) {
 					},
 					{
 						Name: "d",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceName("nvidia.com/vgpu"):            2 * 2,
 							corev1.ResourceName("nvidia.com/total-vgpucores"): 2 * 2 * 30,
 							corev1.ResourceName("nvidia.com/total-vgpumem"):   2 * 2 * 2048,
@@ -742,7 +742,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							// 100m * 3000 = 300
 							corev1.ResourceName("example.com/cpu-credits"): 300,
 							// 100M * 3m = 300k
@@ -783,7 +783,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request(corev1.ResourceCPU, "200m").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 200}),
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 200}),
 				Count:    1,
 			}},
 		},
@@ -806,7 +806,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Request("example.com/gpu", "1").Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.NewRequestsFromMap(resources.MapRequests{"example.com/gpu": 1}),
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"example.com/gpu": 1}),
 				Count:    1,
 			}},
 		},
@@ -824,7 +824,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Obj(),
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 200}),
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 200}),
 				Count:    1,
 			}},
 		},
@@ -846,7 +846,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 			updateOptions: []InfoOption{WithPreserveTotalRequests()},
 			wantRequests: []PodSetResources{{
 				Name:     kueue.DefaultPodSetName,
-				Requests: resources.NewRequestsFromMap(resources.MapRequests{"gpu": 1}),
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 1}),
 				Count:    1,
 			}},
 		},
@@ -1283,7 +1283,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, no flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					}),
@@ -1297,7 +1297,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 		"one podset, multiple flavors": {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1_000,
 						"example.com/gpu":  3,
 					}),
@@ -1316,7 +1316,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{
 					{
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1_000,
 							"example.com/gpu":  3,
 						}),
@@ -1326,7 +1326,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    2_000,
 							corev1.ResourceMemory: 2 * utiltesting.Gi,
 						}),
@@ -1336,7 +1336,7 @@ func TestFlavorResourceUsage(t *testing.T) {
 						},
 					},
 					{
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							"example.com/gpu": 1,
 						}),
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -1557,7 +1557,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1584,7 +1584,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 5000,
 						"nvidia.com/gpu":   1,
 					}),
@@ -1610,7 +1610,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU:    5000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1637,7 +1637,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      1,
@@ -1664,7 +1664,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 			info: &Info{
 				TotalRequests: []PodSetResources{{
 					Name: "ps1",
-					Requests: resources.NewRequestsFromMap(resources.MapRequests{
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceCPU:    10000,
 						corev1.ResourceMemory: 10 * 1024 * 1024,
 						"nvidia.com/gpu":      2,
@@ -1700,7 +1700,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 				TotalRequests: []PodSetResources{
 					{
 						Name: "ps1",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    10000,
 							corev1.ResourceMemory: 10 * 1024 * 1024,
 							"nvidia.com/gpu":      1,
@@ -1708,7 +1708,7 @@ func TestPropagateResourceRequests(t *testing.T) {
 					},
 					{
 						Name: "ps2",
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    20000,
 							corev1.ResourceMemory: 20 * 1024 * 1024,
 							"nvidia.com/gpu":      2,
@@ -1968,7 +1968,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
 						}),
@@ -2000,7 +2000,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 100,
 							"gpus":             2,
 						}),
@@ -2008,7 +2008,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "worker",
 						Count: 2,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024,
 							"foo-accelerator":     2,
 						}),
@@ -2037,7 +2037,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 100,
 							"gpus":             1,
 						}),
@@ -2045,7 +2045,7 @@ func TestWithPreprocessedDRAResources(t *testing.T) {
 					{
 						Name:  "worker",
 						Count: 1,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 512 * 1024 * 1024,
 						}),
 					},
@@ -2094,7 +2094,7 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 1,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 100,
 							"gpu":              1,
 						}),
@@ -2124,7 +2124,7 @@ func TestWithPreprocessedDRAResourcesReplacesExtendedResources(t *testing.T) {
 					{
 						Name:  "main",
 						Count: 2,
-						Requests: resources.NewRequestsFromMap(resources.MapRequests{
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 200,
 							"gpu":              4,
 							"tpu":              2,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This eliminates concrete uses of `MapRequests` outside `pkg/resources` as part of the #13665 cleanup effort.
Cherry-pick of #13668 to `release-0.19`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13665

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Scheduling: Unified the remaining resource-request construction paths to use factory methods that select either the `MapRequests` or `SliceRequests` implementation based on the `VectorizedResourceRequests` feature gate.
```
