### PR TITLE
Watch the class a Workload references

### DIFF
--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -69,6 +69,10 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	if err := wpcRec.SetupWithManager(mgr, cfg); err != nil {
 		return "WorkloadPriorityClass", err
 	}
+	wpcRefRec := NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), opts.RoleTracker)
+	if err := wpcRefRec.SetupWithManager(mgr, cfg); err != nil {
+		return "WorkloadPriorityClassReference", err
+	}
 	qRec := NewLocalQueueReconciler(mgr.GetClient(), qManager, cc,
 		WithAdmissionFairSharingConfig(cfg.AdmissionFairSharing),
 		WithRoleTracker(opts.RoleTracker),

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -69,7 +69,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	if err := wpcRec.SetupWithManager(mgr, cfg); err != nil {
 		return "WorkloadPriorityClass", err
 	}
-	wpcRefRec := NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), opts.RoleTracker)
+	wpcRefRec := NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), mgr.GetAPIReader(), opts.RoleTracker)
 	if err := wpcRefRec.SetupWithManager(mgr, cfg); err != nil {
 		return "WorkloadPriorityClassReference", err
 	}

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -68,7 +66,7 @@ func (r *WorkloadPriorityClassReconciler) logger() logr.Logger {
 }
 
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;update
 
 func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var wpc kueue.WorkloadPriorityClass
@@ -151,38 +149,6 @@ func (r *WorkloadPriorityClassReconciler) Generic(e event.TypedGenericEvent[*kue
 	return false
 }
 
-// workloadPriorityClassRequest returns the class the Workload references, when
-// that reference is to a WorkloadPriorityClass. The name is the same key
-// Reconcile lists by, so a request made here finds the Workload that produced it.
-func workloadPriorityClassRequest(wl *kueue.Workload) (reconcile.Request, bool) {
-	if !workload.IsWorkloadPriorityClass(wl) {
-		return reconcile.Request{}, false
-	}
-	return reconcile.Request{
-		NamespacedName: types.NamespacedName{Name: wl.Spec.PriorityClassRef.Name},
-	}, true
-}
-
-// enqueueReferencedWorkloadPriorityClass enqueues the class a Workload now
-// points at. Written as an event handler rather than a map function because
-// that one enqueues the old object as well, and the class a Workload left has
-// nothing to repair.
-func enqueueReferencedWorkloadPriorityClass() handler.TypedEventHandler[*kueue.Workload, reconcile.Request] {
-	enqueue := func(wl *kueue.Workload, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-		if req, isClass := workloadPriorityClassRequest(wl); isClass {
-			q.Add(req)
-		}
-	}
-	return handler.TypedFuncs[*kueue.Workload, reconcile.Request]{
-		CreateFunc: func(_ context.Context, e event.TypedCreateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(e.Object, q)
-		},
-		UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			enqueue(e.ObjectNew, q)
-		},
-	}
-}
-
 func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload] {
 	return predicate.TypedFuncs[*kueue.Workload]{
 		CreateFunc: func(e event.TypedCreateEvent[*kueue.Workload]) bool {
@@ -204,6 +170,81 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 	}
 }
 
+// WorkloadPriorityClassReferenceReconciler keeps one Workload's priority in step
+// with the class it references. It is keyed on the Workload rather than the
+// class, so a Workload arriving at a class does not cost a pass over every other
+// Workload already using it.
+type WorkloadPriorityClassReferenceReconciler struct {
+	logName     string
+	client      client.Client
+	roleTracker *roletracker.RoleTracker
+}
+
+var _ reconcile.Reconciler = (*WorkloadPriorityClassReferenceReconciler)(nil)
+
+func NewWorkloadPriorityClassReferenceReconciler(
+	client client.Client,
+	roleTracker *roletracker.RoleTracker,
+) *WorkloadPriorityClassReferenceReconciler {
+	return &WorkloadPriorityClassReferenceReconciler{
+		logName:     "workloadpriorityclassreference-reconciler",
+		client:      client,
+		roleTracker: roleTracker,
+	}
+}
+
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;update
+
+func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var wl kueue.Workload
+	if err := r.client.Get(ctx, req.NamespacedName, &wl); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if !workload.IsWorkloadPriorityClass(&wl) {
+		return ctrl.Result{}, nil
+	}
+
+	log := ctrl.LoggerFrom(ctx).WithValues("workload", klog.KObj(&wl))
+	log.V(2).Info("Reconcile Workload priority class reference")
+
+	var wpc kueue.WorkloadPriorityClass
+	if err := r.client.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &wpc); err != nil {
+		// A class that does not exist yet sweeps the workloads referencing it
+		// when it is created.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if wl.Spec.Priority != nil && *wl.Spec.Priority == wpc.Value {
+		log.V(3).Info("Workload priority already up to date")
+		return ctrl.Result{}, nil
+	}
+
+	wl.Spec.Priority = new(wpc.Value)
+	if err := r.client.Update(ctx, &wl); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	log.V(2).Info("Updated workload priority", "newPriority", wpc.Value)
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *WorkloadPriorityClassReferenceReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) error {
+	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
+		Named("workloadpriorityclassreference_controller").
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&kueue.Workload{},
+			&handler.TypedEnqueueRequestForObject[*kueue.Workload]{},
+			workloadPriorityClassRefChanged(),
+		)).
+		WithOptions(controller.Options{
+			NeedLeaderElection:      new(false),
+			MaxConcurrentReconciles: mgr.GetControllerOptions().GroupKindConcurrency[kueue.SchemeGroupVersion.WithKind("Workload").GroupKind().String()],
+			LogConstructor:          roletracker.NewLogConstructor(r.roleTracker, "workloadpriorityclassreference-reconciler"),
+		}).
+		Complete(WithLeadingManager(mgr, r, &kueue.Workload{}, cfg))
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkloadPriorityClassReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) error {
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
@@ -213,16 +254,6 @@ func (r *WorkloadPriorityClassReconciler) SetupWithManager(mgr ctrl.Manager, cfg
 			&kueue.WorkloadPriorityClass{},
 			&handler.TypedEnqueueRequestForObject[*kueue.WorkloadPriorityClass]{},
 			r,
-		)).
-		// A class update reconciled before a Workload starts referencing that
-		// class finds nothing to update and is consumed. The Workload arrives
-		// with whatever value its own lookup returned, so the reference is what
-		// brings the class back for another pass.
-		WatchesRawSource(source.TypedKind(
-			mgr.GetCache(),
-			&kueue.Workload{},
-			enqueueReferencedWorkloadPriorityClass(),
-			workloadPriorityClassRefChanged(),
 		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      new(false),

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -199,11 +199,13 @@ func ownsPriority(wl *kueue.Workload) bool {
 type WorkloadPriorityClassReferenceReconciler struct {
 	logName string
 	client  client.Client
-	// The class is read straight from the API server. This reconcile is queued by
-	// a Workload event, so a cached read can be one this replica took before the
-	// class moved, and the pass that would have repaired it has already decided
-	// there was nothing to do. Reading live means any change after it is one the
-	// class controller still has an event for.
+	// Both objects are read straight from the API server, since neither cached
+	// answer is ordered against what this reconcile is deciding from. The class
+	// read can be one this replica took before the class moved, and the pass that
+	// would have repaired it has already decided there was nothing to do. The
+	// workload read can be one from before this reconcile's own write, which on a
+	// requeue still holds the value the class has since moved to, so the pass
+	// that came back to repair it reports nothing left to do instead.
 	apiReader   client.Reader
 	roleTracker *roletracker.RoleTracker
 }
@@ -227,7 +229,7 @@ func NewWorkloadPriorityClassReferenceReconciler(
 
 func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var wl kueue.Workload
-	if err := r.client.Get(ctx, req.NamespacedName, &wl); err != nil {
+	if err := r.apiReader.Get(ctx, req.NamespacedName, &wl); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	// Checked again here, not only in the predicate: the label can arrive
@@ -258,9 +260,9 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 	// The class can move between the read above and this write, and the pass that
 	// change starts can find the workload already holding the new value and leave
 	// it alone, which leaves nothing to stop this write landing on top of a
-	// correct one. Reading the class again is what notices: a change before this
-	// read is one this sees, and a change after it is one the class controller
-	// still has an event for.
+	// correct one. Reading the class again closes the window this write opened,
+	// and the requeue resolves from the API server rather than from a cache that
+	// has not caught up with the write above.
 	var after kueue.WorkloadPriorityClass
 	if err := r.apiReader.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &after); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -38,6 +38,7 @@ import (
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	clientutil "sigs.k8s.io/kueue/pkg/util/client"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -233,7 +234,7 @@ func NewWorkloadPriorityClassReferenceReconciler(
 	}
 }
 
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;update;patch
 
 func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var wl kueue.Workload
@@ -261,8 +262,13 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 		return ctrl.Result{}, nil
 	}
 
-	wl.Spec.Priority = new(wpc.Value)
-	if err := r.client.Update(ctx, &wl); err != nil {
+	// Patched rather than updated: the workload was read whole from the API
+	// server, and one field of it is this controller's to write. Strict is the
+	// helper's default, so the resourceVersion read above still has to match.
+	if err := clientutil.Patch(ctx, r.client, &wl, func() (bool, error) {
+		wl.Spec.Priority = new(wpc.Value)
+		return true, nil
+	}); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	// The class can move between the read above and this write, and the pass that

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -267,10 +267,11 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 	}
 	// The class can move between the read above and this write, and the pass that
 	// change starts can find the workload already holding the new value and leave
-	// it alone, which leaves nothing to stop this write landing on top of a
-	// correct one. Reading the class again closes the window this write opened,
-	// and the requeue resolves from the API server rather than from a cache that
-	// has not caught up with the write above.
+	// it alone, leaving nothing to stop this write landing on top of a correct one.
+	// Reading the class again catches a move up to this point, from the API server
+	// rather than a cache that has not caught up with the write. A move after this
+	// read is the class's own pass to notice, and that pass can still skip on a
+	// stale cached value: #14006.
 	var after kueue.WorkloadPriorityClass
 	if err := r.apiReader.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &after); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -190,8 +190,14 @@ func ownsPriority(wl *kueue.Workload) bool {
 // class, so a Workload arriving at a class does not cost a pass over every other
 // Workload already using it.
 type WorkloadPriorityClassReferenceReconciler struct {
-	logName     string
-	client      client.Client
+	logName string
+	client  client.Client
+	// The class is read straight from the API server. This reconcile is queued by
+	// a Workload event, so a cached read can be one this replica took before the
+	// class moved, and the pass that would have repaired it has already decided
+	// there was nothing to do. Reading live means any change after it is one the
+	// class controller still has an event for.
+	apiReader   client.Reader
 	roleTracker *roletracker.RoleTracker
 }
 
@@ -199,11 +205,13 @@ var _ reconcile.Reconciler = (*WorkloadPriorityClassReferenceReconciler)(nil)
 
 func NewWorkloadPriorityClassReferenceReconciler(
 	client client.Client,
+	apiReader client.Reader,
 	roleTracker *roletracker.RoleTracker,
 ) *WorkloadPriorityClassReferenceReconciler {
 	return &WorkloadPriorityClassReferenceReconciler{
 		logName:     "workloadpriorityclassreference-reconciler",
 		client:      client,
+		apiReader:   apiReader,
 		roleTracker: roleTracker,
 	}
 }
@@ -225,7 +233,7 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 	log.V(2).Info("Reconcile Workload priority class reference")
 
 	var wpc kueue.WorkloadPriorityClass
-	if err := r.client.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &wpc); err != nil {
+	if err := r.apiReader.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &wpc); err != nil {
 		// A class that does not exist yet sweeps the workloads referencing it
 		// when it is created.
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -19,6 +19,7 @@ package core
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-logr/logr"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -177,6 +178,12 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 	}
 }
 
+// classMovedRequeue is how long the reconcile waits before resolving again when
+// the class changed under it. Short, since the value it just wrote is known to
+// be the wrong one, and not zero, so a class being edited repeatedly does not
+// spin.
+const classMovedRequeue = time.Second
+
 // ownsPriority reports whether this cluster decides the Workload's priority.
 // A Workload MultiKueue created here carries the manager's resolution, and a
 // class of the same name on this cluster is not the one it was resolved from.
@@ -247,6 +254,20 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 	wl.Spec.Priority = new(wpc.Value)
 	if err := r.client.Update(ctx, &wl); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	// The class can move between the read above and this write, and the pass that
+	// change starts can find the workload already holding the new value and leave
+	// it alone, which leaves nothing to stop this write landing on top of a
+	// correct one. Reading the class again is what notices: a change before this
+	// read is one this sees, and a change after it is one the class controller
+	// still has an event for.
+	var after kueue.WorkloadPriorityClass
+	if err := r.apiReader.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &after); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if after.Value != wpc.Value {
+		log.V(2).Info("Class moved while the workload was being written", "wrote", wpc.Value, "now", after.Value)
+		return ctrl.Result{RequeueAfter: classMovedRequeue}, nil
 	}
 	log.V(2).Info("Updated workload priority", "newPriority", wpc.Value)
 	return ctrl.Result{}, nil

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -253,6 +253,8 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 
 	// The workload was read whole, and one field of it is this controller's to
 	// write. Strict is the helper's default, so the read above still has to match.
+	// A conflict belongs to the workqueue, not to a retry here: the helper retries
+	// through the cached client and keeps the class value this closure already read.
 	if err := clientutil.Patch(ctx, r.client, &wl, func() (bool, error) {
 		wl.Spec.Priority = new(wpc.Value)
 		return true, nil

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -158,12 +159,18 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 			if !ownsPriority(e.ObjectNew) {
 				return false
 			}
+			// The reference can stay put while the answer stops being someone
+			// else's. A Workload that loses the MultiKueue origin label carries a
+			// value resolved on the manager, from a class this cluster's own is
+			// under no obligation to agree with.
+			if !ownsPriority(e.ObjectOld) {
+				return true
+			}
 			// Compared as a whole reference, and against the reference rather
 			// than the value: Reconcile writes spec.priority and leaves the
 			// reference alone, so this does not fire on its own writes, and a
 			// move between two groups sharing a name is still a move.
-			old := e.ObjectOld.Spec.PriorityClassRef
-			return old == nil || *old != *e.ObjectNew.Spec.PriorityClassRef
+			return !apiequality.Semantic.DeepEqual(e.ObjectOld.Spec.PriorityClassRef, e.ObjectNew.Spec.PriorityClassRef)
 		},
 		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.Workload]) bool { return false },
 		GenericFunc: func(event.TypedGenericEvent[*kueue.Workload]) bool { return false },

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -100,9 +100,7 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		wl := &workloads.Items[i]
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
-		// The same question the reference reconciler asks, since a Workload
-		// MultiKueue created here holds the priority the manager resolved and a
-		// class of this name on this cluster is not the policy behind it.
+		// The same question the reference reconciler asks.
 		if !ownsPriority(wl) {
 			wlLog.V(3).Info("Workload's priority is not this cluster's to write")
 			continue
@@ -170,16 +168,14 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 				return false
 			}
 			// The reference can stay put while the answer stops being someone
