### PR TITLE
Allow mutating Topology levels when hostname remains the lowest level

### DIFF
--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -112,7 +112,7 @@ type TopologySpec struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=16
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="field is immutable"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf || (self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname' && oldSelf[size(oldSelf) - 1].nodeLabel == 'kubernetes.io/hostname')",message="levels are mutable only when kubernetes.io/hostname is the lowest level both before and after the change"
 	// +kubebuilder:validation:XValidation:rule="size(self.filter(i, size(self.filter(j, j == i)) > 1)) == 0",message="must be unique"
 	// +kubebuilder:validation:XValidation:rule="size(self.filter(i, i.nodeLabel == 'kubernetes.io/hostname')) == 0 || self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname'",message="the kubernetes.io/hostname label can only be used at the lowest level of topology"
 	Levels []TopologyLevel `json:"levels,omitempty"`

--- a/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
+++ b/charts/kueue/templates/crd/kueue.x-k8s.io_topologies.yaml
@@ -152,8 +152,8 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
-                    - message: field is immutable
-                      rule: self == oldSelf
+                    - message: levels are mutable only when kubernetes.io/hostname is the lowest level both before and after the change
+                      rule: self == oldSelf || (self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname' && oldSelf[size(oldSelf) - 1].nodeLabel == 'kubernetes.io/hostname')
                     - message: must be unique
                       rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) == 0
                     - message: the kubernetes.io/hostname label can only be used at the lowest level of topology

--- a/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
+++ b/config/components/crd/bases/kueue.x-k8s.io_topologies.yaml
@@ -133,8 +133,10 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
                 x-kubernetes-validations:
-                - message: field is immutable
-                  rule: self == oldSelf
+                - message: levels are mutable only when kubernetes.io/hostname is
+                    the lowest level both before and after the change
+                  rule: self == oldSelf || (self[size(self) - 1].nodeLabel == 'kubernetes.io/hostname'
+                    && oldSelf[size(oldSelf) - 1].nodeLabel == 'kubernetes.io/hostname')
                 - message: must be unique
                   rule: size(self.filter(i, size(self.filter(j, j == i)) > 1)) ==
                     0

--- a/pkg/cache/scheduler/tas_cache.go
+++ b/pkg/cache/scheduler/tas_cache.go
@@ -106,15 +106,20 @@ func (t *tasCache) AddTopology(topology *kueue.Topology) {
 	t.Lock()
 	defer t.Unlock()
 	name := kueue.TopologyReference(topology.Name)
-	if _, ok := t.topologies[name]; !ok {
-		tInfo := topologyInformation{
-			Levels: utiltas.Levels(topology),
+	tInfo := topologyInformation{
+		Levels: utiltas.Levels(topology),
+	}
+	t.topologies[name] = tInfo
+	for fName, flavorInfo := range t.flavors {
+		if flavorInfo.TopologyName != name {
+			continue
 		}
-		t.topologies[name] = tInfo
-		for fName, flavorInfo := range t.flavors {
-			if flavorInfo.TopologyName == name {
-				t.flavorCache[fName] = t.NewTASFlavorCache(tInfo, flavorInfo)
-			}
+		if c, ok := t.flavorCache[fName]; ok {
+			// Update the levels in place: rebuilding the cache entry would drop
+			// the usage accumulated from admitted workloads.
+			c.updateTopology(tInfo)
+		} else {
+			t.flavorCache[fName] = t.NewTASFlavorCache(tInfo, flavorInfo)
 		}
 	}
 }

--- a/pkg/cache/scheduler/tas_cache_update_test.go
+++ b/pkg/cache/scheduler/tas_cache_update_test.go
@@ -25,6 +25,7 @@ import (
 
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -140,5 +141,57 @@ func TestTASCacheUpdateFlavorNodeLabelsPreservesUsage(t *testing.T) {
 	}
 	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
 		t.Error("Workload usage was removed after updating nodeLabels")
+	}
+}
+
+func TestTASCacheUpdateTopologyLevelsPreservesUsage(t *testing.T) {
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	topology := utiltestingapi.MakeTopology("default").
+		Levels(utiltesting.DefaultRackTopologyLevel, corev1.LabelHostname).
+		Obj()
+	tasCache.AddTopology(topology)
+
+	flavor := utiltestingapi.MakeResourceFlavor("tas-flavor").
+		NodeLabel("node-group", "tas").
+		TopologyName(topology.Name).
+		Obj()
+	tasCache.AddOrUpdateFlavor(flavor)
+
+	const wlKey = workload.Reference("default/wl")
+	topologyRequests := []workload.TopologyDomainRequests{{
+		Values: []string{"x1"},
+		Count:  1,
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU: 1,
+		}),
+	}}
+	originalFlavorCache := tasCache.Get("tas-flavor")
+	originalFlavorCache.addUsage(logr.Discard(), wlKey, topologyRequests)
+
+	updatedTopology := utiltestingapi.MakeTopology("default").
+		Levels(utiltesting.DefaultBlockTopologyLevel, corev1.LabelHostname).
+		Obj()
+	tasCache.AddTopology(updatedTopology)
+
+	updatedFlavorCache := tasCache.Get("tas-flavor")
+	if updatedFlavorCache != originalFlavorCache {
+		t.Fatal("TAS flavor cache was replaced while updating topology levels")
+	}
+
+	wantLevels := []string{utiltesting.DefaultBlockTopologyLevel, corev1.LabelHostname}
+	if diff := cmp.Diff(wantLevels, updatedFlavorCache.TopologyLevels()); diff != "" {
+		t.Errorf("Unexpected levels after update (-want +got):\n%s", diff)
+	}
+	wantUsage := map[utiltas.TopologyDomainID]resources.Requests{
+		"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU:  1,
+			corev1.ResourcePods: 1,
+		}),
+	}
+	if diff := cmp.Diff(wantUsage, updatedFlavorCache.usage, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("Unexpected usage after updating topology levels (-want +got):\n%s", diff)
+	}
+	if _, found := updatedFlavorCache.wlUsage[wlKey]; !found {
+		t.Error("Workload usage was removed after updating topology levels")
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -125,6 +125,12 @@ func (c *TASFlavorCache) updateNodeLabels(nodeLabels map[string]string) {
 	c.flavor.NodeLabels = nodeLabels
 }
 
+func (c *TASFlavorCache) updateTopology(topology topologyInformation) {
+	c.Lock()
+	defer c.Unlock()
+	c.topology = topology
+}
+
 // NodeLabels returns the node labels of the flavor. The returned map is safe to
 // read without holding the lock, because updateNodeLabels always replaces the
 // whole map with a copy owned by the cache, and never mutates it in place.
@@ -138,7 +144,13 @@ func (c *TASFlavorCache) Topology() kueue.TopologyReference {
 	return c.flavor.TopologyName
 }
 
+// TopologyLevels returns the levels of the topology referenced by the flavor.
+// The returned slice is safe to read without holding the lock, because
+// updateTopology always replaces the whole topologyInformation with one owning
+// a freshly built slice, and never mutates it in place.
 func (c *TASFlavorCache) TopologyLevels() []string {
+	c.RLock()
+	defer c.RUnlock()
 	return c.topology.Levels
 }
 

--- a/pkg/controller/tas/topology_controller.go
+++ b/pkg/controller/tas/topology_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -146,7 +147,25 @@ func (r *topologyReconciler) Create(e event.TypedCreateEvent[*kueue.Topology]) b
 	return true
 }
 
