### PR TITLE
fix: Add CreationStore to skip duplicate ProvisioningRequests

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +53,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/podset"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
+	"sigs.k8s.io/kueue/pkg/util/expectations"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -82,11 +84,12 @@ func newProvisioningConfigHelper(c client.Client) (*provisioningConfigHelper, er
 }
 
 type Controller struct {
-	client      client.Client
-	record      events.EventRecorder
-	helper      *provisioningConfigHelper
-	clock       clock.Clock
-	roleTracker *roletracker.RoleTracker
+	client                  client.Client
+	record                  events.EventRecorder
+	helper                  *provisioningConfigHelper
+	clock                   clock.Clock
+	roleTracker             *roletracker.RoleTracker
+	creationExpectations    *expectations.CreationStore
 }
 
 type workloadInfo struct {
@@ -110,11 +113,12 @@ func NewController(client client.Client, record events.EventRecorder, roleTracke
 		return nil, err
 	}
 	return &Controller{
-		client:      client,
-		record:      record,
-		helper:      helper,
-		clock:       realClock,
-		roleTracker: roleTracker,
+		client:               client,
+		record:               record,
+		helper:               helper,
+		clock:                realClock,
+		roleTracker:          roleTracker,
+		creationExpectations: expectations.NewCreationStore("provisioningRequests", 10*time.Second),
 	}, nil
 }
 
@@ -124,12 +128,17 @@ func NewController(client client.Client, record events.EventRecorder, roleTracke
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	wl := &kueue.Workload{}
 
+	log := ctrl.LoggerFrom(ctx)
+
+	// Reset expired creation expectations so that a missed watch event
+	// cannot block provisioning request creation indefinitely.
+	c.creationExpectations.ResetExpired(log)
+
 	err := c.client.Get(ctx, req.NamespacedName, wl)
 	if err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile Workload")
 
 	isFinished := workloadfinish.IsFinished(wl)
@@ -289,7 +298,15 @@ func (c *Controller) syncOwnedProvisionRequest(
 			shouldCreatePr = true
 		}
 		requestName := ProvisioningRequestName(wl.Name, checkName, attempt)
+		prKey := types.NamespacedName{Name: requestName, Namespace: wl.Namespace}
 		if shouldCreatePr {
+			// If a creation expectation is still outstanding for this
+			// ProvisioningRequest, skip creating it again. The expectation
+			// is cleared when the object appears in the informer cache.
+			if !c.creationExpectations.Satisfied(log, prKey) {
+				log.V(3).Info("Skipping ProvisioningRequest creation due to outstanding creation expectation", "requestName", requestName)
+				continue
+			}
 			log.V(3).Info("Creating ProvisioningRequest", "requestName", requestName, "attempt", attempt)
 			req = &autoscaling.ProvisioningRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -342,8 +359,17 @@ func (c *Controller) syncOwnedProvisionRequest(
 
 			if err := c.client.Create(ctx, req); err != nil {
 				msg := fmt.Sprintf("Error creating ProvisioningRequest %q: %v", requestName, err)
+				if apierrors.IsAlreadyExists(err) {
+					// The object already exists on the API server. Set a creation
+					// expectation so we don't immediately retry the create before
+					// the informer cache catches up. The expectation is cleared
+					// when the object appears in a watch event.
+					c.creationExpectations.ExpectCreation(log, prKey)
+					return c.handleError(ctx, wl, ac, req, msg, err)
+				}
 				return c.handleError(ctx, wl, ac, req, msg, err)
 			}
+			c.creationExpectations.ExpectCreation(log, prKey)
 			c.record.Eventf(wl, nil, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
 		}
@@ -855,12 +881,16 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 		client:            c.client,
 		acHandlerOverride: ach.reconcileWorkloadsUsing,
 	}
+	prEventHandler := &provisioningRequestEventHandler{
+		creationExpectations: c.creationExpectations,
+	}
 	err := ctrl.NewControllerManagedBy(mgr).
 		Named("provisioning_workload").
 		For(&kueue.Workload{}).
 		Owns(&autoscaling.ProvisioningRequest{}).
 		Watches(&kueue.AdmissionCheck{}, ach).
 		Watches(&kueue.ProvisioningRequestConfig{}, prch).
+		Watches(&autoscaling.ProvisioningRequest{}, prEventHandler).
 		WithOptions(controller.Options{
 			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-workload"),
 		}).
@@ -885,6 +915,46 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 			LogConstructor: roletracker.NewLogConstructor(c.roleTracker, "provisioning-admissioncheck"),
 		}).
 		Complete(acReconciler)
