### PR TITLE
Stop a failing branch from cancelling the others

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -224,7 +224,12 @@ func (r *Reconciler) reconcileWorkloads(ctx context.Context, lws *leaderworkerse
 
 	toCreate, toUpdate, toDelete := r.filterWorkloads(lws, wlList.Items)
 
-	eg, ctx := errgroup.WithContext(ctx)
+	// The branches hold disjoint sets of Workloads, so one failing is no reason
+	// to abandon the others. A derived context would cancel them, and
+	// parallelize.Until checks for cancellation before each item, so a delete
+	// that failed first could stop the other branches before they ran at all.
+	// The reconcile context still carries shutdown and any deadline.
+	var eg errgroup.Group
 
 	eg.Go(func() error {
 		return parallelize.Until(ctx, len(toCreate), func(i int) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2208,10 +2208,22 @@ func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating the reconciler: %v", err)
 	}
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}); err == nil {
-		t.Fatal("Reconcile returned no error, want the delete failure")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}})
+	if errors.Is(err, errNotOrdered) {
+		t.Fatalf("Reconcile() error = %v, so the branches never interleaved and the ordering below was not exercised", err)
+	}
+	if !errors.Is(err, errDeleting) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, errDeleting)
 	}
 	if cancelledHere.Load() {
 		t.Error("the create branch ran under a context the delete failure had cancelled")
+	}
+	// An uncancelled context is only half of it: the branch also has to have finished its work.
+	created := &kueue.Workload{}
+	if err := kClient.Get(ctx, types.NamespacedName{Name: GetWorkloadName(testLWS, testLWS, "0"), Namespace: testNS}, created); err != nil {
+		t.Fatalf("Getting the Workload the create branch was to make: %v", err)
+	}
+	if created.Spec.Priority == nil || *created.Spec.Priority != 100 {
+		t.Errorf("created Workload priority = %v, want the class value 100", created.Spec.Priority)
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2175,28 +2175,18 @@ func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
 		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
 				reachedOnce.Do(func() { close(createReached) })
-				select {
-				case <-deleteFailed:
-				case <-time.After(30 * time.Second):
+				if !utiltesting.AwaitBranch(deleteFailed) {
 					return errNotOrdered
 				}
-				// A second rather than the microseconds the cancel would take:
-				// the branch it would come from has already failed, so this is
-				// an observation window, and a short one would let a descheduled
-				// goroutine read as no cancellation at all.
-				select {
-				case <-ctx.Done():
+				if utiltesting.ObserveCancellation(ctx) {
 					cancelledHere.Store(true)
-				case <-time.After(time.Second):
 				}
 			}
 			return c.Get(ctx, key, obj, opts...)
 		},
 		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
 			if _, isWorkload := obj.(*kueue.Workload); isWorkload {
-				select {
-				case <-createReached:
-				case <-time.After(30 * time.Second):
+				if !utiltesting.AwaitBranch(createReached) {
 					return errNotOrdered
 				}
 				failedOnce.Do(func() { close(deleteFailed) })

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2180,6 +2180,10 @@ func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
 				case <-time.After(30 * time.Second):
 					return errNotOrdered
 				}
+				// A second rather than the microseconds the cancel would take:
+				// the branch it would come from has already failed, so waiting
+				// costs nothing on a passing run and a short window would let a
+				// descheduled goroutine read as no cancellation at all.
 				select {
 				case <-ctx.Done():
 					cancelledHere.Store(true)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package leaderworkerset
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -32,6 +36,7 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -2130,5 +2135,84 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Unexpected events (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestReconcileWorkloadsDoesNotCancelTheOtherBranches pins that a failing
+// branch leaves the others' context alone. The three hold disjoint sets of
+// Workloads, and parallelize.Until checks for cancellation before each item,
+// so under a derived context a delete that failed first could stop the create
+// and update branches before they ran at all.
+func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		UID(testLWS).
+		Replicas(1).
+		Queue("lq").
+		WorkloadPriorityClass("wpc").
+		Obj()
+	// Not among the names replicas=1 asks for, so the delete branch takes it.
+	surplus := utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "7"), testNS).
+		JobUID(testLWS).
+		OwnerReference(gvk, testLWS, testLWS).
+		Obj()
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
+
+	var (
+		createReached = make(chan struct{})
+		deleteFailed  = make(chan struct{})
+		reachedOnce   sync.Once
+		failedOnce    sync.Once
+		cancelledHere atomic.Bool
+		errNotOrdered = errors.New("the delete branch never failed")
+		errDeleting   = errors.New("deleting the surplus workload")
+	)
+
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{
+		// The class lookup stands in for the create branch: it announces that
+		// the branch is inside a work item, then waits for the delete to fail,
+		// so a cancellation would have landed by the time it looks.
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
+				reachedOnce.Do(func() { close(createReached) })
+				select {
+				case <-deleteFailed:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				select {
+				case <-ctx.Done():
+					cancelledHere.Store(true)
+				case <-time.After(time.Second):
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+				select {
+				case <-createReached:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				failedOnce.Do(func() { close(deleteFailed) })
+				return errDeleting
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(lws, surplus, wpc).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}); err == nil {
+		t.Fatal("Reconcile returned no error, want the delete failure")
+	}
+	if cancelledHere.Load() {
+		t.Error("the create branch ran under a context the delete failure had cancelled")
 	}
 }

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -2181,9 +2181,9 @@ func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
 					return errNotOrdered
 				}
 				// A second rather than the microseconds the cancel would take:
-				// the branch it would come from has already failed, so waiting
-				// costs nothing on a passing run and a short window would let a
-				// descheduled goroutine read as no cancellation at all.
+				// the branch it would come from has already failed, so this is
+				// an observation window, and a short one would let a descheduled
+				// goroutine read as no cancellation at all.
 				select {
 				case <-ctx.Done():
 					cancelledHere.Store(true)

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package leaderworkerset
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -2129,5 +2134,84 @@ func TestReconciler(t *testing.T) {
 				t.Errorf("Unexpected events (-want/+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestReconcileWorkloadsDoesNotCancelTheOtherBranches pins that a failing
+// branch leaves the others' context alone. The three hold disjoint sets of
+// Workloads, and parallelize.Until checks for cancellation before each item,
+// so under a derived context a delete that failed first could stop the create
+// and update branches before they ran at all.
+func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+		UID(testLWS).
+		Replicas(1).
+		Queue("lq").
+		WorkloadPriorityClass("wpc").
+		Obj()
+	// Not among the names replicas=1 asks for, so the delete branch takes it.
+	surplus := utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "7"), testNS).
+		JobUID(testLWS).
+		OwnerReference(gvk, testLWS, testLWS).
+		Obj()
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
+
+	var (
+		createReached = make(chan struct{})
+		deleteFailed  = make(chan struct{})
+		reachedOnce   sync.Once
+		failedOnce    sync.Once
+		cancelledHere atomic.Bool
+		errNotOrdered = errors.New("the delete branch never failed")
+		errDeleting   = errors.New("deleting the surplus workload")
+	)
+
+	clientBuilder := utiltesting.NewClientBuilder(leaderworkersetv1.AddToScheme).WithInterceptorFuncs(interceptor.Funcs{
+		// The class lookup stands in for the create branch: it announces that
+		// the branch is inside a work item, then waits for the delete to fail,
+		// so a cancellation would have landed by the time it looks.
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
+				reachedOnce.Do(func() { close(createReached) })
+				select {
+				case <-deleteFailed:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				select {
+				case <-ctx.Done():
+					cancelledHere.Store(true)
+				case <-time.After(time.Second):
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+				select {
+				case <-createReached:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				failedOnce.Do(func() { close(deleteFailed) })
+				return errDeleting
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	kClient := clientBuilder.WithObjects(lws, surplus, wpc).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: testLWS, Namespace: testNS}}); err == nil {
+		t.Fatal("Reconcile returned no error, want the delete failure")
+	}
+	if cancelledHere.Load() {
+		t.Error("the create branch ran under a context the delete failure had cancelled")
 	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -105,7 +105,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return ctrl.Result{}, err
 	}
 
-	eg, ctx := errgroup.WithContext(ctx)
+	// Finalizing pods and reconciling the Workload touch different objects, so
+	// one failing is no reason to abandon the other. A derived context would
+	// cancel it, and its own lookups would then fail as cancelled rather than
+	// for the reason they were about to find. The reconcile context still
+	// carries shutdown and any deadline.
+	var eg errgroup.Group
 
 	eg.Go(func() error {
 		return r.finalizePods(ctx, sts, podList.Items)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -787,6 +787,10 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 				case <-time.After(30 * time.Second):
 					return errNotOrdered
 				}
+				// A second rather than the microseconds the cancel would take:
+				// the branch it would come from has already failed, so waiting
+				// costs nothing on a passing run and a short window would let a
+				// descheduled goroutine read as no cancellation at all.
 				select {
 				case <-ctx.Done():
 					cancelledHere.Store(true)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -781,19 +781,11 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 		// the time it looks.
 		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
-				select {
-				case <-finalizeFailed:
-				case <-time.After(30 * time.Second):
+				if !utiltesting.AwaitBranch(finalizeFailed) {
 					return errNotOrdered
 				}
-				// A second rather than the microseconds the cancel would take:
-				// the branch it would come from has already failed, so this is
-				// an observation window, and a short one would let a descheduled
-				// goroutine read as no cancellation at all.
-				select {
-				case <-ctx.Done():
+				if utiltesting.ObserveCancellation(ctx) {
 					cancelledHere.Store(true)
-				case <-time.After(time.Second):
 				}
 			}
 			return c.Get(ctx, key, obj, opts...)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,11 +29,13 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -728,5 +734,82 @@ func TestReconciler_ClearOnHoldSetsReason(t *testing.T) {
 				t.Errorf("Unexpected QuotaReserved condition status/reason: got %s/%s, want False/%s", cond.Status, cond.Reason, wantReason)
 			}
 		})
+	}
+}
+
+// TestReconcileDoesNotCancelTheWorkloadBranch pins that a failure while
+// finalizing pods leaves the Workload branch's context alone. The two branches
+// touch different objects, and under a derived context the second one's lookups
+// fail as cancelled rather than for whatever they were about to find.
+func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+		UID("sts-uid").
+		Queue("lq").
+		WorkloadPriorityClass("wpc").
+		CurrentRevision("1").
+		UpdateRevision("2").
+		Obj()
+	pod := testingjobspod.MakePod("pod1", "ns").
+		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
+		Label(appsv1.ControllerRevisionHashLabelKey, "1").
+		Queue("lq").
+		Gate(podconstants.SchedulingGateName).
+		KueueFinalizer().
+		Obj()
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
+
+	var (
+		finalizeFailed = make(chan struct{})
+		once           sync.Once
+		cancelledHere  atomic.Bool
+		errNotOrdered  = errors.New("the finalizing branch never failed")
+		errPodConflict = apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
+	)
+
+	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				once.Do(func() { close(finalizeFailed) })
+				return errPodConflict
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+		// The class lookup stands in for the whole Workload branch: it waits
+		// for the other branch to fail, so a cancellation would have landed by
+		// the time it looks.
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
+				select {
+				case <-finalizeFailed:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				select {
+				case <-ctx.Done():
+					cancelledHere.Store(true)
+				case <-time.After(time.Second):
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Indexing the pod group name: %v", err)
+	}
+	kClient := clientBuilder.WithObjects(sts, pod, wpc).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); err == nil {
+		t.Fatal("Reconcile returned no error, want the finalization failure")
+	}
+	if cancelledHere.Load() {
+		t.Error("the Workload branch ran under a context the finalization failure had cancelled")
 	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -806,10 +806,22 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Creating the reconciler: %v", err)
 	}
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); err == nil {
-		t.Fatal("Reconcile returned no error, want the finalization failure")
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)})
+	if errors.Is(err, errNotOrdered) {
+		t.Fatalf("Reconcile() error = %v, so the branches never interleaved and the ordering below was not exercised", err)
+	}
+	if !errors.Is(err, errPodConflict) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, errPodConflict)
 	}
 	if cancelledHere.Load() {
 		t.Error("the Workload branch ran under a context the finalization failure had cancelled")
+	}
+	// An uncancelled context is only half of it: the branch also has to have finished its work.
+	created := &kueue.Workload{}
+	if err := kClient.Get(ctx, client.ObjectKey{Name: GetWorkloadName("sts-uid", "sts"), Namespace: "ns"}, created); err != nil {
+		t.Fatalf("Getting the Workload the branch was to make: %v", err)
+	}
+	if created.Spec.Priority == nil || *created.Spec.Priority != 100 {
+		t.Errorf("created Workload priority = %v, want the class value 100", created.Spec.Priority)
 	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -742,7 +742,6 @@ func TestReconciler_ClearOnHoldSetsReason(t *testing.T) {
 // touch different objects, and under a derived context the second one's lookups
 // fail as cancelled rather than for whatever they were about to find.
 func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
-	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
 	ctx, _ := utiltesting.ContextWithLog(t)
 
 	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
@@ -788,9 +787,9 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 					return errNotOrdered
 				}
 				// A second rather than the microseconds the cancel would take:
-				// the branch it would come from has already failed, so waiting
-				// costs nothing on a passing run and a short window would let a
-				// descheduled goroutine read as no cancellation at all.
+				// the branch it would come from has already failed, so this is
+				// an observation window, and a short one would let a descheduled
+				// goroutine read as no cancellation at all.
 				select {
 				case <-ctx.Done():
 					cancelledHere.Store(true)

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -17,7 +17,11 @@ limitations under the License.
 package statefulset
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,12 +29,14 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -729,5 +735,82 @@ func TestReconciler_ClearOnHoldSetsReason(t *testing.T) {
 				t.Errorf("Unexpected QuotaReserved condition status/reason: got %s/%s, want False/%s", cond.Status, cond.Reason, wantReason)
 			}
 		})
