### PR TITLE
Apply priority-class changes to compatible workload slices

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -949,22 +949,10 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 			"replacement", klog.KObj(wl), "retained", klog.KObj(retained))
 		live = append(live, retained)
 	}
-	eligible := make([]*kueue.Workload, 0, len(live))
-	for _, slice := range live {
-		if slice == nil {
-			continue
-		}
-		// A slice that reserved quota without a priorityClassRef keeps it: the
-		// API server refuses to add one once quota is reserved, and retrying
-		// would only fail the reconcile for good.
-		if workload.HasQuotaReservation(slice) && workload.HasNoPriority(slice) {
-			log.V(2).Info("Leaving a workload slice that reserved quota with no priority class alone, since one can no longer be added",
-				"workload", klog.KObj(slice))
-			continue
-		}
-		eligible = append(eligible, slice)
-	}
-	return updateWorkloadPriorities(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), eligible...)
+	// The quota-reserved/no-priorityClassRef legality check lives in
+	// updateWorkloadPriorities so the ordinary Job and LeaderWorkerSet paths, which
+	// reach the shared helper without this caller's filtering, get the same guard.
+	return updateWorkloadPriorities(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
 }
 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
@@ -1209,6 +1197,7 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 // belong to one object cannot end up on different values when the class is edited
 // while they are being written.
 func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
+	log := ctrl.LoggerFrom(ctx)
 	jobPriorityClassName := WorkloadPriorityClassName(obj)
 	var (
 		priorityClassRef *kueue.PriorityClassRef
@@ -1216,6 +1205,22 @@ func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.Eve
 		resolved         bool
 	)
 	for _, wl := range wls {
+		if wl == nil {
+			continue
+		}
+		// A workload that reserved quota without a priorityClassRef keeps it: the
+		// API server refuses to add one once quota is reserved (Workload CEL), so
+		// retrying would only fail the reconcile for good. Centralizing the guard
+		// here, rather than in the workload-slice caller alone, covers the ordinary
+		// Job and LeaderWorkerSet paths, which reach this helper directly. Gating on
+		// a non-empty label keeps ordinary no-class reserved workloads from logging
+		// on every reconcile.
+		if jobPriorityClassName != "" && workload.HasQuotaReservation(wl) && workload.HasNoPriority(wl) {
+			log.V(2).Info("Leaving a workload that reserved quota with no priority class alone, since one can no longer be added",
+				"workload", klog.KObj(wl))
+			continue
+		}
+
 		wlPriorityClassName := workloadpatching.PriorityClassName(wl)
 
 		// This handles both: changing priority (old -> new) AND adding priority (none -> new)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1189,13 +1189,13 @@ func PropagateAdmissionGatedByAnnotation(obj client.Object, wl *kueue.Workload) 
 
 // UpdateWorkloadPriority reconciles the priority of each workload that still
 // follows the object's kueue.x-k8s.io/priority-class label. Every workload
-// passed must belong to obj, since the desired class is resolved once for the
-// whole set: that is what stops workloads of one object from ending up on
-// different values when the class is edited while they are being written. The
-// resolved value is then applied to every eligible workload whose full priority
-// state has drifted, so a partial write followed by a class-value change still
-// converges on retry instead of leaving same-name workloads pinned to a stale
-// value. The workloads are written one by one rather than atomically.
+// passed must belong to obj, since the class is resolved once for the whole set
+// rather than per workload, so one batch cannot itself write two different
+// values. The resolved value is applied to every eligible workload whose full
+// priority state has drifted, so a partial write followed by a class-value
+// change converges on retry instead of leaving same-name workloads pinned to a
+// stale value. The workloads are written one by one rather than atomically, and
+// a class edited once every workload already names it is not re-resolved here.
 func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
 	jobPriorityClassName := WorkloadPriorityClassName(obj)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -925,9 +925,6 @@ func (m *IntegrationManager) FindAncestorJobManagedByKueue(ctx context.Context, 
 	}
 }
 
-// ensureOneWorkload will query for the single matched workload corresponding to job and return it.
-// If there are more than one workload, we should delete the excess ones.
-// The returned workload could be nil.
 // syncWorkloadSlicePriority applies a priority-class label change to the slices
 // a compatible scale decision leaves live. Slice compatibility only considers
 // the pod set shape, so the label change arrives here with the old priority
@@ -952,6 +949,7 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 			"replacement", klog.KObj(wl), "retained", klog.KObj(retained))
 		live = append(live, retained)
 	}
+	eligible := make([]*kueue.Workload, 0, len(live))
 	for _, slice := range live {
 		if slice == nil {
 			continue
@@ -964,14 +962,14 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 				"workload", klog.KObj(slice))
 			continue
 		}
-		log.V(6).Info("Reconciling the priority class of a workload slice", "workload", klog.KObj(slice))
-		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), slice, getCustomPriorityClassFuncFromJob(job)); err != nil {
-			return err
-		}
+		eligible = append(eligible, slice)
 	}
-	return nil
+	return updateWorkloadPriorities(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), eligible...)
 }
 
+// ensureOneWorkload will query for the single matched workload corresponding to job and return it.
+// If there are more than one workload, we should delete the excess ones.
+// The returned workload could be nil.
 func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -1203,23 +1201,46 @@ func PropagateAdmissionGatedByAnnotation(obj client.Object, wl *kueue.Workload) 
 
 // UpdateWorkloadPriority updates workload priority if object's kueue.x-k8s.io/priority-class label changed.
 func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
-	jobPriorityClassName := WorkloadPriorityClassName(obj)
-	wlPriorityClassName := workloadpatching.PriorityClassName(wl)
+	return updateWorkloadPriorities(ctx, c, r, obj, customPriorityClassFunc, wl)
+}
 
-	// This handles both: changing priority (old -> new) AND adding priority (none -> new)
-	if (workload.HasNoPriority(wl) || workload.IsWorkloadPriorityClass(wl)) && jobPriorityClassName != wlPriorityClassName {
-		if err := PrepareWorkloadPriority(ctx, c, obj, wl, customPriorityClassFunc); err != nil {
-			return fmt.Errorf("prepare workload priority: %w", err)
+// updateWorkloadPriorities updates each workload whose priority still follows the
+// object's label. The class is looked up once for the whole set, so workloads that
+// belong to one object cannot end up on different values when the class is edited
+// while they are being written.
+func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
+	jobPriorityClassName := WorkloadPriorityClassName(obj)
+	var (
+		priorityClassRef *kueue.PriorityClassRef
+		priority         int32
+		resolved         bool
+	)
+	for _, wl := range wls {
+		wlPriorityClassName := workloadpatching.PriorityClassName(wl)
+
+		// This handles both: changing priority (old -> new) AND adding priority (none -> new)
+		if (workload.HasNoPriority(wl) || workload.IsWorkloadPriorityClass(wl)) && jobPriorityClassName != wlPriorityClassName {
+			if !resolved {
+				var err error
+				// Resolved from the first workload that needs it.
+				priorityClassRef, priority, err = ExtractPriority(ctx, c, obj, wl.Spec.PodSets, customPriorityClassFunc)
+				if err != nil {
+					return fmt.Errorf("prepare workload priority: %w", err)
+				}
+				resolved = true
+			}
+			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
+			wl.Spec.Priority = new(priority)
+			if err := c.Update(ctx, wl); err != nil {
+				return fmt.Errorf("updating existing workload: %w", err)
+			}
+			r.Eventf(obj,
+				nil,
+				corev1.EventTypeNormal, ReasonUpdatedWorkload,
+				"UpdatedWorkload",
+				"Updated workload priority class: %v", klog.KObj(wl),
+			)
 		}
-		if err := c.Update(ctx, wl); err != nil {
-			return fmt.Errorf("updating existing workload: %w", err)
-		}
-		r.Eventf(obj,
-			nil,
-			corev1.EventTypeNormal, ReasonUpdatedWorkload,
-			"UpdatedWorkload",
-			"Updated workload priority class: %v", klog.KObj(wl),
-		)
 	}
 	return nil
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/validate/content"
@@ -1197,66 +1198,27 @@ func PropagateAdmissionGatedByAnnotation(obj client.Object, wl *kueue.Workload) 
 // stale value. The workloads are written one by one rather than atomically, and
 // a class edited once every workload already names it is not re-resolved here.
 func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
-	log := ctrl.LoggerFrom(ctx)
-	jobPriorityClassName := WorkloadPriorityClassName(obj)
+	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), WorkloadPriorityClassName(obj), wls)
 