-			// else's. A Workload that loses the MultiKueue origin label carries a
-			// value resolved on the manager, from a class this cluster's own is
-			// under no obligation to agree with.
+			// else's: a Workload losing the origin label carries the manager's
+			// resolution, not this cluster's.
 			if !ownsPriority(e.ObjectOld) {
 				return true
 			}
-			// Compared as a whole reference, and against the reference rather
-			// than the value: Reconcile writes spec.priority and leaves the
-			// reference alone, so this does not fire on its own writes, and a
-			// move between two groups sharing a name is still a move.
+			// The reference rather than the value, so this does not fire on
+			// Reconcile's own writes, and whole, so a move between two groups
+			// sharing a name is still a move.
 			return !apiequality.Semantic.DeepEqual(e.ObjectOld.Spec.PriorityClassRef, e.ObjectNew.Spec.PriorityClassRef)
 		},
 		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.Workload]) bool { return false },
@@ -187,34 +183,27 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 	}
 }
 
-// classMovedRequeue is how long the reconcile waits before resolving again when
-// the class changed under it. Short, since the value it just wrote is known to
-// be the wrong one, and not zero, so a class being edited repeatedly does not
-// spin.
+// classMovedRequeue is short, since the value just written is known to be the
+// wrong one, and not zero, so a class edited repeatedly does not spin.
 const classMovedRequeue = time.Second
 
-// ownsPriority reports whether this cluster decides the Workload's priority.
-// A Workload MultiKueue created here carries the manager's resolution, and a
-// class of the same name on this cluster is not the one it was resolved from.
+// ownsPriority reports whether this cluster decides the Workload's priority. A
+// Workload MultiKueue created here carries the manager's resolution, from a
+// class this cluster's own of that name need not agree with.
 func ownsPriority(wl *kueue.Workload) bool {
 	_, isMultiKueueRemote := wl.Labels[kueue.MultiKueueOriginLabel]
 	return !isMultiKueueRemote && workload.IsWorkloadPriorityClass(wl)
 }
 
 // WorkloadPriorityClassReferenceReconciler keeps one Workload's priority in step
-// with the class it references. It is keyed on the Workload rather than the
-// class, so a Workload arriving at a class does not cost a pass over every other
-// Workload already using it.
+// with the class it references, keyed on the Workload so that one arriving at a
+// class does not cost a pass over every other Workload already using it.
 type WorkloadPriorityClassReferenceReconciler struct {
 	logName string
 	client  client.Client
-	// Both objects are read straight from the API server, since neither cached
-	// answer is ordered against what this reconcile is deciding from. The class
-	// read can be one this replica took before the class moved, and the pass that
-	// would have repaired it has already decided there was nothing to do. The
-	// workload read can be one from before this reconcile's own write, which on a
-	// requeue still holds the value the class has since moved to, so the pass
-	// that came back to repair it reports nothing left to do instead.
+	// Both read straight from the API server: a cached answer is not ordered
+	// against what this reconcile decides from, and either one being behind
+	// leaves the pass that came to repair the value reporting nothing to do.
 	apiReader   client.Reader
 	roleTracker *roletracker.RoleTracker
 }
@@ -262,22 +251,19 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 		return ctrl.Result{}, nil
 	}
 
-	// Patched rather than updated: the workload was read whole from the API
-	// server, and one field of it is this controller's to write. Strict is the
-	// helper's default, so the resourceVersion read above still has to match.
+	// The workload was read whole, and one field of it is this controller's to
+	// write. Strict is the helper's default, so the read above still has to match.
 	if err := clientutil.Patch(ctx, r.client, &wl, func() (bool, error) {
 		wl.Spec.Priority = new(wpc.Value)
 		return true, nil
 	}); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	// The class can move between the read above and this write, and the pass that
-	// change starts can find the workload already holding the new value and leave
-	// it alone, leaving nothing to stop this write landing on top of a correct one.
-	// Reading the class again catches a move up to this point, from the API server
-	// rather than a cache that has not caught up with the write. A move after this
-	// read is the class's own pass to notice, and that pass can still skip on a
-	// stale cached value: #14006.
+	// A class moving between the read above and this write leaves the pass that
+	// change starts finding the new value already there, so nothing stops this
+	// write landing on a correct one. Reading again catches a move up to here. A
+	// move after it is the class's own pass to notice, and that pass can still
+	// skip on a stale cached value: #14006.
 	var after kueue.WorkloadPriorityClass
 	if err := r.apiReader.Get(ctx, client.ObjectKey{Name: wl.Spec.PriorityClassRef.Name}, &after); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -152,10 +152,10 @@ func (r *WorkloadPriorityClassReconciler) Generic(e event.TypedGenericEvent[*kue
 func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload] {
 	return predicate.TypedFuncs[*kueue.Workload]{
 		CreateFunc: func(e event.TypedCreateEvent[*kueue.Workload]) bool {
-			return workload.IsWorkloadPriorityClass(e.Object)
+			return ownsPriority(e.Object)
 		},
 		UpdateFunc: func(e event.TypedUpdateEvent[*kueue.Workload]) bool {
-			if !workload.IsWorkloadPriorityClass(e.ObjectNew) {
+			if !ownsPriority(e.ObjectNew) {
 				return false
 			}
 			// Compared as a whole reference, and against the reference rather
@@ -168,6 +168,14 @@ func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload]
 		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.Workload]) bool { return false },
 		GenericFunc: func(event.TypedGenericEvent[*kueue.Workload]) bool { return false },
 	}
+}
+
+// ownsPriority reports whether this cluster decides the Workload's priority.
+// A Workload MultiKueue created here carries the manager's resolution, and a
+// class of the same name on this cluster is not the one it was resolved from.
+func ownsPriority(wl *kueue.Workload) bool {
+	_, isMultiKueueRemote := wl.Labels[kueue.MultiKueueOriginLabel]
+	return !isMultiKueueRemote && workload.IsWorkloadPriorityClass(wl)
 }
 
 // WorkloadPriorityClassReferenceReconciler keeps one Workload's priority in step