+	}
+}
+
+// TestReconcileDoesNotCancelTheWorkloadBranch pins that a failure while
+// finalizing pods leaves the Workload branch's context alone. The two branches
+// touch different objects, and under a derived context the second one's lookups
+// fail as cancelled rather than for whatever they were about to find.
+func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{features.TopologyAwareScheduling: false})
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+		UID("sts-uid").
+		Queue("lq").
+		WorkloadPriorityClass("wpc").
+		CurrentRevision("1").
+		UpdateRevision("2").
+		Obj()
+	pod := testingjobspod.MakePod("pod1", "ns").
+		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
+		Label(appsv1.ControllerRevisionHashLabelKey, "1").
+		Queue("lq").
+		Gate(podconstants.SchedulingGateName).
+		KueueFinalizer().
+		Obj()
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
+
+	var (
+		finalizeFailed = make(chan struct{})
+		once           sync.Once
+		cancelledHere  atomic.Bool
+		errNotOrdered  = errors.New("the finalizing branch never failed")
+		errPodConflict = apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
+	)
+
+	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				once.Do(func() { close(finalizeFailed) })
+				return errPodConflict
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+		// The class lookup stands in for the whole Workload branch: it waits
+		// for the other branch to fail, so a cancellation would have landed by
+		// the time it looks.
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, isClass := obj.(*kueue.WorkloadPriorityClass); isClass {
+				select {
+				case <-finalizeFailed:
+				case <-time.After(30 * time.Second):
+					return errNotOrdered
+				}
+				select {
+				case <-ctx.Done():
+					cancelledHere.Store(true)
+				case <-time.After(time.Second):
+				}
+			}
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Indexing the pod group name: %v", err)
+	}
+	kClient := clientBuilder.WithObjects(sts, pod, wpc).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); err == nil {
+		t.Fatal("Reconcile returned no error, want the finalization failure")
+	}
+	if cancelledHere.Load() {
+		t.Error("the Workload branch ran under a context the finalization failure had cancelled")
 	}
 }