-	// First pass: split the workloads this helper may manage into those that
-	// already carry the desired class name (whose value may still be stale) and
-	// those whose class name still has to transition. Resolving only when at least
-	// one workload needs a transition keeps steady-state reconciles from
-	// re-resolving and overwriting the otherwise-mutable priority value.
-	var alreadyNamed, changing []*kueue.Workload
-	for _, wl := range wls {
-		if wl == nil {
-			continue
-		}
-		// A workload that reserved quota without a priorityClassRef keeps it: the
-		// API server refuses to add one once quota is reserved (Workload CEL), so
-		// retrying would only fail the reconcile for good. The skip is unconditional
-		// so that, even under an empty label, a name-changing sibling in the same
-		// batch cannot drag this workload into a nil -> ref update; only the log is
-		// gated on a non-empty label, to avoid noise on ordinary no-class reserved
-		// workloads. Centralizing the guard here, rather than in the workload-slice
-		// caller alone, covers the ordinary Job and LeaderWorkerSet paths, which
-		// reach this helper directly.
-		if workload.HasQuotaReservation(wl) && workload.HasNoPriority(wl) {
-			if jobPriorityClassName != "" {
-				log.V(2).Info("Leaving a workload that reserved quota with no priority class alone, since one can no longer be added",
-					"workload", klog.KObj(wl))
-			}
-			continue
-		}
-		// Only workloads without a priority yet, or already backed by a
-		// WorkloadPriorityClass, follow the label; Pod PriorityClass-backed
-		// workloads are left unchanged.
-		if !workload.HasNoPriority(wl) && !workload.IsWorkloadPriorityClass(wl) {
-			continue
-		}
-		if workloadpatching.PriorityClassName(wl) == jobPriorityClassName {
-			alreadyNamed = append(alreadyNamed, wl)
-		} else {
-			changing = append(changing, wl)
-		}
-	}
-
-	// No eligible workload needs a class transition, so there is nothing to resolve
-	// and nothing to update.
-	if len(changing) == 0 {
+	// Resolving only when at least one workload needs a transition keeps
+	// steady-state reconciles from re-resolving and overwriting the
+	// otherwise-mutable priority value.
+	if len(needsClassChange) == 0 {
 		return nil
 	}
 
-	priorityClassRef, priority, err := ExtractPriority(ctx, c, obj, changing[0].Spec.PodSets, customPriorityClassFunc)
+	priorityClassRef, priority, err := ExtractPriority(ctx, c, obj, needsClassChange[0].Spec.PodSets, customPriorityClassFunc)
 	if err != nil {
 		return fmt.Errorf("prepare workload priority: %w", err)
 	}
 
-	// Second pass: apply the resolved ref/value to every eligible workload whose
-	// full priority state differs. Same-name workloads with a stale value are
-	// repaired before the name-changing ones, so a name mismatch survives as the
-	// retry marker if a write in this batch fails.
-	targets := make([]*kueue.Workload, 0, len(alreadyNamed)+len(changing))
-	targets = append(targets, alreadyNamed...)
-	targets = append(targets, changing...)
+	// Apply the resolved ref/value to every eligible workload whose full priority
+	// state differs. Same-name workloads with a stale value are repaired before the
+	// name-changing ones, so a name mismatch survives as the retry marker if a
+	// write in this batch fails.
+	targets := make([]*kueue.Workload, 0, len(sameClassName)+len(needsClassChange))
+	targets = append(targets, sameClassName...)
+	targets = append(targets, needsClassChange...)
 	for _, wl := range targets {
 		if priorityStateEqual(wl, priorityClassRef, priority) {
 			continue
@@ -1276,6 +1238,42 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 	return nil
 }
 
+// classifyWorkloadsForPriorityUpdate splits the workloads this helper may manage
+// into those that already carry the object's class name, whose value may still be
+// stale, and those whose class name has to transition. The rest are left out: a
+// Pod PriorityClass-backed workload does not follow the label at all, and one that
+// reserved quota without a priorityClassRef can no longer be given one.
+func classifyWorkloadsForPriorityUpdate(log logr.Logger, jobPriorityClassName string, wls []*kueue.Workload) (sameClassName, needsClassChange []*kueue.Workload) {
+	for _, wl := range wls {
+		if wl == nil {
+			continue
+		}
+		// The API server refuses to add a priorityClassRef once quota is reserved
+		// (Workload CEL), so retrying would only fail the reconcile for good. The
+		// skip is unconditional, so that even under an empty label a name-changing
+		// sibling in the same batch cannot drag this workload into a nil -> ref
+		// update; only the log is gated on a non-empty label, to keep ordinary
+		// no-class reserved workloads quiet. Keeping the guard here covers the
+		// ordinary Job and LeaderWorkerSet paths, which reach the helper directly.
+		if workload.HasQuotaReservation(wl) && workload.HasNoPriority(wl) {
+			if jobPriorityClassName != "" {
+				log.V(2).Info("Leaving a workload that reserved quota with no priority class alone, since one can no longer be added",
+					"workload", klog.KObj(wl))
+			}
+			continue
+		}
+		if !workload.HasNoPriority(wl) && !workload.IsWorkloadPriorityClass(wl) {
+			continue
+		}
+		if workloadpatching.PriorityClassName(wl) == jobPriorityClassName {
+			sameClassName = append(sameClassName, wl)
+		} else {
+			needsClassChange = append(needsClassChange, wl)
+		}
+	}
+	return sameClassName, needsClassChange
+}
+
 // priorityStateEqual reports whether the workload's priority already matches the
 // resolved ref and value. It compares the full ref (group, kind, name) and the
 // numeric value, so a same-name workload whose value drifted is not mistaken for
@@ -1284,16 +1282,7 @@ func priorityStateEqual(wl *kueue.Workload, ref *kueue.PriorityClassRef, priorit
 	if wl.Spec.Priority == nil || *wl.Spec.Priority != priority {
 		return false
 	}
-	switch {
-	case wl.Spec.PriorityClassRef == nil && ref == nil:
-		return true
-	case wl.Spec.PriorityClassRef == nil || ref == nil:
-		return false
-	default:
-		return wl.Spec.PriorityClassRef.Group == ref.Group &&
-			wl.Spec.PriorityClassRef.Kind == ref.Kind &&
-			wl.Spec.PriorityClassRef.Name == ref.Name
-	}
+	return apiequality.Semantic.DeepEqual(wl.Spec.PriorityClassRef, ref)
 }
 
 func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob) (match *kueue.Workload, toDelete []*kueue.Workload, err error) {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1216,14 +1216,18 @@ func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.Eve
 		}
 		// A workload that reserved quota without a priorityClassRef keeps it: the
 		// API server refuses to add one once quota is reserved (Workload CEL), so
-		// retrying would only fail the reconcile for good. Centralizing the guard
-		// here, rather than in the workload-slice caller alone, covers the ordinary
-		// Job and LeaderWorkerSet paths, which reach this helper directly. Gating on
-		// a non-empty label keeps ordinary no-class reserved workloads from logging
-		// on every reconcile.
-		if jobPriorityClassName != "" && workload.HasQuotaReservation(wl) && workload.HasNoPriority(wl) {
-			log.V(2).Info("Leaving a workload that reserved quota with no priority class alone, since one can no longer be added",
-				"workload", klog.KObj(wl))
+		// retrying would only fail the reconcile for good. The skip is unconditional
+		// so that, even under an empty label, a name-changing sibling in the same
+		// batch cannot drag this workload into a nil -> ref update; only the log is
+		// gated on a non-empty label, to avoid noise on ordinary no-class reserved
+		// workloads. Centralizing the guard here, rather than in the workload-slice
+		// caller alone, covers the ordinary Job and LeaderWorkerSet paths, which
+		// reach this helper directly.
+		if workload.HasQuotaReservation(wl) && workload.HasNoPriority(wl) {
+			if jobPriorityClassName != "" {
+				log.V(2).Info("Leaving a workload that reserved quota with no priority class alone, since one can no longer be added",
+					"workload", klog.KObj(wl))
+			}
 			continue
 		}
 		// Only workloads without a priority yet, or already backed by a

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -950,9 +950,9 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 		live = append(live, retained)
 	}
 	// The quota-reserved/no-priorityClassRef legality check lives in
-	// updateWorkloadPriorities so the ordinary Job and LeaderWorkerSet paths, which
+	// UpdateWorkloadPriority so the ordinary Job and LeaderWorkerSet paths, which
 	// reach the shared helper without this caller's filtering, get the same guard.
-	return updateWorkloadPriorities(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
+	return UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
 }
 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
@@ -1120,7 +1120,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			}
 		}
 
-		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), match, getCustomPriorityClassFuncFromJob(job)); err != nil {
+		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), match); err != nil {
 			return nil, err
 		}
 	}
@@ -1187,20 +1187,16 @@ func PropagateAdmissionGatedByAnnotation(obj client.Object, wl *kueue.Workload) 
 	return false
 }
 
-// UpdateWorkloadPriority updates workload priority if object's kueue.x-k8s.io/priority-class label changed.
-func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
-	return updateWorkloadPriorities(ctx, c, r, obj, customPriorityClassFunc, wl)
-}
-
-// updateWorkloadPriorities reconciles the priority of each workload that still
-// follows the object's priority-class label. The desired class is resolved once
-// for the whole set, so workloads that belong to one object cannot end up on
-// different values when the class is edited while they are being written; the
+// UpdateWorkloadPriority reconciles the priority of each workload that still
+// follows the object's kueue.x-k8s.io/priority-class label. Every workload
+// passed must belong to obj, since the desired class is resolved once for the
+// whole set: that is what stops workloads of one object from ending up on
+// different values when the class is edited while they are being written. The
 // resolved value is then applied to every eligible workload whose full priority
 // state has drifted, so a partial write followed by a class-value change still
 // converges on retry instead of leaving same-name workloads pinned to a stale
