### PR TITLE
WIP: Add per-namespace LocalQueue defaulting configuration

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -67,6 +67,17 @@ type Configuration struct {
 	// true and the job's namespace matches ManagedJobsNamespaceSelector.
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
+	// LocalQueueDefaultingNamespaceSelector restricts which namespaces
+	// participate in LocalQueue defaulting. When set and the
+	// LocalQueueDefaultingPerNamespace feature gate is enabled, only
+	// workloads in namespaces matching this selector will have the default
+	// LocalQueue label injected if a LocalQueue named "default" exists in
+	// the namespace.
+	// When nil, defaulting is active in all managed namespaces where a
+	// "default" LocalQueue exists (preserving current behavior).
+	// +optional
+	LocalQueueDefaultingNamespaceSelector *metav1.LabelSelector `json:"localQueueDefaultingNamespaceSelector,omitempty"`
+
 	// InternalCertManagement is configuration for internalCertManagement
 	InternalCertManagement *InternalCertManagement `json:"internalCertManagement,omitempty"`
 

--- a/apis/config/v1beta1/zz_generated.conversion.go
+++ b/apis/config/v1beta1/zz_generated.conversion.go
@@ -326,6 +326,7 @@ func autoConvert_v1beta1_Configuration_To_v1beta2_Configuration(in *Configuratio
 	}
 	out.ManageJobsWithoutQueueName = in.ManageJobsWithoutQueueName
 	out.ManagedJobsNamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.ManagedJobsNamespaceSelector))
+	out.LocalQueueDefaultingNamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LocalQueueDefaultingNamespaceSelector))
 	out.InternalCertManagement = (*v1beta2.InternalCertManagement)(unsafe.Pointer(in.InternalCertManagement))
 	if in.WaitForPodsReady != nil {
 		in, out := &in.WaitForPodsReady, &out.WaitForPodsReady
@@ -387,6 +388,7 @@ func autoConvert_v1beta2_Configuration_To_v1beta1_Configuration(in *v1beta2.Conf
 	}
 	out.ManageJobsWithoutQueueName = in.ManageJobsWithoutQueueName
 	out.ManagedJobsNamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.ManagedJobsNamespaceSelector))
