### PR TITLE
Preserve flavor scan progress across scheduling cycles

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -1037,10 +1037,15 @@ func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 	return c.heap.GetByKey(key)
 }
 
-// trackedInfo returns the workload.Info currently tracked for the key, looking in the heap
-// and then in inadmissibleWorkloads. A Workload that failed to be admitted is held in the
-// latter, which Info deliberately does not consult. The inflight Workload is not covered,
-// since it is being scheduled and the scheduler holds its own copy.
+// trackedInfo returns the workload.Info currently tracked for the key, wherever it is held:
+// the heap, inadmissibleWorkloads once the Workload has been tried and could not be admitted,
+// or inflight while the scheduler is processing it. Info covers only the heap.
+//
+// An update to the inflight Workload reaches the LocalQueue but not the heap, since
+// PushOrUpdate deliberately drops it in favour of the newer copy the scheduler requeues at
+// the end of the cycle. The inflight lookup is still worth doing, because the LocalQueue copy
+// is what AddFromLocalQueue replays if the ClusterQueue is reactivated.
+//
 // Users of this method should not modify the returned object.
 func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
 	c.rwm.RLock()
@@ -1048,7 +1053,13 @@ func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
 	if wInfo := c.heap.GetByKey(key); wInfo != nil {
 		return wInfo
 	}
-	return c.inadmissibleWorkloads.get(key)
+	if wInfo := c.inadmissibleWorkloads.get(key); wInfo != nil {
+		return wInfo
+	}
+	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
+		return c.inflight
+	}
+	return nil
 }
 
 // totalElements returns all pending workloads (heap + inadmissible + inflight).

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -1037,6 +1037,20 @@ func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 	return c.heap.GetByKey(key)
 }
 
+// trackedInfo returns the workload.Info currently tracked for the key, looking in the heap
+// and then in inadmissibleWorkloads. A Workload that failed to be admitted is held in the
+// latter, which Info deliberately does not consult. The inflight Workload is not covered,
+// since it is being scheduled and the scheduler holds its own copy.
+// Users of this method should not modify the returned object.
+func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
+	c.rwm.RLock()
+	defer c.rwm.RUnlock()
+	if wInfo := c.heap.GetByKey(key); wInfo != nil {
+		return wInfo
+	}
+	return c.inadmissibleWorkloads.get(key)
+}
+
 // totalElements returns all pending workloads (heap + inadmissible + inflight).
 // The returned order is non-deterministic; callers should sort if needed.
 func (c *ClusterQueue) totalElements() []*workload.Info {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -720,9 +720,20 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	allOptions := append(m.workloadInfoOptions, opts...)
 	wInfo := workload.NewInfo(w, allOptions...)
 	wInfo.UpdateSchedulingHash(log)
-	m.addWorkload(wInfo, q)
 
 	cq := m.hm.ClusterQueue(q.ClusterQueue)
+	// Rebuilding the Info would drop the flavor scan progress an earlier cycle recorded, so
+	// carry it over. Any update to the Workload lands here, and on a busy cluster those
+	// arrive constantly, which would otherwise send the scan back to the first flavor every
+	// time. The progress still expires on its own, since it keeps the scheduling cycle it
+	// was recorded in and lastAssignmentOutdated discards it once it is older than that.
+	if features.Enabled(features.PreserveFlavorScanProgress) && cq != nil {
+		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.LastAssignment != nil {
+			wInfo.LastAssignment = tracked.LastAssignment.Clone()
+		}
+	}
+	m.addWorkload(wInfo, q)
+
 	if cq == nil {
 		return ErrClusterQueueDoesNotExist
 	}

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -727,8 +727,9 @@ func (m *Manager) AddOrUpdateWorkloadWithoutLock(log logr.Logger, w *kueue.Workl
 	// arrive constantly, which would otherwise send the scan back to the first flavor every
 	// time. The progress still expires on its own, since it keeps the scheduling cycle it
 	// was recorded in and lastAssignmentOutdated discards it once it is older than that.
-	if features.Enabled(features.PreserveFlavorScanProgress) && cq != nil {
-		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.LastAssignment != nil {
+	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) && cq != nil {
+		if tracked := cq.trackedInfo(wlKey); tracked != nil && tracked.LastAssignment != nil &&
+			tracked.LastAssignment.MatchesSchedulingShape(wInfo.SchedulingHash) {
 			wInfo.LastAssignment = tracked.LastAssignment.Clone()
 		}
 	}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2413,3 +2413,125 @@ func TestDeleteLocalQueue_UnadmittedWorkloads(t *testing.T) {
 		t.Errorf("expected tracked unadmitted workloads to be empty, got %v", manager.unadmittedWorkloads.statuses)
 	}
 }
+
+// TestAddOrUpdateWorkloadCarriesLastAssignment covers the flavor scan progress surviving a
+// Workload update. Updating a Workload rebuilds its Info, and rebuilding it used to drop
+// LastAssignment, so a cluster where Workloads are updated frequently sent the scan back to
+// the first flavor no matter what an earlier cycle had recorded.
+//
+// Both places a pending Workload can be tracked are covered. A Workload with flavors still
+// to try is pushed back onto the heap, while one whose scan has been exhausted is held in
+// inadmissibleWorkloads, which ClusterQueue.Info deliberately does not consult.
+func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
+	// pendingFlavors has a flavor left to try, so requeueing puts the Workload back on the
+	// heap. exhaustedScan has none, so requeueing holds it as inadmissible.
+	pendingFlavors := func() *workload.AssignmentClusterQueueState {
+		return &workload.AssignmentClusterQueueState{
+			LastTriedFlavorIdx:     []map[corev1.ResourceName]int{{corev1.ResourceCPU: 1}},
+			ClusterQueueGeneration: 3,
+			SchedulingCycle:        7,
+		}
+	}
+	exhaustedScan := func() *workload.AssignmentClusterQueueState {
+		return &workload.AssignmentClusterQueueState{
+			LastTriedFlavorIdx:     []map[corev1.ResourceName]int{{corev1.ResourceCPU: -1}},
+			ClusterQueueGeneration: 3,
+			SchedulingCycle:        7,
+		}
+	}
+
+	cases := map[string]struct {
+		preserveProgress bool
+		// inadmissible pops the Workload and requeues it, as a cycle that failed to admit
+		// it would, which moves it into inadmissibleWorkloads.
+		inadmissible bool
+		recorded     *workload.AssignmentClusterQueueState
+		wantCarried  bool
+	}{
+		"tracked in the heap": {
+			preserveProgress: true,
+			recorded:         pendingFlavors(),
+			wantCarried:      true,
+		},
+		"tracked in inadmissibleWorkloads": {
+			preserveProgress: true,
+			inadmissible:     true,
+			recorded:         exhaustedScan(),
+			wantCarried:      true,
+		},
+		"without the gate the progress is dropped": {
+			preserveProgress: false,
+			recorded:         pendingFlavors(),
+			wantCarried:      false,
+		},
+		"without the gate the progress is dropped for an inadmissible workload": {
+			preserveProgress: false,
+			inadmissible:     true,
+			recorded:         exhaustedScan(),
+			wantCarried:      false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tc.preserveProgress)
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			manager := NewManagerForUnitTests(utiltesting.NewFakeClient(), nil,
+				WithPreemptionExpectations(preemptexpectations.New()))
+			if err := manager.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").Obj()); err != nil {
+				t.Fatalf("Adding ClusterQueue: %v", err)
+			}
+			if err := manager.AddLocalQueue(ctx, utiltestingapi.MakeLocalQueue("lq", "").ClusterQueue("cq").Obj()); err != nil {
+				t.Fatalf("Adding LocalQueue: %v", err)
+			}
+
+			wl := utiltestingapi.MakeWorkload("wl", "").Queue("lq").Obj()
+			if err := manager.AddOrUpdateWorkload(log, wl); err != nil {
+				t.Fatalf("Adding Workload: %v", err)
+			}
+
+			// Stand in for a scheduling cycle that recorded flavor scan progress on the
+			// Workload and then could not admit it.
+			cqImpl := manager.hm.ClusterQueue("cq")
+			key := workload.Key(wl)
+			tracked := cqImpl.trackedInfo(key)
+			if tracked == nil {
+				t.Fatal("Workload is not tracked by the ClusterQueue after being added")
+			}
+			tracked.LastAssignment = tc.recorded
+			if tc.inadmissible {
+				if popped := cqImpl.Pop(); popped == nil {
+					t.Fatal("Popping the Workload returned nothing")
+				}
+				if !cqImpl.requeueIfNotPresent(log, tracked, false, RequeueReasonNoFit, "") {
+					t.Fatal("Requeueing the Workload failed")
+				}
+				if cqImpl.inadmissibleWorkloads.get(key) == nil {
+					t.Fatal("Workload is not held in inadmissibleWorkloads")
+				}
+			}
+
+			updated := wl.DeepCopy()
+			updated.Labels = map[string]string{"updated": "true"}
+			if err := manager.AddOrUpdateWorkload(log, updated); err != nil {
+				t.Fatalf("Updating Workload: %v", err)
+			}
+
+			got := cqImpl.trackedInfo(key)
+			if got == nil {
+				t.Fatal("Workload is not tracked by the ClusterQueue after the update")
+			}
+			var want *workload.AssignmentClusterQueueState
+			if tc.wantCarried {
+				want = tc.recorded
+			}
+			if diff := cmp.Diff(want, got.LastAssignment); diff != "" {
+				t.Errorf("LastAssignment after the update (-want,+got):\n%s", diff)
+			}
+			if tc.wantCarried && got.LastAssignment == tc.recorded {
+				t.Error("LastAssignment was carried by reference; it must be cloned so the two Infos do not alias")
+			}
+		})
+	}
+}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2445,8 +2445,14 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 		// inadmissible pops the Workload and requeues it, as a cycle that failed to admit
 		// it would, which moves it into inadmissibleWorkloads.
 		inadmissible bool