-// value.
-func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
+// value. The workloads are written one by one rather than atomically.
+func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
 	jobPriorityClassName := WorkloadPriorityClassName(obj)
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -928,6 +928,50 @@ func (m *IntegrationManager) FindAncestorJobManagedByKueue(ctx context.Context, 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
 // If there are more than one workload, we should delete the excess ones.
 // The returned workload could be nil.
+// syncWorkloadSlicePriority applies a priority-class label change to the slices
+// a compatible scale decision leaves live. Slice compatibility only considers
+// the pod set shape, so the label change arrives here with the old priority
+// still on the slice.
+//
+// While a scale-up waits for quota the admitted slice is kept alongside its
+// pending replacement and only the replacement is returned, but both are
+// ordered against other Workloads during preemption, so updating one alone
+// would split the Job's priority. wl is nil when a new slice is to be created.
+func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	// Quota-reserved rather than admitted: FindLatestActiveWorkload selects on
+	// the reservation, and the distinction is what makes the skip below matter.
+	retained, err := workloadslicing.FindLatestActiveWorkload(ctx, r.client, object, job.GVK())
+	if err != nil {
+		return err
+	}
+	live := []*kueue.Workload{wl}
+	if retained != nil && (wl == nil || retained.Name != wl.Name) {
+		log.V(4).Info("Workload slice priority applies to the replacement and to the quota-reserved slice it is waiting behind",
+			"replacement", klog.KObj(wl), "retained", klog.KObj(retained))
+		live = append(live, retained)
+	}
+	for _, slice := range live {
+		if slice == nil {
+			continue
+		}
+		// A slice that reserved quota without a priorityClassRef keeps it: the
+		// API server refuses to add one once quota is reserved, and retrying
+		// would only fail the reconcile for good.
+		if workload.HasQuotaReservation(slice) && workload.HasNoPriority(slice) {
+			log.V(2).Info("Leaving a workload slice that reserved quota with no priority class alone, since one can no longer be added",
+				"workload", klog.KObj(slice))
+			continue
+		}
+		log.V(6).Info("Reconciling the priority class of a workload slice", "workload", klog.KObj(slice))
+		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), slice, getCustomPriorityClassFuncFromJob(job)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -1000,6 +1044,9 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			return nil, err
 		}
 		if compatible {
+			if err := r.syncWorkloadSlicePriority(ctx, job, object, wl); err != nil {
+				return nil, err
+			}
 			return wl, nil
 		}
 		// Fallback.

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1192,18 +1192,24 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 	return updateWorkloadPriorities(ctx, c, r, obj, customPriorityClassFunc, wl)
 }
 
-// updateWorkloadPriorities updates each workload whose priority still follows the
-// object's label. The class is looked up once for the whole set, so workloads that
-// belong to one object cannot end up on different values when the class is edited
-// while they are being written.
+// updateWorkloadPriorities reconciles the priority of each workload that still
+// follows the object's priority-class label. The desired class is resolved once
+// for the whole set, so workloads that belong to one object cannot end up on
+// different values when the class is edited while they are being written; the
+// resolved value is then applied to every eligible workload whose full priority
+// state has drifted, so a partial write followed by a class-value change still
+// converges on retry instead of leaving same-name workloads pinned to a stale
+// value.
 func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
 	jobPriorityClassName := WorkloadPriorityClassName(obj)
-	var (
-		priorityClassRef *kueue.PriorityClassRef
-		priority         int32
-		resolved         bool
-	)
+
+	// First pass: split the workloads this helper may manage into those that
+	// already carry the desired class name (whose value may still be stale) and
+	// those whose class name still has to transition. Resolving only when at least
+	// one workload needs a transition keeps steady-state reconciles from
+	// re-resolving and overwriting the otherwise-mutable priority value.
+	var alreadyNamed, changing []*kueue.Workload
 	for _, wl := range wls {
 		if wl == nil {
 			continue
@@ -1220,34 +1226,74 @@ func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.Eve
 				"workload", klog.KObj(wl))
 			continue
 		}
-
-		wlPriorityClassName := workloadpatching.PriorityClassName(wl)
-
-		// This handles both: changing priority (old -> new) AND adding priority (none -> new)
-		if (workload.HasNoPriority(wl) || workload.IsWorkloadPriorityClass(wl)) && jobPriorityClassName != wlPriorityClassName {
-			if !resolved {
-				var err error
-				// Resolved from the first workload that needs it.
-				priorityClassRef, priority, err = ExtractPriority(ctx, c, obj, wl.Spec.PodSets, customPriorityClassFunc)
-				if err != nil {
-					return fmt.Errorf("prepare workload priority: %w", err)
-				}
-				resolved = true
-			}
-			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
-			wl.Spec.Priority = new(priority)
-			if err := c.Update(ctx, wl); err != nil {
-				return fmt.Errorf("updating existing workload: %w", err)
-			}
-			r.Eventf(obj,
-				nil,
-				corev1.EventTypeNormal, ReasonUpdatedWorkload,
-				"UpdatedWorkload",
-				"Updated workload priority class: %v", klog.KObj(wl),
-			)
+		// Only workloads without a priority yet, or already backed by a
+		// WorkloadPriorityClass, follow the label; Pod PriorityClass-backed
+		// workloads are left unchanged.
+		if !workload.HasNoPriority(wl) && !workload.IsWorkloadPriorityClass(wl) {
+			continue
+		}
+		if workloadpatching.PriorityClassName(wl) == jobPriorityClassName {
+			alreadyNamed = append(alreadyNamed, wl)
+		} else {
+			changing = append(changing, wl)
 		}
 	}
+
+	// No eligible workload needs a class transition, so there is nothing to resolve
+	// and nothing to update.
+	if len(changing) == 0 {
+		return nil
+	}
+
+	priorityClassRef, priority, err := ExtractPriority(ctx, c, obj, changing[0].Spec.PodSets, customPriorityClassFunc)
+	if err != nil {
+		return fmt.Errorf("prepare workload priority: %w", err)
+	}
+
+	// Second pass: apply the resolved ref/value to every eligible workload whose
+	// full priority state differs. Same-name workloads with a stale value are
+	// repaired before the name-changing ones, so a name mismatch survives as the
+	// retry marker if a write in this batch fails.
+	targets := make([]*kueue.Workload, 0, len(alreadyNamed)+len(changing))
+	targets = append(targets, alreadyNamed...)
+	targets = append(targets, changing...)
+	for _, wl := range targets {
+		if priorityStateEqual(wl, priorityClassRef, priority) {
+			continue
+		}
+		wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
+		wl.Spec.Priority = new(priority)
+		if err := c.Update(ctx, wl); err != nil {
+			return fmt.Errorf("updating existing workload: %w", err)
+		}
+		r.Eventf(obj,
+			nil,
+			corev1.EventTypeNormal, ReasonUpdatedWorkload,
+			"UpdatedWorkload",
+			"Updated workload priority class: %v", klog.KObj(wl),
+		)
+	}
 	return nil
+}
+
+// priorityStateEqual reports whether the workload's priority already matches the
+// resolved ref and value. It compares the full ref (group, kind, name) and the
+// numeric value, so a same-name workload whose value drifted is not mistaken for
+// up to date.
+func priorityStateEqual(wl *kueue.Workload, ref *kueue.PriorityClassRef, priority int32) bool {
+	if wl.Spec.Priority == nil || *wl.Spec.Priority != priority {
+		return false
+	}
+	switch {
+	case wl.Spec.PriorityClassRef == nil && ref == nil:
+		return true
+	case wl.Spec.PriorityClassRef == nil || ref == nil:
+		return false
+	default:
+		return wl.Spec.PriorityClassRef.Group == ref.Group &&
+			wl.Spec.PriorityClassRef.Kind == ref.Kind &&
+			wl.Spec.PriorityClassRef.Name == ref.Name
+	}
 }
 
 func FindMatchingWorkloads(ctx context.Context, c client.Client, job GenericJob) (match *kueue.Workload, toDelete []*kueue.Workload, err error) {

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+)
+
+// The workloads of one job are written one after another, so a class edited in
+// between could otherwise give each of them a different value, and later
+// reconciles would not repair that because they compare the class name only.
+func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
+	first := utiltestingapi.MakeWorkload("first", "ns").
+		WorkloadPriorityClassRef("low").Priority(10).Obj()
+	second := utiltestingapi.MakeWorkload("second", "ns").
+		WorkloadPriorityClassRef("low").Priority(10).Obj()
+
+	// Every read of the class reports a different value, which stands in for an
+	// administrator editing it while the workloads are being written.
+	reads := 0
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(job, highClass, first, second).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
+					reads++
+					class.Value = int32(100 * reads)
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	live := make([]*kueue.Workload, 0, 2)
+	for _, name := range []string{"first", "second"} {
+		wl := &kueue.Workload{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
+			t.Fatalf("getting workload %s: %v", name, err)
+		}
+		live = append(live, wl)
+	}
+
+	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
+		t.Fatalf("updateWorkloadPriorities: %v", err)
+	}
+
+	got := make([]int32, 0, len(live))
+	for _, wl := range live {
+		if wl.Spec.Priority == nil {
+			t.Fatalf("workload %s has no priority", wl.Name)
+		}
+		got = append(got, *wl.Spec.Priority)
+	}
+	if got[0] != got[1] {
+		t.Errorf("workloads of one job settled on different priorities: %v", got)
+	}
+	if got[0] != 100 {
+		t.Errorf("priority = %d, want the value read before the class changed (100)", got[0])
+	}
+	if live[0].Spec.PriorityClassRef == live[1].Spec.PriorityClassRef {
+		t.Error("both workloads point at one priorityClassRef, so editing either would move both")
+	}
+}

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -18,6 +18,7 @@ package jobframework
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -77,12 +78,25 @@ func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
 		t.Fatalf("updateWorkloadPriorities: %v", err)
 	}
 
+	if reads != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1 (resolved once for the set)", reads)
+	}
+
+	// Re-read the persisted objects so a regression that forgets to write one of
+	// the updates cannot pass by inspecting only the in-memory copies.
 	got := make([]int32, 0, len(live))
