### PR TITLE
Reduce ConsistentDuration to 300ms

### DIFF
--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -41,7 +41,7 @@ const (
 	// VeryLongTimeout is meant for waiting for Kueue startup including
 	// cert propagation and component readiness.
 	VeryLongTimeout         = 5 * time.Minute
-	ConsistentDuration      = 1 * time.Second
+	ConsistentDuration      = 300 * time.Millisecond
 	ShortConsistentDuration = 100 * time.Millisecond
 	ShortInterval           = 10 * time.Millisecond
 	Interval                = time.Millisecond * 250


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:
Integration tests use `ConsistentDuration` set to 1s which is too long. This PR reduces it to 300ms to significantly increase testing speed

#### Which issue(s) this PR fixes:
Fixes #12429 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reduced the standard test duration from 1 second to 300 milliseconds, helping test runs complete faster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->