### PR TITLE
dra: rename prepareCounterCharge to prepareDeviceSelectors for clarity

### DIFF
--- a/pkg/dra/capacity.go
+++ b/pkg/dra/capacity.go
@@ -115,7 +115,7 @@ func determineCapacityForPodSet(
 			claimPath := field.NewPath("spec", "podSets").Index(psIdx).Child("template", "spec", "resourceClaims").Index(j)
 			reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-			classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
+			classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 			if len(errs) > 0 {
 				return nil, errs
 			}

--- a/pkg/dra/counters.go
+++ b/pkg/dra/counters.go
@@ -80,7 +80,7 @@ func GetCounterResourcesForWorkload(
 				claimPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j)
 				reqPath := claimPath.Child("devices", "requests").Index(reqIdx)
 
-				classSelectors, requestSelectors, errs := prepareCounterCharge(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
+				classSelectors, requestSelectors, errs := prepareDeviceSelectors(ctx, cl, req.Exactly.DeviceClassName, req.Exactly.Selectors, classCache, claimPath, reqIdx)
 				if len(errs) > 0 {
 					allErrs = append(allErrs, errs...)
 					return nil, allErrs
@@ -113,7 +113,7 @@ func GetCounterResourcesForWorkload(
 	return perPodSet, nil
 }
 
-func prepareCounterCharge(
+func prepareDeviceSelectors(
 	ctx context.Context,
 	cl client.Client,
 	deviceClassName string,

--- a/pkg/dra/counters_test.go
+++ b/pkg/dra/counters_test.go
@@ -495,7 +495,7 @@ func TestSelectorErrorPaths(t *testing.T) {
 		{
 			name: "DeviceClass lookup error",
 			run: func() field.ErrorList {
-				_, _, errs := prepareCounterCharge(ctx, cl, "missing-device-class", nil, make(map[string]*resourcev1.DeviceClass), claimPath, 1)
+				_, _, errs := prepareDeviceSelectors(ctx, cl, "missing-device-class", nil, make(map[string]*resourcev1.DeviceClass), claimPath, 1)
 				return errs
 			},
 			wantField: reqPath.String(),
@@ -503,7 +503,7 @@ func TestSelectorErrorPaths(t *testing.T) {
 		{
 			name: "request selector compilation error",
 			run: func() field.ErrorList {
-				_, _, errs := prepareCounterCharge(
+				_, _, errs := prepareDeviceSelectors(
 					ctx,
 					cl,
 					"valid-device-class",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Renames `prepareCounterCharge` to `prepareDeviceSelectors`. Given that the helper compiles DeviceClass and request CEL selectors and is used by both counter-based and capacity-based DRA quota paths, the new name may better reflect its shared responsibility.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref discussion in https://github.com/kubernetes-sigs/kueue/pull/13826#discussion_r3722521217
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```