-	for _, wl := range live {
-		if wl.Spec.Priority == nil {
-			t.Fatalf("workload %s has no priority", wl.Name)
+	for _, name := range []string{"first", "second"} {
+		persisted := &kueue.Workload{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
+			t.Fatalf("re-getting workload %s: %v", name, err)
 		}
-		got = append(got, *wl.Spec.Priority)
+		if persisted.Spec.Priority == nil {
+			t.Fatalf("workload %s has no priority", name)
+		}
+		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
+			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
+		}
+		got = append(got, *persisted.Spec.Priority)
 	}
 	if got[0] != got[1] {
 		t.Errorf("workloads of one job settled on different priorities: %v", got)
@@ -147,5 +161,140 @@ func TestUpdateWorkloadPrioritiesLeavesReservedNoRefWorkload(t *testing.T) {
 	}
 	if persisted.Spec.PriorityClassRef != nil {
 		t.Errorf("priorityClassRef = %v, want nil (left unchanged)", persisted.Spec.PriorityClassRef)
+	}
+}
+
+// After a partial write, a later reconcile must still converge every workload of
+// the object on the current value, including one that already carries the right
+// class name but a stale value. A name-only comparison skips such a workload and
+// leaves it pinned to the old value.
+func TestUpdateWorkloadPrioritiesConvergesAfterPartialWrite(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj()
+	// first already carries the class name but the value from before it changed.
+	first := utiltestingapi.MakeWorkload("first", "ns").
+		WorkloadPriorityClassRef("high").Priority(100).Obj()
+	// second still points at the old class, which forces the resolution.
+	second := utiltestingapi.MakeWorkload("second", "ns").
+		WorkloadPriorityClassRef("low").Priority(10).Obj()
+
+	reads := 0
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(job, highClass, first, second).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
+					reads++
+				}
+				return nil
+			},
+		}).
+		Build()
+
+	live := make([]*kueue.Workload, 0, 2)
+	for _, name := range []string{"first", "second"} {
+		wl := &kueue.Workload{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
+			t.Fatalf("getting workload %s: %v", name, err)
+		}
+		live = append(live, wl)
+	}
+
+	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
+		t.Fatalf("updateWorkloadPriorities: %v", err)
+	}
+
+	if reads != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1 (resolved once for the set)", reads)
+	}
+	for _, name := range []string{"first", "second"} {
+		persisted := &kueue.Workload{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
+			t.Fatalf("re-getting workload %s: %v", name, err)
+		}
+		if persisted.Spec.Priority == nil || *persisted.Spec.Priority != 200 {
+			t.Errorf("%s priority = %v, want 200", name, persisted.Spec.Priority)
+		}
+		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
+			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
+		}
+	}
+}
+
+// The split state that breaks name-only convergence is reachable from a real
+// partial write: the first slice persists at the old value, the second fails, the
+// class value then changes, and the retry must still bring both to the new value.
+func TestUpdateWorkloadPrioritiesConvergesAfterConflictRetry(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
+	first := utiltestingapi.MakeWorkload("first", "ns").
+		WorkloadPriorityClassRef("low").Priority(10).Obj()
+	second := utiltestingapi.MakeWorkload("second", "ns").
+		WorkloadPriorityClassRef("low").Priority(10).Obj()
+
+	failSecondOnce := true
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(job, highClass, first, second).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if wl, ok := obj.(*kueue.Workload); ok && wl.Name == "second" && failSecondOnce {
+					failSecondOnce = false
+					return errors.New("simulated conflict")
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	readLive := func() []*kueue.Workload {
+		out := make([]*kueue.Workload, 0, 2)
+		for _, name := range []string{"first", "second"} {
+			wl := &kueue.Workload{}
+			if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
+				t.Fatalf("getting workload %s: %v", name, err)
+			}
+			out = append(out, wl)
+		}
+		return out
+	}
+
+	// First invocation: first persists as high/100, second's update fails.
+	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err == nil {
+		t.Fatal("expected the simulated conflict to surface on the first invocation")
+	}
+
+	// The class value is raised between the partial write and the retry.
+	hc := &kueue.WorkloadPriorityClass{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "high"}, hc); err != nil {
+		t.Fatalf("getting class: %v", err)
+	}
+	hc.Value = 200
+	if err := cl.Update(ctx, hc); err != nil {
+		t.Fatalf("updating class: %v", err)
+	}
+
+	// Retry from freshly-read state: both must converge to high/200.
+	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err != nil {
+		t.Fatalf("retry: %v", err)
+	}
+
+	for _, name := range []string{"first", "second"} {
+		persisted := &kueue.Workload{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
+			t.Fatalf("re-getting workload %s: %v", name, err)
+		}
+		if persisted.Spec.Priority == nil || *persisted.Spec.Priority != 200 {
+			t.Errorf("%s priority = %v, want 200 after retry", name, persisted.Spec.Priority)
+		}
+		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
+			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
+		}
 	}
 }

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -91,5 +92,60 @@ func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
 	}
 	if live[0].Spec.PriorityClassRef == live[1].Spec.PriorityClassRef {
 		t.Error("both workloads point at one priorityClassRef, so editing either would move both")
+	}
+}
+
+// A quota-reserved workload with no priorityClassRef must be left untouched on the
+// ordinary (non-slice) path too: the API server refuses to add a ref once quota is
+// reserved, so attempting the update would wedge the reconcile. The guard lives in
+// the shared helper, which the ordinary Job and LeaderWorkerSet paths reach
+// directly through UpdateWorkloadPriority.
+func TestUpdateWorkloadPrioritiesLeavesReservedNoRefWorkload(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
+	reserved := utiltestingapi.MakeWorkload("reserved", "ns").
+		Condition(metav1.Condition{
+			Type:               kueue.WorkloadQuotaReserved,
+			Status:             metav1.ConditionTrue,
+			Reason:             "AdmittedByTest",
+			Message:            "reserved",
+			LastTransitionTime: metav1.Now(),
+		}).Obj()
+
+	// The fake client does not run the Workload CEL rules, so if the guard is lost
+	// this update would succeed here and set the ref, which the assertions catch.
+	updates := 0
+	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
+		WithObjects(job, highClass, reserved).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if _, ok := obj.(*kueue.Workload); ok {
+					updates++
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	wl := &kueue.Workload{}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "reserved"}, wl); err != nil {
+		t.Fatalf("getting workload: %v", err)
+	}
+
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, wl, nil); err != nil {
+		t.Fatalf("UpdateWorkloadPriority: %v", err)
+	}
+
+	if updates != 0 {
+		t.Errorf("workload was updated %d times, want 0: a priorityClassRef cannot be added after quota reservation", updates)
+	}
+	persisted := &kueue.Workload{}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "reserved"}, persisted); err != nil {
+		t.Fatalf("re-getting workload: %v", err)
+	}
+	if persisted.Spec.PriorityClassRef != nil {
+		t.Errorf("priorityClassRef = %v, want nil (left unchanged)", persisted.Spec.PriorityClassRef)
 	}
 }

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -36,7 +36,7 @@ import (
 // The workloads of one job are written one after another, so a class edited in
 // between could otherwise give each of them a different value, and later
 // reconciles would not repair that because they compare the class name only.
-func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
+func TestUpdateWorkloadPriorityResolvesTheClassOnce(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
@@ -74,8 +74,8 @@ func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
 		live = append(live, wl)
 	}
 
-	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
-		t.Fatalf("updateWorkloadPriorities: %v", err)
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
+		t.Fatalf("UpdateWorkloadPriority: %v", err)
 	}
 
 	if reads != 1 {
@@ -114,7 +114,7 @@ func TestUpdateWorkloadPrioritiesResolvesTheClassOnce(t *testing.T) {
 // reserved, so attempting the update would wedge the reconcile. The guard lives in
 // the shared helper, which the ordinary Job and LeaderWorkerSet paths reach
 // directly through UpdateWorkloadPriority.
-func TestUpdateWorkloadPrioritiesLeavesReservedNoRefWorkload(t *testing.T) {
+func TestUpdateWorkloadPriorityLeavesReservedNoRefWorkload(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
@@ -148,7 +148,7 @@ func TestUpdateWorkloadPrioritiesLeavesReservedNoRefWorkload(t *testing.T) {
 		t.Fatalf("getting workload: %v", err)
 	}
 
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, wl, nil); err != nil {
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, wl); err != nil {
 		t.Fatalf("UpdateWorkloadPriority: %v", err)
 	}
 
@@ -168,7 +168,7 @@ func TestUpdateWorkloadPrioritiesLeavesReservedNoRefWorkload(t *testing.T) {
 // the object on the current value, including one that already carries the right
 // class name but a stale value. A name-only comparison skips such a workload and
 // leaves it pinned to the old value.
-func TestUpdateWorkloadPrioritiesConvergesAfterPartialWrite(t *testing.T) {
+func TestUpdateWorkloadPriorityConvergesAfterPartialWrite(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
@@ -205,8 +205,8 @@ func TestUpdateWorkloadPrioritiesConvergesAfterPartialWrite(t *testing.T) {
 		live = append(live, wl)
 	}
 
-	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
-		t.Fatalf("updateWorkloadPriorities: %v", err)
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
+		t.Fatalf("UpdateWorkloadPriority: %v", err)
 	}
 
 	if reads != 1 {
@@ -229,7 +229,7 @@ func TestUpdateWorkloadPrioritiesConvergesAfterPartialWrite(t *testing.T) {
 // The split state that breaks name-only convergence is reachable from a real
 // partial write: the first slice persists at the old value, the second fails, the
 // class value then changes, and the retry must still bring both to the new value.
-func TestUpdateWorkloadPrioritiesConvergesAfterConflictRetry(t *testing.T) {
+func TestUpdateWorkloadPriorityConvergesAfterConflictRetry(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
@@ -266,7 +266,7 @@ func TestUpdateWorkloadPrioritiesConvergesAfterConflictRetry(t *testing.T) {
 	}
 
 	// First invocation: first persists as high/100, second's update fails.
-	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err == nil {
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err == nil {
 		t.Fatal("expected the simulated conflict to surface on the first invocation")
 	}
 
@@ -281,7 +281,7 @@ func TestUpdateWorkloadPrioritiesConvergesAfterConflictRetry(t *testing.T) {
 	}
 
 	// Retry from freshly-read state: both must converge to high/200.
-	if err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err != nil {
+	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err != nil {
 		t.Fatalf("retry: %v", err)
 	}
 

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -33,268 +33,298 @@ import (
 	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 )
 
-// The workloads of one job are written one after another, so a class edited in
-// between could otherwise give each of them a different value, and later
-// reconciles would not repair that because they compare the class name only.
-func TestUpdateWorkloadPriorityResolvesTheClassOnce(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
-	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
-	first := utiltestingapi.MakeWorkload("first", "ns").
-		WorkloadPriorityClassRef("low").Priority(10).Obj()
-	second := utiltestingapi.MakeWorkload("second", "ns").
-		WorkloadPriorityClassRef("low").Priority(10).Obj()
-
-	// Every read of the class reports a different value, which stands in for an
-	// administrator editing it while the workloads are being written.
-	reads := 0
-	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
-		WithObjects(job, highClass, first, second).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if err := c.Get(ctx, key, obj, opts...); err != nil {
-					return err
-				}
-				if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
-					reads++
-					class.Value = int32(100 * reads)
-				}
-				return nil
-			},
-		}).
-		Build()
-
-	live := make([]*kueue.Workload, 0, 2)
-	for _, name := range []string{"first", "second"} {
-		wl := &kueue.Workload{}
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
-			t.Fatalf("getting workload %s: %v", name, err)
-		}
-		live = append(live, wl)
-	}
-
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
-		t.Fatalf("UpdateWorkloadPriority: %v", err)
-	}
-
-	if reads != 1 {
-		t.Errorf("WorkloadPriorityClass reads = %d, want 1 (resolved once for the set)", reads)
-	}
-
-	// Re-read the persisted objects so a regression that forgets to write one of
-	// the updates cannot pass by inspecting only the in-memory copies.
-	got := make([]int32, 0, len(live))
-	for _, name := range []string{"first", "second"} {
-		persisted := &kueue.Workload{}
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
-			t.Fatalf("re-getting workload %s: %v", name, err)
-		}
-		if persisted.Spec.Priority == nil {
-			t.Fatalf("workload %s has no priority", name)
-		}
-		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
-			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
-		}
-		got = append(got, *persisted.Spec.Priority)
-	}
-	if got[0] != got[1] {
-		t.Errorf("workloads of one job settled on different priorities: %v", got)
-	}
-	if got[0] != 100 {
-		t.Errorf("priority = %d, want the value read before the class changed (100)", got[0])
-	}
-	if live[0].Spec.PriorityClassRef == live[1].Spec.PriorityClassRef {
-		t.Error("both workloads point at one priorityClassRef, so editing either would move both")
-	}
+// priorityStats is counted through the interceptors, for the cases that care how
+// often the class was read or a workload written.
+type priorityStats struct {
+	classReads     int
+	workloadWrites int
 }
 
-// A quota-reserved workload with no priorityClassRef must be left untouched on the
-// ordinary (non-slice) path too: the API server refuses to add a ref once quota is
-// reserved, so attempting the update would wedge the reconcile. The guard lives in
-// the shared helper, which the ordinary Job and LeaderWorkerSet paths reach
-// directly through UpdateWorkloadPriority.
-func TestUpdateWorkloadPriorityLeavesReservedNoRefWorkload(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+func TestUpdateWorkloadPriority(t *testing.T) {
+	// One invocation of the helper, with the change to the cluster that only
+	// means something between two of them.
+	type step struct {
+		before  func(t *testing.T, ctx context.Context, cl client.Client)
+		wantErr bool
+	}
+	// A nil field is not asserted.
+	type wantWorkload struct {
+		refName  *string
+		priority *int32
+	}
 
-	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
-	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
-	reserved := utiltestingapi.MakeWorkload("reserved", "ns").
-		Condition(metav1.Condition{
-			Type:               kueue.WorkloadQuotaReserved,
-			Status:             metav1.ConditionTrue,
-			Reason:             "AdmittedByTest",
-			Message:            "reserved",
-			LastTransitionTime: metav1.Now(),
-		}).Obj()
-
-	// The fake client does not run the Workload CEL rules, so if the guard is lost
-	// this update would succeed here and set the ref, which the assertions catch.
-	updates := 0
-	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
-		WithObjects(job, highClass, reserved).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				if _, ok := obj.(*kueue.Workload); ok {
-					updates++
-				}
-				return c.Update(ctx, obj, opts...)
+	cases := map[string]struct {
+		class        *kueue.WorkloadPriorityClass
+		workloads    []*kueue.Workload
+		interceptors func(s *priorityStats) interceptor.Funcs
+		steps        []step
+		want         map[string]wantWorkload
+		// Nil where the count is not part of what the case pins.
+		wantClassReads     *int
+		wantWorkloadWrites *int
+		wantDistinctRefs   bool
+	}{
+		// The workloads of one job are written one after another, so a class edited
+		// in between could otherwise give each of them a different value, and later
+		// reconciles would not repair that because they compare the class name only.
+		"resolves the class once for the whole set": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("first", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
+				utiltestingapi.MakeWorkload("second", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
 			},
-		}).
-		Build()
-
-	wl := &kueue.Workload{}
-	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "reserved"}, wl); err != nil {
-		t.Fatalf("getting workload: %v", err)
-	}
-
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, wl); err != nil {
-		t.Fatalf("UpdateWorkloadPriority: %v", err)
-	}
-
-	if updates != 0 {
-		t.Errorf("workload was updated %d times, want 0: a priorityClassRef cannot be added after quota reservation", updates)
-	}
-	persisted := &kueue.Workload{}
-	if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "reserved"}, persisted); err != nil {
-		t.Fatalf("re-getting workload: %v", err)
-	}
-	if persisted.Spec.PriorityClassRef != nil {
-		t.Errorf("priorityClassRef = %v, want nil (left unchanged)", persisted.Spec.PriorityClassRef)
-	}
-}
-
-// After a partial write, a later reconcile must still converge every workload of
-// the object on the current value, including one that already carries the right
-// class name but a stale value. A name-only comparison skips such a workload and
-// leaves it pinned to the old value.
-func TestUpdateWorkloadPriorityConvergesAfterPartialWrite(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
-	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj()
-	// first already carries the class name but the value from before it changed.
-	first := utiltestingapi.MakeWorkload("first", "ns").
-		WorkloadPriorityClassRef("high").Priority(100).Obj()
-	// second still points at the old class, which forces the resolution.
-	second := utiltestingapi.MakeWorkload("second", "ns").
-		WorkloadPriorityClassRef("low").Priority(10).Obj()
-
-	reads := 0
-	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
-		WithObjects(job, highClass, first, second).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-				if err := c.Get(ctx, key, obj, opts...); err != nil {
-					return err
+			// Every read reports a different value, standing in for an administrator
+			// editing the class while the workloads are being written.
+			interceptors: func(s *priorityStats) interceptor.Funcs {
+				return interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := c.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
+							s.classReads++
+							class.Value = int32(100 * s.classReads)
+						}
+						return nil
+					},
 				}
