### PR TITLE
[release-0.18] Keep the released ApplyDefaultLocalQueue signature

### DIFF
--- a/pkg/controller/jobframework/api_compat_test.go
+++ b/pkg/controller/jobframework/api_compat_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package jobframework_test holds the checks that have to see the package the
+// way an importer does. Everything else lives in package jobframework.
+package jobframework_test
+
+import (
+	"context"
+
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+)
+
+// The signatures this branch released. A patch release that adds a parameter or
+// a return value to either of them stops compiling here rather than in someone
+// else's build.
+var (
+	_ func(client.Object, func(string) bool) = jobframework.ApplyDefaultLocalQueue
+
+	_ func(context.Context, client.Client, events.EventRecorder, client.Object, *kueue.Workload, func() string) error = jobframework.UpdateWorkloadPriority
+)

--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -70,7 +70,7 @@ func (w *BaseWebhook[T]) Default(ctx context.Context, obj T) error {
 	job := w.FromObject(obj)
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Applying defaults")
-	if err := ApplyDefaultLocalQueue(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
+	if err := ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.Client, job.Object(), w.Queues.DefaultLocalQueueExist, w.ManagedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	ApplyDefaultWorkloadPriorityClass(ctx, w.Client, job.Object())

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -46,28 +46,56 @@ func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient clien
 	return nil
 }
 
-func ApplyDefaultLocalQueue(ctx context.Context, k8sClient client.Client, jobObj client.Object, defaultQueueExist func(string) bool, managedJobsNamespaceSelector labels.Selector) error {
-	if !defaultQueueExist(jobObj.GetNamespace()) {
+// ApplyDefaultLocalQueue applies the default LocalQueue without consulting
+// managedJobsNamespaceSelector. It keeps the signature this branch released, so
+// it is here for callers outside the repository. Kueue's own webhooks call
+// ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector instead.
+func ApplyDefaultLocalQueue(jobObj client.Object, defaultQueueExist func(string) bool) {
+	if !defaultLocalQueueApplies(jobObj, defaultQueueExist) {
+		return
+	}
+	setDefaultLocalQueue(jobObj)
+}
+
+// ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector applies the default
+// LocalQueue only when the object's namespace matches
+// managedJobsNamespaceSelector.
+func ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx context.Context, k8sClient client.Client,
+	jobObj client.Object, defaultQueueExist func(string) bool, managedJobsNamespaceSelector labels.Selector) error {
+	if !defaultLocalQueueApplies(jobObj, defaultQueueExist) {
 		return nil
 	}
-	if QueueNameForObject(jobObj) == "" {
-		// Do not default the queue-name for a job whose owner is already managed by Kueue
-		if IsOwnerManagedByKueueForObject(jobObj) {
-			return nil
-		}
-		if managed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), managedJobsNamespaceSelector); err != nil {
-			return err
-		} else if !managed {
-			return nil
-		}
-		labels := jobObj.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string, 1)
-		}
-		labels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
-		jobObj.SetLabels(labels)
+	// Reached only when the label is about to be set, so an excluded namespace
+	// costs no Namespace read.
+	managed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), managedJobsNamespaceSelector)
+	if err != nil {
+		return err
 	}
+	if !managed {
+		return nil
+	}
+	setDefaultLocalQueue(jobObj)
 	return nil
+}
+
+func defaultLocalQueueApplies(jobObj client.Object, defaultQueueExist func(string) bool) bool {
+	if !defaultQueueExist(jobObj.GetNamespace()) {
+		return false
+	}
+	if QueueNameForObject(jobObj) != "" {
+		return false
+	}
+	// Do not default the queue-name for a job whose owner is already managed by Kueue
+	return !IsOwnerManagedByKueueForObject(jobObj)
+}
+
+func setDefaultLocalQueue(jobObj client.Object) {
+	jobLabels := jobObj.GetLabels()
+	if jobLabels == nil {
+		jobLabels = make(map[string]string, 1)
+	}
+	jobLabels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
+	jobObj.SetLabels(jobLabels)
 }
 
 func ApplyDefaultWorkloadPriorityClass(ctx context.Context, c client.Client, jobObj client.Object) {

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -17,15 +17,19 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -112,7 +116,81 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 	}
 }
 
