### PR TITLE
[release-0.18] Don't prefer a flavor with no preemption candidates over one that fits

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -491,6 +491,15 @@ func isPreferred(a, b granularMode, fungibilityConfig kueue.FlavorFungibility) b
 		return true
 	}
 
+	// A flavor without preemption candidates cannot be admitted in this
+	// scheduling attempt. Rank it below viable modes before applying the
+	// configured fungibility preference, while retaining noFit as the worst mode.
+	aHasNoCandidates := a.preemptionMode == noPreemptionCandidates
+	bHasNoCandidates := b.preemptionMode == noPreemptionCandidates
+	if aHasNoCandidates != bHasNoCandidates {
+		return !aHasNoCandidates
+	}
+
 	borrowingOverPreemption := func() bool {
 		if a.preemptionMode != b.preemptionMode {
 			return a.preemptionMode > b.preemptionMode

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4068,6 +4068,13 @@ func TestLastAssignmentOutdated(t *testing.T) {
 // each cohort get 4 units of CPU in a different flavor.
 func TestHierarchical(t *testing.T) {
 	type rfMap = map[corev1.ResourceName]kueue.ResourceFlavorReference
+	defaultTestClusterQueueFlavors := func() []kueue.FlavorQuotas {
+		return []kueue.FlavorQuotas{
+			*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+		}
+	}
 	cases := map[string]struct {
 		workloadRequests        *utiltestingapi.PodSetWrapper
 		testClusterQueueFlavors []kueue.FlavorQuotas
@@ -4079,7 +4086,8 @@ func TestHierarchical(t *testing.T) {
 		wantAssigment           rfMap
 	}{
 		"Select the top flavor": {
-			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			workloadRequests:        utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: defaultTestClusterQueueFlavors(),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
@@ -4090,14 +4098,15 @@ func TestHierarchical(t *testing.T) {
 			wantAssigment: rfMap{corev1.ResourceCPU: "three"},
 		},
 		"Select the first flavor which fits": {
-			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			workloadRequests:        utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: defaultTestClusterQueueFlavors(),
 			testClusterQueueUsage: resources.FlavorResourceQuantities{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
 			},
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
 		},
-		"Select deeper flavor that fits when shallower flavor has no preemption candidates": {
+		"Select deeper-borrowing flavor that fits when shallower-borrowing flavor has no preemption candidates": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
 			testClusterQueueFlavors: []kueue.FlavorQuotas{
 				*utiltestingapi.MakeFlavorQuotas("one").
@@ -4132,14 +4141,6 @@ func TestHierarchical(t *testing.T) {
 				"two":   utiltestingapi.MakeResourceFlavor("two").Obj(),
 				"three": utiltestingapi.MakeResourceFlavor("three").Obj(),
 			}
-			testClusterQueueFlavors := tc.testClusterQueueFlavors
-			if testClusterQueueFlavors == nil {
-				testClusterQueueFlavors = []kueue.FlavorQuotas{
-					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
-				}
-			}
 			cohorts := []*kueue.Cohort{
 				utiltestingapi.MakeCohort("three").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("three").
@@ -4162,7 +4163,7 @@ func TestHierarchical(t *testing.T) {
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				}).
-				ResourceGroup(testClusterQueueFlavors...).
+				ResourceGroup(tc.testClusterQueueFlavors...).
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).Obj()
@@ -4288,7 +4289,7 @@ func TestIsPreferred(t *testing.T) {
 			},
 			wantPreferred: false,
 		},
-		"explicit PreemptionOverBorrowing prefers fit over shallower no-candidate flavor": {
+		"explicit PreemptionOverBorrowing prefers fit over shallower-borrowing no-candidate flavor": {
 			a: granularMode{preemptionMode: fit, borrowingLevel: 2},
 			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
 			config: kueue.FlavorFungibility{

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4069,12 +4069,14 @@ func TestLastAssignmentOutdated(t *testing.T) {
 func TestHierarchical(t *testing.T) {
 	type rfMap = map[corev1.ResourceName]kueue.ResourceFlavorReference
 	cases := map[string]struct {
-		workloadRequests       *utiltestingapi.PodSetWrapper
-		testClusterQueueUsage  resources.FlavorResourceQuantities
-		otherClusterQueueUsage resources.FlavorResourceQuantities
-		flavorFungibility      *kueue.FlavorFungibility
-		wantMode               FlavorAssignmentMode
-		wantAssigment          rfMap
+		workloadRequests        *utiltestingapi.PodSetWrapper
+		testClusterQueueFlavors []kueue.FlavorQuotas
+		testClusterQueueUsage   resources.FlavorResourceQuantities
+		otherClusterQueueUsage  resources.FlavorResourceQuantities
+		flavorFungibility       *kueue.FlavorFungibility
+		simulationResult        map[resources.FlavorResource]simulationResultForFlavor
+		wantMode                FlavorAssignmentMode
+		wantAssigment           rfMap
 	}{
 		"Select the top flavor": {
 			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
@@ -4095,6 +4097,32 @@ func TestHierarchical(t *testing.T) {
 			wantMode:      Fit,
 			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
 		},
+		"Select deeper flavor that fits when shallower flavor has no preemption candidates": {
+			workloadRequests: utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "4"),
+			testClusterQueueFlavors: []kueue.FlavorQuotas{
+				*utiltestingapi.MakeFlavorQuotas("one").
+					ResourceQuotaWrapper(corev1.ResourceCPU).
+					NominalQuota("4").
+					BorrowingLimit("0").
+					Append().
+					Obj(),
+				*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+			},
+			testClusterQueueUsage: resources.FlavorResourceQuantities{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: resources.NewAmount(4_000),
+			},
+			flavorFungibility: &kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 1},
+			},
+			wantMode:      Fit,
+			wantAssigment: rfMap{corev1.ResourceCPU: "two"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -4103,6 +4131,14 @@ func TestHierarchical(t *testing.T) {
 				"one":   utiltestingapi.MakeResourceFlavor("one").Obj(),
 				"two":   utiltestingapi.MakeResourceFlavor("two").Obj(),
 				"three": utiltestingapi.MakeResourceFlavor("three").Obj(),
+			}
+			testClusterQueueFlavors := tc.testClusterQueueFlavors
+			if testClusterQueueFlavors == nil {
+				testClusterQueueFlavors = []kueue.FlavorQuotas{
+					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
+				}
 			}
 			cohorts := []*kueue.Cohort{
 				utiltestingapi.MakeCohort("three").
@@ -4126,11 +4162,7 @@ func TestHierarchical(t *testing.T) {
 					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 					ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				}).
-				ResourceGroup(
-					*utiltestingapi.MakeFlavorQuotas("one").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("two").Resource(corev1.ResourceCPU, "0").Obj(),
-					*utiltestingapi.MakeFlavorQuotas("three").Resource(corev1.ResourceCPU, "0").Obj(),
-				).
+				ResourceGroup(testClusterQueueFlavors...).
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanPreempt: kueue.TryNextFlavor,
 				}).Obj()
@@ -4179,7 +4211,7 @@ func TestHierarchical(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: tc.testClusterQueueUsage})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared)
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared)
 			assignment := flvAssigner.Assign(log, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -4243,6 +4275,52 @@ func TestIsPreferred(t *testing.T) {
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
 				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: false,
+		},
+		"explicit PreemptionOverBorrowing rejects no-candidate flavor before borrowing comparison": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b: granularMode{preemptionMode: fit, borrowingLevel: 2},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: false,
+		},
+		"explicit PreemptionOverBorrowing prefers fit over shallower no-candidate flavor": {
+			a: granularMode{preemptionMode: fit, borrowingLevel: 2},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: true,
+		},
+		"no-candidate flavor remains preferable to no-fit flavor": {
+			a:             granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b:             granularMode{preemptionMode: noFit, borrowingLevel: 0},
+			wantPreferred: true,
+		},
+		"no-fit flavor remains worse than no-candidate flavor": {
+			a:             granularMode{preemptionMode: noFit, borrowingLevel: 0},
+			b:             granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			wantPreferred: false,
+		},
+		"no-candidate flavors retain borrowing preference": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 2},
+			config: kueue.FlavorFungibility{
+				Preference: makePref(kueue.PreemptionOverBorrowing),
+			},
+			wantPreferred: true,
+		},
+		"no-candidate flavors retain borrowing preference in reverse": {
+			a: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 2},
+			b: granularMode{preemptionMode: noPreemptionCandidates, borrowingLevel: 1},
+			config: kueue.FlavorFungibility{
+				Preference: makePref(kueue.PreemptionOverBorrowing),
 			},
 			wantPreferred: false,
 		},

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6217,6 +6217,131 @@ func TestSchedule(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "high-pob", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
 			},
 		},
+		//     nopc-root (spot: 5)
+		//         |
+		//     nopc-mid
+		//      /      \
+		// nopc-cq    nopc-sibling (on-demand: 5, idle)
+		//
+		// The on-demand flavor of nopc-cq is exhausted and cannot borrow, and
+		// preemption finds no candidates because the admitted workload has the same
+		// priority. The idle sibling keeps on-demand sourceable one level higher than
+		// spot, so under PreemptionOverBorrowing the shallower borrowing level must not
+		// let the unschedulable on-demand flavor outrank spot, which fits.
+		"PreemptionOverBorrowing preference: skip first flavor that has no preemption candidates": {
+			cohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("nopc-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).Obj(),
+				*utiltestingapi.MakeCohort("nopc-mid").Parent("nopc-root").Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("nopc-cq").
+					Cohort("nopc-mid").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+					}).
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.TryNextFlavor,
+						WhenCanPreempt: kueue.TryNextFlavor,
+						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("5").BorrowingLimit("0").Append().
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+					).Obj(),
+				*utiltestingapi.MakeClusterQueue("nopc-sibling").
+					Cohort("nopc-mid").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("spot").
+							Resource(corev1.ResourceCPU, "0").Obj(),
+					).Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("nopc-queue", "default").ClusterQueue("nopc-cq").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("nopc-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("pending-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("admitted-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("nopc-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("pending-nopc", "default").
+					Queue("nopc-queue").
+					Priority(0).
+					Request(corev1.ResourceCPU, "5").
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue nopc-cq",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(
+						utiltestingapi.MakeAdmission("nopc-cq").
+							PodSets(
+								utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+									Assignment(corev1.ResourceCPU, "spot", "5000m").
+									Count(1).
+									Obj(),
+							).
+							Obj(),
+					).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"default/admitted-nopc": *utiltestingapi.MakeAdmission("nopc-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "on-demand", "5000m").
+						Obj()).
+					Obj(),
+				"default/pending-nopc": *utiltestingapi.MakeAdmission("nopc-cq").
+					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+						Assignment(corev1.ResourceCPU, "spot", "5000m").
+						Obj()).
+					Obj(),
+			},
+		},
 		"BorrowingOverPreemption preference: borrow in second flavor instead of preempting in first": {
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("bop-cq").

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -6228,7 +6228,7 @@ func TestSchedule(t *testing.T) {
 		// priority. The idle sibling keeps on-demand sourceable one level higher than
 		// spot, so under PreemptionOverBorrowing the shallower borrowing level must not
 		// let the unschedulable on-demand flavor outrank spot, which fits.
-		"PreemptionOverBorrowing preference: skip first flavor that has no preemption candidates": {
+		"PreemptionOverBorrowing preference: select fitting second flavor over first flavor with no preemption candidates": {
 			cohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("nopc-root").
 					ResourceGroup(


### PR DESCRIPTION
This is a cherry-pick of #13616

/assign mimowo

```release-note
Fixed a bug where a ClusterQueue with `flavorFungibility.preference: PreemptionOverBorrowing` could leave workloads pending indefinitely. A flavor that required preemption but had no preemption candidates could outrank a later flavor that fits, purely because its quota was sourceable at a shallower borrowing level in the cohort tree.
```

/kind bug