@@ -200,7 +208,9 @@ func (r *WorkloadPriorityClassReferenceReconciler) Reconcile(ctx context.Context
 	if err := r.client.Get(ctx, req.NamespacedName, &wl); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if !workload.IsWorkloadPriorityClass(&wl) {
+	// Checked again here, not only in the predicate: the label can arrive
+	// after the request was queued.
+	if !ownsPriority(&wl) {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -99,6 +99,14 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		wl := &workloads.Items[i]
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
+		// The same question the reference reconciler asks, since a Workload
+		// MultiKueue created here holds the priority the manager resolved and a
+		// class of this name on this cluster is not the policy behind it.
+		if !ownsPriority(wl) {
+			wlLog.V(3).Info("Workload's priority is not this cluster's to write")
+			continue
+		}
+
 		// Skip if priority is already up to date
 		if wl.Spec.Priority != nil && *wl.Spec.Priority == wpc.Value {
 			wlLog.V(3).Info("Workload priority already up to date")

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -37,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 // WorkloadPriorityClassReconciler reconciles a WorkloadPriorityClass object
@@ -65,7 +68,7 @@ func (r *WorkloadPriorityClassReconciler) logger() logr.Logger {
 }
 
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloadpriorityclasses,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;update
+// +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;update
 
 func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var wpc kueue.WorkloadPriorityClass
@@ -148,6 +151,59 @@ func (r *WorkloadPriorityClassReconciler) Generic(e event.TypedGenericEvent[*kue
 	return false
 }
 
+// workloadPriorityClassRequest returns the class the Workload references, when
+// that reference is to a WorkloadPriorityClass. The name is the same key
+// Reconcile lists by, so a request made here finds the Workload that produced it.
+func workloadPriorityClassRequest(wl *kueue.Workload) (reconcile.Request, bool) {
+	if !workload.IsWorkloadPriorityClass(wl) {
+		return reconcile.Request{}, false
+	}
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: wl.Spec.PriorityClassRef.Name},
+	}, true
+}
+
+// enqueueReferencedWorkloadPriorityClass enqueues the class a Workload now
+// points at. Written as an event handler rather than a map function because
+// that one enqueues the old object as well, and the class a Workload left has
+// nothing to repair.
+func enqueueReferencedWorkloadPriorityClass() handler.TypedEventHandler[*kueue.Workload, reconcile.Request] {
+	enqueue := func(wl *kueue.Workload, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		if req, isClass := workloadPriorityClassRequest(wl); isClass {
+			q.Add(req)
+		}
+	}
+	return handler.TypedFuncs[*kueue.Workload, reconcile.Request]{
+		CreateFunc: func(_ context.Context, e event.TypedCreateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(e.Object, q)
+		},
+		UpdateFunc: func(_ context.Context, e event.TypedUpdateEvent[*kueue.Workload], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(e.ObjectNew, q)
+		},
+	}
+}
+
+func workloadPriorityClassRefChanged() predicate.TypedPredicate[*kueue.Workload] {
+	return predicate.TypedFuncs[*kueue.Workload]{
+		CreateFunc: func(e event.TypedCreateEvent[*kueue.Workload]) bool {
+			return workload.IsWorkloadPriorityClass(e.Object)
+		},
+		UpdateFunc: func(e event.TypedUpdateEvent[*kueue.Workload]) bool {
+			if !workload.IsWorkloadPriorityClass(e.ObjectNew) {
+				return false
+			}
+			// Compared as a whole reference, and against the reference rather
+			// than the value: Reconcile writes spec.priority and leaves the
+			// reference alone, so this does not fire on its own writes, and a
+			// move between two groups sharing a name is still a move.
+			old := e.ObjectOld.Spec.PriorityClassRef
+			return old == nil || *old != *e.ObjectNew.Spec.PriorityClassRef
+		},
+		DeleteFunc:  func(event.TypedDeleteEvent[*kueue.Workload]) bool { return false },
+		GenericFunc: func(event.TypedGenericEvent[*kueue.Workload]) bool { return false },
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *WorkloadPriorityClassReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Configuration) error {
 	return builder.TypedControllerManagedBy[reconcile.Request](mgr).
@@ -157,6 +213,16 @@ func (r *WorkloadPriorityClassReconciler) SetupWithManager(mgr ctrl.Manager, cfg
 			&kueue.WorkloadPriorityClass{},
 			&handler.TypedEnqueueRequestForObject[*kueue.WorkloadPriorityClass]{},
 			r,
+		)).
+		// A class update reconciled before a Workload starts referencing that
+		// class finds nothing to update and is consumed. The Workload arrives
+		// with whatever value its own lookup returned, so the reference is what
+		// brings the class back for another pass.
+		WatchesRawSource(source.TypedKind(
+			mgr.GetCache(),
+			&kueue.Workload{},
+			enqueueReferencedWorkloadPriorityClass(),
+			workloadPriorityClassRefChanged(),
 		)).
 		WithOptions(controller.Options{
 			NeedLeaderElection:      new(false),

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -291,5 +292,211 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestWorkloadPriorityClassRefChangedPredicate(t *testing.T) {
+	cases := map[string]struct {
+		eventType string
+		oldWL     *kueue.Workload
+		newWL     *kueue.Workload
+		want      bool
+	}{
+		"created already referencing a class": {
+			eventType: "create",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      true,
+		},
+		"created referencing a Pod PriorityClass": {
+			eventType: "create",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+			want:      false,
+		},
+		"created referencing nothing": {
+			eventType: "create",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").Obj(),
+			want:      false,
+		},
+		"reference added": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      true,
+		},
+		// Only the group tells these apart, so a predicate comparing names alone
+		// would call this unchanged and leave the class unreconciled.
+		"moved from a Pod PriorityClass of the same name": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      true,
+		},
+		"moved between classes": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("low").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      true,
+		},
+		// What Reconcile itself writes.
+		"same class, priority value rewritten": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
+			want:      false,
+		},
+		"same class, nothing changed": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      false,
+		},
+		"moved to a Pod PriorityClass": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+			want:      false,
+		},
+		"deleted": {
+			eventType: "delete",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      false,
+		},
+		"generic": {
+			eventType: "generic",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			p := workloadPriorityClassRefChanged()
+			var got bool
+			switch tc.eventType {
+			case "create":
+				got = p.Create(event.TypedCreateEvent[*kueue.Workload]{Object: tc.newWL})
+			case "update":
+				got = p.Update(event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: tc.oldWL, ObjectNew: tc.newWL})
+			case "delete":
+				got = p.Delete(event.TypedDeleteEvent[*kueue.Workload]{Object: tc.oldWL})
+			case "generic":
+				got = p.Generic(event.TypedGenericEvent[*kueue.Workload]{Object: tc.newWL})
+			default:
+				t.Fatalf("unknown event type %q", tc.eventType)
+			}
+			if got != tc.want {
+				t.Errorf("predicate = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnqueueReferencedWorkloadPriorityClass(t *testing.T) {
+	cases := map[string]struct {
+		eventType string
+		oldWL     *kueue.Workload
+		newWL     *kueue.Workload
+		want      []reconcile.Request
+	}{
+		"created referencing a class": {
+			eventType: "create",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "high"}}},
+		},
+		"created referencing a Pod PriorityClass": {
+			eventType: "create",
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+		},
+		// The class being left has nothing to repair, and a map function would
+		// enqueue it too.
+		"moved between classes": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("low").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:      []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "high"}}},
+		},
+		"moved to a Pod PriorityClass": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := enqueueReferencedWorkloadPriorityClass()
+			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+			defer q.ShutDown()
+
+			switch tc.eventType {
+			case "create":
+				h.Create(t.Context(), event.TypedCreateEvent[*kueue.Workload]{Object: tc.newWL}, q)
+			case "update":
+				h.Update(t.Context(), event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: tc.oldWL, ObjectNew: tc.newWL}, q)
+			default:
+				t.Fatalf("unknown event type %q", tc.eventType)
+			}
+
+			var got []reconcile.Request
+			for q.Len() > 0 {
+				req, _ := q.Get()
+				got = append(got, req)
+				q.Done(req)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("enqueued requests (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestWorkloadPriorityClassValueSurvivesLateReference walks the ordering the
+// watch exists for: the class update is reconciled while no Workload references
+// the class yet, and the Workload then arrives carrying the value its own
+// lookup returned before the change.
+func TestWorkloadPriorityClassValueSurvivesLateReference(t *testing.T) {
+	ctx := t.Context()
+	high := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj()
+	wl := utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("low").Priority(100).Obj()
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(high, wl).
+		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+		Build()
+	r := NewWorkloadPriorityClassReconciler(cl, nil)
+
+	classReq := reconcile.Request{NamespacedName: types.NamespacedName{Name: "high"}}
+	if _, err := r.Reconcile(ctx, classReq); err != nil {
+		t.Fatalf("reconciling the class before it is referenced: %v", err)
+	}
+
+	oldWL := wl.DeepCopy()
+	newWL := wl.DeepCopy()
+	newWL.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("high")
+	if err := cl.Update(ctx, newWL); err != nil {
+		t.Fatalf("pointing the workload at the class: %v", err)
+	}
+
+	if !workloadPriorityClassRefChanged().Update(event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: oldWL, ObjectNew: newWL}) {
+		t.Fatal("the reference change was filtered out, so nothing reaches the queue")
+	}
+	q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
+	defer q.ShutDown()
+	enqueueReferencedWorkloadPriorityClass().Update(ctx, event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: oldWL, ObjectNew: newWL}, q)
+	for q.Len() > 0 {
+		req, _ := q.Get()
+		if _, err := r.Reconcile(ctx, req); err != nil {
+			t.Fatalf("reconciling %v: %v", req, err)
+		}
+		q.Done(req)
+	}
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
+		t.Fatalf("reading the workload back: %v", err)
+	}
+	if got.Spec.Priority == nil {
+		t.Fatal("workload priority is unset, want 200")
+	}
+	if *got.Spec.Priority != 200 {
+		t.Errorf("workload priority = %d, want 200", *got.Spec.Priority)
 	}
 }

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -390,59 +389,82 @@ func TestWorkloadPriorityClassRefChangedPredicate(t *testing.T) {
 	}
 }
 
