### PR TITLE
[release-0.18] dra: fix DeviceClass validation error paths

### DIFF
--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -81,9 +81,9 @@ func GetCounterResourcesForWorkload(
 
 				log.V(4).Info("Processing counter charge", "podSet", ps.Name, "deviceClass", deviceClass, "quotaResource", quotaResource, "count", req.Exactly.Count)
 
-				reqPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j).Child("devices", "requests").Index(reqIdx)
+				claimPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j)
 
-				charges, errs := processCounterCharge(ctx, cl, counterConfig, quotaResource, req.Exactly.DeviceClassName, req.Exactly.Selectors, req.Exactly.Count, classCache, reqPath)
+				charges, errs := processCounterCharge(ctx, cl, counterConfig, quotaResource, req.Exactly.DeviceClassName, req.Exactly.Selectors, req.Exactly.Count, classCache, claimPath, reqIdx)
 				if len(errs) > 0 {
 					allErrs = append(allErrs, errs...)
 					return nil, allErrs
@@ -115,9 +115,11 @@ func processCounterCharge(
 	selectors []resourcev1.DeviceSelector,
 	count int64,
 	classCache map[string]*resourcev1.DeviceClass,
-	reqPath *field.Path,
+	claimPath *field.Path,
+	reqIdx int,
 ) (corev1.ResourceList, field.ErrorList) {
 	log := ctrl.LoggerFrom(ctx)
+	reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
 	selectorSelectors, compErrs := compileCELSelectors(
 		[]resourcev1.DeviceSelector{counterConfig.deviceSelector},
@@ -127,7 +129,7 @@ func processCounterCharge(
 		return nil, compErrs
 	}
 
-	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, reqPath, 0)
+	classSelectors, classErr := resolveAndCompileDeviceClass(ctx, cl, deviceClassName, classCache, claimPath, reqIdx)
 	if classErr != nil {
 		return nil, field.ErrorList{classErr}
 	}

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -338,75 +338,117 @@ func TestGroupSlicesByPool(t *testing.T) {
 	}
 }
 
-func TestMatchDevicesWithSelectors_CELErrorPropagation(t *testing.T) {
+func TestSelectorErrorPaths(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
-
-	pools := map[string]*poolInfo{
-		"pool1": {
-			name:               "pool1",
-			generation:         1,
-			resourceSliceCount: 1,
-			slices: []resourcev1.ResourceSlice{
-				{
-					Spec: resourcev1.ResourceSliceSpec{
-						Driver: "gpu.example.com",
-						Pool:   resourcev1.ResourcePool{Name: "pool1", Generation: 1, ResourceSliceCount: 1},
-						Devices: []resourcev1.Device{
-							{
-								Name: "gpu-0",
-								Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-									"gpu.example.com/type": {},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	cache := dracel.NewCache(1, dracel.Features{})
-	result := cache.GetOrCompile("device.driver == 'gpu.example.com'")
-	if result.Error != nil {
-		t.Fatalf("CEL compilation failed: %v", result.Error)
-	}
-
-	reqPath := field.NewPath("test")
-	matched, errs := matchDevicesWithSelectors(ctx, pools, "gpu.example.com",
-		[]dracel.CompilationResult{result}, nil, nil, reqPath)
-
-	if len(errs) == 0 {
-		t.Fatalf("Expected CEL evaluation error to be propagated, got %d matched devices", len(matched))
-	}
-	if !strings.Contains(errs[0].Detail, "unsupported attribute value") {
-		t.Errorf("Expected error containing 'unsupported attribute value', got: %s", errs[0].Detail)
-	}
-}
-
-func TestProcessCounterCharge_DeviceClassErrorUsesRequestPath(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-	cl := utiltesting.NewClientBuilder().Build()
+	cl := utiltesting.NewClientBuilder().WithObjects(&resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "valid-device-class"},
+	}).Build()
 	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
 	reqPath := claimPath.Child("devices", "requests").Index(1)
 
-	_, errs := processCounterCharge(
-		ctx,
-		cl,
-		&deviceClassCounterConfig{},
-		"gpu.memory",
-		"missing-device-class",
-		nil,
-		1,
-		make(map[string]*resourcev1.DeviceClass),
-		claimPath,
-		1,
-		reqPath,
-	)
-
-	if len(errs) != 1 {
-		t.Fatalf("expected one error, got %d: %v", len(errs), errs)
+	cache := dracel.NewCache(1, dracel.Features{})
+	validSelector := cache.GetOrCompile("device.driver == 'gpu.example.com'")
+	if validSelector.Error != nil {
+		t.Fatalf("CEL compilation failed: %v", validSelector.Error)
 	}
-	if errs[0].Field != reqPath.String() {
-		t.Errorf("field path = %q, want %q", errs[0].Field, reqPath.String())
+
+	newPools := func() map[string]*poolInfo {
+		return map[string]*poolInfo{
+			"pool1": {
+				name:               "pool1",
+				generation:         1,
+				resourceSliceCount: 1,
+				slices: []resourcev1.ResourceSlice{{
+					Spec: resourcev1.ResourceSliceSpec{
+						Driver: "gpu.example.com",
+						Pool:   resourcev1.ResourcePool{Name: "pool1", Generation: 1, ResourceSliceCount: 1},
+						Devices: []resourcev1.Device{{
+							Name: "gpu-0",
+							Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+								"gpu.example.com/type": {},
+							},
+						}},
+					},
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		run        func() field.ErrorList
+		wantField  string
+		wantDetail string
+	}{
+		{
+			name: "DeviceClass lookup error",
+			run: func() field.ErrorList {
+				_, errs := processCounterCharge(
+					ctx,
+					cl,
+					&deviceClassCounterConfig{},
+					"gpu.memory",
+					"missing-device-class",
+					nil,
+					1,
+					make(map[string]*resourcev1.DeviceClass),
+					claimPath,
+					1,
+				)
+				return errs
+			},
+			wantField: reqPath.String(),
+		},
+		{
+			name: "request selector compilation error",
+			run: func() field.ErrorList {
+				_, errs := processCounterCharge(
+					ctx,
+					cl,
+					&deviceClassCounterConfig{},
+					"gpu.memory",
+					"valid-device-class",
+					[]resourcev1.DeviceSelector{{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver =="}}},
+					1,
+					make(map[string]*resourcev1.DeviceClass),
+					claimPath,
+					1,
+				)
+				return errs
+			},
+			wantField: reqPath.Child("exactly", "selectors").Index(0).Child("cel", "expression").String(),
+		},
+		{
+			name: "request selector evaluation error",
+			run: func() field.ErrorList {
+				_, errs := matchDevicesWithSelectors(
+					ctx,
+					newPools(),
+					"gpu.example.com",
+					[]dracel.CompilationResult{validSelector},
+					nil,
+					nil,
+					reqPath,
+				)
+				return errs
+			},
+			wantField:  reqPath.String(),
+			wantDetail: "unsupported attribute value",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			errs := tc.run()
+			if len(errs) != 1 {
+				t.Fatalf("expected one error, got %d: %v", len(errs), errs)
+			}
+			if errs[0].Field != tc.wantField {
+				t.Errorf("field path = %q, want %q", errs[0].Field, tc.wantField)
+			}
+			if tc.wantDetail != "" && !strings.Contains(errs[0].Detail, tc.wantDetail) {
+				t.Errorf("error detail = %q, want it to contain %q", errs[0].Detail, tc.wantDetail)
+			}
+		})
 	}
 }

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -382,3 +382,31 @@ func TestMatchDevicesWithSelectors_CELErrorPropagation(t *testing.T) {
 		t.Errorf("Expected error containing 'unsupported attribute value', got: %s", errs[0].Detail)
 	}
 }
+
+func TestProcessCounterCharge_DeviceClassErrorUsesRequestPath(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder().Build()
+	claimPath := field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0)
+	reqPath := claimPath.Child("devices", "requests").Index(1)
+
+	_, errs := processCounterCharge(
+		ctx,
+		cl,
+		&deviceClassCounterConfig{},
+		"gpu.memory",
+		"missing-device-class",
+		nil,
+		1,
+		make(map[string]*resourcev1.DeviceClass),
+		claimPath,
+		1,
+		reqPath,
+	)
+
+	if len(errs) != 1 {
+		t.Fatalf("expected one error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != reqPath.String() {
+		t.Errorf("field path = %q, want %q", errs[0].Field, reqPath.String())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
This is a manual cherry-pick of #13826 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
 This is an adapted backport for `release-0.18`; that branch does not include capacity-based DRA support.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
DRA: Fixed DeviceClass validation errors reporting a duplicated request field path with an incorrect request index in counter-based quota paths.
```