+}
+
+// provisioningRequestEventHandler clears creation expectations when a
+// ProvisioningRequest is observed via a watch event (create/update/delete).
+// This prevents the expectation from blocking re-creation if the cache
+// eventually catches up.
+type provisioningRequestEventHandler struct {
+	creationExpectations *expectations.CreationStore
+}
+
+var _ handler.EventHandler = (*provisioningRequestEventHandler)(nil)
+
+func (h *provisioningRequestEventHandler) Create(ctx context.Context, e event.CreateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pr, ok := e.Object.(*autoscaling.ProvisioningRequest)
+	if !ok {
+		return
+	}
+	key := types.NamespacedName{Name: pr.Name, Namespace: pr.Namespace}
+	h.creationExpectations.CreationObserved(ctrl.LoggerFrom(ctx), key)
+}
+
+func (h *provisioningRequestEventHandler) Update(ctx context.Context, e event.UpdateEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pr, ok := e.ObjectNew.(*autoscaling.ProvisioningRequest)
+	if !ok {
+		return
+	}
+	key := types.NamespacedName{Name: pr.Name, Namespace: pr.Namespace}
+	h.creationExpectations.CreationObserved(ctrl.LoggerFrom(ctx), key)
+}
+
+func (h *provisioningRequestEventHandler) Delete(ctx context.Context, e event.DeleteEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	pr, ok := e.Object.(*autoscaling.ProvisioningRequest)
+	if !ok {
+		return
+	}
+	key := types.NamespacedName{Name: pr.Name, Namespace: pr.Namespace}
+	h.creationExpectations.CreationObserved(ctrl.LoggerFrom(ctx), key)
+}
+
+func (h *provisioningRequestEventHandler) Generic(_ context.Context, _ event.GenericEvent, _ workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 }
 
 func limitObjectName(fullName string) string {

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -377,6 +377,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 				return requeue, c.handleError(ctx, wl, ac, req, msg, err)
 			}
 			c.creationExpectations.ExpectCreation(log, prKey)
+			requeue = true
 			c.record.Eventf(wl, nil, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
 		}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -195,11 +195,16 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	err = c.syncOwnedProvisionRequest(ctx, wl, &wlInfo, checkConfig, activeOrLastPRForChecks)
