### PR TITLE
[release-0.18] TAS: requeue inadmissible workloads after non-TAS pod finishes

### DIFF
--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -122,14 +122,16 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 	}
 }
 
-// Update may add a pod to the cache, or
-// delete a terminated pod.
-func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) {
-	t.nonTasUsageCache.update(pod, log)
+// Update may add a pod to the cache, or delete a terminated pod.
+// Returns the node name when a terminated pod is removed from the cache.
+func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) string {
+	return t.nonTasUsageCache.update(pod, log)
 }
 
-func (t *tasCache) DeletePodByKey(key client.ObjectKey, log logr.Logger) {
-	t.nonTasUsageCache.delete(key, log)
+// DeletePodByKey removes the pod from the non-TAS resource usage cache.
+// Returns the node name when an entry is removed.
+func (t *tasCache) DeletePodByKey(key client.ObjectKey, log logr.Logger) string {
+	return t.nonTasUsageCache.delete(key, log)
 }
 
 func (t *tasCache) SyncNode(node *corev1.Node) {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -41,29 +41,42 @@ type podUsageValue struct {
 	usage resources.Requests
 }
 
-// update may add a pod to the cache, or
-// delete a terminated pod.
-func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
+// removePodUsage removes a pod entry and its node usage from the cache.
+// Returns the node name if the pod was found, empty string otherwise.
+// Must be called under write lock.
+func (n *nonTasUsageCache) removePodUsage(key client.ObjectKey, log logr.Logger) string {
+	if old, found := n.podUsage[key]; found {
+		n.removeNodeUsage(old.node, old.usage, log)
+		delete(n.podUsage, key)
+		return old.node
+	}
+	delete(n.podUsage, key)
+	return ""
+}
+
+// update may add a pod to the cache, or delete a terminated pod.
+// Returns the node name when a terminated pod is removed from the cache.
+func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) string {
 	n.lock.Lock()
 	defer n.lock.Unlock()
 
 	key := client.ObjectKeyFromObject(pod)
 
-	// delete terminated pods as they no longer use any capacity.
 	if utilpod.IsTerminated(pod) {
 		log.V(5).Info("Deleting terminated pod from the cache")
-		if old, found := n.podUsage[key]; found {
-			n.removeNodeUsage(old.node, old.usage, log)
-		}
-		delete(n.podUsage, key)
-		return
+		return n.removePodUsage(key, log)
 	}
 
-	// Remove old entry if pod already exists (handles node migration, resource resize).
+	n.updatePodUsage(key, pod, log)
+	return ""
+}
+
+// updatePodUsage replaces or inserts a pod's usage entry and adjusts node totals.
+// Must be called under write lock.
+func (n *nonTasUsageCache) updatePodUsage(key client.ObjectKey, pod *corev1.Pod, log logr.Logger) {
 	if old, found := n.podUsage[key]; found {
 		n.removeNodeUsage(old.node, old.usage, log)
 	}
-
 	log.V(5).Info("Adding non-TAS pod to the cache")
 	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
 	n.podUsage[key] = podUsageValue{
@@ -73,13 +86,12 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) {
 	n.addNodeUsage(pod.Spec.NodeName, requests)
 }
 
-func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) {
+// delete removes a pod from the cache.
+// Returns the node name when an entry is removed.
+func (n *nonTasUsageCache) delete(key client.ObjectKey, log logr.Logger) string {
 	n.lock.Lock()
 	defer n.lock.Unlock()
-	if old, found := n.podUsage[key]; found {
-		n.removeNodeUsage(old.node, old.usage, log)
-	}
-	delete(n.podUsage, key)
+	return n.removePodUsage(key, log)
 }
 
 // forEachNodeUsage invokes fn for each node's usage while holding the read lock.

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -19,15 +19,91 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
+
+func TestNonTasUsageCacheRemovedNode(t *testing.T) {
+	testCases := map[string]struct {
+		setup    func(cache *nonTasUsageCache, log logr.Logger)
+		action   func(cache *nonTasUsageCache, log logr.Logger) string
+		wantNode string
+	}{
+		"update with succeeded pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodSucceeded
+				return cache.update(pod, log)
+			},
+			wantNode: "node-a",
+		},
+		"update with failed pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodFailed
+				return cache.update(pod, log)
+			},
+			wantNode: "node-a",
+		},
+		"update with terminated pod not in cache returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				pod := makePod("pod1", "ns", "node-a", "2")
+				pod.Status.Phase = corev1.PodSucceeded
+				return cache.update(pod, log)
+			},
+		},
+		"update with running pod returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+		},
+		"delete existing pod returns node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.delete(types.NamespacedName{Namespace: "ns", Name: "pod1"}, log)
+			},
+			wantNode: "node-a",
+		},
+		"delete non-existent pod returns empty": {
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.delete(types.NamespacedName{Namespace: "ns", Name: "ghost"}, log)
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			cache := &nonTasUsageCache{
+				podUsage:  make(map[types.NamespacedName]podUsageValue),
+				nodeUsage: make(map[string]resources.Requests),
+			}
+			if tc.setup != nil {
+				tc.setup(cache, log)
+			}
+			got := tc.action(cache, log)
+			if got != tc.wantNode {
+				t.Errorf("got removedNode=%q, want %q", got, tc.wantNode)
+			}
+		})
+	}
+}
 
 // verifyNodeUsageConsistency recomputes usage from podUsage (old O(pods) algorithm)
 // and verifies it matches the incremental nodeUsage.

