### PR TITLE
[release-0.19] TAS: update nonTasUsageCache on in-place pod resize and node migration

### DIFF
--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -128,7 +128,7 @@ func (t *tasCache) DeleteTopology(name kueue.TopologyReference) {
 }
 
 // Update may add a pod to the cache, or delete a terminated pod.
-// Returns the node name when a terminated pod is removed from the cache.
+// Returns the node name when capacity may have been freed on a node.
 func (t *tasCache) Update(pod *corev1.Pod, log logr.Logger) string {
 	return t.nonTasUsageCache.update(pod, log)
 }

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -55,7 +55,7 @@ func (n *nonTasUsageCache) removePodUsage(key client.ObjectKey, log logr.Logger)
 }
 
 // update may add a pod to the cache, or delete a terminated pod.
-// Returns the node name when a terminated pod is removed from the cache.
+// Returns the node name when capacity may have been freed on a node.
 func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) string {
 	n.lock.Lock()
 	defer n.lock.Unlock()
@@ -67,15 +67,20 @@ func (n *nonTasUsageCache) update(pod *corev1.Pod, log logr.Logger) string {
 		return n.removePodUsage(key, log)
 	}
 
-	n.updatePodUsage(key, pod, log)
-	return ""
+	return n.updatePodUsage(key, pod, log)
 }
 
 // updatePodUsage replaces or inserts a pod's usage entry and adjusts node totals.
+// Returns the old node name only when capacity may have been freed (node
+// migration or a decrease in any resource request).
 // Must be called under write lock.
-func (n *nonTasUsageCache) updatePodUsage(key client.ObjectKey, pod *corev1.Pod, log logr.Logger) {
+func (n *nonTasUsageCache) updatePodUsage(key client.ObjectKey, pod *corev1.Pod, log logr.Logger) string {
+	var oldNode string
+	var oldUsage resources.Requests
 	if old, found := n.podUsage[key]; found {
 		n.removeNodeUsage(old.node, old.usage, log)
+		oldNode = old.node
+		oldUsage = old.usage
 	}
 	log.V(5).Info("Adding non-TAS pod to the cache")
 	requests := resources.NewRequestsFromPodSpec(&pod.Spec)
@@ -84,6 +89,13 @@ func (n *nonTasUsageCache) updatePodUsage(key client.ObjectKey, pod *corev1.Pod,
 		usage: requests,
 	}
 	n.addNodeUsage(pod.Spec.NodeName, requests)
+	if oldNode == "" {
+		return ""
+	}
+	if oldNode != pod.Spec.NodeName || len(oldUsage.GreaterKeys(requests)) > 0 {
+		return oldNode
+	}
+	return ""
 }
 
 // delete removes a pod from the cache.

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -66,10 +66,36 @@ func TestNonTasUsageCacheRemovedNode(t *testing.T) {
 				return cache.update(pod, log)
 			},
 		},
