### PR TITLE
[release-0.18] Preserve sub-milli resource contributions in AdmissionFairSharing usage

### DIFF
--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -368,7 +368,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					&kueue.LocalQueueFairSharingStatus{
 						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
 							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("6827m"),
+								corev1.ResourceCPU: resource.MustParse("6828427124n"),
 							},
 						},
 					}).
@@ -414,7 +414,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					&kueue.LocalQueueFairSharingStatus{
 						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
 							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								corev1.ResourceCPU: resource.MustParse("7980m"),
+								corev1.ResourceCPU: resource.MustParse("7980769063n"),
 							},
 						},
 					}).
@@ -454,7 +454,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					&kueue.LocalQueueFairSharingStatus{
 						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
 							ConsumedResources: map[corev1.ResourceName]resource.Quantity{
-								resourceGPU: resource.MustParse("6827m"),
+								resourceGPU: resource.MustParse("6828427124n"),
 							},
 						},
 					}).

--- a/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
+++ b/pkg/util/admissionfairsharing/admission_fair_sharing_test.go
@@ -118,3 +118,103 @@ func TestCalculateEntryPenaltyWithDRAResources(t *testing.T) {
 		t.Errorf("gpu-logical penalty should be positive, got %v", gpuPenalty)
 	}
 }
+
+func TestCalculateEntryPenaltyWithLongHalfLife(t *testing.T) {
+	afs := &config.AdmissionFairSharing{
+		UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
+		UsageHalfLifeTime:     metav1.Duration{Duration: 168 * time.Hour},
+	}
+
+	penalty := CalculateEntryPenalty(corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("2"),
+		"nvidia.com/gpu":   resource.MustParse("1"),
+	}, afs)
+
+	for _, name := range []corev1.ResourceName{corev1.ResourceCPU, "nvidia.com/gpu"} {
+		got := penalty[name]
+		if got.Sign() <= 0 {
+			t.Errorf("Unexpected %s penalty, expecting a positive value got %s", name, got.String())
+		}
+	}
+}
+
+// A week-long half-life sampled every five minutes drives the decay factor below
+// the point where a per-sample contribution reaches one milli-unit.
+const (
+	longHalfLifeTime = float64(168 * time.Hour / time.Second)
+	samplingElapsed  = float64(5 * time.Minute / time.Second)
+)
+
+// Regression test: with a long half-life the per-sample contribution is below one
+// milli-unit, and must still accumulate across samples instead of being dropped.
+func TestCalculateDecayedConsumedAccumulatesSubMilli(t *testing.T) {
+	usage := corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("2"),
+		"nvidia.com/gpu":   resource.MustParse("1"),
+	}
+
+	consumed := corev1.ResourceList{}
+	var prevCPU, prevGPU resource.Quantity
+	for sample := 1; sample <= 3; sample++ {
+		consumed = CalculateDecayedConsumed(consumed, usage, samplingElapsed, longHalfLifeTime)
+
+		cpu := consumed[corev1.ResourceCPU]
+		gpu := consumed["nvidia.com/gpu"]
+		if cpu.Cmp(prevCPU) <= 0 {
+			t.Errorf("sample %d: cpu did not grow, got %s after %s", sample, cpu.String(), prevCPU.String())
+		}
+		if gpu.Cmp(prevGPU) <= 0 {
+			t.Errorf("sample %d: nvidia.com/gpu did not grow, got %s after %s", sample, gpu.String(), prevGPU.String())
+		}
+		prevCPU, prevGPU = cpu, gpu
+	}
+}
+
+// Decayed usage must approach current usage on the half-life curve, and must never
+// exceed it: accumulated rounding that drifted upwards would inflate a LocalQueue's
+// share indefinitely.
+func TestCalculateDecayedConsumedConvergesToUsage(t *testing.T) {
+	const samplesPerHalfLife = 2016 // 168h / 5m
+
+	usage := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+	consumed := corev1.ResourceList{}
+
+	// 1 - 0.5^n of the way to usage after n half-lives.
+	wantAfterHalfLife := map[int]string{1: "1", 2: "1500m", 3: "1750m"}
+
+	for halfLives := 1; halfLives <= 3; halfLives++ {
+		for range samplesPerHalfLife {
+			consumed = CalculateDecayedConsumed(consumed, usage, samplingElapsed, longHalfLifeTime)
+		}
+
+		got := consumed[corev1.ResourceCPU]
+		want := resource.MustParse(wantAfterHalfLife[halfLives])
+		// Allow a milli-unit of accumulated rounding over thousands of samples.
+		tolerance := resource.MustParse("1m")
+		low, high := want.DeepCopy(), want.DeepCopy()
+		low.Sub(tolerance)
+		high.Add(tolerance)
+		if got.Cmp(low) < 0 || got.Cmp(high) > 0 {
+			t.Errorf("after %d half-lives: expecting ~%s got %s", halfLives, want.String(), got.String())
+		}
+		if total := usage[corev1.ResourceCPU]; got.Cmp(total) > 0 {
+			t.Errorf("after %d half-lives: consumed %s exceeds usage %s", halfLives, got.String(), total.String())
+		}
+	}
+}
+
+func TestCalculateDecayedConsumedKeepsLargeQuantitiesPositive(t *testing.T) {
+	for _, size := range []string{"16Gi", "1Ti", "64Ti"} {
+		t.Run(size, func(t *testing.T) {
+			consumed := CalculateDecayedConsumed(
+				corev1.ResourceList{},
+				corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(size)},
+				samplingElapsed, longHalfLifeTime)
+
+			mem := consumed[corev1.ResourceMemory]
+			if mem.Sign() <= 0 {
+				t.Errorf("Unexpected memory, expecting a positive value got %s", mem.String())
+			}
+		})
+	}
+}

