### PR TITLE
test: seed a non-empty entry penalty in the AFS settlement test

### DIFF
--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -555,17 +555,26 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 			Active(true).
 			Request(corev1.ResourceCPU, "4")
 	}
+	// A reserved Workload's requests are read back from the admission rather than
+	// from the PodSets, so the assignment has to carry them: without it the
+	// settlement recomputes an empty penalty and the test cannot tell the
+	// transitions apart.
+	makeAdmission := func() *kueue.Admission {
+		return utiltestingapi.MakeAdmission("cq").
+			PodSets(utiltestingapi.MakePodSetAssignment("main").Assignment(corev1.ResourceCPU, "rf", "4").Obj()).
+			Obj()
+	}
 	pending := makeWl().Obj()
 	quotaReserved := makeWl().
-		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		ReserveQuotaAt(makeAdmission(), now).
 		Obj()
 	admitted := makeWl().
-		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		ReserveQuotaAt(makeAdmission(), now).
 		AdmittedAt(true, now).
 		Obj()
 	deactivatedAdmitted := makeWl().
 		Active(false).
-		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		ReserveQuotaAt(makeAdmission(), now).
 		AdmittedAt(true, now).
 		Obj()
 
@@ -626,7 +635,11 @@ func TestUpdateSettlesAfsEntryPenalty(t *testing.T) {
 
 			// Seed the penalty with the same amount the settlement recomputes,
 			// mirroring the push done by the scheduler at assume time.
-			qManager.AfsEntryPenalties.Push(lqKey, afs.CalculateEntryPenalty(workload.NewInfo(tc.newWl).SumTotalRequests(reconciler.resourceFormatter), afsConfig))
+			seeded := afs.CalculateEntryPenalty(workload.NewInfo(tc.newWl).SumTotalRequests(reconciler.resourceFormatter), afsConfig)
+			if len(seeded) == 0 {
+				t.Fatal("the seeded penalty is empty, so the settlement would subtract nothing and every case would pass")
+			}
+			qManager.AfsEntryPenalties.Push(lqKey, seeded)
 
 			reconciler.Update(event.TypedUpdateEvent[*kueue.Workload]{
 				ObjectOld: tc.oldWl.DeepCopy(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

Follow-up to #12786, which added `TestUpdateSettlesAfsEntryPenalty`.

Its reserved Workloads carry an admission with no `PodSetAssignments`, and `NewInfo` reads `TotalRequests` back from the admission rather than the PodSets once one is present. So every case seeds an empty entry penalty, settlement subtracts nothing, and the cases differ only because pushing an empty penalty still creates a key for `HasPendingFor` to find.

This adds the Workload's 4 CPU to the assignment and fails fast when the seeded penalty is empty.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

Removing the `PodSets(...)` call from `makeAdmission` now makes both settlement cases fail at the new assertion. Before this change, they still passed.

Found while rebasing #13724, where the pending-penalty assertion checks the amount rather than only key presence.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated fair-sharing settlement test coverage to account for resource assignments in reserved workload admissions.
  * Improved penalty setup validation to ensure expected penalty entries are populated before settlement checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->