-func TestEnqueueReferencedWorkloadPriorityClass(t *testing.T) {
+func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 	cases := map[string]struct {
-		eventType string
-		oldWL     *kueue.Workload
-		newWL     *kueue.Workload
-		want      []reconcile.Request
+		workload     *kueue.Workload
+		class        *kueue.WorkloadPriorityClass
+		wantPriority *int32
+		wantUpdates  int
 	}{
-		"created referencing a class": {
-			eventType: "create",
-			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
-			want:      []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "high"}}},
+		"a value left behind by an earlier reconcile": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(200)),
+			wantUpdates:  1,
 		},
-		"created referencing a Pod PriorityClass": {
-			eventType: "create",
-			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+		"a value already in step with the class": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(200)),
 		},
-		// The class being left has nothing to repair, and a map function would
-		// enqueue it too.
-		"moved between classes": {
-			eventType: "update",
-			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("low").Obj(),
-			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
-			want:      []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "high"}}},
+		// The class sweeps what references it when it is created.
+		"a class that does not exist yet": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+			wantPriority: new(int32(100)),
 		},
-		"moved to a Pod PriorityClass": {
-			eventType: "update",
-			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
-			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+		"a reference to a Pod PriorityClass": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Priority(100).Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(100)),
+		},
+		"no reference at all": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").Priority(100).Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(100)),
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			h := enqueueReferencedWorkloadPriorityClass()
-			q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
-			defer q.ShutDown()
+			ctx, _ := utiltesting.ContextWithLog(t)
+			var updates, workloadLists int
+			objs := []client.Object{tc.workload}
+			if tc.class != nil {
+				objs = append(objs, tc.class)
+			}
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(objs...).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+						updates++
+						return c.Update(ctx, obj, opts...)
+					},
+					List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+						if _, isWorkloads := list.(*kueue.WorkloadList); isWorkloads {
+							workloadLists++
+						}
+						return c.List(ctx, list, opts...)
+					},
+				}).Build()
 
-			switch tc.eventType {
-			case "create":
-				h.Create(t.Context(), event.TypedCreateEvent[*kueue.Workload]{Object: tc.newWL}, q)
-			case "update":
-				h.Update(t.Context(), event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: tc.oldWL, ObjectNew: tc.newWL}, q)
-			default:
-				t.Fatalf("unknown event type %q", tc.eventType)
+			r := NewWorkloadPriorityClassReferenceReconciler(cl, nil)
+			if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tc.workload)}); err != nil {
+				t.Fatalf("Reconcile() = %v", err)
 			}
 
-			var got []reconcile.Request
-			for q.Len() > 0 {
-				req, _ := q.Get()
-				got = append(got, req)
-				q.Done(req)
+			var got kueue.Workload
+			if err := cl.Get(ctx, client.ObjectKeyFromObject(tc.workload), &got); err != nil {
+				t.Fatalf("reading the workload back: %v", err)
 			}
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("enqueued requests (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tc.wantPriority, got.Spec.Priority); diff != "" {
+				t.Errorf("workload priority (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantUpdates, updates); diff != "" {
+				t.Errorf("workload updates (-want +got):\n%s", diff)
+			}
+			// The whole point of keying on the Workload: one arriving at a
+			// class must not cost a pass over every other Workload using it.
+			if workloadLists != 0 {
+				t.Errorf("listed workloads %d times, want none", workloadLists)
 			}
 		})
 	}
@@ -453,7 +475,7 @@ func TestEnqueueReferencedWorkloadPriorityClass(t *testing.T) {
 // the class yet, and the Workload then arrives carrying the value its own
 // lookup returned before the change.
 func TestWorkloadPriorityClassValueSurvivesLateReference(t *testing.T) {
-	ctx := t.Context()
+	ctx, _ := utiltesting.ContextWithLog(t)
 	high := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj()
 	wl := utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("low").Priority(100).Obj()
 
@@ -461,10 +483,9 @@ func TestWorkloadPriorityClassValueSurvivesLateReference(t *testing.T) {
 		WithObjects(high, wl).
 		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
 		Build()
-	r := NewWorkloadPriorityClassReconciler(cl, nil)
 
-	classReq := reconcile.Request{NamespacedName: types.NamespacedName{Name: "high"}}
-	if _, err := r.Reconcile(ctx, classReq); err != nil {
+	classReconciler := NewWorkloadPriorityClassReconciler(cl, nil)
+	if _, err := classReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
 		t.Fatalf("reconciling the class before it is referenced: %v", err)
 	}
 
@@ -478,25 +499,19 @@ func TestWorkloadPriorityClassValueSurvivesLateReference(t *testing.T) {
 	if !workloadPriorityClassRefChanged().Update(event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: oldWL, ObjectNew: newWL}) {
 		t.Fatal("the reference change was filtered out, so nothing reaches the queue")
 	}
-	q := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[reconcile.Request]())
-	defer q.ShutDown()
-	enqueueReferencedWorkloadPriorityClass().Update(ctx, event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: oldWL, ObjectNew: newWL}, q)
-	for q.Len() > 0 {
-		req, _ := q.Get()
-		if _, err := r.Reconcile(ctx, req); err != nil {
-			t.Fatalf("reconciling %v: %v", req, err)
-		}
-		q.Done(req)
+	refReconciler := NewWorkloadPriorityClassReferenceReconciler(cl, nil)
+	if _, err := refReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(wl)}); err != nil {
+		t.Fatalf("reconciling the workload: %v", err)
 	}
 
 	var got kueue.Workload
 	if err := cl.Get(ctx, client.ObjectKeyFromObject(wl), &got); err != nil {
 		t.Fatalf("reading the workload back: %v", err)
 	}
-	if got.Spec.Priority == nil {
-		t.Fatal("workload priority is unset, want 200")
+	if diff := cmp.Diff(new(int32(200)), got.Spec.Priority); diff != "" {
+		t.Errorf("workload priority (-want +got):\n%s", diff)
 	}
-	if *got.Spec.Priority != 200 {
-		t.Errorf("workload priority = %d, want 200", *got.Spec.Priority)
+	if diff := cmp.Diff(kueue.NewWorkloadPriorityClassRef("high"), got.Spec.PriorityClassRef); diff != "" {
+		t.Errorf("workload priority class reference (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -306,6 +306,14 @@ func TestWorkloadPriorityClassRefChangedPredicate(t *testing.T) {
 			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
 			want:      true,
 		},
+		// MultiKueue copies the manager's resolution onto the remote Workload,
+		// and a class of the same name here is not the one it came from.
+		"created by MultiKueue on this cluster": {
+			eventType: "create",
+			newWL: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			want: false,
+		},
 		"created referencing a Pod PriorityClass": {
 			eventType: "create",
 			newWL:     utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
@@ -348,6 +356,13 @@ func TestWorkloadPriorityClassRefChangedPredicate(t *testing.T) {
 			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
 			newWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
 			want:      false,
+		},
+		"reference added on a Workload MultiKueue created here": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			newWL: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			want: false,
 		},
 		"moved to a Pod PriorityClass": {
 			eventType: "update",
@@ -410,6 +425,12 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 		// The class sweeps what references it when it is created.
 		"a class that does not exist yet": {
 			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
+			wantPriority: new(int32(100)),
+		},
+		"a Workload MultiKueue created here": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
 			wantPriority: new(int32(100)),
 		},
 		"a reference to a Pod PriorityClass": {

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -364,6 +364,30 @@ func TestWorkloadPriorityClassRefChangedPredicate(t *testing.T) {
 				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
 			want: false,
 		},
+		// The manager resolved the value this Workload carries. Once the label
+		// saying so is gone, this cluster's class is what it has to follow, and
+		// the reference did not have to move for that to be true.
+		"ownership moved here with the reference unchanged": {
+			eventType: "update",
+			oldWL: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			newWL: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			want:  true,
+		},
+		"ownership moved away with the reference unchanged": {
+			eventType: "update",
+			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			newWL: utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			want: false,
+		},
+		"ownership moved here on a Pod PriorityClass reference": {
+			eventType: "update",
+			oldWL: utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").Obj(),
+			newWL: utiltestingapi.MakeWorkload("wl", "ns").PodPriorityClassRef("high").Obj(),
+			want:  false,
+		},
 		"moved to a Pod PriorityClass": {
 			eventType: "update",
 			oldWL:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -466,6 +466,14 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 			wantPriority: new(int32(200)),
 			wantWrites:   1,
 		},
+		// A reference can arrive before anything has filled the priority, so
+		// unset is a state to resolve rather than a value to leave alone.
+		"a reference with nothing in the priority yet": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(200)),
+			wantWrites:   1,
+		},
 		// The rule this pins: the class wins over a value the user chose. A
 		// Workload created already referencing a class is resolved from it at
 		// once, where before this the value stood until the class next moved.

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -143,6 +143,31 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"reconcile leaves a Workload MultiKueue created here alone": {
+			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Obj(),
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(1000).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Obj(),
+			},
+		},
 		"reconcile skips workloads with up-to-date priority": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads: []kueue.Workload{

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -458,13 +458,13 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 		workload     *kueue.Workload
 		class        *kueue.WorkloadPriorityClass
 		wantPriority *int32
-		wantUpdates  int
+		wantWrites   int
 	}{
 		"a value left behind by an earlier reconcile": {
 			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(100).Obj(),
 			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
 			wantPriority: new(int32(200)),
-			wantUpdates:  1,
+			wantWrites:   1,
 		},
 		// The rule this pins: the class wins over a value the user chose. A
 		// Workload created already referencing a class is resolved from it at
@@ -475,7 +475,7 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(123).Obj(),
 			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
 			wantPriority: new(int32(200)),
-			wantUpdates:  1,
+			wantWrites:   1,
 		},
 		"a value already in step with the class": {
 			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
@@ -507,7 +507,7 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
-			var updates, workloadLists int
+			var writes, workloadLists int
 			objs := []client.Object{tc.workload}
 			if tc.class != nil {
 				objs = append(objs, tc.class)
@@ -515,9 +515,15 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().
 				WithObjects(objs...).
 				WithInterceptorFuncs(interceptor.Funcs{
+					// Counted whichever verb carries it, so the count says how
+					// often the workload was written rather than which call did it.
 					Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
-						updates++
+						writes++
 						return c.Update(ctx, obj, opts...)
+					},
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						writes++
+						return c.Patch(ctx, obj, patch, opts...)
 					},
 					List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 						if _, isWorkloads := list.(*kueue.WorkloadList); isWorkloads {
@@ -539,8 +545,8 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 			if diff := cmp.Diff(tc.wantPriority, got.Spec.Priority); diff != "" {
 				t.Errorf("workload priority (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantUpdates, updates); diff != "" {
-				t.Errorf("workload updates (-want +got):\n%s", diff)
+			if diff := cmp.Diff(tc.wantWrites, writes); diff != "" {
+				t.Errorf("workload writes (-want +got):\n%s", diff)
 			}
 			// The whole point of keying on the Workload: one arriving at a
 			// class must not cost a pass over every other Workload using it.

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -466,6 +466,17 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 			wantPriority: new(int32(200)),
 			wantUpdates:  1,
 		},
+		// The rule this pins: the class wins over a value the user chose. A
+		// Workload created already referencing a class is resolved from it at
+		// once, where before this the value stood until the class next moved.
+		// A later numeric-only update is left alone, so an override is still
+		// available, just not in the same request as the reference.
+		"a value the user chose, against the class it references": {
+			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(123).Obj(),
+			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),
+			wantPriority: new(int32(200)),
+			wantUpdates:  1,
+		},
 		"a value already in step with the class": {
 			workload:     utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
 			class:        utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj(),

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -491,7 +491,7 @@ func TestWorkloadPriorityClassReferenceReconcile(t *testing.T) {
 					},
 				}).Build()
 
-			r := NewWorkloadPriorityClassReferenceReconciler(cl, nil)
+			r := NewWorkloadPriorityClassReferenceReconciler(cl, cl, nil)
 			if _, err := r.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tc.workload)}); err != nil {
 				t.Fatalf("Reconcile() = %v", err)
 			}