--- a/pkg/controller/tas/controllers.go
+++ b/pkg/controller/tas/controllers.go
@@ -17,6 +17,8 @@ limitations under the License.
 package tas
 
 import (
+	"fmt"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -43,9 +45,13 @@ func SetupControllers(mgr ctrl.Manager, queues *qcache.Manager, cache *schdcache
 	if ctrlName, err := nodeRec.SetupWithManager(mgr, cfg); err != nil {
 		return ctrlName, err
 	}
-	nonTasUsageController := newNonTasUsageReconciler(mgr.GetClient(), cache, roleTracker)
+	nonTasUsageController := newNonTasUsageReconciler(mgr.GetClient(), queues, cache, roleTracker)
 	if ctrlName, err := nonTasUsageController.SetupWithManager(mgr); err != nil {
 		return ctrlName, err
+	}
+	if err := mgr.Add(nonTasUsageController); err != nil {
+		return TASNonTasUsageController, fmt.Errorf(
+			"unable to add %s runnable: %w", TASNonTasUsageController, err)
 	}
 	return "", nil
 }

--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -18,42 +18,85 @@ package tas
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
-func newNonTasUsageReconciler(k8sClient client.Client, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *NonTasUsageReconciler {
+const defaultRequeueBatchInterval = 10 * time.Second
+
+func newNonTasUsageReconciler(k8sClient client.Client, queues *qcache.Manager, cache *schdcache.Cache, roleTracker *roletracker.RoleTracker) *NonTasUsageReconciler {
 	return &NonTasUsageReconciler{
-		k8sClient:   k8sClient,
-		cache:       cache,
-		roleTracker: roleTracker,
+		k8sClient:            k8sClient,
+		queues:               queues,
+		cache:                cache,
+		roleTracker:          roleTracker,
+		requeueBatchInterval: defaultRequeueBatchInterval,
+		pending:              pendingRequeue{nodes: sets.New[string]()},
 	}
 }
 
-// NonTasUsageReconciler monitors pods to update
-// the TAS cache with non-TAS usage.
+// pendingRequeue collects freed node names under a mutex and
+// swaps the set atomically on drain.
+type pendingRequeue struct {
+	mu    sync.Mutex
+	nodes sets.Set[string]
+}
+
+func (p *pendingRequeue) notify(nodeName string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.nodes.Insert(nodeName)
+}
+
+func (p *pendingRequeue) drain() sets.Set[string] {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	nodes := p.nodes
+	p.nodes = sets.New[string]()
+	return nodes
+}
+
+// NonTasUsageReconciler monitors pods to update the TAS cache with non-TAS
+// usage and to requeue inadmissible workloads when capacity is freed.
 type NonTasUsageReconciler struct {
 	k8sClient   client.Client
 	cache       *schdcache.Cache
+	queues      *qcache.Manager
 	roleTracker *roletracker.RoleTracker
+
+	requeueBatchInterval time.Duration
+	pending              pendingRequeue
 }
 
 var _ reconcile.Reconciler = (*NonTasUsageReconciler)(nil)
 var _ predicate.TypedPredicate[*corev1.Pod] = (*NonTasUsageReconciler)(nil)
+var _ manager.Runnable = (*NonTasUsageReconciler)(nil)
+var _ manager.LeaderElectionRunnable = (*NonTasUsageReconciler)(nil)
+
+func (r *NonTasUsageReconciler) NeedLeaderElection() bool {
+	return false
+}
 
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 
@@ -67,14 +110,20 @@ func (r *NonTasUsageReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			return ctrl.Result{}, err
 		}
 		log.V(5).Info("Idempotently deleting not found pod")
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
+		if removedNode := r.cache.TASCache().DeletePodByKey(req.NamespacedName, log); removedNode != "" {
+			r.notifyFreedNode(removedNode)
+		}
 		return ctrl.Result{}, nil
 	}
 
 	if belongsToNonTASCache(&pod) {
-		r.cache.TASCache().Update(&pod, log)
+		if freedNode := r.cache.TASCache().Update(&pod, log); freedNode != "" {
+			r.notifyFreedNode(freedNode)
+		}
 	} else {
-		r.cache.TASCache().DeletePodByKey(req.NamespacedName, log)
+		if removedNode := r.cache.TASCache().DeletePodByKey(req.NamespacedName, log); removedNode != "" {
+			r.notifyFreedNode(removedNode)
+		}
 	}
 	return ctrl.Result{}, nil
 }
@@ -96,16 +145,77 @@ func belongsToNonTASCache(pod *corev1.Pod) bool {
 	return true
 }
 
+func (r *NonTasUsageReconciler) notifyFreedNode(nodeName string) {
+	r.pending.notify(nodeName)
+}
+
+// Start implements the Runnable interface. It drains accumulated freed node
+// names at a slow interval to avoid clearing equivalence hashes on every pod
+// event during sustained non-TAS pod churn.
+func (r *NonTasUsageReconciler) Start(ctx context.Context) error {
+	log := ctrl.LoggerFrom(ctx).WithName("non-tas-usage-requeue-drainer")
+	ctx = ctrl.LoggerInto(ctx, log)
+	ticker := time.NewTicker(r.requeueBatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			r.drainPendingNodes(ctx)
+		}
+	}
+}
+
+func (r *NonTasUsageReconciler) drainPendingNodes(ctx context.Context) {
+	nodes := r.pending.drain()
+
+	if nodes.Len() == 0 {
+		return
+	}
+
+	log := ctrl.LoggerFrom(ctx)
+	cqNames := sets.New[kueue.ClusterQueueReference]()
+	flavorCache := r.cache.CloneTASCache()
+	for nodeName := range nodes {
+		var node corev1.Node
+		if err := r.k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				log.V(3).
+					Info("Node deleted, skipping requeue (RF controller handles this)", "node", nodeName)
+				continue
+			}
+			log.Error(
+				err,
+				"Failed to get node for requeue, will retry next cycle",
+				"node",
+				nodeName,
+			)
+			r.notifyFreedNode(nodeName)
+			continue
+		}
+		for name, fc := range flavorCache {
+			if utiltas.NodeMatchesFlavor(node.Labels, fc.NodeLabels(), fc.TopologyLevels()) {
+				for _, cq := range r.cache.ClusterQueuesUsingFlavor(name) {
+					cqNames.Insert(cq)
+				}
+			}
+		}
+	}
+	if cqNames.Len() > 0 {
+		log.V(3).
+			Info("Requeueing inadmissible workloads after non-TAS pod freed capacity",
+				"nodes", sets.List(nodes), "clusterQueues", sets.List(cqNames))
+		qcache.NotifyRetryInadmissible(r.queues, cqNames)
+	}
+}
+
 func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bool {
 	return belongsToNonTASCache(e.Object)
 }
 
