### PR TITLE
[release-0.18] Keep the released UpdateWorkloadPriority signature

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -929,7 +929,7 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 	// The quota-reserved/no-priorityClassRef legality check lives in
 	// UpdateWorkloadPriority so the ordinary Job and LeaderWorkerSet paths, which
 	// reach the shared helper without this caller's filtering, get the same guard.
-	return UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
+	return updateWorkloadPriorities(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
 }
 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
@@ -1097,7 +1097,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			}
 		}
 
-		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), match); err != nil {
+		if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), match, getCustomPriorityClassFuncFromJob(job)); err != nil {
 			return nil, err
 		}
 	}
@@ -1164,16 +1164,25 @@ func PropagateAdmissionGatedByAnnotation(obj client.Object, wl *kueue.Workload) 
 	return false
 }
 
-// UpdateWorkloadPriority reconciles the priority of each workload that still
-// follows the object's kueue.x-k8s.io/priority-class label. Every workload
-// passed must belong to obj, since the class is resolved once for the whole set
-// rather than per workload, so one batch cannot itself write two different
-// values. The resolved value is applied to every eligible workload whose full
-// priority state has drifted, so a partial write followed by a class-value
-// change converges on retry instead of leaving same-name workloads pinned to a
-// stale value. The workloads are written one by one rather than atomically, and
-// a class edited once every workload already names it is not re-resolved here.
-func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
+// UpdateWorkloadPriority updates workload priority if object's kueue.x-k8s.io/priority-class label changed.
+func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error {
+	return updateWorkloadPriorities(ctx, c, r, obj, customPriorityClassFunc, wl)
+}
+
+// updateWorkloadPriorities reconciles the priority of each workload that still
+// follows the object's kueue.x-k8s.io/priority-class label. Every workload passed
+// must belong to obj, since the class is resolved once for the whole set rather
+// than per workload, so one batch cannot itself write two different values. The
+// resolved value is applied to every eligible workload whose full priority state
+// has drifted, so a partial write followed by a class-value change converges on
+// retry instead of leaving same-name workloads pinned to a stale value. The
+// workloads are written one by one rather than atomically, and a class edited once
+// every workload already names it is not re-resolved here.
+//
+// It is unexported on this branch so that the released signature of
+// UpdateWorkloadPriority does not change in a patch release; on main the exported
+// function takes the workloads directly.
+func updateWorkloadPriorities(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error {
 	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), WorkloadPriorityClassName(obj), wls)
 
 	// Resolving only when at least one workload needs a transition keeps

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -243,7 +243,7 @@ func TestUpdateWorkloadPriority(t *testing.T) {
 					st.before(t, ctx, cl)
 				}
 				live = readLive()
-				err := UpdateWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...)
+				err := updateWorkloadPriorities(ctx, cl, &utiltesting.EventRecorder{}, job, nil, live...)
 				switch {
 				case st.wantErr && err == nil:
 					t.Fatalf("invocation %d: want an error, got none", i)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -440,7 +440,7 @@ func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.
 		}
 	}
 
-	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, wl)
+	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, wl, nil)
 	if err != nil {
 		log.Error(err, "Failed to update workload priority")
 		return err


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

This restores the `jobframework.UpdateWorkloadPriority` signature that v0.18.4 shipped, and moves the batch form the workload-slice path needs into an unexported helper.

#13872 backported the workload-slice priority fix to this branch. That fix had also changed the exported function to take its workloads variadically:

```go
-func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, wl *kueue.Workload, customPriorityClassFunc func() string) error
+func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object, customPriorityClassFunc func() string, wls ...*kueue.Workload) error
```

On main that is a reasonable shape, and it is what was asked for there, since the operation really is a batch once a Job's live slices have to settle on one resolution. On a released branch it means the next patch changes an exported signature.

##### Why the branch is different from main

The contributor guide says what `pkg/` is:

> **`pkg/`** contains public-facing library code. Consumers may import these packages.

and the custom Job integration task asks external controllers to add Kueue to their `go.mod` and import `jobframework`. The change is not in any tag yet, so v0.18.4 is still out with the old signature and anyone who compiled against it would have to edit their call site to take v0.18.5, for a release that is otherwise a bug fix.

I looked for an out-of-tree caller of this particular helper and did not find one, so this is about the promise a patch release makes rather than a breakage I can point at.

##### What changes

The exported function takes one Workload again and delegates. The batch implementation is unchanged apart from being renamed and unexported, and the workload-slice path calls it directly. The signature line is now byte-identical to the one in v0.18.4.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

This is the release-0.18 twin of #13876, which @mimowo approved for release-0.19. It is not a cherry-pick, and it deliberately leaves the branch differing from main. The cost of taking it is that the next pick touching this function will conflict here.

On this branch `go build ./...`, `go vet` and `golangci-lint` are clean, the `jobframework`, `job`, `leaderworkerset` and `statefulset` unit suites pass, and so do the 86 Job controller integration specs.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
