### PR TITLE
Resolve the LeaderWorkerSet priority class once per reconcile

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1212,10 +1212,32 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 		return fmt.Errorf("prepare workload priority: %w", err)
 	}
 
-	// Apply the resolved ref/value to every eligible workload whose full priority
-	// state differs. Same-name workloads with a stale value are repaired before the
-	// name-changing ones, so a name mismatch survives as the retry marker if a
-	// write in this batch fails.
+	return applyResolvedPriority(ctx, c, r, obj, priorityClassRef, priority, sameClassName, needsClassChange)
+}
+
+// ApplyWorkloadPriority is UpdateWorkloadPriority with the resolution supplied by
+// the caller, for a reconcile that has already resolved the class for another set
+// of workloads. Two lookups of one class in the same reconcile can return
+// different values, which would leave the sets holding different priorities.
+//
+// The same rule about when to write applies: nothing is touched unless at least
+// one workload needs a class transition, so a steady-state reconcile does not
+// overwrite a value that is otherwise mutable.
+func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
+	priorityClassRef *kueue.PriorityClassRef, priority int32, wls ...*kueue.Workload) error {
+	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), WorkloadPriorityClassName(obj), wls)
+	if len(needsClassChange) == 0 {
+		return nil
+	}
+	return applyResolvedPriority(ctx, c, r, obj, priorityClassRef, priority, sameClassName, needsClassChange)
+}
+
+// applyResolvedPriority writes the resolved ref/value to every eligible workload
+// whose full priority state differs. Same-name workloads with a stale value are
+// repaired before the name-changing ones, so a name mismatch survives as the
+// retry marker if a write in this batch fails.
+func applyResolvedPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
+	priorityClassRef *kueue.PriorityClassRef, priority int32, sameClassName, needsClassChange []*kueue.Workload) error {
 	targets := make([]*kueue.Workload, 0, len(sameClassName)+len(needsClassChange))
 	targets = append(targets, sameClassName...)
 	targets = append(targets, needsClassChange...)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -63,6 +63,7 @@ import (
 	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/equality"
 	"sigs.k8s.io/kueue/pkg/util/kubeversion"
+	"sigs.k8s.io/kueue/pkg/util/parallelize"
 	utilpriority "sigs.k8s.io/kueue/pkg/util/priority"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -1246,19 +1247,18 @@ func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventR
 func applyResolvedPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
 	priorityClassRef *kueue.PriorityClassRef, priority int32, sameClassName, needsClassChange []*kueue.Workload) error {
 	// One workload that will not take the write does not speak for the rest, so
-	// the others are still attempted. A failed one keeps its own state, which is
-	// what the next reconcile sees.
+	// the others are still attempted. Bounded and cancellable, the way each
+	// component's own write was before they were batched.
 	apply := func(wls []*kueue.Workload) error {
-		var errs []error
-		for _, wl := range wls {
+		return parallelize.Until(ctx, len(wls), func(i int) error {
+			wl := wls[i]
 			if priorityStateEqual(wl, priorityClassRef, priority) {
-				continue
+				return nil
 			}
 			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
 			wl.Spec.Priority = new(priority)
 			if err := c.Update(ctx, wl); err != nil {
-				errs = append(errs, fmt.Errorf("updating existing workload: %w", err))
-				continue
+				return fmt.Errorf("updating existing workload %s: %w", klog.KObj(wl), err)
 			}
 			r.Eventf(obj,
 				nil,
@@ -1266,8 +1266,8 @@ func applyResolvedPriority(ctx context.Context, c client.Client, r events.EventR
 				"UpdatedWorkload",
 				"Updated workload priority class: %v", klog.KObj(wl),
 			)
-		}
-		return errors.Join(errs...)
+			return nil
+		})
 	}
 	// Same-name workloads with a stale value go first, so a name mismatch
 	// survives as the retry marker if any of them fails.

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1226,7 +1226,10 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
 	priorityClassRef *kueue.PriorityClassRef, priority int32, wls ...*kueue.Workload) error {
 	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), WorkloadPriorityClassName(obj), wls)
-	if len(needsClassChange) == 0 {
+	// Unlike the lazy path, a caller that already resolved had a reason to, so a
+	// workload that names the class with a value left behind by an earlier
+	// reconcile is repaired here rather than waiting for a name to change.
+	if len(sameClassName) == 0 && len(needsClassChange) == 0 {
 		return nil
 	}
 	return applyResolvedPriority(ctx, c, r, obj, priorityClassRef, priority, sameClassName, needsClassChange)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1223,6 +1223,9 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 // A caller that already resolved had a reason to, so a workload naming the class
 // with a value left behind by an earlier reconcile is repaired here rather than
 // waiting for a name to change. Everything else is left alone.
+//
+// Every workload passed has to belong to obj, and the reference and value have
+// to be what obj resolved to in this reconcile: neither is checked here.
 func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
 	priorityClassRef *kueue.PriorityClassRef, priority int32, wls ...*kueue.Workload) error {
 	className := WorkloadPriorityClassName(obj)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1220,16 +1220,17 @@ func UpdateWorkloadPriority(ctx context.Context, c client.Client, r events.Event
 // of workloads. Two lookups of one class in the same reconcile can return
 // different values, which would leave the sets holding different priorities.
 //
-// The same rule about when to write applies: nothing is touched unless at least
-// one workload needs a class transition, so a steady-state reconcile does not
-// overwrite a value that is otherwise mutable.
+// A caller that already resolved had a reason to, so a workload naming the class
+// with a value left behind by an earlier reconcile is repaired here rather than
+// waiting for a name to change. Everything else is left alone.
 func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
 	priorityClassRef *kueue.PriorityClassRef, priority int32, wls ...*kueue.Workload) error {
-	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), WorkloadPriorityClassName(obj), wls)
-	// Unlike the lazy path, a caller that already resolved had a reason to, so a
-	// workload that names the class with a value left behind by an earlier
-	// reconcile is repaired here rather than waiting for a name to change.
-	if len(sameClassName) == 0 && len(needsClassChange) == 0 {
+	className := WorkloadPriorityClassName(obj)
+	sameClassName, needsClassChange := classifyWorkloadsForPriorityUpdate(ctrl.LoggerFrom(ctx), className, wls)
+	// The repair needs a class to name. Under an empty label every workload
+	// without a reference reads as naming the same one, and rewriting those
+	// would take back a value nothing here owns.
+	if len(needsClassChange) == 0 && (className == "" || len(sameClassName) == 0) {
 		return nil
 	}
 	return applyResolvedPriority(ctx, c, r, obj, priorityClassRef, priority, sameClassName, needsClassChange)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1242,26 +1242,36 @@ func ApplyWorkloadPriority(ctx context.Context, c client.Client, r events.EventR
 // retry marker if a write in this batch fails.
 func applyResolvedPriority(ctx context.Context, c client.Client, r events.EventRecorder, obj client.Object,
 	priorityClassRef *kueue.PriorityClassRef, priority int32, sameClassName, needsClassChange []*kueue.Workload) error {
-	targets := make([]*kueue.Workload, 0, len(sameClassName)+len(needsClassChange))
-	targets = append(targets, sameClassName...)
-	targets = append(targets, needsClassChange...)
-	for _, wl := range targets {
-		if priorityStateEqual(wl, priorityClassRef, priority) {
-			continue
+	// One workload that will not take the write does not speak for the rest, so
+	// the others are still attempted. A failed one keeps its own state, which is
+	// what the next reconcile sees.
+	apply := func(wls []*kueue.Workload) error {
+		var errs []error
+		for _, wl := range wls {
+			if priorityStateEqual(wl, priorityClassRef, priority) {
+				continue
+			}
+			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
+			wl.Spec.Priority = new(priority)
+			if err := c.Update(ctx, wl); err != nil {
+				errs = append(errs, fmt.Errorf("updating existing workload: %w", err))
+				continue
+			}
+			r.Eventf(obj,
+				nil,
+				corev1.EventTypeNormal, ReasonUpdatedWorkload,
+				"UpdatedWorkload",
+				"Updated workload priority class: %v", klog.KObj(wl),
+			)
 		}
-		wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
-		wl.Spec.Priority = new(priority)
-		if err := c.Update(ctx, wl); err != nil {
-			return fmt.Errorf("updating existing workload: %w", err)
-		}
-		r.Eventf(obj,
-			nil,
-			corev1.EventTypeNormal, ReasonUpdatedWorkload,
-			"UpdatedWorkload",
-			"Updated workload priority class: %v", klog.KObj(wl),
-		)
+		return errors.Join(errs...)
 	}
-	return nil
+	// Same-name workloads with a stale value go first, so a name mismatch
+	// survives as the retry marker if any of them fails.
+	if err := apply(sameClassName); err != nil {
+		return err
+	}
+	return apply(needsClassChange)
 }
 
 // classifyWorkloadsForPriorityUpdate splits the workloads this helper may manage

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -392,3 +392,29 @@ func TestApplyWorkloadPriorityAttemptsEverySibling(t *testing.T) {
 		t.Errorf("the sibling was not attempted (-want +got):\n%s", diff)
 	}
 }
+
+// TestApplyWorkloadPriorityRepairsAStaleValue is the other half of the
+// unlabelled case: with a class named, a workload already on it whose value was
+// left behind takes the supplied one.
+func TestApplyWorkloadPriorityRepairsAStaleValue(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	wl := utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj()
+	cl := utiltesting.NewClientBuilder().WithObjects(wl).Build()
+
+	ref := kueue.NewWorkloadPriorityClassRef("high")
+	if err := ApplyWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, ref, 200, wl); err != nil {
+		t.Fatalf("ApplyWorkloadPriority() = %v", err)
+	}
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
+		t.Fatalf("reading the workload back: %v", err)
+	}
+	if diff := cmp.Diff(ref, got.Spec.PriorityClassRef); diff != "" {
+		t.Errorf("priority class reference (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(new(int32(200)), got.Spec.Priority); diff != "" {
+		t.Errorf("priority (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -19,6 +19,8 @@ package jobframework
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -339,7 +341,14 @@ func TestApplyWorkloadPriorityLeavesUnlabelledWorkloadsAlone(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 	job := testingjob.MakeJob("job", "ns").Obj()
 	wl := utiltestingapi.MakeWorkload("wl", "ns").Priority(1000).Obj()
-	cl := utiltesting.NewClientBuilder().WithObjects(wl).Build()
+	var writes int
+	cl := utiltesting.NewClientBuilder().WithObjects(wl).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				writes++
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
 
 	if err := ApplyWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, 0, wl); err != nil {
 		t.Fatalf("ApplyWorkloadPriority() = %v", err)
@@ -354,6 +363,9 @@ func TestApplyWorkloadPriorityLeavesUnlabelledWorkloadsAlone(t *testing.T) {
 	}
 	if got.Spec.PriorityClassRef != nil {
 		t.Errorf("workload gained a priority class reference: %v", got.Spec.PriorityClassRef)
+	}
+	if writes != 0 {
+		t.Errorf("wrote the workload %d times, want none", writes)
 	}
 }
 
@@ -416,5 +428,39 @@ func TestApplyWorkloadPriorityRepairsAStaleValue(t *testing.T) {
 	}
 	if diff := cmp.Diff(new(int32(200)), got.Spec.Priority); diff != "" {
 		t.Errorf("priority (-want +got):\n%s", diff)
+	}
+}
+
+// TestApplyWorkloadPriorityStopsWhenCancelled pins that the batch does not
+// carry on issuing writes after the reconcile is over. Each component used to
+// write from its own worker, which checked for cancellation before starting.
+func TestApplyWorkloadPriorityStopsWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+
+	wls := make([]*kueue.Workload, 0, 20)
+	objs := make([]client.Object, 0, 20)
+	for i := range 20 {
+		wl := utiltestingapi.MakeWorkload(fmt.Sprintf("wl-%d", i), "ns").
+			WorkloadPriorityClassRef("high").Priority(100).Obj()
+		wls = append(wls, wl)
+		objs = append(objs, wl)
+	}
+
+	var writes atomic.Int32
+	cl := utiltesting.NewClientBuilder().WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				writes.Add(1)
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	cancel()
+	_ = ApplyWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job,
+		kueue.NewWorkloadPriorityClassRef("high"), 200, wls...)
+
+	if got := writes.Load(); got != 0 {
+		t.Errorf("wrote %d workloads after cancellation, want none", got)
 	}
 }

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -353,5 +354,41 @@ func TestApplyWorkloadPriorityLeavesUnlabelledWorkloadsAlone(t *testing.T) {
 	}
 	if got.Spec.PriorityClassRef != nil {
 		t.Errorf("workload gained a priority class reference: %v", got.Spec.PriorityClassRef)
+	}
+}
+
+// TestApplyWorkloadPriorityAttemptsEverySibling pins the failure boundary. One
+// workload that will not take the write used to end the batch, leaving the rest
+// waiting on it for as long as it kept failing.
+func TestApplyWorkloadPriorityAttemptsEverySibling(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	job := testingjob.MakeJob("job", "ns").WorkloadPriorityClass("high").Obj()
+	first := utiltestingapi.MakeWorkload("first", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj()
+	second := utiltestingapi.MakeWorkload("second", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj()
+
+	errRefused := errors.New("the write was refused")
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(first, second).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetName() == "first" {
+					return errRefused
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).Build()
+
+	err := ApplyWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job,
+		kueue.NewWorkloadPriorityClassRef("high"), 200, first, second)
+	if !errors.Is(err, errRefused) {
+		t.Fatalf("ApplyWorkloadPriority() = %v, want the refused write reported", err)
+	}
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "second"}, &got); err != nil {
+		t.Fatalf("reading the sibling back: %v", err)
+	}
+	if diff := cmp.Diff(new(int32(200)), got.Spec.Priority); diff != "" {
+		t.Errorf("the sibling was not attempted (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/controller/jobframework/workload_priority_test.go
+++ b/pkg/controller/jobframework/workload_priority_test.go
@@ -24,6 +24,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -326,5 +327,31 @@ func raiseClassTo(value int32) func(t *testing.T, ctx context.Context, cl client
 		if err := cl.Update(ctx, class); err != nil {
 			t.Fatalf("updating class: %v", err)
 		}
+	}
+}
+
+// TestApplyWorkloadPriorityLeavesUnlabelledWorkloadsAlone pins the boundary of
+// the stale-value repair. With no class named, every workload without a
+// reference classifies as naming the same (empty) class, and rewriting those
+// would take back a value that nothing here owns.
+func TestApplyWorkloadPriorityLeavesUnlabelledWorkloadsAlone(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	job := testingjob.MakeJob("job", "ns").Obj()
+	wl := utiltestingapi.MakeWorkload("wl", "ns").Priority(1000).Obj()
+	cl := utiltesting.NewClientBuilder().WithObjects(wl).Build()
+
+	if err := ApplyWorkloadPriority(ctx, cl, &utiltesting.EventRecorder{}, job, nil, 0, wl); err != nil {
+		t.Fatalf("ApplyWorkloadPriority() = %v", err)
+	}
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
+		t.Fatalf("reading the workload back: %v", err)
+	}
+	if got.Spec.Priority == nil || *got.Spec.Priority != 1000 {
+		t.Errorf("workload priority = %d, want it left at 1000", ptr.Deref(got.Spec.Priority, 0))
+	}
+	if got.Spec.PriorityClassRef != nil {
+		t.Errorf("workload gained a priority class reference: %v", got.Spec.PriorityClassRef)
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -366,9 +366,6 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 }
 
-// createWorkload builds and creates one component Workload. resolved carries
-// this reconcile's single lookup of the priority class, and is never nil here
-// because it is set whenever there is anything to create.
 func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int, resolved *resolvedPriority) error {
 	log := ctrl.LoggerFrom(ctx).WithValues(
 		"workload", klog.ObjectRef{Name: workloadName, Namespace: lws.Namespace},

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -24,7 +24,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -234,23 +233,19 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
-	// One lookup for the whole reconcile, made on demand. The delete branch never
-	// asks for it, so a class that cannot be resolved does not stop surplus
-	// Workloads from being cleaned up. Every component is built from the same
-	// PodSets, so one of them answers for the lookup's fallback, and
-	// constructWorkload only reads the scheme.
-	willResolve := len(toCreate) > 0
-	resolvePriority := sync.OnceValues(func() (*resolvedPriority, error) {
-		probe, err := r.constructWorkload(lws, toCreate[0].name, toCreate[0].index)
-		if err != nil {
-			return nil, err
-		}
-		classRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, probe.Spec.PodSets, nil)
-		if err != nil {
-			return nil, fmt.Errorf("prepare workload priority: %w", err)
-		}
-		return &resolvedPriority{classRef: classRef, priority: priority}, nil
-	})
+	// One lookup for the whole reconcile, taken before the branches so every
+	// component gets the same answer. Only the create path forces it: an update
+	// with no class transition resolves nothing, and the helper below is what
+	// decides that. Every component is built from the same PodSets, so one of
+	// them answers for the lookup's fallback, and constructWorkload only reads
+	// the scheme.
+	var (
+		resolved   *resolvedPriority
+		resolveErr error
+	)
+	if len(toCreate) > 0 {
+		resolved, resolveErr = r.resolvePriority(ctx, lws, toCreate[0])
+	}
 
 	// The branches hold disjoint sets of Workloads, so one failing is no reason to
 	// abandon the others, and parallelize.Until checks for cancellation before
@@ -261,11 +256,10 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 	var eg errgroup.Group
 
 	eg.Go(func() error {
+		if resolveErr != nil {
+			return resolveErr
+		}
 		return parallelize.Until(ctx, len(toCreate), func(i int) error {
-			resolved, err := resolvePriority()
-			if err != nil {
-				return err
-			}
 			return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index, resolved)
 		})
 	})
@@ -286,7 +280,12 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 				targets = append(targets, toUpdate[i])
 			}
 		}