@@ -544,7 +544,7 @@ func TestWorkloadPriorityClassValueSurvivesLateReference(t *testing.T) {
 	if !workloadPriorityClassRefChanged().Update(event.TypedUpdateEvent[*kueue.Workload]{ObjectOld: oldWL, ObjectNew: newWL}) {
 		t.Fatal("the reference change was filtered out, so nothing reaches the queue")
 	}
-	refReconciler := NewWorkloadPriorityClassReferenceReconciler(cl, nil)
+	refReconciler := NewWorkloadPriorityClassReferenceReconciler(cl, cl, nil)
 	if _, err := refReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(wl)}); err != nil {
 		t.Fatalf("reconciling the workload: %v", err)
 	}

--- a/pkg/controller/core/workloadpriorityclass_reference_race_test.go
+++ b/pkg/controller/core/workloadpriorityclass_reference_race_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+// This reconcile is queued by a Workload event, so nothing orders its read of
+// the class against the class controller's own pass. Read from a cache, that
+// value can be one this replica took before the class moved, and by the time
+// the write lands the pass that would have repaired it has already looked at a
+// workload that was still correct and left it alone. Nothing is queued after
+// that: the write only changed a number, which the predicate filters.
+func TestReferenceReconcileDoesNotWriteAClassValueItReadEarlier(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	live := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(200).Obj()
+	wl := utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj()
+
+	classReads := 0
+	var cl client.WithWatch
+	builder := utiltesting.NewClientBuilder().
+		WithObjects(live, wl).
+		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				class, ok := obj.(*kueue.WorkloadPriorityClass)
+				if !ok {
+					return nil
+				}
+				classReads++
+				if classReads == 1 {
+					// The reference reconcile's read, taken before this replica
+					// saw the class move.
+					class.Value = 100
+					// While it holds that, the class controller runs on the value
+					// the store now has.
+					sweep := NewWorkloadPriorityClassReconciler(cl, roletracker.NewFakeRoleTracker("leader"))
+					if _, err := sweep.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
+						t.Errorf("class sweep: %v", err)
+					}
+				}
+				return nil
+			},
+		})
+	cl = builder.Build()
+	// The API server itself, which the interceptor above does not sit in front of.
+	apiReader := utiltesting.NewClientBuilder().WithObjects(live, wl).Build()
+
+	ref := NewWorkloadPriorityClassReferenceReconciler(cl, apiReader, roletracker.NewFakeRoleTracker("leader"))
+	if _, err := ref.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}); err != nil {
+		t.Fatalf("reference reconcile: %v", err)
+	}
+
+	var got kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("class reads: %d; workload priority = %d, class value = 200", classReads, ptr.Deref(got.Spec.Priority, -1))
+	if ptr.Deref(got.Spec.Priority, -1) != 200 {
+		t.Errorf("STALE WRITE WON: workload left at %d", ptr.Deref(got.Spec.Priority, -1))
+	}
+}

--- a/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
+++ b/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -203,5 +204,75 @@ func TestReferenceReconcileResolvesTheRequeueFromTheAPIServer(t *testing.T) {
 	t.Logf("class value = 200, workload priority = %d", ptr.Deref(got.Spec.Priority, -1))
 	if ptr.Deref(got.Spec.Priority, -1) != 200 {
 		t.Errorf("WINDOW OPEN: workload left at %d", ptr.Deref(got.Spec.Priority, -1))
+	}
+}
+
+// The patch carries the resourceVersion the workload was read at, so a change
+// landing between that read and the write takes a conflict rather than being
+// crossed. Both cases move what this pass decided from.
+func TestReferenceReconcileConflictsRatherThanCrossingAWrite(t *testing.T) {
+	for name, tc := range map[string]struct {
+		disturb func(*kueue.Workload)
+		want    int32
+	}{
+		// Ownership passed to MultiKueue, so the value this pass resolved is no
+		// longer this cluster's to write and the workload keeps what it had.
+		"the workload becomes MultiKueue's": {
+			disturb: func(wl *kueue.Workload) {
+				wl.Labels = map[string]string{kueue.MultiKueueOriginLabel: "manager"}
+			},
+			want: 200,
+		},
+		"the reference moves to another class": {
+			disturb: func(wl *kueue.Workload) { wl.Spec.PriorityClassRef.Name = "other" },
+			want:    50,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			api := utiltesting.NewClientBuilder().
+				WithObjects(
+					utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+					utiltestingapi.MakeWorkloadPriorityClass("other").PriorityValue(50).Obj(),
+					utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
+				).
+				WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+				Build()
+
+			disturbed := false
+			mgrClient := interceptor.NewClient(api, interceptor.Funcs{
+				Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if _, ok := obj.(*kueue.Workload); ok && !disturbed {
+						disturbed = true
+						var live kueue.Workload
+						if err := api.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &live); err != nil {
+							t.Fatalf("reading the workload to disturb it: %v", err)
+						}
+						tc.disturb(&live)
+						if err := api.Update(ctx, &live); err != nil {
+							t.Fatalf("disturbing the workload: %v", err)
+						}
+					}
+					return c.Patch(ctx, obj, patch, opts...)
+				},
+			})
+
+			ref := NewWorkloadPriorityClassReferenceReconciler(mgrClient, api, roletracker.NewFakeRoleTracker("leader"))
+			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}
+			if _, err := ref.Reconcile(ctx, req); !apierrors.IsConflict(err) {
+				t.Fatalf("first pass returned %v, want a conflict", err)
+			}
+			if _, err := ref.Reconcile(ctx, req); err != nil {
+				t.Fatalf("second pass: %v", err)
+			}
+
+			var got kueue.Workload
+			if err := api.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &got); err != nil {
+				t.Fatal(err)
+			}
+			if ptr.Deref(got.Spec.Priority, -1) != tc.want {
+				t.Errorf("priority %d, want %d", ptr.Deref(got.Spec.Priority, -1), tc.want)
+			}
+		})
 	}
 }

--- a/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
+++ b/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
+	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+// A live read is still a read. The class can move after it, and if the sweep
+// that follows finds the workload already holding the value it is moving to, it
+// writes nothing and leaves the resourceVersion alone, so the write this
+// reconcile is still carrying lands on top of it.
+func TestReferenceReconcileNoticesTheClassMovingUnderIt(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	class := utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj()
+	// Already carrying the value the class is about to move to.
+	wl := utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj()
+
+	var store client.WithWatch
+	moved := false
+	builder := utiltesting.NewClientBuilder().
+		WithObjects(class, wl).
+		WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := c.Get(ctx, key, obj, opts...); err != nil {
+					return err
+				}
+				if _, ok := obj.(*kueue.WorkloadPriorityClass); ok && !moved {
+					moved = true
+					// The read above returned 100. The class moves now, and its
+					// controller runs before this reconcile gets to its write.
+					var live kueue.WorkloadPriorityClass
+					if err := store.Get(ctx, client.ObjectKey{Name: "high"}, &live); err != nil {
+						t.Fatalf("moving the class: %v", err)
+					}
+					live.Value = 200
+					if err := store.Update(ctx, &live); err != nil {
+						t.Fatalf("moving the class: %v", err)
+					}
+					sweep := NewWorkloadPriorityClassReconciler(store, roletracker.NewFakeRoleTracker("leader"))
+					if _, err := sweep.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
+						t.Errorf("class sweep: %v", err)
+					}
+				}
+				return nil
+			},
+		})
+	store = builder.Build()
+
+	ref := NewWorkloadPriorityClassReferenceReconciler(store, store, roletracker.NewFakeRoleTracker("leader"))
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}
+	// Driven the way the manager drives it: a result asking to come back does.
+	passes := 0
+	for {
+		res, err := ref.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("reference reconcile: %v", err)
+		}
+		passes++
+		if res.RequeueAfter == 0 || passes > 4 {
+			break
+		}
+	}
+	t.Logf("passes: %d", passes)
+
+	var got kueue.Workload
+	if err := store.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("class value = 200, workload priority = %d", ptr.Deref(got.Spec.Priority, -1))
+	if ptr.Deref(got.Spec.Priority, -1) != 200 {
+		t.Errorf("WINDOW OPEN: workload left at %d", ptr.Deref(got.Spec.Priority, -1))
+	}
+}

