### PR TITLE
dra: fix DeviceClass validation error paths

### DIFF
--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -115,7 +115,7 @@ func determineCapacityForPodSet(
 			claimPath := field.NewPath("spec", "podSets").Index(psIdx).Child("template", "spec", "resourceClaims").Index(j)
 			reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-			classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
+			classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 			if len(errs) > 0 {
 				return nil, errs
 			}

--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -112,9 +112,10 @@ func determineCapacityForPodSet(
 				continue
 			}
 
-			reqPath := field.NewPath("spec", "podSets").Index(psIdx).Child("template", "spec", "resourceClaims").Index(j).Child("devices", "requests").Index(reqIdx)
+			claimPath := field.NewPath("spec", "podSets").Index(psIdx).Child("template", "spec", "resourceClaims").Index(j)
+			reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-			classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, reqPath)
+			classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 			if len(errs) > 0 {
 				return nil, errs
 			}

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -77,9 +77,10 @@ func GetCounterResourcesForWorkload(
 					continue
 				}
 
-				reqPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j).Child("devices", "requests").Index(reqIdx)
+				claimPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j)
+				reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-				classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, reqPath)
+				classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 				if len(errs) > 0 {
 					allErrs = append(allErrs, errs...)
 					return nil, allErrs
@@ -112,19 +113,21 @@ func GetCounterResourcesForWorkload(
 	return perPodSet, nil
 }
 
-func prepareCounterCharge(
+func prepareDeviceSelectors(
 	ctx context.Context,
 	cl client.Client,
 	deviceClassName string,
 	selectors []resourcev1.DeviceSelector,
 	classCache map[string]*resourcev1.DeviceClass,
-	reqPath *field.Path,
+	claimPath *field.Path,
+	reqIdx int,
 ) ([]dracel.CompilationResult, []dracel.CompilationResult, field.ErrorList) {
-	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, reqPath, 0)
+	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, claimPath, reqIdx)
 	if classErr != nil {
 		return nil, nil, field.ErrorList{classErr}
 	}
 
+	reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 	requestSelectors, compErrs := compileCELSelectors(selectors, reqPath.Child("exactly", "selectors"), "CEL compilation failed")
 	if len(compErrs) > 0 {
 		return nil, nil, compErrs

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -80,7 +80,7 @@ func GetCounterResourcesForWorkload(
 				claimPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j)
 				reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-				classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
+				classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 				if len(errs) > 0 {
 					allErrs = append(allErrs, errs...)
 					return nil, allErrs
@@ -113,7 +113,7 @@ func GetCounterResourcesForWorkload(
 	return perPodSet, nil
 }
 
-func prepareDeviceSelectors(
+func prepareCounterCharge(
 	ctx context.Context,
 	cl client.Client,
 	deviceClassName string,

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -494,3 +494,27 @@ func TestMatchDevicesWithSelectors_CELErrorPropagation(t *testing.T) {
 		t.Errorf("Expected error containing 'unsupported attribute value', got: %s", errs[0].Detail)
 	}
 }
+
+func TestPrepareDeviceSelectors_DeviceClassErrorUsesRequestPath(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder().Build()
+	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
+
+	_, _, errs := prepareDeviceSelectors(
+		ctx,
+		cl,
+		"missing-device-class",
+		nil,
+		make(map[string]*resourcev1.DeviceClass),
+		claimPath,
+		1,
+	)
+
+	if len(errs) != 1 {
+		t.Fatalf("expected one error, got %d: %v", len(errs), errs)
+	}
+	const wantPath = "spec.podSets[0].template.spec.resourceClaims[0].devices.requests[1]"
+	if errs[0].Field != wantPath {
+		t.Errorf("field path = %q, want %q", errs[0].Field, wantPath)
+	}
+}

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -503,7 +503,15 @@ func TestSelectorErrorPaths(t *testing.T) {
 		{
 			name: "request selector compilation error",
 			run: func() field.ErrorList {
-				_, _, errs := prepareCounterCharge(ctx, cl, "valid-device-class", []resourcev1.DeviceSelector{{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver =="}}}, make(map[string]*resourcev1.DeviceClass), claimPath, 1)
+				_, _, errs := prepareCounterCharge(
+					ctx,
+					cl,
+					"valid-device-class",
+					[]resourcev1.DeviceSelector{{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver =="}}},
+					make(map[string]*resourcev1.DeviceClass),
+					claimPath,
+					1,
+				)
 				return errs
 			},
 			wantField: reqPath.Child("exactly", "selectors").Index(0).Child("cel", "expression").String(),

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -500,7 +500,7 @@ func TestPrepareDeviceSelectors_DeviceClassErrorUsesRequestPath(t *testing.T) {
 	cl := utiltesting.NewClientBuilder().Build()
 	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
 
-	_, _, errs := prepareDeviceSelectors(
+	_, _, errs := prepareCounterCharge(
 		ctx,
 		cl,
 		"missing-device-class",

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -450,71 +450,87 @@ func TestGroupSlicesByPool(t *testing.T) {
 	}
 }
 
-func TestMatchDevicesWithSelectors_CELErrorPropagation(t *testing.T) {
+func TestSelectorErrorPaths(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder().WithObjects(&resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-device-class"},
+	}).Build()
+	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
+	reqPath := claimPath.Child("devices", "requests").Index(1)
 
-	pools := map[string]*poolInfo{
-		"pool1": {
-			name:               "pool1",
-			generation:         1,
-			resourceSliceCount: 1,
-			slices: []resourcev1.ResourceSlice{
-				{
+	cache := dracel.NewCache(1, dracel.Features{})
+	validSelector := cache.GetOrCompile("device.driver == 'gpu.example.com'")
+	if validSelector.Error != nil {
+		t.Fatalf("CEL compilation failed: %v", validSelector.Error)
+	}
+
+	newPools := func() map[string]*poolInfo {
+		return map[string]*poolInfo{
+			"pool1": {
+				name:               "pool1",
+				generation:         1,
+				resourceSliceCount: 1,
+				slices: []resourcev1.ResourceSlice{{
 					Spec: resourcev1.ResourceSliceSpec{
 						Driver: "gpu.example.com",
 						Pool:   resourcev1.ResourcePool{Name: "pool1", Generation: 1, ResourceSliceCount: 1},
-						Devices: []resourcev1.Device{
-							{
-								Name: "gpu-0",
-								Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-									"gpu.example.com/type": {},
-								},
+						Devices: []resourcev1.Device{{
+							Name: "gpu-0",
+							Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+								"gpu.example.com/type": {},
 							},
-						},
+						}},
 					},
-				},
+				}},
 			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		run        func() field.ErrorList
+		wantField  string
+		wantDetail string
+	}{
+		{
+			name: "DeviceClass lookup error",
+			run: func() field.ErrorList {
+				_, _, errs := prepareCounterCharge(ctx, cl, "missing-device-class", nil, make(map[string]*resourcev1.DeviceClass), claimPath, 1)
+				return errs
+			},
+			wantField: reqPath.String(),
+		},
+		{
+			name: "request selector compilation error",
+			run: func() field.ErrorList {
+				_, _, errs := prepareCounterCharge(ctx, cl, "valid-device-class", []resourcev1.DeviceSelector{{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver =="}}}, make(map[string]*resourcev1.DeviceClass), claimPath, 1)
+				return errs
+			},
+			wantField: reqPath.Child("exactly", "selectors").Index(0).Child("cel", "expression").String(),
+		},
+		{
+			name: "request selector evaluation error",
+			run: func() field.ErrorList {
+				_, errs := matchDevicesWithSelectors(ctx, newPools(), "gpu.example.com", []dracel.CompilationResult{validSelector}, nil, nil, reqPath)
+				return errs
+			},
+			wantField:  reqPath.String(),
+			wantDetail: "unsupported attribute value",
 		},
 	}
 
-	cache := dracel.NewCache(1, dracel.Features{})
-	result := cache.GetOrCompile("device.driver == 'gpu.example.com'")
-	if result.Error != nil {
-		t.Fatalf("CEL compilation failed: %v", result.Error)
-	}
-
-	reqPath := field.NewPath("test")
-	matched, errs := matchDevicesWithSelectors(ctx, pools, "gpu.example.com",
-		[]dracel.CompilationResult{result}, nil, nil, reqPath)
-
-	if len(errs) == 0 {
-		t.Fatalf("Expected CEL evaluation error to be propagated, got %d matched devices", len(matched))
-	}
-	if !strings.Contains(errs[0].Detail, "unsupported attribute value") {
-		t.Errorf("Expected error containing 'unsupported attribute value', got: %s", errs[0].Detail)
-	}
-}
-
-func TestPrepareDeviceSelectors_DeviceClassErrorUsesRequestPath(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-	cl := utiltesting.NewClientBuilder().Build()
-	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
-
-	_, _, errs := prepareCounterCharge(
-		ctx,
-		cl,
-		"missing-device-class",
-		nil,
-		make(map[string]*resourcev1.DeviceClass),
-		claimPath,
-		1,
-	)
-
-	if len(errs) != 1 {
-		t.Fatalf("expected one error, got %d: %v", len(errs), errs)
-	}
-	const wantPath = "spec.podSets[0].template.spec.resourceClaims[0].devices.requests[1]"
-	if errs[0].Field != wantPath {
-		t.Errorf("field path = %q, want %q", errs[0].Field, wantPath)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.run()
+			if len(errs) != 1 {
+				t.Fatalf("expected one error, got %d: %v", len(errs), errs)
+			}
+			if errs[0].Field != tc.wantField {
+				t.Errorf("field path = %q, want %q", errs[0].Field, tc.wantField)
+			}
+			if tc.wantDetail != "" && !strings.Contains(errs[0].Detail, tc.wantDetail) {
+				t.Errorf("error detail = %q, want it to contain %q", errs[0].Detail, tc.wantDetail)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Tried to fix DRA DeviceClass validation errors being  reported with a duplicated request field path and an incorrect request index. The shared selector-preparation helper now receives the claim-level field path and the actual device-request index. Both counter-based and capacity-based DRA quota paths use the corrected contract.
<img width="635" height="236" alt="patch1" src="https://github.com/user-attachments/assets/ad99b23e-57e7-4d1c-a409-e33d69993c8c" />


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fixed DeviceClass validation errors reporting a duplicated request field path with an incorrect request index in counter-based and capacity-based quota paths.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity request validation to report errors against the correct claim, request field, and index.
  * Corrected device-class resolution and selector processing for resource claims.
  * Improved error details for selector compilation and evaluation failures, including nested expression paths.

* **Tests**
  * Added coverage verifying accurate paths and details across device-class lookup, selector compilation, and selector evaluation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->