### PR TITLE
Self-nominate sohankunkerkar as full approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,7 @@
 aliases:
   kueue-approvers:
     - mimowo
+    - sohankunkerkar
     - tenzen-y
   kueue-reviewers:
     - mbobrovskyi
@@ -16,12 +17,10 @@ aliases:
   dependency-approvers:
     - mbobrovskyi
     - pbundyra
-    - sohankunkerkar
   test-approvers:
     - mbobrovskyi
     - olekzabl
     - pbundyra
-    - sohankunkerkar
   agent-approvers:
     - amy
     - kannon92

--- a/cmd/kueue/OWNERS
+++ b/cmd/kueue/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/config/OWNERS
+++ b/pkg/config/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- sohankunkerkar
 - kannon92

--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/dra/OWNERS
+++ b/pkg/dra/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/features/OWNERS
+++ b/pkg/features/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/resources/OWNERS
+++ b/pkg/resources/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/workload/OWNERS
+++ b/pkg/workload/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar

--- a/pkg/workloadslicing/OWNERS
+++ b/pkg/workloadslicing/OWNERS
@@ -1,4 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-approvers:
-- sohankunkerkar


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Self-nominate @sohankunkerkar as full approver (`kueue-approvers`), replacing scoped per-directory OWNERS entries.

**Approver requirements**

Following https://github.com/kubernetes/community/blob/master/community-membership.md#approver

