### PR TITLE
fix(statefulset): sync workload priority changes

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -18,6 +18,7 @@ package statefulset
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -265,15 +266,19 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		jobframework.RecordAdmissionGatedByUpdateEvent(r.record, sts)
 	}
 
+	var priorityErr error
+	if _, isMultiKueueRemote := sts.Labels[kueue.MultiKueueOriginLabel]; !isMultiKueueRemote {
+		priorityErr = jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, sts, nil, wl)
+	}
+
+	var lifecycleErr error
 	if shouldReleaseReservation {
-		return r.releaseScaleDownReservation(ctx, wl)
+		lifecycleErr = r.releaseScaleDownReservation(ctx, wl)
+	} else if shouldClearOnHold {
+		lifecycleErr = r.clearOnHold(ctx, wl)
 	}
 
-	if shouldClearOnHold {
-		return r.clearOnHold(ctx, wl)
-	}
-
-	return nil
+	return errors.Join(priorityErr, lifecycleErr)
 }
 
 func (r *Reconciler) clearOnHold(ctx context.Context, wl *kueue.Workload) error {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -271,14 +271,24 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		priorityErr = jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, sts, nil, wl)
 	}
 
-	var lifecycleErr error
+	// Releasing the reservation on scale-down is independent of the priority
+	// result: the workload is going away from admission either way.
 	if shouldReleaseReservation {
-		lifecycleErr = r.releaseScaleDownReservation(ctx, wl)
-	} else if shouldClearOnHold {
-		lifecycleErr = r.clearOnHold(ctx, wl)
+		return errors.Join(priorityErr, r.releaseScaleDownReservation(ctx, wl))
 	}
 
-	return errors.Join(priorityErr, lifecycleErr)
+	// Scale-up must wait: clearing OnHold after a failed priority sync would
+	// send the workload back into admission carrying the old priority, and the
+	// retry cannot repair it because the hold is already gone.
+	if priorityErr != nil {
+		return priorityErr
+	}
+
+	if shouldClearOnHold {
+		return r.clearOnHold(ctx, wl)
+	}
+
+	return nil
 }
 
 func (r *Reconciler) clearOnHold(ctx context.Context, wl *kueue.Workload) error {

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -68,6 +69,7 @@ func TestReconciler(t *testing.T) {
 		statefulSet     *appsv1.StatefulSet
 		pods            []corev1.Pod
 		workloads       []kueue.Workload
+		priorityClasses []client.Object
 		wantStatefulSet *appsv1.StatefulSet
 		wantPods        []corev1.Pod
 		wantWorkloads   []kueue.Workload
@@ -238,6 +240,81 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
 					OwnerReference(gvk, "sts", "sts-uid").
+					Obj(),
+			},
+		},
+		"should update WorkloadPriorityClass on an existing Workload": {
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Replicas(0).
+				Queue("lq").
+				WorkloadPriorityClass("high").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					OwnerReference(gvk, "sts", "sts-uid").
+					WorkloadPriorityClassRef("low").
+					Priority(10).
+					Obj(),
+			},
+			priorityClasses: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Replicas(0).
+				Queue("lq").
+				WorkloadPriorityClass("high").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					OwnerReference(gvk, "sts", "sts-uid").
+					WorkloadPriorityClassRef("high").
+					Priority(100).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonUpdatedWorkload,
+					Message:   fmt.Sprintf("Updated workload priority class: ns/%s", GetWorkloadName("sts-uid", "sts")),
+				},
+			},
+		},
+		"should not update manager-owned priority for a MultiKueue remote StatefulSet": {
+			stsKey: client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				WorkloadPriorityClass("low").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					WorkloadPriorityClassRef("high").
+					Priority(100).
+					Obj(),
+			},
+			priorityClasses: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("low").PriorityValue(10).Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				WorkloadPriorityClass("low").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					WorkloadPriorityClassRef("high").
+					Priority(100).
 					Obj(),
 			},
 		},
@@ -693,7 +770,7 @@ func TestReconciler(t *testing.T) {
 				t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
 			}
 
-			objs := make([]client.Object, 0, len(tc.pods)+len(tc.workloads)+1)
+			objs := make([]client.Object, 0, len(tc.pods)+len(tc.workloads)+len(tc.priorityClasses)+1)
 			if tc.statefulSet != nil {
 				objs = append(objs, tc.statefulSet)
 			}
