### PR TITLE
chore: allow parallel golangci-lint runners

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,6 +2,8 @@
 # see: https://golangci-lint.run/usage/configuration/
 
 version: "2"
+run:
+  allow-parallel-runners: true
 linters:
   enable:
     - copyloopvar


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Set `run.allow-parallel-runners: true` in `.golangci.yaml`, matching `.golangci-kal.yaml`.

Without this, concurrent `golangci-lint` runs (for example multi-worktree / multi-agent `make verify-checks`) fail on the global lock at `/tmp/golangci-lint.lock` with `parallel golangci-lint is running`. Enabling parallel runners removes that lock contention for local verify workflows.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:

`.golangci-kal.yaml` already sets this; this brings the main config in line.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

#### Test plan

- [x] `make verify-checks` passes with this change
- [x] Confirm two concurrent `golangci-lint` / `make verify-checks` runs in different worktrees no longer fail with `/tmp/golangci-lint.lock` / `parallel golangci-lint is running`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled parallel execution for linting tasks to improve development workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->