-func shouldReconcilePodUpdate(oldPod, newPod *corev1.Pod) bool {
-	return belongsToNonTASCache(oldPod) != belongsToNonTASCache(newPod)
-}
-
 func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
-	return shouldReconcilePodUpdate(e.ObjectOld, e.ObjectNew)
+	return belongsToNonTASCache(e.ObjectOld) != belongsToNonTASCache(e.ObjectNew)
 }
 
 func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {

--- a/pkg/controller/tas/non_tas_usage_controller_test.go
+++ b/pkg/controller/tas/non_tas_usage_controller_test.go
@@ -17,12 +17,20 @@ limitations under the License.
 package tas
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 )
 
@@ -165,7 +173,7 @@ func TestNonTasUsageReconcilerDelete(t *testing.T) {
 	}
 }
 
-func TestShouldReconcilePodUpdate(t *testing.T) {
+func TestNonTasUsageReconcilerUpdatePredicate(t *testing.T) {
 	tests := []struct {
 		name   string
 		oldPod *corev1.Pod
@@ -244,26 +252,84 @@ func TestShouldReconcilePodUpdate(t *testing.T) {
 		},
 	}
 
+	reconciler := &NonTasUsageReconciler{}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := shouldReconcilePodUpdate(tc.oldPod, tc.newPod)
+			got := reconciler.Update(event.TypedUpdateEvent[*corev1.Pod]{
+				ObjectOld: tc.oldPod,
+				ObjectNew: tc.newPod,
+			})
 			if got != tc.want {
-				t.Errorf("shouldReconcilePodUpdate() = %v, want %v", got, tc.want)
+				t.Errorf("Update() = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestNonTasUsageReconcilerUpdate(t *testing.T) {
-	reconciler := &NonTasUsageReconciler{}
-	oldPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodRunning).Obj()
-	newPod := testingpod.MakePod("pod", "ns").NodeName("node-a").StatusPhase(corev1.PodSucceeded).Obj()
+func TestDrainPendingNodes(t *testing.T) {
+	tests := map[string]struct {
+		initialNodes    []string
+		objects         []corev1.Node
+		interceptGet    bool
+		wantPendingLen  int
+		wantPendingKeys sets.Set[string]
+	}{
+		"empty set is a no-op": {
+			wantPendingLen: 0,
+		},
+		"NotFound node is skipped without re-insert": {
+			initialNodes:   []string{"deleted-node"},
+			wantPendingLen: 0,
+		},
+		"existing node is drained": {
+			initialNodes:   []string{"node-a"},
+			objects:        []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}},
+			wantPendingLen: 0,
+		},
+		"duplicate nodes are deduplicated": {
+			initialNodes: []string{"node-a", "node-a", "node-b"},
+			objects: []corev1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}},
+			},
+			wantPendingLen: 0,
+		},
+		"transient error re-inserts node for next cycle": {
+			initialNodes:    []string{"flaky-node"},
+			interceptGet:    true,
+			wantPendingLen:  1,
+			wantPendingKeys: sets.New[string]("flaky-node"),
+		},
+	}
 