-		recorded     *workload.AssignmentClusterQueueState
-		wantCarried  bool
+		// inflight pops the Workload and leaves it there, as it is while the scheduler
+		// processes it.
+		inflight bool
+		// changeShape alters the Workload's requests in the update, so its scheduling
+		// equivalence hash no longer matches the one the assignment was recorded for.
+		changeShape bool
+		recorded    *workload.AssignmentClusterQueueState
+		wantCarried bool
 	}{
 		"tracked in the heap": {
 			preserveProgress: true,
@@ -2470,11 +2476,31 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 			recorded:         exhaustedScan(),
 			wantCarried:      false,
 		},
+		"tracked as inflight": {
+			preserveProgress: true,
+			inflight:         true,
+			recorded:         pendingFlavors(),
+			wantCarried:      true,
+		},
+		"without the gate the progress is dropped for an inflight workload": {
+			preserveProgress: false,
+			inflight:         true,
+			recorded:         pendingFlavors(),
+			wantCarried:      false,
+		},
+		// The recorded flavor indices were chosen for the old requests, so resuming from
+		// them could skip a flavor the changed Workload now fits.
+		"a changed scheduling shape is not carried": {
+			preserveProgress: true,
+			changeShape:      true,
+			recorded:         pendingFlavors(),
+			wantCarried:      false,
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tc.preserveProgress)
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityPreserveScanProgress, tc.preserveProgress)
 			ctx, log := utiltesting.ContextWithLog(t)
 
 			manager := NewManagerForUnitTests(utiltesting.NewFakeClient(), nil,
@@ -2499,11 +2525,14 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 			if tracked == nil {
 				t.Fatal("Workload is not tracked by the ClusterQueue after being added")
 			}
+			tc.recorded.SchedulingHash = tracked.SchedulingHash
 			tracked.LastAssignment = tc.recorded
-			if tc.inadmissible {
+			if tc.inadmissible || tc.inflight {
 				if popped := cqImpl.Pop(); popped == nil {
 					t.Fatal("Popping the Workload returned nothing")
 				}
+			}
+			if tc.inadmissible {
 				if !cqImpl.requeueIfNotPresent(log, tracked, false, RequeueReasonNoFit, "") {
 					t.Fatal("Requeueing the Workload failed")
 				}
@@ -2514,13 +2543,23 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 
 			updated := wl.DeepCopy()
 			updated.Labels = map[string]string{"updated": "true"}
+			if tc.changeShape {
+				updated.Spec.PodSets[0].Count = wl.Spec.PodSets[0].Count + 3
+			}
 			if err := manager.AddOrUpdateWorkload(log, updated); err != nil {
 				t.Fatalf("Updating Workload: %v", err)
 			}
 
-			got := cqImpl.trackedInfo(key)
+			// PushOrUpdate drops an update to the inflight Workload, so the rebuilt Info
+			// reaches the LocalQueue only. That copy is what AddFromLocalQueue would replay.
+			var got *workload.Info
+			if tc.inflight {
+				got = manager.localQueues[queue.KeyFromWorkload(updated)].items[key]
+			} else {
+				got = cqImpl.trackedInfo(key)
+			}
 			if got == nil {
-				t.Fatal("Workload is not tracked by the ClusterQueue after the update")
+				t.Fatal("Workload is not tracked after the update")
 			}
 			var want *workload.AssignmentClusterQueueState
 			if tc.wantCarried {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -517,6 +517,18 @@ const (
 	// the size, or disable this gate to accept the previous behavior.
 	LWSImmutableGroupSize featuregate.Feature = "LWSImmutableGroupSize"
 
+	// owner: @varunsyal
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/582-preempt-based-on-flavor-order
+	//
+	// Keeps the flavor scan progress recorded in LastTriedFlavorIdx usable in the next
+	// scheduling cycle. Without this the progress is discarded whenever the ClusterQueue's
+	// AllocatableResourceGeneration advances, which happens on every admission or eviction
+	// in the Cohort, and whenever a Workload is skipped because another Workload processed
+	// earlier in the cycle took the capacity or the preemption targets it had been assigned.
+	// Under sustained load either can happen every cycle, leaving the scan to restart from
+	// the first flavor indefinitely.
+	PreserveFlavorScanProgress featuregate.Feature = "PreserveFlavorScanProgress"
+
 	// owner: @iaalm
 	//
 	// pr: https://github.com/kubernetes-sigs/kueue/pull/10009
@@ -557,6 +569,7 @@ var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Featu
 	KueueDRAIntegrationExtendedResource:      {KueueDRAIntegration},
 	KueueDRAIntegrationPartitionableDevices:  {KueueDRAIntegration},
 	KueueDRAIntegrationConsumableCapacity:    {KueueDRAIntegration},
+	PreserveFlavorScanProgress:               {FlavorFungibility},
 }
 
 // defaultVersionedFeatureGates consists of all known Kueue-specific feature keys.
@@ -829,6 +842,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	LWSImmutableGroupSize: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	PreserveFlavorScanProgress: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -527,7 +527,7 @@ const (
 	// earlier in the cycle took the capacity or the preemption targets it had been assigned.
 	// Under sustained load either can happen every cycle, leaving the scan to restart from
 	// the first flavor indefinitely.
-	PreserveFlavorScanProgress featuregate.Feature = "PreserveFlavorScanProgress"
+	FlavorFungibilityPreserveScanProgress featuregate.Feature = "FlavorFungibilityPreserveScanProgress"
 
 	// owner: @iaalm
 	//
@@ -569,7 +569,7 @@ var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Featu
 	KueueDRAIntegrationExtendedResource:      {KueueDRAIntegration},
 	KueueDRAIntegrationPartitionableDevices:  {KueueDRAIntegration},
 	KueueDRAIntegrationConsumableCapacity:    {KueueDRAIntegration},
-	PreserveFlavorScanProgress:               {FlavorFungibility},
+	FlavorFungibilityPreserveScanProgress:    {FlavorFungibility},
 }
 
 // defaultVersionedFeatureGates consists of all known Kueue-specific feature keys.
@@ -845,7 +845,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 
-	PreserveFlavorScanProgress: {
+	FlavorFungibilityPreserveScanProgress: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -685,6 +685,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 			LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, 0, len(requests)),
 			ClusterQueueGeneration: a.cq.AllocatableResourceGeneration,
 			SchedulingCycle:        a.schedulingCycle,
+			SchedulingHash:         a.wl.SchedulingHash,
 		},
 		replaceWorkloadSlice: a.replaceWorkloadSlice,
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -612,6 +612,10 @@ type FlavorAssigner struct {
 	replaceWorkloadSlice *workload.Info
 	quotaCheckStrategy   configapi.QuotaCheckStrategy
 	resourceFormatter    *resources.ResourceFormatter
+
+	// schedulingCycle is the cycle this assignment is being computed in. It is recorded
+	// on the assignment so that a later cycle can tell how old the assignment is.
+	schedulingCycle int64
 }
 
 func New(
@@ -623,6 +627,7 @@ func New(
 	preemptWorkloadSlice *workload.Info,
 	quotaCheckStrategy configapi.QuotaCheckStrategy,
 	resourceFormatter *resources.ResourceFormatter,
+	schedulingCycle int64,
 ) *FlavorAssigner {
 	return &FlavorAssigner{
 		wl:                   wl,
@@ -633,11 +638,8 @@ func New(
 		replaceWorkloadSlice: preemptWorkloadSlice,
 		quotaCheckStrategy:   quotaCheckStrategy,
 		resourceFormatter:    resourceFormatter,
+		schedulingCycle:      schedulingCycle,
 	}
-}
-
-func lastAssignmentOutdated(wl *workload.Info, cq *schdcache.ClusterQueueSnapshot) bool {
-	return cq.AllocatableResourceGeneration > wl.LastAssignment.ClusterQueueGeneration
 }
 
 // Assign assigns a flavor to each of the resources requested in each pod set.
@@ -647,16 +649,6 @@ func lastAssignmentOutdated(wl *workload.Info, cq *schdcache.ClusterQueueSnapsho
 func (a *FlavorAssigner) Assign(ctx context.Context, counts []int32) Assignment {
 	log := log.FromContext(ctx)
 
-	if a.wl.LastAssignment != nil && lastAssignmentOutdated(a.wl, a.cq) {
-		if logV := log.V(6); logV.Enabled() {
-			keysValues := []any{
-				"cq.AllocatableResourceGeneration", a.cq.AllocatableResourceGeneration,
-				"wl.LastAssignment.ClusterQueueGeneration", a.wl.LastAssignment.ClusterQueueGeneration,
-			}
-			logV.Info("Clearing Workload's last assignment because it was outdated", keysValues...)
-		}
-		a.wl.LastAssignment = nil
-	}
 	return a.assignFlavors(ctx, log, counts)
 }
 
@@ -692,6 +684,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		LastState: workload.AssignmentClusterQueueState{
 			LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, 0, len(requests)),
 			ClusterQueueGeneration: a.cq.AllocatableResourceGeneration,
+			SchedulingCycle:        a.schedulingCycle,
 		},
 		replaceWorkloadSlice: a.replaceWorkloadSlice,
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -3648,6 +3648,7 @@ func TestAssignFlavors(t *testing.T) {
 					tc.preemptWorkloadSlice,
 					configapi.QuotaCheckBlockUndeclared,
 					resources.NewResourceFormatter(),
+					0,
 				)
 				assignment := flvAssigner.Assign(ctx, nil)
 				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
@@ -3842,7 +3843,7 @@ func TestReclaimBeforePriorityPreemption(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 			assignment := flvAssigner.Assign(ctx, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -3990,7 +3991,7 @@ func TestDeletedFlavors(t *testing.T) {
 				cache.DeleteResourceFlavor(log, flavorMap["deleted-flavor"])
 				delete(flavorMap, "deleted-flavor")
 
-				flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+				flvAssigner := New(wlInfo, clusterQueue, flavorMap, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 
 				assignment := flvAssigner.Assign(ctx, nil)
 				if repMode := assignment.RepresentativeMode(); repMode != tc.wantRepMode {
@@ -4013,54 +4014,6 @@ func TestDeletedFlavors(t *testing.T) {
 				}
 			})
 		}
-	}
-}
-
-func TestLastAssignmentOutdated(t *testing.T) {
-	type args struct {
-		wl *workload.Info
-		cq *schdcache.ClusterQueueSnapshot
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-		{
-			name: "Cluster queue allocatableResourceIncreasedGen increased",
-			args: args{
-				wl: &workload.Info{
-					LastAssignment: &workload.AssignmentClusterQueueState{
-						ClusterQueueGeneration: 0,
-					},
-				},
-				cq: &schdcache.ClusterQueueSnapshot{
-					AllocatableResourceGeneration: 1,
-				},
-			},
-			want: true,
-		},
-		{
-			name: "AllocatableResourceGeneration not increased",
-			args: args{
-				wl: &workload.Info{
-					LastAssignment: &workload.AssignmentClusterQueueState{
-						ClusterQueueGeneration: 0,
-					},
-				},
-				cq: &schdcache.ClusterQueueSnapshot{
-					AllocatableResourceGeneration: 0,
-				},
-			},
-			want: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := lastAssignmentOutdated(tt.args.wl, tt.args.cq); got != tt.want {
-				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }
 
@@ -4212,7 +4165,7 @@ func TestHierarchical(t *testing.T) {
 			testClusterQueue := snapshot.ClusterQueue("test-clusterqueue")
 			testClusterQueue.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.testClusterQueueUsage}})
 
-			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, testClusterQueue, resourceFlavors, false, &testOracle{tc.simulationResult}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 			assignment := flvAssigner.Assign(ctx, nil)
 			if gotRepMode := assignment.RepresentativeMode(); gotRepMode != tc.wantMode {
 				t.Errorf("Unexpected RepresentativeMode. got %s, want %s", gotRepMode, tc.wantMode)
@@ -5225,7 +5178,7 @@ func TestAssignFlavorsWithAllowedFlavors(t *testing.T) {
 			}
 			cqSnapshot := snapshot.ClusterQueue(kueue.ClusterQueueReference(cq.Name))
 
-			assigner := New(wlInfo, cqSnapshot, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			assigner := New(wlInfo, cqSnapshot, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 			gotAssignment := assigner.Assign(ctx, nil)
 
 			if gotAssignment.RepresentativeMode() != tc.wantRepMode {
@@ -5710,6 +5663,7 @@ func TestIsNoFitDueToCapacityAndLimits(t *testing.T) {
 			assigner := New(
 				wlInfo, cqSnapshot, testFlavors, false, &testOracle{simulationResult: tc.simulationResult},
 				tc.replaceWl, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(),
+				0,
 			)
 			gotAssignment := assigner.Assign(ctx, nil)
 
@@ -5973,7 +5927,7 @@ func TestAssignFlavors_LeaderWorkerSetTASFlavor(t *testing.T) {
 				t.Fatalf("Failed to create CQ snapshot")
 			}
 
-			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter())
+			flvAssigner := New(wlInfo, cq, resourceFlavors, false, &testOracle{}, nil, configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), 0)
 			assignment := flvAssigner.Assign(ctx, nil)
 
 			gotErrors := map[kueue.PodSetReference]error{}
@@ -6055,5 +6009,449 @@ func TestTasFlavorsOnly(t *testing.T) {
 	got := tasFlavorsOnly(in, tasFlavors)
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(FlavorAssignment{})); diff != "" {
 		t.Errorf("tasFlavorsOnly() mismatch (-want,+got):\n%s", diff)
+	}
+}
+
+// Two TAS flavors with one node each, addressed by hostname. Each node holds 4 CPU, so a
+// request above that cannot be placed however much quota the ClusterQueue has.
+func bookmarkTestFlavors() map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor {
+	return map[kueue.ResourceFlavorReference]*kueue.ResourceFlavor{
+		"flavor-1": utiltestingapi.MakeResourceFlavor("flavor-1").
+			NodeLabel("flavor", "one").TopologyName("topology-1").Obj(),
+		"flavor-2": utiltestingapi.MakeResourceFlavor("flavor-2").
+			NodeLabel("flavor", "two").TopologyName("topology-2").Obj(),
+	}
+}
+
+func bookmarkTestNodes() []corev1.Node {
+	return []corev1.Node{
+		*testingnode.MakeNode("node-1").
+			Label("flavor", "one").
+			Label(corev1.LabelHostname, "node-1").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("32"),
+			}).
+			Ready().
+			Obj(),
+		*testingnode.MakeNode("node-2").
+			Label("flavor", "two").
+			Label(corev1.LabelHostname, "node-2").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("32"),
+			}).
+			Ready().
+			Obj(),
+	}
+}
+
+// newBookmarkSnapshot builds a snapshot with the two TAS flavors above, a ClusterQueue
+// holding nominalPerFlavor on each of them, and a sibling ClusterQueue in the same cohort
+// lending cohortSpare, so that a request beyond nominal is reachable by borrowing.
+func newBookmarkSnapshot(
+	ctx context.Context,
+	t *testing.T,
+	log logr.Logger,
+	nominalPerFlavor, cohortSpare string,
+	fungibility kueue.FlavorFungibility,
+) *schdcache.ClusterQueueSnapshot {
+	t.Helper()
+
+	clusterQueue := utiltestingapi.MakeClusterQueue("cq").
+		Cohort("cohort").
+		FlavorFungibility(fungibility).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-1").Resource(corev1.ResourceCPU, nominalPerFlavor).Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-2").Resource(corev1.ResourceCPU, nominalPerFlavor).Obj(),
+		).
+		Obj()
+	sibling := utiltestingapi.MakeClusterQueue("sibling").
+		Cohort("cohort").
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("flavor-1").Resource(corev1.ResourceCPU, cohortSpare).Obj(),
+			*utiltestingapi.MakeFlavorQuotas("flavor-2").Resource(corev1.ResourceCPU, cohortSpare).Obj(),
+		).
+		Obj()
+
+	cache := schdcache.New(utiltesting.NewFakeClient())
+	for _, rf := range bookmarkTestFlavors() {
+		cache.AddOrUpdateResourceFlavor(log, rf)
+	}
+	for _, topology := range []*kueue.Topology{
+		utiltestingapi.MakeTopology("topology-1").Levels(corev1.LabelHostname).Obj(),
+		utiltestingapi.MakeTopology("topology-2").Levels(corev1.LabelHostname).Obj(),
+	} {
+		cache.AddOrUpdateTopology(log, topology)
+	}
+	nodes := bookmarkTestNodes()
+	for i := range nodes {
+		cache.TASCache().SyncNode(&nodes[i])
+	}
+	if err := cache.AddClusterQueue(ctx, clusterQueue); err != nil {
+		t.Fatalf("adding ClusterQueue: %v", err)
+	}
+	if err := cache.AddClusterQueue(ctx, sibling); err != nil {
+		t.Fatalf("adding sibling ClusterQueue: %v", err)
+	}
+
+	snapshot, err := cache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("building snapshot: %v", err)
+	}
+	cqSnapshot := snapshot.ClusterQueue(kueue.ClusterQueueReference(clusterQueue.Name))
+	if cqSnapshot == nil {
+		t.Fatalf("ClusterQueue missing from snapshot")
+	}
+	return cqSnapshot
+}
+
+// bookmarkTestWorkload is a single pod requesting cpu on a required hostname topology.
+func bookmarkTestWorkload(request string) *workload.Info {
+	return workload.NewInfo(utiltestingapi.MakeWorkload("wl", "default").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, request).
+			Obj()).
+		Obj())
+}
+
+// nodeUsageOnFlavorOne consumes cpu on node-1 without charging the ClusterQueue's quota,
+// as happens when another ClusterQueue shares the nodes through the same flavor.
+func nodeUsageOnFlavorOne(cpu string) workload.TASUsage {
+	return workload.TASUsage{
+		"flavor-1": []workload.TopologyDomainRequests{{
+			Values: []string{"node-1"},
+			SinglePodRequests: resources.NewRequestsFromResourceList(corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse(cpu),
+			}),
+			Count: 1,
+		}},
+	}
+}
+
+// bookmarkTestCycle is the scheduling cycle these tests assign in. Nomination and any
+// in-cycle recomputation share it, matching the scheduler.
+const bookmarkTestCycle int64 = 7
+
+// lastTriedFlavorIdx reads the bookmark the assignment recorded for the first PodSet.
+func lastTriedFlavorIdx(a Assignment, res corev1.ResourceName) (int, bool) {
+	if len(a.LastState.LastTriedFlavorIdx) == 0 {
+		return 0, false
+	}
+	idx, ok := a.LastState.LastTriedFlavorIdx[0][res]
+	return idx, ok
+}
+
+// TestFlavorScanRecordsLastTriedFlavorIdx pins down what the cross-cycle flavor bookmark
+// holds for each shape the flavor scan can take, with TAS enabled.
+//
+// LastTriedFlavorIdx is consumed as the starting index of the next scan
+// (NextFlavorToTryForPodSetResource returns idx+1), so it only carries progress when it
+// names a specific flavor. When the scan reaches the last flavor it is set to -1, which
+// means "start over from the first flavor".
+//
+// Note the ordering the topology cases demonstrate: the bookmark is written inside
+// findFlavorForPodSets, while the TAS placement search runs after the flavor loop has
+// finished. A flavor that quota accepts is therefore recorded as tried before TAS gets to
+// reject it, which is why a quota-Fit assignment can still fail to be admitted and be
+// requeued carrying a usable bookmark.
+func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
+	cases := map[string]struct {
+		// nominalPerFlavor is the ClusterQueue's nominal quota on each flavor.
+		nominalPerFlavor string
+		// cohortSpare is the sibling ClusterQueue's nominal quota, lendable to ours.
+		cohortSpare string
+		// request is what the Workload's single pod asks for.
+		request string
+		// clusterQueueUsage pre-consumes quota so the request cannot fit outright.
+		// CPU amounts are milli-units, so 10 CPU is 10_000.
+		clusterQueueUsage resources.FlavorResourceQuantities
+		// nodeUsage pre-consumes capacity on node-1 without charging quota.
+		nodeUsage workload.TASUsage
+		// simulationResult lets a flavor report whether preemption could help.
+		simulationResult map[resources.FlavorResource]simulationResultForFlavor
+		fungibility      kueue.FlavorFungibility
+
+		wantMode           FlavorAssignmentMode
+		wantTriedFlavorIdx int
+		// wantPlan is whether nomination produced a TopologyAssignment. Only an
+		// assignment that carries a plan can later be invalidated mid-cycle, which is
+		// what the in-cycle recomputation is triggered by.
+		wantPlan bool
+	}{
+		"quota and topology both fit on the first flavor: bookmark names it": {
+			nominalPerFlavor: "10",
+			cohortSpare:      "0",
+			request:          "2",
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			wantMode:           Fit,
+			wantTriedFlavorIdx: 0,
+			wantPlan:           true,
+		},
+		"quota fits but the pod is larger than any node: bookmark still names the first flavor": {
+			nominalPerFlavor: "10",
+			cohortSpare:      "0",
+			request:          "6",
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			// The quota scan stopped on flavor-1 and recorded it. TAS then rejected the
+			// flavor, and because the pod cannot fit a node even with every other
+			// Workload preempted the mode ends at NoFit rather than Preempt. Either way
+			// the bookmark was already written and still points at flavor-1.
+			wantMode:           NoFit,
+			wantTriedFlavorIdx: 0,
+		},
+		"quota fits but the topology is fragmented: bookmark still names the first flavor": {
+			nominalPerFlavor: "10",
+			cohortSpare:      "0",
+			// The pod would fit node-1 on its own, so this is fragmentation rather than a
+			// pod that is structurally too large: 2 of the node's 4 CPU are already taken,
+			// leaving too little for a required-topology request of 3.
+			request:   "3",
+			nodeUsage: nodeUsageOnFlavorOne("2"),
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			// The real-state placement search fails, but the search that simulates every
+			// other Workload preempted succeeds, so the mode settles at Preempt. This is
+			// the shape reported in #13658, and the bookmark written during the quota scan
+			// still points at flavor-1.
+			wantMode:           Preempt,
+			wantTriedFlavorIdx: 0,
+		},
+		"fits only by borrowing: bookmark says start over": {
+			nominalPerFlavor: "1",
+			cohortSpare:      "20",
+			request:          "2",
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.TryNextFlavor,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			// Borrowing is not optimal and WhenCanBorrow is TryNextFlavor, so the scan
+			// runs past flavor-1 and reaches the last flavor.
+			wantMode:           Fit,
+			wantTriedFlavorIdx: -1,
+			wantPlan:           true,
+		},
+		"fits only by borrowing, but WhenCanBorrow is MayStopSearch: bookmark names the first flavor": {
+			nominalPerFlavor: "1",
+			cohortSpare:      "20",
+			request:          "2",
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.MayStopSearch,
+				WhenCanPreempt: kueue.TryNextFlavor,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			wantMode:           Fit,
+			wantTriedFlavorIdx: 0,
+			wantPlan:           true,
+		},
+		"needs preemption and candidates exist: bookmark names the first flavor": {
+			nominalPerFlavor: "2",
+			cohortSpare:      "0",
+			request:          "2",
+			clusterQueueUsage: resources.FlavorResourceQuantities{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 0},
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: {preemptioncommon.Preempt, 0},
+			},
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.MayStopSearch,
+				WhenCanPreempt: kueue.MayStopSearch,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			wantMode:           Preempt,
+			wantTriedFlavorIdx: 0,
+		},
+		"needs preemption but no candidates: bookmark says start over whatever the policy": {
+			nominalPerFlavor: "2",
+			cohortSpare:      "0",
+			request:          "2",
+			clusterQueueUsage: resources.FlavorResourceQuantities{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
+			},
+			// Both knobs are the conservative setting, yet shouldTryNextFlavor returns
+			// true for noPreemptionCandidates before either policy is consulted, so no
+			// fungibility configuration can stop the scan here.
+			fungibility: kueue.FlavorFungibility{
+				WhenCanBorrow:  kueue.MayStopSearch,
+				WhenCanPreempt: kueue.MayStopSearch,
+				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+			},
+			wantMode:           Preempt,
+			wantTriedFlavorIdx: -1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibility, true)
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			cqSnapshot := newBookmarkSnapshot(ctx, t, log, tc.nominalPerFlavor, tc.cohortSpare, tc.fungibility)
+			if tc.clusterQueueUsage != nil {
+				cqSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.clusterQueueUsage}})
+			}
+			if tc.nodeUsage != nil {
+				cqSnapshot.AddUsage(workload.Usage{TAS: tc.nodeUsage})
+			}
+
+			wlInfo := bookmarkTestWorkload(tc.request)
+			assigner := New(wlInfo, cqSnapshot, bookmarkTestFlavors(), false,
+				&testOracle{simulationResult: tc.simulationResult}, nil,
+				configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), bookmarkTestCycle)
+			assignment := assigner.Assign(ctx, nil)
+
+			if gotMode := assignment.RepresentativeMode(); gotMode != tc.wantMode {
+				t.Errorf("RepresentativeMode() = %s, want %s", gotMode, tc.wantMode)
+			}
+			got, ok := lastTriedFlavorIdx(assignment, corev1.ResourceCPU)
+			if !ok {
+				t.Fatalf("no bookmark recorded for cpu; mode was %s", assignment.RepresentativeMode())
+			}
+			if got != tc.wantTriedFlavorIdx {
+				t.Errorf("LastTriedFlavorIdx for cpu = %d, want %d", got, tc.wantTriedFlavorIdx)
+			}
+			if gotPlan := assignment.PodSets[0].TopologyAssignment != nil; gotPlan != tc.wantPlan {
+				t.Errorf("produced a TopologyAssignment = %t, want %t", gotPlan, tc.wantPlan)
+			}
+		})
+	}
+}
+
+// TestRecomputeRecordsLastTriedFlavorIdx covers the case where quota and topology both fit
+// at nomination and the placement is invalidated later in the same cycle, which is what
+// triggers the in-cycle recomputation.
+//
+// The recomputation replays flavor assignment with NominationMapping populated so that the
+// nominated flavor is kept, and it is the recomputed assignment that the scheduler stores.
+// Whatever bookmark that second pass records is therefore the one the next cycle inherits.
+//
+// Which bookmark that is depends on where the replayed scan stops. If quota still accepts
+// the nominated flavor the scan breaks on it and the bookmark names it. If quota has since
+// tightened, the scan carries on to the remaining flavors, which the nomination mapping
+// skips one by one, and reaches the last flavor - recording "start over" instead. Both
+// report the same newMode: Preempt, so a log line alone cannot tell them apart.
+func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
+	fungibility := kueue.FlavorFungibility{
+		WhenCanBorrow:  kueue.TryNextFlavor,
+		WhenCanPreempt: kueue.TryNextFlavor,
+		Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+	}
+
+	cases := map[string]struct {
+		// quotaUsageAtRecompute tightens quota before the assignment is replayed.
+		quotaUsageAtRecompute resources.FlavorResourceQuantities
+		// simulationResult applies to the replayed assignment.
+		simulationResult map[resources.FlavorResource]simulationResultForFlavor
+
+		wantRecomputedIdx int
+	}{
+		"quota still accepts the nominated flavor: bookmark keeps naming it": {
+			wantRecomputedIdx: 0,
+		},
+		"quota tightened as well: bookmark says start over": {
+			quotaUsageAtRecompute: resources.FlavorResourceQuantities{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+			},
+			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
+				{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
+				{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 0},
+			},
+			// The replayed scan no longer breaks on flavor-1, so it walks on to flavor-2,
+			// which the nomination mapping skips, and ends on the last flavor.
+			wantRecomputedIdx: -1,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+			features.SetFeatureGateDuringTest(t, features.TASRecomputeAssignmentWithinSchedulingCycle, true)
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibility, true)
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			// Quota is generous at nomination, so both flavors are accepted on quota
+			// grounds and the pod fits an empty node.
+			cqSnapshot := newBookmarkSnapshot(ctx, t, log, "10", "0", fungibility)
+			wlInfo := bookmarkTestWorkload("3")
+			flavors := bookmarkTestFlavors()
+
+			// Nomination: quota fits, topology fits, and a placement is produced.
+			nominated := New(wlInfo, cqSnapshot, flavors, false, &testOracle{}, nil,
+				configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), bookmarkTestCycle).Assign(ctx, nil)
+			if got := nominated.RepresentativeMode(); got != Fit {
+				t.Fatalf("nomination RepresentativeMode() = %s, want %s", got, Fit)
+			}
+			if nominated.PodSets[0].TopologyAssignment == nil {
+				t.Fatal("nomination produced no TopologyAssignment, so there is no placement to invalidate")
+			}
+			nominatedIdx, ok := lastTriedFlavorIdx(nominated, corev1.ResourceCPU)
+			if !ok {
+				t.Fatal("nomination recorded no bookmark for cpu")
+			}
+			if nominatedIdx != 0 {
+				t.Errorf("nomination LastTriedFlavorIdx = %d, want 0", nominatedIdx)
+			}
+
+			// Another Workload admitted later in the same cycle takes most of node-1, so
+			// the placement chosen at nomination no longer fits.
+			cqSnapshot.AddUsage(workload.Usage{TAS: nodeUsageOnFlavorOne("2")})
+			if tc.quotaUsageAtRecompute != nil {
+				cqSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: tc.quotaUsageAtRecompute}})
+			}
+
+			// The scheduler clears LastAssignment and pins the nominated flavors before
+			// replaying the assignment, so that the recomputation stays on the flavor
+			// quota was computed for.
+			wlInfo.LastAssignment = nil
+			mapping := workload.PodSetResourcesToFlavors{}
+			for _, psa := range nominated.PodSets {
+				perResource := workload.ResourceToFlavor{}
+				for res, fa := range psa.Flavors {
+					perResource[res] = fa.Name
+				}
+				mapping[psa.Name] = perResource
+			}
+			wlInfo.NominationMapping = mapping
+
+			recomputed := New(wlInfo, cqSnapshot, flavors, false,
+				&testOracle{simulationResult: tc.simulationResult}, nil,
+				configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), bookmarkTestCycle).Assign(ctx, nil)
+
+			recomputedIdx, ok := lastTriedFlavorIdx(recomputed, corev1.ResourceCPU)
+			if !ok {
+				t.Fatalf("recomputation recorded no bookmark for cpu; mode was %s", recomputed.RepresentativeMode())
+			}
+			if recomputedIdx != tc.wantRecomputedIdx {
+				t.Errorf("recomputation LastTriedFlavorIdx = %d, want %d", recomputedIdx, tc.wantRecomputedIdx)
+			}
+			// Both shapes report the same mode, which is why a mode log line alone cannot
+			// distinguish them.
+			if got := recomputed.RepresentativeMode(); got != Preempt {
+				t.Errorf("recomputation RepresentativeMode() = %s, want %s", got, Preempt)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -236,14 +236,20 @@ func (s *Scheduler) setAdmissionRoutineWrapper(wrapper routine.Wrapper) {
 	s.admissionRoutineWrapper = wrapper
 }
 
-// markSkipped marks the entry as skipped for this cycle. The flavor
-// assignment is cleared so the next cycle retries all flavors (e.g.
-// after Fit no longer fitting, or Preempt being skipped due to an
-// overlapping earlier admission).
+// markSkipped marks the entry as skipped for this cycle.
+//
+// With features.PreserveFlavorScanProgress the flavor assignment is kept, so the next cycle
+// resumes the flavor scan where this one left off rather than starting over. Both callers
+// skip on contention rather than on the flavor itself - capacity taken by a Workload
+// processed earlier in the cycle, or preemption targets claimed by another entry - so the
+// recorded progress is still the best information available. Without the gate the
+// assignment is cleared and the next cycle retries every flavor.
 func (e *entry) markSkipped(msg string) {
 	e.status = skipped
 	e.inadmissibleMsg = msg
-	e.LastAssignment = nil
+	if !features.Enabled(features.PreserveFlavorScanProgress) {
+		e.LastAssignment = nil
+	}
 }
 
 // markPreemptionGated marks the entry as gated pending preemption.
@@ -760,10 +766,33 @@ type partialAssignment struct {
 }
 
 func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap *schdcache.Snapshot) (flavorassigner.Assignment, []*preemption.Target) {
-	assignment, targets := s.getInitialAssignments(ctx, wl, snap)
 	cq := snap.ClusterQueue(wl.ClusterQueue)
+	// The flavor scan resumes from the progress recorded in LastAssignment, so it has to be
+	// dropped once it no longer describes the current state. Deciding that here rather than
+	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
+	// again for each reduced pod count when partial admission is in play.
+	if wl.LastAssignment != nil && lastAssignmentOutdated(wl.LastAssignment, cq.AllocatableResourceGeneration, s.schedulingCycle) {
+		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
+			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
+			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
+		wl.LastAssignment = nil
+	}
+	assignment, targets := s.getInitialAssignments(ctx, wl, snap)
 	updateAssignmentForTAS(ctx, snap, cq, wl, &assignment, targets)
 	return assignment, targets
+}
+
+// lastAssignmentOutdated reports whether the recorded flavor assignment no longer describes
+// the current state of the ClusterQueue, in which case the flavor scan has to start over.
+func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentCQGeneration, currentSchedulingCycle int64) bool {
+	if features.Enabled(features.PreserveFlavorScanProgress) && currentSchedulingCycle-last.SchedulingCycle <= 1 {
+		// An assignment computed in the current or the immediately preceding cycle is not
+		// treated as outdated. The ClusterQueue generation advances on every admission or
+		// eviction in the Cohort, which on a busy cluster discards the flavor progress
+		// recorded one cycle earlier before it can be used.
+		return false
+	}
+	return currentCQGeneration > last.ClusterQueueGeneration
 }
 
 // getInitialAssignments computes the initial resource flavor assignment and any required preemption targets