-		return errors.Join(updateErr, r.applyPriority(ctx, lws, willResolve, resolvePriority, targets))
+		if resolveErr != nil {
+			// resolved is nil here for a different reason than "nothing forced a
+			// lookup", so applyPriority must not read the class again.
+			return errors.Join(updateErr, resolveErr)
+		}
+		return errors.Join(updateErr, r.applyPriority(ctx, lws, resolved, targets))
 	})
 
 	eg.Go(func() error {
@@ -298,20 +297,31 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 	return eg.Wait()
 }
 
-// applyPriority gives wls this reconcile's priority. When nothing else needed
-// the class, the helper is left to decide whether to look it up at all, which
-// keeps a steady-state reconcile from reading it.
+// resolvePriority reads the priority class once for this reconcile, using a
+// component that is about to be created to stand in for the PodSets the
+// lookup falls back to.
+func (r *Reconciler) resolvePriority(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, probeFor workloadToCreate) (*resolvedPriority, error) {
+	probe, err := r.constructWorkload(lws, probeFor.name, probeFor.index)
+	if err != nil {
+		return nil, err
+	}
+	classRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, probe.Spec.PodSets, nil)
+	if err != nil {
+		return nil, fmt.Errorf("prepare workload priority: %w", err)
+	}
+	return &resolvedPriority{classRef: classRef, priority: priority}, nil
+}
+
+// applyPriority gives wls this reconcile's priority. Without one, the helper
+// decides for itself whether the class needs reading at all, which keeps a
+// steady-state reconcile from doing so.
 func (r *Reconciler) applyPriority(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet,
-	willResolve bool, resolve func() (*resolvedPriority, error), wls []*kueue.Workload) error {
+	resolved *resolvedPriority, wls []*kueue.Workload) error {
 	if len(wls) == 0 {
 		return nil
 	}
-	if !willResolve {
+	if resolved == nil {
 		return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, wls...)
-	}
-	resolved, err := resolve()
-	if err != nil {
-		return err
 	}
 	return jobframework.ApplyWorkloadPriority(ctx, r.client, r.record, lws, resolved.classRef, resolved.priority, wls...)
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -232,44 +232,38 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
-	// Building the new Workloads before the fan-out lets the class be resolved
-	// once for the whole set, the same way the update path does below.
-	// constructWorkload only reads the scheme, so this costs no API calls.
-	newWorkloads := make([]*kueue.Workload, 0, len(toCreate))
-	for _, c := range toCreate {
-		wl, err := r.constructWorkload(lws, c.name, c.index)
-		if err != nil {
-			log.Error(err, "Failed to construct Workload", "workload", c.name)
-			return err
-		}
-		newWorkloads = append(newWorkloads, wl)
-	}
 	// Set once the class has been resolved, so the update path below can reuse
 	// this reconcile's answer instead of asking again. It resolves lazily on its
 	// own, so leaving this nil keeps a steady-state reconcile from looking the
 	// class up at all.
 	var resolved *resolvedPriority
-	if len(newWorkloads) > 0 {
+	if len(toCreate) > 0 {
+		// One Workload is built here so the lookup has PodSets to fall back on.
+		// The rest are built inside the fan-out as before, which keeps the peak
+		// bounded by the worker count rather than by the number of components.
+		// constructWorkload only reads the scheme, so building this one twice
+		// costs no API calls.
+		first, err := r.constructWorkload(lws, toCreate[0].name, toCreate[0].index)
+		if err != nil {
+			log.Error(err, "Failed to construct Workload", "workload", toCreate[0].name)
+			return err
+		}
 		// Every component carries the same label, so one lookup answers for all
 		// of them. Resolving per component lets concurrent lookups of the same
 		// class observe different values.
-		priorityClassRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, newWorkloads[0].Spec.PodSets, nil)
+		priorityClassRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, first.Spec.PodSets, nil)
 		if err != nil {
 			log.Error(err, "Failed to prepare Workload priority")
 			return fmt.Errorf("prepare workload priority: %w", err)
 		}
 		resolved = &resolvedPriority{classRef: priorityClassRef, priority: priority}
-		for _, wl := range newWorkloads {
-			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
-			wl.Spec.Priority = new(priority)
-		}
 	}
 
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		return parallelize.Until(ctx, len(newWorkloads), func(i int) error {
-			return r.createWorkload(ctx, lws, newWorkloads[i])
+		return parallelize.Until(ctx, len(toCreate), func(i int) error {
+			return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index, resolved)
 		})
 	})
 