-				if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
-					reads++
-				}
-				return nil
 			},
-		}).
-		Build()
-
-	live := make([]*kueue.Workload, 0, 2)
-	for _, name := range []string{"first", "second"} {
-		wl := &kueue.Workload{}
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
-			t.Fatalf("getting workload %s: %v", name, err)
-		}
-		live = append(live, wl)
-	}
-
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...); err != nil {
-		t.Fatalf("UpdateWorkloadPriority: %v", err)
-	}
-
-	if reads != 1 {
-		t.Errorf("WorkloadPriorityClass reads = %d, want 1 (resolved once for the set)", reads)
-	}
-	for _, name := range []string{"first", "second"} {
-		persisted := &kueue.Workload{}
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
-			t.Fatalf("re-getting workload %s: %v", name, err)
-		}
-		if persisted.Spec.Priority == nil || *persisted.Spec.Priority != 200 {
-			t.Errorf("%s priority = %v, want 200", name, persisted.Spec.Priority)
-		}
-		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
-			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
-		}
-	}
-}
-
-// The split state that breaks name-only convergence is reachable from a real
-// partial write: the first slice persists at the old value, the second fails, the
-// class value then changes, and the retry must still bring both to the new value.
-func TestUpdateWorkloadPriorityConvergesAfterConflictRetry(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
-	highClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
-	first := utiltestingapi.MakeWorkload("first", "ns").
-		WorkloadPriorityClassRef("low").Priority(10).Obj()
-	second := utiltestingapi.MakeWorkload("second", "ns").
-		WorkloadPriorityClassRef("low").Priority(10).Obj()
-
-	failSecondOnce := true
-	cl := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).
-		WithObjects(job, highClass, first, second).
-		WithInterceptorFuncs(interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-				if wl, ok := obj.(*kueue.Workload); ok && wl.Name == "second" && failSecondOnce {
-					failSecondOnce = false
-					return errors.New("simulated conflict")
-				}
-				return c.Update(ctx, obj, opts...)
+			steps: []step{{}},
+			want: map[string]wantWorkload{
+				"first":  {refName: new("high"), priority: new(int32(100))},
+				"second": {refName: new("high"), priority: new(int32(100))},
 			},
-		}).
-		Build()
+			wantClassReads:   new(1),
+			wantDistinctRefs: true,
+		},
 
