### PR TITLE
cleanup: align SliceRequests and MapRequests on handling zero

### DIFF
--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -78,23 +78,6 @@ func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	return NewRequestsFromResourceList(rl)
 }
 
-// NewRequestsFromResourceListRetainZero creates a Requests instance from a corev1.ResourceList,
-// ensuring that explicitly zero-valued resources are retained.
-func NewRequestsFromResourceListRetainZero(rl corev1.ResourceList) Requests {
-	// For now, returning MapRequests ensures zeroes are retained regardless of feature gates.
-	return NewMapRequests(rl)
-}
-
-// NewRequestsFromPodSpecRetainZero creates a Requests instance from a PodSpec,
-// ensuring that explicitly zero-valued resources are retained.
-func NewRequestsFromPodSpecRetainZero(podSpec *corev1.PodSpec) Requests {
-	if podSpec == nil {
-		return CreateEmpty()
-	}
-	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
-	return NewRequestsFromResourceListRetainZero(rl)
-}
-
 // ToMap converts any Requests instance into a MapRequests map.
 func ToMap(r Requests) map[corev1.ResourceName]int64 {
 	if isEmpty(r) {

--- a/pkg/util/limitrange/limitrange.go
+++ b/pkg/util/limitrange/limitrange.go
@@ -70,7 +70,7 @@ func (s Summary) validatePodSpecContainers(containers []corev1.Container, path *
 		if resNames := resources.NewRequestsFromResourceList(cMax).GreaterKeysRL(containerRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}
-		if resNames := resources.NewRequestsFromResourceList(containerRange.Min).GreaterKeys(resources.NewRequestsFromResourceListRetainZero(cMin)); len(resNames) > 0 {
+		if resNames := resources.NewRequestsFromResourceList(containerRange.Min).GreaterKeys(resources.NewRequestsFromResourceList(cMin)); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(containerPath, resNames, RequestsMustNotBeBelowLimitRangeMinMessage))
 		}
 	}
@@ -83,7 +83,7 @@ func (s Summary) ValidatePodSpec(ps *corev1.PodSpec, path *field.Path) field.Err
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.InitContainers, path.Child("initContainers"))...)
 	allErrs = append(allErrs, s.validatePodSpecContainers(ps.Containers, path.Child("containers"))...)
 	if podRange, found := s[corev1.LimitTypePod]; found {
-		total := resources.NewRequestsFromPodSpecRetainZero(ps)
+		total := resources.NewRequestsFromPodSpec(ps)
 		if resNames := total.GreaterKeysRL(podRange.Max); len(resNames) > 0 {
 			allErrs = append(allErrs, field.Invalid(path, resNames, RequestsMustNotBeAboveLimitRangeMaxMessage))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR aligns the `SliceRequests` and `MapRequests` implementations to natively handle and retain zero values. 

Since both implementations already support retaining zero without stripping them, the explicit `NewRequestsFromPodSpecRetainZero` and `NewRequestsFromResourceListRetainZero` functions introduced in #13668 are redundant and have been removed. Their usages were replaced with the default standard functions, making zero-retention the default behavior across the board for observability.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13750

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource validation to consistently ignore zero-valued resource requests when checking container minimums and pod totals.
  * Removed legacy behavior that retained zero-value resources during resource request conversion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->