@@ -795,7 +824,7 @@ func (s *Scheduler) getInitialAssignments(ctx context.Context, wl *workload.Info
 	flvAssigner := flavorassigner.New(
 		wl, cq, snap.ResourceFlavors, fairsharing.Enabled(s.fairSharing),
 		preemption.NewOracle(s.preemptor, snap), replaceableWorkloadSlice,
-		s.quotaCheckStrategy, s.resourceFormatter,
+		s.quotaCheckStrategy, s.resourceFormatter, s.schedulingCycle,
 	)
 	fullAssignment := flvAssigner.Assign(ctx, nil)
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -238,7 +238,7 @@ func (s *Scheduler) setAdmissionRoutineWrapper(wrapper routine.Wrapper) {
 
 // markSkipped marks the entry as skipped for this cycle.
 //
-// With features.PreserveFlavorScanProgress the flavor assignment is kept, so the next cycle
+// With features.FlavorFungibilityPreserveScanProgress the flavor assignment is kept, so the next cycle
 // resumes the flavor scan where this one left off rather than starting over. Both callers
 // skip on contention rather than on the flavor itself - capacity taken by a Workload
 // processed earlier in the cycle, or preemption targets claimed by another entry - so the
@@ -247,7 +247,7 @@ func (s *Scheduler) setAdmissionRoutineWrapper(wrapper routine.Wrapper) {
 func (e *entry) markSkipped(msg string) {
 	e.status = skipped
 	e.inadmissibleMsg = msg
-	if !features.Enabled(features.PreserveFlavorScanProgress) {
+	if !features.Enabled(features.FlavorFungibilityPreserveScanProgress) {
 		e.LastAssignment = nil
 	}
 }
@@ -771,7 +771,7 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 	// dropped once it no longer describes the current state. Deciding that here rather than
 	// inside the assigner keeps it to one place per Workload per cycle: the assigner runs
 	// again for each reduced pod count when partial admission is in play.
-	if wl.LastAssignment != nil && lastAssignmentOutdated(wl.LastAssignment, cq.AllocatableResourceGeneration, s.schedulingCycle) {
+	if wl.LastAssignment != nil && lastAssignmentOutdated(wl.LastAssignment, cq.AllocatableResourceGeneration, s.schedulingCycle, wl.SchedulingHash) {
 		log.FromContext(ctx).V(6).Info("Clearing Workload's last assignment because it was outdated",
 			"cq.AllocatableResourceGeneration", cq.AllocatableResourceGeneration,
 			"wl.LastAssignment.ClusterQueueGeneration", wl.LastAssignment.ClusterQueueGeneration)
@@ -783,14 +783,21 @@ func (s *Scheduler) getAssignments(ctx context.Context, wl *workload.Info, snap 
 }
 
 // lastAssignmentOutdated reports whether the recorded flavor assignment no longer describes
-// the current state of the ClusterQueue, in which case the flavor scan has to start over.
-func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentCQGeneration, currentSchedulingCycle int64) bool {
-	if features.Enabled(features.PreserveFlavorScanProgress) && currentSchedulingCycle-last.SchedulingCycle <= 1 {
+// the current state, in which case the flavor scan has to start over.
+func lastAssignmentOutdated(last *workload.AssignmentClusterQueueState, currentCQGeneration, currentSchedulingCycle int64, currentSchedulingHash workload.EquivalenceHash) bool {
+	if features.Enabled(features.FlavorFungibilityPreserveScanProgress) {
+		// Checked before the cycle age, so that a Workload whose shape changed starts over
+		// even when it was assigned in the preceding cycle.
+		if !last.MatchesSchedulingShape(currentSchedulingHash) {
+			return true
+		}
 		// An assignment computed in the current or the immediately preceding cycle is not
 		// treated as outdated. The ClusterQueue generation advances on every admission or
 		// eviction in the Cohort, which on a busy cluster discards the flavor progress
 		// recorded one cycle earlier before it can be used.
-		return false
+		if currentSchedulingCycle-last.SchedulingCycle <= 1 {
+			return false
+		}
 	}
 	return currentCQGeneration > last.ClusterQueueGeneration
 }

--- a/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
+++ b/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
@@ -1,0 +1,311 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
+	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/util/routine"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+// preserveProgressCycles is how many scheduling cycles each case drives. Anything above
+// two is enough: the behaviour under test is whether the flavor progress recorded in one
+// cycle is still usable in the next.
+const preserveProgressCycles = 4
+
+// equalTestPriority is shared by both Workloads so that a WithinClusterQueue:
+// LowerPriority policy finds no preemption victim.
+const equalTestPriority = 10
+
+// TestScheduleForPreserveFlavorScanProgress drives real scheduling cycles to see whether a
+// Workload whose TAS placement fails on the flavor that quota selected can ever reach the
+// next flavor of its ResourceGroup.
+//
+// It exists because the two smaller tests for this gate (TestLastAssignmentOutdated and
+// TestEntryMarkSkipped) each assert one mechanism in isolation, and neither shows what a
+// Workload actually ends up admitted on. Only a multi-cycle run does, because the gate's
+// whole purpose is to carry flavor progress from one cycle into the next.
+//
+// The cases vary two things:
+//
+//   - the gate, so the change is measured against its own absence;
+//   - whether AllocatableResourceGeneration advances between cycles.
+//
+// The ClusterQueue is fixed at fair sharing with ReclaimWithinCohort: Any and
+// WithinClusterQueue: LowerPriority, since that is the configuration this gate was written
+// for. Neither policy offers the first flavor a way forward: the two Workloads share a
+// priority, so LowerPriority finds no victim in the ClusterQueue, and nothing else in the
+// Cohort is borrowing, so ReclaimWithinCohort has nothing to reclaim.
+//
+// The generation churn is the necessary condition. While it keeps advancing the Workload is
+// never admitted with the gate off: every cycle re-nominates the first flavor, the TAS
+// recompute reports Preempt, no victim is found, and the Workload is requeued with
+// PreemptionNoCandidates. With the gate on it resumes the scan where the previous cycle left
+// off and reaches the second flavor. Once the ClusterQueue settles and the generation stops
+// advancing, the recorded progress is never discarded, so the Workload escapes the first
+// flavor on its own and the gate makes no difference.
+func TestScheduleForPreserveFlavorScanProgress(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	singleLevelTopology := *utiltestingapi.MakeDefaultOneLevelTopology("tas-single-level")
+
+	// flavor-1 has a single node that the blocking Workload fully occupies, so the tested
+	// Workload's topology never fits there. flavor-2 has room for it.
+	nodes := []corev1.Node{
+		*testingnode.MakeNode("node-f1").
+			Label("tas-node", "true").
+			Label("tas-flavor", "f1").
+			Label(corev1.LabelHostname, "node-f1").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj(),
+		*testingnode.MakeNode("node-f2").
+			Label("tas-node", "true").
+			Label("tas-flavor", "f2").
+			Label(corev1.LabelHostname, "node-f2").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("2"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj(),
+	}
+	resourceFlavors := []kueue.ResourceFlavor{
+		*utiltestingapi.MakeResourceFlavor("tas-flavor-1").
+			NodeLabel("tas-flavor", "f1").
+			TopologyName("tas-single-level").
+			Obj(),
+		*utiltestingapi.MakeResourceFlavor("tas-flavor-2").
+			NodeLabel("tas-flavor", "f2").
+			TopologyName("tas-single-level").
+			Obj(),
+	}
+	queues := []kueue.LocalQueue{
+		*utiltestingapi.MakeLocalQueue("tas-lq", "default").ClusterQueue("tas-cq").Obj(),
+	}
+	// blocker occupies node-f1 entirely; pending needs a whole node and so can only be
+	// placed on node-f2. They share a priority so that a LowerPriority policy finds no
+	// victim, matching a ClusterQueue whose Workloads all run at the same priority.
+	blocker := *utiltestingapi.MakeWorkload("blocker", "default").
+		Queue("tas-lq").
+		Creation(now.Add(-time.Minute)).
+		Priority(equalTestPriority).
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			NodeSelector(map[string]string{"tas-flavor": "f1"}).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "2").
+			Obj()).
+		Obj()
+	pending := *utiltestingapi.MakeWorkload("pending", "default").
+		Queue("tas-lq").
+		Creation(now).
+		Priority(equalTestPriority).
+		PodSets(*utiltestingapi.MakePodSet("one", 1).
+			RequiredTopologyRequest(corev1.LabelHostname).
+			Request(corev1.ResourceCPU, "2").
+			Obj()).
+		Obj()
+
+	cases := map[string]struct {
+		gateEnabled bool
+		// noChurn leaves the ClusterQueue's quotas alone between cycles, so
+		// AllocatableResourceGeneration never advances.
+		noChurn bool
+		// wantPendingFlavor is the flavor "pending" must end up admitted on, or empty if
+		// it must remain unadmitted.
+		wantPendingFlavor kueue.ResourceFlavorReference
+	}{
+		"gate disabled": {
+			gateEnabled:       false,
+			wantPendingFlavor: "",
+		},
+		"gate enabled": {
+			gateEnabled:       true,
+			wantPendingFlavor: "tas-flavor-2",
+		},
+		// Without churn the recorded flavor progress is never discarded, so the Workload
+		// escapes the first flavor on its own and the gate makes no difference. This is why
+		// an integration spec cannot discriminate between the two gate states: a settled
+		// ClusterQueue stops advancing its generation.
+		"no generation churn, gate disabled": {
+			gateEnabled:       false,
+			noChurn:           true,
+			wantPendingFlavor: "tas-flavor-2",
+		},
+		"no generation churn, gate enabled": {
+			gateEnabled:       true,
+			noChurn:           true,
+			wantPendingFlavor: "tas-flavor-2",
+		},
+	}
+
+	// Quota on each flavor exceeds what its single node can host, so flavor-1 keeps looking
+	// admissible to the quota-only flavor selection even after its node is fully occupied.
+	// That gap between quota and topology is what can pin a Workload to the first flavor.
+	clusterQueue := *utiltestingapi.MakeClusterQueue("tas-cq").
+		Preemption(kueue.ClusterQueuePreemption{
+			WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+			ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+		}).
+		ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("tas-flavor-1").Resource(corev1.ResourceCPU, "4").Obj(),
+			*utiltestingapi.MakeFlavorQuotas("tas-flavor-2").Resource(corev1.ResourceCPU, "4").Obj(),
+		).
+		Obj()
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+				features.PreserveFlavorScanProgress: tc.gateEnabled,
+			})
+
+			ctx, log := utiltesting.ContextWithLog(t)
+			testWls := []kueue.Workload{*blocker.DeepCopy(), *pending.DeepCopy()}
+			clientBuilder := utiltesting.NewClientBuilder().
+				WithLists(
+					&kueue.WorkloadList{Items: testWls},
+					&kueue.TopologyList{Items: []kueue.Topology{singleLevelTopology}},
+					&corev1.NodeList{Items: nodes},
+					&kueue.LocalQueueList{Items: queues}).
+				WithObjects(utiltesting.MakeNamespace("default")).
+				WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: utiltesting.TreatSSAAsStrategicMerge}).
+				WithStatusSubresource(&kueue.Workload{})
+			_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
+			cl := clientBuilder.Build()
+			recorder := &utiltesting.EventRecorder{}
+			cqCache := schdcache.New(cl, schdcache.WithFairSharing(true))
+			qManager, requeuer := qcache.NewManagerForUnitTestsWithRequeuer(cl, cqCache)
+
+			for i := range nodes {
+				cqCache.TASCache().SyncNode(&nodes[i])
+			}
+			for _, flavor := range resourceFlavors {
+				cqCache.AddOrUpdateResourceFlavor(log, &flavor)
+				cqCache.AddOrUpdateTopology(log, &singleLevelTopology)
+			}
+			if err := cqCache.AddClusterQueue(ctx, &clusterQueue); err != nil {
+				t.Fatalf("Inserting clusterQueue in cache: %v", err)
+			}
+			if err := qManager.AddClusterQueue(ctx, &clusterQueue); err != nil {
+				t.Fatalf("Inserting clusterQueue in manager: %v", err)
+			}
+			cqCopy := clusterQueue.DeepCopy()
+			cqCopy.ResourceVersion = ""
+			if err := cl.Create(ctx, cqCopy); err != nil {
+				t.Fatalf("Creating clusterQueue: %v", err)
+			}
+			for _, q := range queues {
+				if err := qManager.AddLocalQueue(ctx, &q); err != nil {
+					t.Fatalf("Inserting queue %s/%s in manager: %v", q.Namespace, q.Name, err)
+				}
+			}
+
+			scheduler := New(qManager, cqCache, cl, recorder,
+				WithClock(t, testingclock.NewFakeClock(now)),
+				WithFairSharing(&config.FairSharing{}),
+				WithPreemptionExpectations(preemptexpectations.New()))
+			wg := sync.WaitGroup{}
+			scheduler.setAdmissionRoutineWrapper(routine.NewWrapper(
+				func() { wg.Add(1) },
+				func() { wg.Done() },
+			))
+
+			ctx, cancel := context.WithTimeout(ctx, queueingTimeout)
+			go qManager.CleanUpOnContext(ctx)
+			defer cancel()
+
+			for i := range preserveProgressCycles {
+				scheduler.schedule(ctx)
+				wg.Wait()
+				// Reproduce a busy Cohort. AllocatableResourceGeneration only advances when
+				// the quotas actually change (see updateQuotasAndResourceGroups), so flip
+				// flavor-2's quota between two values to force a real bump every cycle. The
+				// bump is what discards LastAssignment in lastAssignmentOutdated, and with
+				// it the flavor progress recorded one cycle earlier. On a cluster with
+				// steady admissions and evictions that bump happens continuously, which is
+				// the condition this gate exists to survive.
+				//
+				// flavor-2 is the one flipped so that flavor-1, the flavor under test,
+				// keeps a constant quota throughout.
+				if !tc.noChurn {
+					churned := clusterQueue.DeepCopy()
+					churnQuota := "4"
+					if i%2 == 0 {
+						churnQuota = "5"
+					}
+					churned.Spec.ResourceGroups[0].Flavors[1].Resources[0].NominalQuota = resource.MustParse(churnQuota)
+					if err := cqCache.UpdateClusterQueue(log, churned); err != nil {
+						t.Fatalf("Updating clusterQueue in cache: %v", err)
+					}
+				}
+				// Move Workloads parked as inadmissible back into the queue so the next
+				// cycle reconsiders them, as the controllers would in a cluster.
+				requeuer.ProcessRequeues(ctx)
+			}
+
+			if got := admittedFlavorForPodSet(ctx, t, cl, "pending"); got != tc.wantPendingFlavor {
+				t.Errorf("workload \"pending\" admitted on flavor %q, want %q", got, tc.wantPendingFlavor)
+			}
+			// The blocker must keep its place on flavor-1 in every case.
+			if got := admittedFlavorForPodSet(ctx, t, cl, "blocker"); got != "tas-flavor-1" {
+				t.Errorf("workload \"blocker\" admitted on flavor %q, want %q", got, "tas-flavor-1")
+			}
+		})
+	}
+}
+
+// admittedFlavorForPodSet returns the flavor assigned to the Workload's only PodSet
+// resource, or an empty reference when the Workload has no quota reservation.
+func admittedFlavorForPodSet(ctx context.Context, t *testing.T, cl client.Client, name string) kueue.ResourceFlavorReference {
+	t.Helper()
+	var wl kueue.Workload
+	if err := cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: name}, &wl); err != nil {
+		t.Fatalf("Getting workload %q: %v", name, err)
+	}
+	if !workload.HasQuotaReservation(&wl) {
+		return ""
+	}
+	for _, psa := range wl.Status.Admission.PodSetAssignments {
+		for _, flavor := range psa.Flavors {
+			return flavor
+		}
+	}
+	return ""
+}