-	readLive := func() []*kueue.Workload {
-		out := make([]*kueue.Workload, 0, 2)
-		for _, name := range []string{"first", "second"} {
-			wl := &kueue.Workload{}
-			if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, wl); err != nil {
-				t.Fatalf("getting workload %s: %v", name, err)
+		// A quota-reserved workload with no priorityClassRef must be left untouched
+		// on the ordinary (non-slice) path too: the API server refuses to add a ref
+		// once quota is reserved, so attempting it would wedge the reconcile. The
+		// fake client does not run those CEL rules, so losing the guard shows up
+		// here as a write that should not have happened.
+		"leaves a quota-reserved workload with no priority class alone": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "AdmittedByTest",
+						Message:            "reserved",
+						LastTransitionTime: metav1.Now(),
+					}).Obj(),
+			},
+			interceptors: countingWrites,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"reserved": {refName: new("")},
+			},
+			wantWorkloadWrites: new(0),
+		},
+
+		// A workload that already carries the right class name but a stale value is
+		// only repaired if the comparison looks past the name.
+		"converges a workload that already names the class but holds a stale value": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("first", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+				utiltestingapi.MakeWorkload("second", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
+			},
+			interceptors: countingClassReads,
+			steps:        []step{{}},
+			want: map[string]wantWorkload{
+				"first":  {refName: new("high"), priority: new(int32(200))},
+				"second": {refName: new("high"), priority: new(int32(200))},
+			},
+			wantClassReads: new(1),
+		},
+
+		// The split state is reachable from a real partial write: the first workload
+		// persists at the old value, the second fails, the class value then changes,
+		// and the retry must still bring both to the new value.
+		"converges after a conflict when the class value changes before the retry": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("first", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
+				utiltestingapi.MakeWorkload("second", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
+			},
+			interceptors: func(s *priorityStats) interceptor.Funcs {
+				failSecondOnce := true
+				return interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						if wl, ok := obj.(*kueue.Workload); ok && wl.Name == "second" && failSecondOnce {
+							failSecondOnce = false
+							return errors.New("simulated conflict")
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				}
+			},
+			steps: []step{
+				{wantErr: true},
+				{before: raiseClassTo(200)},
+			},
+			want: map[string]wantWorkload{
+				"first":  {refName: new("high"), priority: new(int32(200))},
+				"second": {refName: new("high"), priority: new(int32(200))},
+			},
+		},
+
+		// Same-name workloads are repaired before the name-changing ones, so a failed
+		// write leaves a name mismatch behind. That mismatch is the only thing that
+		// makes a later call resolve the class again, so writing the two groups the
+		// other way round strands the stale one for good.
+		"keeps a retry marker when a write fails": {
+			class: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("stale", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+				utiltestingapi.MakeWorkload("transitioning", "ns").WorkloadPriorityClassRef("low").Priority(10).Obj(),
+			},
+			// Fails whichever workload is written second, so the case does not depend
+			// on the order it exists to pin.
+			interceptors: func(s *priorityStats) interceptor.Funcs {
+				return interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						if _, ok := obj.(*kueue.Workload); ok {
+							s.workloadWrites++
+							if s.workloadWrites == 2 {
+								return errors.New("simulated conflict")
+							}
+						}
+						return c.Update(ctx, obj, opts...)
+					},
+				}
+			},
+			steps: []step{{wantErr: true}, {}},
+			want: map[string]wantWorkload{
+				"stale":         {priority: new(int32(200))},
+				"transitioning": {priority: new(int32(200))},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+
+			objs := []client.Object{job, tc.class}
+			names := make([]string, 0, len(tc.workloads))
+			for _, wl := range tc.workloads {
+				objs = append(objs, wl)
+				names = append(names, wl.Name)
 			}
-			out = append(out, wl)
+
+			s := &priorityStats{}
+			builder := utiltesting.NewClientBuilder(batchv1.AddToScheme, kueue.AddToScheme).WithObjects(objs...)
+			if tc.interceptors != nil {
+				builder = builder.WithInterceptorFuncs(tc.interceptors(s))
+			}
+			cl := builder.Build()
+
+			// Read afresh before every invocation, the way a reconcile would, so a
+			// regression that only updates the in-memory copies cannot pass.
+			readLive := func() []*kueue.Workload {
+				out := make([]*kueue.Workload, 0, len(names))
+				for _, n := range names {
+					wl := &kueue.Workload{}
+					if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: n}, wl); err != nil {
+						t.Fatalf("getting workload %s: %v", n, err)
+					}
+					out = append(out, wl)
+				}
+				return out
+			}
+
+			var live []*kueue.Workload
+			for i, st := range tc.steps {
+				if st.before != nil {
+					st.before(t, ctx, cl)
+				}
+				live = readLive()
+				err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...)
+				switch {
+				case st.wantErr && err == nil:
+					t.Fatalf("invocation %d: want an error, got none", i)
+				case !st.wantErr && err != nil:
+					t.Fatalf("invocation %d: %v", i, err)
+				}
+			}
+
+			for n, want := range tc.want {
+				persisted := &kueue.Workload{}
+				if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: n}, persisted); err != nil {
+					t.Fatalf("re-getting workload %s: %v", n, err)
+				}
+				if want.refName != nil {
+					got := ""
+					if persisted.Spec.PriorityClassRef != nil {
+						got = persisted.Spec.PriorityClassRef.Name
+					}
+					if got != *want.refName {
+						t.Errorf("%s priorityClassRef name = %q, want %q", n, got, *want.refName)
+					}
+				}
+				if want.priority != nil {
+					if persisted.Spec.Priority == nil || *persisted.Spec.Priority != *want.priority {
+						t.Errorf("%s priority = %v, want %d", n, persisted.Spec.Priority, *want.priority)
+					}
+				}
+			}
+
+			if tc.wantClassReads != nil && s.classReads != *tc.wantClassReads {
+				t.Errorf("class reads = %d, want %d", s.classReads, *tc.wantClassReads)
+			}
+			if tc.wantWorkloadWrites != nil && s.workloadWrites != *tc.wantWorkloadWrites {
+				t.Errorf("workload writes = %d, want %d", s.workloadWrites, *tc.wantWorkloadWrites)
+			}
+			if tc.wantDistinctRefs && live[0].Spec.PriorityClassRef == live[1].Spec.PriorityClassRef {
+				t.Error("both workloads point at one priorityClassRef, so editing either would move both")
+			}
+		})
+	}
+}
+
+// countingClassReads counts how often the priority class is read, for the cases
+// asserting that it is resolved once for the whole set.
+func countingClassReads(s *priorityStats) interceptor.Funcs {
+	return interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if err := c.Get(ctx, key, obj, opts...); err != nil {
+				return err
+			}
+			if class, ok := obj.(*kueue.WorkloadPriorityClass); ok && class.Name == "high" {
+				s.classReads++
+			}
+			return nil
+		},
+	}
+}
+
+// countingWrites counts workload writes, for the cases asserting that a workload
+// was left alone.
+func countingWrites(s *priorityStats) interceptor.Funcs {
+	return interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*kueue.Workload); ok {
+				s.workloadWrites++
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}
+}
+
+// raiseClassTo changes the class value between two invocations.
+func raiseClassTo(value int32) func(t *testing.T, ctx context.Context, cl client.Client) {
+	return func(t *testing.T, ctx context.Context, cl client.Client) {
+		class := &kueue.WorkloadPriorityClass{}
+		if err := cl.Get(ctx, types.NamespacedName{Name: "high"}, class); err != nil {
+			t.Fatalf("getting class: %v", err)
 		}
-		return out
-	}
-
-	// First invocation: first persists as high/100, second's update fails.
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err == nil {
-		t.Fatal("expected the simulated conflict to surface on the first invocation")
-	}
-
-	// The class value is raised between the partial write and the retry.
-	hc := &kueue.WorkloadPriorityClass{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "high"}, hc); err != nil {
-		t.Fatalf("getting class: %v", err)
-	}
-	hc.Value = 200
-	if err := cl.Update(ctx, hc); err != nil {
-		t.Fatalf("updating class: %v", err)
-	}
-
-	// Retry from freshly-read state: both must converge to high/200.
-	if err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, readLive()...); err != nil {
-		t.Fatalf("retry: %v", err)
-	}
-
-	for _, name := range []string{"first", "second"} {
-		persisted := &kueue.Workload{}
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: name}, persisted); err != nil {
-			t.Fatalf("re-getting workload %s: %v", name, err)
-		}
-		if persisted.Spec.Priority == nil || *persisted.Spec.Priority != 200 {
-			t.Errorf("%s priority = %v, want 200 after retry", name, persisted.Spec.Priority)
-		}
-		if persisted.Spec.PriorityClassRef == nil || persisted.Spec.PriorityClassRef.Name != "high" {
-			t.Errorf("%s priorityClassRef = %v, want high", name, persisted.Spec.PriorityClassRef)
+		class.Value = value
+		if err := cl.Update(ctx, class); err != nil {
+			t.Fatalf("updating class: %v", err)
 		}
 	}
 }

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3462,7 +3462,10 @@ func TestReconciler(t *testing.T) {
 		},
 		// Deterministic counterpart to the integration spec: the fake client has no
 		// such class, so the lookup cannot race with anything creating it.