-		"update with running pod returns empty": {
+		"update with new running pod returns empty": {
 			action: func(cache *nonTasUsageCache, log logr.Logger) string {
 				return cache.update(makePod("pod1", "ns", "node-a", "2"), log)
 			},
+		},
+		"update existing running pod with decreased requests returns old node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "4"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			wantNode: "node-a",
+		},
+		"update existing running pod with increased requests returns empty": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.update(makePod("pod1", "ns", "node-a", "4"), log)
+			},
+		},
+		"update existing running pod moved to new node returns old node": {
+			setup: func(cache *nonTasUsageCache, log logr.Logger) {
+				cache.update(makePod("pod1", "ns", "node-a", "2"), log)
+			},
+			action: func(cache *nonTasUsageCache, log logr.Logger) string {
+				return cache.update(makePod("pod1", "ns", "node-b", "2"), log)
+			},
+			wantNode: "node-a",
 		},
 		"delete existing pod returns node": {
 			setup: func(cache *nonTasUsageCache, log logr.Logger) {

--- a/pkg/controller/tas/non_tas_usage_controller.go
+++ b/pkg/controller/tas/non_tas_usage_controller.go
@@ -18,6 +18,7 @@ package tas
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
@@ -38,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/resources"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
@@ -215,7 +217,24 @@ func (r *NonTasUsageReconciler) Create(e event.TypedCreateEvent[*corev1.Pod]) bo
 }
 
 func (r *NonTasUsageReconciler) Update(e event.TypedUpdateEvent[*corev1.Pod]) bool {
-	return belongsToNonTASCache(e.ObjectOld) != belongsToNonTASCache(e.ObjectNew)
+	return belongsToNonTASCache(e.ObjectOld) != belongsToNonTASCache(e.ObjectNew) ||
+		podUsageChanged(e.ObjectOld, e.ObjectNew)
+}
+
+func podUsageChanged(oldPod, newPod *corev1.Pod) bool {
+	if !belongsToNonTASCache(oldPod) || !belongsToNonTASCache(newPod) {
+		return false
+	}
+	if oldPod.Spec.NodeName != newPod.Spec.NodeName {
+		return true
+	}
+	if oldPod.Generation == newPod.Generation {
+		return false
+	}
+	return !maps.Equal(
+		resources.ToMap(resources.NewRequestsFromPodSpec(&oldPod.Spec)),
+		resources.ToMap(resources.NewRequestsFromPodSpec(&newPod.Spec)),
+	)
 }
 
 func (r *NonTasUsageReconciler) Delete(e event.TypedDeleteEvent[*corev1.Pod]) bool {

--- a/pkg/controller/tas/non_tas_usage_controller_test.go
+++ b/pkg/controller/tas/non_tas_usage_controller_test.go
@@ -250,6 +250,38 @@ func TestNonTasUsageReconcilerUpdatePredicate(t *testing.T) {
 			newPod: testingpod.MakePod("pod", "ns").StatusPhase(corev1.PodPending).Obj(),
 			want:   false,
 		},
+		{
+			name: "reconciles when non-TAS pod resources change (resize)",
+			oldPod: func() *corev1.Pod {
+				p := testingpod.MakePod("pod", "ns").NodeName("node-a").Request(corev1.ResourceCPU, "2").Obj()
+				p.Generation = 1
+				return p
+			}(),
+			newPod: func() *corev1.Pod {
+				p := testingpod.MakePod("pod", "ns").NodeName("node-a").Request(corev1.ResourceCPU, "4").Obj()
+				p.Generation = 2
+				return p
+			}(),
+			want: true,
+		},
+		{
+			name:   "reconciles when non-TAS pod moves between nodes",
+			oldPod: testingpod.MakePod("pod", "ns").NodeName("node-a").Request(corev1.ResourceCPU, "2").Obj(),
+			newPod: testingpod.MakePod("pod", "ns").NodeName("node-b").Request(corev1.ResourceCPU, "2").Obj(),
+			want:   true,
+		},
+		{
+			name:   "ignores non-TAS pod update with same resources",
+			oldPod: testingpod.MakePod("pod", "ns").NodeName("node-a").Request(corev1.ResourceCPU, "2").Obj(),
+			newPod: testingpod.MakePod("pod", "ns").NodeName("node-a").Request(corev1.ResourceCPU, "2").Obj(),
+			want:   false,
+		},
+		{
+			name:   "ignores unscheduled non-TAS pod with changed resources",
+			oldPod: testingpod.MakePod("pod", "ns").Request(corev1.ResourceCPU, "2").Obj(),
+			newPod: testingpod.MakePod("pod", "ns").Request(corev1.ResourceCPU, "4").Obj(),
+			want:   false,
+		},
 	}
 
 	reconciler := &NonTasUsageReconciler{}


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/kubernetes-sigs/kueue/pull/13764

/assign sohankunkerkar
```release-note
TAS: Fixed a bug where in-place pod resize or node migration of a non-TAS pod on a TAS-relevant node never updated the scheduler's usage cache, causing TAS workloads to see stale capacity until the pod terminated.
```