--- a/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
+++ b/pkg/scheduler/scheduler_preserve_flavor_scan_progress_test.go
@@ -193,7 +193,7 @@ func TestScheduleForPreserveFlavorScanProgress(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
-				features.PreserveFlavorScanProgress: tc.gateEnabled,
+				features.FlavorFungibilityPreserveScanProgress: tc.gateEnabled,
 			})
 
 			ctx, log := utiltesting.ContextWithLog(t)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8163,6 +8163,64 @@ func TestRequeueAndUpdate(t *testing.T) {
 	}
 }
 
+// TestEntryMarkSkipped covers whether a Workload skipped because of contention keeps the
+// flavor scan progress it recorded this cycle.
+//
+// Both markSkipped call sites skip on contention rather than on the flavor itself: capacity
+// consumed by a Workload processed earlier in the cycle, or preemption targets already
+// claimed by another entry. features.PreserveFlavorScanProgress decides whether the next
+// cycle resumes the scan or restarts it from the first flavor.
+func TestEntryMarkSkipped(t *testing.T) {
+	cases := map[string]struct {
+		preserveProgress      bool
+		wantLastAssignmentNil bool
+	}{
+		"without the gate the assignment is discarded so every flavor is retried": {
+			preserveProgress:      false,
+			wantLastAssignmentNil: true,
+		},
+		"with the gate the assignment is kept so the scan resumes": {
+			preserveProgress:      true,
+			wantLastAssignmentNil: false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tc.preserveProgress)
+
+			e := entry{
+				Info: workload.Info{
+					LastAssignment: &workload.AssignmentClusterQueueState{
+						LastTriedFlavorIdx: []map[corev1.ResourceName]int{
+							{corev1.ResourceCPU: 0},
+						},
+					},
+				},
+			}
+
+			e.markSkipped("Workload no longer fits after processing another workload")
+
+			if e.status != skipped {
+				t.Errorf("status = %v, want %v", e.status, skipped)
+			}
+			if want := "Workload no longer fits after processing another workload"; e.inadmissibleMsg != want {
+				t.Errorf("inadmissibleMsg = %q, want %q", e.inadmissibleMsg, want)
+			}
+			if got := e.LastAssignment == nil; got != tc.wantLastAssignmentNil {
+				t.Errorf("LastAssignment == nil is %v, want %v", got, tc.wantLastAssignmentNil)
+			}
+			if !tc.wantLastAssignmentNil {
+				// The retained progress must still name the flavor that was tried, since
+				// that is what NextFlavorToTryForPodSetResource reads.
+				if got := e.LastAssignment.LastTriedFlavorIdx[0][corev1.ResourceCPU]; got != 0 {
+					t.Errorf("retained LastTriedFlavorIdx = %d, want 0", got)
+				}
+			}
+		})
+	}
+}
+
 func TestEntryMarkPreemptionOutcome(t *testing.T) {
 	assignmentState := &workload.AssignmentClusterQueueState{}
 
@@ -8884,5 +8942,105 @@ func (r *workloadUpdateWatcherRecorder) NotifyWorkloadUpdate(oldWl, newWl *kueue
 	}
 	if newWl != nil {
 		r.newWl = newWl.DeepCopy()
+	}
+}
+
+func TestLastAssignmentOutdated(t *testing.T) {
+	type args struct {
+		currentSchedulingCycle int64
+		last                   *workload.AssignmentClusterQueueState
+		currentCQGeneration    int64
+	}
+	tests := []struct {
+		name string
+		// preserveProgress enables features.PreserveFlavorScanProgress.
+		preserveProgress bool
+		args             args
+		want             bool
+	}{
+		{
+			name: "Cluster queue allocatableResourceIncreasedGen increased",
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        1,
+				},
+				currentCQGeneration: 1,
+			},
+			want: true,
+		},
+		{
+			name: "AllocatableResourceGeneration not increased",
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        1,
+				},
+				currentCQGeneration: 0,
+			},
+			want: false,
+		},
+		{
+			name:             "assignment from the immediately preceding cycle survives a generation bump",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+				},
+				currentCQGeneration: 1,
+			},
+			want: false,
+		},
+		{
+			name:             "assignment from the current cycle survives a generation bump",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        5,
+				},
+				currentCQGeneration: 1,
+			},
+			want: false,
+		},
+		{
+			name:             "assignment older than one cycle falls back to the generation check",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        3,
+				},
+				currentCQGeneration: 1,
+			},
+			want: true,
+		},
+		{
+			name:             "without the gate the preceding cycle gets no special treatment",
+			preserveProgress: false,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+				},
+				currentCQGeneration: 1,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tt.preserveProgress)
+			if got := lastAssignmentOutdated(tt.args.last, tt.args.currentCQGeneration, tt.args.currentSchedulingCycle); got != tt.want {
+				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -8168,7 +8168,7 @@ func TestRequeueAndUpdate(t *testing.T) {
 //
 // Both markSkipped call sites skip on contention rather than on the flavor itself: capacity
 // consumed by a Workload processed earlier in the cycle, or preemption targets already
-// claimed by another entry. features.PreserveFlavorScanProgress decides whether the next
+// claimed by another entry. features.FlavorFungibilityPreserveScanProgress decides whether the next
 // cycle resumes the scan or restarts it from the first flavor.
 func TestEntryMarkSkipped(t *testing.T) {
 	cases := map[string]struct {
@@ -8187,7 +8187,7 @@ func TestEntryMarkSkipped(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tc.preserveProgress)
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityPreserveScanProgress, tc.preserveProgress)
 
 			e := entry{
 				Info: workload.Info{
@@ -8950,10 +8950,11 @@ func TestLastAssignmentOutdated(t *testing.T) {
 		currentSchedulingCycle int64
 		last                   *workload.AssignmentClusterQueueState
 		currentCQGeneration    int64
+		currentSchedulingHash  workload.EquivalenceHash
 	}
 	tests := []struct {
 		name string
-		// preserveProgress enables features.PreserveFlavorScanProgress.
+		// preserveProgress enables features.FlavorFungibilityPreserveScanProgress.
 		preserveProgress bool
 		args             args
 		want             bool
@@ -9022,6 +9023,66 @@ func TestLastAssignmentOutdated(t *testing.T) {
 			want: true,
 		},
 		{
+			name:             "a changed scheduling shape starts the scan over even in the preceding cycle",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+					SchedulingHash:         "shape-a",
+				},
+				currentCQGeneration:   0,
+				currentSchedulingHash: "shape-b",
+			},
+			want: true,
+		},
+		{
+			name:             "an unchanged scheduling shape keeps the preceding cycle's assignment",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+					SchedulingHash:         "shape-a",
+				},
+				currentCQGeneration:   1,
+				currentSchedulingHash: "shape-a",
+			},
+			want: false,
+		},
+		{
+			name:             "an unknown hash is not treated as a shape change",
+			preserveProgress: true,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+					SchedulingHash:         workload.SchedulingHashUnknown,
+				},
+				currentCQGeneration:   1,
+				currentSchedulingHash: "shape-b",
+			},
+			want: false,
+		},
+		{
+			name:             "without the gate a changed scheduling shape is ignored",
+			preserveProgress: false,
+			args: args{
+				currentSchedulingCycle: 5,
+				last: &workload.AssignmentClusterQueueState{
+					ClusterQueueGeneration: 0,
+					SchedulingCycle:        4,
+					SchedulingHash:         "shape-a",
+				},
+				currentCQGeneration:   0,
+				currentSchedulingHash: "shape-b",
+			},
+			want: false,
+		},
+		{
 			name:             "without the gate the preceding cycle gets no special treatment",
 			preserveProgress: false,
 			args: args{
@@ -9037,8 +9098,8 @@ func TestLastAssignmentOutdated(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			features.SetFeatureGateDuringTest(t, features.PreserveFlavorScanProgress, tt.preserveProgress)
-			if got := lastAssignmentOutdated(tt.args.last, tt.args.currentCQGeneration, tt.args.currentSchedulingCycle); got != tt.want {
+			features.SetFeatureGateDuringTest(t, features.FlavorFungibilityPreserveScanProgress, tt.preserveProgress)
+			if got := lastAssignmentOutdated(tt.args.last, tt.args.currentCQGeneration, tt.args.currentSchedulingCycle, tt.args.currentSchedulingHash); got != tt.want {
 				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -114,6 +114,10 @@ func FromQuotaReservedOrAdmittedToPending(prevStatus, newStatus string) bool {
 type AssignmentClusterQueueState struct {
 	LastTriedFlavorIdx     []map[corev1.ResourceName]int
 	ClusterQueueGeneration int64
+	// SchedulingCycle is the scheduling cycle that computed this assignment. It lets the
+	// assignment from the immediately preceding cycle be treated as current even when the
+	// ClusterQueue generation has moved on.
+	SchedulingCycle int64
 }
 
 type dra struct {
@@ -172,6 +176,7 @@ func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 	c := AssignmentClusterQueueState{
 		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
 		ClusterQueueGeneration: s.ClusterQueueGeneration,
+		SchedulingCycle:        s.SchedulingCycle,
 	}
 	for ps, flavorIdx := range s.LastTriedFlavorIdx {
 		c.LastTriedFlavorIdx[ps] = maps.Clone(flavorIdx)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -118,6 +118,11 @@ type AssignmentClusterQueueState struct {
 	// assignment from the immediately preceding cycle be treated as current even when the
 	// ClusterQueue generation has moved on.
 	SchedulingCycle int64
+	// SchedulingHash is the scheduling equivalence hash of the Workload this assignment was
+	// computed for. LastTriedFlavorIdx is indexed by PodSet and holds flavor indices chosen
+	// for a particular set of requests, so it only carries meaning while the Workload keeps
+	// the shape it had then.
+	SchedulingHash EquivalenceHash
 }
 
 type dra struct {
@@ -177,11 +182,27 @@ func (s *AssignmentClusterQueueState) Clone() *AssignmentClusterQueueState {
 		LastTriedFlavorIdx:     make([]map[corev1.ResourceName]int, len(s.LastTriedFlavorIdx)),
 		ClusterQueueGeneration: s.ClusterQueueGeneration,
 		SchedulingCycle:        s.SchedulingCycle,
+		SchedulingHash:         s.SchedulingHash,
 	}
 	for ps, flavorIdx := range s.LastTriedFlavorIdx {
 		c.LastTriedFlavorIdx[ps] = maps.Clone(flavorIdx)
 	}
 	return &c
+}
+
+// MatchesSchedulingShape reports whether this assignment was computed for the scheduling
+// shape the Workload has now. A change to the PodSets or their requests makes the recorded
+// flavor indices describe a search that no longer applies: resuming from them could skip a
+// flavor the changed Workload would now fit.
+//
+// An unknown hash on either side means SchedulingEquivalenceHashing is disabled and there is
+// nothing to compare, so the shape is taken to be unchanged. That keeps the two features
+// independent, and NextFlavorToTryForPodSetResource still bounds-checks the PodSet index.
+func (s *AssignmentClusterQueueState) MatchesSchedulingShape(current EquivalenceHash) bool {
+	if s.SchedulingHash == SchedulingHashUnknown || current == SchedulingHashUnknown {
+		return true
+	}
+	return s.SchedulingHash == current
 }
 
 // PendingFlavors returns whether there are pending flavors to try

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -259,6 +259,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: PreserveFlavorScanProgress
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -109,6 +109,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: FlavorFungibilityPreserveScanProgress
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true
@@ -259,12 +265,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
-- name: PreserveFlavorScanProgress
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -259,6 +259,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: PreserveFlavorScanProgress
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -109,6 +109,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
+- name: FlavorFungibilityPreserveScanProgress
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: KueueDRAIntegration
   versionedSpecs:
   - default: true
@@ -259,12 +265,6 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.5"
-- name: PreserveFlavorScanProgress
-  versionedSpecs:
-  - default: true
-    lockToDefault: false
-    preRelease: Beta
-    version: "0.20"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/tas/suite_test.go
+++ b/test/integration/singlecluster/tas/suite_test.go
@@ -41,6 +41,7 @@ import (
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/scheduler"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption/fairsharing"
 	"sigs.k8s.io/kueue/pkg/util/webhook"
 	"sigs.k8s.io/kueue/pkg/webhooks"
 	"sigs.k8s.io/kueue/test/integration/framework"
@@ -91,6 +92,9 @@ func managerSetupWithConfig(
 
 		cacheOptions := []schdcache.Option{
 			schdcache.WithResourceTransformations(resourceTransformations),
+			// Nil unless the caller opts in, which keeps fair sharing off for the
+			// suites that do not configure it.
+			schdcache.WithFairSharing(fairsharing.Enabled(controllersCfg.FairSharing)),
 		}
 		cCache := schdcache.New(mgr.GetClient(), cacheOptions...)
 		preemptionExpectations := preemptexpectations.New()
@@ -134,6 +138,7 @@ func managerSetupWithConfig(
 			mgr.GetClient(),
 			mgr.GetEventRecorder(constants.AdmissionName),
 			scheduler.WithPreemptionExpectations(preemptionExpectations),
+			scheduler.WithFairSharing(controllersCfg.FairSharing),
 		)
 		err = sched.Start(ctx)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/test/integration/singlecluster/tas/tas_preserve_flavor_scan_progress_test.go
+++ b/test/integration/singlecluster/tas/tas_preserve_flavor_scan_progress_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	config "sigs.k8s.io/kueue/apis/config/v1beta2"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
+	"sigs.k8s.io/kueue/test/util"
+)
+
+// equalPriority is shared by both Workloads in these specs so that the
+// WithinClusterQueue: LowerPriority policy finds no preemption victim, as happens in a
+// ClusterQueue where every Workload runs at the same priority.
+const equalPriority = 100
+
+// These specs cover the PreserveFlavorScanProgress gate end to end: a Workload whose TAS
+// placement fails on the flavor selected by quota must still reach another flavor of the
+// ResourceGroup and be admitted there.
+var _ = ginkgo.Describe("Topology Aware Scheduling preserving flavor scan progress", ginkgo.Ordered, func() {
+	var (
+		ns           *corev1.Namespace
+		nodes        []corev1.Node
+		topology     *kueue.Topology
+		tasFlavor1   *kueue.ResourceFlavor
+		tasFlavor2   *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+
+	ginkgo.BeforeAll(func() {
+		// Fair sharing on, so the fair-share entry iterator and preemption path drive
+		// this spec rather than the classical ones.
+		fwk.StartManager(ctx, cfg, managerSetupWithConfig(&config.Configuration{
+			FairSharing: &config.FairSharing{},
+		}))
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-preserve-flavor-scan-")
+
+		// One node per flavor. The blocker Workload fills the flavor-1 node, so the
+		// second Workload can only be placed on the flavor-2 node.
+		nodes = []corev1.Node{
+			*testingnode.MakeNode("preserve-f1").
+				Label("node-group", "tas").
+				Label("tas-flavor", "f1").
+				Label(corev1.LabelHostname, "preserve-f1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("preserve-f2").
+				Label("node-group", "tas").
+				Label("tas-flavor", "f2").
+				Label(corev1.LabelHostname, "preserve-f2").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("2"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+		}
+		util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+		topology = utiltestingapi.MakeDefaultOneLevelTopology("default")
+		util.MustCreate(ctx, k8sClient, topology)
+
+		tasFlavor1 = utiltestingapi.MakeResourceFlavor("tas-flavor-1").
+			NodeLabel("node-group", "tas").
+			NodeLabel("tas-flavor", "f1").
+			TopologyName("default").Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor1)
+
+		tasFlavor2 = utiltestingapi.MakeResourceFlavor("tas-flavor-2").
+			NodeLabel("node-group", "tas").
+			NodeLabel("tas-flavor", "f2").
+			TopologyName("default").Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor2)
+
+		// Quota on each flavor exceeds what its single node can host, so flavor-1 keeps
+		// looking admissible to the quota-only flavor selection after its node is full.
+		//
+		// The ClusterQueue sets two preemption policies. Neither policy offers
+		// flavor-1 a way forward here: the two Workloads share a priority, so
+		// WithinClusterQueue: LowerPriority finds no victim in the ClusterQueue, and
+		// no other ClusterQueue in the Cohort is borrowing, so ReclaimWithinCohort
+		// has nothing to reclaim. That combination leaves a Workload pinned to one
+		// flavor.
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			Cohort("tas-cohort").
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+			}).
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas(tasFlavor1.Name).Resource(corev1.ResourceCPU, "4").Obj(),
+				*utiltestingapi.MakeFlavorQuotas(tasFlavor2.Name).Resource(corev1.ResourceCPU, "4").Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+		gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor1, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor2, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		for _, node := range nodes {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+		}
+		gomega.Expect(forceDeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+	})
+
+	// Only the gate-enabled state is run. This spec cannot discriminate between the two
+	// states: a settled ClusterQueue stops advancing AllocatableResourceGeneration, so the
+	// recorded flavor progress is never discarded and the Workload escapes the first flavor
+	// on its own with the gate off too. What it does cover is the gate-enabled path through
+	// the full controller stack rather than the scheduler alone.
+	//
+	// The gate's own effect needs generation churn on every cycle, which is not something an
+	// integration spec can sustain without a background mutator. That is asserted by
+	// TestScheduleForPreserveFlavorScanProgress instead, which drives cycles directly and
+	// covers both gate states under churn as well as the no-churn outcome.
+	ginkgo.It("should admit the workload on the second flavor when the first flavor's topology cannot fit it", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PreserveFlavorScanProgress, true)
+
+		var blocker, pending *kueue.Workload
+
+		ginkgo.By("creating a workload that occupies the whole node of the first flavor", func() {
+			blocker = utiltestingapi.MakeWorkload("blocker", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Priority(equalPriority).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					NodeSelector(map[string]string{"tas-flavor": "f1"}).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, "2").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, blocker)
+		})
+
+		ginkgo.By("verifying the blocker is admitted on the first flavor", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, blocker)
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(blocker), blocker)).To(gomega.Succeed())
+			gomega.Expect(blocker.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+				gomega.Equal(kueue.ResourceFlavorReference(tasFlavor1.Name)))
+		})
+
+		ginkgo.By("creating a workload that needs a whole node and so cannot be placed on the first flavor", func() {
+			pending = utiltestingapi.MakeWorkload("pending", ns.Name).
+				Queue(kueue.LocalQueueName(localQueue.Name)).
+				Priority(equalPriority).
+				PodSets(*utiltestingapi.MakePodSet("worker", 1).
+					RequiredTopologyRequest(corev1.LabelHostname).
+					Request(corev1.ResourceCPU, "2").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, pending)
+		})
+
+		ginkgo.By("verifying it is eventually admitted on the second flavor", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, pending)
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pending), pending)).To(gomega.Succeed())
+			gomega.Expect(pending.Status.Admission.PodSetAssignments[0].Flavors[corev1.ResourceCPU]).To(
+				gomega.Equal(kueue.ResourceFlavorReference(tasFlavor2.Name)))
+			ta := utiltas.InternalFrom(pending.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+			gomega.Expect(ta.Domains).To(gomega.HaveLen(1))
+			gomega.Expect(ta.Domains[0].Values).To(gomega.Equal([]string{"preserve-f2"}))
+		})
+	})
+})