--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -17,8 +17,11 @@ limitations under the License.
 package resource
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
+	"gopkg.in/inf.v0"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -88,14 +91,28 @@ func QuantityToFloat(q *resource.Quantity) float64 {
 	return float64(q.MilliValue()) / 1000
 }
 
-// MulByFloat multiplies every element in q by f.
-// Leverages k8s.io/apimachinery/pkg/api/resource package to provide precision to 3 decimal places
-// It expects f value to be in range [0,1], otherwise an overflow can happen.
+// Decimal multiplication grows the scale on every call, and callers re-multiply
+// the same value indefinitely, so results are rounded back to a fixed scale.
+const mulByFloatScale = 9
+
+// MulByFloat multiplies every element in q by f, which must be finite.
+// Uses arbitrary-precision decimals so that results below one milli-unit are not
+// truncated to zero and large quantities cannot overflow int64. Results are rounded
+// down so that repeatedly scaling a value by a factor below 1 decays it to zero
+// rather than settling on a non-zero fixed point.
 func MulByFloat(q corev1.ResourceList, f float64) corev1.ResourceList {
-	ret := q.DeepCopy()
-	for k, v := range ret {
-		scaledV := float64(v.MilliValue()) * f
-		ret[k] = *resource.NewMilliQuantity(int64(scaledV), resource.DecimalSI)
+	if q == nil {
+		return nil
+	}
+	factor, ok := new(inf.Dec).SetString(strconv.FormatFloat(f, 'f', -1, 64))
+	if !ok {
+		panic(fmt.Sprintf("MulByFloat called with a non-finite factor: %v", f))
+	}
+	ret := make(corev1.ResourceList, len(q))
+	for k, v := range q {
+		scaled := new(inf.Dec).Mul(v.AsDec(), factor)
+		scaled.Round(scaled, mulByFloatScale, inf.RoundDown)
+		ret[k] = *resource.NewDecimalQuantity(*scaled, resource.DecimalSI)
 	}
 	return ret
 }

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -237,6 +237,111 @@ func TestQuantityToFloat(t *testing.T) {
 	}
 }
 
