### PR TITLE
[release-0.18] Tolerate missing owners for terminating objects during GC teardown

### DIFF
--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -36,7 +36,7 @@ import (
 
 func ApplyDefaultForSuspend(ctx context.Context, job GenericJob, k8sClient client.Client,
 	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) error {
-	suspend, err := WorkloadShouldBeSuspended(ctx, job.Object(), k8sClient, manageJobsWithoutQueueName, managedJobsNamespaceSelector)
+	suspend, err := WorkloadShouldBeSuspended(ctx, job.Object(), k8sClient, manageJobsWithoutQueueName, managedJobsNamespaceSelector, WithDeletingObjectTolerance(true))
 	if err != nil {
 		return err
 	}
@@ -146,4 +146,12 @@ func ApplyDefaultForManagedBy(job GenericJob, queues *qcache.Manager, cache *sch
 			}
 		}
 	}
+}
+
+// skipCheckForDeletedObject reports whether suspend/ancestry processing should be skipped
+// for an object that is already being deleted (e.g. during GC teardown, where owners may
+// legitimately be gone already). Gated by SkipAncestorCheckForDeletedWorkloads so affected
+// environments can restore the previous behavior of failing the admission request.
+func skipCheckForDeletedObject(obj client.Object) bool {
+	return features.Enabled(features.SkipAncestorCheckForDeletedWorkloads) && obj.GetDeletionTimestamp() != nil
 }

