### PR TITLE
refactor: Reuse TAS topology trees across scheduler snapshots

### DIFF
--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -213,12 +213,7 @@ func (c *Cache) Snapshot(ctx context.Context, options ...SnapshotOption) (*Snaps
 				aggregatedDomainUsagesForFlavor = aggregatedDomainUsages
 			}
 			var err error
-			tasSnapshots[flavor], err = cache.snapshot(
-				ctx,
-				log,
-				c.tasCache.nodesCache.find(cache.flavor.NodeLabels, cache.topology.Levels),
-				aggregatedDomainUsagesForFlavor,
-			)
+			tasSnapshots[flavor], err = cache.snapshot(ctx, log, aggregatedDomainUsagesForFlavor)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -34,11 +34,11 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 	idx := 0
 	if leaderCount > 0 {
 		sortedWithLeader = s.sortedDomainsWithLeader(domains, false)
-		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && sortedWithLeader[idx].leaderState > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && s.stateOf(sortedWithLeader[idx]).leaderState > 0; idx++ {
 			selectedDomainsCount++
 			lastDomainWithLeader = sortedWithLeader[idx]
-			remainingLeaderCount -= sortedWithLeader[idx].leaderState
-			remainingSliceCount -= sortedWithLeader[idx].sliceStateWithLeader
+			remainingLeaderCount -= s.stateOf(sortedWithLeader[idx]).leaderState
+			remainingSliceCount -= s.stateOf(sortedWithLeader[idx]).sliceStateWithLeader
 		}
 		sortedWithoutLeader = s.sortedDomains(sortedWithLeader[idx:], false)
 	} else {
@@ -49,10 +49,10 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 		return false, 0, nil, nil
 	}
 
