### PR TITLE
Validate GIT_TAG version format and support RC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,7 +366,7 @@ prepare-manifests:
 .PHONY: verify-git-tag
 verify-git-tag:
 	@if [[ ! "$(GIT_TAG)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-devel)?(-[0-9]+-g[0-9a-f]+)?(-dirty)?$$ ]]; then \
-		echo "GIT_TAG must match a supported Kueue tag format, got \"$(GIT_TAG)\"" >&2; \
+		echo "GIT_TAG must match a supported Kueue tag format (e.g. vX.Y.Z, vX.Y.Z-rc.N, or vX.Y.Z-devel-<build>-g<commit>); got \"$(GIT_TAG)\"" >&2; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -365,8 +365,8 @@ prepare-manifests:
 # prepare-manifests rewrite tracked files.
 .PHONY: verify-git-tag
 verify-git-tag:
-	@if [[ "$(GIT_TAG)" != v* ]]; then \
-		echo "GIT_TAG must start with v, got \"$(GIT_TAG)\"" >&2; \
+	@if [[ ! "$(GIT_TAG)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then \
+		echo "GIT_TAG must match vX.X.X* format, got \"$(GIT_TAG)\"" >&2; \
 		exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -365,8 +365,8 @@ prepare-manifests:
 # prepare-manifests rewrite tracked files.
 .PHONY: verify-git-tag
 verify-git-tag:
-	@if [[ ! "$(GIT_TAG)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then \
-		echo "GIT_TAG must match vX.X.X* format, got \"$(GIT_TAG)\"" >&2; \
+	@if [[ ! "$(GIT_TAG)" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+|-devel)?(-[0-9]+-g[0-9a-f]+)?(-dirty)?$$ ]]; then \
+		echo "GIT_TAG must match a supported Kueue tag format, got \"$(GIT_TAG)\"" >&2; \
 		exit 1; \
 	fi
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area release

#### What this PR does / why we need it:

Strengthens `verify-git-tag` to require a numeric `vX.X.X` prefix instead of only a leading `v`. This rejects values such as `vlatest` and `vfoo` while continuing to accept stable, release candidate, and Git-derived suffixes used by artifact builds.

#### Which issue(s) this PR fixes:

Fixes #13828

#### Special notes for your reviewer:

Validation:

- Ran a 14-case `make verify-git-tag` matrix covering stable, release candidate, Git-describe, malformed, missing-prefix, casing, empty, and whitespace values, including the CI timed-shell path.
- Verified `make artifacts GIT_TAG=vfoo` fails at `verify-git-tag` before cleanup or tracked-file changes.
- Ran `git diff --check`.

AI assistance was used to analyze the issue discussion, prepare the change, and validate the final diff. The contributor reviewed the resulting code and test evidence.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git tag validation to support release candidates, development builds, commit suffixes, and dirty working-tree suffixes.
  * Invalid version tags are now rejected more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->