### PR TITLE
Helm: make controller-manager strategy, hostNetwork, and dnsPolicy configurable

### DIFF
--- a/charts/kueue/README.md
+++ b/charts/kueue/README.md
@@ -112,7 +112,9 @@ The following table lists the configurable parameters of the kueue chart and the
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | certManager.issuerRef | object | `{}` | Override the default self-signed cert-manager issuer reference. When set, the chart skips creating its own Issuer and uses this reference for webhook, metrics, and visibility certificates. The referenced issuer must provide the CA data required by Kueue's cert-manager integration. |
+| controllerManager.dnsPolicy | string | `""` | ControllerManager pod's dnsPolicy. Set to ClusterFirstWithHostNet when hostNetwork is enabled. |
 | controllerManager.featureGates | list | `[]` | ControllerManager's feature gates |
+| controllerManager.hostNetwork | bool | `false` | Run the ControllerManager pod on the host network. Needed where the API server reaches the webhook/visibility endpoints via node IPs rather than pod IPs. |
 | controllerManager.imagePullSecrets | list | `[]` | ControllerManager's imagePullSecrets |
 | controllerManager.livenessProbe.failureThreshold | int | `3` | ControllerManager's livenessProbe failureThreshold |
 | controllerManager.livenessProbe.initialDelaySeconds | int | `15` | ControllerManager's livenessProbe initialDelaySeconds |
@@ -137,6 +139,7 @@ The following table lists the configurable parameters of the kueue chart and the
 | controllerManager.readinessProbe.successThreshold | int | `1` | ControllerManager's readinessProbe successThreshold |
 | controllerManager.readinessProbe.timeoutSeconds | int | `1` | ControllerManager's readinessProbe timeoutSeconds |
 | controllerManager.replicas | int | `1` | ControllerManager's replicas count |
+| controllerManager.strategy | object | `{}` | ControllerManager Deployment's update strategy. When hostNetwork is enabled the manager's ports bind to the node, so the default RollingUpdate surge cannot schedule a second pod onto an already-occupied node; set maxSurge: 0 to roll in place. |
 | controllerManager.tolerations | list | `[]` | ControllerManager's tolerations |
 | controllerManager.topologySpreadConstraints | list | `[]` | ControllerManager's topologySpreadConstraints |
 | enableCertManager | bool | `false` | Enable x509 automated certificate management using cert-manager (cert-manager.io) |

--- a/charts/kueue/templates/manager/manager.yaml
+++ b/charts/kueue/templates/manager/manager.yaml
@@ -23,6 +23,10 @@ metadata:
   {{- include "kueue.controllerManager.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
+  {{- with .Values.controllerManager.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
     {{- include "kueue.selectorLabels" . | nindent 6 }}
@@ -39,6 +43,12 @@ spec:
     spec:
       {{- with  .Values.controllerManager.manager.priorityClassName }}
       priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.controllerManager.hostNetwork }}
+      hostNetwork: {{ . }}
+      {{- end }}
+      {{- with .Values.controllerManager.dnsPolicy }}
+      dnsPolicy: {{ . }}
       {{- end }}
       containers:
       - args:

--- a/charts/kueue/tests/manager_test.yaml
+++ b/charts/kueue/tests/manager_test.yaml
@@ -53,6 +53,55 @@ tests:
     asserts:
       - notExists:
           path: spec.template.spec.nodeSelector
+  - it: should set the Deployment strategy when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 0
+            maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.strategy
+          value:
+            type: RollingUpdate
+            rollingUpdate:
+              maxSurge: 0
+              maxUnavailable: 1
+  - it: should not render strategy if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        strategy: {}
+    asserts:
+      - notExists:
+          path: spec.strategy
+  - it: should set hostNetwork and dnsPolicy when provided
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        hostNetwork: true
+        dnsPolicy: ClusterFirstWithHostNet
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: ClusterFirstWithHostNet
+  - it: should not render hostNetwork or dnsPolicy if not set
+    template: manager/manager.yaml
+    set:
+      controllerManager:
+        hostNetwork: false
+        dnsPolicy: ""
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - notExists:
+          path: spec.template.spec.dnsPolicy
   - it: should set tolerations when provided
     template: manager/manager.yaml
     set:

--- a/charts/kueue/values.yaml
+++ b/charts/kueue/values.yaml
@@ -30,6 +30,15 @@ controllerManager:
   featureGates: []
   #  - name: PartialAdmission
   #    enabled: true
+  # -- ControllerManager Deployment's update strategy. When hostNetwork is enabled the
+  # manager's ports bind to the node, so the default RollingUpdate surge cannot schedule
+  # a second pod onto an already-occupied node; set maxSurge: 0 to roll in place.
+  strategy: {}
+  # -- Run the ControllerManager pod on the host network. Needed where the API server
+  # reaches the webhook/visibility endpoints via node IPs rather than pod IPs.
+  hostNetwork: false
+  # -- ControllerManager pod's dnsPolicy. Set to ClusterFirstWithHostNet when hostNetwork is enabled.
+  dnsPolicy: ""
   manager:
     # -- ControllerManager's pod priorityClassName
     priorityClassName:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds three optional, default-off values to the controller-manager Deployment in the Helm chart:

- `controllerManager.strategy` — Deployment rollout strategy
- `controllerManager.hostNetwork`
- `controllerManager.dnsPolicy`

All three are guarded by `with` blocks, so rendered output is unchanged when they are unset.

On clusters where the manager runs `hostNetwork: true`, the webhook port binds to the node, so only one manager pod can run per node. The chart sets no `strategy`, so the Deployment uses the default RollingUpdate surge, which brings up a new pod before terminating an old one. That surge pod cannot schedule onto a node whose port is already held by an existing manager, and the rollout can deadlock. Exposing `strategy` allows `maxSurge: 0` to roll in place; exposing `hostNetwork`/`dnsPolicy` lets that setup be expressed declaratively in the chart.

Added helm-unittest coverage (set and unset cases for each value); the full chart suite passes. `charts/kueue/README.md` was regenerated with helm-docs.

This PR was prepared with AI assistance (Cursor), per the project's AI contribution guidance.

#### Which issue(s) this PR fixes

Fixes #13816

#### Special notes for your reviewer

Default render is byte-identical to before — verified via `helm template` with the values unset.

#### Does this PR introduce a user-facing change?

```release-note
Helm: the controller-manager Deployment now supports optional `controllerManager.strategy`, `controllerManager.hostNetwork`, and `controllerManager.dnsPolicy` values.
```