### PR TITLE
Speed up Netlify preview link verification

### DIFF
--- a/hack/testing/linkchecker/Dockerfile
+++ b/hack/testing/linkchecker/Dockerfile
@@ -2,4 +2,6 @@ FROM python:3.15.0b4-alpine@sha256:c40ec5a55436b283c1570e649ff40a8188e7e0221d7f2
 
 RUN pip install --no-cache-dir linkchecker
 
-ENTRYPOINT ["linkchecker"]
+COPY linkcheckerrc /etc/linkchecker/linkcheckerrc
+
+ENTRYPOINT ["linkchecker", "--config=/etc/linkchecker/linkcheckerrc"]

--- a/hack/testing/linkchecker/linkcheckerrc
+++ b/hack/testing/linkchecker/linkcheckerrc
@@ -1,0 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[checking]
+# Maximum number of requests per second to one host.
+maxrequestspersecond=50

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
   HUGO_BASEURL = "https://kueue.sigs.k8s.io/"
 
 [context.deploy-preview]
-  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && npx -y pagefind --site public"
+  command = "hugo --enableGitInfo --buildFuture -b $DEPLOY_PRIME_URL && npx -y pagefind --site public && cp custom-headers/deploy-preview public/_headers"
   # Runs from "site"; "." includes docs, and "../netlify.toml" includes config changes.
   ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../netlify.toml"
 

--- a/site/custom-headers/deploy-preview
+++ b/site/custom-headers/deploy-preview
@@ -1,0 +1,17 @@
+# Copyright 2026 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add LinkChecker header to allow maxrequestspersecond > 10
+/*
+  LinkChecker: true


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup
/kind website

#### What this PR does / why we need it:
The deploy-preview link check spends most of its runtime in LinkChecker’s per-host throttle.
Changed it to allow up to 50 requests/s (from 10 req/s) on Netlify deploys by adding LinkChecker response header.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #13474

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved link-checking configuration for deploy previews, including controlled request rates and custom headers.
  * Deploy-preview builds now include the appropriate link-checker headers in the generated site.
  * Added licensing information to the link-checker configuration and deploy-preview headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->