### PR TITLE
Fix deprecated datetime.datetime.utcnow() warning

### DIFF
--- a/hack/releasing/log_to_issue.py
+++ b/hack/releasing/log_to_issue.py
@@ -17,7 +17,7 @@
 import sys
 import re
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 LOG_MARKER_START = "<!-- release-log-start -->"
 LOG_MARKER_END = "<!-- release-log-end -->"
@@ -38,7 +38,7 @@ def main():
     repository = os.environ.get("GITHUB_REPOSITORY", "").strip()
     server_url = os.environ.get("GITHUB_SERVER_URL", "https://github.com").strip()
     
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
     action_link = f"{server_url}/{repository}/actions/runs/{run_id}"
 
     issue_body = os.environ.get("ISSUE_BODY", "").strip()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area releasing

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Fix deprecated datetime.datetime.utcnow() warning

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #12763

#### Special notes for your reviewer:
```                                                                                                                                                            
  /home/runner/work/kueue/kueue/hack/releasing/log_to_issue.py:41: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal   
  in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).                                       
      timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S UTC")                                                                                       
    failed to update https://github.com/mbobrovskyi/kueue/issues/360: GraphQL: Resource not accessible by integration (updateIssue)  
```

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