-func (r *topologyReconciler) Update(event.TypedUpdateEvent[*kueue.Topology]) bool {
+func (r *topologyReconciler) Update(e event.TypedUpdateEvent[*kueue.Topology]) bool {
+	if equality.Semantic.DeepEqual(e.ObjectOld.Spec.Levels, e.ObjectNew.Spec.Levels) {
+		return true
+	}
+	log := r.logger().WithValues("topology", klog.KObj(e.ObjectNew))
+	log.V(3).Info("Topology levels updated",
+		"oldLevels", e.ObjectOld.Spec.Levels, "newLevels", e.ObjectNew.Spec.Levels)
+
+	cqNames := r.cache.AddOrUpdateTopology(log, e.ObjectNew)
+	// AddOrUpdateTopology only reports ClusterQueues that transitioned from
+	// pending to active. A levels change keeps the ClusterQueues active but
+	// changes which workloads the topology can accommodate, so the workloads
+	// left inadmissible under the previous levels would otherwise never be
+	// retried. Retry the inadmissible workloads in the ClusterQueues that use
+	// this topology.
+	cqNames.Insert(r.cache.ClusterQueuesUsingTopology(kueue.TopologyReference(e.ObjectNew.Name))...)
+	if len(cqNames) > 0 {
+		qcache.NotifyRetryInadmissible(r.queues, cqNames)
+	}
 	return true
 }
 

--- a/site/content/en/docs/concepts/topology.md
+++ b/site/content/en/docs/concepts/topology.md
@@ -55,10 +55,30 @@ The `levels` field has the following constraints:
 
 - **Minimum items**: 1
 - **Maximum items**: 16
-- **Immutability**: The field cannot be changed after creation
+- **Mutability**: The field can only be changed when `kubernetes.io/hostname`
+  is the lowest (last) level both before and after the change; otherwise it is
+  immutable
 - **Uniqueness**: Each level must have a unique `nodeLabel`
 - **Hostname restriction**: The `kubernetes.io/hostname` label can only be used
   at the lowest (last) level
+
+### Changing the levels of a Topology in use
+
+When `kubernetes.io/hostname` is the lowest level, levels above it can be
+renamed, reordered, added or removed while workloads are admitted: their
+recorded usage is keyed by hostname and is preserved across the change, and
+already admitted workloads are not evicted. Pending workloads are automatically
+retried against the new levels. Keep in mind:
+
+- **When adding a level, label all nodes first, then add the level.** The
+  scheduler only considers nodes that carry the labels of every topology level,
+  so nodes missing the new label are excluded (together with their usage) until
+  they are labeled, which temporarily shrinks the available capacity.
+- **Removing a level makes it unschedulable for workloads that request it.**
+  Workloads with a required or preferred topology request for a removed level
+  can no longer be nominated (or re-nominated, for example during failed node
+  replacement) until the level is restored. Already admitted workloads keep
+  running; admission-time constraints are not re-validated retroactively.
 
 ## Referencing a Topology from a ResourceFlavor
 

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -572,6 +572,395 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 		})
 	})
 