--- a/pkg/controller/jobframework/defaults_test.go
+++ b/pkg/controller/jobframework/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,10 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 	cases := map[string]struct {
 		obj                        client.Object
 		manageJobsWithoutQueueName bool
+		tolerateDeleting           bool
 		wantSuspend                bool
+		wantErr                    error
+		skipAncestorGateOff        bool
 	}{
 		"job with queue name ": {
 			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Queue("default").Obj(),
@@ -86,6 +90,50 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			manageJobsWithoutQueueName: true,
 			wantSuspend:                false,
 		},
+		"job with ownerReference to a deleted known parent while terminating (GC teardown)": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Finalizers("batch.kubernetes.io/job-tracking").
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			tolerateDeleting:           true,
+			// With WithDeletingObjectTolerance (webhook call sites), the suspend check is
+			// skipped entirely for an object that is being deleted, so the missing parent
+			// is never looked up and no suspend is defaulted.
+			wantSuspend: false,
+		},
+		"job with ownerReference to a deleted known parent while terminating, without tolerance": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Finalizers("batch.kubernetes.io/job-tracking").
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			// Without WithDeletingObjectTolerance (reconciler predicates), a missing owner
+			// fails hard even for a terminating object and even with the gate enabled.
+			wantErr: ErrWorkloadOwnerNotFound,
+		},
+		"job with ownerReference to a deleted known parent while terminating, gate disabled": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				DeletionTimestamp(time.Now()).
+				Finalizers("batch.kubernetes.io/job-tracking").
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			tolerateDeleting:           true,
+			skipAncestorGateOff:        true,
+			// With SkipAncestorCheckForDeletedWorkloads disabled, the previous behavior is
+			// restored: a missing owner fails hard even for a terminating object.
+			wantErr: ErrWorkloadOwnerNotFound,
+		},
+		"job with ownerReference to a missing parent while not terminating (cache lag)": {
+			obj: utiltestingjob.MakeJob("test-job", managedNamespace.Name).
+				OwnerReference("nonexistent-parent", batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			manageJobsWithoutQueueName: true,
+			wantErr:                    ErrWorkloadOwnerNotFound,
+		},
 		"job without queue name with manageJobs with feature disabled": {
 			obj:                        utiltestingjob.MakeJob("test-job", managedNamespace.Name).Obj(),
 			manageJobsWithoutQueueName: true,
@@ -105,11 +153,16 @@ func TestWorkloadShouldBeSuspended(t *testing.T) {
 			client := builder.Build()
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			suspend, err := WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector)
-			if err != nil {
-				t.Errorf("Got error: %v", err)
+			features.SetFeatureGateDuringTest(t, features.SkipAncestorCheckForDeletedWorkloads, !tc.skipAncestorGateOff)
+			var opts []WorkloadShouldBeSuspendedOption
+			if tc.tolerateDeleting {
+				opts = append(opts, WithDeletingObjectTolerance(true))
 			}
-			if suspend != tc.wantSuspend {
+			suspend, err := WorkloadShouldBeSuspended(ctx, tc.obj, client, tc.manageJobsWithoutQueueName, namespaceSelector, opts...)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("Unexpected error: got %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantErr == nil && suspend != tc.wantSuspend {
 				t.Errorf("Unexpected result: got %v wanted %v", suspend, tc.wantSuspend)
 			}
 		})

--- a/pkg/controller/jobframework/utils.go
+++ b/pkg/controller/jobframework/utils.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -108,9 +109,34 @@ func RecordWorkloadCreationLatency(ctx context.Context, job client.Object, jobKi
 	metrics.RecordWorkloadCreationLatency(jobKind, latency, customLabelValues, tracker)
 }
 
+type workloadShouldBeSuspendedOptions struct {
+	deletingObjectTolerance bool
+}
+
+// WorkloadShouldBeSuspendedOption configures WorkloadShouldBeSuspended.
+type WorkloadShouldBeSuspendedOption func(*workloadShouldBeSuspendedOptions)
+
+// WithDeletingObjectTolerance makes WorkloadShouldBeSuspended skip the suspend and
+// ancestry checks for an object that is already being deleted; its ancestry may
+// legitimately be gone already (e.g. during GC teardown). Webhook call sites opt in,
+// while reconciler predicates keep the strict behavior.
+func WithDeletingObjectTolerance(tolerate bool) WorkloadShouldBeSuspendedOption {
+	return func(o *workloadShouldBeSuspendedOptions) {
+		o.deletingObjectTolerance = tolerate
+	}
+}
+
 // WorkloadShouldBeSuspended determines whether jobObj should be default suspended on creation
 func WorkloadShouldBeSuspended(ctx context.Context, jobObj client.Object, k8sClient client.Client,
-	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector) (bool, error) {
+	manageJobsWithoutQueueName bool, managedJobsNamespaceSelector labels.Selector, opts ...WorkloadShouldBeSuspendedOption) (bool, error) {
+	var options workloadShouldBeSuspendedOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.deletingObjectTolerance && skipCheckForDeletedObject(jobObj) {
+		ctrl.LoggerFrom(ctx).V(3).Info("Skipping suspend check for an object that is being deleted", "object", klog.KObj(jobObj))
+		return false, nil
+	}
 	// Do not default suspend a job whose ancestor is already managed by Kueue
 	ancestorJob, err := FindAncestorJobManagedByKueue(ctx, k8sClient, jobObj, manageJobsWithoutQueueName)
 	if err != nil || ancestorJob != nil {

--- a/pkg/controller/jobs/deployment/deployment_webhook.go
+++ b/pkg/controller/jobs/deployment/deployment_webhook.go
@@ -76,7 +76,14 @@ func (wh *Webhook) Default(ctx context.Context, obj *appsv1.Deployment) error {
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, deployment.Object())
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, deployment.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		deployment.Object(),
+		wh.client,
+		wh.manageJobsWithoutQueueName,
+		wh.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook.go
@@ -81,7 +81,14 @@ func (wh *Webhook) Default(ctx context.Context, obj *leaderworkersetv1.LeaderWor
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, obj)
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, lws.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		lws.Object(),
+		wh.client,
+		wh.manageJobsWithoutQueueName,
+		wh.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return err
 	}
@@ -193,7 +200,14 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldObj, newObj *leaderwor
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldLeaderWorkerSet.Object(), newLeaderWorkerSet.Object())...)
 	}
 
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newLeaderWorkerSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		newLeaderWorkerSet.Object(),
+		wh.client,
+		wh.manageJobsWithoutQueueName,
+		wh.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/pod/pod_webhook_test.go
+++ b/pkg/controller/jobs/pod/pod_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -195,6 +196,17 @@ func TestDefault(t *testing.T) {
 				Queue("test-queue").
 				OwnerReference("parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
 				Obj(),
+		},
+		"pod with ownerReference to a missing parent while not terminating (cache lag, should error)": {
+			initObjects:       []client.Object{defaultNamespace},
+			podSelector:       &metav1.LabelSelector{},
+			namespaceSelector: defaultNamespaceSelector,
+			pod: testingpod.MakePod("test-pod", defaultNamespace.Name).
+				Queue("test-queue").
+				OwnerReference("deleted-parent-job", batchv1.SchemeGroupVersion.WithKind("Job")).
+				Obj(),
+			enableIntegrations: []string{"batch/job"},
+			wantErr:            jobframework.ErrWorkloadOwnerNotFound,
 		},
 		"pod with owner managed by kueue (RayCluster)": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
@@ -671,8 +683,12 @@ func TestDefault(t *testing.T) {
 				podSelector:                  tc.podSelector,
 			}
 
-			if err := w.Default(ctx, tc.pod); err != nil {
-				t.Errorf("failed to set defaults for v1/pod: %s", err)
+			gotErr := w.Default(ctx, tc.pod)
+			if !errors.Is(gotErr, tc.wantErr) {
+				t.Errorf("Default() error = %v, wantErr %v", gotErr, tc.wantErr)
+			}
+			if gotErr != nil {
+				return
 			}
 
 			if diff := cmp.Diff(tc.want, tc.pod); len(diff) != 0 {

--- a/pkg/controller/jobs/statefulset/statefulset_webhook.go
+++ b/pkg/controller/jobs/statefulset/statefulset_webhook.go
@@ -86,7 +86,14 @@ func (wh *Webhook) Default(ctx context.Context, stsObj *appsv1.StatefulSet) erro
 		return err
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, wh.client, ss.Object())
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, ss.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		ss.Object(),
+		wh.client,
+		wh.manageJobsWithoutQueueName,
+		wh.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return err
 	}
@@ -171,7 +178,14 @@ func (wh *Webhook) ValidateUpdate(ctx context.Context, oldSTSObj, newSTSObj *app
 		allErrs = append(allErrs, webhook.ValidateAdmissionGatedByAnnotationOnUpdate(oldStatefulSet.Object(), newStatefulSet.Object())...)
 	}
 
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, newStatefulSet.Object(), wh.client, wh.manageJobsWithoutQueueName, wh.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		newStatefulSet.Object(),
+		wh.client,
+		wh.manageJobsWithoutQueueName,
+		wh.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/jobs/trainjob/trainjob_webhook.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook.go
@@ -77,7 +77,14 @@ func (w *TrainJobWebhook) Default(ctx context.Context, obj *kftrainerapi.TrainJo
 	}
 	jobframework.ApplyDefaultWorkloadPriorityClass(ctx, w.client, trainJob.Object())
 	jobframework.ApplyDefaultForManagedBy(trainJob, w.queues, w.cache, log)
-	suspend, err := jobframework.WorkloadShouldBeSuspended(ctx, trainJob.Object(), w.client, w.manageJobsWithoutQueueName, w.managedJobsNamespaceSelector)
+	suspend, err := jobframework.WorkloadShouldBeSuspended(
+		ctx,
+		trainJob.Object(),
+		w.client,
+		w.manageJobsWithoutQueueName,
+		w.managedJobsNamespaceSelector,
+		jobframework.WithDeletingObjectTolerance(true),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -540,6 +540,24 @@ const (
 	// pods per group without accounting for quota. Recreate the LeaderWorkerSet to change
 	// the size, or disable this gate to accept the previous behavior.
 	LWSImmutableGroupSize featuregate.Feature = "LWSImmutableGroupSize"
+
+	// owner: @iaalm
+	//
+	// pr: https://github.com/kubernetes-sigs/kueue/pull/10009
+	// Tolerates a missing owner while walking the ownership chain of an object that is
+	// already being deleted (GC teardown with mixed foreground/background deletion), so
+	// Kueue webhooks do not block finalizer removal. Disable to restore the previous
+	// behavior of failing the admission request when an owner cannot be found.
+	//
+	// Note: the tolerance cannot apply at creation time — the API server never creates
+	// an object with a deletionTimestamp itself (one could technically be injected by a
+	// mutating webhook, which is deliberately not covered) — so the strict missing-owner
+	// handling on CREATE (which
+	// protects against acting on a stale informer view of a just-created owner) is
+	// unchanged. The earliest the tolerance can apply is an update after deletion has
+	// begun, and suspend defaulting only ever adds suspend, so no path exists to
+	// unsuspend an object or bypass quota via create-then-delete.
+	SkipAncestorCheckForDeletedWorkloads featuregate.Feature = "SkipAncestorCheckForDeletedWorkloads"
 )
 
 func init() {
@@ -835,6 +853,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	LWSImmutableGroupSize: {
+		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	SkipAncestorCheckForDeletedWorkloads: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -409,6 +409,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: SkipAncestorCheckForDeletedWorkloads
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -409,6 +409,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: SkipAncestorCheckForDeletedWorkloads
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.18"
 - name: SkipFinalizersForPodsSuspendedByParent
   versionedSpecs:
   - default: true

--- a/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -150,6 +151,75 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
+		})
+	})
+
+	// Regression test for GC teardown deadlock:
+	// When foreground and background deletion are mixed in the same ownership chain,
+	// a child LeaderWorkerSet can get stuck in Terminating because the webhook denied
+	// the GC's PATCH to remove the foregroundDeletion finalizer (parent was already gone).
+	ginkgo.When("a child LeaderWorkerSet is terminating with its parent already deleted", func() {
+		ginkgo.It("Should allow removing foregroundDeletion finalizer", func() {
+			lwsGVK := leaderworkersetv1.SchemeGroupVersion.WithKind("LeaderWorkerSet")
+
+			// Create the parent LWS (no finalizers, so it is deleted immediately).
+			parentLWS := testingleaderworkerset.MakeLeaderWorkerSet("parent-lws", ns.Name).
+				Queue("user-queue").
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			util.MustCreate(ctx, k8sClient, parentLWS)
+
+			// Re-read to get the real UID assigned by the API server.
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentLWS), parentLWS)).To(gomega.Succeed())
+
+			// Create the child LWS with an ownerReference to the parent and the
+			// foregroundDeletion finalizer (as the GC would add during teardown).
+			childLWS := testingleaderworkerset.MakeLeaderWorkerSet("child-lws", ns.Name).
+				RolloutStrategy(leaderworkersetv1.RollingUpdateStrategyType).
+				Obj()
+			childLWS.Finalizers = []string{metav1.FinalizerDeleteDependents}
+			isController := true
+			childLWS.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: lwsGVK.GroupVersion().String(),
+					Kind:       lwsGVK.Kind,
+					Name:       parentLWS.Name,
+					UID:        parentLWS.UID,
+					Controller: &isController,
+				},
+			}
+			util.MustCreate(ctx, k8sClient, childLWS)
+
+			// Delete the parent LWS with background propagation: it has no
+			// finalizers so it disappears from the API server immediately,
+			// simulating the "background delete while foreground chain is active"
+			// scenario described in the bug report.
+			background := metav1.DeletePropagationBackground
+			gomega.Expect(k8sClient.Delete(ctx, parentLWS, &client.DeleteOptions{
+				PropagationPolicy: &background,
+			})).To(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentLWS), &leaderworkersetv1.LeaderWorkerSet{})).
+					Should(gomega.MatchError(gomega.ContainSubstring("not found")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			// Delete the child LWS so it enters Terminating state.
+			// The foregroundDeletion finalizer prevents it from being fully removed.
+			gomega.Expect(k8sClient.Delete(ctx, childLWS)).To(gomega.Succeed())
+
+			var terminatingChild leaderworkersetv1.LeaderWorkerSet
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childLWS), &terminatingChild)).To(gomega.Succeed())
+				g.Expect(terminatingChild.DeletionTimestamp).NotTo(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			// Simulate what the GC does: PATCH the child LWS to remove the
+			// foregroundDeletion finalizer.  Without the fix this PATCH is denied
+			// by the mutating webhook with "workload owner not found".
+			patch := client.MergeFrom(terminatingChild.DeepCopy())
+			terminatingChild.Finalizers = nil
+			gomega.Expect(k8sClient.Patch(ctx, &terminatingChild, patch)).To(gomega.Succeed())
 		})
 	})
 })

