### PR TITLE
Release automation: add /milestone-pull ChatOps command

### DIFF
--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -21,6 +21,7 @@ jobs:
        contains(github.event.comment.body, '/wait-for-images') ||
        contains(github.event.comment.body, '/wait-for-prod-images') ||
        contains(github.event.comment.body, '/prepare-pull') ||
+       contains(github.event.comment.body, '/milestone-pull') ||
        contains(github.event.comment.body, '/publish-release'))
     outputs:
       command: ${{ steps.parse.outputs.command }}
@@ -97,6 +98,8 @@ jobs:
               exit 1
             fi
             echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/milestone-pull[[:space:]]*$'; then
+            COMMAND="milestone-pull"
           elif printf '%s' "$BODY" | tr -d '\r' | grep -qE '^/publish-release[[:space:]]*$'; then
             COMMAND="publish-release"
           else
@@ -615,6 +618,119 @@ jobs:
         with:
           command: ${{ needs.authorize.outputs.command }}
           message: ${{ steps.prep_pull.outputs.message || '❌ Failed to prepare pull requests.' }}
+
+  milestone-pull:
+    name: Milestone Pull
+    runs-on: ubuntu-latest
+    needs: authorize
+    timeout-minutes: 30
+    if: ${{ needs.authorize.outputs.command == 'milestone-pull' }}
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          persist-credentials: false
+
+      - name: Checkout kubernetes/test-infra
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: kubernetes/test-infra
+          ref: master
+          fetch-depth: 1
+          path: kubernetes/test-infra
+          persist-credentials: false
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "kueue-release-bot"
+          git config --global user.email "kueue-release-bot@kubernetes.io"
+
+      - name: Create Milestone
+        id: milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          SKIP_PR: "1"
+          KUBERNETES_SIGS_KUEUE_UPSTREAM_REMOTE: origin
+        run: |
+          set +e
+          ./hack/releasing/milestone_pull.sh "$VERSION"
+          SCRIPT_EXIT_CODE=$?
+          set -e
+
+          # Exit 2 means the script declined before doing anything — a patch release, or an
+          # unmet precondition. Reporting that as a creation failure hides the real reason.
+          if [ $SCRIPT_EXIT_CODE -eq 2 ]; then
+            echo "message=❌ \`/milestone-pull\` declined to run for \`$VERSION\`. It applies only to major and minor releases; see the job log for the exact precondition." >> "$GITHUB_OUTPUT"
+            exit $SCRIPT_EXIT_CODE
+          fi
+          if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
+            echo "message=❌ Failed to create the milestone for version \`$VERSION\`." >> "$GITHUB_OUTPUT"
+            exit $SCRIPT_EXIT_CODE
+          fi
+
+          NEXT_MINOR=$(echo "$VERSION" | awk -F. '{printf "%s.%d", $1, $2 + 1}')
+          echo "next_minor=$NEXT_MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Check Bot Credential
+        id: credential
+        env:
+          BOT_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
+        run: |
+          if [ -n "$BOT_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Submit Milestone Applier PR
+        id: mapping_pr
+        if: ${{ steps.credential.outputs.available == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.KUEUE_RELEASE_BOT_TOKEN }}
+          VERSION: ${{ needs.authorize.outputs.version }}
+          GITHUB_USER: ${{ vars.KUEUE_RELEASE_BOT_USER || 'kueue-release-bot' }}
+          SKIP_MILESTONE: "1"
+          KUBERNETES_SIGS_KUEUE_UPSTREAM_REMOTE: origin
+          KUBERNETES_TEST_INFRA_PATH: ${{ github.workspace }}/kubernetes/test-infra
+          KUBERNETES_TEST_INFRA_UPSTREAM_REMOTE: origin
+          KUBERNETES_TEST_INFRA_FORK_REMOTE: fork
+          NEXT_MINOR: ${{ steps.milestone.outputs.next_minor }}
+        run: |
+          gh auth setup-git
+          git -C "$KUBERNETES_TEST_INFRA_PATH" remote add fork \
+            "https://github.com/${GITHUB_USER}/test-infra.git"
+
+          set +e
+          ./hack/releasing/milestone_pull.sh "$VERSION"
+          SCRIPT_EXIT_CODE=$?
+          set -e
+
+          if [ $SCRIPT_EXIT_CODE -ne 0 ]; then
+            echo "message=❌ Milestone \`$NEXT_MINOR\` is present, but the milestone_applier PR failed." >> "$GITHUB_OUTPUT"
+            exit $SCRIPT_EXIT_CODE
+          fi
+
+      - name: Report Success
+        if: ${{ success() }}
+        uses: ./.github/actions/report-result
+        with:
+          command: ${{ needs.authorize.outputs.command }}
+          message: >-
+            ${{ steps.credential.outputs.available == 'true'
+              && format('✅ Milestone `{0}` is present and the milestone_applier PR was submitted to kubernetes/test-infra.', steps.milestone.outputs.next_minor)
+              || format('✅ Milestone `{0}` is present. ⚠️ The milestone_applier PR was not opened: repository secret `KUEUE_RELEASE_BOT_TOKEN` is not configured. Run `SKIP_MILESTONE=1 GITHUB_USER=<your-user> ./hack/releasing/milestone_pull.sh {1}` locally to open it, or ask a maintainer to provision the secret.', steps.milestone.outputs.next_minor, needs.authorize.outputs.version) }}
+
+      - name: Report Failure
+        if: ${{ failure() }}
+        uses: ./.github/actions/report-result
+        with:
+          command: ${{ needs.authorize.outputs.command }}
+          message: ${{ steps.mapping_pr.outputs.message || steps.milestone.outputs.message || '❌ Failed to run the milestone step.' }}
 
   publish-release:
     name: Publish Release

--- a/hack/releasing/milestone_pull/README.md
+++ b/hack/releasing/milestone_pull/README.md
@@ -1,0 +1,170 @@
+# `milestone_pull.sh`
+
+Script: [`../milestone_pull.sh`](../milestone_pull.sh) · ChatOps: `/milestone-pull` · Tests:
+[`../../testing/milestone_pull_test.sh`](../../testing/milestone_pull_test.sh)
+
+Performs the "prepare the repo for the next version" milestone item of the release checklist
+in [`NEW_RELEASE.md`](../../../.github/ISSUE_TEMPLATE/NEW_RELEASE.md). Applies to **major and
+minor** releases only; patch releases have no milestone step and are refused.
+
+It does two things:
+
+1. **Milestone** — ensures an open `v0.X+1` milestone exists in `kubernetes-sigs/kueue`.
+2. **Mapping pull request** — opens a PR against `kubernetes/test-infra` updating prow's
+   `milestone_applier` config so new PRs get the right milestone automatically.
+
+For release `v0.20.0` the PR is a two-line diff in `config/prow/plugins.yaml`:
+
+```diff
+   kubernetes-sigs/kueue:
+-    main: v0.20
++    main: v0.21
++    release-0.20: v0.20
+     release-0.19: v0.19
+```
+
+Reference: [kubernetes/test-infra#37139](https://github.com/kubernetes/test-infra/pull/37139).
+
+For the release process as a whole see [`RELEASE.md`](../../../RELEASE.md); the ChatOps commands
+are defined in [`release-utils.yml`](../../../.github/workflows/release-utils.yml).
+
+---
+
+## Why two phases
+
+The halves write to **different repositories and need different credentials**, so each is
+separately skippable and separately reported. That is also why the workflow invokes the script
+twice rather than once.
+
+| Phase | Writes to | Credential in CI | Available today |
+|---|---|---|---|
+| Milestone | `kubernetes-sigs/kueue` | `secrets.GITHUB_TOKEN` (`issues: write`) | **yes** |
+| Mapping pull request | `kubernetes/test-infra` | `secrets.KUEUE_RELEASE_BOT_TOKEN` | not yet |
+
+Until `KUEUE_RELEASE_BOT_TOKEN` is provisioned, `/milestone-pull` creates the milestone, reports
+that the pull request half is not enabled, and **still succeeds**. Open the pull request locally
+in the meantime with `SKIP_MILESTONE=1`. When the secret lands, the same command does both with
+no change to the script or the workflow.
+
+The phases are not transactional: a created milestone survives a failed pull request. That is
+why the summary reports them separately and why both are idempotent, so a retry picks up where
+the last run stopped rather than duplicating work.
+
+## Usage
+
+### Manually, via the script
+
+This is the path the release checklist points at, and it does both halves today. Requires a
+`kubernetes/test-infra` clone with an `upstream` remote and your fork, plus an authenticated
+`gh`:
+
+```bash
+GITHUB_USER=<your-gh-user> ./hack/releasing/milestone_pull.sh v0.20.0
+```
+
+Inspect before submitting — does everything except create the milestone, push, and open the PR,
+leaving the branch and commit in place:
+
+```bash
+DRY_RUN=1 GITHUB_USER=<your-gh-user> ./hack/releasing/milestone_pull.sh v0.20.0
+```
+
+Then confirm the diff is the two lines and nothing else:
+
+```bash
+git -C ../../kubernetes/test-infra diff --stat HEAD~1
+```
+
+Expect `config/prow/plugins.yaml | 3 ++-`. Anything else is a bug, not a surprise to accept.
+
+### Automatically, via the ChatOps command
+
+Commenting on the release issue runs the same script:
+
+```
+/milestone-pull
+```
+
+The milestone half works today. The pull request half stays disabled until
+`KUEUE_RELEASE_BOT_TOKEN` is configured, so the checklist still points at the script above; once
+the secret lands, this command covers both and the checklist can switch to it.
+
+## Environment
+
+| Variable | Default | Effect |
+|---|---|---|
+| `GITHUB_USER` | *(required for the PR phase)* | Owner of the `kubernetes/test-infra` fork to push to |
+| `GH_TOKEN` | `gh auth` session | Credential for `gh` |
+| `DRY_RUN` | unset | Skip the milestone creation, the push, and the PR |
+| `SKIP_MILESTONE` | unset | Skip phase 1 |
+| `SKIP_PR` | unset | Skip phase 2 |
+| `KUBERNETES_REPOS_PATH` | `../../kubernetes` | Where Kubernetes org clones live |
+| `KUBERNETES_TEST_INFRA_PATH` | `$KUBERNETES_REPOS_PATH/test-infra` | The `test-infra` clone |
+| `KUBERNETES_TEST_INFRA_UPSTREAM_REMOTE` | `upstream` | Remote to branch from |
+| `KUBERNETES_TEST_INFRA_FORK_REMOTE` | `origin` | Remote to push to |
+
+Names and defaults match [`ci_pull.sh`](../ci_pull.sh), so an environment that works for that
+works here.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Both requested phases reached a good terminal state — created, opened, already present, already applied, already open, or skipped |
+| `1` | A requested phase failed |
+| `2` | Usage error or a precondition refusal — bad version, patch release, missing clone, dirty tree, missing release branch, no release issue, unexpected upstream state |
+
+Exit `0` does not on its own mean a pull request exists. Read the summary the script always
+prints:
+
+```text
++++ Summary for v0.20.0
+    milestone v0.21 ......... created
+    mapping pull request .... https://github.com/kubernetes/test-infra/pull/NNNNN
+```
+
+## Safety properties
+
+- **Idempotent.** Rerunning after success is a no-op that reports the existing state. It never
+  bumps `main` twice, never opens a second PR, and never duplicates the milestone.
+- **Scoped edit.** `plugins.yaml` contains **four** blocks keyed `kubernetes-sigs/kueue:` —
+  under `milestone_applier`, `repo_milestone`, `plugins`, and `external_plugins`. The edit
+  tracks the enclosing section so only the first is touched.
+- **No reformatting.** The edit is a line-oriented `awk` pass, not a YAML round-trip, so every
+  other byte of this org-wide shared file is unchanged. That is what keeps the diff reviewable.
+- **Refuses rather than guesses.** An unrecognised upstream shape, or a `main` value that does
+  not match the version being released, is an error naming the file and section — not a
+  best-effort edit.
+- **Existing milestones are never modified.** Not retitled, not reopened, not closed.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `is a patch release ... Nothing to do.` | `PATCH != 0` | Correct — the step is major/minor only |
+| `Unexpected mapping state: found main: v0.19, expected v0.20` | Stale `test-infra` clone, or wrong version passed | `git fetch upstream` in the clone; a rerun for an applied version reports "already applied" instead |
+| `Could not locate milestone_applier -> kubernetes-sigs/kueue -> main` | Upstream restructured `plugins.yaml` | Inspect the file; the edit deliberately refuses rather than guessing |
+| `Dirty tree in <path>` | Uncommitted changes in the `test-infra` clone | Stash or commit them |
+| `already present (closed, left as-is)` | A closed milestone has that title | Intentional — reopen by hand if that is what you want |
+| `No release issue found` | No **open** `Release vX.Y.Z` issue | The step runs while the release issue is still open |
+| Command comment gets no response | Actor not in `OWNERS_ALIASES`, or malformed issue title | Check `release-team` / `kueue-approvers` membership and the `Release vX.Y.Z` title |
+
+## Tests
+
+```bash
+make milestone-pull-test
+```
+
+The unit tests stub `gh` on `PATH` and drive the script against fixtures, so they need no
+network and no credentials. They run in CI via `verify-checks`. The central case builds a
+fixture containing all four `kubernetes-sigs/kueue:` blocks and asserts the output differs by
+exactly the two intended lines.
+
+Shell lint (needs a container engine):
+
+```bash
+make shell-lint
+```
+
+The ChatOps path cannot be tested before merge: `issue_comment` workflows run from the default
+branch, so a PR branch's version of the job never fires.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area release

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Part 2 of milestone release, this is adding chat ops

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13363 Related #13713 

#### Special notes for your reviewer:
AI usage disclosure: this change was developed with AI assistance (Claude Code), per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance). The design, the upstream-file analysis, and all verification were reviewed by me.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ChatOps command to automate milestone pull requests.
  * The workflow can create milestones, update test-infrastructure mappings, and optionally submit a pull request.
  * Added clear success, decline, and failure reporting.

* **Documentation**
  * Added usage instructions, configuration details, exit codes, safety information, troubleshooting guidance, and testing instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->