@@ -348,11 +342,25 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 }
 
-func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, createdWorkload *kueue.Workload) error {
-	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(createdWorkload))
+// createWorkload builds and creates one component Workload. resolved carries
+// this reconcile's single lookup of the priority class, and is never nil here
+// because it is set whenever there is anything to create.
+func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int, resolved *resolvedPriority) error {
+	log := ctrl.LoggerFrom(ctx).WithValues(
+		"workload", klog.ObjectRef{Name: workloadName, Namespace: lws.Namespace},
+		"index", index,
+	)
 	log.V(3).Info("Create LeaderWorkerSet Workload")
 
-	err := r.client.Create(ctx, createdWorkload)
+	createdWorkload, err := r.constructWorkload(lws, workloadName, index)
+	if err != nil {
+		log.Error(err, "Failed to construct Workload")
+		return err
+	}
+	createdWorkload.Spec.PriorityClassRef = resolved.classRef.DeepCopy()
+	createdWorkload.Spec.Priority = new(resolved.priority)
+
+	err = r.client.Create(ctx, createdWorkload)
 	if err != nil {
 		log.Error(err, "Failed to create Workload")
 		return err

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -77,6 +77,14 @@ type workloadToCreate struct {
 	index int
 }
 
+// resolvedPriority is what one lookup of the object's WorkloadPriorityClass
+// returned, so a reconcile that touches more than one set of Workloads gives
+// them all the same answer.
+type resolvedPriority struct {
+	classRef *kueue.PriorityClassRef
+	priority int32
+}
+
 type Reconciler struct {
 	integrationManager           *jobframework.IntegrationManager
 	client                       client.Client
@@ -236,6 +244,11 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 		}
 		newWorkloads = append(newWorkloads, wl)
 	}
+	// Set once the class has been resolved, so the update path below can reuse
+	// this reconcile's answer instead of asking again. It resolves lazily on its
+	// own, so leaving this nil keeps a steady-state reconcile from looking the
+	// class up at all.
+	var resolved *resolvedPriority
 	if len(newWorkloads) > 0 {
 		// Every component carries the same label, so one lookup answers for all
 		// of them. Resolving per component lets concurrent lookups of the same
@@ -245,6 +258,7 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 			log.Error(err, "Failed to prepare Workload priority")
 			return fmt.Errorf("prepare workload priority: %w", err)
 		}
+		resolved = &resolvedPriority{classRef: priorityClassRef, priority: priority}
 		for _, wl := range newWorkloads {
 			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
 			wl.Spec.Priority = new(priority)
@@ -269,6 +283,9 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 		// the loop above. Resolving per component lets concurrent lookups of the
 		// same class observe different values, which would then order the
 		// components of one LeaderWorkerSet against each other.
+		if resolved != nil {
+			return jobframework.ApplyWorkloadPriority(ctx, r.client, r.record, lws, resolved.classRef, resolved.priority, toUpdate...)
+		}
 		return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, toUpdate...)
 	})
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -18,11 +18,13 @@ package leaderworkerset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
@@ -232,55 +234,59 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
-	// Set once the class has been resolved, so the update path below can reuse
-	// this reconcile's answer instead of asking again. It resolves lazily on its
-	// own, so leaving this nil keeps a steady-state reconcile from looking the
-	// class up at all.
-	var resolved *resolvedPriority
-	if len(toCreate) > 0 {
-		// One Workload is built here so the lookup has PodSets to fall back on.
-		// The rest are built inside the fan-out as before, which keeps the peak
-		// bounded by the worker count rather than by the number of components.
-		// constructWorkload only reads the scheme, so building this one twice
-		// costs no API calls.
-		first, err := r.constructWorkload(lws, toCreate[0].name, toCreate[0].index)
+	// One lookup for the whole reconcile, made on demand. The delete branch never
+	// asks for it, so a class that cannot be resolved does not stop surplus
+	// Workloads from being cleaned up. Every component is built from the same
+	// PodSets, so one of them answers for the lookup's fallback, and
+	// constructWorkload only reads the scheme.
+	willResolve := len(toCreate) > 0
+	resolvePriority := sync.OnceValues(func() (*resolvedPriority, error) {
+		probe, err := r.constructWorkload(lws, toCreate[0].name, toCreate[0].index)
 		if err != nil {
-			log.Error(err, "Failed to construct Workload", "workload", toCreate[0].name)
-			return err
+			return nil, err
 		}
-		// Every component carries the same label, so one lookup answers for all
-		// of them. Resolving per component lets concurrent lookups of the same
-		// class observe different values.
-		priorityClassRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, first.Spec.PodSets, nil)
+		classRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, probe.Spec.PodSets, nil)
 		if err != nil {
-			log.Error(err, "Failed to prepare Workload priority")
-			return fmt.Errorf("prepare workload priority: %w", err)
+			return nil, fmt.Errorf("prepare workload priority: %w", err)
 		}
-		resolved = &resolvedPriority{classRef: priorityClassRef, priority: priority}
-	}
+		return &resolvedPriority{classRef: classRef, priority: priority}, nil
+	})
 