- [x] Reviewer of the codebase for at least 3 months
  - Reviewer since [March 2026](https://github.com/kubernetes-sigs/kueue/pull/9776), scoped approver since [June 2026](https://github.com/kubernetes-sigs/kueue/pull/12155)
- [x] Primary reviewer for at least 10 substantial PRs
  - [94 original reviews](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged) excluding cherry-picks, [69 of which were size/M+](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged+-label%3Asize%2FXS+-label%3Asize%2FS)
- [x] Reviewed or merged at least 30 PRs
  - [126 original authored PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged) excluding cherry-picks
  - [94 reviews of others' PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged) excluding cherry-picks
- [x] Nominated by a subproject owner
  - Initiated by @mimowo, endorsed by @tenzen-y

**Contributions**

- [126 original authored PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged) (+ 44 cherry-picks)
- [66 bug fixes](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Fbug)
- [20 features](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Ffeature)
- [4 KEPs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Fkep)
- [28 flake fixes](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Fflake)
- [20 issues filed](https://github.com/kubernetes-sigs/kueue/issues?q=is%3Aissue+author%3Asohankunkerkar)

77 of 126 original PRs are size/M or larger (61%). 8 are size/XXL (1000+ lines each).

My contributions cluster around the following areas:

<details>
<summary><b>DRA Integration (KEP-2941)</b></summary>

Designed and implemented the DRA integration across extended resources, partitionable devices, and consumable capacity. Authored the KEP design documents (#12983, #10283, #8734) and drove beta graduation (#10996).

Representative PRs:
- #13152: Implement consumable capacity quota
- #8597: Add extended resource support for DRA
- #11661: Remove global DRA mapper singleton, use dependency injection
- #8775: Add MultiKueue + DRA integration and e2e tests
- #12883: Integration tests for DRA resource borrowing in cohorts
- #11927, #11929: Fix stale DRA resource requests and requeue after DeviceClass deletion
- #13642: Skip AdminAccess device requests in DRA quota counting
- #8421: E2E tests for DRA

</details>

<details>
<summary><b>Scheduling Equivalence Hashing</b></summary>

Designed and implemented the scheduling equivalence optimization to skip re-evaluation of equivalent inadmissible workloads in BestEffortFIFO scheduling. Graduated to beta.

- #9698: Core implementation
- #11097: Graduate to beta (default to true)
- #11399: Include effective requests in equivalence hash

</details>

<details>
<summary><b>Elastic Jobs / Workload Slicing</b></summary>

Implemented TAS + elastic integration and drove beta graduation.

- #8580: Add TAS + ElasticWorkloads integration
- #11547: Promote ElasticJobsViaWorkloadSlices to beta
- #11300: Webhook validations for elastic beta graduation
- #10272: Refactor elastic job pod ungating to dedicated controller
- #11327, #11195, #8456: Fix workload slice lifecycle ordering bugs

</details>

<details>
<summary><b>TAS</b></summary>

- #8865: Fix PodSpec resources for placement instead of quota-filtered values
- #8709: Requeue inadmissible workloads after non-TAS pod finishes (backported to 0.18/0.19)
- #13555: Enable nodeports plugin in WAS simulator for hostPort feasibility
- #13764: Update nonTasUsageCache on in-place pod resize and node migration
- #8043: Add exclusion stats to TAS failure messages

</details>

<details>
<summary><b>Scheduler / Preemption / Fair Sharing</b></summary>

- #9437: Prevent duplicate preemption requests across scheduling cycles
- #9661: Fix inadmissible workload stuck after priority update
- #9899: Fix Snapshot() sort inconsistency with UsageBasedAdmissionFairSharing
- #9101: Fix non-deterministic workload ordering in ClusterQueue.Snapshot
- #12671: Fix AFS ConsumedResources CPU truncating to zero on self-requeue
- #8919: Exclude finished/deactivated workloads from scheduler cache

</details>

<details>
<summary><b>Stability & Test Infrastructure</b></summary>

[28 flake fixes](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Fflake) · [8 failing-test fixes](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+author%3Asohankunkerkar+is%3Amerged+label%3Akind%2Ffailing-test)

- #4579: Build cert-manager e2e test infrastructure
- #9811: Restructure e2e test timeout constants across 62 files
- #8220: Add WaitForWebhookReady to fix flaky tests after controller restart
- #8111: Wait for kueue controller to acquire leader lease
- #8711: Make performance recorder non-blocking to fix flakiness
- #11625: Restructure DRA e2e tests into baseline/extended layout
- #9079: Fix flaky infinite preemption cycle test with unique CQ names

</details>

<details>
<summary><b>Other</b></summary>

- #7620: Implement delayed admission check retries (KEP-3258)
- #7772: Fix conversion webhook CA bundles during upgrades
- #13420: Add workload execution time histogram metric

</details>

**Beta graduations**

- KueueDRAIntegration (#10996)
- SchedulingEquivalenceHashing (#11097)
- ElasticJobsViaWorkloadSlices (#11547)
- KEP-2941 ER+PD graduation criteria (#12424)

**KEP design**

Authored:
- KEP-2941 consumable capacity (#12983)
- KEP-2941 partitionable devices (#10283)
- KEP-2941 extended resources (#8734)

Reviewed:
- #11720: Observability of inadmissible workloads
- #9841: DRA KEP CEL handling
- #8551: Preemption cost mechanism
- #8396: Limiting quota check to declared resources

**Reviews**

[94 original reviews of others' merged PRs](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged) (excluding cherry-picks), [69 size/M+](https://github.com/kubernetes-sigs/kueue/pulls?q=is%3Apr+reviewed-by%3Asohankunkerkar+-author%3Asohankunkerkar+is%3Amerged+-label%3Asize%2FXS+-label%3Asize%2FS), including:

- #13261: WAS scheduler-library SchedulingSimulator
- #13167, #13102, #13018: DRA ER/PD beta graduation
- #11832: KEP-8190 curve support
- #12419: TAS overlapping CQ head workloads
- #11210: TAS ResourceFlavor:Node assumption fix
- #10973: Event-driven DeviceClass tracking for ER
- #10185: Fix preemption expectations
- #9232: Async inadmissible workload requeueing
- #9808: quotaCheckStrategy
- #9742: CEL expressions in DRA ResourceClaimTemplates

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

Discussed with @mimowo and @tenzen-y — both endorsed this promotion.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project approval assignments, adding a maintainer to the approver group and removing them from test approvals.
  * Removed several component-level ownership records and consolidated approval responsibilities.
  * No changes were made to application functionality, APIs, or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->