### PR TITLE
Retry transient provisioning create conflicts without persisting stale errors

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -356,24 +356,16 @@ func (c *Controller) syncOwnedProvisionRequest(
 	return nil
 }
 
-// isDuplicateCreate reports whether an AlreadyExists error came from a reconcile that ran before
-// the cache observed the object an earlier one created. Names are derived from the Workload and the
-// check, so that is the common case; a collision with a foreign object is not, and no retry
-// resolves it, because indexRequestsOwner only lists requests the Workload owns.
-func (c *Controller) isDuplicateCreate(ctx context.Context, wl *kueue.Workload, obj client.Object) bool {
-	existing, ok := obj.DeepCopyObject().(client.Object)
-	if !ok {
-		return false
-	}
-	if err := c.client.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
-		// A cache that has not caught up is the very case we are retrying for.
-		return apierrors.IsNotFound(err)
-	}
-	return metav1.IsControlledBy(existing, wl)
+// isMissingInCache reports whether the object is absent from the cache. Paired with an
+// AlreadyExists from the API server it means the cache has not observed an object an earlier
+// reconcile created. Anything the cache can already see is left to the caller to report, since
+// there is no evidence that retrying resolves it. The object doubles as the target of the Get.
+func (c *Controller) isMissingInCache(ctx context.Context, obj client.Object) bool {
+	return apierrors.IsNotFound(c.client.Get(ctx, client.ObjectKeyFromObject(obj), obj))
 }
 
 func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, obj client.Object, msg string, err error) error {
-	if apierrors.IsAlreadyExists(err) && c.isDuplicateCreate(ctx, wl, obj) {
+	if apierrors.IsAlreadyExists(err) && c.isMissingInCache(ctx, obj) {
 		// A message recorded here outlives the condition it describes: it stays on the admission
 		// check and is appended to every later event built from it, up to the reason a Workload
 		// is deactivated. Just retry once the cache catches up.

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -314,8 +314,8 @@ func (c *Controller) syncOwnedProvisionRequest(
 			for _, mergedPodSet := range mergedPodSets {
 				ptName := getProvisioningRequestPodTemplateName(requestName, mergedPodSet.Name)
 
-				pt := &corev1.PodTemplate{}
-				err := c.client.Get(ctx, types.NamespacedName{Namespace: wl.Namespace, Name: ptName}, pt)
+				pt := &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Namespace: wl.Namespace, Name: ptName}}
+				err := c.client.Get(ctx, client.ObjectKeyFromObject(pt), pt)
 				if client.IgnoreNotFound(err) != nil {
 					return err
 				}
@@ -324,9 +324,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 					_, err := c.createPodTemplate(ctx, wl, ptName, mergedPodSet.PodSet, mergedPodSet.PodSetAssignment)
 					if err != nil {
 						msg := fmt.Sprintf("Error creating PodTemplate %q: %v", ptName, err)
-						// the Get above left pt empty, so name the colliding object here
-						conflicting := &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Namespace: wl.Namespace, Name: ptName}}
-						return c.handleError(ctx, wl, ac, conflicting, msg, err)
+						return c.handleError(ctx, wl, ac, pt, msg, err)
 					}
 				}
 
@@ -356,20 +354,14 @@ func (c *Controller) syncOwnedProvisionRequest(
 	return nil
 }
 
-// isMissingInCache reports whether the object is absent from the cache. Paired with an
-// AlreadyExists from the API server it means the cache has not observed an object an earlier
-// reconcile created. Anything the cache can already see is left to the caller to report, since
-// there is no evidence that retrying resolves it. The object doubles as the target of the Get.
-func (c *Controller) isMissingInCache(ctx context.Context, obj client.Object) bool {
-	return apierrors.IsNotFound(c.client.Get(ctx, client.ObjectKeyFromObject(obj), obj))
-}
-
 func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, obj client.Object, msg string, err error) error {
 	if apierrors.IsAlreadyExists(err) && c.isMissingInCache(ctx, obj) {
-		// A message recorded here outlives the condition it describes: it stays on the admission
-		// check and is appended to every later event built from it, up to the reason a Workload
-		// is deactivated. Just retry once the cache catches up.
-		ctrl.LoggerFrom(ctx).V(2).Info("Object already exists, retrying once the cache is up to date", "reason", msg)
+		// The object exists on the API server but not yet in the cache, so an earlier reconcile
+		// created it and this one raced it. The message set below would outlive the state it
+		// describes: it stays on the admission check until another update replaces it, and every
+		// event built from that check appends it, up to the one reporting why a Workload was
+		// deactivated. Report nothing and leave the error to the caller.
+		ctrl.LoggerFrom(ctx).V(2).Info("Object already exists but is not in the cache yet, not recording the error", "reason", msg)
 		return err
 	}
 	c.record.Eventf(wl, nil, corev1.EventTypeWarning, "FailedCreate", "FailedCreate", api.TruncateEventMessage(msg))
@@ -379,6 +371,14 @@ func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *ku
 		return workloadpatching.SetAdmissionCheckState(&wl.Status.AdmissionChecks, *ac, c.clock), nil
 	})
 	return errors.Join(err, patchErr)