+	out.LocalQueueDefaultingNamespaceSelector = (*metav1.LabelSelector)(unsafe.Pointer(in.LocalQueueDefaultingNamespaceSelector))
 	out.InternalCertManagement = (*InternalCertManagement)(unsafe.Pointer(in.InternalCertManagement))
 	if in.WaitForPodsReady != nil {
 		in, out := &in.WaitForPodsReady, &out.WaitForPodsReady

--- a/apis/config/v1beta1/zz_generated.deepcopy.go
+++ b/apis/config/v1beta1/zz_generated.deepcopy.go
@@ -107,6 +107,11 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LocalQueueDefaultingNamespaceSelector != nil {
+		in, out := &in.LocalQueueDefaultingNamespaceSelector, &out.LocalQueueDefaultingNamespaceSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.InternalCertManagement != nil {
 		in, out := &in.InternalCertManagement, &out.InternalCertManagement
 		*out = new(InternalCertManagement)

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -69,6 +69,17 @@ type Configuration struct {
 	// true and the job's namespace matches ManagedJobsNamespaceSelector.
 	ManagedJobsNamespaceSelector *metav1.LabelSelector `json:"managedJobsNamespaceSelector,omitempty"`
 
+	// LocalQueueDefaultingNamespaceSelector restricts which namespaces
+	// participate in LocalQueue defaulting. When set and the
+	// LocalQueueDefaultingPerNamespace feature gate is enabled, only
+	// workloads in namespaces matching this selector will have the default
+	// LocalQueue label injected if a LocalQueue named "default" exists in
+	// the namespace.
+	// When nil, defaulting is active in all managed namespaces where a
+	// "default" LocalQueue exists (preserving current behavior).
+	// +optional
+	LocalQueueDefaultingNamespaceSelector *metav1.LabelSelector `json:"localQueueDefaultingNamespaceSelector,omitempty"`
+
 	// InternalCertManagement is configuration for internalCertManagement
 	InternalCertManagement *InternalCertManagement `json:"internalCertManagement,omitempty"`
 

--- a/apis/config/v1beta2/zz_generated.deepcopy.go
+++ b/apis/config/v1beta2/zz_generated.deepcopy.go
@@ -137,6 +137,11 @@ func (in *Configuration) DeepCopyInto(out *Configuration) {
 		*out = new(v1.LabelSelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LocalQueueDefaultingNamespaceSelector != nil {
+		in, out := &in.LocalQueueDefaultingNamespaceSelector, &out.LocalQueueDefaultingNamespaceSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.InternalCertManagement != nil {
 		in, out := &in.InternalCertManagement, &out.InternalCertManagement
 		*out = new(InternalCertManagement)

--- a/cmd/kueue/main.go
+++ b/cmd/kueue/main.go
@@ -613,6 +613,14 @@ func setupControllers(
 	}
 	jfOpts = append(jfOpts, jobframework.WithManagedJobsNamespaceSelector(nsSelector))
 
+	if cfg.LocalQueueDefaultingNamespaceSelector != nil {
+		lqdSelector, err := metav1.LabelSelectorAsSelector(cfg.LocalQueueDefaultingNamespaceSelector)
+		if err != nil {
+			return fmt.Errorf("failed to parse localQueueDefaultingNamespaceSelector: %w", err)
+		}
+		jfOpts = append(jfOpts, jobframework.WithLocalQueueDefaultingNamespaceSelector(lqdSelector))
+	}
+
 	if err := integrationManager.SetupControllers(ctx, mgr, setupLog, jfOpts...); err != nil {
 		return fmt.Errorf(
 			"unable to create controller or webhook for kubernetesVersion %v: %w",

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -59,29 +59,30 @@ const (
 )
 
 var (
-	integrationsPath                      = field.NewPath("integrations")
-	integrationsFrameworksPath            = integrationsPath.Child("frameworks")
-	integrationsExternalFrameworkPath     = integrationsPath.Child("externalFrameworks")
-	managedJobsNamespaceSelectorPath      = field.NewPath("managedJobsNamespaceSelector")
-	waitForPodsReadyPath                  = field.NewPath("waitForPodsReady")
-	requeuingStrategyPath                 = waitForPodsReadyPath.Child("requeuingStrategy")
-	multiKueuePath                        = field.NewPath("multiKueue")
-	clusterProfileAccessProvidersPath     = multiKueuePath.Child("clusterProfile").Child("accessProviders")
-	clusterProfileCredentialProvidersPath = multiKueuePath.Child("clusterProfile").Child("credentialsProviders")
-	fsPreemptionStrategiesPath            = field.NewPath("fairSharing", "preemptionStrategies")
-	afsResourceWeightsPath                = field.NewPath("admissionFairSharing", "resourceWeights")
-	afsPath                               = field.NewPath("admissionFairSharing")
-	internalCertManagementPath            = field.NewPath("internalCertManagement")
-	resourceTransformationPath            = field.NewPath("resources", "transformations")
-	dynamicResourceAllocationPath         = field.NewPath("resources", "deviceClassMappings")
-	objectRetentionPoliciesPath           = field.NewPath("objectRetentionPolicies")
-	objectRetentionPoliciesWorkloadsPath  = objectRetentionPoliciesPath.Child("workloads")
-	tlsPath                               = field.NewPath("tls")
-	featureGatesPath                      = field.NewPath("featureGates")
-	visibilityServerBindAddressPath       = field.NewPath("visibilityServer", "bindAddress")
-	visibilityServerBindPortPath          = field.NewPath("visibilityServer", "bindPort")
-	customLabelsPath                      = field.NewPath("metrics", "customLabels")
-	resourceQuotaCheckStrategyPath        = field.NewPath("resources", "quotaCheckStrategy")
+	integrationsPath                          = field.NewPath("integrations")
+	integrationsFrameworksPath                = integrationsPath.Child("frameworks")
+	integrationsExternalFrameworkPath         = integrationsPath.Child("externalFrameworks")
+	managedJobsNamespaceSelectorPath          = field.NewPath("managedJobsNamespaceSelector")
+	localQueueDefaultingNamespaceSelectorPath = field.NewPath("localQueueDefaultingNamespaceSelector")
+	waitForPodsReadyPath                      = field.NewPath("waitForPodsReady")
+	requeuingStrategyPath                     = waitForPodsReadyPath.Child("requeuingStrategy")
+	multiKueuePath                            = field.NewPath("multiKueue")
+	clusterProfileAccessProvidersPath         = multiKueuePath.Child("clusterProfile").Child("accessProviders")
+	clusterProfileCredentialProvidersPath     = multiKueuePath.Child("clusterProfile").Child("credentialsProviders")
+	fsPreemptionStrategiesPath                = field.NewPath("fairSharing", "preemptionStrategies")
+	afsResourceWeightsPath                    = field.NewPath("admissionFairSharing", "resourceWeights")
+	afsPath                                   = field.NewPath("admissionFairSharing")
+	internalCertManagementPath                = field.NewPath("internalCertManagement")
+	resourceTransformationPath                = field.NewPath("resources", "transformations")
+	dynamicResourceAllocationPath             = field.NewPath("resources", "deviceClassMappings")
+	objectRetentionPoliciesPath               = field.NewPath("objectRetentionPolicies")
+	objectRetentionPoliciesWorkloadsPath      = objectRetentionPoliciesPath.Child("workloads")
+	tlsPath                                   = field.NewPath("tls")
+	featureGatesPath                          = field.NewPath("featureGates")
+	visibilityServerBindAddressPath           = field.NewPath("visibilityServer", "bindAddress")
+	visibilityServerBindPortPath              = field.NewPath("visibilityServer", "bindPort")
+	customLabelsPath                          = field.NewPath("metrics", "customLabels")
+	resourceQuotaCheckStrategyPath            = field.NewPath("resources", "quotaCheckStrategy")
 	// Values in this map should never exceed metrics.MaxCustomLabelsForSourceKind.
 	maxCustomLabelsPerSourceKind = map[configapi.SourceKind]int{
 		configapi.SourceKindWorkload:     min(2, metrics.MaxCustomLabelsForSourceKind),
@@ -103,6 +104,7 @@ func Validate(c *configapi.Configuration, scheme *runtime.Scheme, integrationMan
 	allErrs = append(allErrs, validateResourceTransformations(c)...)
 	allErrs = append(allErrs, validateDeviceClassMappings(c)...)
 	allErrs = append(allErrs, validateManagedJobsNamespaceSelector(c)...)
+	allErrs = append(allErrs, validateLocalQueueDefaultingNamespaceSelector(c)...)
 	allErrs = append(allErrs, validateObjectRetentionPolicies(c)...)
 	allErrs = append(allErrs, validateTLS(c)...)
 	allErrs = append(allErrs, validateVisibilityServer(c)...)
@@ -635,6 +637,34 @@ func validateManagedJobsNamespaceSelector(c *configapi.Configuration) field.Erro
 	for _, pn := range prohibitedNamespaces {
 		if selector.Matches(pn) {
 			allErrs = append(allErrs, field.Invalid(managedJobsNamespaceSelectorPath, c.ManagedJobsNamespaceSelector,
+				fmt.Sprintf("should not match the %q namespace", pn[corev1.LabelMetadataName])))
+		}
+	}
+
+	return allErrs
+}
+
+func validateLocalQueueDefaultingNamespaceSelector(c *configapi.Configuration) field.ErrorList {
+	if c.LocalQueueDefaultingNamespaceSelector == nil {
+		return nil
+	}
+
+	var allErrs field.ErrorList
+
+	prohibitedNamespaces := []labels.Set{{corev1.LabelMetadataName: metav1.NamespaceSystem}}
+	if c.Namespace != nil && *c.Namespace != "" {
+		prohibitedNamespaces = append(prohibitedNamespaces, labels.Set{corev1.LabelMetadataName: *c.Namespace})
+	}
+
+	allErrs = append(allErrs, validation.ValidateLabelSelector(c.LocalQueueDefaultingNamespaceSelector, validation.LabelSelectorValidationOptions{}, localQueueDefaultingNamespaceSelectorPath)...)
+	selector, err := metav1.LabelSelectorAsSelector(c.LocalQueueDefaultingNamespaceSelector)
+	if err != nil {
+		return allErrs
+	}
+
+	for _, pn := range prohibitedNamespaces {
+		if selector.Matches(pn) {
+			allErrs = append(allErrs, field.Invalid(localQueueDefaultingNamespaceSelectorPath, c.LocalQueueDefaultingNamespaceSelector,
 				fmt.Sprintf("should not match the %q namespace", pn[corev1.LabelMetadataName])))
 		}
 	}

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -236,6 +236,37 @@ func TestValidate(t *testing.T) {
 			},
 			wantErr: nil,
 		},
+		"nil localQueueDefaultingNamespaceSelector": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+			},
+			wantErr: nil,
+		},
+		"valid localQueueDefaultingNamespaceSelector": {
+			cfg: &configapi.Configuration{
+				LocalQueueDefaultingNamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"local-queue-defaulting": "true"},
+				},
+				Integrations: defaultIntegrations,
+			},
+			wantErr: nil,
+		},
+		"prohibited namespace in MatchLabels localQueueDefaultingNamespaceSelector": {
+			cfg: &configapi.Configuration{
+				LocalQueueDefaultingNamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						corev1.LabelMetadataName: "kube-system",
+					},
+				},
+				Integrations: defaultIntegrations,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "localQueueDefaultingNamespaceSelector",
+				},
+			},
+		},
 		"no supported waitForPodsReady.requeuingStrategy.timestamp": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -35,26 +35,28 @@ import (
 
 // BaseWebhook applies basic defaulting and validation for jobs.
 type BaseWebhook[T any] struct {
-	IntegrationManager           *IntegrationManager
-	Client                       client.Client
-	ManageJobsWithoutQueueName   bool
-	ManagedJobsNamespaceSelector labels.Selector
-	FromObject                   func(T) GenericJob
-	Queues                       *qcache.Manager
-	Cache                        *schdcache.Cache
+	IntegrationManager                    *IntegrationManager
+	Client                                client.Client
+	ManageJobsWithoutQueueName            bool
+	ManagedJobsNamespaceSelector          labels.Selector
+	LocalQueueDefaultingNamespaceSelector labels.Selector
+	FromObject                            func(T) GenericJob
+	Queues                                *qcache.Manager
+	Cache                                 *schdcache.Cache
 }
 
 func BaseWebhookFactory[T runtime.Object](obj T, fromObject func(T) GenericJob) func(ctrl.Manager, ...Option) error {
 	return func(mgr ctrl.Manager, opts ...Option) error {
 		options := ProcessOptions(opts...)
 		wh := &BaseWebhook[T]{
-			IntegrationManager:           options.IntegrationManager,
-			Client:                       mgr.GetClient(),
-			ManageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-			ManagedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-			FromObject:                   fromObject,
-			Queues:                       options.Queues,
-			Cache:                        options.Cache,
+			IntegrationManager:                    options.IntegrationManager,
+			Client:                                mgr.GetClient(),
+			ManageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+			ManagedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+			LocalQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+			FromObject:                            fromObject,
+			Queues:                                options.Queues,
+			Cache:                                 options.Cache,
 		}
 		if options.NoopWebhook {
 			return webhook.SetupNoopWebhook(mgr, obj)
@@ -73,7 +75,14 @@ func (w *BaseWebhook[T]) Default(ctx context.Context, obj T) error {
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Applying defaults")
 	if w.IntegrationManager != nil {
-		if err := w.IntegrationManager.ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
+		if err := w.IntegrationManager.ApplyDefaultLocalQueue(
+			ctx,
+			w.Client,
+			job.Object(),
+			w.Queues.DefaultLocalQueueExist,
+			w.ManagedJobsNamespaceSelector,
+			w.LocalQueueDefaultingNamespaceSelector,
+		); err != nil {
 			return err
 		}
 		w.IntegrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -51,7 +51,7 @@ func (m *IntegrationManager) ApplyDefaultLocalQueue(
 	k8sClient client.Client,
 	jobObj client.Object,
 	defaultQueueExist func(string) bool,
-	managedJobsNamespaceSelector labels.Selector,
+	managedJobsNamespaceSelector, localQueueDefaultingNamespaceSelector labels.Selector,
 ) error {
 	if !m.defaultLocalQueueApplies(jobObj, defaultQueueExist) {
 		return nil
@@ -64,6 +64,15 @@ func (m *IntegrationManager) ApplyDefaultLocalQueue(
 	}
 	if !managed {
 		return nil
+	}
+	if features.Enabled(features.LocalQueueDefaultingPerNamespace) {
+		defaultingAllowed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), localQueueDefaultingNamespaceSelector)
+		if err != nil {
+			return err
+		}
+		if !defaultingAllowed {
+			return nil
+		}
 	}
 	setDefaultLocalQueue(jobObj)
 	return nil

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -171,7 +172,9 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 	integrationManager := newDefaultsIntegrationManager(t)
 	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	managedNamespace := utiltesting.MakeNamespaceWrapper("managed-ns").Label(corev1.LabelMetadataName, "managed-ns").Obj()
-	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Obj()
+	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Label("lq-defaulting", "true").Obj()
+	defaultingNamespace := utiltesting.MakeNamespaceWrapper("defaulting-ns").Label(corev1.LabelMetadataName, "defaulting-ns").Label("lq-defaulting", "true").Obj()
+	noDefaultingNamespace := utiltesting.MakeNamespaceWrapper("no-defaulting-ns").Label(corev1.LabelMetadataName, "no-defaulting-ns").Obj()
 	ls := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -182,10 +185,16 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 		},
 	}
 	namespaceSelector, _ := metav1.LabelSelectorAsSelector(ls)
+	lqdLS := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"lq-defaulting": "true"},
+	}
+	lqdSelector, _ := metav1.LabelSelectorAsSelector(lqdLS)
 
 	cases := map[string]struct {
-		job            *batchv1.Job
-		wantQueueLabel string
+		featureGates                          map[featuregate.Feature]bool
+		job                                   *batchv1.Job
+		localQueueDefaultingNamespaceSelector labels.Selector
+		wantQueueLabel                        string
 	}{
 		"job in managed namespace gets default queue label": {
 			job:            utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
@@ -199,12 +208,36 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 			job:            utiltestingjob.MakeJob("test-job", managedNamespace.Name).Queue("other").Obj(),
 			wantQueueLabel: "other",
 		},
+		"managed namespace with defaulting label gets default queue label": {
+			featureGates:                          map[featuregate.Feature]bool{features.LocalQueueDefaultingPerNamespace: true},
+			localQueueDefaultingNamespaceSelector: lqdSelector,
+			job:                                   utiltestingjob.MakeJob("test-job", defaultingNamespace.Name).Obj(),
+			wantQueueLabel:                        "default",
+		},
+		"managed namespace without defaulting label does not get default queue label": {
+			featureGates:                          map[featuregate.Feature]bool{features.LocalQueueDefaultingPerNamespace: true},
+			localQueueDefaultingNamespaceSelector: lqdSelector,
+			job:                                   utiltestingjob.MakeJob("test-job", noDefaultingNamespace.Name).Obj(),
+			wantQueueLabel:                        "",
+		},
+		"unmanaged namespace with defaulting label does not get default queue label": {
+			featureGates:                          map[featuregate.Feature]bool{features.LocalQueueDefaultingPerNamespace: true},
+			localQueueDefaultingNamespaceSelector: lqdSelector,
+			job:                                   utiltestingjob.MakeJob("test-job", unmanagedNamespace.Name).Obj(),
+			wantQueueLabel:                        "",
+		},
+		"feature gate disabled ignores defaulting selector": {
+			localQueueDefaultingNamespaceSelector: lqdSelector,
+			job:                                   utiltestingjob.MakeJob("test-job", noDefaultingNamespace.Name).Obj(),
+			wantQueueLabel:                        "default",
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 			builder := utiltesting.NewClientBuilder()
-			builder.WithObjects(managedNamespace, unmanagedNamespace)
+			builder.WithObjects(managedNamespace, unmanagedNamespace, defaultingNamespace, noDefaultingNamespace)
 			cl := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
@@ -212,7 +245,7 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 				return true
 			}
 
-			if err := integrationManager.ApplyDefaultLocalQueue(ctx, cl, tc.job, defaultQueueExist, namespaceSelector); err != nil {
+			if err := integrationManager.ApplyDefaultLocalQueue(ctx, cl, tc.job, defaultQueueExist, namespaceSelector, tc.localQueueDefaultingNamespaceSelector); err != nil {
 				t.Fatalf("ApplyDefaultLocalQueue() returned error: %v", err)
 			}
 

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -172,8 +172,8 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 	integrationManager := newDefaultsIntegrationManager(t)
 	t.Cleanup(integrationManager.EnableIntegrationsForTest(t, "batch/job"))
 	managedNamespace := utiltesting.MakeNamespaceWrapper("managed-ns").Label(corev1.LabelMetadataName, "managed-ns").Obj()
-	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Label("lq-defaulting", "true").Obj()
-	defaultingNamespace := utiltesting.MakeNamespaceWrapper("defaulting-ns").Label(corev1.LabelMetadataName, "defaulting-ns").Label("lq-defaulting", "true").Obj()
+	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Label("local-queue-defaulting", "true").Obj()
+	defaultingNamespace := utiltesting.MakeNamespaceWrapper("defaulting-ns").Label(corev1.LabelMetadataName, "defaulting-ns").Label("local-queue-defaulting", "true").Obj()
 	noDefaultingNamespace := utiltesting.MakeNamespaceWrapper("no-defaulting-ns").Label(corev1.LabelMetadataName, "no-defaulting-ns").Obj()
 	ls := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -186,7 +186,7 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 	}
 	namespaceSelector, _ := metav1.LabelSelectorAsSelector(ls)
 	lqdLS := &metav1.LabelSelector{
-		MatchLabels: map[string]string{"lq-defaulting": "true"},
+		MatchLabels: map[string]string{"local-queue-defaulting": "true"},
 	}
 	lqdSelector, _ := metav1.LabelSelectorAsSelector(lqdLS)
 
@@ -227,6 +227,7 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 			wantQueueLabel:                        "",
 		},
 		"feature gate disabled ignores defaulting selector": {
+			featureGates:                          map[featuregate.Feature]bool{features.LocalQueueDefaultingPerNamespace: false},
 			localQueueDefaultingNamespaceSelector: lqdSelector,
 			job:                                   utiltestingjob.MakeJob("test-job", noDefaultingNamespace.Name).Obj(),
 			wantQueueLabel:                        "default",

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -116,24 +116,25 @@ func (r *JobReconciler) RoleTracker() *roletracker.RoleTracker {
 }
 
 type Options struct {
-	ManageJobsWithoutQueueName   bool
-	ManagedJobsNamespaceSelector labels.Selector
-	WaitForPodsReady             bool
-	KubeServerVersion            *kubeversion.ServerVersionFetcher
-	IntegrationOptions           map[string]any // IntegrationOptions key is "$GROUP/$VERSION, Kind=$KIND".
-	EnabledFrameworks            sets.Set[string]
-	EnabledExternalFrameworks    sets.Set[string]
-	ManagerName                  string
-	LabelKeysToCopy              sets.Set[string]
-	AnnotationsToCopy            sets.Set[string]
-	Queues                       *qcache.Manager
-	Cache                        *schdcache.Cache
-	Clock                        clock.Clock
-	WorkloadRetentionPolicy      WorkloadRetentionPolicy
-	RoleTracker                  *roletracker.RoleTracker
-	CustomLabels                 *metrics.CustomLabels
-	IntegrationManager           *IntegrationManager
-	NoopWebhook                  bool
+	ManageJobsWithoutQueueName            bool
+	ManagedJobsNamespaceSelector          labels.Selector
+	LocalQueueDefaultingNamespaceSelector labels.Selector
+	WaitForPodsReady                      bool
+	KubeServerVersion                     *kubeversion.ServerVersionFetcher
+	IntegrationOptions                    map[string]any // IntegrationOptions key is "$GROUP/$VERSION, Kind=$KIND".
+	EnabledFrameworks                     sets.Set[string]
+	EnabledExternalFrameworks             sets.Set[string]
+	ManagerName                           string
+	LabelKeysToCopy                       sets.Set[string]
+	AnnotationsToCopy                     sets.Set[string]
+	Queues                                *qcache.Manager
+	Cache                                 *schdcache.Cache
+	Clock                                 clock.Clock
+	WorkloadRetentionPolicy               WorkloadRetentionPolicy
+	RoleTracker                           *roletracker.RoleTracker
+	CustomLabels                          *metrics.CustomLabels
+	IntegrationManager                    *IntegrationManager
+	NoopWebhook                           bool
 }
 
 // Option configures the reconciler.
@@ -159,6 +160,13 @@ func WithManageJobsWithoutQueueName(f bool) Option {
 func WithManagedJobsNamespaceSelector(ls labels.Selector) Option {
 	return func(o *Options) {
 		o.ManagedJobsNamespaceSelector = ls
+	}
+}
+
+// WithLocalQueueDefaultingNamespaceSelector restricts which namespaces participate in LocalQueue defaulting.
+func WithLocalQueueDefaultingNamespaceSelector(ls labels.Selector) Option {
+	return func(o *Options) {
+		o.LocalQueueDefaultingNamespaceSelector = ls
 	}
 }
 

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -37,21 +37,23 @@ import (
 )
 
 type Webhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
 }
 
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
 	}
 	obj := &appsv1.Deployment{}
 	if options.NoopWebhook {
@@ -74,7 +76,14 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 	log := ctrl.LoggerFrom(ctx).WithName("deployment-webhook")
 	log.V(5).Info("Propagating queue-name")
 
-	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, deployment.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		wh.client,
+		deployment.Object(),
+		wh.queues.DefaultLocalQueueExist,
+		wh.managedJobsNamespaceSelector,
+		wh.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -66,24 +66,26 @@ func applyWorkloadSliceSchedulingGate(job *Job) {
 }
 
 type JobWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
+	cache                                 *schdcache.Cache
 }
 
 // SetupWebhook configures the webhook for batchJob.
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &JobWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
+		cache:                                 options.Cache,
 	}
 	obj := &batchv1.Job{}
 	if options.NoopWebhook {
@@ -106,7 +108,14 @@ func (w *JobWebhook) Default(ctx context.Context, obj *batchv1.Job) error {
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		job.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -39,24 +39,26 @@ var (
 )
 
 type JobSetWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
+	cache                                 *schdcache.Cache
 }
 
 // SetupJobSetWebhook configures the webhook for kubeflow JobSet.
 func SetupJobSetWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &JobSetWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
+		cache:                                 options.Cache,
 	}
 	obj := &jobsetapi.JobSet{}
 	if options.NoopWebhook {
@@ -79,7 +81,7 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj *jobsetapi.JobSet) erro
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector, w.localQueueDefaultingNamespaceSelector); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, obj)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -43,21 +43,23 @@ import (
 )
 
 type Webhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
 }
 
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
 	}
 	obj := &leaderworkersetv1.LeaderWorkerSet{}
 	if options.NoopWebhook {
@@ -79,7 +81,14 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 	log := ctrl.LoggerFrom(ctx).WithName("leaderworkerset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, obj, wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		wh.client,
+		obj,
+		wh.queues.DefaultLocalQueueExist,
+		wh.managedJobsNamespaceSelector,
+		wh.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -53,26 +53,28 @@ var (
 )
 
 type MpiJobWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	kubeServerVersion            *kubeversion.ServerVersionFetcher
-	queues                       *qcache.Manager
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	kubeServerVersion                     *kubeversion.ServerVersionFetcher
+	queues                                *qcache.Manager
+	cache                                 *schdcache.Cache
 }
 
 // SetupMPIJobWebhook configures the webhook for MPIJob.
 func SetupMPIJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &MpiJobWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		kubeServerVersion:            options.KubeServerVersion,
-		queues:                       options.Queues,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		kubeServerVersion:                     options.KubeServerVersion,
+		queues:                                options.Queues,
+		cache:                                 options.Cache,
 	}
 	obj := &v2beta1.MPIJob{}
 	if options.NoopWebhook {
@@ -95,7 +97,14 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj *v2beta1.MPIJob) error 
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, mpiJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		mpiJob.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, mpiJob.Object())

--- a/pkg/controller/jobs/pod/pod_webhook.go
+++ b/pkg/controller/jobs/pod/pod_webhook.go
@@ -53,24 +53,26 @@ var (
 )
 
 type PodWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	queues                       *qcache.Manager
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	namespaceSelector            *metav1.LabelSelector
-	podSelector                  *metav1.LabelSelector
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	queues                                *qcache.Manager
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	namespaceSelector                     *metav1.LabelSelector
+	podSelector                           *metav1.LabelSelector
 }
 
 // SetupWebhook configures the webhook for pods.
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &PodWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		queues:                       options.Queues,
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		queues:                                options.Queues,
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
 	}
 	obj := &corev1.Pod{}
 	if options.NoopWebhook {
@@ -153,10 +155,16 @@ func (w *PodWebhook) Default(ctx context.Context, obj *corev1.Pod) error {
 		// Local queue defaulting
 		if jobframework.QueueNameForObject(pod.Object()) == "" &&
 			w.queues.DefaultLocalQueueExist(pod.pod.GetNamespace()) {
-			if pod.pod.Labels == nil {
-				pod.pod.Labels = make(map[string]string)
+			defaultingAllowed := true
+			if features.Enabled(features.LocalQueueDefaultingPerNamespace) && w.localQueueDefaultingNamespaceSelector != nil {
+				defaultingAllowed = w.localQueueDefaultingNamespaceSelector.Matches(labels.Set(ns.GetLabels()))
 			}
-			pod.pod.Labels[ctrlconstants.QueueLabel] = string(ctrlconstants.DefaultLocalQueueName)
+			if defaultingAllowed {
+				if pod.pod.Labels == nil {
+					pod.pod.Labels = make(map[string]string)
+				}
+				pod.pod.Labels[ctrlconstants.QueueLabel] = string(ctrlconstants.DefaultLocalQueueName)
+			}
 		}
 
 		w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, pod.Object())

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
@@ -61,6 +62,7 @@ import (
 
 func TestDefault(t *testing.T) {
 	defaultNamespace := utiltesting.MakeNamespaceWrapper("test-ns").Label(corev1.LabelMetadataName, "test-ns").Obj()
+	defaultingNamespace := utiltesting.MakeNamespaceWrapper("defaulting-ns").Label(corev1.LabelMetadataName, "defaulting-ns").Label("local-queue-defaulting", "true").Obj()
 	defaultNamespaceSelector := &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
@@ -85,17 +87,18 @@ func TestDefault(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		featureGates                 map[featuregate.Feature]bool
-		initObjects                  []client.Object
-		pod                          *corev1.Pod
-		defaultLqExist               bool
-		manageJobsWithoutQueueName   bool
-		managedJobsNamespaceSelector labels.Selector
-		namespaceSelector            *metav1.LabelSelector
-		podSelector                  *metav1.LabelSelector
-		enableIntegrations           []string
-		want                         *corev1.Pod
-		wantErr                      error
+		featureGates                          map[featuregate.Feature]bool
+		initObjects                           []client.Object
+		pod                                   *corev1.Pod
+		defaultLqExist                        bool
+		manageJobsWithoutQueueName            bool
+		managedJobsNamespaceSelector          labels.Selector
+		localQueueDefaultingNamespaceSelector labels.Selector
+		namespaceSelector                     *metav1.LabelSelector
+		podSelector                           *metav1.LabelSelector
+		enableIntegrations                    []string
+		want                                  *corev1.Pod
+		wantErr                               error
 	}{
 		"pod with suspend by parent annotation should skip finalizer": {
 			featureGates: map[featuregate.Feature]bool{
@@ -450,6 +453,70 @@ func TestDefault(t *testing.T) {
 				KueueFinalizer().
 				Obj(),
 		},
+		"pod in managed namespace without defaulting label should not get default queue label": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:          false,
+				features.LocalQueueDefaultingPerNamespace: true,
+			},
+			initObjects:    []client.Object{defaultNamespace},
+			defaultLqExist: true,
+			podSelector:    &metav1.LabelSelector{},
+			localQueueDefaultingNamespaceSelector: func() labels.Selector {
+				req, _ := labels.NewRequirement("local-queue-defaulting", selection.In, []string{"true"})
+				return labels.NewSelector().Add(*req)
+			}(),
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Obj(),
+		},
+		"pod in managed namespace with defaulting label gets default queue label": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:          false,
+				features.LocalQueueDefaultingPerNamespace: true,
+			},
+			initObjects:    []client.Object{defaultingNamespace},
+			defaultLqExist: true,
+			podSelector:    &metav1.LabelSelector{},
+			localQueueDefaultingNamespaceSelector: func() labels.Selector {
+				req, _ := labels.NewRequirement("local-queue-defaulting", selection.In, []string{"true"})
+				return labels.NewSelector().Add(*req)
+			}(),
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultingNamespace.Name).
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultingNamespace.Name).
+				Queue("default").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
+		"pod with feature gate disabled ignores defaulting selector": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:          false,
+				features.LocalQueueDefaultingPerNamespace: false,
+			},
+			initObjects:    []client.Object{defaultNamespace},
+			defaultLqExist: true,
+			podSelector:    &metav1.LabelSelector{},
+			localQueueDefaultingNamespaceSelector: func() labels.Selector {
+				req, _ := labels.NewRequirement("local-queue-defaulting", selection.In, []string{"true"})
+				return labels.NewSelector().Add(*req)
+			}(),
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Obj(),
+			want: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("default").
+				ManagedByKueueLabel().
+				KueueSchedulingGate().
+				RoleHash("a9f06f3a").
+				KueueFinalizer().
+				Obj(),
+		},
 		"default queue isn't created, pod has no queue label": {
 			featureGates:      map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 			initObjects:       []client.Object{defaultNamespace},
@@ -669,20 +736,21 @@ func TestDefault(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			if tc.defaultLqExist {
-				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("default", defaultNamespace.Name).
+				if err := queueManager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("default", tc.pod.Namespace).
 					ClusterQueue("cluster-queue").Obj()); err != nil {
 					t.Fatalf("failed to create default local queue: %s", err)
 				}
 			}
 
 			w := &PodWebhook{
-				integrationManager:           integrationManager,
-				client:                       cli,
-				queues:                       queueManager,
-				manageJobsWithoutQueueName:   tc.manageJobsWithoutQueueName,
-				managedJobsNamespaceSelector: tc.managedJobsNamespaceSelector,
-				namespaceSelector:            tc.namespaceSelector,
-				podSelector:                  tc.podSelector,
+				integrationManager:                    integrationManager,
+				client:                                cli,
+				queues:                                queueManager,
+				manageJobsWithoutQueueName:            tc.manageJobsWithoutQueueName,
+				managedJobsNamespaceSelector:          tc.managedJobsNamespaceSelector,
+				localQueueDefaultingNamespaceSelector: tc.localQueueDefaultingNamespaceSelector,
+				namespaceSelector:                     tc.namespaceSelector,
+				podSelector:                           tc.podSelector,
 			}
 
 			gotErr := w.Default(ctx, tc.pod)

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -47,12 +47,13 @@ var (
 )
 
 type RayClusterWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	queues                       *qcache.Manager
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	queues                                *qcache.Manager
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	cache                                 *schdcache.Cache
 }
 
 // SetupRayClusterWebhook configures the webhook for rayv1 RayCluster.