+// The decay factor AdmissionFairSharing derives from a 168h half-life sampled
+// every 5 minutes; small enough that a whole-milli result rounds to zero.
+const longHalfLifeDecayFactor = 0.00034376390587387284
+
+func TestMulByFloat(t *testing.T) {
+	cases := map[string]struct {
+		rl   corev1.ResourceList
+		f    float64
+		want corev1.ResourceList
+	}{
+		"large quantity does not overflow": {
+			rl:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("64Ti")},
+			f:    longHalfLifeDecayFactor,
+			want: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("24190234349953124739n")},
+		},
+		"sub-milli results are preserved for every resource": {
+			rl: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+				"nvidia.com/gpu":      resource.MustParse("1"),
+			},
+			f: longHalfLifeDecayFactor,
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("687527n"),
+				corev1.ResourceMemory: resource.MustParse("5905818933094024n"),
+				"nvidia.com/gpu":      resource.MustParse("343763n"),
+			},
+		},
+		"scaling by one is lossless": {
+			rl:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1500m")},
+			f:    1,
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1500m")},
+		},
+		"nil list stays nil": {
+			rl:   nil,
+			f:    0.5,
+			want: nil,
+		},
+		"empty list stays empty": {
+			rl:   corev1.ResourceList{},
+			f:    0.5,
+			want: corev1.ResourceList{},
+		},
+		"scaling by zero": {
+			rl:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+			f:    0,
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := MulByFloat(tc.rl, tc.f)
+			if (got == nil) != (tc.want == nil) {
+				t.Fatalf("Unexpected nilness, expecting %v got %v", tc.want == nil, got == nil)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("Unexpected result length, expecting %d got %d", len(tc.want), len(got))
+			}
+			for k, wantQ := range tc.want {
+				gotQ := got[k]
+				if gotQ.Cmp(wantQ) != 0 {
+					t.Errorf("Unexpected %s, expecting %s got %s", k, wantQ.String(), gotQ.String())
+				}
+			}
+		})
+	}
+}
+
+// The decay factor is applied to the same value once per sampling interval for
+// the lifetime of a LocalQueue, so the retained scale must not grow with it.
+func TestMulByFloatBoundsScale(t *testing.T) {
+	rl := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+	for range 1000 {
+		rl = MulByFloat(rl, 1-longHalfLifeDecayFactor)
+	}
+
+	q := rl[corev1.ResourceCPU]
+	if got := q.AsDec().Scale(); got > mulByFloatScale {
+		t.Errorf("Unexpected scale, expecting at most %d got %d", mulByFloatScale, got)
+	}
+}
+
+// Repeatedly scaling by a factor below 1 models an idle LocalQueue decaying. Rounding
+// up would settle on a non-zero fixed point and leave usage that never expires.
+func TestMulByFloatDecaysToZero(t *testing.T) {
+	cases := map[string]float64{
+		"168h half-life": 1 - longHalfLifeDecayFactor,
+		"1h half-life":   0.94387431268169349,
+	}
+	for name, factor := range cases {
+		t.Run(name, func(t *testing.T) {
+			rl := corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}
+			for range 200000 {
+				rl = MulByFloat(rl, factor)
+				if q := rl[corev1.ResourceCPU]; q.IsZero() {
+					return
+				}
+			}
+			q := rl[corev1.ResourceCPU]
+			t.Errorf("Unexpected residual usage, expecting decay to 0 got %s", q.String())
+		})
+	}
+}
+
 func TestIsExtendedResourceName(t *testing.T) {
 	cases := map[string]struct {
 		name corev1.ResourceName


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Manual cherry-pick of #13621 onto release-0.18.

#### Which issue(s) this PR fixes:

Fixes #13596

#### Special notes for your reviewer: 

#### Does this PR introduce a user-facing change?

```release-note
AdmissionFairSharing: Fixed a bug where resource usage smaller than one milli-unit was truncated to zero before it could accumulate, so with a long `usageHalfLifeTime` the `consumedResources` for CPU and extended resources such as GPUs stayed at `0` permanently and were ignored by fair sharing.
```
