### PR TITLE
Guard TASFlavorCache.NodeLabels with a read lock

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -125,7 +125,12 @@ func (c *TASFlavorCache) updateNodeLabels(nodeLabels map[string]string) {
 	c.flavor.NodeLabels = nodeLabels
 }
 
+// NodeLabels returns the node labels of the flavor. The returned map is safe to
+// read without holding the lock, because updateNodeLabels always replaces the
+// whole map with a copy owned by the cache, and never mutates it in place.
 func (c *TASFlavorCache) NodeLabels() map[string]string {
+	c.RLock()
+	defer c.RUnlock()
 	return c.flavor.NodeLabels
 }
 

--- a/pkg/cache/scheduler/tas_flavor_test.go
+++ b/pkg/cache/scheduler/tas_flavor_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package scheduler
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -137,4 +139,41 @@ func TestTASFlavorCacheAddAndRemoveUsage(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTASFlavorCacheNodeLabelsConcurrentAccess reproduces the data race between
+// the ResourceFlavor informer handler updating the cached node labels and the
+// node event handlers reading them. It only fails under `go test -race`.
+func TestTASFlavorCacheNodeLabelsConcurrentAccess(t *testing.T) {
+	const (
+		iterations = 1000
+		readers    = 4
+	)
+	const labelKey = "cloud.provider.com/node-group"
+
+	cache := &TASFlavorCache{
+		flavor: flavorInformation{
+			NodeLabels: map[string]string{labelKey: "group-0"},
+		},
+	}
+	nodeLabels := map[string]string{labelKey: "group-0"}
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range iterations {
+			cache.updateNodeLabels(map[string]string{labelKey: fmt.Sprintf("group-%d", i)})
+		}
+	})
+	matches := make([]int, readers)
+	for r := range readers {
+		wg.Go(func() {
+			for range iterations {
+				if utiltas.NodeMatchesFlavor(nodeLabels, cache.NodeLabels(), nil) {
+					matches[r]++
+				}
+			}
+		})
+	}
+	wg.Wait()
+	t.Logf("matches per reader: %v", matches)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

After #13738 introduced updates to cached node labels, `TASFlavorCache.NodeLabels()` could race with `updateNodeLabels()` because the getter read the field without holding the cache lock.

This PR guards the getter with the read lock. No map copy is needed: `AddOrUpdateFlavor` clones the incoming labels, and `updateNodeLabels` replaces the map rather than mutating it in place. The adjacent accessors read fields that are not updated after construction.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13841

#### Special notes for your reviewer:

The regression test exercises concurrent reads and writes. Removing the `RLock` reproduces the race under `go test -race`; it passes with the fix.

Originally detected in https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/13785/pull-kueue-test-integration-shard-2-main/2084754272922112000 and preserved in `artifacts/race.44845`.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when reading flavor node labels while updates occur concurrently.
  * Prevented potential data races during concurrent scheduling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->