### PR TITLE
Emit UpdatedWorkload event for StatefulSet AdmissionGatedBy propagation

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -250,13 +250,18 @@ func (r *Reconciler) reconcileWorkload(ctx context.Context, sts *appsv1.Stateful
 		shouldUpdate = true
 	}
 
-	if features.Enabled(features.AdmissionGatedBy) {
-		gateUpdated := jobframework.PropagateAdmissionGatedByAnnotation(sts, wl)
-		shouldUpdate = gateUpdated || shouldUpdate
-	}
-
 	if shouldUpdate {
 		if err := r.client.Update(ctx, wl); err != nil {
+			return err
+		}
+	}
+
+	// Must run after the Update above: UpdateAdmissionGatedBy patches the
+	// workload, and the patch response overwrites wl with the persisted state.
+	// Running it earlier would discard the in-memory owner reference and queue
+	// name set above before they are written, silently dropping them.
+	if features.Enabled(features.AdmissionGatedBy) {
+		if err := jobframework.UpdateAdmissionGatedBy(ctx, r.client, r.record, sts, wl); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -36,6 +36,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -54,6 +55,14 @@ var (
 
 func TestReconciler(t *testing.T) {
 	now := time.Now()
+	createdWorkloadEvents := []utiltesting.EventRecord{
+		{
+			Key:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			EventType: corev1.EventTypeNormal,
+			Reason:    jobframework.ReasonCreatedWorkload,
+			Message:   fmt.Sprintf("Created Workload: ns/%s", GetWorkloadName("sts-uid", "sts")),
+		},
+	}
 	cases := map[string]struct {
 		featureGates    map[featuregate.Feature]bool
 		stsKey          client.ObjectKey
@@ -63,6 +72,7 @@ func TestReconciler(t *testing.T) {
 		wantStatefulSet *appsv1.StatefulSet
 		wantPods        []corev1.Pod
 		wantWorkloads   []kueue.Workload
+		wantEvents      []utiltesting.EventRecord
 		wantErr         error
 	}{
 		"statefulset not found": {
@@ -262,6 +272,7 @@ func TestReconciler(t *testing.T) {
 					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"should create workload with TAS topology request when TAS enabled": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
@@ -299,6 +310,7 @@ func TestReconciler(t *testing.T) {
 					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"should not create workload when replicas == 0": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
@@ -452,6 +464,7 @@ func TestReconciler(t *testing.T) {
 					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 		"statefulset with multiple AdmissionGatedBy gates should propagate to workload": {
 			featureGates: map[featuregate.Feature]bool{
@@ -489,6 +502,151 @@ func TestReconciler(t *testing.T) {
 					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1,example.com/controller2").
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
+		},
+		"should emit an event when the AdmissionGatedBy annotation is propagated to an existing workload": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonUpdatedWorkload,
+					Message:   `Updated workload AdmissionGatedBy to "example.com/controller1"`,
+				},
+			},
+		},
+		"should propagate the AdmissionGatedBy annotation and emit an event alongside an owner reference update": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonUpdatedWorkload,
+					Message:   `Updated workload AdmissionGatedBy to "example.com/controller1"`,
+				},
+			},
+		},
+		"should emit an event when the AdmissionGatedBy annotation changes value": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: true},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller2").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonUpdatedWorkload,
+					Message:   `Updated workload AdmissionGatedBy to "example.com/controller2"`,
+				},
+			},
+		},
+		"should not propagate the AdmissionGatedBy annotation to an existing workload nor emit an event when the feature gate is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.AdmissionGatedBy: false},
+			stsKey:       client.ObjectKey{Name: "sts", Namespace: "ns"},
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Obj(),
+			},
+			wantStatefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").
+				Queue("lq").
+				Annotation(kueueconstants.AdmissionGatedByAnnotation, "example.com/controller1").
+				DeepCopy(),
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+					Queue("lq").
+					OwnerReference(gvk, "sts", "sts-uid").
+					Annotation(controllerconstants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
+					Obj(),
+			},
 		},
 		"statefulset with AdmissionGatedBy annotation but feature gate disabled should not propagate": {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false, features.AdmissionGatedBy: false},
@@ -522,6 +680,7 @@ func TestReconciler(t *testing.T) {
 					Annotation(controllerconstants.JobOwnerNameAnnotation, "sts").
 					Obj(),
 			},
+			wantEvents: createdWorkloadEvents,
 		},
 	}
 	for name, tc := range cases {
@@ -550,7 +709,8 @@ func TestReconciler(t *testing.T) {
 
 			kClient := clientBuilder.WithObjects(objs...).Build()
 
-			reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+			recorder := &utiltesting.EventRecorder{}
+			reconciler, err := NewReconciler(ctx, kClient, indexer, recorder)
 			if err != nil {
 				t.Errorf("Error creating the reconciler: %v", err)
 			}
@@ -589,6 +749,10 @@ func TestReconciler(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantWorkloads, gotWorkloadList.Items, baseCmpOpts...); diff != "" {
 				t.Errorf("Workloads after reconcile (-want,+got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantEvents, recorder.RecordedEvents, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("Events after reconcile (-want,+got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area integrations

#### What this PR does / why we need it:

The StatefulSet reconciler propagated the `AdmissionGatedBy` annotation to the workload without emitting an event. This uses `UpdateAdmissionGatedBy` instead, which emits a `Normal`/`UpdatedWorkload` event, matching the LeaderWorkerSet integration.

#### Which issue(s) this PR fixes:

Fixes #13861

#### Special notes for your reviewer:

The call runs after `r.client.Update`, because the patch response overwrites `wl` and would otherwise discard the owner reference set just above. Also adds event assertions to `TestReconciler`, which had none.

#### Does this PR introduce a user-facing change?

```release-note
Fixed missing UpdatedWorkload event when the AdmissionGatedBy annotation is propagated from a StatefulSet to its Workload.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StatefulSet workload updates when admission gating changes.
  * Ensured workload changes are saved before applying admission-gating updates.
  * Improved event reporting for workload creation and updates, including owner-reference and admission-gating changes.
  * Ensured admission-gating updates are correctly handled when the related feature is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->