-		"a workload slice is left untouched when the new class does not exist": {
+		// The API server refuses to add a priorityClassRef once quota is reserved,
+		// so the slice keeps none. The fake client does not enforce that rule, which
+		// is what makes this case fail if the reconciler stops skipping the slice.
+		"a workload slice that reserved quota with no priority class is left alone": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
 				features.AssignQueueLabelsForPods:     true,
@@ -3472,27 +3475,25 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
-				WorkloadPriorityClass("missing-wpc").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
-				WorkloadPriorityClass("missing-wpc").
+				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
-			// missing-wpc is deliberately absent.
 			priorityClasses: []client.Object{
-				baseWPCWrapper.Obj(),
+				baseWPCWrapper.Obj(), highWPCWrapper.Obj(),
 			},
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("job", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
-					Priority(baseWPCWrapper.Value).
-					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
@@ -3503,14 +3504,12 @@ func TestReconciler(t *testing.T) {
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
-					Priority(baseWPCWrapper.Value).
-					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
 					Obj(),
 			},
-			wantErr: cmpopts.AnyError,
 		},
 		"shouldn't update workload when priority class no changes": {
 			featureGates: map[featuregate.Feature]bool{

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -52,6 +52,7 @@ import (
 	utiltestingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadpatching "sigs.k8s.io/kueue/pkg/workload/patching"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestPodsReady(t *testing.T) {
@@ -3114,6 +3115,402 @@ func TestReconciler(t *testing.T) {
 					Message:   "Updated workload priority class: ns/job",
 				},
 			},
+		},
+		// An elastic Job whose pod set counts have not changed takes the workload
+		// slice path, which returns the existing slice as compatible before the
+		// priority is reconciled.
+		// The negative half of the slice path, pinned here rather than only in
+		// envtest: a reconcile against a fake client is synchronous, so the failed
+		// lookup is observed rather than inferred from the absence of a change.
+		"the workload slice is left alone when the class does not exist": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass("missing-wpc").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass("missing-wpc").
+				UID("test-uid").
+				Obj(),
+			// missing-wpc is deliberately absent.
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantErr: cmpopts.AnyError,
+		},
+		"the workload slice is updated when priority class has changed for suspended job": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(), highWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated workload priority class: ns/job",
+				},
+			},
+		},
+		// EnsureWorkloadSlices writes the new counts itself before reporting the
+		// slice compatible, so the priority update is a second write to the same
+		// object in one reconcile.
+		"the workload slice takes both a count and a priority class change": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(), highWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated workload priority class: ns/job",
+				},
+			},
+		},
+		// A scale-up waiting for quota keeps the admitted slice alongside its
+		// pending replacement, and normalizeActiveSlices returns only the
+		// replacement. Both are live, so both have to follow the label.
+		"the workload slice and its retained admitted slice both follow the label": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(), highWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("replacement", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "ns/admitted").
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("replacement", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, "ns/admitted").
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			// Compared in order, and the reconciler visits the returned slice
+			// before the retained admitted one.
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated workload priority class: ns/replacement",
+				},
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated workload priority class: ns/admitted",
+				},
+			},
+		},
+		// Scaling up an admitted slice returns no slice at all, because a new one
+		// is about to be created. The admitted slice is still live and still has to
+		// follow the label.
+		"the admitted slice follows the label when a scale-up replaces it": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass(highWPCWrapper.Name).
+				UID("test-uid").
+				Obj(),
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(), highWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("job-job-2e122", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(highWPCWrapper.Value).
+					WorkloadPriorityClassRef(highWPCWrapper.Name).
+					Annotations(map[string]string{
+						constants.ElasticJobAnnotation:              "true",
+						kueue.WorkloadSliceNameAnnotation:           "admitted",
+						workloadslicing.WorkloadSliceReplacementFor: "ns/admitted",
+					}).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "UpdatedWorkload",
+					Message:   "Updated workload priority class: ns/admitted",
+				},
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "CreatedWorkload",
+					Message:   "Created Workload: ns/job-job-2e122",
+				},
+			},
+		},
+		// Deterministic counterpart to the integration spec: the fake client has no
+		// such class, so the lookup cannot race with anything creating it.
+		"a workload slice is left untouched when the new class does not exist": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:      false,
+				features.AssignQueueLabelsForPods:     true,
+				features.ElasticJobsViaWorkloadSlices: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass("missing-wpc").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(true).
+				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				WorkloadPriorityClass("missing-wpc").
+				UID("test-uid").
+				Obj(),
+			// missing-wpc is deliberately absent.
+			priorityClasses: []client.Object{
+				baseWPCWrapper.Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("job", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
+					Queue(localQueueName).
+					Priority(baseWPCWrapper.Value).
+					WorkloadPriorityClassRef(baseWPCWrapper.Name).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					Obj(),
+			},
+			wantErr: cmpopts.AnyError,
 		},
 		"shouldn't update workload when priority class no changes": {
 			featureGates: map[featuregate.Feature]bool{

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -446,7 +446,7 @@ func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.
 		}
 	}
 
-	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, wl, nil)
+	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, wl)
 	if err != nil {
 		log.Error(err, "Failed to update workload priority")
 		return err

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5173,10 +5173,16 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		})
 
 		// The lookup fails, so the slice keeps the priority it was admitted with
-		// rather than being left half updated.
+		// rather than being left half updated. Read here rather than through the
+		// helper, which waits internally: inside Consistently that would retry
+		// until the value came back, and so could not see it move away at all.
 		ginkgo.By("checking the slice keeps the class it was admitted with", func() {
 			gomega.Consistently(func(g gomega.Gomega) {
-				util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, lowPriorityClass.Name, lowPriorityClass.Value, sliceKey)
+				wl := &kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, sliceKey, wl)).To(gomega.Succeed())
+				g.Expect(wl.Spec.PriorityClassRef).ToNot(gomega.BeNil())
+				g.Expect(wl.Spec.PriorityClassRef.Name).To(gomega.Equal(lowPriorityClass.Name))
+				g.Expect(wl.Spec.Priority).To(gomega.Equal(&lowPriorityClass.Value))
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5091,6 +5091,160 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should apply a WorkloadPriorityClass change to an admitted workload slice", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		lowPriorityClass := utiltestingapi.MakeWorkloadPriorityClass("low").PriorityValue(int32(priorityValue)).Obj()
+		util.MustCreate(ctx, k8sClient, lowPriorityClass)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, lowPriorityClass)).To(gomega.Succeed())
+		})
+
+		highPriorityClass := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(int32(highPriorityValue)).Obj()
+		util.MustCreate(ctx, k8sClient, highPriorityClass)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
+		})
+
+		job := testingjob.MakeJob("job-slice-priority", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1000m").
+			Parallelism(1).
+			WorkloadPriorityClass(lowPriorityClass.Name).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		var sliceKey client.ObjectKey
+		ginkgo.By("waiting for the slice to be admitted with the low class", func() {
+			workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, job.Namespace, 1)
+			sliceKey = client.ObjectKeyFromObject(&workloads[0])
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, &workloads[0])
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, lowPriorityClass.Name, lowPriorityClass.Value, sliceKey)
+		})
+
+		// The pod set counts stay the same, so the existing slice is compatible and
+		// the reconciler takes the slicing path rather than the ordinary one.
+		ginkgo.By("changing only the priority class label", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				job.Labels[constants.WorkloadPriorityClassLabel] = highPriorityClass.Name
+				g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the admitted slice follows the label", func() {
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, highPriorityClass.Name, highPriorityClass.Value, sliceKey)
+		})
+	})
+
+	ginkgo.It("Should leave an admitted workload slice alone when the new class does not exist", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		lowPriorityClass := utiltestingapi.MakeWorkloadPriorityClass("low").PriorityValue(int32(priorityValue)).Obj()
+		util.MustCreate(ctx, k8sClient, lowPriorityClass)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, lowPriorityClass)).To(gomega.Succeed())
+		})
+
+		job := testingjob.MakeJob("job-slice-missing-class", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1000m").
+			Parallelism(1).
+			WorkloadPriorityClass(lowPriorityClass.Name).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		var sliceKey client.ObjectKey
+		ginkgo.By("waiting for the slice to be admitted with the low class", func() {
+			workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, job.Namespace, 1)
+			sliceKey = client.ObjectKeyFromObject(&workloads[0])
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, &workloads[0])
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, lowPriorityClass.Name, lowPriorityClass.Value, sliceKey)
+		})
+
+		ginkgo.By("pointing the label at a class that does not exist", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				job.Labels[constants.WorkloadPriorityClassLabel] = "missing-wpc"
+				g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// The lookup fails, so the slice keeps the priority it was admitted with
+		// rather than being left half updated.
+		ginkgo.By("checking the slice keeps the class it was admitted with", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, lowPriorityClass.Name, lowPriorityClass.Value, sliceKey)
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		// On its own the assertion above would also hold if the controller had
+		// simply not reconciled yet. Creating the class makes the slice move,
+		// which shows the reconcile was live and had been refusing the label.
+		ginkgo.By("checking the slice moves once the class exists", func() {
+			missingClass := utiltestingapi.MakeWorkloadPriorityClass("missing-wpc").PriorityValue(int32(highPriorityValue)).Obj()
+			util.MustCreate(ctx, k8sClient, missingClass)
+			ginkgo.DeferCleanup(func() {
+				gomega.Expect(k8sClient.Delete(ctx, missingClass)).To(gomega.Succeed())
+			})
+			util.ExpectWorkloadsWithWorkloadPriority(ctx, k8sClient, missingClass.Name, missingClass.Value, sliceKey)
+		})
+	})
+
+	ginkgo.It("Should not fail reconciliation when a class is added to an admitted slice that has none", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
+
+		highPriorityClass := utiltestingapi.MakeWorkloadPriorityClass("probe-high").PriorityValue(int32(highPriorityValue)).Obj()
+		util.MustCreate(ctx, k8sClient, highPriorityClass)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(k8sClient.Delete(ctx, highPriorityClass)).To(gomega.Succeed())
+		})
+
+		// Deliberately no WorkloadPriorityClass, so the slice is created with a nil
+		// priorityClassRef.
+		job := testingjob.MakeJob("job-probe-noclass", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1000m").
+			Parallelism(1).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		var sliceKey client.ObjectKey
+		ginkgo.By("waiting for the slice to be admitted with no class", func() {
+			workloads := util.ExpectWorkloadsInNamespace(ctx, k8sClient, job.Namespace, 1)
+			sliceKey = client.ObjectKeyFromObject(&workloads[0])
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, &workloads[0])
+			wl := &kueue.Workload{}
+			gomega.Expect(k8sClient.Get(ctx, sliceKey, wl)).To(gomega.Succeed())
+			gomega.Expect(wl.Spec.PriorityClassRef).To(gomega.BeNil())
+		})
+
+		ginkgo.By("adding the label to the admitted job", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				if job.Labels == nil {
+					job.Labels = map[string]string{}
+				}
+				job.Labels[constants.WorkloadPriorityClassLabel] = highPriorityClass.Name
+				g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// The API server refuses to add a priorityClassRef once quota is
+		// reserved, so the slice keeps none rather than the reconcile failing
+		// for good on every retry.
+		ginkgo.By("checking the admitted slice is left alone", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				wl := &kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, sliceKey, wl)).To(gomega.Succeed())
+				g.Expect(wl.Spec.PriorityClassRef).To(gomega.BeNil())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should mark old pending workload-slice evicted by scheduler as finished", func() {
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5222,26 +5222,41 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 			gomega.Expect(wl.Spec.PriorityClassRef).To(gomega.BeNil())
 		})
 