--- a/pkg/util/testing/branches.go
+++ b/pkg/util/testing/branches.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// BranchBarrierTimeout bounds a wait for another goroutine to reach its
+	// step. It is generous because a busy CI runner takes far longer to
+	// schedule one than a laptop does, and because reaching it fails the test
+	// rather than letting it pass quietly, so a long wait costs nothing on a
+	// run that was going to succeed.
+	BranchBarrierTimeout = 30 * time.Second
+
+	// CancellationWindow is how long to watch for a cancellation that would
+	// arrive within microseconds if it were coming at all: whatever would send
+	// it has already failed by the time this is called. It is an observation
+	// window rather than a deadline, and a short one would let a descheduled
+	// goroutine read as no cancellation.
+	CancellationWindow = time.Second
+)
+
+// AwaitBranch reports whether ch was closed before BranchBarrierTimeout.
+func AwaitBranch(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	case <-time.After(BranchBarrierTimeout):
+		return false
+	}
+}
+
+// ObserveCancellation reports whether ctx was cancelled within CancellationWindow.
+func ObserveCancellation(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	case <-time.After(CancellationWindow):
+		return false
+	}
+}

--- a/pkg/util/testing/branches.go
+++ b/pkg/util/testing/branches.go
@@ -22,37 +22,37 @@ import (
 )
 
 const (
-	// BranchBarrierTimeout bounds a wait for another goroutine to reach its
+	// branchBarrierTimeout bounds a wait for another goroutine to reach its
 	// step. It is generous because a busy CI runner takes far longer to
 	// schedule one than a laptop does, and because reaching it fails the test
 	// rather than letting it pass quietly, so a long wait costs nothing on a
 	// run that was going to succeed.
-	BranchBarrierTimeout = 30 * time.Second
+	branchBarrierTimeout = 30 * time.Second
 
-	// CancellationWindow is how long to watch for a cancellation that would
+	// cancellationWindow is how long to watch for a cancellation that would
 	// arrive within microseconds if it were coming at all: whatever would send
 	// it has already failed by the time this is called. It is an observation
 	// window rather than a deadline, and a short one would let a descheduled
 	// goroutine read as no cancellation.
-	CancellationWindow = time.Second
+	cancellationWindow = time.Second
 )
 
