### PR TITLE
Automated cherry pick of #13705: stop watcher goroutines from outliving their owner

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -305,7 +305,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		}
 	}
 
-	watchCtx, rc.watchCancel = context.WithCancel(watchCtx)
+	var watchCancel context.CancelFunc
+	watchCtx, watchCancel = context.WithCancel(watchCtx)
+	rc.setWatchCancel(watchCancel)
 
 	builder := newClientWithWatch
 	if rc.builderOverride != nil {
@@ -420,43 +422,39 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	}
 
 	return func() {
-		rc.watchers.Add(1)
-		go func() {
-			defer rc.watchers.Done()
+		rc.runWatcher(func() {
 			log.V(2).Info("Starting watch")
 			resultCh := newWatcher.ResultChan()
 		watching:
 			for {
-				var r watch.Event
 				select {
 				case <-ctx.Done():
 					break watching
-				case ev, ok := <-resultCh:
+				case r, ok := <-resultCh:
 					if !ok {
 						break watching
 					}
-					r = ev
-				}
-				switch r.Type {
-				case watch.Bookmark:
-					// Bookmark events are periodic signals from the API server to
-					// keep the connection alive. They carry no meaningful payload
-					// and can be safely ignored.
-					log.V(5).Info("Watch bookmark received")
-				case watch.Error:
-					switch s := r.Object.(type) {
-					case *metav1.Status:
-						log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+					switch r.Type {
+					case watch.Bookmark:
+						// Bookmark events are periodic signals from the API server to
+						// keep the connection alive. They carry no meaningful payload
+						// and can be safely ignored.
+						log.V(5).Info("Watch bookmark received")
+					case watch.Error:
+						switch s := r.Object.(type) {
+						case *metav1.Status:
+							log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+						default:
+							log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
+						}
 					default:
-						log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
-					}
-				default:
-					wlKeys, err := w.WorkloadKeysFor(r.Object)
-					if err != nil {
-						log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
-					} else {
-						for _, wlKey := range wlKeys {
-							rc.queueWorkloadEvent(ctx, wlKey)
+						wlKeys, err := w.WorkloadKeysFor(r.Object)
+						if err != nil {
+							log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
+						} else {
+							for _, wlKey := range wlKeys {
+								rc.queueWorkloadEvent(ctx, wlKey)
+							}
 						}
 					}
 				}
@@ -470,7 +468,7 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 					rc.queueWatchEndedEvent(ctx)
 				}
 			}
-		}()
+		})
 	}, nil
 }
 
@@ -549,7 +547,10 @@ func (rc *remoteClient) queueEventsForLQ(ctx context.Context, remoteLQ *kueue.Lo
 		return
 	}
 