+	requeue, err := c.syncOwnedProvisionRequest(ctx, wl, &wlInfo, checkConfig, activeOrLastPRForChecks)
 	if err != nil {
 		// this can also delete unneeded checks
 		log.V(2).Error(err, "syncOwnedProvisionRequest failed")
 		return reconcile.Result{}, err
+	}
+	if requeue {
+		// A creation expectation is outstanding; requeue after the TTL so the
+		// controller wakes up even if the watch event is missed.
+		return reconcile.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	return reconcile.Result{}, nil
@@ -261,8 +266,9 @@ func (c *Controller) syncOwnedProvisionRequest(
 	wlInfo *workloadInfo,
 	checkConfig map[kueue.AdmissionCheckReference]*kueue.ProvisioningRequestConfig,
 	activeOrLastPRForChecks map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest,
-) error {
+) (bool, error) {
 	log := ctrl.LoggerFrom(ctx)
+	requeue := false
 	for checkName, prc := range checkConfig {
 		if prc == nil {
 			// the check is not active
@@ -305,6 +311,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 			// is cleared when the object appears in the informer cache.
 			if !c.creationExpectations.Satisfied(log, prKey) {
 				log.V(3).Info("Skipping ProvisioningRequest creation due to outstanding creation expectation", "requestName", requestName)
+				requeue = true
 				continue
 			}
 			log.V(3).Info("Creating ProvisioningRequest", "requestName", requestName, "attempt", attempt)
@@ -325,7 +332,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 
 			mergedPodSets, err := mergePodSets(wl, &prc.Spec)
 			if err != nil {
-				return err
+				return requeue, err
 			}
 
 			for _, mergedPodSet := range mergedPodSets {
@@ -334,14 +341,14 @@ func (c *Controller) syncOwnedProvisionRequest(
 				pt := &corev1.PodTemplate{ObjectMeta: metav1.ObjectMeta{Namespace: wl.Namespace, Name: ptName}}
 				err := c.client.Get(ctx, client.ObjectKeyFromObject(pt), pt)
 				if client.IgnoreNotFound(err) != nil {
-					return err
+					return requeue, err
 				}
 				if err != nil {
 					// it's a not found, so create it
 					_, err := c.createPodTemplate(ctx, wl, ptName, mergedPodSet.PodSet, mergedPodSet.PodSetAssignment)
 					if err != nil {
 						msg := fmt.Sprintf("Error creating PodTemplate %q: %v", ptName, err)
-						return c.handleError(ctx, wl, ac, pt, msg, err)
+						return requeue, c.handleError(ctx, wl, ac, pt, msg, err)
 					}
 				}
 
@@ -354,7 +361,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 			}
 
 			if err := ctrl.SetControllerReference(wl, req, c.client.Scheme()); err != nil {
-				return err
+				return requeue, err
 			}
 
 			if err := c.client.Create(ctx, req); err != nil {
@@ -365,19 +372,19 @@ func (c *Controller) syncOwnedProvisionRequest(
 					// the informer cache catches up. The expectation is cleared
 					// when the object appears in a watch event.
 					c.creationExpectations.ExpectCreation(log, prKey)
-					return c.handleError(ctx, wl, ac, req, msg, err)
+					return requeue, c.handleError(ctx, wl, ac, req, msg, err)
 				}
-				return c.handleError(ctx, wl, ac, req, msg, err)
+				return requeue, c.handleError(ctx, wl, ac, req, msg, err)
 			}
 			c.creationExpectations.ExpectCreation(log, prKey)
 			c.record.Eventf(wl, nil, corev1.EventTypeNormal, "ProvisioningRequestCreated", "Created", "Created ProvisioningRequest: %q", req.Name)
 			activeOrLastPRForChecks[checkName] = req
 		}
 		if err := c.syncProvisionRequestsPodTemplates(ctx, wl, req); err != nil {
-			return err
+			return requeue, err
 		}
 	}
-	return nil
+	return requeue, nil
 }
 
 func (c *Controller) handleError(ctx context.Context, wl *kueue.Workload, ac *kueue.AdmissionCheckState, obj client.Object, msg string, err error) error {

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -84,12 +84,12 @@ func newProvisioningConfigHelper(c client.Client) (*provisioningConfigHelper, er
 }
 
 type Controller struct {
-	client                  client.Client
-	record                  events.EventRecorder
-	helper                  *provisioningConfigHelper
-	clock                   clock.Clock
-	roleTracker             *roletracker.RoleTracker
-	creationExpectations    *expectations.CreationStore
+	client               client.Client
+	record               events.EventRecorder
+	helper               *provisioningConfigHelper
+	clock                clock.Clock
+	roleTracker          *roletracker.RoleTracker
+	creationExpectations *expectations.CreationStore
 }
 
 type workloadInfo struct {

--- a/pkg/util/expectations/store.go
+++ b/pkg/util/expectations/store.go
@@ -98,9 +98,9 @@ func (e *Store) Satisfied(log logr.Logger, key types.NamespacedName) bool {
 // expectations.
 type CreationStore struct {
 	sync.Mutex
-	name    string
-	ttl     time.Duration
-	store   map[types.NamespacedName]time.Time
+	name  string
+	ttl   time.Duration
+	store map[types.NamespacedName]time.Time
 }
 
 // NewCreationStore creates a CreationStore with the given name and TTL.

--- a/pkg/util/expectations/store.go
+++ b/pkg/util/expectations/store.go
@@ -18,6 +18,7 @@ package expectations
 
 import (
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/types"
@@ -79,6 +80,89 @@ func (e *Store) Satisfied(log logr.Logger, key types.NamespacedName) bool {
 
 	if logV := log.V(4); logV.Enabled() {
 		log.V(4).Info("Retrieved satisfied expectations", "store", e.name, "key", key, "satisfied", !found)
+	}
+	return !found
+}
+
+// CreationStore tracks creation expectations for objects that may not yet be
+// observable in the informer cache.  After a controller successfully creates an
+// object it calls ExpectCreation; once the object appears in a watch event the
+// controller calls CreationObserved.  Satisfied returns true when no
+// outstanding creation expectation exists for the given key.
+//
+// Unlike Store (which tracks UIDs), CreationStore is keyed only by
+// NamespacedName because the UID is not known until after creation.
+//
+// Entries carry a timestamp so that a missed watch event cannot block creation
+// indefinitely; call ResetExpired before checking Satisfied to evict stale
+// expectations.
+type CreationStore struct {
+	sync.Mutex
+	name    string
+	ttl     time.Duration
+	store   map[types.NamespacedName]time.Time
+}
+
+// NewCreationStore creates a CreationStore with the given name and TTL.
+// A zero TTL means entries never expire (caller must ensure observations always
+// fire or manage expiry externally).
+func NewCreationStore(name string, ttl time.Duration) *CreationStore {
+	return &CreationStore{
+		name:  name,
+		ttl:   ttl,
+		store: make(map[types.NamespacedName]time.Time),
+	}
+}
+
+// ExpectCreation records that a create was issued for key.
+func (e *CreationStore) ExpectCreation(log logr.Logger, key types.NamespacedName) {
+	log.V(3).Info("Expecting creation", "store", e.name, "key", key)
+	e.Lock()
+	defer e.Unlock()
+	e.store[key] = time.Now()
+}
+
+// CreationObserved clears the expectation for key after the object has been
+// observed via a watch event.
+func (e *CreationStore) CreationObserved(log logr.Logger, key types.NamespacedName) {
+	log.V(3).Info("Observed creation", "store", e.name, "key", key)
+	e.Lock()
+	defer e.Unlock()
+	delete(e.store, key)
+}
+
+// ResetExpired removes entries whose timestamp is older than the TTL, returning
+// the number of entries removed.  Call this at the start of each reconcile or
+// on a periodic timer so that a missed watch event cannot block creation
+// indefinitely.
+func (e *CreationStore) ResetExpired(log logr.Logger) int {
+	if e.ttl <= 0 {
+		return 0
+	}
+	e.Lock()
+	defer e.Unlock()
+	now := time.Now()
+	expired := 0
+	for key, ts := range e.store {
+		if now.Sub(ts) > e.ttl {
+			delete(e.store, key)
+			expired++
+		}
+	}
+	if expired > 0 {
+		log.V(3).Info("Reset expired creation expectations", "store", e.name, "count", expired)
+	}
+	return expired
+}
+
+// Satisfied returns true if no outstanding creation expectation exists for key
+// (or if it existed but has expired and been cleared by ResetExpired).
+func (e *CreationStore) Satisfied(log logr.Logger, key types.NamespacedName) bool {
+	e.Lock()
+	_, found := e.store[key]
+	e.Unlock()
+	if logV := log.V(4); logV.Enabled() {
+		log.V(4).Info("Retrieved satisfied creation expectations", "store", e.name, "key", key, "satisfied", !found)
 	}
 	return !found
 }

--- a/pkg/util/expectations/store_test.go
+++ b/pkg/util/expectations/store_test.go
@@ -26,6 +26,75 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
+type keyUIDs struct {
+	key  types.NamespacedName
+	uids []types.UID
+}
+
+func TestExpectations(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	initial := []keyUIDs{
+		{
+			key:  types.NamespacedName{Name: "g1"},
+			uids: []types.UID{"a", "b", "c"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g2"},
+			uids: []types.UID{"x", "y", "z"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g3"},
+			uids: []types.UID{"a", "b", "c", "x", "y", "z"},
+		},
+	}
+	expectations := NewStore("test")
+	err := parallelize.Until(ctx, len(initial), func(i int) error {
+		e := initial[i]
+		expectations.ExpectUIDs(log, e.key, e.uids)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Inserting initial UIDs: %v", err)
+	}
+
+	observe := []keyUIDs{
+		{
+			key:  types.NamespacedName{Name: "g1"},
+			uids: []types.UID{"a", "b", "c"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g2"},
+			uids: []types.UID{"x", "y", "z", "x", "y", "z"},
+		},
+		{
+			key:  types.NamespacedName{Name: "g3"},
+			uids: []types.UID{"a", "b", "c", "x", "y"},
+		},
+	}
+	err = parallelize.Until(ctx, len(observe), func(i int) error {
+		e := observe[i]
+		return parallelize.Until(ctx, len(e.uids), func(j int) error {
+			expectations.ObservedUID(log, e.key, e.uids[j])
+			return nil
+		})
+	})
+	if err != nil {
+		t.Fatalf("Observing UIDs: %v", err)
+	}
+
+	wantSatisfied := map[types.NamespacedName]bool{
+		{Name: "g1"}: true,
+		{Name: "g2"}: true,
+		{Name: "g3"}: false,
+	}
+	for key, want := range wantSatisfied {
+		got := expectations.Satisfied(log, key)
+		if got != want {
+			t.Errorf("Got key %s satisfied: %t, want %t", key, got, want)
+		}
+	}
+}
+
 func TestCreationStore(t *testing.T) {
 	log := utiltesting.NewLogger(t)
 	cs := NewCreationStore("test", 0) // no expiry
@@ -93,15 +162,18 @@ func TestCreationStoreResetExpired(t *testing.T) {
 		t.Errorf("Expected key to NOT be satisfied after ExpectCreation")
 	}
 
-	// Before TTL expires, still not satisfied.
-	time.Sleep(10 * time.Millisecond)
+	// Before TTL expires, ResetExpired must retain the expectation.
+	removed := cs.ResetExpired(log)
+	if removed != 0 {
+		t.Errorf("Expected 0 expired entries before TTL expiry, got %d", removed)
+	}
 	if cs.Satisfied(log, key) {
 		t.Errorf("Expected key to NOT be satisfied before TTL expiry")
 	}
 
 	// Wait for TTL to expire, then reset.
 	time.Sleep(100 * time.Millisecond)
-	removed := cs.ResetExpired(log)
+	removed = cs.ResetExpired(log)
 	if removed != 1 {
 		t.Errorf("Expected 1 expired entry to be removed, got %d", removed)
 	}

--- a/pkg/util/expectations/store_test.go
+++ b/pkg/util/expectations/store_test.go
@@ -18,6 +18,7 @@ package expectations
 
 import (
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -25,72 +26,138 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 )
 
-type keyUIDs struct {
-	key  types.NamespacedName
-	uids []types.UID
+func TestCreationStore(t *testing.T) {
+	log := utiltesting.NewLogger(t)
+	cs := NewCreationStore("test", 0) // no expiry
+
+	key1 := types.NamespacedName{Name: "pr1", Namespace: "ns1"}
+	key2 := types.NamespacedName{Name: "pr2", Namespace: "ns2"}
+
+	// Initially all expectations are satisfied (no outstanding creations).
+	if !cs.Satisfied(log, key1) {
+		t.Errorf("Expected key1 to be satisfied initially")
+	}
+	if !cs.Satisfied(log, key2) {
+		t.Errorf("Expected key2 to be satisfied initially")
+	}
+
+	// ExpectCreation records an outstanding creation.
+	cs.ExpectCreation(log, key1)
+	if cs.Satisfied(log, key1) {
+		t.Errorf("Expected key1 to NOT be satisfied after ExpectCreation")
+	}
+	if !cs.Satisfied(log, key2) {
+		t.Errorf("Expected key2 to still be satisfied")
+	}
+
+	// CreationObserved clears the expectation.
+	cs.CreationObserved(log, key1)
+	if !cs.Satisfied(log, key1) {
+		t.Errorf("Expected key1 to be satisfied after CreationObserved")
+	}
+
+	// Multiple expectations can be tracked independently.
+	cs.ExpectCreation(log, key1)
+	cs.ExpectCreation(log, key2)
+	if cs.Satisfied(log, key1) {
+		t.Errorf("Expected key1 to NOT be satisfied")
+	}
+	if cs.Satisfied(log, key2) {
+		t.Errorf("Expected key2 to NOT be satisfied")
+	}
+
+	cs.CreationObserved(log, key1)
+	if !cs.Satisfied(log, key1) {
+		t.Errorf("Expected key1 to be satisfied after CreationObserved")
+	}
+	if cs.Satisfied(log, key2) {
+		t.Errorf("Expected key2 to still NOT be satisfied")
+	}
+
+	cs.CreationObserved(log, key2)
+	if !cs.Satisfied(log, key2) {
+		t.Errorf("Expected key2 to be satisfied after CreationObserved")
+	}
 }
 
-func TestExpectations(t *testing.T) {
-	ctx, log := utiltesting.ContextWithLog(t)
-	initial := []keyUIDs{
-		{
-			key:  types.NamespacedName{Name: "g1"},
-			uids: []types.UID{"a", "b", "c"},
-		},
-		{
-			key:  types.NamespacedName{Name: "g2"},
-			uids: []types.UID{"x", "y", "z"},
-		},
-		{
+func TestCreationStoreResetExpired(t *testing.T) {
+	log := utiltesting.NewLogger(t)
+	ttl := 50 * time.Millisecond
+	cs := NewCreationStore("test", ttl)
 
-			key:  types.NamespacedName{Name: "g3"},
-			uids: []types.UID{"a", "b", "c", "x", "y", "z"},
-		},
+	key := types.NamespacedName{Name: "pr1", Namespace: "ns1"}
+
+	// Record an expectation.
+	cs.ExpectCreation(log, key)
+	if cs.Satisfied(log, key) {
+		t.Errorf("Expected key to NOT be satisfied after ExpectCreation")
 	}
-	expectations := NewStore("test")
-	err := parallelize.Until(ctx, len(initial), func(i int) error {
-		e := initial[i]
-		expectations.ExpectUIDs(log, e.key, e.uids)
+
+	// Before TTL expires, still not satisfied.
+	time.Sleep(10 * time.Millisecond)
+	if cs.Satisfied(log, key) {
+		t.Errorf("Expected key to NOT be satisfied before TTL expiry")
+	}
+
+	// Wait for TTL to expire, then reset.
+	time.Sleep(100 * time.Millisecond)
+	removed := cs.ResetExpired(log)
+	if removed != 1 {
+		t.Errorf("Expected 1 expired entry to be removed, got %d", removed)
+	}
+	if !cs.Satisfied(log, key) {
+		t.Errorf("Expected key to be satisfied after ResetExpired")
+	}
+
+	// ResetExpired on an empty store returns 0.
+	removed = cs.ResetExpired(log)
+	if removed != 0 {
+		t.Errorf("Expected 0 expired entries, got %d", removed)
+	}
+}
+
+func TestCreationStoreConcurrentAccess(t *testing.T) {
+	log := utiltesting.NewLogger(t)
+	cs := NewCreationStore("test", 0)
+	keys := []types.NamespacedName{
+		{Name: "pr1", Namespace: "ns1"},
+		{Name: "pr2", Namespace: "ns2"},
+		{Name: "pr3", Namespace: "ns3"},
+	}
+
+	// Concurrent ExpectCreation + CreationObserved should not race.
+	ctx := t.Context()
+	err := parallelize.Until(ctx, len(keys), func(i int) error {
+		key := keys[i]
+		cs.ExpectCreation(log, key)
+		cs.CreationObserved(log, key)
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("Inserting initial UIDs: %v", err)
+		t.Fatalf("Concurrent access: %v", err)
 	}
 
-	observe := []keyUIDs{
-		{
-			key:  types.NamespacedName{Name: "g1"},
-			uids: []types.UID{"a", "b", "c"},
-		},
-		{
-			key:  types.NamespacedName{Name: "g2"},
-			uids: []types.UID{"x", "y", "z", "x", "y", "z"},
-		},
-		{
-			key:  types.NamespacedName{Name: "g3"},
-			uids: []types.UID{"a", "b", "c", "x", "y"},
-		},
-	}
-	err = parallelize.Until(ctx, len(observe), func(i int) error {
-		e := observe[i]
-		return parallelize.Until(ctx, len(e.uids), func(j int) error {
-			expectations.ObservedUID(log, e.key, e.uids[j])
-			return nil
-		})
-	})
-	if err != nil {
-		t.Fatalf("Observing UIDs: %v", err)
-	}
-
-	wantSatisfied := map[types.NamespacedName]bool{
-		{Name: "g1"}: true,
-		{Name: "g2"}: true,
-		{Name: "g3"}: false,
-	}
-	for key, want := range wantSatisfied {
-		got := expectations.Satisfied(log, key)
-		if got != want {
-			t.Errorf("Got key %s satisfied: %t, want %t", key, got, want)
+	for _, key := range keys {
+		if !cs.Satisfied(log, key) {
+			t.Errorf("Expected key %s to be satisfied after concurrent Expect+Observe", key)
 		}
+	}
+}
+
+func TestCreationStoreNoTTL(t *testing.T) {
+	log := utiltesting.NewLogger(t)
+	cs := NewCreationStore("test", 0) // zero TTL means no expiry
+
+	key := types.NamespacedName{Name: "pr1", Namespace: "ns1"}
+	cs.ExpectCreation(log, key)
+
+	// With zero TTL, ResetExpired should never remove entries.
+	time.Sleep(100 * time.Millisecond)
+	removed := cs.ResetExpired(log)
+	if removed != 0 {
+		t.Errorf("Expected 0 removed entries with zero TTL, got %d", removed)
+	}
+	if cs.Satisfied(log, key) {
+		t.Errorf("Expected key to NOT be satisfied (zero TTL means no auto-expiry)")
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This PR explores and implements creation expectations for `ProvisioningRequest` objects in the provisioning controller to prevent duplicate API calls and `AlreadyExists` errors.

Currently, the provisioning controller handles the delay between creating a `ProvisioningRequest` and it appearing in the informer cache by retrying on subsequent reconciles, getting an `AlreadyExists` error, and backing off. 

This PR introduces a `CreationStore` (with a TTL to prevent indefinite blocking in case of missed watch events) to record an expectation whenever a `ProvisioningRequest` is successfully created or found to already exist. The expectation instructs the controller to skip duplicate creation attempts. The expectation is cleared instantly once the object is observed via a watch event (`Create/Update/Delete`). This simplifies the creation flow and prevents duplicate creates at the source rather than recovering from them afterward.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13880

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provisioning request handling to prevent duplicate requests during reconciliation.
  * Added recovery for stale creation attempts so processing can resume after delays or missed events.
  * Provisioning request events now correctly clear pending creation expectations.
  * Provisioning request errors are now surfaced alongside requeue status.
* **Reliability**
  * Added safeguards for concurrent request creation and event processing.
  * Added expiration handling for pending creation attempts, with configurable timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->