### PR TITLE
Deactive ClusterQueue when there is a cycle in the hierarchy

### DIFF
--- a/pkg/cache/hierarchy/manager.go
+++ b/pkg/cache/hierarchy/manager.go
@@ -107,6 +107,20 @@ func (m *Manager[CQ, C]) UpdateCohortEdge(name, parentName kueue.CohortReference
 	}
 }
 
+func (m *Manager[CQ, C]) UpdateCohortEdgeIfNoCycle(name, parentName kueue.CohortReference, hasCycle func(C) bool) bool {
+	cohort, ok := m.cohorts[name]
+	var oldParentName kueue.CohortReference
+	if ok && cohort.HasParent() {
+		oldParentName = cohort.Parent().GetName()
+	}
+	m.UpdateCohortEdge(name, parentName)
+	if ok && hasCycle(cohort) {
+		m.UpdateCohortEdge(name, oldParentName)
+		return false
+	}
+	return true
+}
+
 func (m *Manager[CQ, C]) DeleteCohort(name kueue.CohortReference) {
 	cohort, ok := m.cohorts[name]
 	if !ok {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -302,17 +302,17 @@ func (m *Manager) deleteFinishedWorkloadWithoutLock(wlKey workload.Reference) {
 	reportCQFinishedWorkloads(cq, m.roleTracker, m.customLabels)
 }
 
-func (m *Manager) AddOrUpdateCohort(ctx context.Context, cohort *kueue.Cohort) {
+func (m *Manager) AddOrUpdateCohort(ctx context.Context, apiCohort *kueue.Cohort) {
 	m.Lock()
 	defer m.Unlock()
-	cohortName := kueue.CohortReference(cohort.Name)
+	cohortName := kueue.CohortReference(apiCohort.Name)
 
 	m.hm.AddCohort(cohortName)
-	m.hm.UpdateCohortEdge(cohortName, cohort.Spec.ParentName)
-	c := m.hm.Cohort(cohortName)
-	if !hierarchy.HasCycle(c) {
-		m.requeuer.notifyCohort(c.getRootUnsafe().GetName())
+	if !m.hm.UpdateCohortEdgeIfNoCycle(cohortName, apiCohort.Spec.ParentName, func(c *cohort) bool { return hierarchy.HasCycle(c) }) {
+		return
 	}
+	c := m.hm.Cohort(cohortName)
+	m.requeuer.notifyCohort(c.getRootUnsafe().GetName())
 }
 
 func (m *Manager) DeleteCohort(cohortName kueue.CohortReference) {

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -538,6 +538,24 @@ func expectGaugeValue(t *testing.T, collector prometheus.Collector, labels map[s
 	}
 }
 
+func TestAddOrUpdateCohortRejectsCycleAndRestoresParent(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	manager := NewManagerForUnitTests(utiltesting.NewFakeClient(), nil)
+	for _, cohort := range []*kueue.Cohort{
+		utiltestingapi.MakeCohort("top").Obj(),
+		utiltestingapi.MakeCohort("parent").Parent("top").Obj(),
+		utiltestingapi.MakeCohort("child").Parent("parent").Obj(),
+	} {
+		manager.AddOrUpdateCohort(ctx, cohort)
+	}
+
+	manager.AddOrUpdateCohort(ctx, utiltestingapi.MakeCohort("parent").Parent("child").Obj())
+	parent := manager.hm.Cohort("parent")
+	if got := parent.Parent().GetName(); got != "top" {
+		t.Errorf("Parent after rejected update = %q, want %q", got, "top")
+	}
+}
+
 func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 	cohorts := []*kueue.Cohort{
@@ -555,6 +573,7 @@ func TestRequeueWorkloadsCohortCycle(t *testing.T) {
 	for _, cohort := range cohorts {
 		manager.AddOrUpdateCohort(ctx, cohort)
 	}
+	manager.hm.UpdateCohortEdge("cohort-c", "cohort-a")
 	if err := manager.AddClusterQueue(ctx, cq); err != nil {
 		t.Fatalf("Failed adding clusterQueue %s: %v", cq.Name, err)
 	}
@@ -593,6 +612,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 		wantActive                map[kueue.ClusterQueueReference][]workload.Reference
 		wantMoveWorkloadsLogCount int
 		wantMovedCount            int
+		forceCycle                bool
 	}{
 		"deduplication with shared root": {
 			// Tree structure:
@@ -688,6 +708,7 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 				"cq1": {"default/a"},
 			},
 			wantActive: nil,
+			forceCycle: true,
 		},
 	}
 
@@ -706,6 +727,9 @@ func TestQueueInadmissibleWorkloads(t *testing.T) {
 
 			for _, cohort := range tc.cohorts {
 				manager.AddOrUpdateCohort(ctx, cohort)
+			}
+			if tc.forceCycle {
+				manager.hm.UpdateCohortEdge("cohort-c", "cohort-a")
 			}
 			for _, cq := range tc.clusterQueues {
 				if err := manager.AddClusterQueue(ctx, cq); err != nil {

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -639,14 +639,15 @@ func (c *Cache) AddOrUpdateCohort(apiCohort *kueue.Cohort) error {
 	defer c.Unlock()
 	cohortName := kueue.CohortReference(apiCohort.Name)
 	c.hm.AddCohort(cohortName)
-	cohort := c.hm.Cohort(cohortName)
-	oldParent := cohort.Parent()
-	c.hm.UpdateCohortEdge(cohortName, apiCohort.Spec.ParentName)
-	if err := cohort.updateCohort(apiCohort, oldParent); err != nil {
-		return err
+	ch := c.hm.Cohort(cohortName)
+	oldParent := ch.Parent()
+	if !c.hm.UpdateCohortEdgeIfNoCycle(cohortName, apiCohort.Spec.ParentName, func(c *cohort) bool { return hierarchy.HasCycle(c) }) {
+		c.updateCohortTreeAndInfoMetricsIfNoCycle(ch)
+		return ErrCohortHasCycle
 	}
+	_ = ch.updateCohort(apiCohort, oldParent)
 	c.handleParentUpdate(oldParent)
-	c.updateCohortTreeAndInfoMetricsIfNoCycle(cohort)
+	c.updateCohortTreeAndInfoMetricsIfNoCycle(ch)
 
 	return nil
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3359,6 +3359,9 @@ func TestCohortCycles(t *testing.T) {
 		if err := cache.AddOrUpdateCohort(cohort); err == nil {
 			t.Fatal("Expected failure when cycle")
 		}
+		if hierarchy.HasCycle(cache.hm.Cohort("cohort")) {
+			t.Fatal("Rejected update must not leave a cycle in the cache")
+		}
 	})
 	t.Run("simple cycle", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
@@ -3373,6 +3376,32 @@ func TestCohortCycles(t *testing.T) {
 		}
 		if err := cache.AddOrUpdateCohort(cohortC); err == nil {
 			t.Fatal("Expected failure when cycle")
+		}
+		if hierarchy.HasCycle(cache.hm.Cohort("cohort-a")) {
+			t.Fatal("Rejected update must not leave a cycle in the cache")
+		}
+	})
+	t.Run("cycle update restores the previous parent", func(t *testing.T) {
+		cache := New(utiltesting.NewFakeClient())
+		for _, cohort := range []*kueue.Cohort{
+			utiltestingapi.MakeCohort("top").Obj(),
+			utiltestingapi.MakeCohort("parent").Parent("top").Obj(),
+			utiltestingapi.MakeCohort("child").Parent("parent").Obj(),
+		} {
+			if err := cache.AddOrUpdateCohort(cohort); err != nil {
+				t.Fatalf("Adding cohort %q: %v", cohort.Name, err)
+			}
+		}
+
+		if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("parent").Parent("child").Obj()); err == nil {
+			t.Fatal("Expected failure when cycle")
+		}
+		parent := cache.hm.Cohort("parent")
+		if got := parent.Parent().Name; got != "top" {
+			t.Errorf("Parent after rejected update = %q, want %q", got, "top")
+		}
+		if hierarchy.HasCycle(parent) {
+			t.Fatal("Rejected update must not leave a cycle in the cache")
 		}
 	})
 	t.Run("clusterqueue add and update return error when cohort has cycle", func(t *testing.T) {
@@ -3390,6 +3419,7 @@ func TestCohortCycles(t *testing.T) {
 		if err := cache.AddOrUpdateCohort(cohortC); err == nil {
 			t.Fatal("Expected failure when cycle")
 		}
+		cache.hm.UpdateCohortEdge("cohort-c", "cohort-a")
 
 		// Error when creating CQ with parent Cohort-A
 		cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
@@ -3416,10 +3446,11 @@ func TestCohortCycles(t *testing.T) {
 	t.Run("clusterqueue leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
 		ctx, log := utiltesting.ContextWithLog(t)
-		cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
-			t.Fatal("Expected failure")
+		cycleCohort := utiltestingapi.MakeCohort("cycle").Obj()
+		if err := cache.AddOrUpdateCohort(cycleCohort); err != nil {
+			t.Fatalf("Adding cohort: %v", err)
 		}
+		cache.hm.UpdateCohortEdge("cycle", "cycle")
 
 		cohort := utiltestingapi.MakeCohort("cohort").
 			ResourceGroup(
@@ -3463,10 +3494,11 @@ func TestCohortCycles(t *testing.T) {
 	t.Run("clusterqueue joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
 		ctx, log := utiltesting.ContextWithLog(t)
-		cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
-			t.Fatal("Expected failure")
+		cycleCohort := utiltestingapi.MakeCohort("cycle").Obj()
+		if err := cache.AddOrUpdateCohort(cycleCohort); err != nil {
+			t.Fatalf("Adding cohort: %v", err)
 		}
+		cache.hm.UpdateCohortEdge("cycle", "cycle")
 		cohort := utiltestingapi.MakeCohort("cohort").
 			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
 		if err := cache.AddOrUpdateCohort(cohort); err != nil {
@@ -3584,10 +3616,11 @@ func TestCohortCycles(t *testing.T) {
 
 	t.Run("cohort leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-		if err := cache.AddOrUpdateCohort(cycleRoot); err == nil {
-			t.Fatal("Expected failure")
+		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Obj()
+		if err := cache.AddOrUpdateCohort(cycleRoot); err != nil {
+			t.Fatalf("Adding cohort: %v", err)
 		}
+		cache.hm.UpdateCohortEdge("cycle-root", "cycle-root")
 		root := utiltestingapi.MakeCohort("root").Obj()
 		if err := cache.AddOrUpdateCohort(root); err != nil {
 			t.Fatal("Expected success")
@@ -3617,12 +3650,13 @@ func TestCohortCycles(t *testing.T) {
 		}
 	})
 
-	t.Run("cohort joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
+	t.Run("cohort joining cohort with cycle rejects move and retains old cohort quota", func(t *testing.T) {
 		cache := New(utiltesting.NewFakeClient())
-		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-		if err := cache.AddOrUpdateCohort(cycleRoot); err == nil {
-			t.Fatal("Expected failure")
+		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Obj()
+		if err := cache.AddOrUpdateCohort(cycleRoot); err != nil {
+			t.Fatalf("Adding cohort: %v", err)
 		}
+		cache.hm.UpdateCohortEdge("cycle-root", "cycle-root")
 		root := utiltestingapi.MakeCohort("root").Obj()
 		if err := cache.AddOrUpdateCohort(root); err != nil {
 			t.Fatal("Expected success")
@@ -3655,12 +3689,14 @@ func TestCohortCycles(t *testing.T) {
 			t.Fatal("Expected failure")
 		}
 
-		// after move
+		// after rejected move
 		{
 			wantRoot := resourceNode{
-				Quotas:       map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{},
-				Usage:        resources.FlavorResourceQuantities{},
+				Quotas: map[resources.FlavorResource]ResourceQuota{},
+				SubtreeQuota: resources.FlavorResourceQuantities{
+					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+				},
+				Usage: resources.FlavorResourceQuantities{},
 			}
 			if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
 				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
@@ -3668,21 +3704,65 @@ func TestCohortCycles(t *testing.T) {
 		}
 	})
 
-	t.Run("ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts", func(t *testing.T) {
-		// AddOrUpdateCohort returns an error when a cycle is formed, but the cycle edge
-		// is already stored in the hierarchy manager before the error is returned.
-		// ResyncGaugeMetrics must not call getRootUnsafe() on cohorts that are part of
-		// a cycle, as that would cause infinite recursion and a stack overflow panic.
-		_, log := utiltesting.ContextWithLog(t)
+	t.Run("cohort joining cohort with cycle retains implicit old cohort quota on rejection", func(t *testing.T) {
+		cache := New(utiltesting.NewFakeClient())
+		cq := utiltestingapi.MakeClusterQueue("cq").
+			Cohort("implicit-parent").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+			).Obj()
+		if err := cache.AddClusterQueue(context.Background(), cq); err != nil {
+			t.Fatalf("Adding cluster queue: %v", err)
+		}
+
+		child := utiltestingapi.MakeCohort("child").Parent("implicit-parent").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj(),
+			).Obj()
+		if err := cache.AddOrUpdateCohort(child); err != nil {
+			t.Fatalf("Adding child cohort: %v", err)
+		}
+
+		wantImplicitParentBefore := resourceNode{
+			Quotas: map[resources.FlavorResource]ResourceQuota{},
+			SubtreeQuota: resources.FlavorResourceQuantities{
+				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
+			},
+			Usage: resources.FlavorResourceQuantities{},
+		}
+		if diff := cmp.Diff(wantImplicitParentBefore, cache.hm.Cohort("implicit-parent").getResourceNode()); diff != "" {
+			t.Fatalf("Unexpected implicit-parent resources before update (-want,+got):\n%s", diff)
+		}
+
+		child.Spec.ParentName = "child"
+		if err := cache.AddOrUpdateCohort(child); err == nil {
+			t.Fatal("Expected failure due to cycle")
+		}
+
+		if diff := cmp.Diff(wantImplicitParentBefore, cache.hm.Cohort("implicit-parent").getResourceNode()); diff != "" {
+			t.Errorf("Unexpected implicit-parent resources after rejected update (-want,+got):\n%s", diff)
+		}
+	})
+
+	t.Run("rejected cycle updates leave metrics resync responsive", func(t *testing.T) {
+		ctx, log := utiltesting.ContextWithLog(t)
 		cache := New(utiltesting.NewFakeClient())
 		cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
 		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
 			t.Fatal("Expected success as no cycle yet")
 		}
-		// cohort-b -> cohort-a creates the cycle; AddOrUpdateCohort returns an error
-		// but cohort-b's parent edge pointing to cohort-a is already persisted.
-		_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
-		// Must not panic with a goroutine stack overflow.
+		if err := cache.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()); err != nil {
+			t.Fatalf("Adding cluster queue: %v", err)
+		}
+		if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()); err == nil {
+			t.Fatal("Expected failure when cycle")
+		}
+		if hierarchy.HasCycle(cache.hm.Cohort("cohort-a")) {
+			t.Fatal("Rejected update must not leave a cycle in the cache")
+		}
+
+		// Simulate a corrupted hierarchy to keep the reporting guard covered.
+		cache.hm.UpdateCohortEdge("cohort-b", "cohort-a")
 		cache.ResyncGaugeMetrics(log)
 	})
 }
@@ -3851,7 +3931,7 @@ func TestClusterQueueAncestors(t *testing.T) {
 		},
 		"with cycle": {
 			cohorts: []*kueue.Cohort{
-				utiltestingapi.MakeCohort("root").Parent("second-right").Obj(),
+				utiltestingapi.MakeCohort("root").Obj(),
 				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
@@ -3867,6 +3947,9 @@ func TestClusterQueueAncestors(t *testing.T) {
 			cache := New(client)
 			for _, cohort := range tc.cohorts {
 				_ = cache.AddOrUpdateCohort(cohort)
+			}
+			if tc.wantErr != nil {
+				cache.hm.UpdateCohortEdge("root", "second-right")
 			}
 
 			gotAncestors, gotErr := cache.ClusterQueueAncestors(tc.cq)
@@ -3985,7 +4068,7 @@ func TestWorkloadAncestors(t *testing.T) {
 		},
 		"with cycle": {
 			cohorts: []*kueue.Cohort{
-				utiltestingapi.MakeCohort("root").Parent("second-right").Obj(),
+				utiltestingapi.MakeCohort("root").Obj(),
 				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
@@ -4012,6 +4095,9 @@ func TestWorkloadAncestors(t *testing.T) {
 			}
 			for _, cq := range tc.cqs {
 				_ = cache.AddClusterQueue(ctx, cq)
+			}
+			if tc.wantErr != nil {
+				cache.hm.UpdateCohortEdge("root", "second-right")
 			}
 
 			gotAncestors, gotErr := cache.workloadAncestors(tc.wl)
@@ -4069,7 +4155,7 @@ func TestAncestors(t *testing.T) {
 		},
 		"with cycle": {
 			cohorts: []*kueue.Cohort{
-				utiltestingapi.MakeCohort("root").Parent("second-right").Obj(),
+				utiltestingapi.MakeCohort("root").Obj(),
 				utiltestingapi.MakeCohort("first-left").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("first-right").Parent("root").Obj(),
 				utiltestingapi.MakeCohort("second-left").Parent("first-left").Obj(),
@@ -4085,6 +4171,9 @@ func TestAncestors(t *testing.T) {
 			cache := New(client)
 			for _, cohort := range tc.cohorts {
 				_ = cache.AddOrUpdateCohort(cohort)
+			}
+			if tc.wantErr != nil {
+				cache.hm.UpdateCohortEdge("root", "second-right")
 			}
 
 			gotAncestors, gotErr := cache.ancestors(tc.cohortName)

--- a/pkg/cache/scheduler/clusterqueue.go
+++ b/pkg/cache/scheduler/clusterqueue.go
@@ -539,8 +539,10 @@ func (c *clusterQueue) deleteWorkload(log logr.Logger, wlKey workload.Reference)
 
 func (c *clusterQueue) reportActiveWorkloads() {
 	clVals := c.GetCustomLabelValues()
-	for ancestor := range c.Parent().PathSelfToRoot() {
-		metrics.ReportCohortSubtreeAdmittedActiveWorkloads(ancestor.Name, ancestor.admittedWorkloadsCount, clVals, c.roleTracker)
+	if c.HasParent() && !hierarchy.HasCycle(c.Parent()) {
+		for ancestor := range c.Parent().PathSelfToRoot() {
+			metrics.ReportCohortSubtreeAdmittedActiveWorkloads(ancestor.Name, ancestor.admittedWorkloadsCount, clVals, c.roleTracker)
+		}
 	}
 	metrics.ReportReservingActiveWorkloads(c.Name, len(c.Workloads), clVals, c.roleTracker)
 }

--- a/pkg/cache/scheduler/cohort_metrics_test.go
+++ b/pkg/cache/scheduler/cohort_metrics_test.go
@@ -854,7 +854,10 @@ func TestResyncGaugeMetrics_SkipsCohortInfoForCycle(t *testing.T) {
 		t.Fatal("Expected success: no cycle yet")
 	}
 	// cohort-b -> cohort-a closes the cycle; error is expected.
-	_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
+	if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()); err == nil {
+		t.Fatal("Expected failure when cycle")
+	}
+	cache.hm.UpdateCohortEdge("cohort-b", "cohort-a")
 
 	// ResyncGaugeMetrics bulk-resets info metrics then selectively re-emits.
 	// Cycle cohorts are skipped (HasCycle=true), so they end up with no CohortInfo.

--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -57,6 +57,7 @@ func TestSnapshot(t *testing.T) {
 		rfs          []*kueue.ResourceFlavor
 		topologies   []*kueue.Topology
 		wls          []*kueue.Workload
+		mutateCache  func(*Cache)
 		wantSnapshot Snapshot
 	}{
 		"empty": {},
@@ -708,6 +709,10 @@ func TestSnapshot(t *testing.T) {
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "0").Obj(),
 					).Obj(),
 			},
+			mutateCache: func(cache *Cache) {
+				cache.hm.UpdateCohortEdge("autocycle", "autocycle")
+				cache.hm.UpdateCohortEdge("cycle-b", "cycle-a")
+			},
 			wantSnapshot: Snapshot{
 				Manager: hierarchy.NewManagerForTest(
 					map[kueue.CohortReference]*CohortSnapshot{
@@ -868,6 +873,9 @@ func TestSnapshot(t *testing.T) {
 			}
 			for _, cohort := range tc.cohorts {
 				_ = cache.AddOrUpdateCohort(cohort)
+			}
+			if tc.mutateCache != nil {
+				tc.mutateCache(cache)
 			}
 			for _, rf := range tc.rfs {
 				cache.AddOrUpdateResourceFlavor(log, rf)

--- a/pkg/controller/core/cohort_controller_test.go
+++ b/pkg/controller/core/cohort_controller_test.go
@@ -150,11 +150,10 @@ func TestCohortReconcileCycleReturnsError(t *testing.T) {
 	}
 }
 
-func TestCohortReconcileCycleCacheSnapshotBehavior(t *testing.T) {
-	// This test verifies the cache Snapshot state during and after a cohort cycle.
-	// When AddOrUpdateCohort errors (cycle detected), the reconciler returns early
-	// without calling qManager.AddOrUpdateCohort. The observable effect is that
-	// cyclic cohorts are excluded from cache.Snapshot until the cycle is resolved.
+func TestCohortReconcileCycleDoesNotCorruptCache(t *testing.T) {
+	// This test verifies that a rejected cycle update leaves the cache in its
+	// prior valid state. The reconciler returns an error and does not update the
+	// queue manager for the rejected update.
 	cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
 	cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()
 	cl := utiltesting.NewClientBuilder().
@@ -171,22 +170,23 @@ func TestCohortReconcileCycleCacheSnapshotBehavior(t *testing.T) {
 		t.Fatalf("unexpected error reconciling cohort-a: %v", err)
 	}
 
-	// Reconcile cohort-b: B -> A closes the cycle. Cache returns error, reconciler propagates it.
-	// qManager.AddOrUpdateCohort is NOT called (early return on error).
+	// Reconcile cohort-b: B -> A closes the cycle. Cache returns an error and
+	// the reconciler propagates it without updating the queue manager.
 	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(cohortB)}); err == nil {
 		t.Fatal("expected error when adding cycle")
 	}
 
-	// During cycle: Snapshot excludes both cohorts.
+	// The rejected update must not corrupt the previously valid A -> B cache
+	// hierarchy, so both cohorts remain available in the snapshot.
 	snapshot, err := cache.Snapshot(ctx)
 	if err != nil {
-		t.Fatalf("unexpected error building snapshot during cycle: %v", err)
+		t.Fatalf("unexpected error building snapshot after rejected cycle: %v", err)
 	}
-	if snap := snapshot.Cohort("cohort-a"); snap != nil {
-		t.Error("cohort-a should be excluded from Snapshot while in a cycle")
+	if snap := snapshot.Cohort("cohort-a"); snap == nil {
+		t.Error("cohort-a should remain in Snapshot after a rejected cycle")
 	}
-	if snap := snapshot.Cohort("cohort-b"); snap != nil {
-		t.Error("cohort-b should be excluded from Snapshot while in a cycle")
+	if snap := snapshot.Cohort("cohort-b"); snap == nil {
+		t.Error("cohort-b should remain in Snapshot after a rejected cycle")
 	}
 
 	// Resolve the cycle: point cohort-b at an unrelated cohort-c.
@@ -202,7 +202,7 @@ func TestCohortReconcileCycleCacheSnapshotBehavior(t *testing.T) {
 		t.Fatalf("unexpected error reconciling cohort-b after cycle resolution: %v", err)
 	}
 
-	// After resolution: A -> B -> C, no cycle. Both cohorts appear in Snapshot.
+	// After resolution: A -> B -> C, no cycle. Both cohorts remain in Snapshot.
 	snapshot, err = cache.Snapshot(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error building snapshot after cycle resolution: %v", err)

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -1914,6 +1914,53 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 3)
 		})
+
+		ginkgo.It("Should keep the last valid hierarchy after rejecting a Cohort cycle", func() {
+			root := utiltestingapi.MakeCohort("root").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			parent := utiltestingapi.MakeCohort("parent").Parent("root").Obj()
+			child := utiltestingapi.MakeCohort("child").Parent("parent").Obj()
+			util.MustCreate(ctx, k8sClient, root)
+			util.MustCreate(ctx, k8sClient, parent)
+			util.MustCreate(ctx, k8sClient, child)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, child, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, parent, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			})
+
+			cq = createQueue(utiltestingapi.MakeClusterQueue("cq").
+				Cohort("parent").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj())
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+
+			wl = createWorkloadWithPriority(kueue.LocalQueueName(cq.Name), "1", 0)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+
+			ginkgo.By("updating the parent to a cycle")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parent), parent)).To(gomega.Succeed())
+				parent.Spec.ParentName = kueue.CohortReference(child.Name)
+				g.Expect(k8sClient.Update(ctx, parent)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("adding capacity to the valid root")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(root), root)).To(gomega.Succeed())
+				root.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("1")
+				g.Expect(k8sClient.Update(ctx, root)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying the pending workload is admitted through the last valid hierarchy")
+			expectAdmission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "1").Obj()).
+				Obj()
+			util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, wl, expectAdmission)
+		})
 	})
 
 	ginkgo.When("Using cohorts for sharing with LendingLimit", func() {


### PR DESCRIPTION
**What type of PR is this?**
`/kind bug`

**What this PR does / why we need it:**
Marks affected ClusterQueues as inactive (`Active: False, Reason: CohortCycleDetected`) when a cycle is detected in the Cohort hierarchy. Workload admission is suspended until the cycle is resolved in the Cohort spec, after which ClusterQueues automatically recover.

**Which issue(s) this PR fixes:**
Fixes #12529

**Special notes for your reviewer:**
The 3 cycle guards in `updateWorkloadUsage`, `reportWeightedShare`, and `Usage()` look like metric niceties but are actually required — `addUsage`/`removeUsage`/`potentialAvailable` all recurse through `parentHRN()` and would infinite-loop on a cycle.

**Does this PR introduce a user-facing change?**

```release-note
Cohorts: Fixed a possible controller hang after an invalid Cohort hierarchy cycle update. ClusterQueues in a cyclic Cohort now surface a clear `CohortCycleDetected` condition instead of hanging.
```