@@ -705,6 +782,7 @@ func TestReconciler(t *testing.T) {
 			for _, wl := range tc.workloads {
 				objs = append(objs, wl.DeepCopy())
 			}
+			objs = append(objs, tc.priorityClasses...)
 
 			kClient := clientBuilder.WithObjects(objs...).Build()
 
@@ -754,6 +832,55 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Events after reconcile (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestReconcilerReleasesReservationWhenPriorityUpdateFails(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	now := time.Now()
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+		UID("sts-uid").
+		Replicas(0).
+		Queue("lq").
+		WorkloadPriorityClass("missing").
+		Obj()
+	wl := utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+		Queue("lq").
+		OwnerReference(gvk, "sts", "sts-uid").
+		WorkloadPriorityClassRef("low").
+		Priority(10).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+		AdmittedAt(true, now).
+		Obj()
+
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithObjects(sts, wl).
+		WithStatusSubresource(sts, wl)
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+	}
+	cl := clientBuilder.Build()
+	reconciler, err := NewReconciler(ctx, cl, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("NewReconciler() error: %v", err)
+	}
+
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)})
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("Reconcile() error = %v, want NotFound", err)
+	}
+
+	got := &kueue.Workload{}
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
+		t.Fatalf("failed to get workload: %v", err)
+	}
+	if got.Status.Admission != nil {
+		t.Fatalf("expected admission to be released, got %+v", got.Status.Admission)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, kueue.WorkloadQuotaReserved)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != kueue.WorkloadOnHold {
+		t.Fatalf("unexpected quota reserved condition: %+v", cond)
 	}
 }
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -884,6 +884,112 @@ func TestReconcilerReleasesReservationWhenPriorityUpdateFails(t *testing.T) {
 	}
 }
 