-	eg, ctx := errgroup.WithContext(ctx)
+	// The branches hold disjoint sets of Workloads, so one failing is no reason to
+	// abandon the others, and parallelize.Until checks for cancellation before
+	// each item. A derived context would let a create that could not resolve the
+	// class stop a surplus Workload from ever being deleted. The reconcile
+	// context still carries shutdown and any deadline. #13775 makes the same
+	// change for the same reason; whichever lands second drops it.
+	var eg errgroup.Group
 
 	eg.Go(func() error {
 		return parallelize.Until(ctx, len(toCreate), func(i int) error {
+			resolved, err := resolvePriority()
+			if err != nil {
+				return err
+			}
 			return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index, resolved)
 		})
 	})
 
 	eg.Go(func() error {
-		if err := parallelize.Until(ctx, len(toUpdate), func(i int) error {
-			return r.updateWorkload(ctx, lws, toUpdate[i])
-		}); err != nil {
+		updated := make([]bool, len(toUpdate))
+		updateErr := parallelize.Until(ctx, len(toUpdate), func(i int) error {
+			err := r.updateWorkload(ctx, lws, toUpdate[i])
+			updated[i] = err == nil
 			return err
+		})
+		// Priority goes to the components whose other updates landed. One failing
+		// queue-name write used to hold back only its own component, and moving
+		// the priority out of the loop should not widen that.
+		targets := make([]*kueue.Workload, 0, len(toUpdate))
+		for i, ok := range updated {
+			if ok {
+				targets = append(targets, toUpdate[i])
+			}
 		}
-		// Priority is applied to the whole set at once rather than from inside
-		// the loop above. Resolving per component lets concurrent lookups of the
-		// same class observe different values, which would then order the
-		// components of one LeaderWorkerSet against each other.
-		if resolved != nil {
-			return jobframework.ApplyWorkloadPriority(ctx, r.client, r.record, lws, resolved.classRef, resolved.priority, toUpdate...)
-		}
-		return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, toUpdate...)
+		return errors.Join(updateErr, r.applyPriority(ctx, lws, willResolve, resolvePriority, targets))
 	})
 
 	eg.Go(func() error {
@@ -290,6 +296,24 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 	})
 
 	return eg.Wait()
