### PR TITLE
TAS: skip flavors whose placement failed in recent scheduling cycles

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1701,20 +1701,23 @@ in the Cohort — and again whenever the Workload's `Info` is rebuilt in the que
 update event, including the status update Kueue itself writes while requeueing. Under sustained load
 both happen every cycle, so the flavor walk restarts from the first flavor indefinitely.
 
-We therefore record, per Workload, the flavors for which the placement search found no viable topology
-domains, and skip them during flavor selection in later cycles. The record is held by the scheduler
-rather than on the Workload's `Info`, so that neither mechanism above discards it, and entries expire
-after a fixed number of scheduling cycles. Cycle-based expiry is deliberate: any invalidation signal
-derived from cluster state fires many times per cycle on a large flavor with steady churn, dropping the
-record precisely in the conditions it is meant to address, while tracking which change could make a
-given Workload fit would require remembering the domains its search rejected. A flavor is recorded only
-once the Workload has failed to be admitted for the cycle with no preemption or migration pending, so a
-preemption that could still admit it there is not discarded. This behavior was introduced in 0.20.0 and
-guarded by the `TASSkipRecentlyFailedFlavors` feature gate (disabled by default as Alpha). Two
-limitations are known: the placement result reports only the first failing PodSet, so a Workload with
-several converges more slowly; and the record is in memory, so a restart or leader change re-walks
-flavors already tried — the cycle counter the expiry is measured against restarts with it, so the two
-stay consistent.
+We therefore record, for single-PodSet Workloads, the flavors for which the placement search found no
+viable topology domains, and skip them during flavor selection in later cycles. The record is held by
+the scheduler rather than on the Workload's `Info`, so that neither mechanism above discards it, and
+entries expire after a fixed number of scheduling cycles. Cycle-based expiry is deliberate: any
+invalidation signal derived from cluster state fires many times per cycle on a large flavor with steady
+churn, dropping the record precisely in the conditions it is meant to address, while tracking which
+change could make a given Workload fit would require remembering the domains its search rejected. A
+flavor is recorded only once the Workload has failed to be admitted for the cycle with no preemption or
+migration pending, so a preemption that could still admit it there is not discarded. This behavior was
+introduced in 0.20.0 and guarded by the `TASSkipRecentlyFailedFlavors` feature gate (disabled by default
+as Alpha).
+
+Multi-PodSet Workloads are excluded. PodSets are placed in sequence and consume each other's capacity, so
+a failure reported for one PodSet only proves that the combination of flavors did not fit, not that the
+named PodSet cannot use its own flavor. Recording it per PodSet would therefore skip combinations that
+were never tried. Such Workloads continue to rely on `LastTriedFlavorIdx`, which carries the same
+attribution but is not made durable here.
 
 ### Two-level Topology Aware scheduling
 In consideration of a [Story 5](#story-5) a two-level scheduling is introduced.

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -58,6 +58,7 @@
       - [Until v0.14](#until-v014)
       - [Since v0.15](#since-v015)
     - [Re-computation of TAS assignments within the workload evaluation phase](#re-computation-of-tas-assignments-within-the-workload-evaluation-phase)
+    - [Skipping flavors whose TAS placement failed in recent cycles](#skipping-flavors-whose-tas-placement-failed-in-recent-cycles)
   - [Two-level Topology Aware scheduling](#two-level-topology-aware-scheduling)
     - [Example](#example-1)
   - [Multi-level Topology Aware scheduling](#multi-level-topology-aware-scheduling)
@@ -1684,6 +1685,36 @@ previously evaluated Workloads. During this recomputation, the PodSet-to-Resourc
 remains sticky so that the quota calculations made earlier in the cycle remain valid.
 This behavior was introduced in 0.19.0 and guarded by the `TASRecomputeAssignmentWithinSchedulingCycle`
 feature gate (enabled by defualt as Beta). The fix is also cherry-picked to 0.17.6 and 0.18.2.
+
+#### Skipping flavors whose TAS placement failed in recent cycles
+
+The recomputation above is triggered by the stale-placement check, so it only covers Workloads whose
+placement succeeded during nomination and was invalidated later in the same cycle; it cannot help one
+whose placement already failed during nomination. Such a Workload can stay pinned to a single
+ResourceFlavor across cycles, because flavors are selected on quota alone and the placement check runs
+only after a flavor has been selected, so its verdict cannot influence the selection. A flavor whose
+`nominalQuota` exceeds what its nodes can actually host therefore keeps being selected and keeps
+failing placement, even when another flavor of the ResourceGroup has ample topological capacity. The
+flavors a Workload has already tried are tracked in `LastTriedFlavorIdx`, but that state is discarded
+whenever the ClusterQueue's `AllocatableResourceGeneration` advances — on every admission or eviction
+in the Cohort — and again whenever the Workload's `Info` is rebuilt in the queue cache on a Workload
+update event, including the status update Kueue itself writes while requeueing. Under sustained load
+both happen every cycle, so the flavor walk restarts from the first flavor indefinitely.
+
+We therefore record, per Workload, the flavors for which the placement search found no viable topology
+domains, and skip them during flavor selection in later cycles. The record is held by the scheduler
+rather than on the Workload's `Info`, so that neither mechanism above discards it, and entries expire
+after a fixed number of scheduling cycles. Cycle-based expiry is deliberate: any invalidation signal
+derived from cluster state fires many times per cycle on a large flavor with steady churn, dropping the
+record precisely in the conditions it is meant to address, while tracking which change could make a
+given Workload fit would require remembering the domains its search rejected. A flavor is recorded only
+once the Workload has failed to be admitted for the cycle with no preemption or migration pending, so a
+preemption that could still admit it there is not discarded. This behavior was introduced in 0.20.0 and
+guarded by the `TASSkipRecentlyFailedFlavors` feature gate (disabled by default as Alpha). Two
+limitations are known: the placement result reports only the first failing PodSet, so a Workload with
+several converges more slowly; and the record is in memory, so a restart or leader change re-walks
+flavors already tried — the cycle counter the expiry is measured against restarts with it, so the two
+stay consistent.
 
 ### Two-level Topology Aware scheduling
 In consideration of a [Story 5](#story-5) a two-level scheduling is introduced.

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -51,6 +51,7 @@ feature-gates:
   - name: TASRespectNodeAffinityPreferred
   - name: TASHandleOverlappingFlavors
   - name: TASRecomputeAssignmentWithinSchedulingCycle
+  - name: TASSkipRecentlyFailedFlavors
   - name: TASAssignmentsEncodingByHostnamePrefix
   - name: SkipReassignmentForPodOwnedWorkloads
 disable-supported: true

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -522,6 +522,14 @@ const (
 	// pods per group without accounting for quota. Recreate the LeaderWorkerSet to change
 	// the size, or disable this gate to accept the previous behavior.
 	LWSImmutableGroupSize featuregate.Feature = "LWSImmutableGroupSize"
+
+	// owner: @varunsyal
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	//
+	// Remembers, for a bounded number of scheduling cycles, the flavors whose TAS placement
+	// failed for a Workload, so that subsequent cycles skip them and try the remaining flavors
+	// of the ClusterQueue instead of repeatedly re-picking the first quota-fitting flavor.
+	TASSkipRecentlyFailedFlavors featuregate.Feature = "TASSkipRecentlyFailedFlavors"
 )
 
 func init() {
@@ -541,6 +549,7 @@ var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Featu
 	UnadmittedWorkloadsExplicitStatus:        {UnadmittedWorkloadsObservability},
 	TASHandleOverlappingFlavors:              {TopologyAwareScheduling},
 	TASProfileMixed:                          {TopologyAwareScheduling},
+	TASSkipRecentlyFailedFlavors:             {TopologyAwareScheduling},
 	ElasticJobsViaWorkloadSlicesWithTAS:      {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
 	KueueDRAIntegrationExtendedResource:      {KueueDRAIntegration},
 	KueueDRAIntegrationPartitionableDevices:  {KueueDRAIntegration},
@@ -821,6 +830,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	LWSImmutableGroupSize: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	TASSkipRecentlyFailedFlavors: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -90,11 +90,10 @@ type Assignment struct {
 	//
 	// The scheduler carries these across scheduling cycles (see
 	// features.TASSkipRecentlyFailedFlavors) so that the next cycle tries the
-	// remaining flavors of the ClusterQueue instead of re-picking the same one.
-	//
-	// TODO(#13658): TASAssignmentsResult.Failure reports only the first failing
-	// PodSet, so a Workload with several failing PodSets records one of them per
-	// cycle. Record every failing PodSet once Failure can report them all.
+	// remaining flavors of the ClusterQueue instead of re-picking the same one. It
+	// only does so for single-PodSet Workloads: PodSets are placed in sequence and
+	// consume each other's capacity, so for several PodSets a reported failure
+	// describes the arrangement rather than the PodSet named here.
 	FailedFlavorPlacements map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -82,6 +82,35 @@ type Assignment struct {
 
 	// NoFitReason contains the reason why the overall assignment failed with NoFit.
 	NoFitReason string
+
+	// FailedFlavorPlacements records, per PodSet, the flavors for which the TAS
+	// placement search found no viable topology domains during this assignment.
+	// A flavor listed here was rejected on placement grounds, not on quota grounds,
+	// so retrying it is pointless until the flavor's topology gains capacity.
+	//
+	// The scheduler carries these across scheduling cycles (see
+	// features.TASSkipRecentlyFailedFlavors) so that the next cycle tries the
+	// remaining flavors of the ClusterQueue instead of re-picking the same one.
+	//
+	// TODO(#13658): TASAssignmentsResult.Failure reports only the first failing
+	// PodSet, so a Workload with several failing PodSets records one of them per
+	// cycle. Record every failing PodSet once Failure can report them all.
+	FailedFlavorPlacements map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
+}
+
+// recordFailedFlavorPlacement notes that the TAS placement search rejected flavor
+// for podSet, so later scheduling cycles can skip it while it stays infeasible.
+func (a *Assignment) recordFailedFlavorPlacement(podSet kueue.PodSetReference, flavor kueue.ResourceFlavorReference) {
+	if flavor == "" {
+		return
+	}
+	if a.FailedFlavorPlacements == nil {
+		a.FailedFlavorPlacements = make(map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference], 1)
+	}
+	if a.FailedFlavorPlacements[podSet] == nil {
+		a.FailedFlavorPlacements[podSet] = sets.New[kueue.ResourceFlavorReference]()
+	}
+	a.FailedFlavorPlacements[podSet].Insert(flavor)
 }
 
 // UpdateForTASResult updates the Assignment with the TAS result
@@ -603,6 +632,14 @@ type FlavorAssigner struct {
 	replaceWorkloadSlice *workload.Info
 	quotaCheckStrategy   configapi.QuotaCheckStrategy
 	resourceFormatter    *resources.ResourceFormatter
+
+	// failedFlavorPlacements lists, per PodSet, the flavors whose TAS placement failed
+	// in a recent scheduling cycle. They are skipped during flavor selection so that a
+	// Workload advances to the remaining flavors of the ClusterQueue instead of being
+	// re-nominated to a flavor that quota alone still reports as fitting.
+	//
+	// Empty unless features.TASSkipRecentlyFailedFlavors is enabled.
+	failedFlavorPlacements map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
 }
 
 func New(
@@ -614,16 +651,18 @@ func New(
 	preemptWorkloadSlice *workload.Info,
 	quotaCheckStrategy configapi.QuotaCheckStrategy,
 	resourceFormatter *resources.ResourceFormatter,
+	failedFlavorPlacements map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference],
 ) *FlavorAssigner {
 	return &FlavorAssigner{
-		wl:                   wl,
-		cq:                   cq,
-		resourceFlavors:      resourceFlavors,
-		enableFairSharing:    enableFairSharing,
-		oracle:               oracle,
-		replaceWorkloadSlice: preemptWorkloadSlice,
-		quotaCheckStrategy:   quotaCheckStrategy,
-		resourceFormatter:    resourceFormatter,
+		wl:                     wl,
+		cq:                     cq,
+		resourceFlavors:        resourceFlavors,
+		enableFairSharing:      enableFairSharing,
+		oracle:                 oracle,
+		replaceWorkloadSlice:   preemptWorkloadSlice,
+		quotaCheckStrategy:     quotaCheckStrategy,
+		resourceFormatter:      resourceFormatter,
+		failedFlavorPlacements: failedFlavorPlacements,
 	}
 }
 
@@ -819,6 +858,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				// There is at least one PodSet which does not fit
 				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
 				psAssignment.reason(failure.Reason)
+				assignment.recordFailedFlavorPlacement(failure.PodSetName, failure.Flavor)
 				// update the mode for all flavors and the representative mode
 				assignment.updateMode(failure.PodSetName, Preempt)
 			} else {
@@ -841,6 +881,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				if features.Enabled(features.UnadmittedWorkloadsObservability) {
 					psAssignment.markFlavorAttempt(failure.Flavor, NoFit, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
 				}
+				assignment.recordFailedFlavorPlacement(failure.PodSetName, failure.Flavor)
 				// update the mode for all flavors and the representative mode
 				assignment.updateMode(failure.PodSetName, NoFit)
 			} else {
@@ -1049,6 +1090,11 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		}
 		if features.Enabled(features.ConcurrentAdmission) && !concurrentadmission.IsFlavorAllowedForVariant(a.wl.Obj, fName) {
 			status.appendf("skipping flavor %s due to WorkloadAllowedResourceFlavorAnnotation annotation", fName)
+			continue
+		}
+		if a.placementFailedRecently(fName, psIDs) {
+			log.V(5).Info("Skipping flavor as its topology placement failed in a recent scheduling cycle", "resName", resName, "flavorName", fName)
+			status.appendf("skipping flavor %s for resource %s as its topology placement failed in a recent scheduling cycle", fName, resName)
 			continue
 		}
 
@@ -1346,6 +1392,24 @@ func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.
 		}
 	})
 	return filtered
+}
+
+// placementFailedRecently reports whether the flavor's TAS placement failed for any of
+// the PodSets in the group during a recent scheduling cycle, in which case re-picking it
+// would repeat a placement search already known to fail.
+//
+// Returns false unless features.TASSkipRecentlyFailedFlavors is enabled, because the
+// scheduler only supplies failedFlavorPlacements while the gate is on.
+func (a *FlavorAssigner) placementFailedRecently(fName kueue.ResourceFlavorReference, psIDs []int) bool {
+	if len(a.failedFlavorPlacements) == 0 {
+		return false
+	}
+	for _, psID := range psIDs {
+		if a.failedFlavorPlacements[a.wl.Obj.Spec.PodSets[psID].Name].Has(fName) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldRespectNominationMapping returns true if flavor stickiness should be enforced.

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3648,6 +3648,7 @@ func TestAssignFlavors(t *testing.T) {
 					tc.preemptWorkloadSlice,
 					configapi.QuotaCheckBlockUndeclared,
 					resources.NewResourceFormatter(),
+					nil,
 				)
 				assignment := flvAssigner.Assign(ctx, nil)
 				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
@@ -3842,7 +3843,7 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), nil)
 			assignment := flvAssigner.Assign(ctx, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -3990,7 +3991,7 @@ func TestDeletedFlavors(t *testing.T) {
 				cache.DeleteResourceFlavor(log, flavorMap["deleted-flavor"])
 				delete(flavorMap, "deleted-flavor")
 
-				flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+				flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), nil)
 
 				assignment := flvAssigner.Assign(ctx, nil)
 				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
@@ -4179,7 +4180,7 @@ func TestHierarchical(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), nil)
 			assignment := flvAssigner.Assign(ctx, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -5146,7 +5147,7 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 			}
 			cqSnapshot := snapshot.ClusterQueue(kueue.ClusterQueueReference(cq.Name))
 
-			assigner := New(wlInfo, cqSnapshot, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			assigner := New(wlInfo, cqSnapshot, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), nil)
 			gotAssignment := assigner.Assign(ctx, nil)
 
 			if gotAssignment.RepresentativeMode() != tc.wantRepMode {
@@ -5631,6 +5632,7 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			assigner := New(
 				wlInfo, cqSnapshot, testFlavors, false, &testOracle{simulationResult: tc.simulationResult},
 				tc.replaceWl, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(),
+				nil,
 			)
 			gotAssignment := assigner.Assign(ctx, nil)
 
@@ -5894,7 +5896,7 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 				t.Fatalf("Failed to create CQ snapshot")
 			}
 
-			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), nil)
 			assignment := flvAssigner.Assign(ctx, nil)
 
 			gotErrors := map[kueue.PodSetReference]error{}
@@ -5976,5 +5978,150 @@ func TestTasFlavorsOnly(t *testing.T) {
 	got := tasFlavorsOnly(in, tasFlavors)
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(FlavorAssignment{})); diff != "" {
 		t.Errorf("tasFlavorsOnly() mismatch (-want,+got):\n%s", diff)
+	}
+}
+
+func flavorSets(pairs map[kueue.PodSetReference][]kueue.ResourceFlavorReference) map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference] {
+	if pairs == nil {
+		return nil
+	}
+	out := make(map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference], len(pairs))
+	for ps, flavors := range pairs {
+		out[ps] = sets.New(flavors...)
+	}
+	return out
+}
+
+func TestRecordFailedFlavorPlacement(t *testing.T) {
+	cases := map[string]struct {
+		record []struct {
+			podSet kueue.PodSetReference
+			flavor kueue.ResourceFlavorReference
+		}
+		want map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
+	}{
+		"nothing recorded leaves the map nil": {
+			want: nil,
+		},
+		"a single failure is recorded": {
+			record: []struct {
+				podSet kueue.PodSetReference
+				flavor kueue.ResourceFlavorReference
+			}{
+				{podSet: "main", flavor: "flavor-a"},
+			},
+			want: flavorSets(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+		},
+		"failures accumulate per PodSet": {
+			record: []struct {
+				podSet kueue.PodSetReference
+				flavor kueue.ResourceFlavorReference
+			}{
+				{podSet: "main", flavor: "flavor-a"},
+				{podSet: "main", flavor: "flavor-b"},
+			},
+			want: flavorSets(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a", "flavor-b"}}),
+		},
+		"PodSets are tracked independently": {
+			record: []struct {
+				podSet kueue.PodSetReference
+				flavor kueue.ResourceFlavorReference
+			}{
+				{podSet: "leader", flavor: "flavor-a"},
+				{podSet: "worker", flavor: "flavor-b"},
+			},
+			want: flavorSets(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{
+				"leader": {"flavor-a"},
+				"worker": {"flavor-b"},
+			}),
+		},
+		"repeating a failure is idempotent": {
+			record: []struct {
+				podSet kueue.PodSetReference
+				flavor kueue.ResourceFlavorReference
+			}{
+				{podSet: "main", flavor: "flavor-a"},
+				{podSet: "main", flavor: "flavor-a"},
+			},
+			want: flavorSets(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+		},
+		"an empty flavor is ignored": {
+			record: []struct {
+				podSet kueue.PodSetReference
+				flavor kueue.ResourceFlavorReference
+			}{
+				{podSet: "main", flavor: ""},
+			},
+			want: nil,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := &Assignment{}
+			for _, r := range tc.record {
+				a.recordFailedFlavorPlacement(r.podSet, r.flavor)
+			}
+			if diff := cmp.Diff(tc.want, a.FailedFlavorPlacements, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("FailedFlavorPlacements differs (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPlacementFailedRecently(t *testing.T) {
+	wl := utiltestingapi.MakeWorkload("wl", "ns").
+		PodSets(
+			*utiltestingapi.MakePodSet("leader", 1).Obj(),
+			*utiltestingapi.MakePodSet("worker", 1).Obj(),
+		).Obj()
+
+	cases := map[string]struct {
+		recorded map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+		flavor   kueue.ResourceFlavorReference
+		psIDs    []int
+		want     bool
+	}{
+		"no record: nothing is skipped": {
+			flavor: "flavor-a",
+			psIDs:  []int{0},
+			want:   false,
+		},
+		"a flavor recorded for the PodSet is skipped": {
+			recorded: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"leader": {"flavor-a"}},
+			flavor:   "flavor-a",
+			psIDs:    []int{0},
+			want:     true,
+		},
+		"a flavor that was not recorded is not skipped": {
+			recorded: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"leader": {"flavor-a"}},
+			flavor:   "flavor-b",
+			psIDs:    []int{0},
+			want:     false,
+		},
+		"a record for another PodSet does not skip this one": {
+			recorded: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"worker": {"flavor-a"}},
+			flavor:   "flavor-a",
+			psIDs:    []int{0},
+			want:     false,
+		},
+		"a record for any PodSet in the group skips the flavor": {
+			recorded: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"worker": {"flavor-a"}},
+			flavor:   "flavor-a",
+			psIDs:    []int{0, 1},
+			want:     true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			a := &FlavorAssigner{
+				wl:                     &workload.Info{Obj: wl},
+				failedFlavorPlacements: flavorSets(tc.recorded),
+			}
+			if got := a.placementFailedRecently(tc.flavor, tc.psIDs); got != tc.want {
+				t.Errorf("placementFailedRecently(%q, %v) = %t, want %t", tc.flavor, tc.psIDs, got, tc.want)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -94,6 +94,34 @@ type Scheduler struct {
 	// schedulingCycle identifies the number of scheduling
 	// attempts since the last restart.
 	schedulingCycle int64
+
+	// failedFlavorPlacements remembers, per Workload, the flavors whose TAS placement
+	// failed in a recent scheduling cycle, so that the next cycles skip them and try
+	// the remaining flavors of the ClusterQueue instead of re-picking the same one.
+	// Entries expire after failedFlavorPlacementTTL cycles.
+	//
+	// Deliberately in-memory and scoped to this Scheduler instance: entries are stamped
+	// with schedulingCycle, which also restarts from zero on process restart or leader
+	// change, so the two always agree. Persisting entries without switching the TTL to
+	// wall-clock time would make stale stamps compare as arbitrarily fresh and block a
+	// flavor forever. Losing the map on restart only costs re-walking flavors already
+	// tried, which is how LastAssignment already behaves.
+	//
+	// Only accessed from schedule(), which runs in a single goroutine, so no locking.
+	failedFlavorPlacements map[types.UID]failedFlavorPlacement
+}
+
+// failedFlavorPlacementTTL is how many scheduling cycles a recorded TAS placement
+// failure keeps a flavor out of consideration for a Workload. It doubles as the bound
+// on how many flavors a Workload can walk before its record expires and the walk
+// restarts from the first flavor.
+const failedFlavorPlacementTTL = 4
+
+// failedFlavorPlacement holds the flavors whose TAS placement failed for a Workload,
+// stamped with the scheduling cycle of the most recent failure.
+type failedFlavorPlacement struct {
+	flavors       map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
+	recordedCycle int64
 }
 
 type options struct {
@@ -214,6 +242,7 @@ func New(queues *qcache.Manager, cache *schdcache.Cache, cl client.Client, recor
 		roleTracker:             options.roleTracker,
 		customLabels:            options.customLabels,
 		resourceFormatter:       options.resourceFormatter,
+		failedFlavorPlacements:  make(map[types.UID]failedFlavorPlacement),
 	}
 	return s
 }
@@ -298,6 +327,80 @@ func (s *Scheduler) reportSkippedPreemptions(p map[kueue.ClusterQueueReference]i
 	}
 }
 
+// placementRetryPending reports whether an action already issued for the entry may still
+// admit it on the flavor it was nominated to. Recording a placement failure in that case
+// would skip the flavor next cycle and discard a viable preemption or migration path.
+func placementRetryPending(reason qcache.RequeueReason) bool {
+	switch reason {
+	case qcache.RequeueReasonPendingPreemption,
+		qcache.RequeueReasonPendingMigration,
+		qcache.RequeueReasonPreemptionGated:
+		return true
+	}
+	return false
+}
+
+// recordFailedFlavorPlacements persists the flavors whose TAS placement failed for an
+// entry that was not admitted this cycle, so that later cycles try other flavors.
+//
+// Recording happens here rather than where the failure is detected because only after
+// the whole cycle has run do we know that no preemption or migration is in flight which
+// could still admit the Workload on its nominated flavor.
+//
+// Newly failed flavors are merged into any unexpired record and the stamp is refreshed,
+// so a Workload that keeps discovering fresh failures keeps walking. Once every flavor
+// is recorded the assignment short-circuits to NoFit before the TAS search runs, so
+// nothing refreshes the stamp and the record expires, restarting the walk.
+func (s *Scheduler) recordFailedFlavorPlacements(log logr.Logger, e *entry) {
+	if !features.Enabled(features.TASSkipRecentlyFailedFlavors) {
+		return
+	}
+	if len(e.assignment.FailedFlavorPlacements) == 0 || placementRetryPending(e.requeueReason) {
+		return
+	}
+	record, ok := s.failedFlavorPlacements[e.Obj.UID]
+	if !ok || s.failedFlavorPlacementExpired(record) {
+		record = failedFlavorPlacement{flavors: make(map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference], len(e.assignment.FailedFlavorPlacements))}
+	}
+	for psName, flavors := range e.assignment.FailedFlavorPlacements {
+		if record.flavors[psName] == nil {
+			record.flavors[psName] = sets.New[kueue.ResourceFlavorReference]()
+		}
+		record.flavors[psName].Insert(flavors.UnsortedList()...)
+	}
+	record.recordedCycle = s.schedulingCycle
+	s.failedFlavorPlacements[e.Obj.UID] = record
+	log.V(2).Info("Recorded flavors whose TAS placement failed; they are skipped until the record expires",
+		"workload", klog.KObj(e.Obj), "flavors", record.flavors, "expiresAfterCycle", record.recordedCycle+failedFlavorPlacementTTL-1)
+}
+
+// failedFlavorPlacementsFor returns the flavors to skip for a Workload, or nil when it
+// has no unexpired record.
+func (s *Scheduler) failedFlavorPlacementsFor(uid types.UID) map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference] {
+	if !features.Enabled(features.TASSkipRecentlyFailedFlavors) {
+		return nil
+	}
+	record, ok := s.failedFlavorPlacements[uid]
+	if !ok || s.failedFlavorPlacementExpired(record) {
+		return nil
+	}
+	return record.flavors
+}
+
+func (s *Scheduler) failedFlavorPlacementExpired(record failedFlavorPlacement) bool {
+	return s.schedulingCycle-record.recordedCycle >= failedFlavorPlacementTTL
+}
+
+// sweepFailedFlavorPlacements drops expired records, which also reclaims the entries of
+// Workloads that have since been admitted or deleted.
+func (s *Scheduler) sweepFailedFlavorPlacements() {
+	for uid, record := range s.failedFlavorPlacements {
+		if s.failedFlavorPlacementExpired(record) {
+			delete(s.failedFlavorPlacements, uid)
+		}
+	}
+}
+
 func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	s.schedulingCycle++
 	log := roletracker.WithReplicaRole(ctrl.LoggerFrom(ctx), s.roleTracker).WithValues("schedulingCycle", s.schedulingCycle)
@@ -307,6 +410,7 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 	defer func() {
 		log.V(2).Info("Scheduling cycle complete", "duration", s.clock.Since(cycleStartTime))
 	}()
+	s.sweepFailedFlavorPlacements()
 
 	// 1. Get the heads from the queues, including their desired clusterQueue.
 	// This operation blocks while the queues are empty.
@@ -360,6 +464,12 @@ func (s *Scheduler) schedule(ctx context.Context) wait.SpeedSignal {
 		// When the workload is evicted by scheduler we skip requeueAndUpdate.
 		// The eviction process will be finalized by the workload controller.
 		if e.status != assumed && e.status != evicted {
+			// Runs after every processEntry, so e.assignment is the post-recompute one:
+			// updateAssignmentIfNeeded replaces it wholesale, which drops the failures
+			// seen during nomination. That is intentional — a flavor whose placement
+			// recovered is not recorded, and one that failed again is re-derived by the
+			// recompute's own TAS search, since stickiness keeps it on the same flavor.
+			s.recordFailedFlavorPlacements(log, &e)
 			s.requeueAndUpdate(ctx, e)
 		} else {
 			result = metrics.AdmissionResultSuccess
@@ -796,6 +906,7 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 		wl, cq, snap.ResourceFlavors, fairsharing.Enabled(s.fairSharing),
 		preemption.NewOracle(s.preemptor, snap), replaceableWorkloadSlice,
 		s.quotaCheckStrategy, s.resourceFormatter,
+		s.failedFlavorPlacementsFor(wl.Obj.UID),
 	)
 	fullAssignment := flvAssigner.Assign(ctx, nil)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -355,6 +355,16 @@ func (s *Scheduler) recordFailedFlavorPlacements(log logr.Logger, e *entry) {
 	if !features.Enabled(features.TASSkipRecentlyFailedFlavors) {
 		return
 	}
+	// PodSets are placed one after another within a single search and consume each
+	// other's capacity, so a failure reported for one PodSet of a multi-PodSet Workload
+	// only proves that the whole arrangement did not fit. Recording it against that
+	// PodSet would claim more than was learned, and would skip arrangements that were
+	// never tried and might fit - for example excluding worker->flavor-1 also rules out
+	// leader->flavor-2 combined with worker->flavor-1. Multi-PodSet Workloads therefore
+	// keep relying on LastTriedFlavorIdx alone.
+	if len(e.Obj.Spec.PodSets) > 1 {
+		return
+	}
 	if len(e.assignment.FailedFlavorPlacements) == 0 || placementRetryPending(e.requeueReason) {
 		return
 	}

--- a/pkg/scheduler/scheduler_tas_skip_failed_flavors_test.go
+++ b/pkg/scheduler/scheduler_tas_skip_failed_flavors_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -285,11 +286,19 @@ func failedPlacements(pairs map[kueue.PodSetReference][]kueue.ResourceFlavorRefe
 }
 
 // entryWithFailedPlacements builds an entry as it looks after a scheduling cycle in
-// which the TAS placement search rejected the given flavors.
-func entryWithFailedPlacements(reason qcache.RequeueReason, placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference) *entry {
+// which the TAS placement search rejected the given flavors. podSetCount controls the
+// shape of the Workload, since recording is limited to single-PodSet Workloads.
+func entryWithFailedPlacements(reason qcache.RequeueReason, placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference, podSetCount int) *entry {
+	podSets := make([]kueue.PodSet, podSetCount)
+	for i := range podSets {
+		podSets[i] = kueue.PodSet{Name: kueue.PodSetReference("ps" + strconv.Itoa(i))}
+	}
 	return &entry{
 		Info: workload.Info{
-			Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns", UID: testWorkloadUID}},
+			Obj: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns", UID: testWorkloadUID},
+				Spec:       kueue.WorkloadSpec{PodSets: podSets},
+			},
 		},
 		requeueReason: reason,
 		assignment: flavorassigner.Assignment{
@@ -301,6 +310,9 @@ func entryWithFailedPlacements(reason qcache.RequeueReason, placements map[kueue
 func TestRecordFailedFlavorPlacements(t *testing.T) {
 	cases := map[string]struct {
 		enabled bool
+		// multiPodSet builds the Workload with two PodSets instead of one. Recording is
+		// limited to single-PodSet Workloads, so this must suppress it.
+		multiPodSet bool
 		// cycles are replayed in order; each records one entry at the given cycle.
 		cycles []struct {
 			cycle      int64
@@ -433,8 +445,9 @@ func TestRecordFailedFlavorPlacements(t *testing.T) {
 			readAtCycle: 2,
 			want:        nil,
 		},
-		"tracks each PodSet separately": {
-			enabled: true,
+		"multi-PodSet Workload records nothing": {
+			enabled:     true,
+			multiPodSet: true,
 			cycles: []struct {
 				cycle      int64
 				reason     qcache.RequeueReason
@@ -444,10 +457,7 @@ func TestRecordFailedFlavorPlacements(t *testing.T) {
 				{cycle: 2, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"worker": {"flavor-b"}}},
 			},
 			readAtCycle: 3,
-			want: failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{
-				"leader": {"flavor-a"},
-				"worker": {"flavor-b"},
-			}),
+			want:        nil,
 		},
 	}
 
@@ -456,10 +466,14 @@ func TestRecordFailedFlavorPlacements(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASSkipRecentlyFailedFlavors, tc.enabled)
 			_, log := utiltesting.ContextWithLog(t)
 
+			podSetCount := 1
+			if tc.multiPodSet {
+				podSetCount = 2
+			}
 			s := &Scheduler{failedFlavorPlacements: make(map[types.UID]failedFlavorPlacement)}
 			for _, c := range tc.cycles {
 				s.schedulingCycle = c.cycle
-				s.recordFailedFlavorPlacements(log, entryWithFailedPlacements(c.reason, c.placements))
+				s.recordFailedFlavorPlacements(log, entryWithFailedPlacements(c.reason, c.placements, podSetCount))
 			}
 
 			s.schedulingCycle = tc.readAtCycle

--- a/pkg/scheduler/scheduler_tas_skip_failed_flavors_test.go
+++ b/pkg/scheduler/scheduler_tas_skip_failed_flavors_test.go
@@ -1,0 +1,503 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/util/routine"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// TestScheduleForTASSkipRecentlyFailedFlavors exercises the cross-cycle behavior of the
+// TASSkipRecentlyFailedFlavors gate: a Workload whose TAS placement fails on the first
+// flavor must reach the second flavor on a later cycle, rather than being re-nominated
+// to the first flavor forever because quota alone still reports it as fitting.
+//
+// This needs its own runner because the shared runTASScheduleTestCases harness drives a
+// single scheduling cycle, and the behavior under test only appears across cycles.
+func TestScheduleForTASSkipRecentlyFailedFlavors(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	singleLevelTopology := *utiltestingapi.MakeDefaultOneLevelTopology("tas-single-level")
+
+	// flavor-1 has a single node that the blocking Workload fully occupies, so the
+	// tested Workload's topology never fits there. flavor-2 has room for it.
+	nodes := []corev1.Node{
+		*testingnode.MakeNode("node-f1").
+			Label("tas-node", "true").
+			Label("tas-flavor", "f1").
+			Label(corev1.LabelHostname, "node-f1").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj(),
+		*testingnode.MakeNode("node-f2").
+			Label("tas-node", "true").
+			Label("tas-flavor", "f2").
+			Label(corev1.LabelHostname, "node-f2").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj(),
+	}
+	resourceFlavors := []kueue.ResourceFlavor{
+		*utiltestingapi.MakeResourceFlavor("tas-flavor-1").
+			NodeLabel("tas-flavor", "f1").
+			TopologyName("tas-single-level").
+			Obj(),
+		*utiltestingapi.MakeResourceFlavor("tas-flavor-2").
+			NodeLabel("tas-flavor", "f2").
+			TopologyName("tas-single-level").
+			Obj(),
+	}
+	// Quota on flavor-1 exceeds what its single node can actually host, so the flavor
+	// keeps looking admissible to the quota-only picker after the node is occupied.
+	// The default flavorFungibility (WhenCanPreempt: Preempt) makes the picker stop at
+	// flavor-1 once its mode is downgraded to Preempt, which is what pins the Workload
+	// there across cycles.
+	clusterQueue := *utiltestingapi.MakeClusterQueue("tas-cq").
+		Preemption(kueue.ClusterQueuePreemption{
+			WithinClusterQueue:  kueue.PreemptionPolicyNever,
+			ReclaimWithinCohort: kueue.PreemptionPolicyNever,
+		}).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("tas-flavor-1").Resource(corev1.ResourceCPU, "4").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("tas-flavor-2").Resource(corev1.ResourceCPU, "4").Obj(),
+		).
+		Obj()
+	queues := []kueue.LocalQueue{
+		*utiltestingapi.MakeLocalQueue("tas-lq", "default").ClusterQueue("tas-cq").Obj(),
+	}
+	// blocker occupies node-f1 entirely; pending needs a whole node and can only be
+	// placed on node-f2.
+	blocker := *utiltestingapi.MakeWorkload("blocker", "default").
+		Queue("tas-lq").
+		Creation(now.Add(-time.Minute)).
+		Priority(10).
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			NodeSelector(map[string]string{"tas-flavor": "f1"}).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "2").
+			Obj()).
+		Obj()
+	pending := *utiltestingapi.MakeWorkload("pending", "default").
+		Queue("tas-lq").
+		Creation(now).
+		Priority(5).
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "2").
+			Obj()).
+		Obj()
+
+	cases := map[string]struct {
+		gateEnabled bool
+		// cycles is how many scheduling cycles to drive.
+		cycles int
+		// wantPendingFlavor is the flavor "pending" must end up admitted on, or empty
+		// if it must remain unadmitted.
+		wantPendingFlavor kueue.ResourceFlavorReference
+	}{
+		"gate disabled: pending stays pinned to the first flavor and is never admitted": {
+			gateEnabled:       false,
+			cycles:            failedFlavorPlacementTTL + 1,
+			wantPendingFlavor: "",
+		},
+		"gate enabled: pending reaches the second flavor on a later cycle": {
+			gateEnabled:       true,
+			cycles:            failedFlavorPlacementTTL + 1,
+			wantPendingFlavor: "tas-flavor-2",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.TASSkipRecentlyFailedFlavors: tc.gateEnabled,
+			})
+
+			ctx, log := utiltesting.ContextWithLog(t)
+			testWls := []kueue.Workload{*blocker.DeepCopy(), *pending.DeepCopy()}
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithLists(
+					&kueue.WorkloadList{Items: testWls},
+					&kueue.TopologyList{Items: []kueue.Topology{singleLevelTopology}},
+					&corev1.NodeList{Items: nodes},
+					&kueue.LocalQueueList{Items: queues}).
+				WithObjects(utiltesting.MakeNamespace("default")).
+				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+				WithStatusSubresource(&kueue.Workload{})
+			_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+			cl := clientBuilder.Build()
+			recorder := &utiltesting.EventRecorder{}
+			cqCache := schdcache.New(cl)
+			qManager, requeuer := qcache.NewManagerForUnitTestsWithRequeuer(cl, cqCache)
+
+			for i := range nodes {
+				cqCache.TASCache().SyncNode(&nodes[i])
+			}
+			for _, flavor := range resourceFlavors {
+				cqCache.AddOrUpdateResourceFlavor(log, &flavor)
+				cqCache.AddOrUpdateTopology(log, &singleLevelTopology)
+			}
+			if err := cqCache.AddClusterQueue(ctx, &clusterQueue); err != nil {
+				t.Fatalf("Inserting clusterQueue in cache: %v", err)
+			}
+			if err := qManager.AddClusterQueue(ctx, &clusterQueue); err != nil {
+				t.Fatalf("Inserting clusterQueue in manager: %v", err)
+			}
+			cqCopy := clusterQueue.DeepCopy()
+			cqCopy.ResourceVersion = ""
+			if err := cl.Create(ctx, cqCopy); err != nil {
+				t.Fatalf("Creating clusterQueue: %v", err)
+			}
+			for _, q := range queues {
+				if err := qManager.AddLocalQueue(ctx, &q); err != nil {
+					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				}
+			}
+
+			scheduler := New(qManager, cqCache, cl, recorder,
+				WithClock(t, testingclock.NewFakeClock(now)),
+				WithPreemptionExpectations(preemptexpectations.New()))
+			wg := sync.WaitGroup{}
+			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+				func() { wg.Add(1) },
+				func() { wg.Done() },
+			))
+
+			ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+			go qManager.CleanUpOnContext(ctx)
+			defer cancel()
+
+			for i := range tc.cycles {
+				scheduler.schedule(ctx)
+				wg.Wait()
+				// Reproduce a busy cohort. AllocatableResourceGeneration only advances
+				// when the quotas actually change (see updateQuotasAndResourceGroups), so
+				// flip flavor-2's quota between two values to force a real bump each
+				// cycle. The bump discards LastAssignment (see lastAssignmentOutdated)
+				// and with it the built-in flavor bookmark, which on a cluster with
+				// steady admissions and evictions happens every cycle. That is the
+				// condition the cross-cycle record exists to survive.
+				//
+				// flavor-2 is the one flipped so that flavor-1, the flavor under test,
+				// keeps a constant quota throughout.
+				churned := clusterQueue.DeepCopy()
+				churnQuota := "4"
+				if i%2 == 0 {
+					churnQuota = "5"
+				}
+				churned.Spec.ResourceGroups[0].Flavors[1].Resources[0].NominalQuota = resource.MustParse(churnQuota)
+				if err := cqCache.UpdateClusterQueue(log, churned); err != nil {
+					t.Fatalf("Updating clusterQueue in cache: %v", err)
+				}
+				// Move workloads that were parked as inadmissible back into the queue so
+				// the next cycle reconsiders them, as the controllers would in a cluster.
+				requeuer.ProcessRequeues(ctx)
+			}
+
+			gotFlavor := admittedFlavor(ctx, t, cl, "pending")
+			if gotFlavor != tc.wantPendingFlavor {
+				t.Errorf("workload \"pending\" admitted on flavor %q, want %q", gotFlavor, tc.wantPendingFlavor)
+			}
+			// The blocker must keep its place on flavor-1 either way.
+			if got := admittedFlavor(ctx, t, cl, "blocker"); got != "tas-flavor-1" {
+				t.Errorf("workload \"blocker\" admitted on flavor %q, want %q", got, "tas-flavor-1")
+			}
+		})
+	}
+}
+
+// admittedFlavor returns the flavor assigned to the Workload's only PodSet resource, or
+// an empty reference when the Workload has no quota reservation.
+func admittedFlavor(ctx context.Context, t *testing.T, cl client.Client, name string) kueue.ResourceFlavorReference {
+	t.Helper()
+	var wl kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &wl); err != nil {
+		t.Fatalf("Getting workload %q: %v", name, err)
+	}
+	if !workload.HasQuotaReservation(&wl) {
+		return ""
+	}
+	for _, psa := range wl.Status.Admission.PodSetAssignments {
+		for _, flavor := range psa.Flavors {
+			return flavor
+		}
+	}
+	return ""
+}
+
+const testWorkloadUID = types.UID("test-wl-uid")
+
+func failedPlacements(pairs map[kueue.PodSetReference][]kueue.ResourceFlavorReference) map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference] {
+	if pairs == nil {
+		return nil
+	}
+	out := make(map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference], len(pairs))
+	for ps, flavors := range pairs {
+		out[ps] = sets.New(flavors...)
+	}
+	return out
+}
+
+// entryWithFailedPlacements builds an entry as it looks after a scheduling cycle in
+// which the TAS placement search rejected the given flavors.
+func entryWithFailedPlacements(reason qcache.RequeueReason, placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference) *entry {
+	return &entry{
+		Info: workload.Info{
+			Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns", UID: testWorkloadUID}},
+		},
+		requeueReason: reason,
+		assignment: flavorassigner.Assignment{
+			FailedFlavorPlacements: failedPlacements(placements),
+		},
+	}
+}
+
+func TestRecordFailedFlavorPlacements(t *testing.T) {
+	cases := map[string]struct {
+		enabled bool
+		// cycles are replayed in order; each records one entry at the given cycle.
+		cycles []struct {
+			cycle      int64
+			reason     qcache.RequeueReason
+			placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+		}
+		readAtCycle int64
+		want        map[kueue.PodSetReference]sets.Set[kueue.ResourceFlavorReference]
+	}{
+		"gate disabled: nothing is recorded": {
+			enabled: false,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonPreemptionNoCandidates, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 2,
+			want:        nil,
+		},
+		"records the failed flavor": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonPreemptionNoCandidates, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 2,
+			want:        failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+		},
+		"accumulates flavors across cycles": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+				{cycle: 2, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-b"}}},
+			},
+			readAtCycle: 3,
+			want:        failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a", "flavor-b"}}),
+		},
+		"a fresh failure refreshes the stamp of earlier ones": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+				{cycle: failedFlavorPlacementTTL, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-b"}}},
+			},
+			// flavor-a alone would have expired by now, but the later write kept it.
+			readAtCycle: failedFlavorPlacementTTL + 1,
+			want:        failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a", "flavor-b"}}),
+		},
+		"record expires after the TTL": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 1 + failedFlavorPlacementTTL,
+			want:        nil,
+		},
+		"record survives up to the last cycle within the TTL": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: failedFlavorPlacementTTL,
+			want:        failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+		},
+		"pending preemption keeps the flavor available for the preemption retry": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonPendingPreemption, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 2,
+			want:        nil,
+		},
+		"pending migration keeps the flavor available": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonPendingMigration, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 2,
+			want:        nil,
+		},
+		"preemption gated keeps the flavor available": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonPreemptionGated, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}},
+			},
+			readAtCycle: 2,
+			want:        nil,
+		},
+		"an assignment without placement failures records nothing": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: nil},
+			},
+			readAtCycle: 2,
+			want:        nil,
+		},
+		"tracks each PodSet separately": {
+			enabled: true,
+			cycles: []struct {
+				cycle      int64
+				reason     qcache.RequeueReason
+				placements map[kueue.PodSetReference][]kueue.ResourceFlavorReference
+			}{
+				{cycle: 1, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"leader": {"flavor-a"}}},
+				{cycle: 2, reason: qcache.RequeueReasonNoFit, placements: map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"worker": {"flavor-b"}}},
+			},
+			readAtCycle: 3,
+			want: failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{
+				"leader": {"flavor-a"},
+				"worker": {"flavor-b"},
+			}),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TASSkipRecentlyFailedFlavors, tc.enabled)
+			_, log := utiltesting.ContextWithLog(t)
+
+			s := &Scheduler{failedFlavorPlacements: make(map[types.UID]failedFlavorPlacement)}
+			for _, c := range tc.cycles {
+				s.schedulingCycle = c.cycle
+				s.recordFailedFlavorPlacements(log, entryWithFailedPlacements(c.reason, c.placements))
+			}
+
+			s.schedulingCycle = tc.readAtCycle
+			got := s.failedFlavorPlacementsFor(testWorkloadUID)
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("failedFlavorPlacementsFor() returned unexpected flavors (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSweepFailedFlavorPlacements(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASSkipRecentlyFailedFlavors, true)
+
+	const (
+		freshUID   = types.UID("fresh")
+		expiredUID = types.UID("expired")
+	)
+	s := &Scheduler{
+		schedulingCycle: 10,
+		failedFlavorPlacements: map[types.UID]failedFlavorPlacement{
+			freshUID: {
+				flavors:       failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+				recordedCycle: 10 - failedFlavorPlacementTTL + 1,
+			},
+			expiredUID: {
+				flavors:       failedPlacements(map[kueue.PodSetReference][]kueue.ResourceFlavorReference{"main": {"flavor-a"}}),
+				recordedCycle: 10 - failedFlavorPlacementTTL,
+			},
+		},
+	}
+
+	s.sweepFailedFlavorPlacements()
+
+	if _, ok := s.failedFlavorPlacements[expiredUID]; ok {
+		t.Errorf("sweepFailedFlavorPlacements() kept the expired record for %q", expiredUID)
+	}
+	if _, ok := s.failedFlavorPlacements[freshUID]; !ok {
+		t.Errorf("sweepFailedFlavorPlacements() dropped the unexpired record for %q", freshUID)
+	}
+}

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -473,6 +473,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+- name: TASSkipRecentlyFailedFlavors
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TASValidateWorkloadSliceSize
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -473,6 +473,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.18"
+- name: TASSkipRecentlyFailedFlavors
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: TASValidateWorkloadSliceSize
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -41,6 +41,7 @@ import (
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption/fairsharing"
 	"sigs.k8s.io/kueue/pkg/util/webhook"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -91,6 +92,9 @@ func managerSetupWithConfig(
 
 		cacheOptions := []schdcache.Option{
 			schdcache.WithResourceTransformations(resourceTransformations),
+			// Nil unless the caller opts in, which keeps fair sharing off for the
+			// suites that do not configure it.
+			schdcache.WithFairSharing(fairsharing.Enabled(controllersCfg.FairSharing)),
 		}
 		cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
 		preemptionExpectations := preemptexpectations.New()
@@ -134,6 +138,7 @@ func managerSetupWithConfig(
 			mgr.GetClient(),
 			mgr.GetEventRecorder(constants.AdmissionName),
 			scheduler.WithPreemptionExpectations(preemptionExpectations),
+			scheduler.WithFairSharing(controllersCfg.FairSharing),
 		)
 		err = sched.Start(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/singlecluster/tas/tas_skip_failed_flavors_test.go
+++ b/test/integration/singlecluster/tas/tas_skip_failed_flavors_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// equalPriority is shared by both Workloads in these specs so that the
+// WithinClusterQueue: LowerPriority policy finds no preemption victim, as happens in a
+// ClusterQueue where every Workload runs at the same priority.
+const equalPriority = 100
+
+// These specs cover the TASSkipRecentlyFailedFlavors gate end to end: a Workload whose
+// TAS placement fails on the flavor selected by quota must reach another flavor of the
+// ResourceGroup on a later scheduling cycle.
+//
+// The gate-off counterpart is covered by the unit test
+// TestScheduleForTASSkipRecentlyFailedFlavors, which drives scheduling cycles directly
+// and can force the ClusterQueue generation churn that discards LastAssignment. Here we
+// assert the positive outcome only, since the number of cycles and the surrounding churn
+// are not controllable from an integration spec.
+var _ = ginkgo.Describe("Topology Aware Scheduling skipping recently failed flavors", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		nodes        []corev1.Node
+		topology     *kueue.Topology
+		tasFlavor1   *kueue.ResourceFlavor
+		tasFlavor2   *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		// Fair sharing on, so the fair-share entry iterator and preemption path drive
+		// this spec rather than the classical ones.
+		fwk.StartManager(ctx, cfg, managerSetupWithConfig(&config.Configuration{
+			FairSharing: &config.FairSharing{},
+		}))
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASSkipRecentlyFailedFlavors, true)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-skip-failed-flavors-")
+
+		// One node per flavor. The blocker Workload fills the flavor-1 node, so the
+		// second Workload can only be placed on the flavor-2 node.
+		nodes = []corev1.Node{
+			*testingnode.MakeNode("skip-f1").
+				Label("node-group", "tas").
+				Label("tas-flavor", "f1").
+				Label(corev1.LabelHostname, "skip-f1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("skip-f2").
+				Label("node-group", "tas").
+				Label("tas-flavor", "f2").
+				Label(corev1.LabelHostname, "skip-f2").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+		}
+		util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+		topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		util.MustCreate(ctx, k8sClient, topology)
+
+		tasFlavor1 = utiltestingapi.MakeResourceFlavor("tas-flavor-1").
+			NodeLabel("node-group", "tas").
+			NodeLabel("tas-flavor", "f1").
+			TopologyName("default").Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor1)
+
+		tasFlavor2 = utiltestingapi.MakeResourceFlavor("tas-flavor-2").
+			NodeLabel("node-group", "tas").
+			NodeLabel("tas-flavor", "f2").
+			TopologyName("default").Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor2)
+
+		// Quota on each flavor exceeds what its single node can host, so flavor-1 keeps
+		// looking admissible to the quota-only flavor selection after its node is full.
+		//
+		// The test runs with a specific preemption policy. Neither offers
+		// flavor-1 a way forward here: the two Workloads share a priority, so
+		// LowerPriority finds no victim within the ClusterQueue, and no other
+		// ClusterQueue in the Cohort is borrowing for ReclaimWithinCohort to reclaim
+		// from. That combination is what leaves a Workload pinned to one flavor.
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			Cohort("tas-cohort").
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+			}).
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(tasFlavor1.Name).Resource(corev1.ResourceCPU, "4").Obj(),
+				*utiltestingapi.MakeFlavorQuotas(tasFlavor2.Name).Resource(corev1.ResourceCPU, "4").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor1, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor2, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		for _, node := range nodes {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+		}
+		gomega.Expect(forceDeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	ginkgo.It("should admit the workload on the second flavor when the first flavor's topology cannot fit it", func() {
+		var blocker, pending *kueue.Workload
+
+		ginkgo.By("creating a workload that occupies the whole node of the first flavor", func() {
+			blocker = utiltestingapi.MakeWorkload("blocker", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Priority(equalPriority).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					NodeSelector(map[string]string{"tas-flavor": "f1"}).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, "2").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, blocker)
+		})
+
+		ginkgo.By("verifying the blocker is admitted on the first flavor", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, blocker)
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(blocker), blocker)).To(gomega.Succeed())
+			gomega.Expect(blocker.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+				gomega.Equal(kueue.ResourceFlavorReference(tasFlavor1.Name)))
+		})
+
+		ginkgo.By("creating a workload that needs a whole node and so cannot be placed on the first flavor", func() {
+			pending = utiltestingapi.MakeWorkload("pending", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Priority(equalPriority).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, "2").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, pending)
+		})
+
+		ginkgo.By("verifying it is eventually admitted on the second flavor", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, pending)
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pending), pending)).To(gomega.Succeed())
+			gomega.Expect(pending.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+				gomega.Equal(kueue.ResourceFlavorReference(tasFlavor2.Name)))
+			ta := utiltas.InternalFrom(pending.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+			gomega.Expect(ta.Domains).To(gomega.HaveLen(1))
+			gomega.Expect(ta.Domains[0].Values).To(gomega.Equal([]string{"skip-f2"}))
+		})
+	})
+})