-	got := reconciler.Update(event.TypedUpdateEvent[*corev1.Pod]{
-		ObjectOld: oldPod,
-		ObjectNew: newPod,
-	})
-	if !got {
-		t.Errorf("Update() = %v, want %v", got, true)
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := fake.NewClientBuilder()
+			for i := range tc.objects {
+				builder = builder.WithObjects(&tc.objects[i])
+			}
+			if tc.interceptGet {
+				builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+						return errors.New("transient error")
+					},
+				})
+			}
+			cl := builder.Build()
+			cache := schdcache.New(cl)
+			r := newNonTasUsageReconciler(cl, nil, cache, nil)
+
+			for _, n := range tc.initialNodes {
+				r.notifyFreedNode(n)
+			}
+			r.drainPendingNodes(t.Context())
+
+			if r.pending.nodes.Len() != tc.wantPendingLen {
+				t.Errorf("pendingRequeueNodes has %d items, want %d", r.pending.nodes.Len(), tc.wantPendingLen)
+			}
+			if tc.wantPendingKeys != nil && !r.pending.nodes.Equal(tc.wantPendingKeys) {
+				t.Errorf("pendingRequeueNodes = %v, want %v", r.pending.nodes, tc.wantPendingKeys)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/8709

/assign sohankunkerkar

```release-note
TAS: Fixed a bug where inadmissible TAS workloads were not automatically requeued when non-TAS pods terminated, potentially leaving workloads stuck pending despite available capacity.
```