+	ginkgo.When("Updating Topology levels", func() {
+		var (
+			nodes      []corev1.Node
+			topology   *kueue.Topology
+			tasFlavor  *kueue.ResourceFlavor
+			cq         *kueue.ClusterQueue
+			localQueue *kueue.LocalQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			nodes = []corev1.Node{
+				*testingnode.MakeNode("y1").
+					Label("node-group", "tas").
+					Label("cloud.provider.com/rack", "r1").
+					Label("cloud.provider.com/block", "b1").
+					Label("cloud.provider.com/zone", "z1").
+					Label(corev1.LabelHostname, "y1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("y2").
+					Label("node-group", "tas").
+					Label("cloud.provider.com/rack", "r2").
+					Label("cloud.provider.com/block", "b2").
+					Label(corev1.LabelHostname, "y2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			}
+			util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+			topology = utiltestingapi.MakeTopology("levels-topology").
+				Levels("cloud.provider.com/rack", corev1.LabelHostname).
+				Obj()
+			util.MustCreate(ctx, k8sClient, topology)
+
+			tasFlavor = utiltestingapi.MakeResourceFlavor("levels-tas-flavor").
+				NodeLabel("node-group", "tas").
+				TopologyName(topology.Name).
+				Obj()
+			util.MustCreate(ctx, k8sClient, tasFlavor)
+
+			cq = utiltestingapi.MakeClusterQueue("levels-cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).
+					Resource(corev1.ResourceCPU, "6").
+					Obj()).
+				Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			localQueue = utiltestingapi.MakeLocalQueue("levels-local-queue", ns.Name).
+				ClusterQueue(cq.Name).
+				Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, cq, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+			for i := range nodes {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, &nodes[i], true)
+			}
+		})
+
+		updateLevels := func(levels ...string) error {
+			var updated kueue.Topology
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(topology), &updated); err != nil {
+				return err
+			}
+			updated.Spec.Levels = make([]kueue.TopologyLevel, len(levels))
+			for i, level := range levels {
+				updated.Spec.Levels[i] = kueue.TopologyLevel{NodeLabel: level}
+			}
+			return k8sClient.Update(ctx, &updated)
+		}
+
+		makeHostnameWorkload := func(name, cpu string) *kueue.Workload {
+			podSet := utiltestingapi.MakePodSet("worker", 1).
+				RequiredTopologyRequest(corev1.LabelHostname).
+				Request(corev1.ResourceCPU, cpu)
+			return utiltestingapi.MakeWorkload(name, ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*podSet.Obj()).
+				Obj()
+		}
+
+		ginkgo.It("should allow mutating levels only when hostname stays the lowest level", func() {
+			ginkgo.By("renaming a middle level with hostname lowest before and after", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/block", corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("rejecting an update that drops the hostname level", func() {
+				// Eventually: a conflict with the reconciler adding the finalizer
+				// must be retried until the CEL rejection itself is observed.
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/block")).
+						To(gomega.MatchError(gomega.ContainSubstring("levels are mutable only when")))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("rejecting any update of a topology whose lowest level is not hostname", func() {
+				rackOnly := utiltestingapi.MakeTopology("rack-only").
+					Levels("cloud.provider.com/rack").
+					Obj()
+				util.MustCreate(ctx, k8sClient, rackOnly)
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updated kueue.Topology
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(rackOnly), &updated)).To(gomega.Succeed())
+					updated.Spec.Levels = []kueue.TopologyLevel{{NodeLabel: "cloud.provider.com/block"}}
+					g.Expect(k8sClient.Update(ctx, &updated)).
+						To(gomega.MatchError(gomega.ContainSubstring("levels are mutable only when")))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, rackOnly, true)
+			})
+		})
+
+		ginkgo.It("should requeue a workload pending on a missing level after the level is added", func() {
+			podSet := utiltestingapi.MakePodSet("worker", 1).
+				RequiredTopologyRequest("cloud.provider.com/block").
+				Request(corev1.ResourceCPU, "1")
+			wl := utiltestingapi.MakeWorkload("wl-block", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*podSet.Obj()).
+				Obj()
+
+			ginkgo.By("creating a workload requiring a level absent from the topology", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+			})
+
+			ginkgo.By("adding the missing level to the topology", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/block", "cloud.provider.com/rack", corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the pending workload is retried and admitted", func() {
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			})
+		})
+
+		ginkgo.It("should preserve admitted usage when a middle level is renamed", func() {
+			wl1 := makeHostnameWorkload("wl1", "1")
+			ginkgo.By("admitting a workload under the original levels", func() {
+				util.MustCreate(ctx, k8sClient, wl1)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+
+			ginkgo.By("renaming the middle level", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/block", corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			wl2 := makeHostnameWorkload("wl2", "2")
+			ginkgo.By("admitting a workload that only fits on the untouched node", func() {
+				util.MustCreate(ctx, k8sClient, wl2)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl2)
+			})
+
+			wl3 := makeHostnameWorkload("wl3", "2")
+			ginkgo.By("verifying capacity consumed before the rename is still accounted", func() {
+				// One node has 1 CPU left (wl1) and the other is full (wl2): if
+				// wl1's usage had been dropped on the rename, wl3 would fit.
+				util.MustCreate(ctx, k8sClient, wl3)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl3)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl1)
+			})
+		})
+
+		ginkgo.It("should maintain usage when a level above hostname is removed", func() {
+			wlA := makeHostnameWorkload("wl-a", "2")
+			wlB := makeHostnameWorkload("wl-b", "2")
+			ginkgo.By("admitting workloads taking all node capacity under the original levels", func() {
+				util.MustCreate(ctx, k8sClient, wlA)
+				util.MustCreate(ctx, k8sClient, wlB)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA, wlB)
+			})
+
+			ginkgo.By("removing the rack level", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels(corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			wlC := makeHostnameWorkload("wl-c", "1")
+			ginkgo.By("verifying a new workload remains blocked by the carried-over usage", func() {
+				util.MustCreate(ctx, k8sClient, wlC)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wlC)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA, wlB)
+			})
+		})
+
+		ginkgo.It("should not evict an admitted workload that would violate a newly added level", func() {
+			ginkgo.By("reducing the topology to hostname only", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels(corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			extraNode := testingnode.MakeNode("y3").
+				Label("node-group", "tas").
+				Label("cloud.provider.com/rack", "r1").
+				Label("cloud.provider.com/block", "b1").
+				Label(corev1.LabelHostname, "y3").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("1"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj()
+			util.CreateNodesWithStatus(ctx, k8sClient, []corev1.Node{*extraNode})
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, extraNode, true)
+			})
+
+			spanPodSet := utiltestingapi.MakePodSet("worker", 2).
+				PreferredTopologyRequest(corev1.LabelHostname).
+				Request(corev1.ResourceCPU, "2")
+			wlSpan := utiltestingapi.MakeWorkload("wl-span", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*spanPodSet.Obj()).
+				Obj()
+			ginkgo.By("admitting a workload that spans both racks under hostname-only levels", func() {
+				util.MustCreate(ctx, k8sClient, wlSpan)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlSpan)
+			})
+
+			ginkgo.By("adding the rack level", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/rack", corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the spanning workload is not evicted", func() {
+				// Consistently: a final admitted check alone would also pass if the
+				// workload was evicted and quickly re-admitted.
+				gomega.Consistently(func(g gomega.Gomega) {
+					var updated kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlSpan), &updated)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(&updated)).To(gomega.BeTrue())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			rackPodSet := utiltestingapi.MakePodSet("worker", 1).
+				RequiredTopologyRequest("cloud.provider.com/rack").
+				Request(corev1.ResourceCPU, "1")
+			wlSmall := utiltestingapi.MakeWorkload("wl-small", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*rackPodSet.Obj()).
+				Obj()
+			ginkgo.By("admitting a small workload next to it within one rack", func() {
+				util.MustCreate(ctx, k8sClient, wlSmall)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlSmall)
+			})
+		})
+
+		ginkgo.It("should keep admitted workloads and block new nominations for a removed level", func() {
+			makeRackWorkload := func(name string) *kueue.Workload {
+				podSet := utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest("cloud.provider.com/rack").
+					Request(corev1.ResourceCPU, "1")
+				return utiltestingapi.MakeWorkload(name, ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(*podSet.Obj()).
+					Obj()
+			}
+
+			wlRack := makeRackWorkload("wl-rack")
+			ginkgo.By("admitting a workload requiring the rack level", func() {
+				util.MustCreate(ctx, k8sClient, wlRack)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlRack)
+			})
+
+			ginkgo.By("removing the rack level", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels(corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("verifying the admitted workload is not disturbed", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					var updated kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlRack), &updated)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(&updated)).To(gomega.BeTrue())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			wlRack2 := makeRackWorkload("wl-rack-2")
+			ginkgo.By("verifying a new workload requiring the removed level cannot be nominated", func() {
+				util.MustCreate(ctx, k8sClient, wlRack2)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wlRack2)
+			})
+		})
+
+		ginkgo.It("should evict a workload whose required level was removed when its node fails", func() {
+			podSet := utiltestingapi.MakePodSet("worker", 1).
+				RequiredTopologyRequest("cloud.provider.com/rack").
+				Request(corev1.ResourceCPU, "1")
+			wl := utiltestingapi.MakeWorkload("wl-replace", ns.Name).
+				OwnerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "owner-job", "owner-job-uid").
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				PodSets(*podSet.Obj()).
+				Obj()
+
+			var admittedNode string
+			ginkgo.By("admitting a workload requiring the rack level", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				for req := range utiltas.InternalSeqFrom(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment) {
+					admittedNode = req.Values[len(req.Values)-1]
+					break
+				}
+				gomega.Expect(admittedNode).NotTo(gomega.BeEmpty())
+			})
+
+			ginkgo.By("removing the rack level", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels(corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("making the admitted node NotReady to trigger node replacement", func() {
+				var nodeToUpdate corev1.Node
+				gomega.Expect(k8sClient.Get(ctx, apitypes.NamespacedName{Name: admittedNode}, &nodeToUpdate)).To(gomega.Succeed())
+				util.SetNodeCondition(ctx, k8sClient, &nodeToUpdate, &corev1.NodeCondition{
+					Type:               corev1.NodeReady,
+					Status:             corev1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-tas.NodeFailureDelay)),
+				})
+			})
+
+			ginkgo.By("verifying the workload is evicted rather than silently kept on the failed node", func() {
+				// The replacement cannot be computed: the flavor no longer has the
+				// requested level, so the assigner rejects it before a replacement
+				// domain is looked up. The workload is evicted for node failures
+				// instead of staying pinned to the failed node.
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updated kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+					cond := apimeta.FindStatusCondition(updated.Status.Conditions, kueue.WorkloadEvicted)
+					g.Expect(cond).NotTo(gomega.BeNil())
+					g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadEvictedDueToNodeFailures))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
+		ginkgo.It("should shrink capacity to labeled nodes when a partially labeled level is added", func() {
+			ginkgo.By("adding a zone level that only one node carries", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(updateLevels("cloud.provider.com/zone", "cloud.provider.com/rack", corev1.LabelHostname)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			wlZoneA := makeHostnameWorkload("wl-zone-a", "2")
+			ginkgo.By("admitting a workload that fits on the labeled node", func() {
+				util.MustCreate(ctx, k8sClient, wlZoneA)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlZoneA)
+			})
+
+			wlZoneB := makeHostnameWorkload("wl-zone-b", "1")
+			ginkgo.By("verifying capacity of unlabeled nodes is not usable", func() {
+				util.MustCreate(ctx, k8sClient, wlZoneB)
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wlZoneB)
+			})
+
+			ginkgo.By("labeling the remaining node completes the migration", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var node corev1.Node
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: "y2"}, &node)).To(gomega.Succeed())
+					node.Labels["cloud.provider.com/zone"] = "z2"
+					g.Expect(k8sClient.Update(ctx, &node)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlZoneB)
+			})
+		})
+	})
+
 	ginkgo.When("Updating TAS ResourceFlavor nodeLabels", func() {
 		var (
 			nodes       []corev1.Node
@@ -8245,7 +8634,7 @@ var _ = ginkgo.Describe("Topology validations", func() {
 					}
 				},
 				gomega.Succeed()),
-			ginkgo.Entry("updating levels is prohibited",
+			ginkgo.Entry("appending a level below hostname is prohibited",
 				utiltestingapi.MakeDefaultOneLevelTopology("valid"),
 				func(topology *kueue.Topology) {
 					topology.Spec.Levels = append(topology.Spec.Levels, kueue.TopologyLevel{
@@ -8253,10 +8642,22 @@ var _ = ginkgo.Describe("Topology validations", func() {
 					})
 				},
 				utiltesting.BeInvalidError()),
-			ginkgo.Entry("updating levels order is prohibited",
+			ginkgo.Entry("reordering levels above hostname is allowed",
 				utiltestingapi.MakeDefaultThreeLevelTopology("default"),
 				func(topology *kueue.Topology) {
 					topology.Spec.Levels[0], topology.Spec.Levels[1] = topology.Spec.Levels[1], topology.Spec.Levels[0]
+				},
+				gomega.Succeed()),
+			ginkgo.Entry("moving hostname away from the lowest level is prohibited",
+				utiltestingapi.MakeDefaultThreeLevelTopology("default"),
+				func(topology *kueue.Topology) {
+					topology.Spec.Levels[1], topology.Spec.Levels[2] = topology.Spec.Levels[2], topology.Spec.Levels[1]
+				},
+				utiltesting.BeInvalidError()),
+			ginkgo.Entry("updating levels of a topology without hostname is prohibited",
+				utiltestingapi.MakeDefaultTwoLevelTopology("valid"),
+				func(topology *kueue.Topology) {
+					topology.Spec.Levels[0].NodeLabel = "changed"
 				},
 				utiltesting.BeInvalidError()),
 		)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Implements option 2 from the discussion in #3733 ([agreed here](https://github.com/kubernetes-sigs/kueue/issues/3733#issuecomment-5202608247)): `Topology.spec.levels` becomes mutable when `kubernetes.io/hostname` is the lowest level **both before and after** the change.

Why this restriction makes the change safe: when hostname is the lowest level, the persisted `TopologyAssignment` of admitted workloads records only the hostname level (higher levels are omitted), so the usage ledger is keyed by hostname and no admitted workload is re-addressed by a middle-level change.

Changes:

- **API**: the `self == oldSelf` CEL rule on `spec.levels` (`v1beta2` only — `v1beta1` is deprecated and intentionally left immutable, per review) is relaxed to also accept transitions where the lowest level is `kubernetes.io/hostname` on both sides; CRD manifests regenerated.
- **Cache**: `tasCache.AddTopology` becomes an upsert; existing `TASFlavorCache` entries are updated **in place** (`updateTopology`, mirroring `updateNodeLabels`/`updateTolerations`) so the usage accumulated from admitted workloads is preserved — rebuilding the entry would drop it.
- **Controller**: the Topology `Update` predicate (previously a no-op, since levels were immutable) now propagates the new levels to the cache and retries the inadmissible workloads of the ClusterQueues using the topology — same shape as the ResourceFlavor `tolerations`/`nodeTaints`/`nodeLabels` requeue fixes.

Integration tests (all in `test/integration/singlecluster/tas`):

1. the CEL invariant (middle-level rename allowed; dropping hostname rejected; any mutation of a non-hostname-lowest topology rejected);
2. a workload pending on a missing level is requeued and admitted after the level is added — verified load-bearing: with the controller/cache changes reverted, this spec fails by timeout;
3. usage admitted before a middle-level rename is still accounted after it (a workload that would only fit if the usage had been dropped stays pending);
4. usage is likewise maintained when a level above hostname is *removed* (nodes stay full for new workloads);
5. adding a level does not evict an admitted workload spanning the new level's domains, and a new workload can still be placed next to it within one domain;
6. the pre-existing update-validation table now pins all four transitions: reorder above hostname allowed, appending below hostname rejected, displacing hostname rejected, and any mutation of a non-hostname topology rejected.

#### Which issue(s) this PR fixes:

Relates to #3733 (topology mutability). The `topologyName` option (mutable reference) is left as a follow-up, per the discussion.

#### Special notes for your reviewer:

AI tooling (Claude Code) was used to assist; the invariant analysis, red/green verification and regression runs were reviewed manually.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Allowed mutating `Topology.spec.levels` when `kubernetes.io/hostname` is the lowest level both before and after the change. Workloads left pending under the previous levels are automatically retried, and the usage of already-admitted workloads is preserved across the change.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Topology levels can be updated when `kubernetes.io/hostname` remains the lowest level.
  * Pending workloads are retried after relevant topology changes.
  * Admitted assignments and capacity remain preserved when topology levels are renamed, removed, or added.
  * Compatible topology changes continue to support existing workloads while preventing new requests for removed levels.

* **Bug Fixes**
  * Topology and flavor cache data now refresh correctly after updates.
  * Unchanged topology updates are ignored, while invalid changes remain rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->