### PR TITLE
Gate AFS entry penalties by admission mode and scheduling pass

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -940,7 +940,7 @@ func (s *Scheduler) admit(ctx context.Context, e *entry, cq *schdcache.ClusterQu
 		// by an event.
 		_ = s.cache.DeleteWorkload(log, workload.Key(cacheWl))
 		s.queues.NotifyWorkloadUpdateWatchers(cacheWl, nil)
-		if afs.Enabled(s.admissionFairSharing) {
+		if s.shouldApplyEntryPenalty(e) {
 			s.updateEntryPenalty(log, e, subtract)
 		}
 		if apierrors.IsNotFound(err) {
@@ -973,7 +973,7 @@ func (s *Scheduler) assumeWorkload(log logr.Logger, e *entry, cq *schdcache.Clus
 	e.markAssumed()
 	log.V(2).Info("Workload assumed in the cache")
 
-	if afs.Enabled(s.admissionFairSharing) {
+	if s.shouldApplyEntryPenalty(e) {
 		s.updateEntryPenalty(log, e, add)
 		// Trigger LocalQueue reconciler to apply any pending penalties
 		s.queues.NotifyWorkloadUpdateWatchers(e.Obj, cacheWl)
@@ -1208,6 +1208,25 @@ func filterByNames(requests corev1.ResourceList, allowed sets.Set[corev1.Resourc
 		}
 	}
 	return filtered
+}
+
+// shouldApplyEntryPenalty gates both the entry-penalty push at assume time and
+// its rollback on a failed admission patch, so the two always pair up.
+func (s *Scheduler) shouldApplyEntryPenalty(e *entry) bool {
+	if !afs.Enabled(s.admissionFairSharing) {
+		return false
+	}
+	// Only UsageBasedAdmissionFairSharing ClusterQueues settle, so a penalty pushed
+	// for any other ClusterQueue would never be consolidated and would inflate the
+	// LocalQueue's usage until restart.
+	if e.clusterQueueSnapshot.AdmissionScope.AdmissionMode != kueue.UsageBasedAdmissionFairSharing {
+		return false
+	}
+	// A second scheduling pass (delayed topology, node-failure replacement)
+	// re-assumes an already-reserved workload whose penalty was pushed on the first
+	// pass. One reservation contributes at most one push, mirroring netUsage, which
+	// books no additional quota for an already-reserved workload.
+	return !workload.HasQuotaReservation(e.Obj)
 }
 
 func (s *Scheduler) updateEntryPenalty(log logr.Logger, e *entry, op usageOp) {

--- a/pkg/scheduler/scheduler_afs_secondpass_test.go
+++ b/pkg/scheduler/scheduler_afs_secondpass_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testingclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/util/routine"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// TestSecondPassDoesNotRepushEntryPenalty exercises the real scheduler second-pass
+// path (delayed topology assignment) for an AdmissionFairSharing ClusterQueue and
+// asserts that re-assuming a workload which already holds a quota reservation does not
+// push another entry penalty.
+//
+// This is the end-to-end companion to the predicate-level TestShouldApplyEntryPenalty:
+// it proves the second-pass re-assume actually reaches the push site, so the
+// HasQuotaReservation guard is load-bearing rather than merely correct in isolation.
+// On main (no guard) the second-pass assume pushes a duplicate penalty that a single
+// settlement can never clear; here the bucket must stay empty.
+func TestSecondPassDoesNotRepushEntryPenalty(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+	afsConfig := &config.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
+		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+	}
+
+	topology := *utiltestingapi.MakeDefaultOneLevelTopology("tas-single-level")
+	tasFlavor := *utiltestingapi.MakeResourceFlavor("tas-default").
+		NodeLabel("tas-node", "true").
+		TopologyName("tas-single-level").
+		Obj()
+	node := *testingnode.MakeNode("x1").
+		Label("tas-node", "true").
+		Label(corev1.LabelHostname, "x1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+			corev1.ResourcePods:   resource.MustParse("10"),
+		}).
+		Ready().
+		Obj()
+	provCheck := *utiltestingapi.MakeAdmissionCheck("prov-check").
+		ControllerName(kueue.ProvisioningRequestControllerName).
+		Condition(metav1.Condition{Type: kueue.AdmissionCheckActive, Status: metav1.ConditionTrue}).
+		Obj()
+	cq := *utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+			Resource(corev1.ResourceCPU, "50").
+			Resource(corev1.ResourceMemory, "50Gi").Obj()).
+		AdmissionChecks(kueue.AdmissionCheckReference(provCheck.Name)).
+		AdmissionMode(kueue.UsageBasedAdmissionFairSharing).
+		Obj()
+	lq := *utiltestingapi.MakeLocalQueue("lq", "default").
+		FairSharing(&kueue.FairSharing{Weight: new(resource.MustParse("1"))}).
+		ClusterQueue("cq").
+		Obj()
+
+	// A workload mid-second-pass: it already holds quota from the first pass (which
+	// pushed and settled its entry penalty already), all admission checks are ready,
+	// and only the delayed topology assignment is still pending. The second pass
+	// re-assumes it to complete the assignment.
+	wl := *utiltestingapi.MakeWorkload("foo", "default").
+		Queue("lq").
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment("one").
+					Assignment(corev1.ResourceCPU, "tas-default", "1000m").
+					DelayedTopologyRequest(kueue.DelayedTopologyRequestStatePending).
+					Obj()).
+				Obj(), now).
+		AdmissionCheck(kueue.AdmissionCheckState{Name: "prov-check", State: kueue.CheckStateReady}).
+		Obj()
+
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithLists(
+			&kueue.WorkloadList{Items: []kueue.Workload{wl}},
+			&kueue.ClusterQueueList{Items: []kueue.ClusterQueue{cq}},
+			&kueue.LocalQueueList{Items: []kueue.LocalQueue{lq}}).
+		WithObjects(utiltesting.MakeNamespace("default"), &provCheck).
+		WithStatusSubresource(&kueue.Workload{}).
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge})
+	if err := tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder)); err != nil {
+		t.Fatalf("setting up TAS indexes: %v", err)
+	}
+	cl := clientBuilder.Build()
+
+	recorder := &utiltesting.EventRecorder{}
+	cqCache := schdcache.New(cl, schdcache.WithFairSharing(true), schdcache.WithAdmissionFairSharing(afsConfig))
+	qManager := qcache.NewManagerForUnitTests(cl, cqCache, qcache.WithClock(fakeClock), qcache.WithAdmissionFairSharing(afsConfig))
+
+	cqCache.TASCache().SyncNode(&node)
+	cqCache.AddOrUpdateAdmissionCheck(log, &provCheck)
+	cqCache.AddOrUpdateResourceFlavor(log, &tasFlavor)
+	cqCache.AddOrUpdateTopology(log, &topology)
+	if err := cqCache.AddClusterQueue(ctx, &cq); err != nil {
+		t.Fatalf("inserting clusterQueue in cache: %v", err)
+	}
+	if err := qManager.AddClusterQueue(ctx, &cq); err != nil {
+		t.Fatalf("inserting clusterQueue in manager: %v", err)
+	}
+	if err := qManager.AddLocalQueue(ctx, &lq); err != nil {
+		t.Fatalf("inserting localQueue in manager: %v", err)
+	}
+	// The reserved workload contributes its usage to the cache, mirroring production.
+	cqCache.AddOrUpdateWorkload(log, &wl)
+	if !qManager.QueueSecondPassIfNeeded(ctx, &wl, 0) {
+		t.Fatal("expected the workload to be queued for a second pass")
+	}
+	fakeClock.Step(time.Second)
+
+	scheduler := New(qManager, cqCache, cl, recorder,
+		WithFairSharing(&config.FairSharing{}),
+		WithAdmissionFairSharing(afsConfig),
+		WithClock(t, fakeClock),
+		WithPreemptionExpectations(preemptexpectations.New()))
+	wg := sync.WaitGroup{}
+	scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+		func() { wg.Add(1) },
+		func() { wg.Done() },
+	))
+
+	schedCtx, cancel := context.WithTimeout(ctx, queueingTimeout)
+	defer cancel()
+	go qManager.CleanUpOnContext(schedCtx)
+
+	scheduler.schedule(schedCtx)
+	wg.Wait()
+
+	// Guard against a vacuous test: the second pass must actually have run and admitted
+	// the workload (completing the topology assignment), otherwise no re-assume happened
+	// and the penalty assertion below would pass trivially.
+	gotWl := &kueue.Workload{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(&wl), gotWl); err != nil {
+		t.Fatalf("getting workload after scheduling: %v", err)
+	}
+	if !workload.IsAdmitted(gotWl) {
+		t.Fatalf("expected the second pass to admit the workload, but it is not admitted: %+v", gotWl.Status.Conditions)
+	}
+
+	lqKey := utilqueue.NewLocalQueueReference("default", "lq")
+	if qManager.AfsEntryPenalties.HasPendingFor(lqKey) {
+		t.Errorf("second pass pushed a duplicate entry penalty for an already-reserved workload; bucket = %v, want empty",
+			qManager.AfsEntryPenalties.Peek(lqKey))
+	}
+}