--- a/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
+++ b/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
@@ -129,6 +129,36 @@ func TestReferenceReconcileResolvesTheRequeueFromTheAPIServer(t *testing.T) {
 	// to the API server.
 	var mgrClient client.WithWatch
 	moved := false
+	// The class moves once the workload write has landed, whichever verb carried
+	// it. Its own informer sees that, which is what queues the sweep, while the
+	// workload informer is still behind the write.
+	afterWorkloadWrite := func(ctx context.Context, obj client.Object) error {
+		if _, ok := obj.(*kueue.Workload); !ok || moved {
+			return nil
+		}
+		moved = true
+		var live kueue.WorkloadPriorityClass
+		if err := api.Get(ctx, client.ObjectKey{Name: "high"}, &live); err != nil {
+			t.Fatalf("moving the class: %v", err)
+		}
+		live.Value = 200
+		if err := api.Update(ctx, &live); err != nil {
+			t.Fatalf("moving the class: %v", err)
+		}
+		var cached kueue.WorkloadPriorityClass
+		if err := cache.Get(ctx, client.ObjectKey{Name: "high"}, &cached); err != nil {
+			t.Fatalf("moving the class: %v", err)
+		}
+		live.ResourceVersion = cached.ResourceVersion
+		if err := cache.Update(ctx, &live); err != nil {
+			t.Fatalf("moving the class: %v", err)
+		}
+		sweep := NewWorkloadPriorityClassReconciler(mgrClient, roletracker.NewFakeRoleTracker("leader"))
+		if _, err := sweep.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
+			t.Errorf("class sweep: %v", err)
+		}
+		return nil
+	}
 	mgrClient = interceptor.NewClient(api, interceptor.Funcs{
 		Get: func(ctx context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			return cache.Get(ctx, key, obj, opts...)
@@ -140,34 +170,13 @@ func TestReferenceReconcileResolvesTheRequeueFromTheAPIServer(t *testing.T) {
 			if err := c.Update(ctx, obj, opts...); err != nil {
 				return err
 			}
-			if _, ok := obj.(*kueue.Workload); !ok || moved {
-				return nil
+			return afterWorkloadWrite(ctx, obj)
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if err := c.Patch(ctx, obj, patch, opts...); err != nil {
+				return err
 			}
-			moved = true
-			// The class moves once the write has landed. Its own informer sees
-			// that, which is what queues the sweep, while the workload informer
-			// is still behind the write.
-			var live kueue.WorkloadPriorityClass
-			if err := api.Get(ctx, client.ObjectKey{Name: "high"}, &live); err != nil {
-				t.Fatalf("moving the class: %v", err)
-			}
-			live.Value = 200
-			if err := api.Update(ctx, &live); err != nil {
-				t.Fatalf("moving the class: %v", err)
-			}
-			var cached kueue.WorkloadPriorityClass
-			if err := cache.Get(ctx, client.ObjectKey{Name: "high"}, &cached); err != nil {
-				t.Fatalf("moving the class: %v", err)
-			}
-			live.ResourceVersion = cached.ResourceVersion
-			if err := cache.Update(ctx, &live); err != nil {
-				t.Fatalf("moving the class: %v", err)
-			}
-			sweep := NewWorkloadPriorityClassReconciler(mgrClient, roletracker.NewFakeRoleTracker("leader"))
-			if _, err := sweep.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
-				t.Errorf("class sweep: %v", err)
-			}
-			return nil
+			return afterWorkloadWrite(ctx, obj)
 		},
 	})
 

--- a/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
+++ b/pkg/controller/core/workloadpriorityclass_reference_toctou_test.go
@@ -86,14 +86,109 @@ func TestReferenceReconcileNoticesTheClassMovingUnderIt(t *testing.T) {
 			t.Fatalf("reference reconcile: %v", err)
 		}
 		passes++
-		if res.RequeueAfter == 0 || passes > 4 {
+		if res.RequeueAfter == 0 {
 			break
+		}
+		if passes == 4 {
+			t.Fatalf("still asking to come back after %d passes", passes)
 		}
 	}
 	t.Logf("passes: %d", passes)
 
 	var got kueue.Workload
 	if err := store.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &got); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("class value = 200, workload priority = %d", ptr.Deref(got.Spec.Priority, -1))
+	if ptr.Deref(got.Spec.Priority, -1) != 200 {
+		t.Errorf("WINDOW OPEN: workload left at %d", ptr.Deref(got.Spec.Priority, -1))
+	}
+}
+
+// The pass above comes back to a cache the write it made need not have reached
+// yet. Read from there, the workload still holds the value the class has since
+// moved to, so the pass sent to repair it finds nothing to do and the API server
+// keeps what the first pass wrote. Nothing follows: the watch catching up only
+// changes a number, which the predicate filters, and the class controller has
+// already spent its event.
+func TestReferenceReconcileResolvesTheRequeueFromTheAPIServer(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	newStore := func() client.WithWatch {
+		return utiltesting.NewClientBuilder().
+			WithObjects(
+				utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(100).Obj(),
+				utiltestingapi.MakeWorkload("wl", "ns").WorkloadPriorityClassRef("high").Priority(200).Obj(),
+			).
+			WithIndex(&kueue.Workload{}, indexer.WorkloadPriorityClassKey, indexer.IndexWorkloadPriorityClass).
+			Build()
+	}
+	api, cache := newStore(), newStore()
+
+	// What a manager hands a reconciler: reads served by an informer, writes sent
+	// to the API server.
+	var mgrClient client.WithWatch
+	moved := false
+	mgrClient = interceptor.NewClient(api, interceptor.Funcs{
+		Get: func(ctx context.Context, _ client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			return cache.Get(ctx, key, obj, opts...)
+		},
+		List: func(ctx context.Context, _ client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			return cache.List(ctx, list, opts...)
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if err := c.Update(ctx, obj, opts...); err != nil {
+				return err
+			}
+			if _, ok := obj.(*kueue.Workload); !ok || moved {
+				return nil
+			}
+			moved = true
+			// The class moves once the write has landed. Its own informer sees
+			// that, which is what queues the sweep, while the workload informer
+			// is still behind the write.
+			var live kueue.WorkloadPriorityClass
+			if err := api.Get(ctx, client.ObjectKey{Name: "high"}, &live); err != nil {
+				t.Fatalf("moving the class: %v", err)
+			}
+			live.Value = 200
+			if err := api.Update(ctx, &live); err != nil {
+				t.Fatalf("moving the class: %v", err)
+			}
+			var cached kueue.WorkloadPriorityClass
+			if err := cache.Get(ctx, client.ObjectKey{Name: "high"}, &cached); err != nil {
+				t.Fatalf("moving the class: %v", err)
+			}
+			live.ResourceVersion = cached.ResourceVersion
+			if err := cache.Update(ctx, &live); err != nil {
+				t.Fatalf("moving the class: %v", err)
+			}
+			sweep := NewWorkloadPriorityClassReconciler(mgrClient, roletracker.NewFakeRoleTracker("leader"))
+			if _, err := sweep.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "high"}}); err != nil {
+				t.Errorf("class sweep: %v", err)
+			}
+			return nil
+		},
+	})
+
+	ref := NewWorkloadPriorityClassReferenceReconciler(mgrClient, api, roletracker.NewFakeRoleTracker("leader"))
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"}}
+	for passes := 1; ; passes++ {
+		res, err := ref.Reconcile(ctx, req)
+		if err != nil {
+			t.Fatalf("reference reconcile: %v", err)
+		}
+		if res.RequeueAfter == 0 {
+			t.Logf("passes: %d", passes)
+			break
+		}
+		if passes == 4 {
+			t.Fatalf("still asking to come back after %d passes", passes)
+		}
+	}
+
+	var got kueue.Workload
+	if err := api.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "wl"}, &got); err != nil {
 		t.Fatal(err)
 	}
 	t.Logf("class value = 200, workload priority = %d", ptr.Deref(got.Spec.Priority, -1))

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -104,7 +104,7 @@ func managerWorkloadPriorityClassReferenceSetup(ctx context.Context, mgr manager
 	controllersCfg := &config.Configuration{}
 	mgr.GetScheme().Default(controllersCfg)
 
-	reconciler := core.NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), nil)
+	reconciler := core.NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), mgr.GetAPIReader(), nil)
 	gomega.Expect(reconciler.SetupWithManager(mgr, controllersCfg)).To(gomega.Succeed())
 }
 

--- a/test/integration/singlecluster/controller/core/suite_test.go
+++ b/test/integration/singlecluster/controller/core/suite_test.go
@@ -91,6 +91,23 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	managerAndControllerSetup(nil, runScheduler)(ctx, mgr)
 }
 
+// managerWorkloadPriorityClassReferenceSetup starts the Workload-keyed
+// reconciler on its own. The class-keyed one is left out so a repair can only
+// have come from the reference.
+func managerWorkloadPriorityClassReferenceSetup(ctx context.Context, mgr manager.Manager) {
+	err := indexer.Setup(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	failedWebhook, err := webhooks.Setup(mgr, nil)
+	gomega.Expect(err).ToNot(gomega.HaveOccurred(), "webhook", failedWebhook)
+
+	controllersCfg := &config.Configuration{}
+	mgr.GetScheme().Default(controllersCfg)
+
+	reconciler := core.NewWorkloadPriorityClassReferenceReconciler(mgr.GetClient(), nil)
+	gomega.Expect(reconciler.SetupWithManager(mgr, controllersCfg)).To(gomega.Succeed())
+}
+
 func managerAndControllerSetup(
 	controllersCfg *config.Configuration,
 	options ...managerSetupOption,

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -557,73 +557,6 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 		})
 	})
 