--- a/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/statefulset_webhook_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -87,6 +88,70 @@ var _ = ginkgo.Describe("StatefulSet Webhook", func() {
 							"Queue name should not be injected to pod template labels",
 						)
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		// Regression test for GC teardown deadlock:
+		// When foreground and background deletion are mixed in the same ownership chain,
+		// a child STS can get stuck in Terminating because the webhook denied the GC's
+		// PATCH to remove the foregroundDeletion finalizer (parent was already gone).
+		ginkgo.When("a child StatefulSet is terminating with its parent already deleted", func() {
+			ginkgo.It("Should allow removing foregroundDeletion finalizer", func() {
+				stsGVK := appsv1.SchemeGroupVersion.WithKind("StatefulSet")
+
+				// Create the parent STS (no finalizers, so it is deleted immediately).
+				parentSTS := testingstatefulset.MakeStatefulSet("parent-sts", ns.Name).Queue("user-queue").Obj()
+				util.MustCreate(ctx, k8sClient, parentSTS)
+
+				// Re-read to get the real UID assigned by the API server.
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentSTS), parentSTS)).To(gomega.Succeed())
+
+				// Create the child STS with an ownerReference to the parent and the
+				// foregroundDeletion finalizer (as the GC would add during teardown).
+				childSTS := testingstatefulset.MakeStatefulSet("child-sts", ns.Name).Obj()
+				childSTS.Finalizers = []string{metav1.FinalizerDeleteDependents}
+				isController := true
+				childSTS.OwnerReferences = []metav1.OwnerReference{
+					{
+						APIVersion: stsGVK.GroupVersion().String(),
+						Kind:       stsGVK.Kind,
+						Name:       parentSTS.Name,
+						UID:        parentSTS.UID,
+						Controller: &isController,
+					},
+				}
+				util.MustCreate(ctx, k8sClient, childSTS)
+
+				// Delete the parent STS with background propagation: it has no
+				// finalizers so it disappears from the API server immediately,
+				// simulating the "background delete while foreground chain is active"
+				// scenario described in the bug report.
+				background := metav1.DeletePropagationBackground
+				gomega.Expect(k8sClient.Delete(ctx, parentSTS, &client.DeleteOptions{
+					PropagationPolicy: &background,
+				})).To(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(parentSTS), &appsv1.StatefulSet{})).
+						Should(gomega.MatchError(gomega.ContainSubstring("not found")))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				// Delete the child STS so it enters Terminating state.
+				// The foregroundDeletion finalizer prevents it from being fully removed.
+				gomega.Expect(k8sClient.Delete(ctx, childSTS)).To(gomega.Succeed())
+
+				var terminatingChild appsv1.StatefulSet
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childSTS), &terminatingChild)).To(gomega.Succeed())
+					g.Expect(terminatingChild.DeletionTimestamp).NotTo(gomega.BeNil())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				// Simulate what the GC does: PATCH the child STS to remove the
+				// foregroundDeletion finalizer.  Without the fix this PATCH is denied
+				// by the mutating webhook with "workload owner not found".
+				patch := client.MergeFrom(terminatingChild.DeepCopy())
+				terminatingChild.Finalizers = nil
+				gomega.Expect(k8sClient.Patch(ctx, &terminatingChild, patch)).To(gomega.Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Manual cherry-pick of #13857 (`2e37cfa5c`) onto `release-0.18`; the automated cherry-pick failed to apply due to conflicts.

Branch adaptations on top of the original commit:

- `jobframework` on this branch still uses package-level functions (pre-`IntegrationManager` refactor), so the `WithDeletingObjectTolerance` option was applied to the package-level `WorkloadShouldBeSuspended` / `ApplyDefaultForSuspend` signatures;
- the `SkipAncestorCheckForDeletedWorkloads` feature gate is registered as Beta at version `0.18` to match this branch, and the feature-gate lists were regenerated with `make generate-featuregates`;
- dropped an unrelated `PodIntegrationValidateGroupOwner` gate hunk that the conflict context carried over from `main` (#13014 is not on this branch).

Verified locally: unit tests for all touched packages pass, both GC-teardown integration specs (StatefulSet + LeaderWorkerSet in `webhook/jobs`) pass, and `make ci-lint` reports 0 issues.

#### Which issue(s) this PR fixes:

Cherry-pick of #13857.

#### Special notes for your reviewer:

AI tooling (Claude Code) was used to assist the cherry-pick; the conflict resolution and verification were reviewed manually.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where deleting a child object whose owner was already deleted (e.g. mixed foreground/background propagation during namespace teardown) could leave the child stuck in Terminating, because Kueue webhooks denied the garbage collector's finalizer-removal request with "workload owner not found". The tolerance applies only to objects already being deleted, and is gated by the new `SkipAncestorCheckForDeletedWorkloads` feature gate (Beta, enabled by default).
```
