### PR TITLE
test(lws): add e2e coverage for queue-name on pod templates

### DIFF
--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -866,7 +866,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			func(alsoSetOnWorkerTemplate bool) {
 				lwsWrapper := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-					Size(3).
+					Size(2).
 					Replicas(1).
 					RequestAndLimit(corev1.ResourceCPU, "200m").
 					Queue(lq.Name).
@@ -920,7 +920,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 						g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
 							leaderworkersetv1.SetNameLabelKey: lws.Name,
 						}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
-						g.Expect(pods.Items).To(gomega.HaveLen(3))
+						g.Expect(pods.Items).To(gomega.HaveLen(2))
 						for _, pod := range pods.Items {
 							g.Expect(pod.Spec.SchedulingGates).NotTo(gomega.ContainElement(corev1.PodSchedulingGate{
 								Name: podconstants.SchedulingGateName,
@@ -955,7 +955,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 						g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
 							leaderworkersetv1.SetNameLabelKey: lws.Name,
 						}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
-						g.Expect(pods.Items).To(gomega.HaveLen(3))
+						g.Expect(pods.Items).To(gomega.HaveLen(2))
 						for _, pod := range pods.Items {
 							g.Expect(pod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{
 								Name: podconstants.SchedulingGateName,

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -862,6 +862,162 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
+		ginkgo.DescribeTable("should override the template queue-name, then admit, evict and re-activate correctly",
+			func(alsoSetOnWorkerTemplate bool) {
+				lwsWrapper := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
+					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+					Size(3).
+					Replicas(1).
+					RequestAndLimit(corev1.ResourceCPU, "200m").
+					Queue(lq.Name).
+					LeaderTemplate(corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "c",
+									Args:  util.BehaviorWaitForDeletion,
+									Image: util.GetAgnHostImage(),
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											corev1.ResourceCPU: resource.MustParse("200m"),
+										},
+									},
+								},
+							},
+							NodeSelector: map[string]string{},
+						},
+					}).
+					LeaderTemplateSpecLabel(ctrlconstants.QueueLabel, "user-queue").
+					TerminationGracePeriod(1)
+				if alsoSetOnWorkerTemplate {
+					lwsWrapper.WorkerTemplateSpecLabel(ctrlconstants.QueueLabel, "user-queue")
+				}
+				lws := lwsWrapper.Obj()
+
+				ginkgo.By("Create a LeaderWorkerSet with queue-name set on the pod templates", func() {
+					util.MustCreate(ctx, k8sClient, lws)
+				})
+
+				wlLookupKey := util.WorkloadKeyForLeaderWorkerSet(lws, "0")
+
+				ginkgo.By("Checking that the workload is admitted", func() {
+					util.ExpectWorkloadsToBeAdmittedByKeysWithTimeout(ctx, k8sClient, util.MediumTimeout, wlLookupKey)
+				})
+
+				ginkgo.By("Waiting for replicas to be ready", func() {
+					createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking that the pods are ungated", func() {
+					pods := &corev1.PodList{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+							leaderworkersetv1.SetNameLabelKey: lws.Name,
+						}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+						g.Expect(pods.Items).To(gomega.HaveLen(3))
+						for _, pod := range pods.Items {
+							g.Expect(pod.Spec.SchedulingGates).NotTo(gomega.ContainElement(corev1.PodSchedulingGate{
+								Name: podconstants.SchedulingGateName,
+							}))
+						}
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				createdWorkload := &kueue.Workload{}
+				ginkgo.By("Deactivate the workload to simulate eviction", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+						createdWorkload.Spec.Active = new(false)
+						g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				// The original report observed the Workload keeping ADMITTED=true while its pods
+				// stayed gated, so assert the eviction propagates to the Workload, not only to the pods.
+				ginkgo.By("Checking that the workload is evicted and releases its quota", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+						g.Expect(createdWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadEvicted, kueue.WorkloadDeactivated))
+						g.Expect(createdWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusFalse(kueue.WorkloadAdmitted))
+						g.Expect(createdWorkload.Status.Conditions).To(utiltesting.HaveConditionStatusFalse(kueue.WorkloadQuotaReserved))
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking that pods are gated after eviction", func() {
+					pods := &corev1.PodList{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+							leaderworkersetv1.SetNameLabelKey: lws.Name,
+						}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+						g.Expect(pods.Items).To(gomega.HaveLen(3))
+						for _, pod := range pods.Items {
+							g.Expect(pod.Spec.SchedulingGates).To(gomega.ContainElement(corev1.PodSchedulingGate{
+								Name: podconstants.SchedulingGateName,
+							}))
+						}
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Waiting for replicas to not be ready", func() {
+					createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(0)))
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusFalseAndReason("Available", "AllGroupsReady"))
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Re-activate the workload", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
+						createdWorkload.Spec.Active = new(true)
+						g.Expect(k8sClient.Update(ctx, createdWorkload)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking that the workload is admitted again", func() {
+					util.ExpectWorkloadsToBeAdmittedByKeysWithTimeout(ctx, k8sClient, util.MediumTimeout, wlLookupKey)
+				})
+
+				ginkgo.By("Waiting for replicas to be ready again", func() {
+					createdLeaderWorkerSet := &leaderworkersetv1.LeaderWorkerSet{}
+
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
+						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
+						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Delete the LeaderWorkerSet", func() {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
+				})
+
+				ginkgo.By("Check pods are deleted", func() {
+					pods := &corev1.PodList{}
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.MatchingLabels{
+							leaderworkersetv1.SetNameLabelKey: lws.Name,
+						}, client.InNamespace(lws.Namespace))).Should(gomega.Succeed())
+						g.Expect(pods.Items).To(gomega.BeEmpty())
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Check workload is deleted", func() {
+					util.ExpectObjectToBeDeletedWithTimeout(ctx, k8sClient, createdWorkload, false, util.MediumTimeout)
+				})
+			},
+			ginkgo.Entry("with queue-name set on the leader template", false),
+			ginkgo.Entry("with queue-name set on the leader and worker templates", true),
+		)
+
 		ginkgo.It("should allow to change queue-name if ReadyReplicas=0", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -862,7 +862,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
-		ginkgo.DescribeTable("should override the template queue-name, then admit, evict and re-activate correctly",
+		ginkgo.DescribeTable("should admit, evict and re-activate the group correctly",
 			func(alsoSetOnWorkerTemplate bool) {
 				lwsWrapper := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).
 					Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
@@ -911,7 +911,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
 						g.Expect(createdLeaderWorkerSet.Status.ReadyReplicas).To(gomega.Equal(int32(1)))
 						g.Expect(createdLeaderWorkerSet.Status.Conditions).To(utiltesting.HaveConditionStatusTrueAndReason("Available", "AllGroupsReady"))
-					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
 				ginkgo.By("Checking that the pods are ungated", func() {
@@ -938,8 +938,8 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				// The original report observed the Workload keeping ADMITTED=true while its pods
-				// stayed gated, so assert the eviction propagates to the Workload, not only to the pods.
+				// Deactivation has to reach the Workload, not just the pods. Asserting the re-gating
+				// alone would not catch quota staying reserved.
 				ginkgo.By("Checking that the workload is evicted and releases its quota", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing
/area integrations

#### What this PR does / why we need it:

Added a `DescribeTable` exercising a LeaderWorkerSet whose leader template, and optionally worker template, carries `kueue.x-k8s.io/queue-name` while the top-level label points at a different queue.

The existing e2e case has not set `leaderTemplate`, so LeaderWorkerSet derives the leader pod from the worker template and the explicit `leaderTemplate` path went untested. That case also only checked that pods were re-gated after deactivation, leaving the Workload side of eviction unasserted, which is the part the original report was about: the Workload kept `Admitted=true` while its pods stayed scheduling gated.

The new cases assert `Evicted=True` with reason `Deactivated`, `Admitted=false` and `QuotaReserved=false` after deactivation, and that re-activating the Workload returns the group to admitted and ready.

#### Which issue(s) this PR fixes:

Fixes #10965

#### Special notes for your reviewer:

This is purely additive and complements #10969, which added the defaulter unit tests and the e2e case with `queue-name` on the worker template. That case is left untouched and remains the worker-template-only variant.

The new table, relative to what is already covered:
- an explicit `leaderTemplate` carrying `queue-name`, as leader-only and as leader + worker, matching the original reproducer.
- explicit assertions on the Workload after deactivation, `Evicted=True/Deactivated`, `Admitted=false` and `QuotaReserved=false`, covering the "eviction silently fails" part of the report.
- a re-activation round trip back to admitted and ready.

No integration (envtest) coverage is added because the LeaderWorkerSet controller is not available under envtest, so the leader/worker template split can only be exercised e2e.

I verified locally on a kind cluster with the LeaderWorkerSet operator, via `make test-e2e-extended` filtered to `feature:leaderworkerset`, with both entries passing.

One observation while verifying, not addressed in this PR. Just in case, I noted here. The existing case calls the bare 10s `util.ExpectWorkloadsToBeAdmittedByKeys` immediately after creating its LeaderWorkerSet. On a cold cluster I saw that window exceeded when it happened to be the first LWS spec to run, so the new cases use `ExpectWorkloadsToBeAdmittedByKeysWithTimeout` with `util.MediumTimeout` instead. I would be happy to apply the same change to the existing case in a follow-up if you think it is worth doing.

AI disclosure: Claude Code was used to audit the existing coverage, draft the test and review it. I reviewed all of the changes before submitting.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for workload eviction and reactivation when queue labels are configured on leader and worker templates.
  * Verified quota release, pod re-gating, re-admission, readiness restoration, and cleanup across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->