### PR TITLE
Flatten the default LocalQueue defaulting path

### DIFF
--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -53,27 +53,40 @@ func (m *IntegrationManager) ApplyDefaultLocalQueue(
 	defaultQueueExist func(string) bool,
 	managedJobsNamespaceSelector labels.Selector,
 ) error {
-	if !defaultQueueExist(jobObj.GetNamespace()) {
+	if !m.defaultLocalQueueApplies(jobObj, defaultQueueExist) {
 		return nil
 	}
-	if QueueNameForObject(jobObj) == "" {
-		// Do not default the queue-name for a job whose owner is already managed by Kueue
-		if m.IsOwnerManagedByKueueForObject(jobObj) {
-			return nil
-		}
-		if managed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), managedJobsNamespaceSelector); err != nil {
-			return err
-		} else if !managed {
-			return nil
-		}
-		labels := jobObj.GetLabels()
-		if labels == nil {
-			labels = make(map[string]string, 1)
-		}
-		labels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
-		jobObj.SetLabels(labels)
+	// Reached only when the label is about to be set, so an object that is not a
+	// candidate costs no Namespace read.
+	managed, err := namespaceMatchesSelector(ctx, k8sClient, jobObj.GetNamespace(), managedJobsNamespaceSelector)
+	if err != nil {
+		return err
 	}
+	if !managed {
+		return nil
+	}
+	setDefaultLocalQueue(jobObj)
 	return nil
+}
+
+func (m *IntegrationManager) defaultLocalQueueApplies(jobObj client.Object, defaultQueueExist func(string) bool) bool {
+	if !defaultQueueExist(jobObj.GetNamespace()) {
+		return false
+	}
+	if QueueNameForObject(jobObj) != "" {
+		return false
+	}
+	// Do not default the queue-name for a job whose owner is already managed by Kueue
+	return !m.IsOwnerManagedByKueueForObject(jobObj)
+}
+
+func setDefaultLocalQueue(jobObj client.Object) {
+	jobLabels := jobObj.GetLabels()
+	if jobLabels == nil {
+		jobLabels = make(map[string]string, 1)
+	}
+	jobLabels[constants.QueueLabel] = string(constants.DefaultLocalQueueName)
+	jobObj.SetLabels(jobLabels)
 }
 
 func (m *IntegrationManager) ApplyDefaultWorkloadPriorityClass(ctx context.Context, c client.Client, jobObj client.Object) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

`ApplyDefaultLocalQueue` kept its rules inside the queue-name check, so the namespace lookup sat three levels in and the order the checks run in was hard to follow. The preconditions become a named predicate, the labelling becomes its own function, and what is left reads as the sequence it is.

Behaviour is unchanged, and so is the exported surface: `go doc -all ./pkg/controller/jobframework` is identical before and after.

@mimowo asked for this in https://github.com/kubernetes-sigs/kueue/pull/13887#discussion_r3725943245, where the same split fell out of restoring the released signature on the release branches. Keeping the three branches structurally the same should also make a later pick touching this function apply the same way on each.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

The compatibility wrapper from #13887 is deliberately not here. On `main` this is a method on `IntegrationManager`, and that API change belongs to the next minor.

`go build ./...`, the `jobframework` and `jobs` unit suites, and `golangci-lint` are clean.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default queue assignment to avoid unnecessary namespace lookups for ineligible objects.
  * Preserved existing eligibility requirements, including an available default queue, no explicitly selected queue, and no Kueue-managed owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->