### PR TITLE
[release-0.18] fix(webhook): validate labels and annotations in Workload PodSets template metadata

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -524,6 +524,13 @@ const (
 	//
 	// Rejects Workloads with non-positive TAS slice sizes in PodSet topology requests.
 	TASValidateWorkloadSliceSize featuregate.Feature = "TASValidateWorkloadSliceSize"
+
+	// owner: @Dasmat13
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/12775
+	//
+	// WorkloadValidationForPodSetMetadata enables validation of labels and annotations
+	// in PodSet template metadata during Workload creation and update.
+	WorkloadValidationForPodSetMetadata featuregate.Feature = "WorkloadValidationForPodSetMetadata"
 )
 
 func init() {
@@ -812,6 +819,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	TASValidateWorkloadSliceSize: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
+	},
+
+	WorkloadValidationForPodSetMetadata: {
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -155,6 +155,12 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
+	// validate metadata labels and annotations
+	if features.Enabled(features.WorkloadValidationForPodSetMetadata) {
+		allErrs = append(allErrs, metav1validation.ValidateLabels(ps.Template.Labels, path.Child("template", "metadata", "labels"))...)
+		allErrs = append(allErrs, apivalidation.ValidateAnnotations(ps.Template.Annotations, path.Child("template", "metadata", "annotations"))...)
+	}
+
 	// validate initContainers
 	icPath := path.Child("template", "spec", "initContainers")
 	for ci := range ps.Template.Spec.InitContainers {

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
@@ -159,6 +161,70 @@ func TestValidateWorkload(t *testing.T) {
 			wantErr: field.ErrorList{
 				field.Invalid(firstPodSetSpecPath.Child("initContainers").Index(0).Child("resources", "requests").Key(string(corev1.ResourceCPU)), nil, ""),
 			},
+		},
+		"should accept invalid podSet template metadata when WorkloadValidationForPodSetMetadata is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidationForPodSetMetadata: false},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					kueue.PodSet{
+						Name:  "bad-metadata",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"valid": "invalid value with spaces, test-wec1",
+								},
+								Annotations: map[string]string{
+									"invalid/annotation/key/too/long/invalid": "val",
+								},
+							},
+						},
+					},
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject invalid podSet template label value": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidationForPodSetMetadata: true},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					kueue.PodSet{
+						Name:  "bad-metadata",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"valid": "invalid value with spaces",
+								},
+							},
+						},
+					},
+				).
+				Obj(),
+			wantErr: metav1validation.ValidateLabels(map[string]string{
+				"valid": "invalid value with spaces",
+			}, podSetsPath.Index(0).Child("template", "metadata", "labels")),
+		},
+		"should reject invalid podSet template annotation key": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidationForPodSetMetadata: true},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					kueue.PodSet{
+						Name:  "bad-metadata",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									"invalid/annotation/key/too/long/invalid": "val",
+								},
+							},
+						},
+					},
+				).
+				Obj(),
+			wantErr: apivalidation.ValidateAnnotations(map[string]string{
+				"invalid/annotation/key/too/long/invalid": "val",
+			}, podSetsPath.Index(0).Child("template", "metadata", "annotations")),
 		},
 		"should reject negative container resource limit": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
@@ -631,6 +697,8 @@ func TestValidateWorkload(t *testing.T) {
 
 func TestValidateWorkloadUpdate(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
+	specPath := field.NewPath("spec")
+	podSetsPath := specPath.Child("podSets")
 	testCases := map[string]struct {
 		featureGates map[featuregate.Feature]bool
 
@@ -668,6 +736,55 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				).
 				Obj(),
 			wantErr: nil,
+		},
+		"should accept invalid podSet template metadata on update when WorkloadValidationForPodSetMetadata is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidationForPodSetMetadata: false},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					kueue.PodSet{
+						Name:  "driver",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"valid": "invalid value with spaces, test-wec1",
+								},
+								Annotations: map[string]string{
+									"invalid/annotation/key/too/long/invalid": "val",
+								},
+							},
+						},
+					},
+				).
+				Obj(),
+			wantErr: nil,
+		},
+		"should reject invalid podSet template label value on update": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidationForPodSetMetadata: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(
+					kueue.PodSet{
+						Name:  "driver",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{
+								Labels: map[string]string{
+									"valid": "invalid value with spaces",
+								},
+							},
+						},
+					},
+				).
+				Obj(),
+			wantErr: metav1validation.ValidateLabels(map[string]string{
+				"valid": "invalid value with spaces",
+			}, podSetsPath.Index(0).Child("template", "metadata", "labels")),
 		},
 		"reclaimable pod count cannot change down": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -593,3 +593,9 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: WorkloadValidationForPodSetMetadata
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -593,3 +593,9 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: WorkloadValidationForPodSetMetadata
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"


### PR DESCRIPTION
## Description

Cherry-pick of #13679 on release-0.18

## Release Note

```release-note
Workload: Fixed a bug where Workloads with invalid labels or annotations in PodSet template metadata could be admitted and fail later when creating Pods. Kueue now rejects them during admission, controlled by the WorkloadValidationForPodSetMetadata feature gate (Beta, enabled by default).
```