--- a/test/integration/singlecluster/tas/tas_skip_failed_flavors_test.go
+++ b/test/integration/singlecluster/tas/tas_skip_failed_flavors_test.go
@@ -117,11 +117,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling skipping recently failed flav
 		// Quota on each flavor exceeds what its single node can host, so flavor-1 keeps
 		// looking admissible to the quota-only flavor selection after its node is full.
 		//
-		// The test runs with a specific preemption policy. Neither offers
+		// The ClusterQueue sets two preemption policies. Neither policy offers
 		// flavor-1 a way forward here: the two Workloads share a priority, so
-		// LowerPriority finds no victim within the ClusterQueue, and no other
-		// ClusterQueue in the Cohort is borrowing for ReclaimWithinCohort to reclaim
-		// from. That combination is what leaves a Workload pinned to one flavor.
+		// WithinClusterQueue: LowerPriority finds no victim in the ClusterQueue, and
+		// no other ClusterQueue in the Cohort is borrowing, so ReclaimWithinCohort
+		// has nothing to reclaim. That combination leaves a Workload pinned to one
+		// flavor.
 		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
 			Cohort("tas-cohort").
 			Preemption(kueue.ClusterQueuePreemption{


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area tas

#### What this PR does / why we need it:

ResourceFlavors are selected on quota alone, and the TAS placement check runs only *after* a flavor has been selected, so its verdict cannot influence the selection. A flavor whose `nominalQuota` exceeds what its nodes can actually host therefore keeps being selected and keeps failing placement, and the Workload never advances to another flavor of the ResourceGroup even when that flavor has ample topological capacity.

Kueue already tracks which flavors a Workload has tried, in `LastTriedFlavorIdx`, but that state does not survive a busy cluster — see the reviewer notes below for the two independent mechanisms that discard it. Under sustained load both fire every cycle, so the flavor walk restarts from the first flavor indefinitely.

This PR records, for single-PodSet Workloads, the flavors for which the TAS placement search found no viable topology domains, and skips them during flavor selection in later cycles. The record is held by the scheduler, expires after a fixed number of scheduling cycles, and is only written once the Workload has failed to be admitted for the cycle with no
preemption or migration pending, so a preemption that could still admit it on that flavor is not discarded.

Guarded by the new alpha `TASSkipRecentlyFailedFlavors` feature gate, disabled by default.

#### Which issue(s) this PR fixes:

Fixes #13658 

The longer-term fix is TAS-aware flavor selection mentioned in [#10824](https://github.com/kubernetes-sigs/kueue/issues/10824) and https://github.com/kubernetes-sigs/kueue/issues/13695 that addresses the same failure at its source and would eventually retire this gate.

#### Special notes for your reviewer:

AI assistance was used to draft parts of this change and this PR description (per the Kubernetes AI Tool Usage Policy). All logic, tests, and KEP updates were reviewed by a human before submission.

**Why the record is not stored in `LastAssignment`** — the obvious-looking implementation does not work, because two independent mechanisms discard that state:

1. `lastAssignmentOutdated` nils it whenever `cq.AllocatableResourceGeneration` advances, which happens on every admission or eviction in the Cohort. `markSkipped`, `markPreemptionGated`, `markPreemptionOutcome` and `issueMigration` also nil it directly, and a stuck Workload hits one of those nearly every cycle.
2. `AddOrUpdateWorkloadWithoutLock` builds a fresh `workload.Info` and `PushOrUpdate` swaps it into the heap, so any Workload update event discards it — including the status patch Kueue itself writes while requeueing.

A field on `workload.Info` survives (1) but not (2). Keying the record on the scheduler by Workload UID survives both. Mechanism (2) looks like a pre-existing durability gap in `LastTriedFlavorIdx` that is worth its own issue, independent of this PR.

**Why expiry is cycle-based rather than derived from cluster state** — per the discussion in #13691: on a large flavor with steady admissions and evictions, any per-flavor invalidation signal fires many times per cycle, so a state-based record would be dropped before it could take effect, precisely in the conditions it targets. Determining whether
a specific change could make a specific Workload fit would mean tracking the domains its search rejected, which is considerably more state and does not generalize once flavors overlap on topology. TTL is currently 4 cycles (`failedFlavorPlacementTTL`).

**Testing.**
- Unit (`pkg/scheduler`): asserts both directions — with the gate off the Workload stays pinned and is never admitted; with it on it reaches the second flavor. Forces real `AllocatableResourceGeneration` churn between cycles so the built-in bookmark is discarded, reproducing the scenario in #13658 . Also covers TTL expiry, accumulation across cycles, stamp refresh, the preemption-pending suppression, and the gate-off path.
- Unit (`pkg/scheduler/flavorassigner`): the recording helper and the skip predicate.
- Integration (`test/integration/singlecluster/tas`): end-to-end with Fair Sharing enabled and `WithinClusterQueue: LowerPriority` / `ReclaimWithinCohort: Any`, so the fair-share entry iterator and preemption path drive the spec. Asserts the positive outcome only; the gate-off direction is covered by the unit test, since cycle counts and churn are not controllable from an integration spec.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Added an alpha `TASSkipRecentlyFailedFlavors` feature gate (disabled by default) that records the ResourceFlavors whose topology placement failed for a a single-PodSet Workload and skips them for a bounded number of scheduling cycles. This prevents a Workload from staying pinned across cycles to a flavor whose `nominalQuota` exceeds what its nodes can host, which previously left it Pending indefinitely under sustained load.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Alpha `TASSkipRecentlyFailedFlavors` feature gate, disabled by default.
  * Recently failed topology flavor placements are temporarily skipped during subsequent scheduling cycles, helping workloads try viable alternatives.
  * Failure records expire after four scheduling cycles and persist across scheduler state updates.
  * Applies to single-PodSet workloads; multi-PodSet workloads retain existing flavor-selection behavior.

* **Documentation**
  * Documented configuration, behavior, limitations, and lifecycle details for the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->