+// TestApplyDefaultLocalQueue covers the function this branch released, which
+// has no namespace filtering of its own.
 func TestApplyDefaultLocalQueue(t *testing.T) {
+	cases := map[string]struct {
+		job               *batchv1.Job
+		defaultQueueExist bool
+		wantQueueLabel    string
+	}{
+		"a job with no queue gets the default one": {
+			job:               utiltestingjob.MakeJob("test-job", "ns").Obj(),
+			defaultQueueExist: true,
+			wantQueueLabel:    "default",
+		},
+		"an existing queue is not overwritten": {
+			job:               utiltestingjob.MakeJob("test-job", "ns").Queue("other").Obj(),
+			defaultQueueExist: true,
+			wantQueueLabel:    "other",
+		},
+		"no default queue in the namespace": {
+			job:            utiltestingjob.MakeJob("test-job", "ns").Obj(),
+			wantQueueLabel: "",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ApplyDefaultLocalQueue(tc.job, func(string) bool { return tc.defaultQueueExist })
+
+			if got := tc.job.Labels[constants.QueueLabel]; got != tc.wantQueueLabel {
+				t.Errorf("queue label: got %q, want %q", got, tc.wantQueueLabel)
+			}
+		})
+	}
+}
+
+// The namespace is read only when the label is about to be set. A job that is
+// not a candidate must not need it, or a namespace the webhook cannot read
+// would start failing admission.
+func TestApplyDefaultLocalQueueWithManagedJobsNamespaceSelectorSkipsNamespaceRead(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Namespace); ok {
+					return errors.New("the namespace was read")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).Build()
+
+	cases := map[string]struct {
+		job               *batchv1.Job
+		defaultQueueExist bool
+	}{
+		"no default queue in the namespace": {
+			job: utiltestingjob.MakeJob("test-job", "ns").Obj(),
+		},
+		"the job already names a queue": {
+			job:               utiltestingjob.MakeJob("test-job", "ns").Queue("other").Obj(),
+			defaultQueueExist: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, cl, tc.job,
+				func(string) bool { return tc.defaultQueueExist }, labels.Everything())
+			if err != nil {
+				t.Errorf("ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector() = %v, want no error", err)
+			}
+		})
+	}
+}
+
+func TestApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(t *testing.T) {
 	managedNamespace := utiltesting.MakeNamespaceWrapper("managed-ns").Label(corev1.LabelMetadataName, "managed-ns").Obj()
 	unmanagedNamespace := utiltesting.MakeNamespaceWrapper("unmanaged-ns").Label(corev1.LabelMetadataName, "unmanaged-ns").Obj()
 	ls := &metav1.LabelSelector{
@@ -155,8 +233,8 @@ func TestApplyDefaultLocalQueue(t *testing.T) {
 				return true
 			}
 
-			if err := ApplyDefaultLocalQueue(ctx, cl, tc.job, defaultQueueExist, namespaceSelector); err != nil {
-				t.Fatalf("ApplyDefaultLocalQueue() returned error: %v", err)
+			if err := ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, cl, tc.job, defaultQueueExist, namespaceSelector); err != nil {
+				t.Fatalf("ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector() returned error: %v", err)
 			}
 
 			got := tc.job.Labels[constants.QueueLabel]

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -72,7 +72,7 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 	log := ctrl.LoggerFrom(ctx).WithName("deployment-webhook")
 	log.V(5).Info("Propagating queue-name")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, deployment.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, wh.client, deployment.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -104,7 +104,7 @@ func (w *JobWebhook) Default(ctx context.Context, obj *batchv1.Job) error {
 	log := ctrl.LoggerFrom(ctx).WithName("job-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/jobset/jobset_webhook.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook.go
@@ -77,7 +77,7 @@ func (w *JobSetWebhook) Default(ctx context.Context, obj *jobsetapi.JobSet) erro
 	log := ctrl.LoggerFrom(ctx).WithName("jobset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, obj, w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, obj)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -77,7 +77,7 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 	log := ctrl.LoggerFrom(ctx).WithName("leaderworkerset-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, obj, wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, wh.client, obj, wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -93,7 +93,7 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj *v2beta1.MPIJob) error 
 	log := ctrl.LoggerFrom(ctx).WithName("mpijob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, mpiJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, mpiJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, mpiJob.Object())

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -87,7 +87,7 @@ func (w *RayClusterWebhook) Default(ctx context.Context, obj *rayv1.RayCluster) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("raycluster-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/rayjob/rayjob_webhook.go
+++ b/pkg/controller/jobs/rayjob/rayjob_webhook.go
@@ -78,7 +78,7 @@ func (w *RayJobWebhook) Default(ctx context.Context, obj *rayv1.RayJob) error {
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayjob-webhook")
 	log.V(5).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/rayservice/rayservice_webhook.go
+++ b/pkg/controller/jobs/rayservice/rayservice_webhook.go
@@ -89,7 +89,7 @@ func (w *RayServiceWebhook) Default(ctx context.Context, obj *rayv1.RayService) 
 	job := fromObject(obj)
 	log := ctrl.LoggerFrom(ctx).WithName("rayservice-webhook")
 	log.V(10).Info("Applying defaults")
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_webhook.go
@@ -81,7 +81,7 @@ func (w *SparkApplicationWebhook) Default(ctx context.Context, obj *sparkv1beta2
 	log := ctrl.LoggerFrom(ctx).WithName("sparkapplication-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, job.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, job.Object())

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -82,7 +82,7 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 
 	log.V(5).Info("Propagating queue-name")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, wh.client, ss.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, wh.client, ss.Object(), wh.queues.DefaultLocalQueueExist, wh.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -72,7 +72,7 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	log := ctrl.LoggerFrom(ctx).WithName("trainjob-webhook")
 	log.V(5).Info("Applying defaults")
 
-	if err := jobframework.ApplyDefaultLocalQueue(ctx, w.client, trainJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
+	if err := jobframework.ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx, w.client, trainJob.Object(), w.queues.DefaultLocalQueueExist, w.managedJobsNamespaceSelector); err != nil {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

This restores the `jobframework.ApplyDefaultLocalQueue` signature that v0.18.4 shipped:

```go
func ApplyDefaultLocalQueue(jobObj client.Object, defaultQueueExist func(string) bool)
```

#13460 backported the fix for #13374, where a Job in a namespace excluded by `managedJobsNamespaceSelector` could still be given the default queue label and end up suspended. That fix also gave the exported function a context, a client, the selector and an error return, so the next patch release from this branch would stop compiling for anyone importing it.

Reverting the backport is not an option, since the runtime bug is real. Instead the released function is back with the behaviour it released, and the selector-aware form is now `ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector`, which every in-tree webhook calls. Both share the eligibility check and the labelling step, so the two cannot drift apart, and the namespace is still read only when the label is about to be set. A job that is not a candidate never needs it, which matters where the webhook cannot read the namespace.

##### What this leaves behind

Comparing `go doc -all ./pkg/controller/jobframework` between the v0.18.4 worktree and this branch, the only difference is one added line:

```
> func ApplyDefaultLocalQueueWithManagedJobsNamespaceSelector(ctx context.Context, k8sClient client.Client, ...
```

`ApplyDefaultLocalQueue` no longer differs, and neither does `UpdateWorkloadPriority` after #13877.

#### Which issue(s) this PR fixes:

Refs #13886

#### Special notes for your reviewer:

This is the release-0.18 twin of #13887, which @mimowo is reviewing. The two branches carry byte-identical copies of this function, so it is the same change cherry-picked.

It deliberately differs from `main`, where the helper is now a method on `IntegrationManager`. @mimowo asked for the helper split itself to go to `main` as a separate cleanup, and that will follow there.

The new `api_compat_test.go` sits in `package jobframework_test` so it sees the package the way an importer does. Adding a return value to `ApplyDefaultLocalQueue` fails there even though a plain call statement would still compile, which I checked by making that change locally.

On this branch `go build ./...`, `go vet ./pkg/...` and `golangci-lint` are clean, and the `jobframework` and `jobs` unit suites pass.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