+}
+
+// applyPriority gives wls this reconcile's priority. When nothing else needed
+// the class, the helper is left to decide whether to look it up at all, which
+// keeps a steady-state reconcile from reading it.
+func (r *Reconciler) applyPriority(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet,
+	willResolve bool, resolve func() (*resolvedPriority, error), wls []*kueue.Workload) error {
+	if len(wls) == 0 {
+		return nil
+	}
+	if !willResolve {
+		return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, wls...)
+	}
+	resolved, err := resolve()
+	if err != nil {
+		return err
+	}
+	return jobframework.ApplyWorkloadPriority(ctx, r.client, r.record, lws, resolved.classRef, resolved.priority, wls...)
 }
 
 // filterWorkloads compares the desired state of a LeaderWorkerSet with existing workloads,

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -224,18 +224,52 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
+	// Building the new Workloads before the fan-out lets the class be resolved
+	// once for the whole set, the same way the update path does below.
+	// constructWorkload only reads the scheme, so this costs no API calls.
+	newWorkloads := make([]*kueue.Workload, 0, len(toCreate))
+	for _, c := range toCreate {
+		wl, err := r.constructWorkload(lws, c.name, c.index)
+		if err != nil {
+			log.Error(err, "Failed to construct Workload", "workload", c.name)
+			return err
+		}
+		newWorkloads = append(newWorkloads, wl)
+	}
+	if len(newWorkloads) > 0 {
+		// Every component carries the same label, so one lookup answers for all
+		// of them. Resolving per component lets concurrent lookups of the same
+		// class observe different values.
+		priorityClassRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, newWorkloads[0].Spec.PodSets, nil)
+		if err != nil {
+			log.Error(err, "Failed to prepare Workload priority")
+			return fmt.Errorf("prepare workload priority: %w", err)
+		}
+		for _, wl := range newWorkloads {
+			wl.Spec.PriorityClassRef = priorityClassRef.DeepCopy()
+			wl.Spec.Priority = new(priority)
+		}
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 
 	eg.Go(func() error {
-		return parallelize.Until(ctx, len(toCreate), func(i int) error {
-			return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index)
+		return parallelize.Until(ctx, len(newWorkloads), func(i int) error {
+			return r.createWorkload(ctx, lws, newWorkloads[i])
 		})
 	})
 
 	eg.Go(func() error {
-		return parallelize.Until(ctx, len(toUpdate), func(i int) error {
+		if err := parallelize.Until(ctx, len(toUpdate), func(i int) error {
 			return r.updateWorkload(ctx, lws, toUpdate[i])
-		})
+		}); err != nil {
+			return err
+		}
+		// Priority is applied to the whole set at once rather than from inside
+		// the loop above. Resolving per component lets concurrent lookups of the
+		// same class observe different values, which would then order the
+		// components of one LeaderWorkerSet against each other.
+		return jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, toUpdate...)
 	})
 
 	eg.Go(func() error {
@@ -297,26 +331,11 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
 }
 
-func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {
-	log := ctrl.LoggerFrom(ctx).WithValues(
-		"workload", klog.ObjectRef{Name: workloadName, Namespace: lws.Namespace},
-		"index", index,
-	)
+func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, createdWorkload *kueue.Workload) error {
+	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(createdWorkload))
 	log.V(3).Info("Create LeaderWorkerSet Workload")
 
-	createdWorkload, err := r.constructWorkload(lws, workloadName, index)
-	if err != nil {
-		log.Error(err, "Failed to construct Workload")
-		return err
-	}
-
-	err = jobframework.PrepareWorkloadPriority(ctx, r.client, lws, createdWorkload, nil)
-	if err != nil {
-		log.Error(err, "Failed to prepare Workload priority")
-		return err
-	}
-
-	err = r.client.Create(ctx, createdWorkload)
+	err := r.client.Create(ctx, createdWorkload)
 	if err != nil {
 		log.Error(err, "Failed to create Workload")
 		return err
@@ -444,12 +463,6 @@ func (r *Reconciler) updateWorkload(ctx context.Context, lws *leaderworkersetv1.
 			log.Error(err, "Failed to update AdmissionGatedBy")
 			return err
 		}
-	}
-
-	err := jobframework.UpdateWorkloadPriority(ctx, r.client, r.record, lws, nil, wl)
-	if err != nil {
-		log.Error(err, "Failed to update workload priority")
-		return err
 	}
 
 	return nil

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -233,12 +233,25 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
-	// One lookup for the whole reconcile, taken before the branches so every
-	// component gets the same answer. Only the create path forces it: an update
-	// with no class transition resolves nothing, and the helper below is what
-	// decides that. Every component is built from the same PodSets, so one of
-	// them answers for the lookup's fallback, and constructWorkload only reads
-	// the scheme.
+	// The branches hold disjoint sets of Workloads, so one failing is no reason to
+	// abandon the others, and parallelize.Until checks for cancellation before
+	// each item. A derived context would let a create that could not resolve the
+	// class stop a surplus Workload from ever being deleted. The reconcile
+	// context still carries shutdown and any deadline. #13921 is where this
+	// change belongs; this copy goes on rebase once that lands.
+	var eg errgroup.Group
+
+	// Cleanup owes the lookup nothing, so it starts before it.
+	eg.Go(func() error {
+		return parallelize.Until(ctx, len(toDelete), func(i int) error {
+			return r.deleteWorkload(ctx, toDelete[i])
+		})
+	})
+
+	// One lookup for the whole reconcile, taken before the create and update
+	// branches so every component gets the same answer. Only the create path
+	// forces it: an update with no class transition resolves nothing, and the
+	// helper below is what decides that.
 	var (
 		resolved   *resolvedPriority
 		resolveErr error
@@ -246,14 +259,6 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 	if len(toCreate) > 0 {
 		resolved, resolveErr = r.resolvePriority(ctx, lws, toCreate[0])
 	}
-
-	// The branches hold disjoint sets of Workloads, so one failing is no reason to
-	// abandon the others, and parallelize.Until checks for cancellation before
-	// each item. A derived context would let a create that could not resolve the
-	// class stop a surplus Workload from ever being deleted. The reconcile
-	// context still carries shutdown and any deadline. #13775 makes the same
-	// change for the same reason; whichever lands second drops it.
-	var eg errgroup.Group
 
 	eg.Go(func() error {
 		if resolveErr != nil {
@@ -288,12 +293,6 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 		return errors.Join(updateErr, r.applyPriority(ctx, lws, resolved, targets))
 	})
 
-	eg.Go(func() error {
-		return parallelize.Until(ctx, len(toDelete), func(i int) error {
-			return r.deleteWorkload(ctx, toDelete[i])
-		})
-	})
-
 	return eg.Wait()
 }
 
@@ -301,11 +300,17 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 // component that is about to be created to stand in for the PodSets the
 // lookup falls back to.
 func (r *Reconciler) resolvePriority(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, probeFor workloadToCreate) (*resolvedPriority, error) {
-	probe, err := r.constructWorkload(lws, probeFor.name, probeFor.index)
-	if err != nil {
-		return nil, err
+	// The lookup returns from the label branch before it reads any PodSets, so
+	// only a set without a class needs a Workload built to ask with.
+	var podSets []kueue.PodSet
+	if jobframework.WorkloadPriorityClassName(lws) == "" {
+		probe, err := r.constructWorkload(lws, probeFor.name, probeFor.index)
+		if err != nil {
+			return nil, err
+		}
+		podSets = probe.Spec.PodSets
 	}
-	classRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, probe.Spec.PodSets, nil)
+	classRef, priority, err := jobframework.ExtractPriority(ctx, r.client, lws, podSets, nil)
 	if err != nil {
 		return nil, fmt.Errorf("prepare workload priority: %w", err)
 	}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2276,3 +2276,82 @@ func TestReconcilerResolvesPriorityClassOnceOnCreate(t *testing.T) {
 		}
 	}
 }
+
+// TestReconcilerResolvesPriorityClassOnceForMixedSets covers a reconcile that
+// both creates and updates components. Resolving once per path still lets the
+// two see different values of one class.
+func TestReconcilerResolvesPriorityClassOnceForMixedSets(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.TopologyAwareScheduling: false,
+	})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		WorkloadPriorityClass("new-wpc").
+		Replicas(2).
+		UID(testLWS).
+		Obj()
+
+	// One component already has a Workload on the old class, the other does not
+	// exist yet, so this reconcile updates one and creates one.
+	existing := utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+		JobUID(testLWS).
+		OwnerReference(gvk, testLWS, testLWS).
+		Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+		Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+		Annotation(constants.JobOwnerNameAnnotation, testLWS).
+		Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		PodSets(
+			*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+				RestartPolicy("").
+				Image(utiltestingjobs.TestDefaultContainerImage).
+				Obj()).
+		WorkloadPriorityClassRef("old-wpc").
+		Priority(1000).
+		Obj()
+
+	var classReads atomic.Int32
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kueue.WorkloadPriorityClass); ok {
+					classReads.Add(1)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(
+		lws,
+		utiltestingapi.MakeWorkloadPriorityClass("old-wpc").PriorityValue(1000).Obj(),
+		utiltestingapi.MakeWorkloadPriorityClass("new-wpc").PriorityValue(5000).Obj(),
+		existing,
+	).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if got := classReads.Load(); got != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1", got)
+	}
+
+	var got kueue.WorkloadList
+	if err := kClient.List(ctx, &got, client.InNamespace(testNS)); err != nil {
+		t.Fatalf("Listing workloads: %v", err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("ended with %d workloads, want 2", len(got.Items))
+	}
+	for _, wl := range got.Items {
+		if wl.Spec.Priority == nil || *wl.Spec.Priority != 5000 {
+			t.Errorf("%s: priority = %v, want 5000", wl.Name, wl.Spec.Priority)
+		}
+	}
+}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package leaderworkerset
 
 import (
+	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,6 +34,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -2130,5 +2133,146 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Unexpected events (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestReconcilerResolvesPriorityClassOnceForTheSet pins that a reconcile which
+// moves several component Workloads onto the same class reads that class once.
+// Resolving per component let concurrent lookups observe different values of
+// one class, which then ordered the components against each other.
+func TestReconcilerResolvesPriorityClassOnceForTheSet(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.TopologyAwareScheduling: false,
+	})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		WorkloadPriorityClass("new-wpc").
+		Replicas(2).
+		UID(testLWS).
+		Obj()
+
+	component := func(index string) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, index), testNS).
+			JobUID(testLWS).
+			OwnerReference(gvk, testLWS, testLWS).
+			Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+			Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+			Annotation(constants.JobOwnerNameAnnotation, testLWS).
+			Annotation(constants.ComponentWorkloadIndexAnnotation, index).
+			Finalizers(kueue.ResourceInUseFinalizerName).
+			PodSets(
+				*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					RestartPolicy("").
+					Image(utiltestingjobs.TestDefaultContainerImage).
+					Obj()).
+			WorkloadPriorityClassRef("old-wpc").
+			Priority(1000).
+			Obj()
+	}
+
+	var classReads atomic.Int32
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kueue.WorkloadPriorityClass); ok {
+					classReads.Add(1)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(
+		lws,
+		utiltestingapi.MakeWorkloadPriorityClass("old-wpc").PriorityValue(1000).Obj(),
+		utiltestingapi.MakeWorkloadPriorityClass("new-wpc").PriorityValue(5000).Obj(),
+		component("0"),
+		component("1"),
+	).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if got := classReads.Load(); got != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1", got)
+	}
+
+	var got kueue.WorkloadList
+	if err := kClient.List(ctx, &got, client.InNamespace(testNS)); err != nil {
+		t.Fatalf("Listing workloads: %v", err)
+	}
+	for _, wl := range got.Items {
+		if wl.Spec.PriorityClassRef == nil || wl.Spec.PriorityClassRef.Name != "new-wpc" {
+			t.Errorf("%s: priorityClassRef = %v, want new-wpc", wl.Name, wl.Spec.PriorityClassRef)
+		}
+		if wl.Spec.Priority == nil || *wl.Spec.Priority != 5000 {
+			t.Errorf("%s: priority = %v, want 5000", wl.Name, wl.Spec.Priority)
+		}
+	}
+}
+
+// TestReconcilerResolvesPriorityClassOnceOnCreate is the other half: a reconcile
+// that creates several component Workloads reads the class once as well.
+func TestReconcilerResolvesPriorityClassOnceOnCreate(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.TopologyAwareScheduling: false,
+	})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		WorkloadPriorityClass("new-wpc").
+		Replicas(2).
+		UID(testLWS).
+		Obj()
+
+	var classReads atomic.Int32
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kueue.WorkloadPriorityClass); ok {
+					classReads.Add(1)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(
+		lws,
+		utiltestingapi.MakeWorkloadPriorityClass("new-wpc").PriorityValue(5000).Obj(),
+	).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if got := classReads.Load(); got != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1", got)
+	}
+
+	var got kueue.WorkloadList
+	if err := kClient.List(ctx, &got, client.InNamespace(testNS)); err != nil {
+		t.Fatalf("Listing workloads: %v", err)
+	}
+	if len(got.Items) != 2 {
+		t.Fatalf("created %d workloads, want 2", len(got.Items))
+	}
+	for _, wl := range got.Items {
+		if wl.Spec.PriorityClassRef == nil || wl.Spec.PriorityClassRef.Name != "new-wpc" {
+			t.Errorf("%s: priorityClassRef = %v, want new-wpc", wl.Name, wl.Spec.PriorityClassRef)
+		}
+		if wl.Spec.Priority == nil || *wl.Spec.Priority != 5000 {
+			t.Errorf("%s: priority = %v, want 5000", wl.Name, wl.Spec.Priority)
+		}
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2421,9 +2421,13 @@ func TestReconcilerRepairsStaleValueUnderTheSameClass(t *testing.T) {
 	if err := kClient.List(ctx, &got, client.InNamespace(testNS)); err != nil {
 		t.Fatalf("Listing workloads: %v", err)
 	}
+	want := kueue.NewWorkloadPriorityClassRef("high")
 	for _, wl := range got.Items {
-		if wl.Spec.Priority == nil || *wl.Spec.Priority != 200 {
-			t.Errorf("%s: priority = %v, want 200", wl.Name, wl.Spec.Priority)
+		if diff := cmp.Diff(want, wl.Spec.PriorityClassRef); diff != "" {
+			t.Errorf("%s: priority class reference (-want +got):\n%s", wl.Name, diff)
+		}
+		if diff := cmp.Diff(new(int32(200)), wl.Spec.Priority); diff != "" {
+			t.Errorf("%s: priority (-want +got):\n%s", wl.Name, diff)
 		}
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -18,6 +18,7 @@ package leaderworkerset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2356,5 +2358,155 @@ func TestReconcilerResolvesPriorityClassOnceForMixedSets(t *testing.T) {
 		if wl.Spec.Priority == nil || *wl.Spec.Priority != 5000 {
 			t.Errorf("%s: priority = %v, want 5000", wl.Name, wl.Spec.Priority)
 		}
+	}
+}
+
+func lwsComponent(index, className string, priority int32) *kueue.Workload {
+	return utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, index), testNS).
+		JobUID(testLWS).
+		OwnerReference(gvk, testLWS, testLWS).
+		Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+		Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+		Annotation(constants.JobOwnerNameAnnotation, testLWS).
+		Annotation(constants.ComponentWorkloadIndexAnnotation, index).
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			RestartPolicy("").
+			Image(utiltestingjobs.TestDefaultContainerImage).
+			Obj()).
+		WorkloadPriorityClassRef(className).
+		Priority(priority).
+		Obj()
+}
+
+// TestReconcilerRepairsStaleValueUnderTheSameClass covers the set that already
+// names the class but was left on an older value. A reconcile that had to
+// resolve the class for something else carries the answer to it too.
+func TestReconcilerRepairsStaleValueUnderTheSameClass(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		WorkloadPriorityClass("high").Replicas(2).UID(testLWS).Obj()
+
+	var classReads atomic.Int32
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*kueue.WorkloadPriorityClass); ok {
+					classReads.Add(1)
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(lws,
+		utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+		// Already names the class, but on the value an earlier reconcile saw.
+		lwsComponent("0", "high", 100)).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	if got := classReads.Load(); got != 1 {
+		t.Errorf("WorkloadPriorityClass reads = %d, want 1", got)
+	}
+	var got kueue.WorkloadList
+	if err := kClient.List(ctx, &got, client.InNamespace(testNS)); err != nil {
+		t.Fatalf("Listing workloads: %v", err)
+	}
+	for _, wl := range got.Items {
+		if wl.Spec.Priority == nil || *wl.Spec.Priority != 200 {
+			t.Errorf("%s: priority = %v, want 200", wl.Name, wl.Spec.Priority)
+		}
+	}
+}
+
+// TestReconcilerDeletesSurplusWhenTheClassIsMissing pins that the branches stay
+// independent. Resolving the class for the components being created must not
+// stop a surplus Workload from being cleaned up.
+func TestReconcilerDeletesSurplusWhenTheClassIsMissing(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		WorkloadPriorityClass("missing-wpc").Replicas(2).UID(testLWS).Obj()
+	surplus := lwsComponent("5", "missing-wpc", 100)
+
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme)
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(lws, lwsComponent("0", "missing-wpc", 100), surplus).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err == nil {
+		t.Fatal("Reconcile returned no error, want the missing class")
+	}
+
+	var got kueue.Workload
+	err = kClient.Get(ctx, client.ObjectKeyFromObject(surplus), &got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("the surplus Workload is still there (err = %v), want it deleted", err)
+	}
+}
+
+// TestReconcilerKeepsPriorityPerComponentOnUpdateFailure pins the failure
+// boundary. Moving priority out of the per-component loop must not let one
+// component's queue-name write hold back everyone else's priority.
+func TestReconcilerKeepsPriorityPerComponentOnUpdateFailure(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
+	ctx, _ := utiltesting.ContextWithLog(t)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		Queue("lws-queue").
+		WorkloadPriorityClass("new-wpc").
+		Replicas(2).
+		UID(testLWS).
+		Obj()
+	// Neither carries the queue name yet, so both go through the queue write
+	// first, and only one of them fails there.
+	blocked := lwsComponent("0", "old-wpc", 1000)
+	healthy := lwsComponent("1", "old-wpc", 1000)
+
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if wl, ok := obj.(*kueue.Workload); ok && wl.Name == blocked.Name {
+					return apierrors.NewConflict(kueue.Resource("workloads"), wl.Name, errors.New("conflict"))
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(lws,
+		utiltestingapi.MakeWorkloadPriorityClass("old-wpc").PriorityValue(1000).Obj(),
+		utiltestingapi.MakeWorkloadPriorityClass("new-wpc").PriorityValue(5000).Obj(),
+		blocked, healthy).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, request); err == nil {
+		t.Fatal("Reconcile returned no error, want the conflict")
+	}
+
+	var got kueue.Workload
+	if err := kClient.Get(ctx, client.ObjectKeyFromObject(healthy), &got); err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Spec.Priority == nil || *got.Spec.Priority != 5000 {
+		t.Errorf("%s: priority = %v, want 5000; one component's failure held back the rest",
+			got.Name, got.Spec.Priority)
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2350,6 +2350,9 @@ func TestReconcilerResolvesPriorityClassOnceForMixedSets(t *testing.T) {
 		t.Fatalf("ended with %d workloads, want 2", len(got.Items))
 	}
 	for _, wl := range got.Items {
+		if wl.Spec.PriorityClassRef == nil || wl.Spec.PriorityClassRef.Name != "new-wpc" {
+			t.Errorf("%s: priorityClassRef = %v, want new-wpc", wl.Name, wl.Spec.PriorityClassRef)
+		}
 		if wl.Spec.Priority == nil || *wl.Spec.Priority != 5000 {
 			t.Errorf("%s: priority = %v, want 5000", wl.Name, wl.Spec.Priority)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

The LeaderWorkerSet reconciler resolved the `WorkloadPriorityClass` once per component Workload rather than once per reconcile. Both of its paths did it from inside `parallelize.Until`:

```go
eg.Go(func() error {
    return parallelize.Until(ctx, len(toCreate), func(i int) error {
        return r.createWorkload(ctx, lws, toCreate[i].name, toCreate[i].index)
    })
})
```

`createWorkload` called `PrepareWorkloadPriority` and `updateWorkload` called `UpdateWorkloadPriority`, and both reach `ExtractPriority`, which performs a fresh `Get` of the class. A LeaderWorkerSet with N components therefore fanned out into N goroutines that each read the same class. If its value changed while that fan-out was in flight, the components kept whatever their own lookup returned, and Kueue then ordered the components of one owner against each other during preemption using different values.

Nothing brings them back together on its own. `WorkloadPriorityClassReconciler` lists by class name, so a later value update does find them all, but there is no guarantee that one happens.

##### What changes

The update path hands the components whose class name has to change to the helper after the per-component work, so one lookup covers them all. The ones already on the name are not handed over: their value is mutable and may be someone's, and batching the set is not a reason for a sibling's transition to decide it.

The create path resolves once before the fan-out and leaves the rest of it alone, so the peak stays bounded by the eight workers `parallelize.Until` runs rather than by the number of components.

A reconcile can do both, and resolving once per path would still have read the class twice and given the two sets different values of it. The create path's answer is carried into the update path through `ApplyWorkloadPriority`, which writes a resolution the caller already has to the set the caller already classified, rather than doing either again. The set to act on comes from `ClassifyWorkloadsForPriorityUpdate`, the helper's own splitter, now exported so the LeaderWorkerSet reconciler asks the same question the helper does and knows whether to resolve at all. It takes the object rather than the class name, which is what each of its callers was passing anyway. `ApplyWorkloadPriority` is the only new function; nothing that was already exported changes.

It keeps the rule about when to write, so a set where nothing needs a class transition is still left alone and a steady-state reconcile does not look the class up at all.

The writes are the caller's own `parallelize.Until`, one Workload per call to the helper. That keeps the fan-out this reconciler already had without the helper's write model changing for anyone else who reaches it.

##### What that rule costs, and why the fix is not here

Not handing over the components already on the name has a price, and it is written down beside the rule now rather than left to be rediscovered.

A batch is not all-or-nothing. One component takes the write, another loses it to a conflict, and if the class value moves before the retry the two are split: the one that landed already names the class, so it never reaches the helper, and the retry moves only the straggler. Both start at `low/10`, the class resolves at `high/100` and moves to `200` before the retry, and the set ends at `high/100` and `high/200`.

What would settle that is a sweep by class name, and it may already have passed: the class event fires before the straggler starts naming the class, which is #13866. Its fix is #13920 and is not merged, so it is not something to defer to yet.

Repairing it is a three-line change (hand the helper the whole set and let its same-name phase run), and it reverses the rule above rather than extending it. That deserves its own argument rather than riding on this one, so it is a follow-up. That repair is left to #13866/#13920 rather than carried here.

##### Only the label path

A set that names no `WorkloadPriorityClass` is untouched: each component resolves its own Pod `PriorityClass` on create and on update, exactly as before.

#13820 puts that choice up front: the split has to say which PodSets one resolution uses, "or the split would have to apply only to the label path", and it says the issue is not about Pod `PriorityClass`-backed Workloads. Taking the label path is the smaller of the two, and it is where the race the issue describes actually lives. A `WorkloadPriorityClass` value is mutable; a Kubernetes `PriorityClass` value is immutable in place. Delete and recreate under the same name, and the lifecycle of a global default, can still make two reads disagree, but those are separate concerns and outside #13820, so the Pod `PriorityClass` fallback stays per component rather than being given one snapshot to share.

An earlier revision of this PR shared one resolution across the fallback too, and the cost showed up quickly. Nothing rewrites a Workload's PodSets after it is created, so a component from an earlier revision names an earlier class, which is ordinary during a group-level rolling update with `maxSurge`. One shared answer then came from whichever source the reconcile shape supplied, and the same owner in the same state gave different results depending only on whether a sibling happened to be missing:

```
                         component 0
update only              old-pc, 100
one component missing    new-pc, 900
```

Not sharing that path removes the question rather than answering it. Gone with it: the probe Workload built to ask with, the grouping by class name, an exported lookup, and their tests.

Workloads whose priority came from a Pod `PriorityClass` are still left out of the reconciliation itself, as #13781 describes.

##### What this leaves alone

This branch keeps the behaviour #13921 merged: create, update and delete run under a plain `errgroup.Group`, so one branch does not cancel the others and `Wait` returns the first branch error.

`updateWorkload` writes the queue name and the admission-gated-by annotation, and this PR does not add PodSets to that. Refreshing them would change what an admitted component is charged for, which is a different question from which class it names.

#### Which issue(s) this PR fixes:

Fixes #13820

#### Special notes for your reviewer:

The LeaderWorkerSet cases are one table, `TestReconcilerWorkloadPriorityClass` in `leaderworkerset_reconciler_priority_test.go`, each case building its components in full the way `TestReconciler` does. That file is where the repo's split-test-files rule puts a feature needing its own gates and resources, rather than four hundred more lines in a file already past two thousand six hundred. Four of its seven cases count `WorkloadPriorityClass` reads through a named interceptor and expect a single read for two components. The other three pin what is left alone, what is still deleted when the class is missing, and what one component's failed write costs the others.

On the helper's side, `TestApplyWorkloadPriority` holds the two cases where nothing may be written, and the across-calls case folds into `TestUpdateWorkloadPriority`, whose `steps` field already runs a case over more than one invocation. No table field holds an anonymous function: the counting and refusing interceptors are named helpers beside the ones this file already had.

Giving the update branch its own resolution instead of the create branch's fails the part-created-part-updated case, and only it.

Both PRs this was waiting on have landed, #13921 on 12 August and #13775 on 19 August, and the branch is rebased on top of them. Rebased again on 16 September onto `aa9bd94`; the one conflict was the case table in `workload_priority_test.go`, where #14565 had added `job` and `podPriorityClass` fields beside this branch's `ownerClass`, and all three are kept. Three commits followed the rebase, all test and comment only: the component builder in the LeaderWorkerSet priority table is inlined at each case, as asked; the doc comments on the priority functions are cut to what the code does and the one reason it does not show; and the table carries its feature gate per case. It calls the merged `ExtractPriority` with its recorder argument, and the errgroup behaviour is main's rather than a duplicate carried here. `ExtractPriority` stayed exported, so the rename I said one of us would owe the other is not needed. Nothing is left to sequence.

##### The shared write path keeps its semantics

An earlier revision of this PR made `applyResolvedPriority` concurrent and best-effort, which is not a LeaderWorkerSet-local change: the Job path reaches the same helper, and since #13780 it hands it the workload-slice live set. Whether one refusal decides that the other is attempted, and which error is reported, is a contract for every caller, so it is not this PR's to change on the way past. The helper is back to the serial loop it had.

What this reconciler wanted from it is the bounded fan-out, and that is now on its own side of the call: `parallelize.Until` over the transition targets, one Workload per call, each with the same resolution. Nothing else that reaches the helper moves.

##### Branch failures

#13921 settled the outer three: plain `errgroup.Group`, branches that do not cancel each other, `Wait` returning the first branch error. This PR keeps all of it. What it had added was an inner `errors.Join` in the update branch that `Wait` would then discard, so the create branch owns the resolution failure, which cannot be set without one, and the update branch no longer repeats it.

One error is all that survives either way: `Wait` keeps the first branch error and `parallelize.Until` keeps one of its own and drops the rest. A failed priority write is therefore logged against the workload it belongs to before it is returned, since the log is the only place that name is kept.

One thing inside the update branch does change, and it is worth saying rather than claiming the error surface is untouched. Metadata and priority are two stages there now, so a metadata error and a priority error can both survive, joined, where a single `parallelize.Until` would have kept one. That reads as more to debug rather than less, so it stays; the outer first-error behaviour is unaffected.

##### Not in this one

Repairing a value stranded under an unchanged name, described above, is left to #13866/#13920.

The update path still finishes every component's metadata write before any priority write begins, so a component slow to return delays the others' transitions, and a slow class lookup holds the create and update branches while the delete branch runs. Within a reconcile that costs nothing, since it cannot return until every branch has finished either way. What it does widen is the window under cancellation: `parallelize.Until` stops dispatching once the context is done but reports no error of its own, so a cancellation landing between the two stages can leave every metadata write done and no priority write started. In practice that is manager shutdown, and the informer's initial event reconciles it again. Restructuring the branch around a resolution each component waits on independently would close it, and it is a redesign; so would giving `parallelize.Until` a cancellation contract, and that belongs with all its callers rather than this one.

#14484 is the third. Under an owner naming no class, a batch holding both a workload with no reference and a sibling transitioning off one can write the first along with the second. A guard for it was in this branch until the fallback narrowed to per-component, which left it as shared behaviour carrying no weight here.

#14482 was the other one, and #14565 has since fixed it on `main`: a quota-reserved Workload whose transition the CEL rules would refuse is skipped in the write loop. That loop is `applyResolvedPriority`, the path both `UpdateWorkloadPriority` and `ApplyWorkloadPriority` reach, so the LeaderWorkerSet path inherits the skip without a line of its own.

##### On the level of the coverage

Everything added here is unit-level, against `utiltesting.NewClientBuilder`. Where it could also go, and did not:

`test/integration/singlecluster/controller/jobs` holds an envtest suite for every integration except this one; the only LeaderWorkerSet suite under `test/integration` is for the webhook. The framework already knows the type, so standing one up is not blocked on anything (`util.LeaderWorkerSetCrds` exists and `framework.go` already adds the scheme), but it is a suite, with its own manager setup and its own question about what a LeaderWorkerSet reconciler suite should cover, rather than a case.

There is a real end-to-end suite, `test/e2e/singlecluster/extended/leaderworkerset_test.go`, whose describe is named "LeaderWorkerSet integration", plus a TAS one. Those run against an API server, so a priority case there would exercise the CEL rules a fake client does not, which is what would have caught #14482 before #14565. I have not added one: e2e is where the slowest feedback is, and what changes here is how many times one class is read in a reconcile, which the read counts pin directly.

Say the word if you would rather have either, and which.

##### Verification

`make verify` and `make ci-lint` are clean, the latter at zero issues across every module, and `go vet ./...` covers the test files as well as the rest. `jobframework`, `leaderworkerset`, `statefulset` and `core` pass under `go test -race -count=1`, and the first two also under `-race -shuffle=on -count=20` at the default `GOMAXPROCS`.

Every case was checked by breaking the thing it is there for, so none of them is passing for a reason other than the one it names:

| what was broken | which cases fail |
|---|---|
| the update branch resolves on its own instead of taking the create branch's | part created and part updated |
| `ApplyWorkloadPriority` put back to the per-call `UpdateWorkloadPriority` | components all move to the class; part created and part updated |
| the same-name half of `ClassifyWorkloadsForPriorityUpdate` handed over too | already naming the class; sibling transitioning |
| the create branch resolves once per component | all created; part created and part updated; already naming the class |
| the delete branch stops deleting | surplus deleted with the class missing |
| the update branch abandons the rest once one write fails | one component's failed write |

#### Does this PR introduce a user-facing change?

```release-note
LeaderWorkerSet: Fixed components created or transitioned to the same WorkloadPriorityClass in one reconciliation observing different class values because the class was resolved separately for each component.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workloads reconciled together now consistently receive the same priority configuration.
  * Priority settings are resolved once per reconciliation, reducing repeated processing and unnecessary updates.
  * Mixed sets of new and existing Workloads receive coordinated priority updates.
  * Priority values are repaired only when a class transition requires it.
* **Bug Fixes**
  * Prevented partial priority changes when lookups or updates fail.
  * Workloads without named priority classes retain individual priority settings.
  * Existing values remain stable when no transition is required.
  * Surplus Workloads are removed even when a priority class is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


