+// A scale-up must not clear OnHold when the priority class the StatefulSet now
+// names cannot be resolved: the workload would go back into scheduling carrying
+// its old priority, and the retry cannot repair it because the hold is gone.
+func TestReconcilerKeepsOnHoldWhenPriorityUpdateFails(t *testing.T) {
+	testCases := map[string]struct {
+		stsPriorityClass string
+		classExists      bool
+		wantErr          bool
+		wantOnHold       bool
+		wantClassRef     string
+		wantPriority     int32
+	}{
+		"missing class keeps the workload on hold at its old priority": {
+			stsPriorityClass: "missing",
+			classExists:      false,
+			wantErr:          true,
+			wantOnHold:       true,
+			wantClassRef:     "low",
+			wantPriority:     10,
+		},
+		"resolvable class clears on hold and applies the new priority": {
+			stsPriorityClass: "high",
+			classExists:      true,
+			wantErr:          false,
+			wantOnHold:       false,
+			wantClassRef:     "high",
+			wantPriority:     100,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Replicas(1).
+				Queue("lq").
+				WorkloadPriorityClass(tc.stsPriorityClass).
+				Obj()
+			wl := utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+				Queue("lq").
+				OwnerReference(gvk, "sts", "sts-uid").
+				WorkloadPriorityClassRef("low").
+				Priority(10).
+				Condition(metav1.Condition{
+					Type:   kueue.WorkloadQuotaReserved,
+					Status: metav1.ConditionFalse,
+					Reason: kueue.WorkloadOnHold,
+				}).
+				Obj()
+
+			objects := []client.Object{sts, wl}
+			if tc.classExists {
+				objects = append(objects, utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj())
+			}
+
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithObjects(objects...).
+				WithStatusSubresource(sts, wl)
+			indexer := utiltesting.AsIndexer(clientBuilder)
+			if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+				t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+			}
+			cl := clientBuilder.Build()
+			reconciler, err := NewReconciler(ctx, cl, indexer, &utiltesting.EventRecorder{})
+			if err != nil {
+				t.Fatalf("NewReconciler() error: %v", err)
+			}
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)})
+			if tc.wantErr && err == nil {
+				t.Fatalf("Reconcile() error = nil, want an error")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("Reconcile() error = %v, want nil", err)
+			}
+
+			got := &kueue.Workload{}
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
+				t.Fatalf("failed to get workload: %v", err)
+			}
+
+			cond := apimeta.FindStatusCondition(got.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if cond == nil {
+				t.Fatalf("QuotaReserved condition not found")
+			}
+			onHold := cond.Status == metav1.ConditionFalse && cond.Reason == kueue.WorkloadOnHold
+			if onHold != tc.wantOnHold {
+				t.Errorf("OnHold = %t, want %t (condition %s/%s)", onHold, tc.wantOnHold, cond.Status, cond.Reason)
+			}
+
+			gotClassRef := ""
+			if got.Spec.PriorityClassRef != nil {
+				gotClassRef = got.Spec.PriorityClassRef.Name
+			}
+			if gotClassRef != tc.wantClassRef {
+				t.Errorf("priorityClassRef = %q, want %q", gotClassRef, tc.wantClassRef)
+			}
+			if got.Spec.Priority == nil || *got.Spec.Priority != tc.wantPriority {
+				t.Errorf("priority = %v, want %d", got.Spec.Priority, tc.wantPriority)
+			}
+		})
+	}
+}
+
 func TestGetWorkloadName(t *testing.T) {
 	testCases := map[string]struct {
 		uid1      types.UID

--- a/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/statefulset"
@@ -149,6 +150,59 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 			g.Expect(workloads.Items).To(gomega.HaveLen(1))
 			g.Expect(workloads.Items[0].Name).To(gomega.Equal(legacyName))
 			util.MustHaveOwnerReference(g, workloads.Items[0].OwnerReferences, createdSTS, k8sClient.Scheme())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should update the Workload priority when the StatefulSet priority class changes", func() {
+		ginkgo.By("Creating a low priority WorkloadPriorityClass")
+		lowPriority := utiltestingapi.MakeWorkloadPriorityClass("low-" + ns.Name).PriorityValue(10).Obj()
+		util.MustCreate(ctx, k8sClient, lowPriority)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, lowPriority, true)
+		})
+
+		ginkgo.By("Creating a high priority WorkloadPriorityClass")
+		highPriority := utiltestingapi.MakeWorkloadPriorityClass("high-" + ns.Name).PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, highPriority)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, highPriority, true)
+		})
+
+		ginkgo.By("Creating a StatefulSet with the low priority class")
+		sts := testingstatefulset.MakeStatefulSet("test-sts", ns.Name).
+			Queue("lq").
+			WorkloadPriorityClass(lowPriority.Name).
+			Request(corev1.ResourceCPU, "100m").
+			Obj()
+		util.MustCreate(ctx, k8sClient, sts)
+
+		ginkgo.By("Checking that the Workload was created with the low priority class")
+		wlKey := types.NamespacedName{
+			Name:      statefulset.GetWorkloadName(sts.UID, sts.Name),
+			Namespace: ns.Name,
+		}
+		wl := &kueue.Workload{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Spec.PriorityClassRef).ShouldNot(gomega.BeNil())
+			g.Expect(wl.Spec.PriorityClassRef.Name).To(gomega.Equal(lowPriority.Name))
+			g.Expect(wl.Spec.Priority).To(gomega.Equal(new(int32(10))))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Updating the StatefulSet WorkloadPriorityClass label to high priority")
+		createdSTS := &appsv1.StatefulSet{}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
+			createdSTS.Labels[controllerconstants.WorkloadPriorityClassLabel] = highPriority.Name
+			g.Expect(k8sClient.Update(ctx, createdSTS)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("Verifying the existing Workload uses the new priority")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+			g.Expect(wl.Spec.PriorityClassRef).ShouldNot(gomega.BeNil())
+			g.Expect(wl.Spec.PriorityClassRef.Name).To(gomega.Equal(highPriority.Name))
+			g.Expect(wl.Spec.Priority).To(gomega.Equal(new(int32(100))))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

Synchronizes changes to the `kueue.x-k8s.io/priority-class` label from a StatefulSet to its existing Workload.

The StatefulSet reconciler now reuses the shared workload-priority update path.

Note that this path still issues two API writes when a reconcile has both a pending Workload mutation (owner reference, queue name, annotations) and a priority class change: one in the `shouldUpdate` block and one inside `UpdateWorkloadPriority`. Collapsing them into a single write needs a helper that resolves the class and mutates the priority fields in memory, which is wider than this fix, so it is left as a follow-up.

This does not duplicate an existing PR: the linked issue and open PRs were checked by issue number and by the StatefulSet / WorkloadPriorityClass keywords before implementation.

AI assistance disclosure: AI assistance was used for repository inspection, implementation support, and test preparation. I reviewed every changed line, verified the regression against the unmodified base, and ran the tests listed below. The commit message was reviewed and explicitly approved by the human submitter.

Validation:

- `go test ./pkg/controller/jobs/statefulset ./pkg/controller/jobframework`
- `go vet ./pkg/controller/jobs/statefulset ./pkg/controller/jobframework`
- `KUBEBUILDER_ASSETS=<envtest-1.36.2> PROJECT_DIR=$PWD/ go test ./test/integration/singlecluster/controller/jobs/statefulset -run '^TestAPIs$' -ginkgo.focus='Should update the Workload priority when the StatefulSet priority class changes' -count=1`

Regression proof: the new unit case fails against unmodified `upstream/main`, retaining the old class and priority (`low`, `10`) instead of applying (`high`, `100`).

#### Which issue(s) this PR fixes:

Fixes #13827

#### Special notes for your reviewer:

The integration test covers the full update path from a StatefulSet label change to the existing Workload.

#### Does this PR introduce a user-facing change?

```release-note
StatefulSet: Fixed a bug that prevented updating workload priority after changing the `kueue.x-k8s.io/priority-class`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changing a StatefulSet’s workload priority class now updates the associated Workload’s priority class reference and priority value.
  * Priority synchronization errors are reported immediately to ensure reconciliation issues are visible.
  * Remote MultiKueue workloads retain their manager-controlled priority.
  * Quota reservations are released when a workload priority class cannot be resolved.
  * Workloads remain on hold when priority resolution fails and resume only after the priority is successfully resolved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