--- a/pkg/scheduler/scheduler_afs_test.go
+++ b/pkg/scheduler/scheduler_afs_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/routine"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 func TestScheduleForAFS(t *testing.T) {
@@ -947,5 +948,72 @@ func TestScheduleForAFS(t *testing.T) {
 				},
 			)
 		}
+	}
+}
+
+func TestShouldApplyEntryPenalty(t *testing.T) {
+	// shouldApplyEntryPenalty reads the AdmissionFairSharing gate through
+	// afs.Enabled; pin it so the cases below turn on the config and the
+	// ClusterQueue mode rather than on the process-global default.
+	features.SetFeatureGateDuringTest(t, features.AdmissionFairSharing, true)
+	now := time.Now().Truncate(time.Second)
+	afsConfig := &config.AdmissionFairSharing{
+		UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Second},
+		UsageSamplingInterval: metav1.Duration{Duration: 1 * time.Second},
+	}
+
+	pendingWl := utiltestingapi.MakeWorkload("wl", "ns").
+		Queue("lq").
+		Request(corev1.ResourceCPU, "4").
+		Obj()
+	reservedWl := utiltestingapi.MakeWorkload("wl", "ns").
+		Queue("lq").
+		Request(corev1.ResourceCPU, "4").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		Obj()
+
+	cases := map[string]struct {
+		afsConfig     *config.AdmissionFairSharing
+		admissionMode kueue.AdmissionMode
+		wl            *kueue.Workload
+		want          bool
+	}{
+		"pushes for a first-pass workload on a usage-based ClusterQueue": {
+			afsConfig:     afsConfig,
+			admissionMode: kueue.UsageBasedAdmissionFairSharing,
+			wl:            pendingWl,
+			want:          true,
+		},
+		"skips when no AdmissionFairSharing config is set": {
+			admissionMode: kueue.UsageBasedAdmissionFairSharing,
+			wl:            pendingWl,
+			want:          false,
+		},
+		"skips for a ClusterQueue without usage-based admission mode": {
+			afsConfig: afsConfig,
+			wl:        pendingWl,
+			want:      false,
+		},
+		"skips a second-pass workload that already holds a quota reservation": {
+			afsConfig:     afsConfig,
+			admissionMode: kueue.UsageBasedAdmissionFairSharing,
+			wl:            reservedWl,
+			want:          false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := &Scheduler{admissionFairSharing: tc.afsConfig}
+			e := &entry{
+				Info: *workload.NewInfo(tc.wl),
+				clusterQueueSnapshot: &schdcache.ClusterQueueSnapshot{
+					AdmissionScope: kueue.AdmissionScope{AdmissionMode: tc.admissionMode},
+				},
+			}
+
+			if got := s.shouldApplyEntryPenalty(e); got != tc.want {
+				t.Errorf("shouldApplyEntryPenalty() = %t, want %t", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The scheduler added an entry penalty on every Workload assumption whenever AdmissionFairSharing was enabled. This left stale penalties in two cases:

- ClusterQueues not using `UsageBasedAdmissionFairSharing`, because they never settle entry penalties. Their pending penalty also permanently defeats the LocalQueue reconciler's sampling-interval short-circuit.
- Second-pass Workloads, because re-assuming a Workload that already holds a quota reservation added another penalty, while admission settles only one.

`shouldApplyEntryPenalty` now gates both the push and its rollback. Entry penalties are applied only to first-pass Workloads in usage-based ClusterQueues, so each reservation contributes at most one penalty.

Extracted from #13724 as a standalone, cherry-pickable fix.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13495

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
AdmissionFairSharing: Fixed stale fair-sharing usage caused by entry penalties being applied to non-usage-based ClusterQueues or reapplied during second scheduling passes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate admission penalties when workloads undergo a second scheduling pass.
  * Ensured entry penalties are applied only when admission fair sharing and usage-based admission are configured, and no quota reservation already exists.
  * Excluded unsupported cluster queues from penalty calculations.

* **Tests**
  * Added coverage for delayed topology assignment and second-pass scheduling.
  * Added validation for entry-penalty behavior across supported and unsupported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->