### PR TITLE
Do not treat a workload slice being evicted as the chain's active slice

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -135,6 +135,68 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		// The newer slice is on its way out: eviction sets its condition before
+		// the reservation is released, so it still reports one. The older slice
+		// is the one still holding capacity, and it grants a single pod.
+		"an evicted slice does not set the ungating cap": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					Creation(now.Add(-time.Minute)).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "1").
+								Obj()).
+							Obj(), now.Add(-time.Minute),
+					).
+					AdmittedAt(true, now.Add(-time.Minute)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-2", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "3").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					EvictedAt(now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-0", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+				*testingpod.MakePod("pod-1", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+		},
 		"ungate multiple pods": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -124,17 +124,21 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkload returns the newest non-finished workload slice owned
-// by the provided job object/gvk that holds a quota reservation, or nil if none
-// qualifies. This is the chain's "active" slice: its granted PodSet counts
-// define the admitted capacity.
+// FindLatestActiveWorkload returns the newest non-finished, non-evicted workload
+// slice owned by the provided job object/gvk that holds a quota reservation, or
+// nil if none qualifies. This is the chain's "active" slice: its granted PodSet
+// counts define the admitted capacity.
+//
+// Eviction is two writes: the condition is set first, and the reservation is
+// released after. A slice in between still reports a reservation while its
+// capacity is on the way out, so it is not the one to measure against.
 func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
 	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
 	if err != nil {
 		return nil, err
 	}
 	for i := range slices.Backward(workloads) {
-		if workload.HasQuotaReservation(&workloads[i]) {
+		if workload.HasQuotaReservation(&workloads[i]) && !workloadevict.IsEvicted(&workloads[i]) {
 			return &workloads[i], nil
 		}
 	}
@@ -277,9 +281,10 @@ func normalizeActiveSlices(
 		if workloadevict.IsEvicted(wl) {
 			continue
 		}
-		if latestNonEvicted == nil || wl.CreationTimestamp.After(latestNonEvicted.CreationTimestamp.Time) {
-			latestNonEvicted = wl
-		}
+		// The input is already sorted oldest-first with a UID tie-break, so the
+		// last one seen is the latest. Comparing timestamps here would keep the
+		// first of two created in the same second instead.
+		latestNonEvicted = wl
 		if !workload.HasQuotaReservation(wl) {
 			continue
 		}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1139,6 +1139,18 @@ func TestNormalizeActiveSlices(t *testing.T) {
 			},
 			want: want{survivor: "wl-d", keptAdmitted: "wl-c"},
 		},
+		// Neither holds a reservation, so the survivor is the latest one. The
+		// caller passes these already sorted with a UID tie-break, so the last
+		// is the latest even when both were created in the same second.
+		"two pending slices created in the same second": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-a", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+				*utiltestingapi.MakeWorkload("wl-b", "ns").ResourceVersion("1").Creation(now).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			want: want{survivor: "wl-b"},
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -1386,6 +1398,70 @@ func TestScaledDown(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			if got := ScaledDown(tt.args.oldCounts, tt.args.newCounts); got != tt.want {
 				t.Errorf("ScaledDown() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindLatestActiveWorkload(t *testing.T) {
+	now := time.Now()
+	admission := utiltestingapi.MakeAdmission("cq").Obj()
+
+	live := func(name string, created time.Time) *utiltestingapi.WorkloadWrapper {
+		return testWorkload(name, testJobObject.Name, testJobObject.UID, created).
+			ReserveQuotaAt(admission, created)
+	}
+
+	cases := map[string]struct {
+		workloads []kueue.Workload
+		want      string
+	}{
+		"none": {},
+		"the only reserved one": {
+			workloads: []kueue.Workload{*live("only", now).Obj()},
+			want:      "only",
+		},
+		"the newest reserved one": {
+			workloads: []kueue.Workload{
+				*live("older", now.Add(-time.Minute)).Obj(),
+				*live("newer", now).Obj(),
+			},
+			want: "newer",
+		},
+		// Eviction sets its condition before the reservation is released, so a
+		// slice can still report one while its capacity is on the way out. The
+		// older slice is the one still holding capacity.
+		"a newer slice that is being evicted": {
+			workloads: []kueue.Workload{
+				*live("older", now.Add(-time.Minute)).Obj(),
+				*live("evicting", now).EvictedAt(now).Obj(),
+			},
+			want: "older",
+		},
+		"every slice is being evicted": {
+			workloads: []kueue.Workload{
+				*live("one", now.Add(-time.Minute)).EvictedAt(now).Obj(),
+				*live("two", now).EvictedAt(now).Obj(),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cl := testWorkloadClientBuilder().
+				WithLists(&kueue.WorkloadList{Items: tc.workloads}).Build()
+
+			got, err := FindLatestActiveWorkload(ctx, cl, testJobObject, testJobGVK)
+			if err != nil {
+				t.Fatalf("FindLatestActiveWorkload() error = %v", err)
+			}
+			var gotName string
+			if got != nil {
+				gotName = got.Name
+			}
+			if gotName != tc.want {
+				t.Errorf("FindLatestActiveWorkload() = %q, want %q", gotName, tc.want)
 			}
 		})
 	}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4441,6 +4441,93 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
 	})
 
+	ginkgo.It("Should stop ungating once the slice holding the reservation is evicted", framework.SlowSpec, func() {
+		// Eviction is two writes: the condition is set first and the
+		// reservation released after, and the reconciler only releases it once
+		// the job is no longer active. In between the slice still reports the
+		// capacity it is giving up, and the ungater used to keep letting pods
+		// through against it.
+		testJob := testingjob.MakeJob("evicting-slice", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1").
+			Parallelism(3).
+			Completions(3).
+			Obj()
+		util.MustCreate(ctx, k8sClient, testJob)
+
+		var (
+			slice  *kueue.Workload
+			podSet kueue.PodSetReference
+		)
+		ginkgo.By("admitting the slice at three pods", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				workloads := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+				g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+				slice = &workloads.Items[0]
+				g.Expect(workload.IsAdmitted(slice)).Should(gomega.BeTrue())
+				g.Expect(slice.Spec.PodSets[0].Count).Should(gomega.BeEquivalentTo(int32(3)))
+				podSet = slice.Spec.PodSets[0].Name
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		mintGatedPod := func(name string) {
+			pod := testingpod.MakePod(name, ns.Name).
+				Annotation(kueue.WorkloadAnnotation, slice.Name).
+				Annotation(kueue.WorkloadSliceNameAnnotation, slice.Name).
+				Label(pkgconstants.PodSetLabel, string(podSet)).
+				Gate(kueue.ElasticJobSchedulingGate).
+				Obj()
+			util.MustCreate(ctx, k8sClient, pod)
+		}
+
+		ginkgo.By("ungating two pods, which leaves room under the granted three", func() {
+			mintGatedPod("pod-0")
+			mintGatedPod("pod-1")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// The reservation is cleared by the job reconciler only once the job is
+		// no longer active, so an active job is what holds the window open.
+		ginkgo.By("reporting the job as active", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+				testJob.Status.Active = 1
+				g.Expect(k8sClient.Status().Update(ctx, testJob)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("evicting the slice while it still holds its reservation", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(slice), slice)).Should(gomega.Succeed())
+				apimeta.SetStatusCondition(&slice.Status.Conditions, metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadEvictedByPreemption,
+					Message: "preempted",
+				})
+				g.Expect(k8sClient.Status().Update(ctx, slice)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(slice), slice)).Should(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(slice)).Should(gomega.BeTrue())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("the third pod stays gated, since the capacity it would take is being released", func() {
+			mintGatedPod("pod-2")
+			// Held for the full timeout rather than the usual consistency
+			// window: without the fix the ungater takes about a second to
+			// reach this pod, which is longer than that window.
+			gomega.Consistently(func(g gomega.Gomega) {
+				g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(2))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should support job scale-down and scale-up", framework.SlowSpec, func() {
 		testJob := testingjob.MakeJob("job1", ns.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4519,11 +4519,11 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 
 		ginkgo.By("the third pod stays gated, since the capacity it would take is being released", func() {
 			mintGatedPod("pod-2")
-			// Longer than the usual consistency window, which is shorter than
-			// the second or so the ungater takes to reach a newly created pod.
+			// The usual window is shorter than the second or so the ungater
+			// takes to reach a newly created pod.
 			gomega.Consistently(func(g gomega.Gomega) {
 				g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(2))
-			}, 2*time.Second, util.Interval).Should(gomega.Succeed())
+			}, util.LongConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
 		// The same pod goes through once the slice is live again, which is what

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4519,11 +4519,23 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 
 		ginkgo.By("the third pod stays gated, since the capacity it would take is being released", func() {
 			mintGatedPod("pod-2")
-			// Held for the full timeout rather than the usual consistency
-			// window: without the fix the ungater takes about a second to
-			// reach this pod, which is longer than that window.
+			// Longer than the usual consistency window, which is shorter than
+			// the second or so the ungater takes to reach a newly created pod.
 			gomega.Consistently(func(g gomega.Gomega) {
 				g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(2))
+			}, 2*time.Second, util.Interval).Should(gomega.Succeed())
+		})
+
+		// The same pod goes through once the slice is live again, which is what
+		// separates the assertion above from a reconcile that never happened.
+		ginkgo.By("ungating it after the eviction is undone", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(slice), slice)).Should(gomega.Succeed())
+				apimeta.RemoveStatusCondition(&slice.Status.Conditions, kueue.WorkloadEvicted)
+				g.Expect(k8sClient.Status().Update(ctx, slice)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(sets.List(ungatedPodNames(g, ns.Name))).Should(gomega.HaveLen(3))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/util/constants.go
+++ b/test/util/constants.go
@@ -43,9 +43,12 @@ const (
 	VeryLongTimeout         = 5 * time.Minute
 	ConsistentDuration      = 300 * time.Millisecond
 	ShortConsistentDuration = 100 * time.Millisecond
-	ShortInterval           = 10 * time.Millisecond
-	Interval                = time.Millisecond * 250
-	LongInterval            = time.Second * 1
+	// LongConsistentDuration is for asserting that something does not happen
+	// when a controller would take longer than ConsistentDuration to do it.
+	LongConsistentDuration = 2 * time.Second
+	ShortInterval          = 10 * time.Millisecond
+	Interval               = time.Millisecond * 250
+	LongInterval           = time.Second * 1
 	// DRAExampleDriverName is the DeviceClass name registered by the dra-example-driver.
 	DRAExampleDriverName = "gpu.example.com"
 )


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area core

#### What this PR does / why we need it:

`FindLatestActiveWorkload` returns the newest slice in the chain that holds a quota reservation. Eviction is two writes: `prepareForEviction` sets the `Evicted` condition, and the reservation is released afterwards. A slice observed in between still reports one, so the helper could return the slice whose capacity is on the way out rather than the one still holding it.

That matters because of who reads it. The elastic job ungater resolves the chain's active slice and then uses its granted counts as the cap for removing `ElasticJobSchedulingGate`:

```go
granted := workload.ExtractPodSetCountsFromWorkload(wl)
```

So the cap was raised to capacity that is being released. With an older slice granting one pod, a newer evicting slice granting three, and two gated pods, both were ungated. The regression added here reports `count=2` without the fix and `count=1` with it, which is what the live slice grants.

##### The second change

`normalizeActiveSlices` picked its latest non-evicted slice with `CreationTimestamp.After`, which keeps the first of two slices created in the same second rather than the last. `FindNotFinishedWorkloads` already sorts oldest-first with a UID tie-break for that case, added by #12931. Everything that is not selected is finished as out of sync, so the two orderings disagreed about which slice survives. The input is already sorted, so the last one seen is the latest.

#### Which issue(s) this PR fixes:

Fixes #13913

#### Special notes for your reviewer:

The helper is shared: the ungater calls it from `activeSlice` deliberately, to order the chain the same way as the slicing code. So the regression is in both places, at the helper and at the ungater where the consequence lands.

Both changes fail their own test when reverted, which I checked: the helper returns `evicting` instead of `older`, and the survivor becomes `wl-a` instead of `wl-b`.

`go build ./...`, `go vet ./pkg/...` and `golangci-lint` are clean, and `pkg/workloadslicing` and `pkg/controller/elasticjobs` pass under `go test -race -count=20`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed elastic job pods being ungated against a workload slice that was already being evicted, which allowed more pods to start than the slice still holding the reservation granted.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload scheduling so evicted workloads no longer affect pod admission decisions.
  * Ensured the most recent active workload is selected consistently, including workloads created within the same second.
  * Prevented additional pods from being admitted when the active workload’s capacity has been reached.

* **Tests**
  * Added coverage for evicted workloads, active reservations, capacity limits, and same-second workload creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->