### PR TITLE
Automated cherry pick of #12562: TAS: infer flavor for grouped PodSets with no managed resource requests

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -784,15 +784,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		finalConsidered := finalizeFlavorAssignmentAttempts(consideredFlavors)
 		atLeastOnePodsAssignmentFailed := false
 		for _, podSet := range podSets {
-			var reqKeys []corev1.ResourceName
-			if podSet.podSet.Requests != nil {
-				podSet.podSet.Requests.ForEach(func(name corev1.ResourceName, _ int64) {
-					reqKeys = append(reqKeys, name)
-				})
-			}
-			podSetFlavors := utilmaps.FilterKeys(groupFlavors, reqKeys)
-
-			podSet.podSetAssignment.Flavors = podSetFlavors
+			podSet.podSetAssignment.Flavors = a.resolvePodSetFlavors(log, podSet, groupFlavors)
 			podSet.podSetAssignment.Status = groupStatus
 			podSet.podSetAssignment.FlavorAssignmentAttempts = finalConsidered
 
@@ -861,6 +853,43 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 	return assignment
 }
 
+// resolvePodSetFlavors returns the flavors podSet should be assigned, given the flavors
+// already resolved for its whole PodSet group (groupFlavors). Normally this is just
+// groupFlavors filtered down to the resources podSet itself requests. A PodSet requesting
+// none of the group's managed resources (e.g. an LWS leader) would otherwise end up with no
+// flavor and be rejected from TAS, so such a PodSet instead falls back to the group's TAS
+// flavor(s) if it belongs to a topology group. A ClusterQueue-wide fallback can be revisited
+// later if users request it.
+func (a *FlavorAssigner) resolvePodSetFlavors(log logr.Logger, idxPodSet indexedPodSet, groupFlavors ResourceAssignment) ResourceAssignment {
+	// For PodSets with requests, keep only flavors for resources this PodSet requests.
+	if idxPodSet.podSet.Requests != nil && idxPodSet.podSet.Requests.Len() != 0 {
+		var reqKeys []corev1.ResourceName
+		idxPodSet.podSet.Requests.ForEach(func(name corev1.ResourceName, _ int64) {
+			reqKeys = append(reqKeys, name)
+		})
+		podSetFlavors := utilmaps.FilterKeys(groupFlavors, reqKeys)
+		log.V(5).Info("Resolved PodSet flavors from group flavors",
+			"podSet", idxPodSet.podSet.Name,
+			"requestedResources", idxPodSet.podSet.Requests.Len(),
+			"resolvedFlavors", len(podSetFlavors))
+		return podSetFlavors
+	}
+
+	// For PodSets without requests, reuse TAS flavors from the topology group when available.
+	if groupName := podSetGroupName(&a.wl.Obj.Spec.PodSets[idxPodSet.originalIndex]); groupName != nil {
+		// A PodSet with no resource requests in a topology group (e.g. an LWS leader) still needs a
+		// resolved TAS flavor so it can be placed; keep the group's TAS flavor(s) instead
+		// of filtering the group's resolution down to nothing.
+		podSetFlavors := tasFlavorsOnly(groupFlavors, a.cq.TASFlavors)
+		if len(podSetFlavors) > 0 {
+			log.V(5).Info("Using TAS flavors from topology group for PodSet with no resource requests", "podSet", idxPodSet.podSet.Name, "flavors", podSetFlavors)
+			return podSetFlavors
+		}
+	}
+
+	return nil
+}
+
 func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 	if a.RepresentativeMode() != NoFit {
 		return
@@ -908,6 +937,17 @@ func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
 		overallReason = mostSevereReason(overallReason, podSetReason)
 	}
 	a.NoFitReason = overallReason