-	rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}
+	select {
+	case rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}:
+	case <-ctx.Done():
+	}
 }
 
 func (rc *remoteClient) getFailedConnAttempts() uint {
@@ -578,6 +579,26 @@ func (rc *remoteClient) setClient(c SelectivelyCachingClient) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 	rc.client = c
+}
+
+// setWatchCancel stores the cancel func of the watch context the next watchers will observe.
+// A non-nil value is what marks the client as accepting new watchers, see runWatcher.
+func (rc *remoteClient) setWatchCancel(cancel context.CancelFunc) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.watchCancel = cancel
+}
+
+// runWatcher starts fn as a tracked watcher goroutine, unless the watchers were already
+// stopped. Registering under rc.mu makes it mutually exclusive with StopWatchers, so a
+// watcher can never begin after StopWatchers has decided what to wait for.
+func (rc *remoteClient) runWatcher(fn func()) {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	if rc.watchCancel == nil {
+		return
+	}
+	rc.watchers.Go(fn)
 }
 
 // StopWatchers cancels the watch context and blocks until every watcher goroutine returned.

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -424,45 +424,9 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	return func() {
 		rc.runWatcher(func() {
 			log.V(2).Info("Starting watch")
-			resultCh := newWatcher.ResultChan()
-		watching:
-			for {
-				select {
-				case <-ctx.Done():
-					break watching
-				case r, ok := <-resultCh:
-					if !ok {
-						break watching
-					}
-					switch r.Type {
-					case watch.Bookmark:
-						// Bookmark events are periodic signals from the API server to
-						// keep the connection alive. They carry no meaningful payload
-						// and can be safely ignored.
-						log.V(5).Info("Watch bookmark received")
-					case watch.Error:
-						switch s := r.Object.(type) {
-						case *metav1.Status:
-							log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
-						default:
-							log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
-						}
-					default:
-						wlKeys, err := w.WorkloadKeysFor(r.Object)
-						if err != nil {
-							log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
-						} else {
-							for _, wlKey := range wlKeys {
-								rc.queueWorkloadEvent(ctx, wlKey)
-							}
-						}
-					}
-				}
-			}
+			rc.consumeWatch(ctx, log, newWatcher, w)
 			log.V(2).Info("Watch ended", "ctxErr", ctx.Err())
-			// If the context is not yet Done , queue a reconcile to attempt reconnection
 			if ctx.Err() == nil {
-				// reconnect if this is the first watch failing.
 				if wasConnected := rc.connState.markDisconnected(rc.clock.Now()); wasConnected {
 					log.V(2).Info("Queue reconcile for reconnect", "cluster", rc.clusterName)
 					rc.queueWatchEndedEvent(ctx)
@@ -470,6 +434,48 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 			}
 		})
 	}, nil
+}
+
+// consumeWatch dispatches events until the watch ends or ctx is cancelled. Cancelling does
+// not close the result channel, so the ctx arm is what lets StopWatchers join this goroutine.
+func (rc *remoteClient) consumeWatch(ctx context.Context, log logr.Logger, watcher watch.Interface, w jobframework.MultiKueueWatcher) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r, ok := <-watcher.ResultChan():
+			if !ok {
+				return
+			}
+			rc.handleWatchEvent(ctx, log, r, w)
+		}
+	}
+}
+
+func (rc *remoteClient) handleWatchEvent(ctx context.Context, log logr.Logger, r watch.Event, w jobframework.MultiKueueWatcher) {
+	switch r.Type {
+	case watch.Bookmark:
+		// Bookmark events are periodic signals from the API server to
+		// keep the connection alive. They carry no meaningful payload
+		// and can be safely ignored.
+		log.V(5).Info("Watch bookmark received")
+	case watch.Error:
+		switch s := r.Object.(type) {
+		case *metav1.Status:
+			log.V(3).Info("Watch error", "status", s.Status, "message", s.Message, "reason", s.Reason)
+		default:
+			log.V(3).Info("Watch error with unexpected type", "type", fmt.Sprintf("%T", s))
+		}
+	default:
+		wlKeys, err := w.WorkloadKeysFor(r.Object)
+		if err != nil {
+			log.Error(err, "Cannot get workload keys", "jobKind", r.Object.GetObjectKind().GroupVersionKind())
+			return
+		}
+		for _, wlKey := range wlKeys {
+			rc.queueWorkloadEvent(ctx, wlKey)
+		}
+	}
 }
 
 func (rc *remoteClient) startQueueWatchers(ctx context.Context) error {
@@ -547,10 +553,7 @@ func (rc *remoteClient) queueEventsForLQ(ctx context.Context, remoteLQ *kueue.Lo
 		return
 	}
 
-	select {
-	case rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}:
-	case <-ctx.Done():
-	}
+	rc.cqUpdateCh <- event.TypedGenericEvent[kueue.ClusterQueueReference]{Object: localLQ.Spec.ClusterQueue}
 }
 
 func (rc *remoteClient) getFailedConnAttempts() uint {
@@ -626,10 +629,7 @@ func (rc *remoteClient) disconnect() {
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
-		select {
-		case rc.wlUpdateCh <- event.GenericEvent{Object: localWl}:
-		case <-ctx.Done():
-		}
+		rc.wlUpdateCh <- event.GenericEvent{Object: localWl}
 	} else if !apierrors.IsNotFound(err) {
 		ctrl.LoggerFrom(ctx).Error(err, "reading local workload")
 	}
@@ -638,10 +638,7 @@ func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.Name
 func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 	cluster := &kueue.MultiKueueCluster{}
 	if err := rc.localClient.Get(ctx, types.NamespacedName{Name: rc.clusterName}, cluster); err == nil {
-		select {
-		case rc.watchEndedCh <- event.GenericEvent{Object: cluster}:
-		case <-ctx.Done():
-		}
+		rc.watchEndedCh <- event.GenericEvent{Object: cluster}
 	} else {
 		ctrl.LoggerFrom(ctx).Error(err, "sending watch ended event")
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -122,6 +122,7 @@ type remoteClient struct {
 	watchEndedCh chan<- event.GenericEvent
 	cqUpdateCh   chan<- event.TypedGenericEvent[kueue.ClusterQueueReference]
 	watchCancel  func()
+	watchers     sync.WaitGroup
 	config       *clientConfig
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
@@ -419,9 +420,23 @@ func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w job
 	}
 
 	return func() {
+		rc.watchers.Add(1)
 		go func() {
+			defer rc.watchers.Done()
 			log.V(2).Info("Starting watch")
-			for r := range newWatcher.ResultChan() {
+			resultCh := newWatcher.ResultChan()
+		watching:
+			for {
+				var r watch.Event
+				select {
+				case <-ctx.Done():
+					break watching
+				case ev, ok := <-resultCh:
+					if !ok {
+						break watching
+					}
+					r = ev
+				}
 				switch r.Type {
 				case watch.Bookmark:
 					// Bookmark events are periodic signals from the API server to
@@ -565,13 +580,17 @@ func (rc *remoteClient) setClient(c SelectivelyCachingClient) {
 	rc.client = c
 }
 
+// StopWatchers cancels the watch context and blocks until every watcher goroutine returned.
 func (rc *remoteClient) StopWatchers() {
 	rc.mu.Lock()
-	defer rc.mu.Unlock()
 	if rc.watchCancel != nil {
 		rc.watchCancel()
 		rc.watchCancel = nil
 	}
+	rc.mu.Unlock()
+
+	// Not under rc.mu: watcher goroutines take it themselves via getClient.
+	rc.watchers.Wait()
 }
 
 // disconnect stops the watchers and marks the client as disconnected without
@@ -586,7 +605,10 @@ func (rc *remoteClient) disconnect() {
 func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.NamespacedName) {
 	localWl := &kueue.Workload{}
 	if err := rc.localClient.Get(ctx, wlKey, localWl); err == nil {
-		rc.wlUpdateCh <- event.GenericEvent{Object: localWl}
+		select {
+		case rc.wlUpdateCh <- event.GenericEvent{Object: localWl}:
+		case <-ctx.Done():
+		}
 	} else if !apierrors.IsNotFound(err) {
 		ctrl.LoggerFrom(ctx).Error(err, "reading local workload")
 	}
@@ -595,7 +617,10 @@ func (rc *remoteClient) queueWorkloadEvent(ctx context.Context, wlKey types.Name
 func (rc *remoteClient) queueWatchEndedEvent(ctx context.Context) {
 	cluster := &kueue.MultiKueueCluster{}
 	if err := rc.localClient.Get(ctx, types.NamespacedName{Name: rc.clusterName}, cluster); err == nil {
-		rc.watchEndedCh <- event.GenericEvent{Object: cluster}
+		select {
+		case rc.watchEndedCh <- event.GenericEvent{Object: cluster}:
+		case <-ctx.Done():
+		}
 	} else {
 		ctrl.LoggerFrom(ctx).Error(err, "sending watch ended event")
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -687,6 +687,15 @@ func TestUpdateConfig(t *testing.T) {
 			}
 			reconciler.builderOverride = fakeClientBuilder(ctx)
 
+			// Reconcile starts watcher goroutines that log through this test's logger.
+			// Nothing else joins them, so without this they outlive the test and race
+			// with tRunner's teardown.
+			t.Cleanup(func() {
+				for _, rc := range reconciler.remoteClients {
+					rc.StopWatchers()
+				}
+			})
+
 			if tc.skipInsecureKubeconfig {
 				features.SetFeatureGateDuringTest(t, features.MultiKueueAllowInsecureKubeconfigs, true)
 			}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1530,3 +1530,94 @@ func TestRemoteClientConcurrentSetConfigAndReaders(t *testing.T) {
 		_ = remoteCl.List(ctx, &kueue.LocalQueueList{}) // clusterqueue.go-style read
 	})
 }
+
+func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	fw := watch.NewFake()
+	t.Cleanup(fw.Stop)
+
+	rc := newTestClient(ctx, []byte("placeholder"), nil, nil)
+	rc.client = NewNeverCachingClient(getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
+		Watch: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+			return fw, nil
+		},
+	}).Build())
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	rc.setWatchCancel(cancel)
+
+	startWatcher, err := rc.establishWatcher(watchCtx, "Workload", &workloadKueueWatcher{})
+	if err != nil {
+		t.Fatalf("unexpected error establishing the watcher: %v", err)
+	}
+	startWatcher()
+
+	stopped := make(chan struct{})
+	go func() {
+		rc.StopWatchers()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(30 * time.Second):
+		t.Fatal("StopWatchers did not return: the watcher goroutine was never joined")
+	}
+}
+
+func TestQueueEventSendsUnblockOnCancel(t *testing.T) {
+	baseCtx, _ := utiltesting.ContextWithLog(t)
+
+	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl1", Namespace: "ns1"}}
+	lq := &kueue.LocalQueue{
+		ObjectMeta: metav1.ObjectMeta{Name: "lq1", Namespace: "ns1"},
+		Spec:       kueue.LocalQueueSpec{ClusterQueue: "cq1"},
+	}
+	cluster := &kueue.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: "worker1"}}
+
+	cases := map[string]func(ctx context.Context, rc *remoteClient){
+		"queueWorkloadEvent on wlUpdateCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueWorkloadEvent(ctx, types.NamespacedName{Namespace: "ns1", Name: "wl1"})
+		},
+		"queueWatchEndedEvent on watchEndedCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueWatchEndedEvent(ctx)
+		},
+		"queueEventsForLQ on cqUpdateCh": func(ctx context.Context, rc *remoteClient) {
+			rc.queueEventsForLQ(ctx, lq)
+		},
+	}
+
+	for name, send := range cases {
+		t.Run(name, func(t *testing.T) {
+			rc := &remoteClient{
+				clusterName:  "worker1",
+				localClient:  getClientBuilder(baseCtx).WithObjects(wl, lq, cluster).Build(),
+				wlUpdateCh:   make(chan event.GenericEvent),
+				watchEndedCh: make(chan event.GenericEvent),
+				cqUpdateCh:   make(chan event.TypedGenericEvent[kueue.ClusterQueueReference]),
+				clock:        clock.RealClock{},
+			}
+
+			ctx, cancel := context.WithCancel(baseCtx)
+			returned := make(chan struct{})
+			go func() {
+				send(ctx, rc)
+				close(returned)
+			}()
+
+			select {
+			case <-returned:
+				t.Fatal("send returned before cancellation; it never blocked on the channel")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			cancel()
+			select {
+			case <-returned:
+			case <-time.After(30 * time.Second):
+				t.Fatal("send did not unblock on cancellation")
+			}
+		})
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -852,6 +852,7 @@ func TestReconnectBackoff(t *testing.T) {
 			rc.clock = fc
 			rc.builderOverride = reconciler.builderOverride
 			reconciler.remoteClients["worker1"] = rc
+			t.Cleanup(rc.StopWatchers)
 
 			req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "worker1"}}
 
@@ -1431,6 +1432,11 @@ func TestSetRemoteClientConfigDoesNotBlockOtherClusters(t *testing.T) {
 	reconciler := newClustersReconciler(localClient, TestNamespace, 0, defaultOrigin, nil, nil, &NoOpClusterProfileCreds{}, nil)
 	reconciler.rootContext = ctx
 	reconciler.builderOverride = gatedBuilder
+	t.Cleanup(func() {
+		for _, rc := range reconciler.remoteClients {
+			rc.StopWatchers()
+		}
+	})
 
 	slowDone := make(chan struct{})
 	go func() {
@@ -1563,61 +1569,5 @@ func TestStopWatchersJoinsParkedWatcher(t *testing.T) {
 	case <-stopped:
 	case <-time.After(30 * time.Second):
 		t.Fatal("StopWatchers did not return: the watcher goroutine was never joined")
-	}
-}
-
-func TestQueueEventSendsUnblockOnCancel(t *testing.T) {
-	baseCtx, _ := utiltesting.ContextWithLog(t)
-
-	wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Name: "wl1", Namespace: "ns1"}}
-	lq := &kueue.LocalQueue{
-		ObjectMeta: metav1.ObjectMeta{Name: "lq1", Namespace: "ns1"},
-		Spec:       kueue.LocalQueueSpec{ClusterQueue: "cq1"},
-	}
-	cluster := &kueue.MultiKueueCluster{ObjectMeta: metav1.ObjectMeta{Name: "worker1"}}
-
-	cases := map[string]func(ctx context.Context, rc *remoteClient){
-		"queueWorkloadEvent on wlUpdateCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueWorkloadEvent(ctx, types.NamespacedName{Namespace: "ns1", Name: "wl1"})
-		},
-		"queueWatchEndedEvent on watchEndedCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueWatchEndedEvent(ctx)
-		},
-		"queueEventsForLQ on cqUpdateCh": func(ctx context.Context, rc *remoteClient) {
-			rc.queueEventsForLQ(ctx, lq)
-		},
-	}
-
-	for name, send := range cases {
-		t.Run(name, func(t *testing.T) {
-			rc := &remoteClient{
-				clusterName:  "worker1",
-				localClient:  getClientBuilder(baseCtx).WithObjects(wl, lq, cluster).Build(),
-				wlUpdateCh:   make(chan event.GenericEvent),
-				watchEndedCh: make(chan event.GenericEvent),
-				cqUpdateCh:   make(chan event.TypedGenericEvent[kueue.ClusterQueueReference]),
-				clock:        clock.RealClock{},
-			}
-
-			ctx, cancel := context.WithCancel(baseCtx)
-			returned := make(chan struct{})
-			go func() {
-				send(ctx, rc)
-				close(returned)
-			}()
-
-			select {
-			case <-returned:
-				t.Fatal("send returned before cancellation; it never blocked on the channel")
-			case <-time.After(100 * time.Millisecond):
-			}
-
-			cancel()
-			select {
-			case <-returned:
-			case <-time.After(30 * time.Second):
-				t.Fatal("send did not unblock on cancellation")
-			}
-		})
 	}
 }


### PR DESCRIPTION
Cherry pick of #13705 on release-0.18.

#13705: stop watcher goroutines from outliving their owner

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind flake


```release-note
MultiKueue: Fixed an issue where remote-cluster watcher goroutines could continue running after a worker cluster was removed, disconnected, or reconfigured.
```