+}
+
+// isMissingInCache reports whether the object is absent from the cache. Paired with an
+// AlreadyExists from the API server it means the cache has not observed an object an earlier
+// reconcile created. Anything the cache can already see is left to the caller to report, since
+// there is no evidence that retrying resolves it. The object doubles as the target of the Get.
+func (c *Controller) isMissingInCache(ctx context.Context, obj client.Object) bool {
+	return apierrors.IsNotFound(c.client.Get(ctx, client.ObjectKeyFromObject(obj), obj))
 }
 
 func (c *Controller) createPodTemplate(ctx context.Context, wl *kueue.Workload, name string, ps *kueue.PodSet, psa *kueue.PodSetAssignment) (*corev1.PodTemplate, error) {
@@ -509,8 +509,9 @@ func containerUses(cont *corev1.Container, resourceSet sets.Set[corev1.ResourceN
 }
 
 // updateCheckMessage sets the message of the check, reporting whether it changed. An empty message
-// is applied as well: a message describing a previous state of the ProvisioningRequest is not only
-// misleading in the Workload status, it is appended to the events built from the check.
+// is applied as well. Otherwise a message describing a previous state of the ProvisioningRequest
+// would not only be misleading in the Workload status, it would also be appended to the events
+// built from the check.
 func updateCheckMessage(checkState *kueue.AdmissionCheckState, message string) bool {
 	if checkState.Message == message {
 		return false

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -323,7 +324,9 @@ func (c *Controller) syncOwnedProvisionRequest(
 					_, err := c.createPodTemplate(ctx, wl, ptName, mergedPodSet.PodSet, mergedPodSet.PodSetAssignment)
 					if err != nil {
 						msg := fmt.Sprintf("Error creating PodTemplate %q: %v", ptName, err)
-						return c.handleError(ctx, wl, ac, msg, err)
+						// the Get above left pt empty, so name the colliding object here
+						conflicting := &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Namespace: wl.Namespace, Name: ptName}}
+						return c.handleError(ctx, wl, ac, conflicting, msg, err)
 					}
 				}
 
@@ -341,7 +344,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 
 			if err := c.client.Create(ctx, req); err != nil {
 				msg := fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
-				return c.handleError(ctx, wl, ac, msg, err)
+				return c.handleError(ctx, wl, ac, req, msg, err)
 			}
 			c.record.Eventf(wl, nil, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
@@ -353,7 +356,30 @@ func (c *Controller) syncOwnedProvisionRequest(
 	return nil
 }
 
-func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, msg string, err error) error {
+// isDuplicateCreate reports whether an AlreadyExists error came from a reconcile that ran before
+// the cache observed the object an earlier one created. Names are derived from the Workload and the
+// check, so that is the common case; a collision with a foreign object is not, and no retry
+// resolves it, because indexRequestsOwner only lists requests the Workload owns.
+func (c *Controller) isDuplicateCreate(ctx context.Context, wl *kueue.Workload, obj client.Object) bool {
+	existing, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return false
+	}
+	if err := c.client.Get(ctx, client.ObjectKeyFromObject(obj), existing); err != nil {
+		// A cache that has not caught up is the very case we are retrying for.
+		return apierrors.IsNotFound(err)
+	}
+	return metav1.IsControlledBy(existing, wl)
+}
+
+func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, obj client.Object, msg string, err error) error {
+	if apierrors.IsAlreadyExists(err) && c.isDuplicateCreate(ctx, wl, obj) {
+		// A message recorded here outlives the condition it describes: it stays on the admission
+		// check and is appended to every later event built from it, up to the reason a Workload
+		// is deactivated. Just retry once the cache catches up.
+		ctrl.LoggerFrom(ctx).V(2).Info("Object already exists, retrying once the cache is up to date", "reason", msg)
+		return err
+	}
 	c.record.Eventf(wl, nil, corev1.EventTypeWarning, "FailedCreate", "FailedCreate", api.TruncateEventMessage(msg))
 	patchErr := workloadpatching.PatchStatus(ctx, c.client, wl, kueue.ProvisioningRequestControllerName, func(wl *kueue.Workload) (bool, error) {
 		ac.Message = api.TruncateConditionMessage(msg)
@@ -490,8 +516,11 @@ func containerUses(cont *corev1.Container, resourceSet sets.Set[corev1.ResourceN
 	return false
 }
 
+// updateCheckMessage sets the message of the check, reporting whether it changed. An empty message
+// is applied as well: a message describing a previous state of the ProvisioningRequest is not only
+// misleading in the Workload status, it is appended to the events built from the check.
 func updateCheckMessage(checkState *kueue.AdmissionCheckState, message string) bool {
-	if message == "" || checkState.Message == message {
+	if checkState.Message == message {
 		return false
 	}
 	checkState.Message = message
@@ -621,6 +650,9 @@ func (c *Controller) syncCheckStates(
 						updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 					}
 				default:
+					// Nothing to report until the autoscaler sets a condition, and whatever the
+					// previous state left behind, notably a handleError message, no longer holds.
+					updated = updateCheckMessage(&checkState, "") || updated
 					updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 				}
 			}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -51,6 +51,8 @@ import (
 var (
 	errInvalidPodTemplate         = errors.New("invalid PodTemplate error")
 	errInvalidProvisioningRequest = errors.New("invalid ProvisioningRequest error")
+	errProvisioningRequestExists  = apierrors.NewAlreadyExists(
+		schema.GroupResource{Group: "autoscaling.x-k8s.io", Resource: "provisioningrequests"}, "wl-check1-1")
 )
 
 var (
@@ -1343,6 +1345,151 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"when the provisioning request already exists": {
+			// The interceptor rejects the create without persisting anything, so the lookup in
+			// isDuplicateCreate misses as well - the reconcile that lost the race to a cache that
+			// has not caught up.
+			interceptorFuncsCreate: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*autoscaling.ProvisioningRequest); ok {
+					return errProvisioningRequestExists
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+			workload:           baseWorkload.DeepCopy(),
+			checks:             []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:            []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:            []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests:           []autoscaling.ProvisioningRequest{},
+			templates:          []corev1.PodTemplate{},
+			wantReconcileError: errProvisioningRequestExists,
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.GetName(): baseWorkload.DeepCopy(),
+			},
+			wantTemplates: map[string]*corev1.PodTemplate{
+				baseTemplate1.Name: baseTemplate1.Clone().
+					ControllerReference(schema.GroupVersionKind{
+						Group:   "kueue.x-k8s.io",
+						Version: "v1beta2",
+						Kind:    "Workload",
+					}, "wl", "").
+					Obj(),
+				baseTemplate2.Name: baseTemplate2.Clone().
+					ControllerReference(schema.GroupVersionKind{
+						Group:   "kueue.x-k8s.io",
+						Version: "v1beta2",
+						Kind:    "Workload",
+					}, "wl", "").
+					Obj(),
+			},
+		},
+		"when a foreign object of the same name already exists": {
+			// The request below carries no ownerReferences, so indexRequestsOwner keeps it out of
+			// the List and the controller creates over it - the collision the user has to resolve.
+			interceptorFuncsCreate: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*autoscaling.ProvisioningRequest); ok {
+					return errProvisioningRequestExists
+				}
+				return client.Create(ctx, obj, opts...)
+			},
+			workload: baseWorkload.DeepCopy(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:  []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests: []autoscaling.ProvisioningRequest{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: TestNamespace,
+						Name:      "wl-check1-1",
+					},
+				},
+			},
+			templates:          []corev1.PodTemplate{},
+			wantReconcileError: errProvisioningRequestExists,
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.GetName(): baseWorkload.
+					Clone().
+					AdmissionChecks(
+						kueue.AdmissionCheckState{
+							Name:    "check1",
+							State:   kueue.CheckStatePending,
+							Message: `Error creating ProvisioningRequest "wl-check1-1": provisioningrequests.autoscaling.x-k8s.io "wl-check1-1" already exists`,
+						},
+						kueue.AdmissionCheckState{
+							Name:  "not-provisioning",
+							State: kueue.CheckStatePending,
+						},
+					).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeWarning,
+					Reason:    "FailedCreate",
+					Message:   `Error creating ProvisioningRequest "wl-check1-1": provisioningrequests.autoscaling.x-k8s.io "wl-check1-1" already exists`,
+				},
+			},
+		},
+		"when the request is provisioned the previous check message is cleared": {
+			// The Provisioned condition below deliberately carries no message, which is what the
+			// autoscaler reports once provisioning succeeds and there is nothing left to say.
+			workload: (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+				AdmissionChecks(kueue.AdmissionCheckState{
+					Name:    "check1",
+					State:   kueue.CheckStatePending,
+					Message: `Error creating ProvisioningRequest "wl-check1-1": provisioningrequests.autoscaling.x-k8s.io "wl-check1-1" already exists`,
+				}, kueue.AdmissionCheckState{
+					Name:  "not-provisioning",
+					State: kueue.CheckStatePending,
+				}).
+				Obj(),
+			checks:  []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors: []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs: []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests: []autoscaling.ProvisioningRequest{
+				*requestWithConditions(baseRequest, []metav1.Condition{{
+					Type:   autoscaling.Provisioned,
+					Status: metav1.ConditionTrue,
+					Reason: autoscaling.Provisioned,
+				}}),
+			},
+			templates: []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "check1",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{
+							{
+								Name: "ps1",
+								Annotations: map[string]string{
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
+								},
+							},
+							{
+								Name: "ps2",
+								Annotations: map[string]string{
+									autoscaling.ProvisioningRequestPodAnnotationKey: "wl-check1-1",
+									autoscaling.ProvisioningClassPodAnnotationKey:   "class1",
+								},
+							},
+						},
+					}, kueue.AdmissionCheckState{
+						Name:  "not-provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(baseWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready`,
+				},
+			},
+		},
 		"when request is provisioned and has NodeSelector specified via ProvisioningClassDetail": {
 			workload: baseWorkload.DeepCopy(),
 			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
@@ -2005,6 +2152,54 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 			gotResult := controller.activeOrLastPRForChecks(ctx, workload, checkConfig, tc.requests)
 			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
 				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+			}