+}
+
+// tasFlavorsOnly returns the subset of resourceAssignment whose flavor is a TAS flavor.
+func tasFlavorsOnly(resourceAssignment ResourceAssignment, tasFlavors map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot) ResourceAssignment {
+	result := make(ResourceAssignment, len(resourceAssignment))
+	for resName, flavorAssignment := range resourceAssignment {
+		if _, isTAS := tasFlavors[flavorAssignment.Name]; isTAS {
+			result[resName] = flavorAssignment
+		}
+	}
+	return result
 }
 
 func findRGIndicesByFlavor(cq *schdcache.ClusterQueueSnapshot, flavor kueue.ResourceFlavorReference) []int {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 
@@ -42,6 +43,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -5647,5 +5649,331 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestAssignFlavors_LeaderWorkerSetTASFlavor exercises the full flavor-assignment pipeline
+// (not just WorkloadsTopologyRequests in isolation) for PodSet groups where one member -
+// e.g. an LWS leader - requests none of the group's managed resources. Such a PodSet must
+// still end up with the group's resolved TAS flavor so it can be placed.
+func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+
+	resourceFlavors := map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+		"tas-a":   utiltestingapi.MakeResourceFlavor("tas-a").TopologyName("tas-topo-a").Obj(),
+		"tas-b":   utiltestingapi.MakeResourceFlavor("tas-b").TopologyName("tas-topo-b").Obj(),
+		"non-tas": utiltestingapi.MakeResourceFlavor("non-tas").Obj(),
+	}
+	topologies := []*kueue.Topology{
+		utiltestingapi.MakeTopology("tas-topo-a").Levels(corev1.LabelHostname).Obj(),
+		utiltestingapi.MakeTopology("tas-topo-b").Levels(corev1.LabelHostname).Obj(),
+	}
+
+	cases := map[string]struct {
+		wlPods            []kueue.PodSet
+		clusterQueue      kueue.ClusterQueue
+		wantPodSetErrors  map[kueue.PodSetReference]error
+		wantPodSetFlavors map[kueue.PodSetReference]ResourceAssignment
+	}{
+		"leader without a managed request infers the group's TAS flavor": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu-a", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-b").
+						Resource(corev1.ResourceMemory, "8Gi").
+						Obj(),
+				).Obj(),
+			wantPodSetErrors: map[kueue.PodSetReference]error{},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"leader": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+				"worker": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"leader without a group is rejected (ClusterQueue-wide fallback is not supported)": {
+			// Current behavior: a no-request PodSet without PodSetGroup does not inherit
+			// a TAS flavor from ClusterQueue-wide state.
+			// Potential future support: allow a ClusterQueue-wide fallback if requested.
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu-a", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).Obj(),
+			wantPodSetErrors: map[kueue.PodSetReference]error{
+				"leader": ErrNoTASFlavorAssigned,
+			},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"leader": {},
+				"worker": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"peers in the same group resolving to different TAS flavors are rejected": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker-a", 1).
+					Request("example.com/gpu-a", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker-b", 1).
+					Request("example.com/gpu-b", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-b").
+						Resource("example.com/gpu-b", "4").
+						Obj(),
+				).Obj(),
+			wantPodSetErrors: map[kueue.PodSetReference]error{
+				"leader": &MultipleTASFlavorsAssignedError{Flavors: []kueue.ResourceFlavorReference{"tas-a", "tas-b"}},
+			},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"leader":   {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}, "example.com/gpu-b": {Name: "tas-b", Mode: Fit, TriedFlavorIdx: -1}},
+				"worker-a": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+				"worker-b": {"example.com/gpu-b": {Name: "tas-b", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"multiple groups: leaders infer flavors from their own groups": {
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader1", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker1", 1).
+					Request("example.com/gpu-a", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("leader2", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group2").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker2", 1).
+					Request("example.com/gpu-b", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group2").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-a").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-b").
+						Resource("example.com/gpu-b", "4").
+						Obj(),
+				).Obj(),
+			wantPodSetErrors: map[kueue.PodSetReference]error{},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				// Verify both leaders inferred their flavors from their groups
+				"leader1": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+				"worker1": {"example.com/gpu-a": {Name: "tas-a", Mode: Fit, TriedFlavorIdx: -1}},
+				"leader2": {"example.com/gpu-b": {Name: "tas-b", Mode: Fit, TriedFlavorIdx: -1}},
+				"worker2": {"example.com/gpu-b": {Name: "tas-b", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+		"leader in group where peer resolves to non-TAS flavor is rejected": {
+			// Exercises the topology-group TAS fallback path in resolvePodSetFlavors:
+			// tasFlavorsOnly returns empty because the group's resolved flavor is non-TAS.
+			// With no TAS flavors available in cq.TASFlavors, the leader ends up with empty
+			// Flavors and podSetTopologyRequest returns ErrNoTASCacheInformation (checked
+			// before onlyTASFlavor).
+			wlPods: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu-a", "1").
+					PodSetGroup("group1").
+					Obj(),
+			},
+			clusterQueue: *utiltestingapi.MakeClusterQueue("test-clusterqueue").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("non-tas").
+						Resource("example.com/gpu-a", "4").
+						Obj(),
+				).Obj(),
+			wantPodSetErrors: map[kueue.PodSetReference]error{
+				"leader": ErrNoTASCacheInformation,
+			},
+			wantPodSetFlavors: map[kueue.PodSetReference]ResourceAssignment{
+				"leader": {},
+				"worker": {"example.com/gpu-a": {Name: "non-tas", Mode: Fit, TriedFlavorIdx: -1}},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			wlInfo := workload.NewInfo(&kueue.Workload{Spec: kueue.WorkloadSpec{PodSets: tc.wlPods}})
+
+			cache := schdcache.New(utiltesting.NewFakeClient())
+			if err := cache.AddClusterQueue(ctx, &tc.clusterQueue); err != nil {
+				t.Fatalf("Failed to add CQ to cache: %v", err)
+			}
+			for _, rf := range resourceFlavors {
+				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+			for _, topology := range topologies {
+				cache.AddOrUpdateTopology(log, topology)
+			}
+			nodes := []corev1.Node{
+				*testingnode.MakeNode("tas-node-a").
+					Label(corev1.LabelHostname, "tas-node-a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("32"),
+						"example.com/gpu-a": resource.MustParse("4"),
+						"example.com/gpu-b": resource.MustParse("4"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("tas-node-b").
+					Label(corev1.LabelHostname, "tas-node-b").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("32"),
+						"example.com/gpu-a": resource.MustParse("4"),
+						"example.com/gpu-b": resource.MustParse("4"),
+					}).
+					Ready().
+					Obj(),
+			}
+			for i := range nodes {
+				cache.TASCache().SyncNode(&nodes[i])
+			}
+			if err := cache.AddOrUpdateCohort(utiltestingapi.MakeCohort(tc.clusterQueue.Spec.CohortName).Obj()); err != nil {
+				t.Fatalf("Failed to create a cohort: %v", err)
+			}
+
+			snapshot, err := cache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error while building snapshot: %v", err)
+			}
+			cq := snapshot.ClusterQueue(kueue.ClusterQueueReference(tc.clusterQueue.Name))
+			if cq == nil {
+				t.Fatalf("Failed to create CQ snapshot")
+			}
+
+			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			assignment := flvAssigner.Assign(ctx, nil)
+
+			gotErrors := map[kueue.PodSetReference]error{}
+			gotFlavors := map[kueue.PodSetReference]ResourceAssignment{}
+			for _, ps := range assignment.PodSets {
+				if ps.Status.err != nil {
+					gotErrors[ps.Name] = ps.Status.err
+				}
+				gotFlavors[ps.Name] = ps.Flavors
+			}
+			if diff := cmp.Diff(tc.wantPodSetErrors, gotErrors, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("podSet errors mismatch (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantPodSetFlavors, gotFlavors, cmpopts.IgnoreUnexported(FlavorAssignment{}), cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("podSet flavors mismatch (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestWorkloadsTopologyRequests_RequiredTopologyRejectedForElasticWorkloadSlices(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlicesWithTAS, true)
+
+	assignment := Assignment{
+		PodSets: []PodSetAssignment{
+			{Name: "leader", Flavors: ResourceAssignment{}, Count: 1, Status: *NewStatus()},
+			{Name: "worker", Flavors: ResourceAssignment{"example.com/gpu": {Name: "tas", Mode: Fit, TriedFlavorIdx: -1}}, Count: 1, Status: *NewStatus()},
+		},
+	}
+	wl := workload.NewInfo(&kueue.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kueue.x-k8s.io/elastic-job": "true",
+			},
+		},
+		Spec: kueue.WorkloadSpec{
+			PodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("leader", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+				*utiltestingapi.MakePodSet("worker", 1).
+					Request("example.com/gpu", "1").
+					RequiredTopologyRequest(corev1.LabelHostname).
+					PodSetGroup("group1").
+					Obj(),
+			},
+		},
+	})
+	cq := schdcache.ClusterQueueSnapshot{
+		TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+			"tas": {},
+		},
+		ResourceGroups: []schdcache.ResourceGroup{
+			{
+				CoveredResources: sets.New(corev1.ResourceName("example.com/gpu")),
+				Flavors:          []kueue.ResourceFlavorReference{"tas"},
+			},
+		},
+	}
+
+	_ = assignment.WorkloadsTopologyRequests(testr.New(t), wl, &cq)
+
+	if !errors.Is(assignment.PodSets[0].Status.err, ErrElasticRequiredTopologyNotSupported) {
+		t.Fatalf("expected leader podSet error to be %v, got %v", ErrElasticRequiredTopologyNotSupported, assignment.PodSets[0].Status.err)
+	}
+}
+
+func TestTasFlavorsOnly(t *testing.T) {
+	tasFlavors := map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{"tas": {}}
+	in := ResourceAssignment{
+		"example.com/gpu":  {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+		corev1.ResourceCPU: {Name: "quota", Mode: Fit, TriedFlavorIdx: -1},
+	}
+	want := ResourceAssignment{
+		"example.com/gpu": {Name: "tas", Mode: Fit, TriedFlavorIdx: -1},
+	}
+	got := tasFlavorsOnly(in, tasFlavors)
+	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(FlavorAssignment{})); diff != "" {
+		t.Errorf("tasFlavorsOnly() mismatch (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -121,11 +121,6 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 			}
 		}
 	}
-	var podSetGroupName *string
-	if podSet.TopologyRequest != nil {
-		podSetGroupName = podSet.TopologyRequest.PodSetGroupName
-	}
-
 	return &schdcache.TASPodSetRequests{
 		Count:              podCount,
 		SinglePodRequests:  singlePodRequests,
@@ -133,9 +128,17 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 		PodSetUpdates:      podSetUpdates,
 		Flavor:             *tasFlvr,
 		Implied:            isTASImplied,
-		PodSetGroupName:    podSetGroupName,
+		PodSetGroupName:    podSetGroupName(podSet),
 		PreviousAssignment: previousAssignment,
 	}, nil
+}
+
+// podSetGroupName returns ps's PodSetGroupName, or nil if ps has no TopologyRequest.
+func podSetGroupName(ps *kueue.PodSet) *string {
+	if ps.TopologyRequest == nil {
+		return nil
+	}
+	return ps.TopologyRequest.PodSetGroupName
 }
 
 func onlyTASFlavor(


### PR DESCRIPTION
Cherry pick of #12562 on release-0.19.

#12562: TAS: infer flavor for grouped PodSets with no managed resource requests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind regression

/area release

```release-note
TAS: Fixed a bug where a grouped PodSet (e.g. an LWS leader) with no requests for the TAS-managed resource was rejected with "no TAS flavor assigned".
```