-	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && sortedWithoutLeader[idx].sliceState > 0; idx++ {
+	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && s.stateOf(sortedWithoutLeader[idx]).sliceState > 0; idx++ {
 		selectedDomainsCount++
 		lastDomain = sortedWithoutLeader[idx]
-		remainingSliceCount -= sortedWithoutLeader[idx].sliceState
+		remainingSliceCount -= s.stateOf(sortedWithoutLeader[idx]).sliceState
 	}
 	if remainingSliceCount > 0 {
 		return false, 0, nil, nil
@@ -61,13 +61,13 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 }
 
 // The balance threshold value is maximum possible minimum number of slices placed on a domain in a balanced placement solution.
-func balanceThresholdValue(sliceCount int32, selectedDomainsCount int32, lastDomainWithLeader *domain, lastDomain *domain) int32 {
+func balanceThresholdValue(s *TASFlavorSnapshot, sliceCount int32, selectedDomainsCount int32, lastDomainWithLeader *domain, lastDomain *domain) int32 {
 	threshold := sliceCount / selectedDomainsCount
 	if lastDomainWithLeader != nil {
-		threshold = min(threshold, lastDomainWithLeader.sliceStateWithLeader)
+		threshold = min(threshold, s.stateOf(lastDomainWithLeader).sliceStateWithLeader)
 	}
 	if lastDomain != nil {
-		threshold = min(threshold, lastDomain.sliceState)
+		threshold = min(threshold, s.stateOf(lastDomain).sliceState)
 	}
 	return threshold
 }
@@ -84,7 +84,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 
 	orderedDomains := slices.Clone(domains)
 	if prioritizeByEntropy {
-		slices.SortFunc(orderedDomains, compareDomainCapacityAndEntropy)
+		slices.SortFunc(orderedDomains, s.compareDomainCapacityAndEntropy)
 	} else {
 		slices.SortFunc(orderedDomains, compareDomainLevelValues)
 	}
@@ -98,6 +98,7 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	domainPlacements[0][leaderCount] = map[int32][]*domain{sliceCount * sliceSize: {}}
 
 	for _, d := range orderedDomains {
+		dState := s.stateOf(d)
 		for i := optimalNumberOfDomains; i > 0; i-- {
 			for _, beforeLeader := range slices.Sorted(maps.Keys(domainPlacements[i-1])) {
 				for _, beforeState := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
@@ -109,9 +110,9 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 					copy(newPlacement, beforePlacement)
 					newPlacement = append(newPlacement, d)
 					// Case 1: Pick this domain with leader
-					if beforeLeader > 0 && d.leaderState > 0 {
-						afterLeader := beforeLeader - d.leaderState
-						afterState := beforeState - d.stateWithLeader
+					if beforeLeader > 0 && dState.leaderState > 0 {
+						afterLeader := beforeLeader - dState.leaderState
+						afterState := beforeState - dState.stateWithLeader
 						if domainPlacements[i][afterLeader] == nil {
 							domainPlacements[i][afterLeader] = make(map[int32][]*domain)
 						}
@@ -120,8 +121,8 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 						}
 					}
 					// Case 2: Pick this domain without leader
-					if d.sliceState > 0 {
-						afterState := beforeState - d.state
+					if dState.sliceState > 0 {
+						afterState := beforeState - dState.state
 						if domainPlacements[i][beforeLeader] == nil {
 							domainPlacements[i][beforeLeader] = make(map[int32][]*domain)
 						}
@@ -160,22 +161,23 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	leadersLeft := leaderCount
 	var extraSlicesToTake int32
 	for _, domain := range resultDomains {
+		domainState := s.stateOf(domain)
 		switch {
 		case leadersLeft > 0:
-			extraSlicesToTake = min(domain.sliceStateWithLeader-threshold, extraSlicesLeft)
-			domain.leaderState = 1
+			extraSlicesToTake = min(domainState.sliceStateWithLeader-threshold, extraSlicesLeft)
+			domainState.leaderState = 1
 			leadersLeft--
 		case extraSlicesLeft > 0:
-			extraSlicesToTake = min(domain.sliceState-threshold, extraSlicesLeft)
-			domain.leaderState = 0
+			extraSlicesToTake = min(domainState.sliceState-threshold, extraSlicesLeft)
+			domainState.leaderState = 0
 		default:
-			domain.leaderState = 0
+			domainState.leaderState = 0
 			extraSlicesToTake = 0
 		}
-		domain.state = (threshold + extraSlicesToTake) * sliceSize
-		domain.sliceState = (threshold + extraSlicesToTake)
-		domain.sliceStateWithLeader = domain.sliceState
-		domain.stateWithLeader = domain.state - domain.leaderState
+		domainState.state = (threshold + extraSlicesToTake) * sliceSize
+		domainState.sliceState = (threshold + extraSlicesToTake)
+		domainState.sliceStateWithLeader = domainState.sliceState
+		domainState.stateWithLeader = domainState.state - domainState.leaderState
 		extraSlicesLeft -= extraSlicesToTake
 	}
 	if extraSlicesLeft > 0 || leadersLeft > 0 {
@@ -184,14 +186,14 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	return resultDomains, ""
 }
 
-func calculateDomainsEntropy(domains []*domain) float64 {
+func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 	if len(domains) == 0 {
 		return 0.0
 	}
 
 	var total int32
 	for _, d := range domains {
-		total += d.state
+		total += s.stateOf(d).state
 	}
 
 	if total == 0 {
@@ -201,23 +203,23 @@ func calculateDomainsEntropy(domains []*domain) float64 {
 	var entropy float64
 	totalF := float64(total)
 	for _, d := range domains {
-		if d.state > 0 {
-			pI := float64(d.state) / totalF
+		if state := s.stateOf(d).state; state > 0 {
+			pI := float64(state) / totalF
 			entropy += -pI * math.Log2(pI)
 		}
 	}
 	return entropy
 }
 
-func compareDomainCapacityAndEntropy(a, b *domain) int {
-	if r := b.leaderState - a.leaderState; r != 0 {
+func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
+	if r := s.stateOf(b).leaderState - s.stateOf(a).leaderState; r != 0 {
 		return int(r)
 	}
-	if r := b.sliceStateWithLeader - a.sliceStateWithLeader; r != 0 {
+	if r := s.stateOf(b).sliceStateWithLeader - s.stateOf(a).sliceStateWithLeader; r != 0 {
 		return int(r)
 	}
-	aEntropy := calculateDomainsEntropy(a.children)
-	bEntropy := calculateDomainsEntropy(b.children)
+	aEntropy := s.calculateDomainsEntropy(a.children)
+	bEntropy := s.calculateDomainsEntropy(b.children)
 	if bEntropy > aEntropy {
 		return 1
 	}
@@ -251,16 +253,16 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 	var currFitDomain []*domain
 
 	for _, requestedLevelSiblingDomains := range requestedLevelDomainsToConsider {
-		candidateDomains := cloneDomains(requestedLevelSiblingDomains)
+		candidateDomains := s.cloneDomains(requestedLevelSiblingDomains)
 		lowerLevelDomains := getLowerLevelDomains(s, candidateDomains, params.requestedLevelIdx, params.sliceLevelIdx)
 		fits, selectedDomainsCount, lastDomainWithLeader, lastDomain := evaluateGreedyAssignment(s, lowerLevelDomains, sliceCount, params.leaderCount)
 		if !fits {
 			continue
 		}
-		threshold := balanceThresholdValue(sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
+		threshold := balanceThresholdValue(s, sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		thresholdWithLeaderReservation := threshold
 		if params.leaderCount > 0 && lastDomain != nil {
-			thresholdWithLeaderReservation = min(threshold, lastDomain.sliceStateWithLeader)
+			thresholdWithLeaderReservation = min(threshold, s.stateOf(lastDomain).sliceStateWithLeader)
 		}
 		if threshold >= bestThreshold {
 			s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
@@ -271,7 +273,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 					continue
 				}
 				threshold = thresholdWithLeaderReservation
-				candidateDomains = cloneDomains(requestedLevelSiblingDomains)
+				candidateDomains = s.cloneDomains(requestedLevelSiblingDomains)
 				s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
 				fitsAfterPruning, requestedLevelDomainCount, _, _ = evaluateGreedyAssignment(s, candidateDomains, sliceCount, params.leaderCount)
 			}
@@ -319,63 +321,67 @@ func getLowerLevelDomains(s *TASFlavorSnapshot, domains []*domain, levelIdx, sli
 	return domains
 }
 
-func clearState(d *domain) {
-	d.state = int32(0)
-	d.sliceState = int32(0)
-	d.stateWithLeader = int32(0)
-	d.sliceStateWithLeader = int32(0)
-	d.leaderState = int32(0)
+func (s *TASFlavorSnapshot) clearState(d *domain) {
+	st := s.stateOf(d)
+	*st = domainState{affinityScore: st.affinityScore}
 	for _, child := range d.children {
-		clearState(child)
+		s.clearState(child)
 	}
 }
 
-func clearLeaderCapacity(d *domain) {
-	d.stateWithLeader = int32(0)
-	d.sliceStateWithLeader = int32(0)
-	d.leaderState = int32(0)
+func (s *TASFlavorSnapshot) clearLeaderCapacity(d *domain) {
+	domainState := s.stateOf(d)
+	domainState.stateWithLeader = 0
+	domainState.sliceStateWithLeader = 0
+	domainState.leaderState = 0
 	for _, child := range d.children {
-		clearLeaderCapacity(child)
+		s.clearLeaderCapacity(child)
 	}
 }
 
-func cloneDomains(domains []*domain) []*domain {
+// cloneDomains deep-copies the given domain subtrees, giving every copied
+// domain its own per-snapshot state slot initialized from the original's
+// current state. This lets the balanced-placement algorithm speculatively
+// mutate (e.g. prune) the copies without corrupting the state of the shared
+// domains, which other candidate sets and the fallback path still need.
+func (s *TASFlavorSnapshot) cloneDomains(domains []*domain) []*domain {
 	result := make([]*domain, len(domains))
 	for i, d := range domains {
-		result[i] = cloneDomain(d, nil)
+		result[i] = s.cloneDomain(d, nil)
 	}
 	return result
 }
 
-func cloneDomain(d *domain, parent *domain) *domain {
-	clone := *d
+func (s *TASFlavorSnapshot) cloneDomain(d *domain, parent *domain) *domain {
+	clone := s.shallowCloneWithState(d)
 	clone.parent = parent
 	clone.children = make([]*domain, len(d.children))
 	for i, child := range d.children {
-		clone.children[i] = cloneDomain(child, &clone)
+		clone.children[i] = s.cloneDomain(child, clone)
 	}
-	return &clone
+	return clone
 }
 
-func pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
-	if d.sliceState < threshold {
-		clearState(d)
+func (s *TASFlavorSnapshot) pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
+	domainState := s.stateOf(d)
+	if domainState.sliceState < threshold {
+		s.clearState(d)
 		return
 	}
 	// The domain can still be used for workers, but not as the leader host at this threshold.
-	if leaderRequired && d.leaderState > 0 && d.sliceStateWithLeader < threshold {
-		clearLeaderCapacity(d)
+	if leaderRequired && domainState.leaderState > 0 && domainState.sliceStateWithLeader < threshold {
+		s.clearLeaderCapacity(d)
 	}
 }
 
 func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
 	for _, d := range domains {
 		for _, c := range d.children {
-			pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
+			s.pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
 		}
 	}
 	for _, d := range domains {
 		s.fillInCountsHelper(d, sliceSize, sliceLevelIdx, level, nil, leaderRequired)
-		pruneDomainNodeBelowThreshold(d, threshold, leaderRequired)
+		s.pruneDomainNodeBelowThreshold(d, threshold, leaderRequired)
 	}
 }

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -32,44 +32,86 @@ func domainIDs(domains []*domain) []string {
 	return utilslices.Map(domains, func(d **domain) string { return string((*d).id) })
 }
 
+func addDomainWithState(s *TASFlavorSnapshot, d *domain, st domainState) *domain {
+	d.idx = len(s.state)
+	s.state = append(s.state, st)
+	return d
+}
+
 func TestSelectOptimalDomainSetToFit(t *testing.T) {
-	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 9, sliceState: 9, leaderState: 1, stateWithLeader: 8, sliceStateWithLeader: 8}
-	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 6, sliceState: 6, leaderState: 0, stateWithLeader: 6, sliceStateWithLeader: 6}
-	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 4, sliceState: 4, leaderState: 1, stateWithLeader: 3, sliceStateWithLeader: 3}
-	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 2, sliceState: 2, leaderState: 0, stateWithLeader: 2, sliceStateWithLeader: 2}
+	d1 := testDomainSpec{
+		domain: domain{id: "d1", levelValues: []string{"d1"}},
+		state: domainState{
+			state:                9,
+			sliceState:           9,
+			leaderState:          1,
+			stateWithLeader:      8,
+			sliceStateWithLeader: 8,
+		},
+	}
+	d2 := testDomainSpec{
+		domain: domain{id: "d2", levelValues: []string{"d2"}},
+		state: domainState{
+			state:                6,
+			sliceState:           6,
+			leaderState:          0,
+			stateWithLeader:      6,
+			sliceStateWithLeader: 6,
+		},
+	}
+	d3 := testDomainSpec{
+		domain: domain{id: "d3", levelValues: []string{"d3"}},
+		state: domainState{
+			state:                4,
+			sliceState:           4,
+			leaderState:          1,
+			stateWithLeader:      3,
+			sliceStateWithLeader: 3,
+		},
+	}
+	d4 := testDomainSpec{
+		domain: domain{id: "d4", levelValues: []string{"d4"}},
+		state: domainState{
+			state:                2,
+			sliceState:           2,
+			leaderState:          0,
+			stateWithLeader:      2,
+			sliceStateWithLeader: 2,
+		},
+	}
 
 	testCases := map[string]struct {
-		domains     []*domain
+		domains     []testDomainSpec
 		workerCount int32
 		leaderCount int32
 		want        []string
 	}{
 		"no fit": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 22,
 			leaderCount: 0,
 			want:        []string{},
 		},
 		"simple fit one domain": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 5,
 			leaderCount: 1,
 			want:        []string{"d1"},
 		},
 		"perfect fit with two domains": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 9,
 			leaderCount: 1,
 			want:        []string{"d2", "d3"},
 		},
 		"perfect fit with two domains 2": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 10,
 			leaderCount: 1,
 			want:        []string{"d1", "d4"},
 		},
 		"best fit, single domain": {
-			domains:     []*domain{d1, d2, d3, d4},
+			domains:     []testDomainSpec{d1, d2, d3, d4},
 			workerCount: 5,
 			leaderCount: 0,
 			want:        []string{"d2"},
@@ -79,8 +121,9 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil, &defaultChecker{})
-			got := selectOptimalDomainSetToFit(s, tc.domains, tc.workerCount, tc.leaderCount, 1, true)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+			domains := addDomainsWithState(s, tc.domains)
+			got := selectOptimalDomainSetToFit(s, domains, tc.workerCount, tc.leaderCount, 1, true)
 			gotIDs := make([]string, len(got))
 			for i, d := range got {
 				gotIDs[i] = string(d.id)
@@ -107,12 +150,13 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+			equalState := domainState{state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3}
 			domains := []*domain{
-				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
-				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
-				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
-				{id: "leaf-zz", levelValues: []string{"block-a", "host-zz"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+				addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-m", levelValues: []string{"block-b", "host-m"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}}, equalState),
+				addDomainWithState(s, &domain{id: "leaf-zz", levelValues: []string{"block-a", "host-zz"}}, equalState),
 			}
 
 			got := selectOptimalDomainSetToFit(s, domains, 1, 0, 1, tc.prioritizeByEntropy)
@@ -126,23 +170,43 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 
 func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 	testCases := map[string]struct {
-		domains []*domain
+		domains func(s *TASFlavorSnapshot) []*domain
 		want    []string
 	}{
 		"tie-breaking on level values when capacity and entropy are equal": {
-			domains: []*domain{
-				{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
-				{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
-				{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				leaderState := domainState{leaderState: 1, sliceStateWithLeader: 5}
+				childState := domainState{state: 2}
+				return []*domain{
+					addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderState),
+					addDomainWithState(s, &domain{id: "leaf-m", levelValues: []string{"block-b", "host-m"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderState),
+					addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, children: []*domain{
+						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
+					}}, leaderState),
+				}
 			},
 			want: []string{"leaf-z", "leaf-a", "leaf-m"},
 		},
 		"capacity overrides entropy, and higher entropy overrides level values": {
-			domains: []*domain{
-				{id: "lower-leader", levelValues: []string{"a"}, leaderState: 0, sliceStateWithLeader: 100, children: []*domain{{state: 50}, {state: 50}}},
-				{id: "lower-capacity", levelValues: []string{"b"}, leaderState: 1, sliceStateWithLeader: 4, children: []*domain{{state: 2}, {state: 2}}},
-				{id: "low-entropy", levelValues: []string{"c"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 4}, {state: 0}}},
-				{id: "high-entropy", levelValues: []string{"d"}, leaderState: 1, sliceStateWithLeader: 5, children: []*domain{{state: 2}, {state: 2}}},
+			domains: func(s *TASFlavorSnapshot) []*domain {
+				return []*domain{
+					addDomainWithState(s, &domain{id: "lower-leader", levelValues: []string{"a"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{state: 50}), addDomainWithState(s, &domain{}, domainState{state: 50}),
+					}}, domainState{leaderState: 0, sliceStateWithLeader: 100}),
+					addDomainWithState(s, &domain{id: "lower-capacity", levelValues: []string{"b"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{state: 2}), addDomainWithState(s, &domain{}, domainState{state: 2}),
+					}}, domainState{leaderState: 1, sliceStateWithLeader: 4}),
+					addDomainWithState(s, &domain{id: "low-entropy", levelValues: []string{"c"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{state: 4}), addDomainWithState(s, &domain{}, domainState{state: 0}),
+					}}, domainState{leaderState: 1, sliceStateWithLeader: 5}),
+					addDomainWithState(s, &domain{id: "high-entropy", levelValues: []string{"d"}, children: []*domain{
+						addDomainWithState(s, &domain{}, domainState{state: 2}), addDomainWithState(s, &domain{}, domainState{state: 2}),
+					}}, domainState{leaderState: 1, sliceStateWithLeader: 5}),
+				}
 			},
 			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
 		},
@@ -150,9 +214,12 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			slices.SortFunc(tc.domains, compareDomainCapacityAndEntropy)
+			_, log := utiltesting.ContextWithLog(t)
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+			got := tc.domains(s)
+			slices.SortFunc(got, s.compareDomainCapacityAndEntropy)
 
-			if diff := cmp.Diff(tc.want, domainIDs(tc.domains)); diff != "" {
+			if diff := cmp.Diff(tc.want, domainIDs(got)); diff != "" {
 				t.Errorf("unexpected domain order (-want,+got): %s", diff)
 			}
 		})
@@ -160,85 +227,124 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 }
 
 func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
-	d1 := &domain{id: "d1", levelValues: []string{"d1"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d2 := &domain{id: "d2", levelValues: []string{"d2"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d3 := &domain{id: "d3", levelValues: []string{"d3"}, state: 18, sliceState: 18, stateWithLeader: 18, leaderState: 0, sliceStateWithLeader: 18}
-	d4 := &domain{id: "d4", levelValues: []string{"d4"}, state: 10, sliceState: 10, stateWithLeader: 10, leaderState: 0, sliceStateWithLeader: 10}
-	d5 := &domain{id: "d5", levelValues: []string{"d5"}, state: 2, sliceState: 2, stateWithLeader: 2, leaderState: 0, sliceStateWithLeader: 2}
+	d1 := testDomainSpec{
+		domain: domain{id: "d1", levelValues: []string{"d1"}},
+		state: domainState{
+			state:                18,
+			sliceState:           18,
+			stateWithLeader:      18,
+			leaderState:          0,
+			sliceStateWithLeader: 18,
+		},
+	}
+	d2 := testDomainSpec{
+		domain: domain{id: "d2", levelValues: []string{"d2"}},
+		state: domainState{
+			state:                18,
+			sliceState:           18,
+			stateWithLeader:      18,
+			leaderState:          0,
+			sliceStateWithLeader: 18,
+		},
+	}
+	d3 := testDomainSpec{
+		domain: domain{id: "d3", levelValues: []string{"d3"}},
+		state: domainState{
+			state:                18,
+			sliceState:           18,
+			stateWithLeader:      18,
+			leaderState:          0,
+			sliceStateWithLeader: 18,
+		},
+	}
+	d4 := testDomainSpec{
+		domain: domain{id: "d4", levelValues: []string{"d4"}},
+		state: domainState{
+			state:                10,
+			sliceState:           10,
+			stateWithLeader:      10,
+			leaderState:          0,
+			sliceStateWithLeader: 10,
+		},
+	}
+	d5 := testDomainSpec{
+		domain: domain{id: "d5", levelValues: []string{"d5"}},
+		state: domainState{
+			state:                2,
+			sliceState:           2,
+			stateWithLeader:      2,
+			leaderState:          0,
+			sliceStateWithLeader: 2,
+		},
+	}
 
 	testCases := map[string]struct {
-		domains     []*domain
+		domains     []testDomainSpec
 		sliceCount  int32
 		leaderCount int32
 		sliceSize   int32
 		threshold   int32
-		want        []*domain
+		want        map[string]domainState
 	}{
 		"simple balanced placement on two domains": {
-			domains:     []*domain{d1, d2, d3},
+			domains:     []testDomainSpec{d1, d2, d3},
 			sliceCount:  20,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   10,
-			want: []*domain{
-				{id: "d1", sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
-				{id: "d2", sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
+			want: map[string]domainState{
+				"d1": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
+				"d2": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
 			},
 		},
 		"simple placement on three domains": {
-			domains:     []*domain{d1, d2, d3},
+			domains:     []testDomainSpec{d1, d2, d3},
 			sliceCount:  40,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   13,
-			want: []*domain{
-				{id: "d1", sliceState: 14, state: 14, stateWithLeader: 14, sliceStateWithLeader: 14, leaderState: 0},
-				{id: "d2", sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
-				{id: "d3", sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
+			want: map[string]domainState{
+				"d1": {sliceState: 14, state: 14, stateWithLeader: 14, sliceStateWithLeader: 14, leaderState: 0},
+				"d2": {sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
+				"d3": {sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
 			},
 		},
 		"find smallest domain that fits": {
-			domains:     []*domain{d1, d2, d3, d4, d5},
+			domains:     []testDomainSpec{d1, d2, d3, d4, d5},
 			sliceCount:  2,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   2,
-			want: []*domain{
-				{id: "d5", sliceState: 2, state: 2, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 0},
+			want: map[string]domainState{
+				"d5": {sliceState: 2, state: 2, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 0},
 			},
 		},
 		"correctly select domains": {
-			domains:     []*domain{d1, d2, d3, d4, d5},
+			domains:     []testDomainSpec{d1, d2, d3, d4, d5},
 			sliceCount:  25,
 			leaderCount: 0,
 			sliceSize:   1,
 			threshold:   10,
-			want: []*domain{
-				{id: "d1", sliceState: 15, state: 15, stateWithLeader: 15, sliceStateWithLeader: 15, leaderState: 0},
-				{id: "d4", sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
+			want: map[string]domainState{
+				"d1": {sliceState: 15, state: 15, stateWithLeader: 15, sliceStateWithLeader: 15, leaderState: 0},
+				"d4": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
 			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			domains := make([]*domain, len(tc.domains))
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil, &defaultChecker{})
-			for i, d := range tc.domains {
-				clone := *d
-				domains[i] = &clone
-			}
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+			domains := addDomainsWithState(s, tc.domains)
 
 			got, _ := placeSlicesOnDomainsBalanced(s, domains, tc.sliceCount, tc.leaderCount, tc.sliceSize, tc.threshold)
 
-			if diff := cmp.Diff(
-				tc.want,
-				got,
-				cmp.AllowUnexported(domain{}),
-				cmpopts.IgnoreFields(domain{}, "parent", "children", "levelValues"),
-				cmpopts.SortSlices(func(a, b *domain) bool { return a.id < b.id }),
-			); diff != "" {
+			gotStates := make(map[string]domainState, len(got))
+			for _, d := range got {
+				gotStates[string(d.id)] = *s.stateOf(d)
+			}
+			if diff := cmp.Diff(tc.want, gotStates, cmp.AllowUnexported(domainState{})); diff != "" {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
 			}
 		})
@@ -247,10 +353,11 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 
 func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 	_, log := utiltesting.ContextWithLog(t)
-	s := newTASFlavorSnapshot(log, "dummy", []string{}, nil, &defaultChecker{})
+	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+	equalState := domainState{state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3}
 	domains := []*domain{
-		{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
-		{id: "leaf-z", levelValues: []string{"block-a", "host-z"}, state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3},
+		addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
+		addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}}, equalState),
 	}
 
 	got, reason := placeSlicesOnDomainsBalanced(s, domains, 1, 0, 1, 1)
@@ -264,12 +371,13 @@ func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 }
 
 func TestPruneDomainsBelowThreshold(t *testing.T) {
-	domainState := func(d *domain) [5]int32 {
-		return [5]int32{d.state, d.sliceState, d.stateWithLeader, d.sliceStateWithLeader, d.leaderState}
+	domainStateValues := func(s *TASFlavorSnapshot, d *domain) [5]int32 {
+		st := s.stateOf(d)
+		return [5]int32{st.state, st.sliceState, st.stateWithLeader, st.sliceStateWithLeader, st.leaderState}
 	}
 
 	testCases := map[string]struct {
-		domains        func() ([]*domain, map[string]*domain)
+		domains        func(s *TASFlavorSnapshot) ([]*domain, map[string]*domain)
 		threshold      int32
 		sliceSize      int32
 		sliceLevelIdx  int
@@ -278,47 +386,51 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 		want           map[string][5]int32
 	}{
 		"keeps worker only domain": {
-			domains: func() ([]*domain, map[string]*domain) {
-				leaderLeaf := &domain{
-					id:                   "leader-leaf",
+			domains: func(s *TASFlavorSnapshot) ([]*domain, map[string]*domain) {
+				leaderLeaf := addDomainWithState(s, &domain{
+					id: "leader-leaf",
+				}, domainState{
 					state:                6,
 					sliceState:           6,
 					leaderState:          1,
 					stateWithLeader:      5,
 					sliceStateWithLeader: 5,
-				}
-				leaderDomain := &domain{
-					id:                   "leader-domain",
+				})
+				leaderDomain := addDomainWithState(s, &domain{
+					id:       "leader-domain",
+					children: []*domain{leaderLeaf},
+				}, domainState{
 					state:                6,
 					sliceState:           6,
 					leaderState:          1,
 					stateWithLeader:      5,
 					sliceStateWithLeader: 5,
-					children:             []*domain{leaderLeaf},
-				}
+				})
 				leaderLeaf.parent = leaderDomain
-				workerOnlyLeaf := &domain{
-					id:                   "worker-only-leaf",
+				workerOnlyLeaf := addDomainWithState(s, &domain{
+					id: "worker-only-leaf",
+				}, domainState{
 					state:                5,
 					sliceState:           5,
 					leaderState:          1,
 					stateWithLeader:      4,
 					sliceStateWithLeader: 4,
-				}
-				workerOnlyDomain := &domain{
-					id:                   "worker-only-domain",
+				})
+				workerOnlyDomain := addDomainWithState(s, &domain{
+					id:       "worker-only-domain",
+					children: []*domain{workerOnlyLeaf},
+				}, domainState{
 					state:                5,
 					sliceState:           5,
 					leaderState:          1,
 					stateWithLeader:      4,
 					sliceStateWithLeader: 4,
-					children:             []*domain{workerOnlyLeaf},
-				}
+				})
 				workerOnlyLeaf.parent = workerOnlyDomain
-				parentDomain := &domain{
+				parentDomain := addDomainWithState(s, &domain{
 					id:       "parent-domain",
 					children: []*domain{leaderDomain, workerOnlyDomain},
-				}
+				}, domainState{})
 				leaderDomain.parent = parentDomain
 				workerOnlyDomain.parent = parentDomain
 				return []*domain{parentDomain}, map[string]*domain{
@@ -344,20 +456,50 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			domains, domainsByName := tc.domains()
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{}, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+			domains, domainsByName := tc.domains(s)
 
 			s.pruneDomainsBelowThreshold(domains, tc.threshold, tc.sliceSize, tc.sliceLevelIdx, tc.level, tc.leaderRequired)
 
 			got := make(map[string][5]int32, len(tc.want))
 			for name := range tc.want {
-				got[name] = domainState(domainsByName[name])
+				got[name] = domainStateValues(s, domainsByName[name])
 			}
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("Unexpected domain state (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestPruneDomainsBelowThresholdPreservesAffinityScore(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
+	prunedLeaf := addDomainWithState(s, &domain{id: "pruned-leaf"}, domainState{
+		sliceState:    1,
+		affinityScore: 100,
+	})
+	keptLeaf := addDomainWithState(s, &domain{id: "kept-leaf"}, domainState{
+		state:           4,
+		sliceState:      4,
+		stateWithLeader: 4,
+		affinityScore:   10,
+	})
+	parent := addDomainWithState(s, &domain{
+		id:       "parent",
+		children: []*domain{prunedLeaf, keptLeaf},
+	}, domainState{})
+	prunedLeaf.parent = parent
+	keptLeaf.parent = parent
+
+	s.pruneDomainsBelowThreshold([]*domain{parent}, 2, 1, 1, 0, false)
+
+	if got, want := s.stateOf(prunedLeaf).affinityScore, int64(100); got != want {
+		t.Errorf("Unexpected pruned leaf affinity score: got %d, want %d", got, want)
+	}
+	if got, want := s.stateOf(parent).affinityScore, int64(110); got != want {
+		t.Errorf("Unexpected parent affinity score: got %d, want %d", got, want)
 	}
 }
 
@@ -422,18 +564,19 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", []string{"block", "rack"}, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{"block", "rack"}, nil, 0), nil, &defaultChecker{})
 			domainsByID := make(map[string]*domain, len(tc.domains))
 			for _, spec := range tc.domains {
-				d := &domain{
-					id:                   utiltas.TopologyDomainID(spec.id),
-					levelValues:          spec.levelValues,
+				d := addDomainWithState(s, &domain{
+					id:          utiltas.TopologyDomainID(spec.id),
+					levelValues: spec.levelValues,
+				}, domainState{
 					state:                spec.state,
 					sliceState:           spec.sliceState,
 					stateWithLeader:      spec.stateWithLeader,
 					sliceStateWithLeader: spec.sliceStateWithLeader,
 					leaderState:          spec.leaderState,
-				}
+				})
 				if len(spec.parentID) == 0 {
 					s.domainsPerLevel[0][d.id] = d
 				} else {

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -8385,12 +8385,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 					aggregatedDomainUsage = tc.aggregatedDomainUsages
 				}
-				snapshot, err := tasFlavorCache.snapshot(
-					ctx,
-					log,
-					tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
-					aggregatedDomainUsage,
-				)
+				snapshot, err := tasFlavorCache.snapshot(ctx, log, aggregatedDomainUsage)
 				if err != nil {
 					t.Fatalf("TASFlavorSnapshot creation failed: %v", err)
 				}
@@ -8862,12 +8857,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			if features.Enabled(features.TASHandleOverlappingFlavors) && tas.IsLowestLevelHostname(tasFlavorCache.topology.Levels) {
 				aggregatedDomainUsages = tc.aggregatedDomainUsages
 			}
-			snapshot, err := tasFlavorCache.snapshot(
-				ctx,
-				log,
-				tasCache.nodesCache.find(tasFlavorCache.flavor.NodeLabels, tasFlavorCache.topology.Levels),
-				aggregatedDomainUsages,
-			)
+			snapshot, err := tasFlavorCache.snapshot(ctx, log, aggregatedDomainUsages)
 			if err != nil {
 				t.Fatalf("TASFlavorSnapshot creation failed: %v", err)
 			}

--- a/pkg/cache/scheduler/tas_cache_update_test.go
+++ b/pkg/cache/scheduler/tas_cache_update_test.go
@@ -116,6 +116,7 @@ func TestTASCacheUpdateFlavorNodeLabelsPreservesUsage(t *testing.T) {
 		}),
 	}}
 	originalFlavorCache := tasCache.Get("tas-flavor")
+	originalTree, _ := originalFlavorCache.cachedOrBuiltTree()
 	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
 
 	updatedNodeLabels := map[string]string{"node-group": "other"}
@@ -125,6 +126,10 @@ func TestTASCacheUpdateFlavorNodeLabelsPreservesUsage(t *testing.T) {
 	updatedFlavorCache := tasCache.Get("tas-flavor")
 	if updatedFlavorCache != originalFlavorCache {
 		t.Fatal("TAS flavor cache was replaced while updating nodeLabels")
+	}
+	updatedTree, _ := updatedFlavorCache.cachedOrBuiltTree()
+	if updatedTree == originalTree {
+		t.Error("Topology tree was reused after updating nodeLabels")
 	}
 
 	wantUsage := map[utiltas.TopologyDomainID]resources.Requests{
@@ -166,6 +171,7 @@ func TestTASCacheUpdateTopologyLevelsPreservesUsage(t *testing.T) {
 		}),
 	}}
 	originalFlavorCache := tasCache.Get("tas-flavor")
+	originalTree, _ := originalFlavorCache.cachedOrBuiltTree()
 	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
 
 	updatedTopology := utiltestingapi.MakeTopology("default").
@@ -177,10 +183,17 @@ func TestTASCacheUpdateTopologyLevelsPreservesUsage(t *testing.T) {
 	if updatedFlavorCache != originalFlavorCache {
 		t.Fatal("TAS flavor cache was replaced while updating topology levels")
 	}
+	updatedTree, _ := updatedFlavorCache.cachedOrBuiltTree()
+	if updatedTree == originalTree {
+		t.Error("Topology tree was reused after updating topology levels")
+	}
 
 	wantLevels := []string{utiltesting.DefaultBlockTopologyLevel, corev1.LabelHostname}
 	if diff := cmp.Diff(wantLevels, updatedFlavorCache.TopologyLevels()); diff != "" {
 		t.Errorf("Unexpected levels after update (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(wantLevels, updatedTree.levelKeys); diff != "" {
+		t.Errorf("Unexpected topology tree levels after update (-want +got):\n%s", diff)
 	}
 	wantUsage := map[utiltas.TopologyDomainID]resources.Requests{
 		"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
@@ -193,5 +206,11 @@ func TestTASCacheUpdateTopologyLevelsPreservesUsage(t *testing.T) {
 	}
 	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
 		t.Error("Workload usage was removed after updating topology levels")
+	}
+
+	tasCache.AddTopology(updatedTopology)
+	resyncedTree, _ := updatedFlavorCache.cachedOrBuiltTree()
+	if resyncedTree != updatedTree {
+		t.Error("Topology tree was rebuilt after re-applying unchanged topology levels")
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"sync"
 
@@ -97,6 +98,19 @@ type TASFlavorCache struct {
 	schedulingSimulator simulator.SchedulingSimulator
 
 	resourceFormatter *resources.ResourceFormatter
+
+	// nodesCache provides the nodes matching the flavor, and the generation
+	// used to decide whether the cached topology tree can still be reused.
+	nodesCache *nodesCache
+
+	// treeLock guards tree. It is separate from the embedded RWMutex because
+	// snapshot() holds only the read lock, but must store the tree it built.
+	treeLock sync.Mutex
+
+	// tree caches the static topology structure derived from the node set at
+	// tree.generation. It is shared read-only by the snapshots of the flavor
+	// and reused across scheduling cycles until the node set changes.
+	tree *topologyTree
 }
 
 func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
@@ -110,6 +124,7 @@ func (t *tasCache) NewTASFlavorCache(topologyInfo topologyInformation,
 		nonTasUsageCache:    t.nonTasUsageCache,
 		schedulingSimulator: t.schedulingSimulator,
 		resourceFormatter:   t.resourceFormatter,
+		nodesCache:          t.nodesCache,
 	}
 }
 
@@ -122,13 +137,26 @@ func (c *TASFlavorCache) updateTolerations(tolerations []corev1.Toleration) {
 func (c *TASFlavorCache) updateNodeLabels(nodeLabels map[string]string) {
 	c.Lock()
 	defer c.Unlock()
+	if maps.Equal(c.flavor.NodeLabels, nodeLabels) {
+		return
+	}
 	c.flavor.NodeLabels = nodeLabels
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	c.tree = nil
 }
 
 func (c *TASFlavorCache) updateTopology(topology topologyInformation) {
 	c.Lock()
 	defer c.Unlock()
+	levelsChanged := !slices.Equal(c.topology.Levels, topology.Levels)
 	c.topology = topology
+	if !levelsChanged {
+		return
+	}
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	c.tree = nil
 }
 
 // NodeLabels returns the node labels of the flavor. The returned map is safe to
@@ -155,33 +183,30 @@ func (c *TASFlavorCache) TopologyLevels() []string {
 }
 
 func (c *TASFlavorCache) snapshot(
-	ctx context.Context, log logr.Logger, nodes []*corev1.Node, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
+	ctx context.Context, log logr.Logger, aggregatedDomainUsages map[utiltas.TopologyDomainID]resources.Requests,
 ) (*TASFlavorSnapshot, error) {
 	c.RLock()
 	defer c.RUnlock()
 
+	tree, treeReused := c.cachedOrBuiltTree()
+
 	infoKV := []any{
 		"nodeLabels", c.flavor.NodeLabels,
 		"levels", c.topology.Levels,
-		"nodeCount", len(nodes),
+		"nodeCount", len(tree.nodes),
+		"treeReused", treeReused,
 	}
 	if features.Enabled(features.TASHandleOverlappingFlavors) {
 		infoKV = append(infoKV, "crossFlavorAggregation", aggregatedDomainUsages != nil)
 	}
 	log.V(3).Info("Constructing TAS snapshot", infoKV...)
 
-	feasibilityChecker, err := c.schedulingSimulator.NewFeasibilityChecker(ctx, nodes)
+	feasibilityChecker, err := c.schedulingSimulator.NewFeasibilityChecker(ctx, tree.nodes)
 	if err != nil {
 		return nil, err
 	}
 
-	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, c.topology.Levels, c.flavor.Tolerations, feasibilityChecker, withResourceFormatter(c.resourceFormatter))
-
-	nodeToDomain := make(map[string]utiltas.TopologyDomainID)
-	for _, node := range nodes {
-		nodeToDomain[node.Name] = snapshot.addNode(node)
-	}
-	snapshot.initialize()
+	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, tree, c.flavor.Tolerations, feasibilityChecker, withResourceFormatter(c.resourceFormatter))
 
 	tasDomainUsages := c.usage
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
@@ -191,11 +216,43 @@ func (c *TASFlavorCache) snapshot(
 		snapshot.addTASUsage(domainID, usage)
 	}
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
-		if domainID, ok := nodeToDomain[nodeName]; ok {
+		if domainID, ok := tree.nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)
 		}
 	})
 	return snapshot, nil
+}
+
+// cachedOrBuiltTree returns the cached topology tree when its nodesCache
+// generation is current. Otherwise, it builds a candidate and returns the
+// newest tree retained in the cache, which may have been stored by a concurrent
+// caller. The returned tree must not be mutated.
+func (c *TASFlavorCache) cachedOrBuiltTree() (*topologyTree, bool) {
+	if tree := c.cachedTree(); tree != nil && tree.generation == c.nodesCache.currentGeneration() {
+		return tree, true
+	}
+	// snapshot already holds c.RLock. Do not use c.NodeLabels here: a recursive
+	// RLock can deadlock if a writer is waiting between the two acquisitions.
+	nodes, generation := c.nodesCache.find(c.flavor.NodeLabels, c.topology.Levels)
+	tree := newTopologyTree(c.topology.Levels, nodes, generation)
+	return c.storeTree(tree), false
+}
+
+func (c *TASFlavorCache) cachedTree() *topologyTree {
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	return c.tree
+}
+
+func (c *TASFlavorCache) storeTree(tree *topologyTree) *topologyTree {
+	c.treeLock.Lock()
+	defer c.treeLock.Unlock()
+	// Concurrent snapshot callers may race to store a rebuilt tree; keep the
+	// newest one so the cache cannot regress to an older generation.
+	if c.tree == nil || tree.generation > c.tree.generation {
+		c.tree = tree
+	}
+	return c.tree
 }
 
 func (c *TASFlavorCache) addUsage(log logr.Logger, key workload.Reference, topologyRequests []workload.TopologyDomainRequests) {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"iter"
 	"maps"
 	"math"
 	"slices"
@@ -49,18 +50,9 @@ var (
 	errCodeAssumptionsViolated = errors.New("code assumptions violated")
 )
 
-// domain holds the static information about placement of a topology
-// domain in the hierarchy of topology domains.
-type domain struct {
-	// id is the globally unique id of the domain
-	id utiltas.TopologyDomainID
-
-	// parent points to domain which is a parent in topology structure
-	parent *domain
-
-	// children points to domains which are children in topology structure
-	children []*domain
-
+// domainState is the per-snapshot mutable state of a domain during the
+// assignment algorithm, addressed by domain.idx.
+type domainState struct {
 	// state is a temporary state of the topology domains during the
 	// assignment algorithm.
 	//
@@ -86,18 +78,14 @@ type domain struct {
 	sliceStateWithLeader int32
 	leaderState          int32
 
-	// levelValues stores the mapping from domain ID back to the
-	// ordered list of values
-	levelValues []string
-
 	// affinityScore is the sum of weights of all preferred affinity terms that match the node.
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
 }
 
-// leafDomain extends the domain with information for the lowest-level domain.
-type leafDomain struct {
-	domain
+// leafState is the per-snapshot mutable state of a leaf domain, addressed by
+// leafDomain.leafIdx.
+type leafState struct {
 	// freeCapacity represents the total node capacity minus the non-TAS usage,
 	// coming from Pods which are not managed by workloads admitted by TAS
 	// (typically static Pods, DaemonSets, or Deployments).
@@ -110,29 +98,32 @@ type leafDomain struct {
 	// It is lazily calculated using LazyRequests and updated incrementally during TAS usage changes, avoiding repeated
 	// map cloning and resource subtraction during capacity checks (e.g. preemption).
 	cachedRemainingCapacity resources.LazyRequests
-
-	// node at the leaf, if the lowest level is a node
-	node *corev1.Node
 }
 
-func (l *leafDomain) GetID() utiltas.TopologyDomainID {
-	return l.id
+// leafCandidate adapts a shared leafDomain to the simulator's
+// MatchedCandidate interface. The affinity score the simulator writes is
+// per-snapshot state, so the candidate carries a reference to the snapshot
+// owning the state instead of mutating the shared leaf.
+type leafCandidate struct {
+	leaf *leafDomain
+	s    *TASFlavorSnapshot
 }
 
-func (l *leafDomain) GetNode() *corev1.Node {
-	return l.node
+func (c *leafCandidate) GetID() utiltas.TopologyDomainID {
+	return c.leaf.id
 }
 
-func (l *leafDomain) SetAffinityScore(score int64) {
-	l.affinityScore = score
+func (c *leafCandidate) GetNode() *corev1.Node {
+	return c.leaf.node
 }
 
-func (l *leafDomain) GetAffinityScore() int64 {
-	return l.affinityScore
+func (c *leafCandidate) SetAffinityScore(score int64) {
+	c.s.state[c.leaf.idx].affinityScore = score
 }
 
-type domainByID map[utiltas.TopologyDomainID]*domain
-type leafDomainByID map[utiltas.TopologyDomainID]*leafDomain
+func (c *leafCandidate) GetAffinityScore() int64 {
+	return c.s.state[c.leaf.idx].affinityScore
+}
 
 type TASFlavorSnapshot struct {
 	log logr.Logger
@@ -141,27 +132,24 @@ type TASFlavorSnapshot struct {
 	// ResourceFlavor spec.topologyName field.
 	topologyName kueue.TopologyReference
 
-	// levelKeys denotes the ordered list of topology keys set as label keys
-	// on the Topology object
-	levelKeys []string
+	// topologyTree is the static topology structure, shared with the other
+	// snapshots of the flavor. It must not be mutated.
+	*topologyTree
 
-	// leaves maps domainID to domains that are at the lowest level of topology structure
-	leaves leafDomainByID
+	// state holds the per-snapshot mutable domain state, indexed by
+	// domain.idx.
+	state []domainState
 
-	// roots maps domainID to domains that are at the highest level of topology structure
-	roots domainByID
+	// leafStates holds the per-snapshot mutable leaf state, indexed by
+	// leafDomain.leafIdx.
+	leafStates []leafState
 
-	// domains maps domainID to every domain available in the topology structure
-	domains domainByID
-
-	// domainsPerLevel stores the static tree information
-	domainsPerLevel []domainByID
+	// leafCandidates adapts the shared leaves to the simulator's mutable
+	// candidate interface, indexed by leafDomain.leafIdx.
+	leafCandidates []leafCandidate
 
 	// tolerations represents the list of tolerations defined for the resource flavor
 	tolerations []corev1.Toleration
-
-	// isLowestLevelNode indicates if kubernetes.io/hostname is the lowest topology level
-	isLowestLevelNode bool
 
 	// matchingLeavesCache caches the set of qualified leaves for a PodSet
 	// of a Workload to avoid recalculating selectors/taints during preemption simulations or
@@ -172,6 +160,39 @@ type TASFlavorSnapshot struct {
 	feasibilityChecker simulator.NodeFeasibilityChecker
 
 	resourceFormatter *resources.ResourceFormatter
+}
+
+// stateOf returns the snapshot's mutable state of the given shared domain.
+func (s *TASFlavorSnapshot) stateOf(d *domain) *domainState {
+	return &s.state[d.idx]
+}
+
+// leafStateOf returns the snapshot's mutable state of the given shared leaf.
+func (s *TASFlavorSnapshot) leafStateOf(l *leafDomain) *leafState {
+	return &s.leafStates[l.leafIdx]
+}
+
+// candidates yields the snapshot's candidate adapters for all leaves.
+func (s *TASFlavorSnapshot) candidates() iter.Seq[*leafCandidate] {
+	return func(yield func(*leafCandidate) bool) {
+		for i := range s.leafCandidates {
+			if !yield(&s.leafCandidates[i]) {
+				return
+			}
+		}
+	}
+}
+
+// shallowCloneWithState returns a shallow copy of d with independent state
+// initialized from d's current state.
+//
+// WARNING: This may reallocate s.state. Callers must not retain pointers
+// returned by stateOf across this call.
+func (s *TASFlavorSnapshot) shallowCloneWithState(d *domain) *domain {
+	clone := *d
+	clone.idx = len(s.state)
+	s.state = append(s.state, s.state[d.idx])
+	return &clone
 }
 
 type podSetMatchKey struct {
@@ -198,10 +219,13 @@ func withResourceFormatter(formatter *resources.ResourceFormatter) tasFlavorSnap
 	}
 }
 
+// newTASFlavorSnapshot creates a snapshot backed by the shared topology tree,
+// with fresh per-snapshot state: the leaves start at their static capacity
+// with no usage, and the assignment-algorithm scratch state is zeroed.
 func newTASFlavorSnapshot(
 	log logr.Logger,
 	topologyName kueue.TopologyReference,
-	levels []string,
+	tree *topologyTree,
 	tolerations []corev1.Toleration,
 	feasibilityChecker simulator.NodeFeasibilityChecker,
 	opts ...tasFlavorSnapshotOption,
@@ -213,118 +237,30 @@ func newTASFlavorSnapshot(
 		}
 	}
 
-	domainsPerLevel := make([]domainByID, len(levels))
-	for level := range levels {
-		domainsPerLevel[level] = make(domainByID)
-	}
-
 	snapshot := &TASFlavorSnapshot{
 		log:                log,
 		topologyName:       topologyName,
-		levelKeys:          slices.Clone(levels),
-		leaves:             make(leafDomainByID),
+		topologyTree:       tree,
+		state:              make([]domainState, tree.domainCount),
+		leafStates:         make([]leafState, len(tree.leaves)),
+		leafCandidates:     make([]leafCandidate, len(tree.leaves)),
 		tolerations:        slices.Clone(tolerations),
-		domains:            make(domainByID),
-		roots:              make(domainByID),
-		domainsPerLevel:    domainsPerLevel,
-		isLowestLevelNode:  len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
 		feasibilityChecker: feasibilityChecker,
 		resourceFormatter:  options.resourceFormatter,
+	}
+	for _, leaf := range tree.leaves {
+		snapshot.leafStates[leaf.leafIdx].freeCapacity = leaf.capacity.Clone()
+		snapshot.leafCandidates[leaf.leafIdx] = leafCandidate{leaf: leaf, s: snapshot}
 	}
 	return snapshot
 }
 
-func (s *TASFlavorSnapshot) addNode(node *corev1.Node) utiltas.TopologyDomainID {
-	var levelValues []string
-	var domainID utiltas.TopologyDomainID
-	var leafFound bool
-
-	if s.isLowestLevelNode {
-		// When the lowest level is kubernetes.io/hostname, directly extract hostname.
-		hostname := node.Labels[corev1.LabelHostname]
-		domainID = utiltas.TopologyDomainID(hostname)
-		_, leafFound = s.leaves[domainID]
-		// Only compute levelValues when we actually need to create a new leafDomain.
-		if !leafFound {
-			levelValues = utiltas.LevelValues(s.levelKeys, node.Labels)
-		}
-	} else {
-		// Compute full level values and domain ID.
-		levelValues = utiltas.LevelValues(s.levelKeys, node.Labels)
-		domainID = utiltas.DomainID(levelValues)
-		_, leafFound = s.leaves[domainID]
-	}
-	if !leafFound {
-		leafDomain := leafDomain{domain: domain{id: domainID, levelValues: levelValues}}
-
-		if s.isLowestLevelNode {
-			leafDomain.node = node
-		}
-		s.leaves[domainID] = &leafDomain
-	}
-	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
-	s.addCapacity(domainID, capacity)
-	return domainID
-}
-
-func (s *TASFlavorSnapshot) lowestLevel() string {
-	return s.levelKeys[len(s.levelKeys)-1]
-}
-
-func (s *TASFlavorSnapshot) highestLevel() string {
-	return s.levelKeys[0]
-}
-
-// initialize prepares the topology tree structure. This structure holds
-// for a given the list of topology domains with additional static and dynamic
-// information. This function initializes the static information which
-// represents the edges to the parent and child domains. This structure is
-// reused for multiple workloads during a single scheduling cycle.
-func (s *TASFlavorSnapshot) initialize() {
-	for _, leafDomain := range s.leaves {
-		domain := &leafDomain.domain
-		s.domains[domain.id] = domain
-		s.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
-		s.initializeHelper(domain)
-	}
-}
-
-// initializeHelper is a recursive helper for initialize() method
-func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
-	if len(dom.levelValues) == 1 {
-		s.roots[dom.id] = dom
-		return
-	}
-	parentValues := dom.levelValues[:len(dom.levelValues)-1]
-	parentID := utiltas.DomainID(parentValues)
-	parent, parentFound := s.domains[parentID]
-	if !parentFound {
-		// create parent
-		parent = &domain{id: parentID, levelValues: parentValues}
-
-		s.domainsPerLevel[len(parentValues)-1][parentID] = parent
-		s.domains[parentID] = parent
-		s.initializeHelper(parent)
-	}
-	// connect parent and child
-	dom.parent = parent
-	parent.children = append(parent.children, dom)
-}
-
-func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
-	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = resources.CreateEmpty()
-	}
-	s.leaves[domainID].freeCapacity.Add(capacity)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
-}
-
 func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	// The usage for non-TAS pods is only accounted for "TAS" nodes  - with at
-	// least one TAS pod, and so the addCapacity function to initialize
-	// freeCapacity is already called.
-	s.leaves[domainID].freeCapacity.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	// domainID comes from topologyTree.nodeToDomain, while leaves is populated
+	// from the same node set by newTopologyTree, so the corresponding leaf exists.
+	leafState := s.leafStateOf(s.leaves[domainID])
+	leafState.freeCapacity.Sub(usage)
+	leafState.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
@@ -338,11 +274,12 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
-	if leaf.cachedRemainingCapacity.IsEmpty() {
-		leaf.cachedRemainingCapacity = resources.NewLazyRequests(leaf.freeCapacity)
-		leaf.cachedRemainingCapacity.Sub(leaf.tasUsage)
+	leafState := s.leafStateOf(leaf)
+	if leafState.cachedRemainingCapacity.IsEmpty() {
+		leafState.cachedRemainingCapacity = resources.NewLazyRequests(leafState.freeCapacity)
+		leafState.cachedRemainingCapacity.Sub(leafState.tasUsage)
 	}
-	return leaf.cachedRemainingCapacity.Get()
+	return leafState.cachedRemainingCapacity.Get()
 }
 
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -353,11 +290,12 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.CreateEmpty()
+	leafState := s.leafStateOf(s.leaves[domainID])
+	if leafState.tasUsage == nil {
+		leafState.tasUsage = resources.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Add(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	leafState.tasUsage.Add(usage)
+	leafState.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -368,11 +306,12 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.CreateEmpty()
+	leafState := s.leafStateOf(s.leaves[domainID])
+	if leafState.tasUsage == nil {
+		leafState.tasUsage = resources.CreateEmpty()
 	}
-	s.leaves[domainID].tasUsage.Sub(usage)
-	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
+	leafState.tasUsage.Sub(usage)
+	leafState.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 type domainCapacityDetails struct {
@@ -397,9 +336,10 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
+		leafState := s.leafStateOf(leaf)
 		details[domainID] = domainCapacityDetails{
-			FreeCapacity: s.resourceDetails(leaf.freeCapacity),
-			TasUsage:     s.resourceDetails(leaf.tasUsage),
+			FreeCapacity: s.resourceDetails(leafState.freeCapacity),
+			TasUsage:     s.resourceDetails(leafState.tasUsage),
 		}
 	}
 
@@ -1099,12 +1039,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 				// The pre-populated sliceState was computed for the
 				// outermost slice level and is not valid here.
 				for _, d := range sortedLowerDomains {
-					d.sliceState = d.state / sliceSizeOnLevel
-					d.sliceStateWithLeader = d.stateWithLeader / sliceSizeOnLevel
+					dState := s.stateOf(d)
+					dState.sliceState = dState.state / sliceSizeOnLevel
+					dState.sliceStateWithLeader = dState.stateWithLeader / sliceSizeOnLevel
 				}
 			}
 
-			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domain.state, domain.leaderState, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
+			domainState := s.stateOf(domain)
+			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domainState.state, domainState.leaderState, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
 			newCurrFitDomain = append(newCurrFitDomain, addCurrFitDomain...)
 		}
 		currFitDomain = newCurrFitDomain
@@ -1117,14 +1059,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		var workerFitDomains []*domain
 		for _, domain := range currFitDomain {
 			// select domains with leaders
-			if domain.leaderState > 0 {
-				copiedDomain := *domain
-				copiedDomain.state = copiedDomain.leaderState
-				leaderFitDomains = append(leaderFitDomains, &copiedDomain)
+			if leaderState := s.stateOf(domain).leaderState; leaderState > 0 {
+				copiedDomain := s.shallowCloneWithState(domain)
+				s.stateOf(copiedDomain).state = leaderState
+				leaderFitDomains = append(leaderFitDomains, copiedDomain)
 			}
 
 			// select domains with workers
-			if domain.state > 0 {
+			if s.stateOf(domain).state > 0 {
 				workerFitDomains = append(workerFitDomains, domain)
 			}
 		}
@@ -1305,16 +1247,16 @@ func getSliceSizeWithSinglePodAsDefault(tr *kueue.PodSetTopologyRequest) (int32,
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
-func findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domain {
+func (s *TASFlavorSnapshot) findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domain {
 	getState := func(d *domain) int32 {
-		return d.state
+		return s.stateOf(d).state
 	}
 	if leaderCount > 0 {
 		getState = func(d *domain) int32 {
-			return d.stateWithLeader
+			return s.stateOf(d).stateWithLeader
 		}
 	}
-	return findBestFitDomainBy(domains, count, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, count, getState, leaderCount)
 }
 
 // findBestFitDomainForSlices returns the first domain with the smallest
@@ -1322,28 +1264,28 @@ func findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domai
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
-func findBestFitDomainForSlices(domains []*domain, sliceCount int32, leaderCount int32) *domain {
+func (s *TASFlavorSnapshot) findBestFitDomainForSlices(domains []*domain, sliceCount int32, leaderCount int32) *domain {
 	getState := func(d *domain) int32 {
-		return d.sliceState
+		return s.stateOf(d).sliceState
 	}
 	if leaderCount > 0 {
 		getState = func(d *domain) int32 {
-			return d.sliceStateWithLeader
+			return s.stateOf(d).sliceStateWithLeader
 		}
 	}
-	return findBestFitDomainBy(domains, sliceCount, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, sliceCount, getState, leaderCount)
 }
 
-type domainState func(d *domain) int32
+type domainStateGetter func(d *domain) int32
 
-func findBestFitDomainBy(domains []*domain, needed int32, state domainState, leaderCount int32) *domain {
-	candidates := topAffinityTierDomains(domains)
+func (s *TASFlavorSnapshot) findBestFitDomainBy(domains []*domain, needed int32, state domainStateGetter, leaderCount int32) *domain {
+	candidates := s.topAffinityTierDomains(domains)
 	bestDomain := candidates[0]
 	bestDomainState := int32(math.MaxInt32)
 	found := false
 
 	for _, domain := range candidates {
-		if domain.leaderState < leaderCount {
+		if s.stateOf(domain).leaderState < leaderCount {
 			continue
 		}
 		domainState := state(domain)
@@ -1378,9 +1320,9 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 	topDomain := sortedDomain[0]
 
 	sliceCount := state.count / state.sliceSize
-	if useBestFitAlgorithm(state.unconstrained) && topDomain.sliceStateWithLeader >= sliceCount && topDomain.leaderState >= state.leaderCount {
+	if useBestFitAlgorithm(state.unconstrained) && s.stateOf(topDomain).sliceStateWithLeader >= sliceCount && s.stateOf(topDomain).leaderState >= state.leaderCount {
 		// optimize the potentially last domain
-		topDomain = findBestFitDomainForSlices(sortedDomain, sliceCount, state.leaderCount)
+		topDomain = s.findBestFitDomainForSlices(sortedDomain, sliceCount, state.leaderCount)
 	}
 	notFitReason := func(slicesFitCount, totalRequestsSlicesCount int32) string {
 		if len(state.multiLayerConstraints) > 0 {
@@ -1391,34 +1333,35 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 
 	if useLeastFreeCapacityAlgorithm(state.unconstrained) {
 		for _, candidateDomain := range sortedDomain {
-			candidateCapacity := candidateDomain.sliceState
+			candidateDomainState := s.stateOf(candidateDomain)
+			candidateCapacity := candidateDomainState.sliceState
 			if state.leaderCount > 0 {
-				if candidateDomain.leaderState < state.leaderCount {
+				if candidateDomainState.leaderState < state.leaderCount {
 					continue
 				}
-				candidateCapacity = candidateDomain.sliceStateWithLeader
+				candidateCapacity = candidateDomainState.sliceStateWithLeader
 			}
 			if candidateCapacity >= sliceCount {
 				return searchLevelIdx, []*domain{candidateDomain}, ""
 			}
 		}
 		if state.required {
-			maxCapacityFound := sortedDomain[len(sortedDomain)-1].state
+			maxCapacityFound := s.stateOf(sortedDomain[len(sortedDomain)-1]).state
 			return 0, nil, notFitReason(maxCapacityFound, sliceCount)
 		}
 	}
-	if topDomain.sliceStateWithLeader < sliceCount || topDomain.leaderState < state.leaderCount {
+	if s.stateOf(topDomain).sliceStateWithLeader < sliceCount || s.stateOf(topDomain).leaderState < state.leaderCount {
 		if state.required {
 			// Scan remaining domains to support preferred affinity before failing
 			if features.Enabled(features.TASRespectNodeAffinityPreferred) {
 				for i := 1; i < len(sortedDomain); i++ {
 					d := sortedDomain[i]
-					if d.sliceStateWithLeader >= sliceCount && d.leaderState >= state.leaderCount {
-						return searchLevelIdx, []*domain{findBestFitDomainForSlices(sortedDomain[i:], sliceCount, state.leaderCount)}, ""
+					if s.stateOf(d).sliceStateWithLeader >= sliceCount && s.stateOf(d).leaderState >= state.leaderCount {
+						return searchLevelIdx, []*domain{s.findBestFitDomainForSlices(sortedDomain[i:], sliceCount, state.leaderCount)}, ""
 					}
 				}
 			}
-			return 0, nil, notFitReason(topDomain.sliceState, sliceCount)
+			return 0, nil, notFitReason(s.stateOf(topDomain).sliceState, sliceCount)
 		}
 		if searchLevelIdx > 0 && !state.unconstrained {
 			return s.findLevelWithFitDomains(searchLevelIdx-1, state)
@@ -1429,22 +1372,22 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		// Prioritize before selecting the fitting set, since later descent cannot
 		// recover a feasible leader domain omitted here. updateCountsToMinimumGeneric
 		// repeats this for each newly produced domain set during descent.
-		sortedDomain = prioritizeLeaderDomain(sortedDomain, state.count, state.leaderCount, state.sliceSize, true)
+		sortedDomain = s.prioritizeLeaderDomain(sortedDomain, state.count, state.leaderCount, state.sliceSize, true)
 
 		// Assign leaders first from a domain that preserves total worker capacity.
 		// After assigning all leaders, sort the remaining domains by worker capacity
 		// and assign the remaining workers.
 		idx := 0
-		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && sortedDomain[idx].leaderState > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && s.stateOf(sortedDomain[idx]).leaderState > 0; idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && sortedDomain[idx].sliceStateWithLeader >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.stateOf(sortedDomain[idx]).sliceStateWithLeader >= remainingSliceCount {
 				// optimize the last domain
-				domain = findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, remainingLeaderCount)
+				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, remainingLeaderCount)
 			}
 			results = append(results, domain)
 
-			remainingLeaderCount -= domain.leaderState
-			remainingSliceCount -= domain.sliceStateWithLeader
+			remainingLeaderCount -= s.stateOf(domain).leaderState
+			remainingSliceCount -= s.stateOf(domain).sliceStateWithLeader
 		}
 		if remainingLeaderCount > 0 {
 			return 0, nil, notFitReason(state.leaderCount-remainingLeaderCount, sliceCount)
@@ -1455,13 +1398,13 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained)
 		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain); idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && sortedDomain[idx].sliceState >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.stateOf(sortedDomain[idx]).sliceState >= remainingSliceCount {
 				// optimize the last domain
-				domain = findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, 0)
+				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, 0)
 			}
 			results = append(results, domain)
 
-			remainingSliceCount -= domain.sliceState
+			remainingSliceCount -= s.stateOf(domain).sliceState
 		}
 		if remainingSliceCount > 0 {
 			return 0, nil, notFitReason(sliceCount-remainingSliceCount, sliceCount)
@@ -1478,13 +1421,13 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 // consecutive matches from the beginning and truncates the slice as soon as the score drops.
 // This prevents the capacity-focused BestFit algorithm from optimizing across affinity tiers,
 // guaranteeing that affinity scores take absolute precedence over capacity minimization.
-func topAffinityTierDomains(candidates []*domain) []*domain {
+func (s *TASFlavorSnapshot) topAffinityTierDomains(candidates []*domain) []*domain {
 	if !features.Enabled(features.TASRespectNodeAffinityPreferred) || len(candidates) == 0 {
 		return candidates
 	}
-	score := candidates[0].affinityScore
+	score := s.stateOf(candidates[0]).affinityScore
 	for i, c := range candidates {
-		if c.affinityScore != score {
+		if s.stateOf(c).affinityScore != score {
 			return candidates[:i]
 		}
 	}
@@ -1509,11 +1452,9 @@ func useLeastFreeCapacityAlgorithm(unconstrained bool) bool {
 // Parameters:
 //   - domain: the domain being consumed
 //   - remainingDomains: the slice of domains that are still eligible for best-fit optimization
-//   - withLeader: pointer to the domain field that represents capacity with a leader present
-//     (use &domain.stateWithLeader for pods, &domain.sliceStateWithLeader for slices)
-//   - primary: pointer to the domain field that represents the primary unit being distributed
-//     (use &domain.state for pods, &domain.sliceState for slices)
-//   - sliceSize: factor to set domain.state when finalizing or partially consuming
+//   - withLeader: pointer to the per-snapshot capacity with a leader present
+//   - primary: pointer to the per-snapshot primary unit being distributed
+//   - sliceSize: factor to set the pod count when finalizing or partially consuming
 //     (use 1 for pods, the actual sliceSize for slices)
 //   - slices: whether we're distributing slices (true) or pods (false)
 func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
@@ -1527,35 +1468,35 @@ func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
 	sliceSize int32,
 	slices bool,
 ) (*domain, bool) {
-	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && domain.leaderState >= *remainingLeaderCount {
+	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && s.stateOf(domain).leaderState >= *remainingLeaderCount {
 		// optimize the last domain
 		if slices {
-			domain = findBestFitDomainForSlices(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &domain.sliceStateWithLeader
-			primary = &domain.sliceState
+			domain = s.findBestFitDomainForSlices(remainingDomains, *remainingPrimary, *remainingLeaderCount)
+			withLeader = &s.stateOf(domain).sliceStateWithLeader
+			primary = &s.stateOf(domain).sliceState
 		} else {
-			domain = findBestFitDomain(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &domain.stateWithLeader
-			primary = &domain.state
+			domain = s.findBestFitDomain(remainingDomains, *remainingPrimary, *remainingLeaderCount)
+			withLeader = &s.stateOf(domain).stateWithLeader
+			primary = &s.stateOf(domain).state
 		}
 	}
 
-	if *withLeader >= *remainingPrimary && domain.leaderState >= *remainingLeaderCount {
+	domainState := s.stateOf(domain)
+	if *withLeader >= *remainingPrimary && domainState.leaderState >= *remainingLeaderCount {
 		*primary = *remainingPrimary
-		domain.leaderState = *remainingLeaderCount
-		domain.state = *remainingPrimary * sliceSize
+		domainState.leaderState = *remainingLeaderCount
+		domainState.state = *remainingPrimary * sliceSize
 		return domain, true
 	}
-
 	if *withLeader > *remainingPrimary {
 		*withLeader = *remainingPrimary
 	}
-	if domain.leaderState > *remainingLeaderCount {
-		domain.leaderState = *remainingLeaderCount
+	if domainState.leaderState > *remainingLeaderCount {
+		domainState.leaderState = *remainingLeaderCount
 	}
 	*primary = *withLeader
-	domain.state = *withLeader * sliceSize
-	*remainingLeaderCount -= domain.leaderState
+	domainState.state = *withLeader * sliceSize
+	*remainingLeaderCount -= domainState.leaderState
 	*remainingPrimary -= *withLeader
 	return domain, false
 }
@@ -1563,7 +1504,7 @@ func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
 // prioritizeLeaderDomain preserves the capacity summarized by fillInCountsHelper.
 // That summary subtracts the smallest eligible child leader penalty, so descent
 // must select a leader-capable domain whose penalty fits within the available slack.
-func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int32, slicesEnabled bool) []*domain {
+func (s *TASFlavorSnapshot) prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int32, slicesEnabled bool) []*domain {
 	if leaderCount == 0 || len(domains) < 2 {
 		return domains
 	}
@@ -1573,21 +1514,22 @@ func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int
 	if slicesEnabled {
 		requiredCapacity /= sliceSize
 		for _, domain := range domains {
-			availableCapacity += domain.sliceState
+			availableCapacity += s.stateOf(domain).sliceState
 		}
 	} else {
 		for _, domain := range domains {
-			availableCapacity += domain.state
+			availableCapacity += s.stateOf(domain).state
 		}
 	}
 
 	for i, domain := range domains {
-		if domain.leaderState < leaderCount {
+		domainState := s.stateOf(domain)
+		if domainState.leaderState < leaderCount {
 			continue
 		}
-		leaderPenalty := domain.state - domain.stateWithLeader
+		leaderPenalty := domainState.state - domainState.stateWithLeader
 		if slicesEnabled {
-			leaderPenalty = domain.sliceState - domain.sliceStateWithLeader
+			leaderPenalty = domainState.sliceState - domainState.sliceStateWithLeader
 		}
 		if availableCapacity-leaderPenalty < requiredCapacity {
 			continue
@@ -1605,7 +1547,7 @@ func prioritizeLeaderDomain(domains []*domain, count, leaderCount, sliceSize int
 }
 
 func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, count int32, leaderCount int32, sliceSize int32, unconstrained bool, slices bool) []*domain {
-	domains = prioritizeLeaderDomain(domains, count, leaderCount, sliceSize, slices)
+	domains = s.prioritizeLeaderDomain(domains, count, leaderCount, sliceSize, slices)
 	result := make([]*domain, 0)
 	remainingPrimary := count
 	if slices {
@@ -1618,9 +1560,19 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 			var d *domain
 			var completed bool
 			if slices {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &dom.sliceStateWithLeader, &dom.sliceState, sliceSize, true)
+				d, completed = s.consumeWithLeadersGeneric(
+					dom,
+					domains[i:],
+					&remainingPrimary,
+					&remainingLeaderCount,
+					unconstrained,
+					&s.stateOf(dom).sliceStateWithLeader,
+					&s.stateOf(dom).sliceState,
+					sliceSize,
+					true,
+				)
 			} else {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &dom.stateWithLeader, &dom.state, 1, false)
+				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &s.stateOf(dom).stateWithLeader, &s.stateOf(dom).state, 1, false)
 			}
 			result = append(result, d)
 			if completed {
@@ -1631,35 +1583,37 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 
 		// No leaders remaining: handle tail without leaders
 		if slices {
-			if useBestFitAlgorithm(unconstrained) && dom.sliceState >= remainingPrimary {
+			if useBestFitAlgorithm(unconstrained) && s.stateOf(dom).sliceState >= remainingPrimary {
 				// optimize the last domain
-				dom = findBestFitDomainForSlices(domains[i:], remainingPrimary, 0)
+				dom = s.findBestFitDomainForSlices(domains[i:], remainingPrimary, 0)
 			}
-			dom.leaderState = 0
-			if dom.sliceState >= remainingPrimary {
-				dom.state = remainingPrimary * sliceSize
-				dom.sliceState = remainingPrimary
+			domState := s.stateOf(dom)
+			domState.leaderState = 0
+			if domState.sliceState >= remainingPrimary {
+				domState.state = remainingPrimary * sliceSize
+				domState.sliceState = remainingPrimary
 				result = append(result, dom)
 				return result
 			}
-			dom.state = dom.sliceState * sliceSize
-			remainingPrimary -= dom.sliceState
+			domState.state = domState.sliceState * sliceSize
+			remainingPrimary -= domState.sliceState
 			result = append(result, dom)
 			continue
 		}
 
 		// pods (slices=false)
-		if useBestFitAlgorithm(unconstrained) && dom.state >= remainingPrimary {
+		if useBestFitAlgorithm(unconstrained) && s.stateOf(dom).state >= remainingPrimary {
 			// optimize the last domain
-			dom = findBestFitDomain(domains[i:], remainingPrimary, 0)
+			dom = s.findBestFitDomain(domains[i:], remainingPrimary, 0)
 		}
-		dom.leaderState = 0
-		if dom.state >= remainingPrimary {
-			dom.state = remainingPrimary
+		domState := s.stateOf(dom)
+		domState.leaderState = 0
+		if domState.state >= remainingPrimary {
+			domState.state = remainingPrimary
 			result = append(result, dom)
 			return result
 		}
-		remainingPrimary -= dom.state
+		remainingPrimary -= domState.state
 		result = append(result, dom)
 	}
 	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
@@ -1678,13 +1632,13 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 	}
 	assignment.Levels = s.levelKeys[levelIdx:]
 	for _, domain := range domains {
-		if domain.state == 0 {
+		if s.stateOf(domain).state == 0 {
 			// It may happen when PodSet count is 0 or when using LeastFreeCapacity algorithm.
 			continue
 		}
 		assignment.Domains = append(assignment.Domains, utiltas.TopologyDomainAssignment{
 			Values: domain.levelValues[levelIdx:],
-			Count:  domain.state,
+			Count:  s.stateOf(domain).state,
 		})
 	}
 	return assignment
@@ -1725,25 +1679,26 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if a.leaderState != b.leaderState {
-			return cmp.Compare(b.leaderState, a.leaderState)
+		aState, bState := s.stateOf(a), s.stateOf(b)
+		if aState.leaderState != bState.leaderState {
+			return cmp.Compare(bState.leaderState, aState.leaderState)
 		}
 
-		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
-			return cmp.Compare(b.affinityScore, a.affinityScore)
+		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
+			return cmp.Compare(bState.affinityScore, aState.affinityScore)
 		}
 
-		if a.sliceStateWithLeader != b.sliceStateWithLeader {
+		if aState.sliceStateWithLeader != bState.sliceStateWithLeader {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(a.sliceStateWithLeader, b.sliceStateWithLeader)
+				return cmp.Compare(aState.sliceStateWithLeader, bState.sliceStateWithLeader)
 			}
-			return cmp.Compare(b.sliceStateWithLeader, a.sliceStateWithLeader)
+			return cmp.Compare(bState.sliceStateWithLeader, aState.sliceStateWithLeader)
 		}
 
-		if a.stateWithLeader != b.stateWithLeader {
-			return cmp.Compare(a.stateWithLeader, b.stateWithLeader)
+		if aState.stateWithLeader != bState.stateWithLeader {
+			return cmp.Compare(aState.stateWithLeader, bState.stateWithLeader)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1763,21 +1718,22 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		if respectNodeAffinityPreferred && a.affinityScore != b.affinityScore {
-			return cmp.Compare(b.affinityScore, a.affinityScore)
+		aState, bState := s.stateOf(a), s.stateOf(b)
+		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
+			return cmp.Compare(bState.affinityScore, aState.affinityScore)
 		}
 
-		if a.sliceState != b.sliceState {
+		if aState.sliceState != bState.sliceState {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(a.sliceState, b.sliceState)
+				return cmp.Compare(aState.sliceState, bState.sliceState)
 			}
-			return cmp.Compare(b.sliceState, a.sliceState)
+			return cmp.Compare(bState.sliceState, aState.sliceState)
 		}
 
-		if a.state != b.state {
-			return cmp.Compare(a.state, b.state)
+		if aState.state != bState.state {
+			return cmp.Compare(aState.state, bState.state)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1788,16 +1744,11 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 // fillInCounts computes per-domain pod, slice, and leader capacities from the
 // pod requirements, then rolls those capacities up the topology tree.
 func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) error {
-	for _, domain := range s.domains {
-		// cleanup the state in case some remaining values are present from computing
-		// assignments for previous PodSets.
-		domain.state = 0
-		domain.stateWithLeader = 0
-		domain.sliceState = 0
-		domain.sliceStateWithLeader = 0
-		domain.leaderState = 0
-		domain.affinityScore = 0
-	}
+	// cleanup the state in case some remaining values are present from computing
+	// assignments for previous PodSets. Truncating to discard the state
+	// slots of domain copies made for the previous PodSet.
+	s.state = s.state[:s.domainCount]
+	clear(s.state)
 	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
 	if features.Enabled(features.TASCacheNodeMatchResults) {
 		matchingLeaves, stats, err := s.getMatchingLeaves(ctx, requirements)
@@ -1807,12 +1758,12 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
 			leaf := s.leaves[ml.GetID()]
-			leaf.affinityScore += ml.GetAffinityScore()
+			s.stateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
 		if s.isLowestLevelNode {
-			feasibleLeaves, err := s.feasibilityChecker.FindFeasibleNodes(ctx, simulator.AsCandidates(maps.Values(s.leaves)), &requirements.podRequirements, &state.stats.NodeExclusionStats)
+			feasibleLeaves, err := s.feasibilityChecker.FindFeasibleNodes(ctx, simulator.AsCandidates(s.candidates()), &requirements.podRequirements, &state.stats.NodeExclusionStats)
 
 			if err != nil {
 				return err
@@ -1820,13 +1771,13 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 
 			for _, ml := range feasibleLeaves {
 				leaf := s.leaves[ml.GetID()]
-				leaf.affinityScore += ml.GetAffinityScore()
+				s.stateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 				s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 			}
 		} else {
 			state.stats.TotalNodes += len(s.leaves)
-			for _, leaf := range s.leaves {
-				s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
+			for candidate := range s.candidates() {
+				s.fillLeafCounts(candidate.leaf, requirements, state, cachingRemainingResourcesEnabled)
 			}
 		}
 	}
@@ -1842,8 +1793,8 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 		stats := newTASExclusionStats()
 		stats.TotalNodes += len(s.leaves)
 		result := make([]simulator.MatchedCandidate, 0, len(s.leaves))
-		for _, leaf := range s.leaves {
-			result = append(result, leaf)
+		for candidate := range s.candidates() {
+			result = append(result, candidate)
 		}
 		return result, stats, nil
 	}
@@ -1857,7 +1808,7 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 
 	leafStats := newTASExclusionStats()
 	var err error
-	feasibleLeaves, err := s.feasibilityChecker.FindFeasibleNodes(ctx, simulator.AsCandidates(maps.Values(s.leaves)), &requirements.podRequirements, &leafStats.NodeExclusionStats)
+	feasibleLeaves, err := s.feasibilityChecker.FindFeasibleNodes(ctx, simulator.AsCandidates(s.candidates()), &requirements.podRequirements, &leafStats.NodeExclusionStats)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1877,15 +1828,16 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 }
 
 func (s *TASFlavorSnapshot) remainingCapacityForLeaf(leaf *leafDomain, simulateEmpty, cachingRemainingResourcesEnabled bool) resources.LazyRequests {
+	leafState := s.leafStateOf(leaf)
 	if cachingRemainingResourcesEnabled {
 		if simulateEmpty {
-			return resources.NewLazyRequests(leaf.freeCapacity)
+			return resources.NewLazyRequests(leafState.freeCapacity)
 		}
 		return resources.NewLazyRequests(s.getRemainingCapacity(leaf))
 	}
-	remainingCapacity := resources.NewLazyRequests(leaf.freeCapacity)
+	remainingCapacity := resources.NewLazyRequests(leafState.freeCapacity)
 	if !simulateEmpty {
-		remainingCapacity.Sub(leaf.tasUsage)
+		remainingCapacity.Sub(leafState.tasUsage)
 	}
 	return remainingCapacity
 }
@@ -1903,21 +1855,22 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		remainingCapacity.Sub(leafAssumedUsage)
 	}
 	var limitingRes corev1.ResourceName
-	leaf.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
+	leafDomainState := s.stateOf(&leaf.domain)
+	leafDomainState.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
 
 	// Track resource exclusions: if this node can't fit even one pod,
 	// identify which resource is the bottleneck.
-	if leaf.state == 0 && limitingRes != "" {
+	if leafDomainState.state == 0 && limitingRes != "" {
 		state.stats.recordResourceExclusion(limitingRes)
 	}
 
-	leaf.leaderState = 0
+	leafDomainState.leaderState = 0
 	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity.Get()) > 0 {
-		leaf.leaderState = 1
+		leafDomainState.leaderState = 1
 		remainingCapacity.Sub(requirements.leaderRequests)
 	}
 
-	leaf.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
+	leafDomainState.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
 }
 
 func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {
@@ -1930,12 +1883,13 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {
+	domainState := s.stateOf(domain)
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
 			// initialize the sliceState if leaf is the request slice level
-			domain.sliceState = domain.state / sliceSize
-			domain.sliceStateWithLeader = domain.stateWithLeader / sliceSize
+			domainState.sliceState = domainState.state / sliceSize
+			domainState.sliceStateWithLeader = domainState.stateWithLeader / sliceSize
 		}
 		return
 	}
@@ -1958,40 +1912,41 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	for _, child := range domain.children {
 		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, childLevel, sliceSizeAtLevel, leaderRequired)
 
-		childState := child.state
-		childStateWithLeader := child.stateWithLeader
+		childDomainState := s.stateOf(child)
+		childState := childDomainState.state
+		childStateWithLeader := childDomainState.stateWithLeader
 		if hasInnerConstraint {
-			childState = (child.state / innerSize) * innerSize
-			childStateWithLeader = (child.stateWithLeader / innerSize) * innerSize
+			childState = (childDomainState.state / innerSize) * innerSize
+			childStateWithLeader = (childDomainState.stateWithLeader / innerSize) * innerSize
 		}
 
 		childrenCapacity += childState
-		sliceCapacity += child.sliceState
-		if !leaderRequired || child.leaderState > 0 {
+		sliceCapacity += childDomainState.sliceState
+		if !leaderRequired || childDomainState.leaderState > 0 {
 			hasWithLeaderCapacityContributor = true
 			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
-			minSliceStateWithLeaderDifference = min(child.sliceState-child.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+			minSliceStateWithLeaderDifference = min(childDomainState.sliceState-childDomainState.sliceStateWithLeader, minSliceStateWithLeaderDifference)
 		}
-		leaderState = max(child.leaderState, leaderState)
-		affinityScore += child.affinityScore
+		leaderState = max(childDomainState.leaderState, leaderState)
+		affinityScore += childDomainState.affinityScore
 	}
-	domain.state = childrenCapacity
+	domainState.state = childrenCapacity
 	sliceStateWithLeader := int32(0)
 	if hasWithLeaderCapacityContributor {
-		domain.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
+		domainState.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
 		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
 	} else {
-		domain.stateWithLeader = 0
+		domainState.stateWithLeader = 0
 	}
-	domain.leaderState = leaderState
-	domain.affinityScore = affinityScore
+	domainState.leaderState = leaderState
+	domainState.affinityScore = affinityScore
 	if level == sliceLevelIdx {
 		// initialize the sliceState for the requested slice level.
-		sliceCapacity = domain.state / sliceSize
-		sliceStateWithLeader = domain.stateWithLeader / sliceSize
+		sliceCapacity = domainState.state / sliceSize
+		sliceStateWithLeader = domainState.stateWithLeader / sliceSize
 	}
-	domain.sliceState = sliceCapacity
-	domain.sliceStateWithLeader = sliceStateWithLeader
+	domainState.sliceState = sliceCapacity
+	domainState.sliceStateWithLeader = sliceStateWithLeader
 }
 
 func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCount, sliceSize int32, stats *tasExclusionStats) string {
@@ -2016,13 +1971,13 @@ func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCou
 	return builder.String()
 }
 
-func countSlicesInSubtree(d *domain, currentLevel, targetLevel int, sliceSize int32) int32 {
+func (s *TASFlavorSnapshot) countSlicesInSubtree(d *domain, currentLevel, targetLevel int, sliceSize int32) int32 {
 	if currentLevel == targetLevel {
-		return d.state / sliceSize
+		return s.stateOf(d).state / sliceSize
 	}
 	var total int32
 	for _, child := range d.children {
-		total += countSlicesInSubtree(child, currentLevel+1, targetLevel, sliceSize)
+		total += s.countSlicesInSubtree(child, currentLevel+1, targetLevel, sliceSize)
 	}
 	return total
 }
@@ -2041,8 +1996,8 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 	// domainsPerLevel is map-backed and iteration order is random.
 	var bestDomain *domain
 	for _, d := range s.domainsPerLevel[requiredLevelIdx] {
-		if bestDomain == nil || d.sliceState > bestDomain.sliceState ||
-			(d.sliceState == bestDomain.sliceState && d.id < bestDomain.id) {
+		if bestDomain == nil || s.stateOf(d).sliceState > s.stateOf(bestDomain).sliceState ||
+			(s.stateOf(d).sliceState == s.stateOf(bestDomain).sliceState && d.id < bestDomain.id) {
 			bestDomain = d
 		}
 	}
@@ -2056,7 +2011,7 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 			continue
 		}
 		neededSlices := count / c.Size
-		fitSlices := countSlicesInSubtree(bestDomain, requiredLevelIdx, targetLevelIdx, c.Size)
+		fitSlices := s.countSlicesInSubtree(bestDomain, requiredLevelIdx, targetLevelIdx, c.Size)
 		fmt.Fprintf(&builder, "; %d/%d slice(s) fit on level %s", fitSlices, neededSlices, c.Topology)
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -19,11 +19,15 @@ package scheduler
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
@@ -41,6 +45,14 @@ type benchTopology struct {
 	racksPerBlock  int
 	flavors        int
 	withNonTASPods bool
+}
+
+type benchSnapshotMode struct {
+	name            string
+	heartbeatUpdate bool
+	// invalidationPeriod bumps the nodesCache generation on every cycle that is a
+	// multiple of it; 0 never invalidates.
+	invalidationPeriod int
 }
 
 func buildBenchNodes(t benchTopology) []corev1.Node {
@@ -73,6 +85,12 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16, flavors: 15, withNonTASPods: true},
 		{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16},
 	}
+	modes := []benchSnapshotMode{
+		{name: "reuse"},
+		{name: "heartbeat", heartbeatUpdate: true},
+		{name: "invalidate-every-cycle", invalidationPeriod: 1},
+		{name: "invalidate-every-2-cycles", invalidationPeriod: 2},
+	}
 
 	for _, topo := range topologies {
 		flavors := max(1, topo.flavors)
@@ -80,48 +98,168 @@ func BenchmarkTASFlavorSnapshot(b *testing.B) {
 		if topo.withNonTASPods {
 			name += "/withNonTASPods"
 		}
-		b.Run(name, func(b *testing.B) {
-			b.ReportAllocs()
-			log := logr.Discard()
+		for _, mode := range modes {
+			runBenchmarkTASFlavorSnapshot(b, topo, flavors, fmt.Sprintf("%s/mode=%s", name, mode.name), mode)
+		}
+	}
+}
 
-			nodes := buildBenchNodes(topo)
-			levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+func runBenchmarkTASFlavorSnapshot(b *testing.B, topo benchTopology, flavors int, name string, mode benchSnapshotMode) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		log := logr.Discard()
 
-			tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+		nodes := buildBenchNodes(topo)
+		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+
+		tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+		for i := range nodes {
+			tasCache.SyncNode(&nodes[i])
+		}
+
+		if topo.withNonTASPods {
 			for i := range nodes {
-				tasCache.SyncNode(&nodes[i])
+				pod := testingpod.MakePod(fmt.Sprintf("bg-%d", i), "default").
+					NodeName(nodes[i].Name).
+					Request(corev1.ResourceCPU, "1").
+					Request(corev1.ResourceMemory, "1Gi").
+					StatusPhase(corev1.PodRunning).
+					Obj()
+				tasCache.UpdateNonTASUsage(pod, log)
 			}
+		}
 
-			if topo.withNonTASPods {
-				for i := range nodes {
-					pod := testingpod.MakePod(fmt.Sprintf("bg-%d", i), "default").
-						NodeName(nodes[i].Name).
-						Request(corev1.ResourceCPU, "1").
-						Request(corev1.ResourceMemory, "1Gi").
-						StatusPhase(corev1.PodRunning).
-						Obj()
-					tasCache.UpdateNonTASUsage(pod, log)
+		flavorCaches := make([]*TASFlavorCache, flavors)
+		for i := range flavorCaches {
+			flavorCaches[i] = tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: levels},
+				flavorInformation{TopologyName: "default"},
+			)
+		}
+
+		// Build the initial tree outside the timed loop. This makes reuse a
+		// cache-hit-only benchmark and gives the update modes a tree to
+		// invalidate.
+		for _, flavorCache := range flavorCaches {
+			if _, err := flavorCache.snapshot(b.Context(), log, nil); err != nil {
+				b.Fatalf("initial TASFlavorSnapshot creation failed: %v", err)
+			}
+		}
+
+		// Only fields dropped by copyAndStripNode differ, so syncing this must not
+		// bump the nodesCache generation.
+		heartbeatNode := (&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+			ResourceVersion("heartbeat").
+			ConditionHeartbeat(corev1.NodeReady, metav1.NewTime(time.Unix(1, 0))).
+			Obj()
+		invalidatingNodes := []*corev1.Node{
+			(&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("97")}).Obj(),
+			(&testingnode.NodeWrapper{Node: *nodes[0].DeepCopy()}).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("96")}).Obj(),
+		}
+
+		cycle := 0
+		for b.Loop() {
+			switch {
+			case mode.heartbeatUpdate:
+				tasCache.SyncNode(heartbeatNode)
+			case mode.invalidationPeriod > 0 && cycle%mode.invalidationPeriod == 0:
+				update := cycle / mode.invalidationPeriod
+				tasCache.SyncNode(invalidatingNodes[update%len(invalidatingNodes)])
+			}
+			for _, flavorCache := range flavorCaches {
+				if _, err := flavorCache.snapshot(b.Context(), log, nil); err != nil {
+					b.Fatalf("TASFlavorSnapshot creation failed: %v", err)
 				}
 			}
+			cycle++
+		}
+	})
+}
 
-			flavorCaches := make([]*TASFlavorCache, flavors)
-			for i := range flavorCaches {
-				flavorCaches[i] = tasCache.NewTASFlavorCache(
-					topologyInformation{Levels: levels},
-					flavorInformation{TopologyName: "default"},
-				)
-			}
+func BenchmarkTASFlavorAssignment(b *testing.B) {
+	features.SetFeatureGateDuringTest(b, features.TASBalancedPlacement, true)
 
-			flavorNodes := make([][]*corev1.Node, len(flavorCaches))
-			for i, flavorCache := range flavorCaches {
-				flavorNodes[i] = tasCache.nodesCache.find(flavorCache.flavor.NodeLabels, flavorCache.topology.Levels)
-			}
+	benchmarks := []struct {
+		name       string
+		topology   benchTopology
+		withLeader bool
+	}{
+		{name: "nodes=100/workersOnly", topology: benchTopology{nodes: 100, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=500/workersOnly", topology: benchTopology{nodes: 500, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=2500/workersOnly", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}},
+		{name: "nodes=2500/withLeader", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}, withLeader: true},
+	}
+	for _, benchmark := range benchmarks {
+		runBenchmarkTASFlavorAssignment(b, benchmark.topology, benchmark.name, benchmark.withLeader)
+	}
+}
 
-			for b.Loop() {
-				for i, flavorCache := range flavorCaches {
-					_, _ = flavorCache.snapshot(b.Context(), log, flavorNodes[i], nil)
-				}
-			}
+func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name string, withLeader bool) {
+	b.Run(name, func(b *testing.B) {
+		b.ReportAllocs()
+		log := logr.Discard()
+		nodes := buildBenchNodes(topo)
+		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+
+		tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+		for i := range nodes {
+			tasCache.SyncNode(&nodes[i])
+		}
+		flavorCache := tasCache.NewTASFlavorCache(
+			topologyInformation{Levels: levels},
+			flavorInformation{TopologyName: "default"},
+		)
+		snapshot, err := flavorCache.snapshot(b.Context(), log, nil)
+		if err != nil {
+			b.Fatalf("TASFlavorSnapshot creation failed: %v", err)
+		}
+
+		requests := balancedPlacementBenchRequests(topo, withLeader)
+		result := snapshot.FindTopologyAssignmentsForFlavor(b.Context(), requests)
+		if failure := result.Failure(); failure != nil {
+			b.Fatalf("balanced placement preflight failed: %s", failure.Reason)
+		}
+		if len(snapshot.state) == len(snapshot.domains) {
+			b.Fatal("balanced placement preflight did not clone domain state")
+		}
+
+		for b.Loop() {
+			result = snapshot.FindTopologyAssignmentsForFlavor(b.Context(), requests)
+		}
+		if failure := result.Failure(); failure != nil {
+			b.Fatalf("repeated balanced placement failed: %s", failure.Reason)
+		}
+	})
+}
+
+func balancedPlacementBenchRequests(topo benchTopology, withLeader bool) FlavorTASRequests {
+	preferredLevel := benchRackLabel
+	groupName := "benchmark-group"
+	nodesInBlock := min(topo.nodes, topo.nodesPerRack*topo.racksPerBlock)
+	requests := FlavorTASRequests{{
+		PodSet: &kueue.PodSet{
+			Name: "workers",
+			TopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: &preferredLevel,
+			},
+		},
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU: 8000,
+		}),
+		Count:           int32(nodesInBlock * 9),
+		PodSetGroupName: &groupName,
+	}}
+	if withLeader {
+		requests = append(requests, TASPodSetRequests{
+			PodSet: &kueue.PodSet{Name: "leader"},
+			SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+				corev1.ResourceCPU: 72000,
+			}),
+			Count:           1,
+			PodSetGroupName: &groupName,
 		})
 	}
+	return requests
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -35,17 +35,46 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
+type testDomainSpec struct {
+	domain domain
+	state  domainState
+}
+
+func addDomainsWithState(s *TASFlavorSnapshot, specs []testDomainSpec) []*domain {
+	result := make([]*domain, len(specs))
+	for i, spec := range specs {
+		d := spec.domain
+		d.idx = len(s.state)
+		s.state = append(s.state, spec.state)
+		result[i] = &d
+	}
+	return result
+}
+
+func newFreeCapacityTestSnapshot(states map[tas.TopologyDomainID]leafState) *TASFlavorSnapshot {
+	leaves := make(leafDomainByID, len(states))
+	leafStates := make([]leafState, 0, len(states))
+	for id, state := range states {
+		leaves[id] = &leafDomain{domain: domain{id: id}, leafIdx: len(leafStates)}
+		leafStates = append(leafStates, state)
+	}
+	return &TASFlavorSnapshot{
+		topologyTree: &topologyTree{leaves: leaves},
+		leafStates:   leafStates,
+	}
+}
+
 func TestFreeCapacityPerDomain(t *testing.T) {
 	cases := map[string]struct {
-		// leaves is a function, so that the requests are built with the
+		// snapshot is a function, so that the requests are built with the
 		// VectorizedResourceRequests feature gate already set.
-		leaves   func() leafDomainByID
+		snapshot func() *TASFlavorSnapshot
 		expected string
 	}{
 		"domains with free capacity and TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{
-					"domain2": &leafDomain{
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{
+					"domain2": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    1000,
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 2 GiB
@@ -55,7 +84,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 							corev1.ResourceCPU:    500,
 						}),
 					},
-					"domain1": &leafDomain{
+					"domain1": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceMemory: 4 * 1024 * 1024 * 1024, // 4 GiB
 							corev1.ResourceCPU:    2000,
@@ -67,32 +96,34 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 							corev1.ResourceMemory: 2 * 1024 * 1024 * 1024, // 1 GiB
 						}),
 					},
-				}
+				})
 			},
 			expected: `{"domain1":{"freeCapacity":{"cpu":"2","memory":"4Gi","nvidia.com/gpu":"1"},"tasUsage":{"cpu":"500m","memory":"2Gi","nvidia.com/gpu":"1"}},"domain2":{"freeCapacity":{"cpu":"1","memory":"2Gi"},"tasUsage":{"cpu":"500m","memory":"1Gi"}}}`,
 		},
 		"domain with free capacity, but without TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{
-					"domain1": &leafDomain{
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{
+					"domain1": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1000,
 						}),
 						// tasUsage is left nil, as there is no TAS workload
 						// admitted in the domain.
 					},
-				}
+				})
 			},
 			expected: `{"domain1":{"freeCapacity":{"cpu":"1"},"tasUsage":{}}}`,
 		},
 		"domain without free capacity and without TAS usage": {
-			leaves: func() leafDomainByID {
-				return leafDomainByID{"domain1": &leafDomain{}}
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{"domain1": {}})
 			},
 			expected: `{"domain1":{"freeCapacity":{},"tasUsage":{}}}`,
 		},
 		"snapshot without domains": {
-			leaves:   func() leafDomainByID { return leafDomainByID{} },
+			snapshot: func() *TASFlavorSnapshot {
+				return newFreeCapacityTestSnapshot(nil)
+			},
 			expected: `{}`,
 		},
 	}
@@ -102,7 +133,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 			t.Run(fmt.Sprintf("%s, VectorizedResourceRequests=%t", name, enableVectorizedRequests), func(t *testing.T) {
 				features.SetFeatureGateDuringTest(t, features.VectorizedResourceRequests, enableVectorizedRequests)
 
-				snapshot := &TASFlavorSnapshot{leaves: tc.leaves()}
+				snapshot := tc.snapshot()
 				var wantErr error
 
 				got, gotErr := snapshot.SerializeFreeCapacityPerDomain()
@@ -118,13 +149,14 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 }
 
 func TestMergeTopologyAssignments(t *testing.T) {
-	nodes := []corev1.Node{
-		*node.MakeNode("x").Label("level-1", "a").Label("level-2", "b").Obj(),
-		*node.MakeNode("y").Label("level-1", "a").Label("level-2", "c").Obj(),
-		*node.MakeNode("z").Label("level-1", "d").Label("level-2", "e").Obj(),
-		*node.MakeNode("w").Label("level-1", "d").Label("level-2", "f").Obj(),
+	nodes := []*corev1.Node{
+		node.MakeNode("x").Label("level-1", "a").Label("level-2", "b").Obj(),
+		node.MakeNode("y").Label("level-1", "a").Label("level-2", "c").Obj(),
+		node.MakeNode("z").Label("level-1", "d").Label("level-2", "e").Obj(),
+		node.MakeNode("w").Label("level-1", "d").Label("level-2", "f").Obj(),
 	}
 	levels := []string{"level-1", "level-2"}
+	tree := newTopologyTree(levels, nodes, 0)
 
 	cases := map[string]struct {
 		a    *tas.TopologyAssignment
@@ -392,11 +424,7 @@ func TestMergeTopologyAssignments(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil, &defaultChecker{})
-			for i := range nodes {
-				s.addNode(&nodes[i])
-			}
-			s.initialize()
+			s := newTASFlavorSnapshot(log, "dummy", tree, nil, &defaultChecker{})
 
 			got := s.mergeTopologyAssignments(tc.a, tc.b)
 			if diff := cmp.Diff(tc.want, *got); diff != "" {
@@ -467,7 +495,7 @@ func TestHasLevel(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "dummy", levels, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree(levels, nil, 0), nil, &defaultChecker{})
 			got := s.HasLevel(tc.podSetTopologyRequest)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("unexpected HasLevel result (-want,+got): %s", diff)
@@ -485,87 +513,254 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 	levels := []string{"block"}
 
 	testCases := map[string]struct {
-		domains                              []*domain
+		domains                              []testDomainSpec
 		unconstrained                        bool
 		enableTASPreferredSchedulingAffinity bool
 		wantOrder                            []string
 	}{
 		"affinityScore descending: higher affinity score comes first": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"high-affinity", "low-affinity"},
 		},
 		"affinityScore ignored when feature gate is disabled": {
 			enableTASPreferredSchedulingAffinity: false,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
 		"leaderState descending: domains that can host leader come first": {
-			domains: []*domain{
-				{id: "no-leader", leaderState: 0, sliceStateWithLeader: 10, stateWithLeader: 10, levelValues: []string{"a"}},
-				{id: "has-leader", leaderState: 1, sliceStateWithLeader: 1, stateWithLeader: 1, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "no-leader", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          0,
+						sliceStateWithLeader: 10,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "has-leader", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 1,
+						stateWithLeader:      1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"has-leader", "no-leader"},
 		},
 		"leader capability prioritized over preferred affinity": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "preferred-no-leader", affinityScore: 100, leaderState: 0, sliceStateWithLeader: 0, stateWithLeader: 0, levelValues: []string{"a"}},
-				{id: "non-preferred-has-leader", affinityScore: 10, leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "preferred-no-leader", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore:        100,
+						leaderState:          0,
+						sliceStateWithLeader: 0,
+						stateWithLeader:      0,
+					},
+				},
+				{
+					domain: domain{id: "non-preferred-has-leader", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore:        10,
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"non-preferred-has-leader", "preferred-no-leader"},
 		},
 		"BestFit: sliceStateWithLeader descending": {
-			domains: []*domain{
-				{id: "a", leaderState: 1, sliceStateWithLeader: 3, stateWithLeader: 1, levelValues: []string{"a"}},
-				{id: "b", leaderState: 1, sliceStateWithLeader: 1, stateWithLeader: 1, levelValues: []string{"b"}},
-				{id: "c", leaderState: 1, sliceStateWithLeader: 2, stateWithLeader: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 3,
+						stateWithLeader:      1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 1,
+						stateWithLeader:      1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 2,
+						stateWithLeader:      1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
 		"LeastFreeCapacity: sliceStateWithLeader ascending": {
-			domains: []*domain{
-				{id: "a", leaderState: 1, sliceStateWithLeader: 3, stateWithLeader: 1, levelValues: []string{"a"}},
-				{id: "b", leaderState: 1, sliceStateWithLeader: 1, stateWithLeader: 1, levelValues: []string{"b"}},
-				{id: "c", leaderState: 1, sliceStateWithLeader: 2, stateWithLeader: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 3,
+						stateWithLeader:      1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 1,
+						stateWithLeader:      1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 2,
+						stateWithLeader:      1,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
 		"BestFit: stateWithLeader ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 100, levelValues: []string{"a"}},
-				{id: "small", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
-				{id: "medium", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      50,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"LeastFreeCapacity: stateWithLeader ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 100, levelValues: []string{"a"}},
-				{id: "small", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
-				{id: "medium", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      50,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"levelValues ascending as final tiebreaker": {
-			domains: []*domain{
-				{id: "c", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"c"}},
-				{id: "a", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"a"}},
-				{id: "b", leaderState: 1, sliceStateWithLeader: 5, stateWithLeader: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						leaderState:          1,
+						sliceStateWithLeader: 5,
+						stateWithLeader:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "b", "c"},
@@ -576,9 +771,9 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(levels, nil, 0), nil, &defaultChecker{})
 
-			sorted := s.sortedDomainsWithLeader(tc.domains, tc.unconstrained)
+			sorted := s.sortedDomainsWithLeader(addDomainsWithState(s, tc.domains), tc.unconstrained)
 
 			gotOrder := make([]string, len(sorted))
 			for i, d := range sorted {
@@ -601,70 +796,188 @@ func TestSortedDomains(t *testing.T) {
 	levels := []string{"block"}
 
 	testCases := map[string]struct {
-		domains                              []*domain
+		domains                              []testDomainSpec
 		unconstrained                        bool
 		enableTASPreferredSchedulingAffinity bool
 		wantOrder                            []string
 	}{
 		"affinityScore descending: higher affinity score comes first": {
 			enableTASPreferredSchedulingAffinity: true,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, sliceState: 5, state: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, sliceState: 5, state: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore: 10,
+						sliceState:    5,
+						state:         10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore: 100,
+						sliceState:    5,
+						state:         10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"high-affinity", "low-affinity"},
 		},
 		"affinityScore ignored when feature gate is disabled": {
 			enableTASPreferredSchedulingAffinity: false,
-			domains: []*domain{
-				{id: "low-affinity", affinityScore: 10, sliceState: 5, state: 10, levelValues: []string{"a"}},
-				{id: "high-affinity", affinityScore: 100, sliceState: 5, state: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
+					state: domainState{
+						affinityScore: 10,
+						sliceState:    5,
+						state:         10,
+					},
+				},
+				{
+					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
+					state: domainState{
+						affinityScore: 100,
+						sliceState:    5,
+						state:         10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
 		"BestFit: sliceState descending": {
-			domains: []*domain{
-				{id: "a", sliceState: 3, state: 1, levelValues: []string{"a"}},
-				{id: "b", sliceState: 1, state: 1, levelValues: []string{"b"}},
-				{id: "c", sliceState: 2, state: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceState: 3,
+						state:      1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceState: 1,
+						state:      1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceState: 2,
+						state:      1,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
 		"LeastFreeCapacity: sliceState ascending": {
-			domains: []*domain{
-				{id: "a", sliceState: 3, state: 1, levelValues: []string{"a"}},
-				{id: "b", sliceState: 1, state: 1, levelValues: []string{"b"}},
-				{id: "c", sliceState: 2, state: 1, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceState: 3,
+						state:      1,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceState: 1,
+						state:      1,
+					},
+				},
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceState: 2,
+						state:      1,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
 		"BestFit: state ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", sliceState: 5, state: 100, levelValues: []string{"a"}},
-				{id: "small", sliceState: 5, state: 10, levelValues: []string{"b"}},
-				{id: "medium", sliceState: 5, state: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						sliceState: 5,
+						state:      100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						sliceState: 5,
+						state:      10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						sliceState: 5,
+						state:      50,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"LeastFreeCapacity: state ascending as tiebreaker": {
-			domains: []*domain{
-				{id: "large", sliceState: 5, state: 100, levelValues: []string{"a"}},
-				{id: "small", sliceState: 5, state: 10, levelValues: []string{"b"}},
-				{id: "medium", sliceState: 5, state: 50, levelValues: []string{"c"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "large", levelValues: []string{"a"}},
+					state: domainState{
+						sliceState: 5,
+						state:      100,
+					},
+				},
+				{
+					domain: domain{id: "small", levelValues: []string{"b"}},
+					state: domainState{
+						sliceState: 5,
+						state:      10,
+					},
+				},
+				{
+					domain: domain{id: "medium", levelValues: []string{"c"}},
+					state: domainState{
+						sliceState: 5,
+						state:      50,
+					},
+				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
 		"levelValues ascending as final tiebreaker": {
-			domains: []*domain{
-				{id: "c", sliceState: 5, state: 10, levelValues: []string{"c"}},
-				{id: "a", sliceState: 5, state: 10, levelValues: []string{"a"}},
-				{id: "b", sliceState: 5, state: 10, levelValues: []string{"b"}},
+			domains: []testDomainSpec{
+				{
+					domain: domain{id: "c", levelValues: []string{"c"}},
+					state: domainState{
+						sliceState: 5,
+						state:      10,
+					},
+				},
+				{
+					domain: domain{id: "a", levelValues: []string{"a"}},
+					state: domainState{
+						sliceState: 5,
+						state:      10,
+					},
+				},
+				{
+					domain: domain{id: "b", levelValues: []string{"b"}},
+					state: domainState{
+						sliceState: 5,
+						state:      10,
+					},
+				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "b", "c"},
@@ -675,9 +988,9 @@ func TestSortedDomains(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, tc.enableTASPreferredSchedulingAffinity)
 			_, log := utiltesting.ContextWithLog(t)
-			s := newTASFlavorSnapshot(log, "test", levels, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(levels, nil, 0), nil, &defaultChecker{})
 
-			sorted := s.sortedDomains(tc.domains, tc.unconstrained)
+			sorted := s.sortedDomains(addDomainsWithState(s, tc.domains), tc.unconstrained)
 
 			gotOrder := make([]string, len(sorted))
 			for i, d := range sorted {
@@ -739,7 +1052,7 @@ func TestCompareDomainLevelValues(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			s := newTASFlavorSnapshot(log, "test", tc.levels, nil, &defaultChecker{})
+			s := newTASFlavorSnapshot(log, "test", newTopologyTree(tc.levels, nil, 0), nil, &defaultChecker{})
 			got := s.compareDomainLevelValues(tc.a, tc.b)
 			if (got < 0 && tc.want >= 0) || (got > 0 && tc.want <= 0) || (got == 0 && tc.want != 0) {
 				t.Errorf("compareDomainLevelValues() = %d, want sign matching %d", got, tc.want)
@@ -1051,7 +1364,6 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.TASCachingRemainingResources, enableCaching)
 
 			_, log := utiltesting.ContextWithLog(t)
-			snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{"hostname"}, nil, &defaultChecker{})
 			nodeObj := node.MakeNode("node-a").
 				Label("hostname", "node-a").
 				StatusAllocatable(corev1.ResourceList{
@@ -1060,7 +1372,8 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 				}).
 				Ready().
 				Obj()
-			domainID := snapshot.addNode(nodeObj)
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", newTopologyTree([]string{"hostname"}, []*corev1.Node{nodeObj}, 0), nil, &defaultChecker{})
+			domainID := snapshot.nodeToDomain[nodeObj.Name]
 
 			leaf := snapshot.leaves[domainID]
 			g.Expect(leaf).ToNot(gomega.BeNil())

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -177,3 +177,27 @@ func TestTASFlavorCacheNodeLabelsConcurrentAccess(t *testing.T) {
 	wg.Wait()
 	t.Logf("matches per reader: %v", matches)
 }
+
+func TestStoreTreeReturnsNewest(t *testing.T) {
+	cache := &TASFlavorCache{}
+	newer := &topologyTree{generation: 2}
+	if got := cache.storeTree(newer); got != newer {
+		t.Fatal("storeTree did not return the newly stored tree")
+	}
+
+	older := &topologyTree{generation: 1}
+	if got := cache.storeTree(older); got != newer {
+		t.Fatal("storeTree returned an older tree instead of the cached tree")
+	}
+	if got := cache.cachedTree(); got != newer {
+		t.Fatal("storeTree replaced the cached tree with an older tree")
+	}
+
+	equalGeneration := &topologyTree{generation: 2}
+	if got := cache.storeTree(equalGeneration); got != newer {
+		t.Fatal("storeTree did not return the cached tree for an equal generation")
+	}
+	if got := cache.cachedTree(); got != newer {
+		t.Fatal("storeTree replaced the cached tree with an equal-generation tree")
+	}
+}

--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -17,17 +17,29 @@ limitations under the License.
 package scheduler
 
 import (
+	"maps"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
 type nodesCache struct {
-	lock  sync.RWMutex
+	lock sync.RWMutex
+
+	// nodes stores stripped Node views that nodesCache treats as immutable. sync
+	// replaces an entry rather than mutating it. The views share Labels, Taints,
+	// and Allocatable with the input Node, so callers must not mutate those fields
+	// after sync.
 	nodes map[string]*corev1.Node
+
+	// generation counts changes to scheduling-relevant node data. It increments
+	// when a node is added or removed, or when its labels, taints, or allocatable
+	// resources change - not on every Node update event.
+	generation int64
 }
 
 func newNodesCache() *nodesCache {
@@ -43,11 +55,16 @@ func (t *nodesCache) sync(node *corev1.Node) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	if schedulableAndReady {
-		t.nodes[node.Name] = copyAndStripNode(node)
-	} else {
+	if !schedulableAndReady {
 		t.deleteWithoutLock(node.Name)
+		return
 	}
+	stripped := copyAndStripNode(node)
+	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
+		return
+	}
+	t.nodes[node.Name] = stripped
+	t.generation++
 }
 
 func (t *nodesCache) delete(nodeName string) {
@@ -57,10 +74,16 @@ func (t *nodesCache) delete(nodeName string) {
 }
 
 func (t *nodesCache) deleteWithoutLock(nodeName string) {
-	delete(t.nodes, nodeName)
+	if _, found := t.nodes[nodeName]; found {
+		delete(t.nodes, nodeName)
+		t.generation++
+	}
 }
 
-func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*corev1.Node {
+// find returns the nodes matching the flavor along with the generation at
+// which they were read, so that structures derived from the result can later
+// be revalidated against currentGeneration.
+func (t *nodesCache) find(nodeLabels map[string]string, levels []string) ([]*corev1.Node, int64) {
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	filteredNodes := make([]*corev1.Node, 0, len(t.nodes))
@@ -69,7 +92,13 @@ func (t *nodesCache) find(nodeLabels map[string]string, levels []string) []*core
 			filteredNodes = append(filteredNodes, node)
 		}
 	}
-	return filteredNodes
+	return filteredNodes, t.generation
+}
+
+func (t *nodesCache) currentGeneration() int64 {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	return t.generation
 }
 
 // copyAndStripNode creates a minimal copy of the Node object containing only the
@@ -90,4 +119,14 @@ func copyAndStripNode(node *corev1.Node) *corev1.Node {
 			Allocatable: node.Status.Allocatable,
 		},
 	}
+}
+
+// strippedNodesEqual reports whether two stripped nodes carry semantically
+// identical scheduling-relevant information. It is used to avoid bumping the
+// nodesCache generation for Node updates that do not affect TAS scheduling,
+// such as kubelet heartbeats.
+func strippedNodesEqual(a, b *corev1.Node) bool {
+	return maps.Equal(a.Labels, b.Labels) &&
+		equality.Semantic.DeepEqual(a.Spec.Taints, b.Spec.Taints) &&
+		equality.Semantic.DeepEqual(a.Status.Allocatable, b.Status.Allocatable)
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 )
@@ -142,11 +144,129 @@ func TestNodesCacheFind(t *testing.T) {
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			gotNodes := nc.find(tc.nodeLabels, tc.levels)
+			gotNodes, _ := nc.find(tc.nodeLabels, tc.levels)
 			if diff := cmp.Diff(tc.wantNodes, gotNodes, cmpopts.SortSlices(func(a, b *corev1.Node) bool {
 				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodesCacheGeneration(t *testing.T) {
+	baseNode := func() *node.NodeWrapper {
+		return node.MakeNode("gen-test").
+			Label("cloud.provider.com/zone", "us-east-1a").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}).
+			Ready()
+	}
+
+	testCases := map[string]struct {
+		prime     []*corev1.Node
+		op        func(nc *nodesCache)
+		wantDelta int64
+	}{
+		"sync of a new ready node bumps": {
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 1,
+		},
+		"re-sync of an identical node does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 0,
+		},
+		"heartbeat-only update does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().
+					ResourceVersion("2").
+					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
+					Obj())
+			},
+			wantDelta: 0,
+		},
+		"equivalent allocatable expressed in different units does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4000m"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 0,
+		},
+		"label change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
+			},
+			wantDelta: 1,
+		},
+		"allocatable change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"taint change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Taints(corev1.Taint{
+					Key:    "example.com/gpu",
+					Effect: corev1.TaintEffectNoSchedule,
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"transition to unschedulable removes the node and bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Unschedulable().Obj())
+			},
+			wantDelta: 1,
+		},
+		"sync of an absent not-ready node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.sync(node.MakeNode("gen-test").Obj())
+			},
+			wantDelta: 0,
+		},
+		"delete of an existing node bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.delete("gen-test")
+			},
+			wantDelta: 1,
+		},
+		"delete of an absent node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.delete("other")
+			},
+			wantDelta: 0,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			nc := newNodesCache()
+			for _, n := range tc.prime {
+				nc.sync(n)
+			}
+			before := nc.currentGeneration()
+			tc.op(nc)
+			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
+				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -1,0 +1,233 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+// domain holds the static information about placement of a topology
+// domain in the hierarchy of topology domains.
+// Its per-snapshot mutable state lives in TASFlavorSnapshot.state,
+// addressed by idx.
+type domain struct {
+	// id is the globally unique id of the domain
+	id utiltas.TopologyDomainID
+
+	// idx is the dense index of the domain within its topologyTree, used to
+	// address the per-snapshot state in TASFlavorSnapshot.state.
+	idx int
+
+	// parent points to domain which is a parent in topology structure
+	parent *domain
+
+	// children points to domains which are children in topology structure
+	children []*domain
+
+	// levelValues stores the mapping from domain ID back to the
+	// ordered list of values
+	levelValues []string
+}
+
+// leafDomain extends the domain with static information for the lowest-level
+// domain. Its per-snapshot mutable state lives in
+// TASFlavorSnapshot.leafStates, addressed by leafIdx.
+type leafDomain struct {
+	domain
+
+	// leafIdx is the dense index of the leaf within its topologyTree, used
+	// to address the per-snapshot state in TASFlavorSnapshot.leafStates.
+	leafIdx int
+
+	// capacity is the static capacity of the leaf: the summed allocatable of
+	// its nodes, before subtracting any usage.
+	capacity resources.Requests
+
+	// node at the leaf, if the lowest level is a node
+	node *corev1.Node
+}
+
+type domainByID map[utiltas.TopologyDomainID]*domain
+type leafDomainByID map[utiltas.TopologyDomainID]*leafDomain
+
+// topologyTree holds the static topology structure derived from the node set
+// at a given nodesCache generation: the domain hierarchy, the per-leaf static
+// capacity and the node membership. It is built once per generation, cached
+// on the TASFlavorCache, and shared read-only by every snapshot created from it.
+// All mutable per-cycle values live on the TASFlavorSnapshot instead, so
+// concurrent snapshots never share mutable state.
+type topologyTree struct {
+	// generation is the nodesCache generation the tree was built from.
+	generation int64
+
+	// levelKeys denotes the ordered list of topology keys set as label keys
+	// on the Topology object
+	levelKeys []string
+
+	// leaves maps domainID to domains that are at the lowest level of topology structure
+	leaves leafDomainByID
+
+	// roots maps domainID to domains that are at the highest level of topology structure
+	roots domainByID
+
+	// domains maps domainID to every domain available in the topology structure
+	domains domainByID
+
+	// domainCount is the number of allocated domains. It can exceed len(domains)
+	// when domains at different topology levels have colliding IDs.
+	domainCount int
+
+	// domainsPerLevel stores the static tree information
+	domainsPerLevel []domainByID
+
+	// isLowestLevelNode indicates if kubernetes.io/hostname is the lowest topology level
+	isLowestLevelNode bool
+
+	// nodes lists the nodes matching the flavor which the tree was built
+	// from.
+	nodes []*corev1.Node
+
+	// nodeToDomain maps node names to their leaf domain ID, used to apply
+	// per-node non-TAS usage onto snapshots.
+	nodeToDomain map[string]utiltas.TopologyDomainID
+}
+
+// newTopologyTree builds the static topology structure from the given node
+// set, read at the given nodesCache generation.
+func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *topologyTree {
+	domainsPerLevel := make([]domainByID, len(levels))
+	for level := range levels {
+		domainsPerLevel[level] = make(domainByID)
+	}
+
+	tree := &topologyTree{
+		generation:        generation,
+		levelKeys:         slices.Clone(levels),
+		leaves:            make(leafDomainByID),
+		domains:           make(domainByID),
+		roots:             make(domainByID),
+		domainsPerLevel:   domainsPerLevel,
+		isLowestLevelNode: len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
+		nodes:             slices.Clip(slices.Clone(nodes)),
+		nodeToDomain:      make(map[string]utiltas.TopologyDomainID, len(nodes)),
+	}
+	for _, node := range nodes {
+		tree.nodeToDomain[node.Name] = tree.addNode(node)
+	}
+	tree.initialize()
+	return tree
+}
+
+func (t *topologyTree) addNode(node *corev1.Node) utiltas.TopologyDomainID {
+	var levelValues []string
+	var domainID utiltas.TopologyDomainID
+	var leafFound bool
+
+	if t.isLowestLevelNode {
+		// When the lowest level is kubernetes.io/hostname, directly extract hostname.
+		hostname := node.Labels[corev1.LabelHostname]
+		domainID = utiltas.TopologyDomainID(hostname)
+		_, leafFound = t.leaves[domainID]
+		// Only compute levelValues when we actually need to create a new leafDomain.
+		if !leafFound {
+			levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
+		}
+	} else {
+		// Compute full level values and domain ID.
+		levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
+		domainID = utiltas.DomainID(levelValues)
+		_, leafFound = t.leaves[domainID]
+	}
+	if !leafFound {
+		leafDomain := leafDomain{
+			domain:  domain{id: domainID, levelValues: levelValues},
+			leafIdx: len(t.leaves),
+		}
+
+		if t.isLowestLevelNode {
+			leafDomain.node = node
+		}
+		t.leaves[domainID] = &leafDomain
+	}
+	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
+	t.addCapacity(domainID, capacity)
+	return domainID
+}
+
+func (t *topologyTree) lowestLevel() string {
+	return t.levelKeys[len(t.levelKeys)-1]
+}
+
+func (t *topologyTree) highestLevel() string {
+	return t.levelKeys[0]
+}
+
+func (t *topologyTree) indexDomain(dom *domain) {
+	dom.idx = t.domainCount
+	t.domainCount++
+}
+
+// initialize prepares the topology tree structure. This structure holds
+// for a given the list of topology domains with additional static
+// information. This function initializes the static information which
+// represents the edges to the parent and child domains, and assigns each
+// domain its dense index used to address per-snapshot state. This structure
+// is reused by all snapshots until the node set changes.
+func (t *topologyTree) initialize() {
+	for _, leafDomain := range t.leaves {
+		domain := &leafDomain.domain
+		t.indexDomain(domain)
+		t.domains[domain.id] = domain
+		t.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
+		t.initializeHelper(domain)
+	}
+}
+
+// initializeHelper is a recursive helper for initialize() method
+func (t *topologyTree) initializeHelper(dom *domain) {
+	if len(dom.levelValues) == 1 {
+		t.roots[dom.id] = dom
+		return
+	}
+	parentValues := dom.levelValues[:len(dom.levelValues)-1]
+	parentID := utiltas.DomainID(parentValues)
+	parent, parentFound := t.domains[parentID]
+	if !parentFound {
+		// create parent
+		parent = &domain{id: parentID, levelValues: parentValues}
+		t.indexDomain(parent)
+
+		t.domainsPerLevel[len(parentValues)-1][parentID] = parent
+		t.domains[parentID] = parent
+		t.initializeHelper(parent)
+	}
+	// connect parent and child
+	dom.parent = parent
+	parent.children = append(parent.children, dom)
+}
+
+func (t *topologyTree) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
+	if t.leaves[domainID].capacity == nil {
+		t.leaves[domainID].capacity = resources.CreateEmpty()
+	}
+	t.leaves[domainID].capacity.Add(capacity)
+}

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -1,0 +1,459 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+const (
+	treeTestBlockLabel = "cloud.provider.com/topology-block"
+	treeTestRackLabel  = "cloud.provider.com/topology-rack"
+)
+
+func makeTreeTestNode(name, block, rack string) *corev1.Node {
+	return testingnode.MakeNode(name).
+		Label(treeTestBlockLabel, block).
+		Label(treeTestRackLabel, rack).
+		Label(corev1.LabelHostname, name).
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("4"),
+			corev1.ResourceMemory: resource.MustParse("16Gi"),
+			corev1.ResourcePods:   resource.MustParse("110"),
+		}).
+		Ready().
+		Obj()
+}
+
+func treeTestBalancedRequests(name kueue.PodSetReference) FlavorTASRequests {
+	preferredLevel := treeTestRackLabel
+	return FlavorTASRequests{{
+		PodSet: &kueue.PodSet{
+			Name: name,
+			TopologyRequest: &kueue.PodSetTopologyRequest{
+				Preferred: &preferredLevel,
+			},
+		},
+		SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+		Count:             6,
+	}}
+}
+
+func TestNewTopologyTreeCopiesAndRightSizesNodeSlice(t *testing.T) {
+	nodes := make([]*corev1.Node, 1, 100)
+	nodes[0] = makeTreeTestNode("n1", "b1", "r1")
+
+	tree := newTopologyTree([]string{corev1.LabelHostname}, nodes, 0)
+	if got, want := cap(tree.nodes), len(tree.nodes); got != want {
+		t.Errorf("tree.nodes capacity = %d, want %d", got, want)
+	}
+
+	nodes[0] = nil
+	if tree.nodes[0] == nil {
+		t.Error("topology tree retained the input node slice")
+	}
+}
+
+// snapshotDomainDump is a comparison representation of one domain of a
+// TASFlavorSnapshot, used to verify that snapshots sharing a cached topology
+// tree behave exactly like snapshots built from scratch.
+type snapshotDomainDump struct {
+	Parent       utiltas.TopologyDomainID
+	Children     []utiltas.TopologyDomainID
+	LevelValues  []string
+	Root         bool
+	Leaf         bool
+	NodeName     string
+	FreeCapacity resources.Requests
+	TASUsage     resources.Requests
+}
+
+func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[utiltas.TopologyDomainID]snapshotDomainDump {
+	t.Helper()
+	perLevelCount := 0
+	for _, level := range s.domainsPerLevel {
+		perLevelCount += len(level)
+	}
+	if perLevelCount != len(s.domains) {
+		t.Errorf("domainsPerLevel holds %d domains, want %d", perLevelCount, len(s.domains))
+	}
+	dump := make(map[utiltas.TopologyDomainID]snapshotDomainDump, len(s.domains))
+	for id, dom := range s.domains {
+		d := snapshotDomainDump{
+			LevelValues: dom.levelValues,
+			Root:        s.roots[id] == dom,
+		}
+		if dom.parent != nil {
+			d.Parent = dom.parent.id
+		}
+		for _, child := range dom.children {
+			d.Children = append(d.Children, child.id)
+		}
+		slices.Sort(d.Children)
+		if leaf, found := s.leaves[id]; found {
+			d.Leaf = true
+			leafState := s.leafStateOf(leaf)
+			if leafState.freeCapacity != nil {
+				d.FreeCapacity = leafState.freeCapacity.Clone()
+			}
+			if leafState.tasUsage != nil {
+				d.TASUsage = leafState.tasUsage.Clone()
+			}
+			if leaf.node != nil {
+				d.NodeName = leaf.node.Name
+			}
+		}
+		dump[id] = d
+	}
+	return dump
+}
+
+func TestSnapshotWithReusedTreeMatchesColdBuild(t *testing.T) {
+	testCases := map[string]struct {
+		levels         []string
+		tasUsageValues []string
+	}{
+		"lowest level is hostname": {
+			levels:         []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname},
+			tasUsageValues: []string{"b1", "r1", "n1"},
+		},
+		"lowest level is not hostname": {
+			levels:         []string{treeTestBlockLabel, treeTestRackLabel},
+			tasUsageValues: []string{"b1", "r1"},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+			for _, n := range []*corev1.Node{
+				makeTreeTestNode("n1", "b1", "r1"),
+				makeTreeTestNode("n2", "b1", "r1"),
+				makeTreeTestNode("n3", "b1", "r2"),
+				makeTreeTestNode("n4", "b2", "r3"),
+			} {
+				tasCache.SyncNode(n)
+			}
+			tasCache.UpdateNonTASUsage(testingpod.MakePod("bg-1", "default").
+				NodeName("n1").
+				Request(corev1.ResourceCPU, "500m").
+				StatusPhase(corev1.PodRunning).
+				Obj(), log)
+			fc := tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: tc.levels},
+				flavorInformation{TopologyName: "default"},
+			)
+			fc.addUsage(log, "wl", []workload.TopologyDomainRequests{{
+				Values:            tc.tasUsageValues,
+				SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
+				Count:             2,
+			}})
+
+			cold, err := fc.snapshot(ctx, log, nil)
+			if err != nil {
+				t.Fatalf("cold snapshot failed: %v", err)
+			}
+			tree := fc.cachedTree()
+			if tree == nil {
+				t.Fatal("expected the cold build to store the topology tree")
+			}
+			reused, err := fc.snapshot(ctx, log, nil)
+			if err != nil {
+				t.Fatalf("second snapshot failed: %v", err)
+			}
+			if fc.cachedTree() != tree {
+				t.Error("expected the second snapshot to reuse the cached tree, but it was rebuilt")
+			}
+			if reused.topologyTree != tree {
+				t.Error("expected the second snapshot to share the cached tree")
+			}
+			if diff := cmp.Diff(dumpSnapshotTree(t, cold), dumpSnapshotTree(t, reused), cmp.Comparer(resources.Equal)); diff != "" {
+				t.Errorf("unexpected difference between cold-built and tree-reusing snapshots (-cold,+reused):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSnapshotsSharingTreeAreIsolated(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	first, err := fc.snapshot(ctx, log, nil)
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	second, err := fc.snapshot(ctx, log, nil)
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	leafID := utiltas.TopologyDomainID("n1")
+	if first.leaves[leafID] != second.leaves[leafID] {
+		t.Fatal("expected both snapshots to share the tree's leaf domain")
+	}
+	firstDump := dumpSnapshotTree(t, first)
+
+	// Mutating one snapshot, as the scheduler does during a cycle, must not
+	// leak into snapshots of other cycles.
+	second.addTASUsage(leafID, resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}))
+	second.addNonTASUsage(leafID, resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 500}))
+	third, err := fc.snapshot(ctx, log, nil)
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+	if diff := cmp.Diff(firstDump, dumpSnapshotTree(t, third), cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("usage applied to one snapshot leaked into another (-first,+third):\n%s", diff)
+	}
+}
+
+func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
+	ctx, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+	snapshot, err := fc.snapshot(ctx, log, nil)
+	if err != nil {
+		t.Fatalf("snapshot failed: %v", err)
+	}
+
+	requests := treeTestBalancedRequests("workers")
+	first := snapshot.FindTopologyAssignmentsForFlavor(ctx, requests)
+	if failure := first.Failure(); failure != nil {
+		t.Fatalf("first assignment failed: %s", failure.Reason)
+	}
+	if len(snapshot.state) <= len(snapshot.domains) {
+		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.state), len(snapshot.domains))
+	}
+
+	second := snapshot.FindTopologyAssignmentsForFlavor(ctx, requests)
+	if failure := second.Failure(); failure != nil {
+		t.Fatalf("second assignment failed: %s", failure.Reason)
+	}
+	if diff := cmp.Diff(first, second); diff != "" {
+		t.Errorf("assignment changed after resetting clone state (-first,+second):\n%s", diff)
+	}
+}
+
+func TestSnapshotsSharingTreeCanAssignConcurrently(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
+	ctx, log := utiltesting.ContextWithLog(t)
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+	tasCache.SyncNode(makeTreeTestNode("n2", "b1", "r2"))
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+		flavorInformation{TopologyName: "default"},
+	)
+
+	snapshots := make([]*TASFlavorSnapshot, 2)
+	for i := range snapshots {
+		var err error
+		snapshots[i], err = fc.snapshot(ctx, log, nil)
+		if err != nil {
+			t.Fatalf("snapshot %d failed: %v", i, err)
+		}
+	}
+	if snapshots[0].topologyTree != snapshots[1].topologyTree {
+		t.Fatal("expected snapshots to share the cached topology tree")
+	}
+
+	start := make(chan struct{})
+	results := make(chan TASAssignmentsResult, len(snapshots))
+	for _, snapshot := range snapshots {
+		go func(snapshot *TASFlavorSnapshot) {
+			<-start
+			var result TASAssignmentsResult
+			for range 20 {
+				result = snapshot.FindTopologyAssignmentsForFlavor(ctx, treeTestBalancedRequests("workers"))
+				if result.Failure() != nil {
+					break
+				}
+			}
+			results <- result
+		}(snapshot)
+	}
+	close(start)
+
+	got := make([]TASAssignmentsResult, 0, len(snapshots))
+	for range snapshots {
+		result := <-results
+		if failure := result.Failure(); failure != nil {
+			t.Fatalf("concurrent assignment failed: %s", failure.Reason)
+		}
+		got = append(got, result)
+	}
+	if diff := cmp.Diff(got[0], got[1]); diff != "" {
+		t.Errorf("concurrent snapshots produced different assignments (-first,+second):\n%s", diff)
+	}
+}
+
+func TestTopologyTreeInvalidation(t *testing.T) {
+	tests := map[string]struct {
+		initialNodeLabels map[string]string
+		mutate            func(*tasCache, *TASFlavorCache)
+		wantTreeReused    bool
+		validate          func(*testing.T, *TASFlavorSnapshot)
+	}{
+		"heartbeat-only update": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				node := makeTreeTestNode("n1", "b1", "r1")
+				node.ResourceVersion = "2"
+				node.Status.Conditions[0].LastHeartbeatTime = metav1.Now()
+				tasCache.SyncNode(node)
+			},
+			wantTreeReused: true,
+		},
+		"allocatable change": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				node := makeTreeTestNode("n1", "b1", "r1")
+				node.Status.Allocatable[corev1.ResourceCPU] = resource.MustParse("8")
+				tasCache.SyncNode(node)
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				n1State := snapshot.leafStateOf(snapshot.leaves[utiltas.TopologyDomainID("n1")])
+				if gotCapacity := n1State.freeCapacity.GetValue(corev1.ResourceCPU); gotCapacity != 8000 {
+					t.Errorf("snapshot has cpu capacity %d, want 8000", gotCapacity)
+				}
+			},
+		},
+		"node added": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				tasCache.SyncNode(makeTreeTestNode("n3", "b3", "r3"))
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				if _, found := snapshot.domains[utiltas.DomainID([]string{"b3"})]; !found {
+					t.Error("snapshot does not contain the added node's block domain")
+				}
+			},
+		},
+		"node deletion": {
+			mutate: func(tasCache *tasCache, _ *TASFlavorCache) {
+				tasCache.DeleteNodeByName("n2")
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				if _, found := snapshot.domains[utiltas.DomainID([]string{"b2"})]; found {
+					t.Error("snapshot still contains the deleted node's block domain")
+				}
+			},
+		},
+		"flavor node selector change": {
+			initialNodeLabels: map[string]string{treeTestBlockLabel: "b1"},
+			mutate: func(_ *tasCache, fc *TASFlavorCache) {
+				fc.updateNodeLabels(map[string]string{treeTestBlockLabel: "b2"})
+			},
+			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
+				if _, found := snapshot.leaves[utiltas.TopologyDomainID("n2")]; !found {
+					t.Error("snapshot does not contain n2, newly selected by the flavor")
+				}
+				if _, found := snapshot.leaves[utiltas.TopologyDomainID("n1")]; found {
+					t.Error("snapshot still contains n1, no longer selected by the flavor")
+				}
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+			tasCache.SyncNode(makeTreeTestNode("n1", "b1", "r1"))
+			tasCache.SyncNode(makeTreeTestNode("n2", "b2", "r2"))
+			fc := tasCache.NewTASFlavorCache(
+				topologyInformation{Levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname}},
+				flavorInformation{TopologyName: "default", NodeLabels: tc.initialNodeLabels},
+			)
+
+			if _, err := fc.snapshot(ctx, log, nil); err != nil {
+				t.Fatalf("initial snapshot failed: %v", err)
+			}
+			tree := fc.cachedTree()
+			if tree == nil {
+				t.Fatal("expected the cold build to store the topology tree")
+			}
+
+			tc.mutate(&tasCache, fc)
+			snapshot, err := fc.snapshot(ctx, log, nil)
+			if err != nil {
+				t.Fatalf("snapshot after cache mutation failed: %v", err)
+			}
+			if gotTreeReused := fc.cachedTree() == tree; gotTreeReused != tc.wantTreeReused {
+				t.Errorf("cached tree reused = %t, want %t", gotTreeReused, tc.wantTreeReused)
+			}
+			if tc.validate != nil {
+				tc.validate(t, snapshot)
+			}
+		})
+	}
+}
+
+func makeTopologyTreeWithCollidingLeafAndRootIDs() *topologyTree {
+	return newTopologyTree(
+		[]string{treeTestBlockLabel, corev1.LabelHostname},
+		[]*corev1.Node{
+			makeTreeTestNode("block-a", "block-b", "r1"),
+			makeTreeTestNode("block-b", "block-a", "r1"),
+		},
+		0,
+	)
+}
+
+func TestTopologyTreeStateIndexesWhenDomainIDsCollide(t *testing.T) {
+	_, log := utiltesting.ContextWithLog(t)
+	tree := makeTopologyTreeWithCollidingLeafAndRootIDs()
+	snapshot := newTASFlavorSnapshot(log, "default", tree, nil, &defaultChecker{})
+	seen := make(map[int]*domain, tree.domainCount)
+	for _, levelDomains := range tree.domainsPerLevel {
+		for _, dom := range levelDomains {
+			if dom.idx < 0 || dom.idx >= len(snapshot.state) {
+				t.Errorf("domain %q has state index %d, outside [0, %d)", dom.levelValues, dom.idx, len(snapshot.state))
+				continue
+			}
+			if other, found := seen[dom.idx]; found {
+				t.Errorf("domains %q and %q share state index %d", other.levelValues, dom.levelValues, dom.idx)
+			}
+			seen[dom.idx] = dom
+		}
+	}
+	if got := len(seen); got != tree.domainCount {
+		t.Errorf("domains with state indexes = %d, want %d", got, tree.domainCount)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

TAS snapshots previously rebuilt the complete topology tree for every scheduling cycle, including the domain hierarchy, node-to-domain mapping, and leaf capacities. Most of this data remains unchanged between cycles.

This PR:
- Caches an immutable topology tree for each TAS flavor.
- Reuses the tree while scheduling-relevant node data remains unchanged.
- Keeps mutable scheduling state in each snapshot so concurrently created snapshots remain isolated.
- Tracks semantic node changes to invalidate cached trees when labels, taints, or allocatable resources change.
- Avoids invalidation for node updates that do not affect TAS scheduling.

Benchmark configuration:
- 2,500 nodes
- 15 TAS flavors
- One non-TAS pod per node

Snapshot scenario | CPU time | Allocated bytes | Allocations
-- | -- | -- | --
Cached tree reused | −71.74% | −60.96% | −64.50%
Tree invalidated every snapshot cycle | +5.55% | +10.54% | +23.57%
Tree invalidated every 2 snapshot cycles | −32.54% | −25.05% | −20.28%

pprof flame graphs
Before:

<img width="3006" height="1128" alt="image" src="https://github.com/user-attachments/assets/27c0d0af-9a9c-4354-8de6-c4e996588659" />

After:

<img width="3006" height="1192" alt="image" src="https://github.com/user-attachments/assets/a60e3d79-4988-4c1d-a9c6-0e7dc23fb694" />

#### Which issue(s) this PR fixes:

Part of #12580

#### Does this PR introduce a user-facing change?

```release-note
TAS: Reduced CPU time and memory allocations for snapshot creation by reusing cached topology trees when scheduling-relevant Node data is unchanged. Controlled by the `TASCacheTopologyTree` feature gate, which is Beta and enabled by default.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved scheduling efficiency by reusing topology information across placement calculations.
  * Reduced unnecessary refreshes for heartbeat-only and unchanged node updates.

* **Scheduling**
  * Improved balanced placement consistency with isolated scheduling state.
  * Enhanced handling of capacity, topology changes, pruning, fallback placement, and leader assignments.

* **Reliability**
  * Improved consistency during concurrent topology updates.
  * Preserved the newest topology information during cache refreshes.

* **Testing**
  * Expanded coverage for placement, topology changes, cache invalidation, and capacity handling.
  * Added benchmarks for topology reuse and assignment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->