-// AwaitBranch reports whether ch was closed before BranchBarrierTimeout.
+// AwaitBranch reports whether ch was closed before branchBarrierTimeout.
 func AwaitBranch(ch <-chan struct{}) bool {
 	select {
 	case <-ch:
 		return true
-	case <-time.After(BranchBarrierTimeout):
+	case <-time.After(branchBarrierTimeout):
 		return false
 	}
 }
 
-// ObserveCancellation reports whether ctx was cancelled within CancellationWindow.
+// ObserveCancellation reports whether ctx was cancelled within cancellationWindow.
 func ObserveCancellation(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():
 		return true
-	case <-time.After(CancellationWindow):
+	case <-time.After(cancellationWindow):
 		return false
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

The LeaderWorkerSet and StatefulSet reconcilers each run independent operations under one `errgroup.WithContext`, so the first error cancels the derived context the remaining work is using.

In `reconcileWorkloads` the three branches hold disjoint sets of Workloads. `parallelize.Until` hands the context to `workqueue.ParallelizeUntil`, which checks it before every item, so a delete that failed first can leave the create and update branches returning without ever calling their work item.

In the StatefulSet reconciler the Workload branch does start, but once the cancellation lands its own API calls fail with `context canceled` rather than for whatever they were about to find.

Both now run under a plain `errgroup.Group` and keep the reconcile context, which still carries shutdown and any deadline. `Wait` still returns the first error. What changes is that a failing reconcile finishes the independent work rather than abandoning it.

#### Which issue(s) this PR fixes:

Fixes #13902

#### Special notes for your reviewer:

This was part of #13775 and comes out on its own because it is a behaviour change of its own, which @mimowo asked about there.

Each reconciler gets a case that orders one branch's failure ahead of another branch's lookup, then records whether that lookup ran under a cancelled context. Both fail on the unfixed reconcilers, the leaderworkerset one with the create branch cancelled by the delete failure and the statefulset one with the Workload branch cancelled by the finalization failure.

The ordering is a handshake rather than a sleep: the lookup announces that its branch is inside a work item, the other branch waits for that before failing, and the lookup then waits for the failure before checking its context. Neither case reproduces the leaderworkerset skip-before-start race itself, since `parallelize.Until` offers no injection point before it calls a work item, so they pin the property the fix rests on instead.

`make ci-lint` is clean and both suites pass under `go test -race -count=5`.

#### Does this PR introduce a user-facing change?

```release-note
LeaderWorkerSet & StatefulSet: Fixed reconciliation errors in one independent branch cancelling the other branches. 
LeaderWorkerSet Workload creation, update, and deletion branches now continue independently, as do StatefulSet 
Pod finalization and Workload reconciliation.
```

This does not reach the StatefulSet's `syncQueueLabel`, which runs before the group is built, so a Pod queue-label patch that keeps failing still keeps the Workload branch from starting at all. That half is the same shape and is tracked in #14013.

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload and pod reconciliation reliability when one operation encounters an error.
  * Independent reconciliation tasks now continue processing instead of being canceled prematurely.
  * Ensured workloads are created or updated with the correct priority even when another concurrent operation fails.
  * Preserved expected shutdown and deadline behavior during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