@@ -62,12 +63,13 @@ func SetupRayClusterWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		opt(&options)
 	}
 	wh := &RayClusterWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		queues:                       options.Queues,
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		queues:                                options.Queues,
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		cache:                                 options.Cache,
 	}
 	obj := &rayv1.RayCluster{}
 	if options.NoopWebhook {
@@ -89,7 +91,14 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj *rayv1.RayCluster) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		job.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -41,24 +41,26 @@ var (
 )
 
 type RayJobWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	queues                       *qcache.Manager
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	queues                                *qcache.Manager
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	cache                                 *schdcache.Cache
 }
 
 // SetupRayJobWebhook configures the webhook for RayJob.
 func SetupRayJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &RayJobWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		queues:                       options.Queues,
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		queues:                                options.Queues,
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		cache:                                 options.Cache,
 	}
 	obj := &rayv1.RayJob{}
 	if options.NoopWebhook {
@@ -80,7 +82,14 @@ func (w *RayJobWebhook) Default(ctx context.Context, obj *rayv1.RayJob) error {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.V(5).Info("Applying defaults")
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		job.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -45,12 +45,13 @@ var (
 )
 
 type RayServiceWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	queues                       *qcache.Manager
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	queues                                *qcache.Manager
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	cache                                 *schdcache.Cache
 }
 
 func fromObject(obj runtime.Object) *RayService {
@@ -64,12 +65,13 @@ func SetupRayServiceWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error
 		opt(&options)
 	}
 	wh := &RayServiceWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		queues:                       options.Queues,
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		queues:                                options.Queues,
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		cache:                                 options.Cache,
 	}
 	obj := &rayv1.RayService{}
 	if options.NoopWebhook {
@@ -91,7 +93,14 @@ func (w *RayServiceWebhook) Default(ctx context.Context, obj *rayv1.RayService) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		job.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -44,23 +44,25 @@ var (
 )
 
 type SparkApplicationWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	queues                       *qcache.Manager
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	queues                                *qcache.Manager
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	cache                                 *schdcache.Cache
 }
 
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &SparkApplicationWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		queues:                       options.Queues,
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		queues:                                options.Queues,
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		cache:                                 options.Cache,
 	}
 	obj := &sparkv1beta2.SparkApplication{}
 	if options.NoopWebhook {
@@ -83,7 +85,14 @@ func (w *SparkApplicationWebhook) Default(ctx context.Context, obj *sparkv1beta2
 	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		job.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -41,21 +41,23 @@ import (
 )
 
 type Webhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
 }
 
 func SetupWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &Webhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
 	}
 	obj := &appsv1.StatefulSet{}
 	if options.NoopWebhook {
@@ -84,7 +86,14 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 
 	log.V(5).Info("Propagating queue-name")
 
-	if err := wh.integrationManager.ApplyDefaultLocalQueue(ctx, wh.client, ss.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := wh.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		wh.client,
+		ss.Object(),
+		wh.queues.DefaultLocalQueueExist,
+		wh.managedJobsNamespaceSelector,
+		wh.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	wh.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -34,24 +34,26 @@ import (
 )
 
 type TrainJobWebhook struct {
-	integrationManager           *jobframework.IntegrationManager
-	client                       client.Client
-	manageJobsWithoutQueueName   bool
-	managedJobsNamespaceSelector labels.Selector
-	queues                       *qcache.Manager
-	cache                        *schdcache.Cache
+	integrationManager                    *jobframework.IntegrationManager
+	client                                client.Client
+	manageJobsWithoutQueueName            bool
+	managedJobsNamespaceSelector          labels.Selector
+	localQueueDefaultingNamespaceSelector labels.Selector
+	queues                                *qcache.Manager
+	cache                                 *schdcache.Cache
 }
 
 // SetupTrainJobWebhook configures the webhook for kubeflow TrainJob.
 func SetupTrainJobWebhook(mgr ctrl.Manager, opts ...jobframework.Option) error {
 	options := jobframework.ProcessOptions(opts...)
 	wh := &TrainJobWebhook{
-		integrationManager:           options.IntegrationManager,
-		client:                       mgr.GetClient(),
-		manageJobsWithoutQueueName:   options.ManageJobsWithoutQueueName,
-		managedJobsNamespaceSelector: options.ManagedJobsNamespaceSelector,
-		queues:                       options.Queues,
-		cache:                        options.Cache,
+		integrationManager:                    options.IntegrationManager,
+		client:                                mgr.GetClient(),
+		manageJobsWithoutQueueName:            options.ManageJobsWithoutQueueName,
+		managedJobsNamespaceSelector:          options.ManagedJobsNamespaceSelector,
+		localQueueDefaultingNamespaceSelector: options.LocalQueueDefaultingNamespaceSelector,
+		queues:                                options.Queues,
+		cache:                                 options.Cache,
 	}
 	obj := &kftrainerapi.TrainJob{}
 	if options.NoopWebhook {
@@ -74,7 +76,14 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	log := ctrl.LoggerFrom(ctx).WithName("trainjob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := w.integrationManager.ApplyDefaultLocalQueue(ctx, w.client, trainJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := w.integrationManager.ApplyDefaultLocalQueue(
+		ctx,
+		w.client,
+		trainJob.Object(),
+		w.queues.DefaultLocalQueueExist,
+		w.managedJobsNamespaceSelector,
+		w.localQueueDefaultingNamespaceSelector,
+	); err != nil {
 		return err
 	}
 	w.integrationManager.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -609,7 +609,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	LocalQueueDefaultingPerNamespace: {
-		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	TASProfileMixed: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -88,6 +88,12 @@ const (
 	// Enabled gathering of LocalQueue metrics
 	LocalQueueMetrics featuregate.Feature = "LocalQueueMetrics"
 
+	// owner: @PannagaRao
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/11520-local-queue-defaulting-per-namespace
+	//
+	// Enable per-namespace control over LocalQueue defaulting via localQueueDefaultingNamespaceSelector.
+	LocalQueueDefaultingPerNamespace featuregate.Feature = "LocalQueueDefaultingPerNamespace"
+
 	// owner: @pbundyra
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
@@ -600,6 +606,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	LocalQueueMetrics: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},
 		{Version: version.MustParse("0.17"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	LocalQueueDefaultingPerNamespace: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 	TASProfileMixed: {
 		{Version: version.MustParse("0.10"), Default: false, PreRelease: featuregate.Alpha},

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -76,6 +76,20 @@ a kueue.x-k8s.io/queue-name label will be managed by Kueue only when ManageJobsW
 true and the job's namespace matches ManagedJobsNamespaceSelector.</p>
 </td>
 </tr>
+<tr><td><code>localQueueDefaultingNamespaceSelector</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
+</td>
+<td>
+   <p>LocalQueueDefaultingNamespaceSelector restricts which namespaces
+participate in LocalQueue defaulting. When set and the
+LocalQueueDefaultingPerNamespace feature gate is enabled, only
+workloads in namespaces matching this selector will have the default
+LocalQueue label injected if a LocalQueue named &quot;default&quot; exists in
+the namespace.
+When nil, defaulting is active in all managed namespaces where a
+&quot;default&quot; LocalQueue exists (preserving current behavior).</p>
+</td>
+</tr>
 <tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>
 <a href="#config-kueue-x-k8s-io-v1beta1-InternalCertManagement"><code>InternalCertManagement</code></a>
 </td>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -76,6 +76,20 @@ a kueue.x-k8s.io/queue-name label will be managed by Kueue only when ManageJobsW
 true and the job's namespace matches ManagedJobsNamespaceSelector.</p>
 </td>
 </tr>
+<tr><td><code>localQueueDefaultingNamespaceSelector</code><br/>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#labelselector-v1-meta"><code>k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector</code></a>
+</td>
+<td>
+   <p>LocalQueueDefaultingNamespaceSelector restricts which namespaces
+participate in LocalQueue defaulting. When set and the
+LocalQueueDefaultingPerNamespace feature gate is enabled, only
+workloads in namespaces matching this selector will have the default
+LocalQueue label injected if a LocalQueue named &quot;default&quot; exists in
+the namespace.
+When nil, defaulting is active in all managed namespaces where a
+&quot;default&quot; LocalQueue exists (preserving current behavior).</p>
+</td>
+</tr>
 <tr><td><code>internalCertManagement</code> <B>[Required]</B><br/>
 <a href="#config-kueue-x-k8s-io-v1beta2-InternalCertManagement"><code>InternalCertManagement</code></a>
 </td>

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -149,9 +149,9 @@
     version: "0.18"
 - name: LocalQueueDefaultingPerNamespace
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: LocalQueueMetrics
   versionedSpecs:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -147,6 +147,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: LocalQueueDefaultingPerNamespace
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: LocalQueueMetrics
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -149,9 +149,9 @@
     version: "0.18"
 - name: LocalQueueDefaultingPerNamespace
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: LocalQueueMetrics
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -147,6 +147,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.18"
+- name: LocalQueueDefaultingPerNamespace
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: LocalQueueMetrics
   versionedSpecs:
   - default: false

--- a/test/e2e/sequential/baseline/localqueuedefaultingpernamespace_test.go
+++ b/test/e2e/sequential/baseline/localqueuedefaultingpernamespace_test.go
@@ -1,0 +1,323 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe(
+	"LocalQueueDefaultingPerNamespace",
+	ginkgo.Label("feature:localqueuedefaultingpernamespace", util.Shard0),
+	ginkgo.Ordered,
+	func() {
+		var (
+			managedDefaultingNs   *corev1.Namespace
+			managedNoDefaultingNs *corev1.Namespace
+			unmanagedNs           *corev1.Namespace
+			rf                    *kueue.ResourceFlavor
+			cq                    *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				cfg.ManageJobsWithoutQueueName = true
+				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kueue-managed": "true"},
+				}
+				cfg.LocalQueueDefaultingNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"local-queue-defaulting": "true"},
+				}
+			})
+
+			managedDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed":          "true",
+						"local-queue-defaulting": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedDefaultingNs)).To(gomega.Succeed())
+
+			managedNoDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-no-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedNoDefaultingNs)).To(gomega.Succeed())
+
+			unmanagedNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "unmanaged-",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, unmanagedNs)).To(gomega.Succeed())
+
+			rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, rf)
+
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(rf.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			for _, ns := range []*corev1.Namespace{managedDefaultingNs, managedNoDefaultingNs} {
+				lq := utiltestingapi.MakeLocalQueue("default", ns.Name).ClusterQueue("cluster-queue").Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+			}
+			unmanagedLq := utiltestingapi.MakeLocalQueue("default", unmanagedNs.Name).ClusterQueue("cluster-queue").Obj()
+			util.MustCreate(ctx, k8sClient, unmanagedLq)
+		})
+
+		ginkgo.AfterAll(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedDefaultingNs)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedNoDefaultingNs)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, unmanagedNs)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.MediumTimeout)
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.MediumTimeout)
+		})
+
+		ginkgo.It("should inject default queue label in managed namespace with defaulting label", func() {
+			var job *batchv1.Job
+			var createdJob *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-defaulting", managedDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job gets the default queue label", func() {
+				createdJob = &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the job has been admitted", func() {
+				wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not inject default queue label in managed namespace without defaulting label", func() {
+			var job *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-no-defaulting", managedNoDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job does not get the default queue label", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(controllerconstants.QueueLabel))
+			})
+		})
+
+		ginkgo.It("should not inject default queue label in unmanaged namespace", func() {
+			var job *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-unmanaged", unmanagedNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job does not get the default queue label", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(controllerconstants.QueueLabel))
+			})
+		})
+
+		ginkgo.It("should inject default queue label for a Pod in managed namespace with defaulting label", func() {
+			var pod *corev1.Pod
+
+			ginkgo.By("creating a pod without a queue name", func() {
+				pod = testingpod.MakePod("pod-defaulting", managedDefaultingNs.Name).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+					Obj()
+				util.MustCreate(ctx, k8sClient, pod)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, pod, true)
+				})
+			})
+
+			ginkgo.By("verifying the pod gets the default queue label", func() {
+				createdPod := &corev1.Pod{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, createdPod)).To(gomega.Succeed())
+					g.Expect(createdPod.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not inject default queue label for a Pod in managed namespace without defaulting label", func() {
+			var pod *corev1.Pod
+
+			ginkgo.By("creating a pod without a queue name", func() {
+				pod = testingpod.MakePod("pod-no-defaulting", managedNoDefaultingNs.Name).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+					Obj()
+				util.MustCreate(ctx, k8sClient, pod)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, pod, true)
+				})
+			})
+
+			ginkgo.By("verifying the pod does not get the default queue label", func() {
+				createdPod := &corev1.Pod{}
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, createdPod)).To(gomega.Succeed())
+				gomega.Expect(createdPod.Labels).ShouldNot(gomega.HaveKey(controllerconstants.QueueLabel))
+			})
+		})
+	},
+)
+
+var _ = ginkgo.Describe(
+	"LocalQueueDefaultingPerNamespace disabled",
+	ginkgo.Label("feature:localqueuedefaultingpernamespace", util.Shard0),
+	ginkgo.Ordered,
+	func() {
+		var (
+			managedNoDefaultingNs *corev1.Namespace
+			rf                    *kueue.ResourceFlavor
+			cq                    *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				cfg.ManageJobsWithoutQueueName = true
+				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kueue-managed": "true"},
+				}
+				cfg.LocalQueueDefaultingNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"local-queue-defaulting": "true"},
+				}
+				cfg.FeatureGates = map[string]bool{
+					string(features.LocalQueueDefaultingPerNamespace): false,
+				}
+			})
+
+			managedNoDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-no-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedNoDefaultingNs)).To(gomega.Succeed())
+
+			rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, rf)
+
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(rf.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("default", managedNoDefaultingNs.Name).ClusterQueue("cluster-queue").Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterAll(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedNoDefaultingNs)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.MediumTimeout)
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.MediumTimeout)
+		})
+
+		ginkgo.It("should inject default queue label when feature gate is disabled", func() {
+			var job *batchv1.Job
+			var createdJob *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-gate-disabled", managedNoDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job gets the default queue label", func() {
+				createdJob = &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the job has been admitted", func() {
+				wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	},
+)

--- a/test/e2e/sequential/baseline/localqueuedefaultingpernamespace_test.go
+++ b/test/e2e/sequential/baseline/localqueuedefaultingpernamespace_test.go
@@ -1,0 +1,280 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package baseline
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	workloadjob "sigs.k8s.io/kueue/pkg/controller/jobs/job"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+var _ = ginkgo.Describe(
+	"LocalQueueDefaultingPerNamespace",
+	ginkgo.Label("feature:localqueuedefaultingpernamespace", util.Shard0),
+	ginkgo.Ordered,
+	func() {
+		var (
+			managedDefaultingNs   *corev1.Namespace
+			managedNoDefaultingNs *corev1.Namespace
+			unmanagedNs           *corev1.Namespace
+			rf                    *kueue.ResourceFlavor
+			cq                    *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				cfg.ManageJobsWithoutQueueName = true
+				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kueue-managed": "true"},
+				}
+				cfg.LocalQueueDefaultingNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"local-queue-defaulting": "true"},
+				}
+			})
+
+			managedDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed":          "true",
+						"local-queue-defaulting": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedDefaultingNs)).To(gomega.Succeed())
+
+			managedNoDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-no-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedNoDefaultingNs)).To(gomega.Succeed())
+
+			unmanagedNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "unmanaged-",
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, unmanagedNs)).To(gomega.Succeed())
+
+			rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, rf)
+
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(rf.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			for _, ns := range []*corev1.Namespace{managedDefaultingNs, managedNoDefaultingNs} {
+				lq := utiltestingapi.MakeLocalQueue("default", ns.Name).ClusterQueue("cluster-queue").Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+			}
+			unmanagedLq := utiltestingapi.MakeLocalQueue("default", unmanagedNs.Name).ClusterQueue("cluster-queue").Obj()
+			util.MustCreate(ctx, k8sClient, unmanagedLq)
+		})
+
+		ginkgo.AfterAll(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedDefaultingNs)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedNoDefaultingNs)).To(gomega.Succeed())
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, unmanagedNs)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.MediumTimeout)
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.MediumTimeout)
+		})
+
+		ginkgo.It("should inject default queue label in managed namespace with defaulting label", func() {
+			var job *batchv1.Job
+			var createdJob *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-defaulting", managedDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job gets the default queue label", func() {
+				createdJob = &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the job has been admitted", func() {
+				wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should not inject default queue label in managed namespace without defaulting label", func() {
+			var job *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-no-defaulting", managedNoDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job does not get the default queue label", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(controllerconstants.QueueLabel))
+			})
+		})
+
+		ginkgo.It("should not inject default queue label in unmanaged namespace", func() {
+			var job *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-unmanaged", unmanagedNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job does not get the default queue label", func() {
+				createdJob := &batchv1.Job{}
+				gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+				gomega.Expect(createdJob.Labels).ShouldNot(gomega.HaveKey(controllerconstants.QueueLabel))
+			})
+		})
+	},
+)
+
+var _ = ginkgo.Describe(
+	"LocalQueueDefaultingPerNamespace disabled",
+	ginkgo.Label("feature:localqueuedefaultingpernamespace", util.Shard0),
+	ginkgo.Ordered,
+	func() {
+		var (
+			managedNoDefaultingNs *corev1.Namespace
+			rf                    *kueue.ResourceFlavor
+			cq                    *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeAll(func() {
+			util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *config.Configuration) {
+				cfg.ManageJobsWithoutQueueName = true
+				cfg.ManagedJobsNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kueue-managed": "true"},
+				}
+				cfg.LocalQueueDefaultingNamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{"local-queue-defaulting": "true"},
+				}
+				cfg.FeatureGates = map[string]bool{
+					string(features.LocalQueueDefaultingPerNamespace): false,
+				}
+			})
+
+			managedNoDefaultingNs = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "managed-no-defaulting-",
+					Labels: map[string]string{
+						"kueue-managed": "true",
+					},
+				},
+			}
+			gomega.Expect(k8sClient.Create(ctx, managedNoDefaultingNs)).To(gomega.Succeed())
+
+			rf = utiltestingapi.MakeResourceFlavor("default").Obj()
+			util.MustCreate(ctx, k8sClient, rf)
+
+			cq = utiltestingapi.MakeClusterQueue("cluster-queue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(rf.Name).
+						Resource(corev1.ResourceCPU, "2").
+						Resource(corev1.ResourceMemory, "2G").Obj()).Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("default", managedNoDefaultingNs.Name).ClusterQueue("cluster-queue").Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+		})
+
+		ginkgo.AfterAll(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, managedNoDefaultingNs)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, cq, true, util.MediumTimeout)
+			util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, rf, true, util.MediumTimeout)
+		})
+
+		ginkgo.It("should inject default queue label when feature gate is disabled", func() {
+			var job *batchv1.Job
+			var createdJob *batchv1.Job
+
+			ginkgo.By("creating an unsuspended job without a queue name", func() {
+				job = testingjob.MakeJob("job-gate-disabled", managedNoDefaultingNs.Name).
+					Suspend(false).
+					Image(util.GetAgnHostImage(), util.BehaviorExitFast).
+					Obj()
+				util.MustCreate(ctx, k8sClient, job)
+				ginkgo.DeferCleanup(func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, job, true)
+				})
+			})
+
+			ginkgo.By("verifying the job gets the default queue label", func() {
+				createdJob = &batchv1.Job{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: job.Name, Namespace: job.Namespace}, createdJob)).To(gomega.Succeed())
+					g.Expect(createdJob.Labels).Should(gomega.HaveKeyWithValue(controllerconstants.QueueLabel, "default"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the job has been admitted", func() {
+				wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: job.Namespace}
+				createdWorkload := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+					g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+	},
+)


### PR DESCRIPTION
Signed-off-by: Pannaga Rao Bhoja Ramamanohara

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes-sigs/kueue/pull/13782

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add localQueueDefaultingNamespaceSelector to the Configuration API to control which namespaces participate in LocalQueue defaulting, gated behind the LocalQueueDefaultingPerNamespace feature gate.
```