-		ginkgo.By("adding the label to the admitted job", func() {
+		ginkgo.By("waiting for the job to be running", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				g.Expect(job.Spec.Suspend).Should(gomega.Equal(new(false)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// A priority class cannot be added to a job that is not suspended, so the
+		// label arrives in the same update that suspends it.
+		ginkgo.By("suspending the job and adding the label in one update", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
 				if job.Labels == nil {
 					job.Labels = map[string]string{}
 				}
 				job.Labels[constants.WorkloadPriorityClassLabel] = highPriorityClass.Name
+				job.Spec.Suspend = new(true)
 				g.Expect(k8sClient.Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		// The API server refuses to add a priorityClassRef once quota is
-		// reserved, so the slice keeps none rather than the reconcile failing
-		// for good on every retry.
-		ginkgo.By("checking the admitted slice is left alone", func() {
-			gomega.Consistently(func(g gomega.Gomega) {
-				wl := &kueue.Workload{}
-				g.Expect(k8sClient.Get(ctx, sliceKey, wl)).To(gomega.Succeed())
-				g.Expect(wl.Spec.PriorityClassRef).To(gomega.BeNil())
-			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		// The API server refuses to add a priorityClassRef once quota is reserved.
+		// Resuming the job is what shows the reconcile got past the slice priority
+		// sync: were the update attempted, it would fail before the job is started.
+		ginkgo.By("checking the controller resumes the job", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).Should(gomega.Succeed())
+				g.Expect(job.Spec.Suspend).Should(gomega.Equal(new(false)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("checking the admitted slice kept no priority class", func() {
+			wl := &kueue.Workload{}
+			gomega.Expect(k8sClient.Get(ctx, sliceKey, wl)).To(gomega.Succeed())
+			gomega.Expect(wl.Spec.PriorityClassRef).To(gomega.BeNil())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

This makes an elastic Job pick up a change to its `kueue.x-k8s.io/priority-class` label, which it currently ignores whenever the pod set counts have stayed the same.

The slicing branch of `ensureOneWorkload` hands back the existing slice as soon as it is judged compatible:

```go
		wl, compatible, err := workloadslicing.EnsureWorkloadSlices(ctx, r.client, r.clock, podSets, object, job.GVK())
		if err != nil {
			return nil, err
		}
		if compatible {
			return wl, nil
		}
```

That return sits above the `UpdateWorkloadPriority` call at the end of the same function, which is the only place the priority transition is applied. Compatibility says something about the pod set shape and nothing else, so a label-only edit reaches the return with the old priority still on the slice. `pkg/workloadslicing` does not reconcile priority either; it contains no reference to it.

The change runs the same transition the ordinary path runs, on the compatible slice, before returning it. `EnsureWorkloadSlices` reports compatible with a nil slice when a new one is to be created; the quota-reserved slice it is replacing is still live, so that case is covered too.

#### Which issue(s) this PR fixes:

Fixes #13778

#### Special notes for your reviewer:

Six reconciler cases, five helper cases in `TestUpdateWorkloadPriority`, and three integration specs. The reconciler cases carry the negative path, since a reconcile against a fake client is synchronous and a swallowed lookup error fails them, where an integration assertion that the slice is unchanged would also hold if the reconcile had simply not run yet.

The unit case in `pkg/controller/jobs/job/job_controller_test.go` is the existing `"the workload is updated when priority class has changed for suspended job"` scenario with the elastic annotation added, so the two sit next to each other and the elastic one is visibly the same transition. Without the fix the Workload comes back holding `test-wpc` while the label says `test-wpc-high`.

The integration spec matters more here, because an admitted slice is the realistic case and it is the one the API server has an opinion about. `priorityClassRef` carries CEL rules that make it immutable once quota is reserved, with `priorityClassRef.name` immutable only for `scheduling.k8s.io/priorityclass`. A `WorkloadPriorityClass` name change on an admitted slice is therefore allowed, and the spec confirms that against a real API server rather than a fake client that would not run those rules.

Deliberately unchanged: the slicing path and the ordinary path still share one definition of the transition, including the guard from #8480 that leaves Pod `PriorityClass`-backed Workloads alone. `UpdateWorkloadPriority` now takes the workloads variadically, and the slicing path calls it with the whole live set, so the rules stay in one place. That boundary is #13781, and the release note is worded to exclude it rather than imply this covers every slice.

A slice that reserved quota without a `priorityClassRef` is skipped, because the CEL rules on `Workload` refuse to add one once quota is reserved and every retry would fail. Without that guard an elastic Job with no priority class went into a permanent reconcile error loop the moment someone added the label. The fake client does not run CEL, so the reconciler case fails outright if the skip is dropped. The integration spec adds the label in the same update that suspends the Job, which the webhook requires, and then waits for the controller to resume it, which a wedged reconcile never does.

A scale-up waiting for quota keeps the admitted slice alongside its pending replacement, and `normalizeActiveSlices` returns only the replacement. Both are live and both take part in preemption victim ordering, so updating only the returned one would split the Job's priority across its own slices. Both are synchronised, and `"the workload slice and its retained admitted slice both follow the label"` covers that state: it fails if only the selected slice is updated.

The class is resolved once for the whole live set rather than per slice. Resolving per slice let a class edited between the two lookups leave them on different values, and later reconciles do not repair that because the comparison is on the class name. The `resolves the class once for the whole set` case reports a different value on each lookup and fails if the resolution moves back inside the loop, and `keeps a retry marker when a write fails` pins the order the second pass writes in, which nothing caught before it was added.

Also unchanged, and worth a separate look rather than a quiet fix here: the same early return skips `UpdateAdmissionGatedBy`, which the ordinary path calls a few lines below `UpdateWorkloadPriority`, and maximum execution time, which slice compatibility does not compare. That is #13836.

This also removes one of the paths #13775 documents as silent, since the warning event there is raised from the lookup this return was skipping.

Resolving once is also not the same as convergence. It stops one batch from writing two different values, but the `WorkloadPriorityClass` controller can still repair one workload between two writes here, and once every workload already names the class nothing re-resolves its value. That ordering predates this PR, reproduces with a single Workload on the ordinary path, and is #13866; the helper's comment is worded to that boundary.

One thing deliberately left out. It is #13837, so the reasoning is not only here.

Count and priority are still not written atomically. `EnsureWorkloadSlices` persists a changed count before this code resolves the class, so a missing class leaves the new count beside the old priority. That state predates this change: before it the count was written and the priority was never resolved at all, permanently and silently. Now the same write happens, the reconcile fails and retries, and it converges once the class exists. Making it atomic means either resolving the priority before `EnsureWorkloadSlices` runs, which would refuse a legitimate scale-down because of an unrelated label typo, or having that helper return a plan instead of writing inside itself. The second is the right shape and belongs in its own change.

This PR was written in part with the assistance of generative AI. I confirmed the behaviour with a failing test before writing the fix, and ran the unit, integration and race suites myself.

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed the bug that changes to the `kueue.x-k8s.io/priority-class` label were not
reflected on the live Workload slices.
```