--- a/test/integration/singlecluster/tas/tas_preserve_flavor_scan_progress_test.go
+++ b/test/integration/singlecluster/tas/tas_preserve_flavor_scan_progress_test.go
@@ -37,7 +37,7 @@ import (
 // ClusterQueue where every Workload runs at the same priority.
 const equalPriority = 100
 
-// These specs cover the PreserveFlavorScanProgress gate end to end: a Workload whose TAS
+// These specs cover the FlavorFungibilityPreserveScanProgress gate end to end: a Workload whose TAS
 // placement fails on the flavor selected by quota must still reach another flavor of the
 // ResourceGroup and be admitted there.
 var _ = ginkgo.Describe("Topology Aware Scheduling preserving flavor scan progress", ginkgo.Ordered, func() {
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling preserving flavor scan progre
 	// TestScheduleForPreserveFlavorScanProgress instead, which drives cycles directly and
 	// covers both gate states under churn as well as the no-churn outcome.
 	ginkgo.It("should admit the workload on the second flavor when the first flavor's topology cannot fit it", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.PreserveFlavorScanProgress, true)
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.FlavorFungibilityPreserveScanProgress, true)
 
 		var blocker, pending *kueue.Workload
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

The flavor scan records where it stopped in `LastTriedFlavorIdx` so the next cycle can resume from there. On a busy cluster it never gets to. **Three independent mechanisms discard that progress:**

1. `lastAssignmentOutdated` discards the assignment whenever the ClusterQueue's `AllocatableResourceGeneration` advances — which happens on **every admission or eviction anywhere in the Cohort**.
2. `markSkipped` clears it when a Workload is skipped because another Workload processed earlier in the same cycle took the capacity or preemption targets it had been assigned.
3. Any update to the Workload rebuilds its `workload.Info` in `AddOrUpdateWorkloadWithoutLock`, dropping the progress outright.

Under sustained load all three fire constantly, so the scan restarts from the first flavor indefinitely. A Workload whose quota fits flavor A but whose topology cannot be placed there is re-nominated to A forever and never reaches flavor B, even when B has room.

This PR:

- treats an assignment from the **current or immediately preceding** cycle as current, via a new `SchedulingCycle` field on `AssignmentClusterQueueState`;
- keeps it when a Workload is skipped, since both skip reasons are in-cycle contention rather than a verdict on the flavor;
- carries it across a Workload update.

The progress still expires on its own — it keeps the cycle it was recorded in, so anything older than one cycle falls back to the generation check.

It also **moves the staleness decision out of the flavor assigner into the scheduler**. `Assign` was clearing `LastAssignment` on the Workload it had been handed — a surprising side effect of computing an assignment — and it runs once per reduced pod count under partial admission, so the check ran more than once per Workload per cycle. `getAssignments` now decides once.

Guarded by the new `PreserveFlavorScanProgress` feature gate: **beta, enabled by default**, so the fix applies without opt-in while remaining switchable off.

#### Which issue(s) this PR fixes:

Fixes kubernetes-sigs/kueue#13658

#### Special notes for your reviewer:

This approach follows the discussion with @mimowo captured in https://github.com/kubernetes-sigs/kueue/pull/13691#issuecomment-5214224883

**Previously considered alternatives.**

- **PR #13691** — a `TASFlavorFallback` gate letting the in-cycle TAS recompute fall through to the next flavor, which would also require recomputing DRS and refreshing the fair-sharing ordering mid-cycle.
- **PR #13800** — a TTL-bounded map of recently failed flavor placements on the `Scheduler`, which adds a structure parallel to `LastAssignment`.

This PR fixes the existing mechanism instead, and is not TAS-specific.

**The generation churn is the necessary condition, and the tests establish it in both directions.** `TestScheduleForPreserveFlavorScanProgress` drives real scheduling cycles against a fair-sharing ClusterQueue with `ReclaimWithinCohort: Any` / `WithinClusterQueue: LowerPriority`:

| | gate off | gate on |
|---|---|---|
| generation advancing every cycle | **never admitted** | reaches the second flavor |
| ClusterQueue settled | reaches the second flavor | reaches the second flavor |

The gate-off/churn case reproduces the reported signature line for line — `Re-computing the assignment as it doesn't fit for TAS` → `newMode: Preempt` → `no candidate workloads allowed for preemption` → requeue with `PreemptionNoCandidates`, every cycle. The no-churn row is why the generation lookup is not a reliable signal: it is the *only* reason the progress ever survives today.

**Where this does not help.** When the scan ends on the last flavor it records `-1` ("start over") and there is no progress to preserve. Two such cases are covered:

- Preemption needed but no candidates exist — `shouldTryNextFlavor` returns true for `noPreemptionCandidates` *before* either fungibility policy is consulted, so **no `flavorFungibility` configuration** yields a usable index here.
- The in-cycle recomputation runs and quota has also tightened, so the replayed scan walks past the nominated flavor to the end.

Both report the same `newMode: Preempt` as the case this PR does fix, so a log line alone cannot distinguish them.

**Deliberately out of scope:**

- **The remaining `LastAssignment = nil` sites** (`markPreemptionGated`, `markPreemptionOutcome`, and the flavor-migration eviction). Removing these needs a decision per site — whether migration should preserve progress at all, and whether preemption being gated is contention or a verdict on the flavor — and none of those paths has test coverage today. The TAS-recompute clear must stay regardless: it deliberately restarts the scan and then pins via `NominationMapping`.
- **Renaming `AssignmentClusterQueueState` → `FlavorSearchState`, and dropping `ClusterQueueGeneration`.** Agreed on the direction. Keeping both out here so this stays reviewable and cherry-pickable; they belong together as one follow-up on main, since once the generation lookup is gone the struct really is just a flavor-search state.

AI assistance was used for parts of this change.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a Workload could be re-nominated to the same ResourceFlavor indefinitely and never reach the remaining flavors of its ResourceGroup. The flavor scan progress recorded for a Workload was discarded whenever the ClusterQueue's allocatable resource generation advanced, whenever the Workload was skipped due to in-cycle contention, or whenever the Workload was updated, all of which happen continuously on a busy Cohort. This most visibly affected Topology-Aware Scheduling, where a Workload whose topology cannot be placed on the flavor selected by quota needs to fall through to the next flavor. Controlled by the new `PreserveFlavorScanProgress` feature gate, enabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved flavor-scanning progress across scheduling cycles, helping workloads continue from the last attempted flavor after contention or queue updates.
  * Added the `FlavorFungibilityPreserveScanProgress` beta feature, enabled by default in version 0.20.
  * Retained assignment progress when workload scheduling requirements remain compatible.

* **Bug Fixes**
  * Prevented unnecessary flavor-scan resets while still resetting stale assignments when scheduling requirements or scheduling context changes.
  * Improved workload placement across available flavors during topology-aware scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->