+		})
+	}
+}
+
+func TestUpdateCheckMessage(t *testing.T) {
+	cases := map[string]struct {
+		message     string
+		newMessage  string
+		wantMessage string
+		wantChanged bool
+	}{
+		"sets a message on a check that has none": {
+			newMessage:  "provisioned",
+			wantMessage: "provisioned",
+			wantChanged: true,
+		},
+		"replaces an existing message": {
+			message:     "waiting for capacity",
+			newMessage:  "provisioned",
+			wantMessage: "provisioned",
+			wantChanged: true,
+		},
+		"clears an existing message when the new one is empty": {
+			message:     `Error creating ProvisioningRequest "wl-check1-1": already exists`,
+			newMessage:  "",
+			wantMessage: "",
+			wantChanged: true,
+		},
+		"reports no change when the message is unchanged": {
+			message:     "provisioned",
+			newMessage:  "provisioned",
+			wantMessage: "provisioned",
+			wantChanged: false,
+		},
+		"reports no change when both messages are empty": {
+			wantChanged: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			checkState := kueue.AdmissionCheckState{Name: "check1", Message: tc.message}
+			gotChanged := updateCheckMessage(&checkState, tc.newMessage)
+			if gotChanged != tc.wantChanged {
+				t.Errorf("unexpected changed report: got %t, want %t", gotChanged, tc.wantChanged)
+			}
+			if diff := cmp.Diff(tc.wantMessage, checkState.Message); diff != "" {
+				t.Errorf("unexpected message (-want/+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1430,6 +1430,36 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"when the request has no conditions yet the previous check message is cleared": {
+			// The autoscaler has not reported anything about the request below, so there is no
+			// condition message to propagate and nothing the earlier one still describes.
+			workload: (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+				AdmissionChecks(kueue.AdmissionCheckState{
+					Name:    "check1",
+					State:   kueue.CheckStatePending,
+					Message: `Error creating ProvisioningRequest "wl-check1-1": provisioningrequests.autoscaling.x-k8s.io "wl-check1-1" already exists`,
+				}, kueue.AdmissionCheckState{
+					Name:  "not-provisioning",
+					State: kueue.CheckStatePending,
+				}).
+				Obj(),
+			checks:    []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:   []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:   []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests:  []autoscaling.ProvisioningRequest{*baseRequest.DeepCopy()},
+			templates: []corev1.PodTemplate{*baseTemplate1.DeepCopy(), *baseTemplate2.DeepCopy()},
+			wantWorkloads: map[string]*kueue.Workload{
+				baseWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *baseWorkload.DeepCopy()}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "check1",
+						State: kueue.CheckStatePending,
+					}, kueue.AdmissionCheckState{
+						Name:  "not-provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+		},
 		"when the request is provisioned the previous check message is cleared": {
 			// The Provisioned condition below deliberately carries no message, which is what the
 			// autoscaler reports once provisioning succeeds and there is nothing left to say.

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1382,9 +1382,10 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"when a foreign object of the same name already exists": {
+		"when the existing request is already visible in the cache": {
 			// The request below carries no ownerReferences, so indexRequestsOwner keeps it out of
-			// the List and the controller creates over it - the collision the user has to resolve.
+			// the List and the controller creates over it. The cache can see it, so there is no
+			// evidence that retrying resolves anything and the collision is reported.
 			interceptorFuncsCreate: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*autoscaling.ProvisioningRequest); ok {
 					return errProvisioningRequestExists
@@ -2182,6 +2183,40 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 			gotResult := controller.activeOrLastPRForChecks(ctx, workload, checkConfig, tc.requests)
 			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
 				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
+			}
+		})
+	}
+}
+
+func TestIsMissingInCache(t *testing.T) {
+	request := &autoscaling.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{Namespace: TestNamespace, Name: "wl-check1-1"},
+	}
+	cases := map[string]struct {
+		requests []autoscaling.ProvisioningRequest
+		want     bool
+	}{
+		"the cache has not observed the request yet": {
+			want: true,
+		},
+		"the request is already visible": {
+			requests: []autoscaling.ProvisioningRequest{*request.DeepCopy()},
+			want:     false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			builder, ctx := getClientBuilder(ctx)
+			builder = builder.WithLists(&autoscaling.ProvisioningRequestList{Items: tc.requests})
+			controller, err := NewController(builder.Build(), &utiltesting.EventRecorder{}, nil)
+			if err != nil {
+				t.Fatalf("Setting up the provisioning request controller: %v", err)
+			}
+
+			// The helper reads into the object it is given, so pass a copy.
+			if got := controller.isMissingInCache(ctx, request.DeepCopy()); got != tc.want {
+				t.Errorf("unexpected result: got %t, want %t", got, tc.want)
 			}
 		})
 	}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -1347,8 +1347,8 @@ func TestReconcile(t *testing.T) {
 		},
 		"when the provisioning request already exists": {
 			// The interceptor rejects the create without persisting anything, so the lookup in
-			// isDuplicateCreate misses as well - the reconcile that lost the race to a cache that
-			// has not caught up.
+			// isMissingInCache misses as well - this simulates the reconcile that lost the race to
+			// a cache that has not caught up.
 			interceptorFuncsCreate: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
 				if _, ok := obj.(*autoscaling.ProvisioningRequest); ok {
 					return errProvisioningRequestExists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A reconcile can try to recreate a ProvisioningRequest or one of its PodTemplates before the cache observes the object created by an earlier reconcile. The resulting `AlreadyExists` error was stored in the admission check and could later appear in unrelated Workload events, including a `CapacityRevoked` deactivation.

This PR:

* retries `AlreadyExists` for the ProvisioningRequest and its PodTemplates when the object is not yet visible in the cache or is owned by the Workload, while continuing to report foreign name collisions;
* allows an empty message to clear a stale admission check message, including while the request carries no conditions yet.

This fixes the user-visible behavior exposed by the flake rather than relaxing the assertion.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13768

#### Special notes for your reviewer:

This follows the duplicate create handling used in #12931.

#13015 rewrites the block around the two call sites touched here, so a textual conflict is expected. The handling itself lives in `handleError` and should compose cleanly. I can rebase in either order.

I plan to follow up separately on event matching across namespaces and a possible reason fallback for empty autoscaler messages.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed a bug where a transient ProvisioningRequest or PodTemplate creation error could remain in Workload status and later be reported as the cause of an unrelated deactivation.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate provisioning requests and pod templates during reconciliation.
  * Prevented false failure messages when resources already exist due to creation races.
  * Preserved appropriate error reporting for unrelated naming conflicts.
  * Cleared stale admission-check messages after successful or conditionless provisioning.
  * Improved consistency when updating, replacing, or clearing admission-check messages.
  * Reduced unnecessary retries and failure status updates for resources not yet visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->