### PR TITLE
Validate GIT_TAG for release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,7 +376,12 @@ artifacts: clean-artifacts kustomize helm-chart-package prepare-manifests ## Gen
 	CGO_ENABLED=$(CGO_ENABLED) GO_CMD="$(GO_CMD)" LD_FLAGS="$(LD_FLAGS)" BUILD_PATH="$(ARTIFACTS)" BUILD_NAME=kubectl-kueue PLATFORMS="$(CLI_PLATFORMS)" ./hack/multiplatform-build.sh ./cmd/kueuectl/main.go
 
 .PHONY: release-artifacts
+release-artifacts: export GIT_TAG := $(GIT_TAG)
 release-artifacts: ## Generate release artifacts.
+	@if [[ "$${GIT_TAG}" != v* ]]; then \
+		echo "GIT_TAG must start with v" >&2; \
+		exit 1; \
+	fi
 	$(MAKE) artifacts ARTIFACTS="$(RELEASE_ARTIFACTS)"
 
 .PHONY: prepare-release-branch

--- a/Makefile
+++ b/Makefile
@@ -361,9 +361,8 @@ prepare-manifests:
 	cd cmd/experimental/kueue-populator/config && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_KUEUE_POPULATOR)
 	cd cmd/experimental/kueue-priority-booster/config && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_KUEUE_PRIORITY_BOOSTER)
 
-# Must stay the first artifacts prerequisite: helm-chart-package and
-# prepare-manifests rewrite tracked files, so an invalid tag has to fail
-# before them to avoid leaving the working tree modified.
+# Keep first so serial builds fail before helm-chart-package and
+# prepare-manifests rewrite tracked files.
 .PHONY: verify-git-tag
 verify-git-tag:
 	@if [[ "$(GIT_TAG)" != v* ]]; then \

--- a/Makefile
+++ b/Makefile
@@ -361,9 +361,19 @@ prepare-manifests:
 	cd cmd/experimental/kueue-populator/config && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_KUEUE_POPULATOR)
 	cd cmd/experimental/kueue-priority-booster/config && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_KUEUE_PRIORITY_BOOSTER)
 
+# Must stay the first artifacts prerequisite: helm-chart-package and
+# prepare-manifests rewrite tracked files, so an invalid tag has to fail
+# before them to avoid leaving the working tree modified.
+.PHONY: verify-git-tag
+verify-git-tag:
+	@if [[ "$(GIT_TAG)" != v* ]]; then \
+		echo "GIT_TAG must start with v, got \"$(GIT_TAG)\"" >&2; \
+		exit 1; \
+	fi
+
 .PHONY: artifacts
 artifacts: DEST_CHART_DIR="$(ARTIFACTS)"
-artifacts: clean-artifacts kustomize helm-chart-package prepare-manifests ## Generate local artifacts.
+artifacts: verify-git-tag clean-artifacts kustomize helm-chart-package prepare-manifests ## Generate local artifacts.
 	$(KUSTOMIZE) build config/default -o $(ARTIFACTS)/manifests.yaml
 	$(KUSTOMIZE) build config/dev -o $(ARTIFACTS)/manifests-dev.yaml
 	$(KUSTOMIZE) build config/alpha-enabled -o $(ARTIFACTS)/manifests-alpha-enabled.yaml
@@ -376,12 +386,7 @@ artifacts: clean-artifacts kustomize helm-chart-package prepare-manifests ## Gen
 	CGO_ENABLED=$(CGO_ENABLED) GO_CMD="$(GO_CMD)" LD_FLAGS="$(LD_FLAGS)" BUILD_PATH="$(ARTIFACTS)" BUILD_NAME=kubectl-kueue PLATFORMS="$(CLI_PLATFORMS)" ./hack/multiplatform-build.sh ./cmd/kueuectl/main.go
 
 .PHONY: release-artifacts
-release-artifacts: export GIT_TAG := $(GIT_TAG)
 release-artifacts: ## Generate release artifacts.
-	@if [[ "$${GIT_TAG}" != v* ]]; then \
-		echo "GIT_TAG must start with v" >&2; \
-		exit 1; \
-	fi
 	$(MAKE) artifacts ARTIFACTS="$(RELEASE_ARTIFACTS)"
 
 .PHONY: prepare-release-branch


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area release

#### What this PR does / why we need it:

Validates `GIT_TAG` at the `release-artifacts` boundary and fails before artifact generation unless the tag starts with `v`.

The repository now uses `artifacts` for local artifacts and `release-artifacts` for release bundles. Placing the validation on the release target protects the draft-release workflow without affecting local builds or unrelated targets.

#### Which issue(s) this PR fixes:

Fixes #7215

#### Special notes for your reviewer:

Validation performed:

- Built the complete release artifact set with `GIT_TAG=v0.20.0-rc.0`, including Helm charts, rendered manifests, and all four CLI platform binaries.
- Verified stable, RC, default, environment, command-line, and recursive Make propagation.
- Verified empty, missing-prefix, embedded-`v`, uppercase-`V`, and leading-space tags fail before artifact generation.
- Verified `importer-build` still succeeds outside a Git repository with the Go build stubbed, covering the regression seen in the earlier attempt.
- Ran `git diff --check`.

AI assistance was used to analyze the issue and prepare the change. The contributor reviewed the resulting diff and validation evidence.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure release tags use the required `v` prefix before artifacts are generated.
  * Prevented artifact packaging and manifest updates from proceeding with incorrectly formatted tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->