-	ginkgo.When("a workload starts referencing a WorkloadPriorityClass after that class was last reconciled", func() {
-		var source, target *kueue.WorkloadPriorityClass
-
-		ginkgo.BeforeEach(func() {
-			source = utiltestingapi.MakeWorkloadPriorityClass("reference-source").PriorityValue(100).Obj()
-			util.MustCreate(ctx, k8sClient, source)
-			ginkgo.DeferCleanup(func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, source, true)
-			})
-
-			target = utiltestingapi.MakeWorkloadPriorityClass("reference-target").PriorityValue(100).Obj()
-			util.MustCreate(ctx, k8sClient, target)
-			ginkgo.DeferCleanup(func() {
-				util.ExpectObjectToBeDeleted(ctx, k8sClient, target, true)
-			})
-		})
-		ginkgo.AfterEach(func() {
-			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-		})
-
-		ginkgo.It("should take the value of the class it moved to", func() {
-			settled := utiltestingapi.MakeWorkload("settled", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
-				WorkloadPriorityClassRef("reference-target").
-				Priority(0).
-				Obj()
-			util.MustCreate(ctx, k8sClient, settled)
-
-			wl = utiltestingapi.MakeWorkload("wl", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
-				WorkloadPriorityClassRef("reference-source").
-				Priority(100).
-				Obj()
-			util.MustCreate(ctx, k8sClient, wl)
-
-			// Raising the class is the only repair that no Workload event can
-			// account for, so seeing it land says the class controller has
-			// worked through everything queued for this class. Anything that
-			// reaches wl after this point came from the reference it moved to.
-			ginkgo.By("raising the target class and waiting for the class controller to carry it", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)).To(gomega.Succeed())
-					target.Value = 200
-					g.Expect(k8sClient.Update(ctx, target)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(settled), &updatedQueueWorkload)).To(gomega.Succeed())
-					g.Expect(updatedQueueWorkload.Spec.Priority).To(gomega.Equal(new(int32(200))))
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			// The value is left behind on purpose: it is what a lookup that read
-			// the class before its last change would have written.
-			ginkgo.By("moving the reference and leaving the value alone", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
-					updatedQueueWorkload.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("reference-target")
-					g.Expect(k8sClient.Update(ctx, &updatedQueueWorkload)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &finalQueueWorkload)).To(gomega.Succeed())
-				g.Expect(finalQueueWorkload.Spec.PriorityClassRef).To(gomega.Equal(kueue.NewWorkloadPriorityClassRef("reference-target")))
-				g.Expect(finalQueueWorkload.Spec.Priority).To(gomega.Equal(new(int32(200))))
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		})
-	})
-
 	ginkgo.When("the workload has a maximum execution time set", func() {
 		ginkgo.It("should deactivate the workload when the time expires", framework.SlowSpec, func() {
 			// due time rounding in conditions, the workload will stay admitted
@@ -1846,5 +1779,60 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 				},
 			)
 		})
+	})
+})
+
+var _ = ginkgo.Describe("Workload priority class reference", ginkgo.Label("controller:workload", "area:core"), func() {
+	var (
+		ns             *corev1.Namespace
+		source, target *kueue.WorkloadPriorityClass
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Only the reference reconciler, so nothing else can repair the value.
+		fwk.StartManager(ctx, cfg, managerWorkloadPriorityClassReferenceSetup)
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "core-wpc-ref-")
+
+		source = utiltestingapi.MakeWorkloadPriorityClass("reference-source").PriorityValue(100).Obj()
+		util.MustCreate(ctx, k8sClient, source)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, source, true)
+		})
+
+		target = utiltestingapi.MakeWorkloadPriorityClass("reference-target").PriorityValue(200).Obj()
+		util.MustCreate(ctx, k8sClient, target)
+		ginkgo.DeferCleanup(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, target, true)
+		})
+	})
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.It("should take the value of the class it moved to", func() {
+		wl := utiltestingapi.MakeWorkload("wl", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			WorkloadPriorityClassRef("reference-source").
+			Priority(100).
+			Obj()
+		util.MustCreate(ctx, k8sClient, wl)
+
+		// The value is left behind on purpose: it is what a lookup that read
+		// the class before its last change would have written.
+		ginkgo.By("moving the reference and leaving the value alone", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var got kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+				got.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("reference-target")
+				g.Expect(k8sClient.Update(ctx, &got)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got kueue.Workload
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.PriorityClassRef).To(gomega.Equal(kueue.NewWorkloadPriorityClassRef("reference-target")))
+			g.Expect(got.Spec.Priority).To(gomega.Equal(new(int32(200))))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1890,4 +1890,36 @@ var _ = ginkgo.Describe("Workload priority class reference", ginkgo.Label("contr
 		gomega.Eventually(expectPriority(owned, 200), util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Consistently(expectPriority(remote, 0), util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("should take the class over when the Workload stops being MultiKueue's", func() {
+		// Nothing about the reference moves here. What moves is who answers for
+		// the value, and the label is the only thing that said so.
+		remote := utiltestingapi.MakeWorkload("handed-over", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			WorkloadPriorityClassRef("reference-source").
+			Priority(0).
+			Label(kueue.MultiKueueOriginLabel, "manager").
+			Obj()
+		util.MustCreate(ctx, k8sClient, remote)
+
+		expectPriority := func(want int32) func(gomega.Gomega) {
+			return func(g gomega.Gomega) {
+				var got kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(remote), &got)).To(gomega.Succeed())
+				g.Expect(got.Spec.Priority).To(gomega.Equal(new(want)))
+			}
+		}
+		gomega.Consistently(expectPriority(0), util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+		ginkgo.By("dropping the origin label and leaving the reference where it is", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var got kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(remote), &got)).To(gomega.Succeed())
+				delete(got.Labels, kueue.MultiKueueOriginLabel)
+				g.Expect(got.Spec.PriorityClassRef).To(gomega.Equal(kueue.NewWorkloadPriorityClassRef("reference-source")))
+				g.Expect(k8sClient.Update(ctx, &got)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		gomega.Eventually(expectPriority(100), util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
 })

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1813,12 +1813,25 @@ var _ = ginkgo.Describe("Workload priority class reference", ginkgo.Label("contr
 	ginkgo.It("should take the value of the class it moved to", func() {
 		wl := utiltestingapi.MakeWorkload("wl", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
 			WorkloadPriorityClassRef("reference-source").
-			Priority(100).
+			Priority(0).
 			Obj()
 		util.MustCreate(ctx, k8sClient, wl)
 
+		// The create request has to be spent before the reference moves. It is
+		// enqueued for every workload this cluster owns the priority of, and it
+		// re-reads the workload, so one still in the queue could be what applies
+		// the target value and the reference event would go untested.
+		ginkgo.By("waiting for the create to settle on the source value", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				var got kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+				g.Expect(got.Spec.Priority).To(gomega.Equal(new(int32(100))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		// The value is left behind on purpose: it is what a lookup that read
-		// the class before its last change would have written.
+		// the class before its last change would have written. Writing it does
+		// not touch the reference, so it does not enqueue anything itself.
 		ginkgo.By("moving the reference and leaving the value alone", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var got kueue.Workload

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -557,6 +557,46 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 		})
 	})
 
+	ginkgo.When("a workload starts referencing a WorkloadPriorityClass after that class was last reconciled", func() {
+		var source, target *kueue.WorkloadPriorityClass
+
+		ginkgo.BeforeEach(func() {
+			source = utiltestingapi.MakeWorkloadPriorityClass("reference-source").PriorityValue(100).Obj()
+			util.MustCreate(ctx, k8sClient, source)
+			target = utiltestingapi.MakeWorkloadPriorityClass("reference-target").PriorityValue(200).Obj()
+			util.MustCreate(ctx, k8sClient, target)
+		})
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, source)).To(gomega.Succeed())
+			gomega.Expect(k8sClient.Delete(ctx, target)).To(gomega.Succeed())
+		})
+		ginkgo.It("should take the value of the class it moved to", func() {
+			wl = utiltestingapi.MakeWorkload("wl", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+				WorkloadPriorityClassRef("reference-source").
+				Priority(100).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			// Nothing referenced the target while it was being reconciled, so
+			// the reference is what has to bring it back for another pass. The
+			// value is left behind on purpose: it is what a lookup that read
+			// the class before its last change would have written.
+			ginkgo.By("moving the reference and leaving the value alone", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedQueueWorkload)).To(gomega.Succeed())
+					updatedQueueWorkload.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("reference-target")
+					g.Expect(k8sClient.Update(ctx, &updatedQueueWorkload)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &finalQueueWorkload)).To(gomega.Succeed())
+				g.Expect(finalQueueWorkload.Spec.Priority).To(gomega.Equal(new(int32(200))))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.When("the workload has a maximum execution time set", func() {
 		ginkgo.It("should deactivate the workload when the time expires", framework.SlowSpec, func() {
 			// due time rounding in conditions, the workload will stay admitted

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -563,24 +563,50 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 		ginkgo.BeforeEach(func() {
 			source = utiltestingapi.MakeWorkloadPriorityClass("reference-source").PriorityValue(100).Obj()
 			util.MustCreate(ctx, k8sClient, source)
-			target = utiltestingapi.MakeWorkloadPriorityClass("reference-target").PriorityValue(200).Obj()
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, source, true)
+			})
+
+			target = utiltestingapi.MakeWorkloadPriorityClass("reference-target").PriorityValue(100).Obj()
 			util.MustCreate(ctx, k8sClient, target)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, target, true)
+			})
 		})
 		ginkgo.AfterEach(func() {
 			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
-			gomega.Expect(k8sClient.Delete(ctx, source)).To(gomega.Succeed())
-			gomega.Expect(k8sClient.Delete(ctx, target)).To(gomega.Succeed())
 		})
+
 		ginkgo.It("should take the value of the class it moved to", func() {
+			settled := utiltestingapi.MakeWorkload("settled", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+				WorkloadPriorityClassRef("reference-target").
+				Priority(0).
+				Obj()
+			util.MustCreate(ctx, k8sClient, settled)
+
 			wl = utiltestingapi.MakeWorkload("wl", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
 				WorkloadPriorityClassRef("reference-source").
 				Priority(100).
 				Obj()
 			util.MustCreate(ctx, k8sClient, wl)
 
-			// Nothing referenced the target while it was being reconciled, so
-			// the reference is what has to bring it back for another pass. The
-			// value is left behind on purpose: it is what a lookup that read
+			// Raising the class is the only repair that no Workload event can
+			// account for, so seeing it land says the class controller has
+			// worked through everything queued for this class. Anything that
+			// reaches wl after this point came from the reference it moved to.
+			ginkgo.By("raising the target class and waiting for the class controller to carry it", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(target), target)).To(gomega.Succeed())
+					target.Value = 200
+					g.Expect(k8sClient.Update(ctx, target)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(settled), &updatedQueueWorkload)).To(gomega.Succeed())
+					g.Expect(updatedQueueWorkload.Spec.Priority).To(gomega.Equal(new(int32(200))))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			// The value is left behind on purpose: it is what a lookup that read
 			// the class before its last change would have written.
 			ginkgo.By("moving the reference and leaving the value alone", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -592,6 +618,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &finalQueueWorkload)).To(gomega.Succeed())
+				g.Expect(finalQueueWorkload.Spec.PriorityClassRef).To(gomega.Equal(kueue.NewWorkloadPriorityClassRef("reference-target")))
 				g.Expect(finalQueueWorkload.Spec.Priority).To(gomega.Equal(new(int32(200))))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1848,4 +1848,46 @@ var _ = ginkgo.Describe("Workload priority class reference", ginkgo.Label("contr
 			g.Expect(got.Spec.Priority).To(gomega.Equal(new(int32(200))))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("should leave a Workload MultiKueue created here alone", func() {
+		// Paired with one this cluster does own. Repairing that one is what says the
+		// controller has worked through the events, so the other staying put is a
+		// decision rather than a window that closed before the write landed.
+		owned := utiltestingapi.MakeWorkload("owned", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			WorkloadPriorityClassRef("reference-source").
+			Priority(0).
+			Obj()
+		remote := utiltestingapi.MakeWorkload("remote", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			WorkloadPriorityClassRef("reference-source").
+			Priority(0).
+			Label(kueue.MultiKueueOriginLabel, "manager").
+			Obj()
+		util.MustCreate(ctx, k8sClient, owned)
+		util.MustCreate(ctx, k8sClient, remote)
+
+		expectPriority := func(wl *kueue.Workload, want int32) func(gomega.Gomega) {
+			return func(g gomega.Gomega) {
+				var got kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+				g.Expect(got.Spec.Priority).To(gomega.Equal(new(want)))
+			}
+		}
+
+		gomega.Eventually(expectPriority(owned, 100), util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Consistently(expectPriority(remote, 0), util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+		ginkgo.By("moving both references", func() {
+			for _, wl := range []*kueue.Workload{owned, remote} {
+				gomega.Eventually(func(g gomega.Gomega) {
+					var got kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+					got.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("reference-target")
+					g.Expect(k8sClient.Update(ctx, &got)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			}
+		})
+
+		gomega.Eventually(expectPriority(owned, 200), util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Consistently(expectPriority(remote, 0), util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The WorkloadPriorityClass controller reacts only to class events, and reconciles a class by listing the Workloads that reference it. A class update processed before any Workload references that class therefore finds nothing to update, and the update is consumed.

The Workload then arrives carrying whatever value its own lookup returned, and nothing brings the two together again. The controller does not watch Workloads, so the reference appearing is not an event it sees.

This adds a second reconciler for that event. It is keyed on the Workload rather than the class: it reads the one class the Workload references and repairs that Workload alone. The class reconciler is untouched and keeps answering class events with the pass over everything using them.

Keying on the Workload is what keeps the cost per event constant. Enqueuing the class from a Workload event would make a Workload arriving at a class cost a pass over every other Workload already on it, and `WorkloadPriorityClassDefaulting` lets a single class be shared across a cluster. Constant per event is not the whole cost, though: the reconcile reads both objects from the API server rather than from the cache, two uncached reads on the path that finds nothing to do and three when it writes, and the informer hands it one event per eligible Workload when the manager starts. So a start over a large set is O(N) uncached reads, against the 300 QPS the client is configured for by default and shares with scheduling.

The reference is compared whole rather than by name, so a Workload moving from a Pod `PriorityClass` to a `WorkloadPriorityClass` of the same name still counts as a move. Value-only writes enqueue nothing, which is what keeps the controller off its own writes and off the class reconciler's.

#### Which issue(s) this PR fixes:

Fixes #13866
The ownership guard that issue asks for is also in #14116, where it belongs on its own. It is still here as well, so the two cannot both land as they stand: each defines `ownsPriority` in this package. Land #14116 first and I will drop the guard, its unit case and its integration case from this branch, leaving only the Workload-keyed reconciler, which calls the helper #14116 provides.

#### Special notes for your reviewer:

One rule this changes and I would rather have argued about than assumed. A Workload created already referencing a class is now resolved from it at once. Before this, a value the user gave stood until the class next moved, because only a class event ran the sweep. A later numeric-only update is left alone once the reference's own reconcile has run, so an override remains available, though not in the same request that sets the reference and not while that reconcile is still queued: one written before it runs is read live and put back to the class value. `a value the user chose, against the class it references` pins it. If the other reading is wanted, that the user's value survives until the class moves, say so and I will invert it.


It is a separate controller rather than another request shape on the existing one because `WithLeadingManager` reads the request key as the object type it is given: a non-leading replica Gets that type and discards the request on NotFound, so a Workload key against a class-typed wrapper would drop events across a failover.

No new index, and no manifest change. The reconciler Gets the class by name, and the RBAC it needs on Workloads is already in the generated role.

A Workload whose reference moves to a Pod `PriorityClass` is left alone. #13781 is where that ownership question is being settled, and this stays on the near side of it.

This does not cover #13779. A Job blocked on a class that does not exist has no Workload, so there is no create or update to watch.

The new controller runs in non-leading replicas through `WithLeadingManager`, like the fourteen that already do. The follower path there hands every request the same object to decode into, which #13978 fixes; this PR does not add that, but it does add a caller.

#14006 is left alone too, and it is the larger of the two. The class-keyed reconciler decides whether to skip a Workload from the same cache it lists from, so a class edited back to a value that cache still holds is a no-op against an API server holding something else. That reproduces on main with the sweep as the only writer, so it is not something this PR introduces, but this PR does add another `spec.priority` writer and therefore another way into the same interleaving. It cannot be closed from inside this reconciler: for any last read of the class there is a later moment, and the reconcile has returned by then. It rests until a restart or a leader failover, since both controllers take a Create event for everything they watch when the manager starts.

A Workload carrying `MultiKueueOriginLabel` is skipped, since the manager owns the priority it was created with and a class of the same name on this cluster is not the one it was resolved from. That reads the label as the statement of ownership it is meant to be, which is what #14227 is separately keeping true: a local Workload built from a Job or Pod already carrying it would be skipped here and by the sweep, and neither this PR nor #14227 rewrites one already in that state.

That question now gets asked on both paths. It started here, on the reference reconciler, and left the class-keyed sweep writing every Workload its index returned, which is the path #13929 describes: a same-named class on a worker overwriting a remote Workload's priority. Rather than let the sweep grow a second answer to the same question, it calls `ownsPriority`, the one this PR already defines. The index restricts that list to references whose kind and group are a `WorkloadPriorityClass`, so the other half of `ownsPriority` is already true for everything the sweep sees and the only behaviour that moves is the remote one.

The reconciler table counts writes and asserts that no Workload list happens on this path, so putting the class-wide pass back fails it. The integration case starts only this controller, so nothing else can repair the value. It creates a Workload at a value neither class holds, waits for the create to settle on the source, then moves the reference and waits for the target. Writing the value does not touch the reference, so nothing re-enqueues in between and the target can only be reached through the reference event. It fails without the new controller, with the Workload left at its old value.

One shape I considered and did not take, worth a second opinion rather than my own. `controller.Options` in controller-runtime v0.24.1 carries `EnableWarmup`, which starts a leader-only controller's sources on followers without running its workers, so the queue is warm at election without a lease-period requeue loop per Workload. That fits this reconciler better than the package's current pattern, since it keeps no follower state of its own, but it would be kueue's first use of the option and it is beta upstream, so it reads to me as a choice for `pkg/controller/core` as a whole rather than one to make inside a bugfix. Tracked in #14386.

One operational consequence worth stating rather than leaving to be measured: this reconciler takes its worker count from the same key the Workload reconciler does, `GroupKindConcurrency["Workload.kueue.x-k8s.io"]`, because it is keyed on the same object. That option is per controller by definition, so a configured value of C now buys C workers here as well as C there, and there is no separate knob for the direct-read path this one uses. It also joins the Workload reconciler in running on non-leading replicas, which is what every controller in `pkg/controller/core` does, so each follower now carries a second lease-period requeue loop over the Workloads that reference a class. Both follow the package's existing shape rather than departing from it, but neither is visible from the configuration.

`make ci-lint` is clean, `pkg/controller/core` passes under `go test -race -count=5`, and the singlecluster core integration suite passes.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a race that could leave a Workload with a stale priority value after it started referencing a WorkloadPriorityClass, when the class was reconciled before the reference appeared. A reference that is newly created or changed now resolves to the class's current value.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workloads now automatically update their priority when their referenced WorkloadPriorityClass changes.
  * Newly created workloads with a priority-class reference are reconciled automatically.
  * Workloads can adopt a referenced class’s priority after transitioning from remote ownership.
  * A numeric priority set on a workload is replaced by its class's value once the reference is resolved.

* **Bug Fixes**
  * Ignores irrelevant, deleted, remote, or unsupported priority-class events to prevent unnecessary updates.
  * Validates referenced priority classes before applying changes.
  * Prevents stale priority data from overwriting newer workload priorities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











