### PR TITLE
DRA: preserve preprocessed resources on backoff requeue

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -400,6 +400,7 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 			equality.Semantic.DeepEqual(oldInfo.Obj.Spec, wInfo.Obj.Spec) &&
 			!priorityBoostAnnotationChanged(oldInfo, wInfo) &&
 			equality.Semantic.DeepEqual(oldInfo.Obj.Status.ReclaimablePods, wInfo.Obj.Status.ReclaimablePods) &&
+			equality.Semantic.DeepEqual(oldInfo.Obj.Status.RequeueState, wInfo.Obj.Status.RequeueState) &&
 			equality.Semantic.DeepEqual(apimeta.FindStatusCondition(oldInfo.Obj.Status.Conditions, kueue.WorkloadEvicted),
 				apimeta.FindStatusCondition(wInfo.Obj.Status.Conditions, kueue.WorkloadEvicted)) &&
 			equality.Semantic.DeepEqual(apimeta.FindStatusCondition(oldInfo.Obj.Status.Conditions, kueue.WorkloadRequeued),

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -250,6 +250,33 @@ func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
 	}
 }
 
+func TestPushOrUpdateRequeueStateChanged(t *testing.T) {
+	now := time.Now()
+	ctx, log := utiltesting.ContextWithLog(t)
+	cq := newClusterQueueImpl(ctx, nil, nil, defaultOrdering, testingclock.NewFakeClock(now))
+
+	wlWaiting := utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
+		Creation(now).
+		RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(time.Hour)))).
+		Obj()
+	cq.PushOrUpdate(workload.NewInfo(log, wlWaiting))
+
+	if inadmissible, _ := cq.DumpInadmissible(); len(inadmissible) != 1 {
+		t.Fatalf("got %d inadmissible workloads after first push, want 1", len(inadmissible))
+	}
+
+	wlElapsed := wlWaiting.DeepCopy()
+	wlElapsed.Status.RequeueState.RequeueAt = nil
+	cq.PushOrUpdate(workload.NewInfo(log, wlElapsed))
+
+	if active, _ := cq.Dump(); len(active) != 1 {
+		t.Errorf("got %d active workloads, want 1", len(active))
+	}
+	if inadmissible, _ := cq.DumpInadmissible(); len(inadmissible) != 0 {
+		t.Errorf("got %d inadmissible workloads, want 0", len(inadmissible))
+	}
+}
+
 func TestPushOrUpdateGenerationChanged(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -127,7 +127,7 @@ func (r *WorkloadReconciler) handleDRAConsumableCapacity(
 	return dra.MergeDRAResources(draResources, capacityResources), false, ctrl.Result{}, nil
 }
 
-func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, err error) {
+func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, queueOptions []workload.InfoOption, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	workload.AdjustResources(ctx, r.client, wl)
@@ -142,9 +142,9 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 			return updated, nil
 		})
 		if err != nil {
-			return true, ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
+			return true, ctrl.Result{}, nil, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
 		}
-		return true, ctrl.Result{}, nil
+		return true, ctrl.Result{}, nil, nil
 	}
 
 	log.V(3).Info("Processing DRA resources for workload")
@@ -154,7 +154,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	// Process ResourceClaimTemplates (existing DRA path)
 	draResources, fieldErrs := dra.GetResourceRequestsForResourceClaimTemplates(ctx, r.client, sliceCache, r.draMapper, wl)
 	if len(fieldErrs) > 0 {
-		return r.markDRAInadmissible(ctx, wl, fieldErrs, "Failed to process DRA resources for workload")
+		done, result, err := r.markDRAInadmissible(ctx, wl, fieldErrs, "Failed to process DRA resources for workload")
+		return done, result, nil, err
 	}
 
 	// Process Extended Resources backed by DRA
@@ -162,7 +163,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
 		extendedResources, replaced, extFieldErrs := dra.ResolveExtendedResourceQuota(ctx, r.client, r.draMapper, wl)
 		if len(extFieldErrs) > 0 {
-			return r.markDRAInadmissible(ctx, wl, extFieldErrs, "Failed to process DRA extended resources for workload")
+			done, result, err := r.markDRAInadmissible(ctx, wl, extFieldErrs, "Failed to process DRA extended resources for workload")
+			return done, result, nil, err
 		}
 		// Merge extended resources into draResources. When a DeviceClass appears
 		// in both paths, the extended resources path uses the deviceClassMappings
@@ -175,7 +177,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && r.resourceSliceAPIAvailable {
 		counterResources, counterFieldErrs := dra.GetCounterResourcesForWorkload(ctx, r.client, sliceCache, r.draMapper, wl)
 		if len(counterFieldErrs) > 0 {
-			return r.markDRAInadmissible(ctx, wl, counterFieldErrs, "Failed to process DRA counter resources for workload")
+			done, result, err := r.markDRAInadmissible(ctx, wl, counterFieldErrs, "Failed to process DRA counter resources for workload")
+			return done, result, nil, err
 		}
 		draResources = dra.MergeDRAResources(draResources, counterResources)
 	}
@@ -184,7 +187,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && r.resourceSliceAPIAvailable {
 		ccResources, ccDone, ccResult, ccErr := r.handleDRAConsumableCapacity(ctx, wl, sliceCache, draResources)
 		if ccDone {
-			return true, ccResult, ccErr
+			return true, ccResult, nil, ccErr
 		}
 		draResources = ccResources
 	}
@@ -206,7 +209,6 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		log.V(3).Info("Cleared previous inadmissible conditions after successful DRA processing")
 	}
 
-	var queueOptions []workload.InfoOption
 	if len(draResources) > 0 || len(replacedExtendedResources) > 0 {
 		queueOptions = append(queueOptions, workload.WithPreprocessedDRAResources(draResources, replacedExtendedResources))
 	}
@@ -214,7 +216,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if workload.IsAdmissible(wl) {
 		if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
 			log.V(2).Info("Failed to add DRA workload to queue", "error", err)
-			return true, ctrl.Result{}, err
+			return true, ctrl.Result{}, nil, err
 		}
 	} else {
 		if !r.cache.AddOrUpdateWorkload(log, wl.DeepCopy()) {
@@ -222,7 +224,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		}
 	}
 	log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
-	return false, ctrl.Result{}, nil
+	return false, ctrl.Result{}, queueOptions, nil
 }
 
 func (r *WorkloadReconciler) markDRAInadmissible(ctx context.Context, wl *kueue.Workload, fieldErrs field.ErrorList, logMsg string) (bool, ctrl.Result, error) {
@@ -520,8 +522,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 		return ctrl.Result{}, nil
 	}
+	var draQueueOptions []workload.InfoOption
 	if workload.Status(&wl) == workload.StatusPending && dra.NeedsDRAReconcile(&wl, r.draBackedResources) {
-		if done, result, err := r.handleDRA(ctx, &wl); done {
+		var done bool
+		var result ctrl.Result
+		var err error
+		if done, result, draQueueOptions, err = r.handleDRA(ctx, &wl); done {
 			return result, err
 		}
 	}
@@ -558,7 +564,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 					return ctrl.Result{}, nil
 				}
 
-				if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy()); err != nil {
+				if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), draQueueOptions...); err != nil {
 					log.V(2).Info("failed to put the workload back into queue", "error", err)
 					return ctrl.Result{}, err
 				}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -128,6 +128,10 @@ func (r *WorkloadReconciler) handleDRAConsumableCapacity(
 	return dra.MergeDRAResources(draResources, capacityResources), false, ctrl.Result{}, nil
 }
 
+// handleDRA preprocesses DRA-backed resources for a pending workload and queues it.
+// Returns done=true when reconciliation should stop (error or terminal DRA outcome).
+// When done=false, queueOptions holds the InfoOptions the caller must pass to any
+// subsequent AddOrUpdateWorkload in the same reconcile (e.g. the backoff-requeue path).
 func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, queueOptions []workload.InfoOption, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -531,11 +535,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 	}
 	var draQueueOptions []workload.InfoOption
 	if workload.Status(&wl) == workload.StatusPending && dra.NeedsDRAReconcile(&wl, r.draBackedResources) {
-		var done bool
-		var result ctrl.Result
-		var err error
-		if done, result, draQueueOptions, err = r.handleDRA(ctx, &wl); done {
+		if done, result, opts, err := r.handleDRA(ctx, &wl); done {
 			return result, err
+		} else {
+			draQueueOptions = opts
 		}
 	}
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -132,6 +132,8 @@ func (r *WorkloadReconciler) handleDRAConsumableCapacity(
 // Returns done=true when reconciliation should stop (error or terminal DRA outcome).
 // When done=false, queueOptions holds the InfoOptions the caller must pass to any
 // subsequent AddOrUpdateWorkload in the same reconcile (e.g. the backoff-requeue path).
+// Queueing is skipped when RequeueAt is set so the backoff path can queue once with
+// queueOptions, but preprocessing still runs and queueOptions are always returned.
 func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, queueOptions []workload.InfoOption, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -218,17 +220,24 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		queueOptions = append(queueOptions, workload.WithPreprocessedDRAResources(draResources, replacedExtendedResources))
 	}
 
+	waitingForBackoff := wl.Status.RequeueState != nil && wl.Status.RequeueState.RequeueAt != nil
+
 	if workload.IsAdmissible(wl) {
-		if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
-			log.V(2).Info("Failed to add DRA workload to queue", "error", err)
-			return true, ctrl.Result{}, nil, err
+		if !waitingForBackoff {
+			if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
+				log.V(2).Info("Failed to add DRA workload to queue", "error", err)
+				return true, ctrl.Result{}, nil, err
+			}
+			log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
+		} else {
+			log.V(3).Info("Successfully pre-processed DRA workload; queueing deferred until backoff elapses")
 		}
 	} else {
 		if !r.cache.AddOrUpdateWorkload(log, wl.DeepCopy()) {
 			log.V(2).Info("ClusterQueue for workload didn't exist; ignored for now")
 		}
+		log.V(3).Info("Successfully pre-processed DRA workload for cache")
 	}
-	log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
 	return false, ctrl.Result{}, queueOptions, nil
 }
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -128,7 +128,7 @@ func (r *WorkloadReconciler) handleDRAConsumableCapacity(
 	return dra.MergeDRAResources(draResources, capacityResources), false, ctrl.Result{}, nil
 }
 
-func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, err error) {
+func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, queueOptions []workload.InfoOption, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	workload.AdjustResources(ctx, r.client, wl)
@@ -143,9 +143,9 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 			return updated, nil
 		})
 		if err != nil {
-			return true, ctrl.Result{}, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
+			return true, ctrl.Result{}, nil, fmt.Errorf("failed to update workload status for DRA resource claims error: %w", err)
 		}
-		return true, ctrl.Result{}, nil
+		return true, ctrl.Result{}, nil, nil
 	}
 
 	log.V(3).Info("Processing DRA resources for workload")
@@ -155,7 +155,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	// Process ResourceClaimTemplates (existing DRA path)
 	draResources, fieldErrs := dra.GetResourceRequestsForResourceClaimTemplates(ctx, r.client, sliceCache, r.draMapper, wl)
 	if len(fieldErrs) > 0 {
-		return r.markDRAInadmissible(ctx, wl, fieldErrs, "Failed to process DRA resources for workload")
+		done, result, err := r.markDRAInadmissible(ctx, wl, fieldErrs, "Failed to process DRA resources for workload")
+		return done, result, nil, err
 	}
 
 	// Process Extended Resources backed by DRA
@@ -163,7 +164,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationExtendedResource) {
 		extendedResources, replaced, extFieldErrs := dra.ResolveExtendedResourceQuota(ctx, r.client, r.draMapper, wl)
 		if len(extFieldErrs) > 0 {
-			return r.markDRAInadmissible(ctx, wl, extFieldErrs, "Failed to process DRA extended resources for workload")
+			done, result, err := r.markDRAInadmissible(ctx, wl, extFieldErrs, "Failed to process DRA extended resources for workload")
+			return done, result, nil, err
 		}
 		// Merge extended resources into draResources. When a DeviceClass appears
 		// in both paths, the extended resources path uses the deviceClassMappings
@@ -176,7 +178,8 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && r.resourceSliceAPIAvailable {
 		counterResources, counterFieldErrs := dra.GetCounterResourcesForWorkload(ctx, r.client, sliceCache, r.draMapper, wl)
 		if len(counterFieldErrs) > 0 {
-			return r.markDRAInadmissible(ctx, wl, counterFieldErrs, "Failed to process DRA counter resources for workload")
+			done, result, err := r.markDRAInadmissible(ctx, wl, counterFieldErrs, "Failed to process DRA counter resources for workload")
+			return done, result, nil, err
 		}
 		draResources = dra.MergeDRAResources(draResources, counterResources)
 	}
@@ -185,7 +188,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && r.resourceSliceAPIAvailable {
 		ccResources, ccDone, ccResult, ccErr := r.handleDRAConsumableCapacity(ctx, wl, sliceCache, draResources)
 		if ccDone {
-			return true, ccResult, ccErr
+			return true, ccResult, nil, ccErr
 		}
 		draResources = ccResources
 	}
@@ -207,7 +210,6 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		log.V(3).Info("Cleared previous inadmissible conditions after successful DRA processing")
 	}
 
-	var queueOptions []workload.InfoOption
 	if len(draResources) > 0 || len(replacedExtendedResources) > 0 {
 		queueOptions = append(queueOptions, workload.WithPreprocessedDRAResources(draResources, replacedExtendedResources))
 	}
@@ -215,7 +217,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 	if workload.IsAdmissible(wl) {
 		if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
 			log.V(2).Info("Failed to add DRA workload to queue", "error", err)
-			return true, ctrl.Result{}, err
+			return true, ctrl.Result{}, nil, err
 		}
 	} else {
 		if !r.cache.AddOrUpdateWorkload(log, wl.DeepCopy()) {
@@ -223,7 +225,7 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		}
 	}
 	log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
-	return false, ctrl.Result{}, nil
+	return false, ctrl.Result{}, queueOptions, nil
 }
 
 func (r *WorkloadReconciler) markDRAInadmissible(ctx context.Context, wl *kueue.Workload, fieldErrs field.ErrorList, logMsg string) (bool, ctrl.Result, error) {
@@ -527,8 +529,12 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		}
 		return ctrl.Result{}, nil
 	}
+	var draQueueOptions []workload.InfoOption
 	if workload.Status(&wl) == workload.StatusPending && dra.NeedsDRAReconcile(&wl, r.draBackedResources) {
-		if done, result, err := r.handleDRA(ctx, &wl); done {
+		var done bool
+		var result ctrl.Result
+		var err error
+		if done, result, draQueueOptions, err = r.handleDRA(ctx, &wl); done {
 			return result, err
 		}
 	}
@@ -575,7 +581,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 				// resources, not the raw spec.
 				wlCopy := wl.DeepCopy()
 				workload.AdjustResources(ctx, r.client, wlCopy)
-				if err := r.queues.AddOrUpdateWorkload(log, wlCopy); err != nil {
+				if err := r.queues.AddOrUpdateWorkload(log, wlCopy, draQueueOptions...); err != nil {
 					log.V(2).Info("failed to put the workload back into queue", "error", err)
 					return ctrl.Result{}, err
 				}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -132,8 +132,6 @@ func (r *WorkloadReconciler) handleDRAConsumableCapacity(
 // Returns done=true when reconciliation should stop (error or terminal DRA outcome).
 // When done=false, queueOptions holds the InfoOptions the caller must pass to any
 // subsequent AddOrUpdateWorkload in the same reconcile (e.g. the backoff-requeue path).
-// Queueing is skipped when RequeueAt is set so the backoff path can queue once with
-// queueOptions, but preprocessing still runs and queueOptions are always returned.
 func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) (done bool, result ctrl.Result, queueOptions []workload.InfoOption, err error) {
 	log := ctrl.LoggerFrom(ctx)
 
@@ -220,18 +218,12 @@ func (r *WorkloadReconciler) handleDRA(ctx context.Context, wl *kueue.Workload) 
 		queueOptions = append(queueOptions, workload.WithPreprocessedDRAResources(draResources, replacedExtendedResources))
 	}
 
-	waitingForBackoff := wl.Status.RequeueState != nil && wl.Status.RequeueState.RequeueAt != nil
-
 	if workload.IsAdmissible(wl) {
-		if !waitingForBackoff {
-			if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
-				log.V(2).Info("Failed to add DRA workload to queue", "error", err)
-				return true, ctrl.Result{}, nil, err
-			}
-			log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
-		} else {
-			log.V(3).Info("Successfully pre-processed DRA workload; queueing deferred until backoff elapses")
+		if err := r.queues.AddOrUpdateWorkload(log, wl.DeepCopy(), queueOptions...); err != nil {
+			log.V(2).Info("Failed to add DRA workload to queue", "error", err)
+			return true, ctrl.Result{}, nil, err
 		}
+		log.V(3).Info("Successfully pre-processed and queued DRA workload in scheduler")
 	} else {
 		if !r.cache.AddOrUpdateWorkload(log, wl.DeepCopy()) {
 			log.V(2).Info("ClusterQueue for workload didn't exist; ignored for now")

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -216,6 +216,40 @@ func TestReconcileDRA(t *testing.T) {
 				Obj(),
 			wantEvents: nil,
 		},
+		"reconcile DRA ResourceClaimTemplate requeued after backoff should keep DRA resources in queue": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:              true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
+			wantDRAResourceTotal: new(int64(1)),
+			wantWorkloadsInQueue: new(1),
+			workload: utiltestingapi.MakeWorkload("wlDRARequeuedAfterBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(-time.Hour)))).
+				Obj(),
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 1).
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("gpu", "2").Obj(),
+				).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wlDRARequeuedAfterBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), nil).
+				Obj(),
+			wantEvents: nil,
+		},
 		"reconcile DRA ResourceClaimTemplate multi-pod should be pre-processed and queued": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -224,13 +224,16 @@ func TestReconcileDRA(t *testing.T) {
 				Obj(),
 			wantEvents: nil,
 		},
-		"reconcile DRA workload waiting for backoff should preprocess but not queue": {
+		"reconcile DRA workload waiting for backoff should preprocess and queue as inadmissible": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,
 				features.MultiKueueOrchestratedPreemption: false,
 			},
-			wantWorkloadsInQueue: new(0),
-			wantResult:           reconcile.Result{RequeueAfter: time.Hour},
+			wantDRAResourceTotal:     new(int64(1)),
+			wantWorkloadsInQueue:     new(1),
+			wantWorkloadInHeap:       new(false),
+			wantWorkloadInadmissible: new(true),
+			wantResult:               reconcile.Result{RequeueAfter: time.Hour},
 			workload: utiltestingapi.MakeWorkload("wlDRAWaitingForBackoff", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
@@ -263,13 +266,21 @@ func TestReconcileDRA(t *testing.T) {
 				features.KueueDRAIntegration:              true,
 				features.MultiKueueOrchestratedPreemption: false,
 			},
-			wantDRAResourceTotal: new(int64(1)),
-			wantWorkloadsInQueue: new(1),
+			wantDRAResourceTotal:     new(int64(1)),
+			wantWorkloadsInQueue:     new(1),
+			wantWorkloadInHeap:       new(true),
+			wantWorkloadInadmissible: new(false),
 			workload: utiltestingapi.MakeWorkload("wlDRARequeuedAfterBackoff", "ns").
 				Queue("lq").
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message: "Exceeded the PodsReady timeout ns",
+				}).
 				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(-time.Hour)))).
 				Obj(),
 			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
@@ -288,6 +299,12 @@ func TestReconcileDRA(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 					ResourceClaimTemplate("gpu", "gpu-template").
 					Obj()).
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message: "Exceeded the PodsReady timeout ns",
+				}).
 				RequeueState(new(int32(1)), nil).
 				Obj(),
 			wantEvents: nil,
@@ -298,12 +315,20 @@ func TestReconcileDRA(t *testing.T) {
 				features.KueueDRAIntegrationExtendedResource: true,
 				features.MultiKueueOrchestratedPreemption:    false,
 			},
-			wantDRAResourceTotal:   new(int64(1)),
-			wantAbsentDRAResources: []corev1.ResourceName{"example.com/gpu"},
-			wantWorkloadsInQueue:   new(1),
+			wantDRAResourceTotal:     new(int64(1)),
+			wantAbsentDRAResources:   []corev1.ResourceName{"example.com/gpu"},
+			wantWorkloadsInQueue:     new(1),
+			wantWorkloadInHeap:       new(true),
+			wantWorkloadInadmissible: new(false),
 			workload: utiltestingapi.MakeWorkload("wlDRAExtendedRequeuedAfterBackoff", "ns").
 				Queue("lq").
 				Request("example.com/gpu", "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message: "Exceeded the PodsReady timeout ns",
+				}).
 				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(-time.Hour)))).
 				Obj(),
 			additionalObjects: []client.Object{
@@ -320,6 +345,12 @@ func TestReconcileDRA(t *testing.T) {
 			wantWorkload: utiltestingapi.MakeWorkload("wlDRAExtendedRequeuedAfterBackoff", "ns").
 				Queue("lq").
 				Request("example.com/gpu", "1").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadRequeued,
+					Status:  metav1.ConditionFalse,
+					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
+					Message: "Exceeded the PodsReady timeout ns",
+				}).
 				RequeueState(new(int32(1)), nil).
 				Obj(),
 			wantEvents: nil,

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -224,6 +224,40 @@ func TestReconcileDRA(t *testing.T) {
 				Obj(),
 			wantEvents: nil,
 		},
+		"reconcile DRA ResourceClaimTemplate requeued after backoff should keep DRA resources in queue": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:              true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
+			wantDRAResourceTotal: new(int64(1)),
+			wantWorkloadsInQueue: new(1),
+			workload: utiltestingapi.MakeWorkload("wlDRARequeuedAfterBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(-time.Hour)))).
+				Obj(),
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 1).
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("gpu", "2").Obj(),
+				).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wlDRARequeuedAfterBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), nil).
+				Obj(),
+			wantEvents: nil,
+		},
 		"reconcile DRA ResourceClaimTemplate multi-pod should be pre-processed and queued": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -258,6 +258,38 @@ func TestReconcileDRA(t *testing.T) {
 				Obj(),
 			wantEvents: nil,
 		},
+		"reconcile DRA extended resource requeued after backoff should replace extended resource in queue": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:                 true,
+				features.KueueDRAIntegrationExtendedResource: true,
+				features.MultiKueueOrchestratedPreemption:    false,
+			},
+			wantDRAResourceTotal:   new(int64(1)),
+			wantAbsentDRAResources: []corev1.ResourceName{"example.com/gpu"},
+			wantWorkloadsInQueue:   new(1),
+			workload: utiltestingapi.MakeWorkload("wlDRAExtendedRequeuedAfterBackoff", "ns").
+				Queue("lq").
+				Request("example.com/gpu", "1").
+				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(-time.Hour)))).
+				Obj(),
+			additionalObjects: []client.Object{
+				utiltesting.MakeDeviceClass("gpu-class").
+					ExtendedResourceName("example.com/gpu").
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("gpu", "2").Obj(),
+				).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wlDRAExtendedRequeuedAfterBackoff", "ns").
+				Queue("lq").
+				Request("example.com/gpu", "1").
+				RequeueState(new(int32(1)), nil).
+				Obj(),
+			wantEvents: nil,
+		},
 		"reconcile DRA ResourceClaimTemplate multi-pod should be pre-processed and queued": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,

--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -224,6 +224,40 @@ func TestReconcileDRA(t *testing.T) {
 				Obj(),
 			wantEvents: nil,
 		},
+		"reconcile DRA workload waiting for backoff should preprocess but not queue": {
+			featureGates: map[featuregate.Feature]bool{
+				features.KueueDRAIntegration:              true,
+				features.MultiKueueOrchestratedPreemption: false,
+			},
+			wantWorkloadsInQueue: new(0),
+			wantResult:           reconcile.Result{RequeueAfter: time.Hour},
+			workload: utiltestingapi.MakeWorkload("wlDRAWaitingForBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(time.Hour)))).
+				Obj(),
+			resourceClaimTemplates: []*resourcev1.ResourceClaimTemplate{
+				utiltesting.MakeResourceClaimTemplate("gpu-template", "ns").
+					DeviceRequest("gpu-request", "gpu.example.com", 1).
+					Obj(),
+			},
+			cq: utiltestingapi.MakeClusterQueue("cq").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("flavor1").
+						Resource("gpu", "2").Obj(),
+				).Obj(),
+			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wlDRAWaitingForBackoff", "ns").
+				Queue("lq").
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					ResourceClaimTemplate("gpu", "gpu-template").
+					Obj()).
+				RequeueState(new(int32(1)), new(metav1.NewTime(fakeClock.Now().Add(time.Hour)))).
+				Obj(),
+			wantEvents: nil,
+		},
 		"reconcile DRA ResourceClaimTemplate requeued after backoff should keep DRA resources in queue": {
 			featureGates: map[featuregate.Feature]bool{
 				features.KueueDRAIntegration:              true,

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1029,6 +1029,8 @@ type reconcileTestCase struct {
 	wantDRAResourceTotal      *int64
 	wantAbsentDRAResources    []corev1.ResourceName
 	wantWorkloadsInQueue      *int
+	wantWorkloadInHeap        *bool
+	wantWorkloadInadmissible  *bool
 	wantWorkload              *kueue.Workload
 	wantWorkloadUseMergePatch *kueue.Workload // workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
 	wantError                 error
@@ -2710,8 +2712,14 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 									}
 									for _, resName := range tc.wantAbsentDRAResources {
 										if len(wlInfo.TotalRequests) > 0 && wlInfo.TotalRequests[0].Requests != nil {
-											if got := wlInfo.TotalRequests[0].Requests.GetValue(resName); got > 0 {
-												t.Errorf("Expected resource %q to be absent from queued TotalRequests, but got %d", resName, got)
+											var found bool
+											wlInfo.TotalRequests[0].Requests.ForEach(func(name corev1.ResourceName, _ int64) {
+												if name == resName {
+													found = true
+												}
+											})
+											if found {
+												t.Errorf("Expected resource %q to be absent from queued TotalRequests", resName)
 											}
 										}
 									}
@@ -2721,6 +2729,18 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 						}
 						if tc.wantWorkloadsInQueue != nil && *tc.wantWorkloadsInQueue > 0 && !foundInQueue {
 							t.Errorf("DRA workload not found in queue - expected to be queued for processing")
+						}
+
+						wlRef := workload.Key(testWl)
+						if tc.wantWorkloadInHeap != nil || tc.wantWorkloadInadmissible != nil {
+							inHeap := workloadRefInDump(qManager.Dump(), cqName, wlRef)
+							inInadmissible := workloadRefInDump(qManager.DumpInadmissible(), cqName, wlRef)
+							if tc.wantWorkloadInHeap != nil && inHeap != *tc.wantWorkloadInHeap {
+								t.Errorf("Expected workload in heap=%v, got %v", *tc.wantWorkloadInHeap, inHeap)
+							}
+							if tc.wantWorkloadInadmissible != nil && inInadmissible != *tc.wantWorkloadInadmissible {
+								t.Errorf("Expected workload in inadmissible=%v, got %v", *tc.wantWorkloadInadmissible, inInadmissible)
+							}
 						}
 					} else {
 						t.Errorf("LocalQueue not found in queue manager - DRA workload should have been queued")
@@ -2943,7 +2963,18 @@ func needsDRAQueueVerification(tc reconcileTestCase, testWl *kueue.Workload) boo
 		len(tc.resourceClaimTemplates) > 0 ||
 		tc.wantDRAResourceTotal != nil ||
 		len(tc.wantAbsentDRAResources) > 0 ||
-		tc.wantWorkloadsInQueue != nil
+		tc.wantWorkloadsInQueue != nil ||
+		tc.wantWorkloadInHeap != nil ||
+		tc.wantWorkloadInadmissible != nil
+}
+
+func workloadRefInDump(dump map[kueue.ClusterQueueReference][]workload.Reference, cqName kueue.ClusterQueueReference, wlRef workload.Reference) bool {
+	for _, ref := range dump[cqName] {
+		if ref == wlRef {
+			return true
+		}
+	}
+	return false
 }
 
 func setupDRACache(objs []client.Object) *dra.ExtendedResourceCache {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2969,12 +2970,7 @@ func needsDRAQueueVerification(tc reconcileTestCase, testWl *kueue.Workload) boo
 }
 
 func workloadRefInDump(dump map[kueue.ClusterQueueReference][]workload.Reference, cqName kueue.ClusterQueueReference, wlRef workload.Reference) bool {
-	for _, ref := range dump[cqName] {
-		if ref == wlRef {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(dump[cqName], wlRef)
 }
 
 func setupDRACache(objs []client.Object) *dra.ExtendedResourceCache {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2719,7 +2719,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 								break
 							}
 						}
-						if tc.wantWorkloadsInQueue != nil && !foundInQueue {
+						if tc.wantWorkloadsInQueue != nil && *tc.wantWorkloadsInQueue > 0 && !foundInQueue {
 							t.Errorf("DRA workload not found in queue - expected to be queued for processing")
 						}
 					} else {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -1027,6 +1027,7 @@ type reconcileTestCase struct {
 	patchErr                  error
 	listErr                   error
 	wantDRAResourceTotal      *int64
+	wantAbsentDRAResources    []corev1.ResourceName
 	wantWorkloadsInQueue      *int
 	wantWorkload              *kueue.Workload
 	wantWorkloadUseMergePatch *kueue.Workload // workload version to compensate for the difference between use of Apply and Merge patch in FakeClient
@@ -2593,9 +2594,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 					setupLocalQueue(ctx, t, cl, qManager, tc.lq, tc.shouldDeleteLQ)
 				}
 
-				if testWl != nil && testWl.Namespace == "ns" &&
-					len(testWl.Spec.PodSets) > 0 &&
-					len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 {
+				if needsDRAMapperSetup(tc, testWl) {
 					draConfig := []configapi.DeviceClassMapping{
 						{
 							Name:             corev1.ResourceName("foo"),
@@ -2603,7 +2602,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 						},
 						{
 							Name:             corev1.ResourceName("gpu"),
-							DeviceClassNames: []corev1.ResourceName{"gpu.example.com"},
+							DeviceClassNames: []corev1.ResourceName{"gpu.example.com", "gpu-class"},
 						},
 					}
 					draMapper := dra.NewResourceMapper()
@@ -2673,9 +2672,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 				}
 
 				// For DRA tests, verify that workloads are properly queued/cached
-				if tc.featureGates[features.KueueDRAIntegration] && testWl != nil &&
-					len(testWl.Spec.PodSets) > 0 &&
-					len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 {
+				if needsDRAQueueVerification(tc, testWl) {
 					workloadKey := client.ObjectKeyFromObject(testWl)
 
 					if cqName, found := qManager.ClusterQueueFromLocalQueue(utilqueue.KeyFromWorkload(testWl)); found {
@@ -2694,7 +2691,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 						for _, wlInfo := range pendingWorkloads {
 							if wlInfo.Obj.Name == workloadKey.Name && wlInfo.Obj.Namespace == workloadKey.Namespace {
 								foundInQueue = true
-								if len(tc.resourceClaimTemplates) > 0 && wlInfo.TotalRequests != nil {
+								if wlInfo.TotalRequests != nil && (tc.wantDRAResourceTotal != nil || len(tc.wantAbsentDRAResources) > 0) {
 									t.Logf("DRA workload found in queue with TotalRequests: %+v", wlInfo.TotalRequests)
 
 									if tc.wantDRAResourceTotal != nil {
@@ -2709,6 +2706,13 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 											}
 										} else {
 											t.Errorf("Expected TotalRequests with DRA resources, but TotalRequests is empty")
+										}
+									}
+									for _, resName := range tc.wantAbsentDRAResources {
+										if len(wlInfo.TotalRequests) > 0 && wlInfo.TotalRequests[0].Requests != nil {
+											if got := wlInfo.TotalRequests[0].Requests.GetValue(resName); got > 0 {
+												t.Errorf("Expected resource %q to be absent from queued TotalRequests, but got %d", resName, got)
+											}
 										}
 									}
 								}
@@ -2912,6 +2916,34 @@ func setupLocalQueue(ctx context.Context, t *testing.T, cl client.Client, qManag
 			t.Fatalf("couldn't delete the local queue: %v", err)
 		}
 	}
+}
+
+func needsDRAMapperSetup(tc reconcileTestCase, testWl *kueue.Workload) bool {
+	if testWl == nil || testWl.Namespace != "ns" || len(testWl.Spec.PodSets) == 0 {
+		return false
+	}
+	if len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 {
+		return true
+	}
+	if tc.featureGates[features.KueueDRAIntegrationExtendedResource] {
+		for _, obj := range tc.additionalObjects {
+			if _, ok := obj.(*resourcev1.DeviceClass); ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func needsDRAQueueVerification(tc reconcileTestCase, testWl *kueue.Workload) bool {
+	if !tc.featureGates[features.KueueDRAIntegration] || testWl == nil || len(testWl.Spec.PodSets) == 0 {
+		return false
+	}
+	return len(testWl.Spec.PodSets[0].Template.Spec.ResourceClaims) > 0 ||
+		len(tc.resourceClaimTemplates) > 0 ||
+		tc.wantDRAResourceTotal != nil ||
+		len(tc.wantAbsentDRAResources) > 0 ||
+		tc.wantWorkloadsInQueue != nil
 }
 
 func setupDRACache(objs []client.Object) *dra.ExtendedResourceCache {

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -262,6 +262,75 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.It("Should re-admit ResourceClaimTemplate workload with DRA resources after PodsReady backoff", framework.SlowSpec, func() {
+			ginkgo.By("Restarting the controller with WaitForPodsReady enabled")
+			fwk.StopManager(ctx)
+			fwk.StartManager(ctx, cfg, managerSetup(func(c *config.Configuration) {
+				c.WaitForPodsReady = &config.WaitForPodsReady{
+					BlockAdmission: new(true),
+					Timeout:        metav1.Duration{Duration: util.TinyTimeout},
+					RequeuingStrategy: &config.RequeuingStrategy{
+						Timestamp:          new(config.EvictionTimestamp),
+						BackoffBaseSeconds: new(int32(1)),
+						BackoffMaxSeconds:  new(int32(config.DefaultRequeuingBackoffMaxSeconds)),
+					},
+				}
+			}))
+			defer func() {
+				ginkgo.By("Restarting the controller with the default config")
+				fwk.StopManager(ctx)
+				fwk.StartManager(ctx, cfg, managerSetup(nil))
+			}()
+
+			ginkgo.By("Creating a ResourceClaimTemplate")
+			rct := utiltesting.MakeResourceClaimTemplate("backoff-template", ns.Name).
+				DeviceRequest("device-request", "foo.example.com", 2).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, rct)).To(gomega.Succeed())
+
+			ginkgo.By("Creating a workload that references the ResourceClaimTemplate")
+			wl := utiltestingapi.MakeWorkload("test-wl-backoff", ns.Name).
+				Queue("test-lq").
+				Obj()
+			wl.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{
+				{
+					Name:                      "device-template",
+					ResourceClaimTemplateName: new("backoff-template"),
+				},
+			}
+			wl.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{
+				{Name: "device-template"},
+			}
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Verifying workload is admitted with DRA resources")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, clusterQueue.Name, wl)
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName("foo")))
+				g.Expect(assignment.ResourceUsage["foo"]).To(gomega.Equal(resource.MustParse("2")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Waiting for PodsReady timeout eviction and finishing backoff")
+			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(wl), util.TinyTimeout)
+			util.SetRequeuedConditionWithPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(wl))
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wl)
+
+			ginkgo.By("Verifying workload is re-admitted with DRA resources after backoff")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, clusterQueue.Name, wl)
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName("foo")))
+				g.Expect(assignment.ResourceUsage["foo"]).To(gomega.Equal(resource.MustParse("2")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.It("Should handle multiple workloads with ResourceClaimTemplates", func() {
 			ginkgo.By("Creating ResourceClaimTemplates")
 			rct1 := utiltesting.MakeResourceClaimTemplate("device-template-1", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When `KueueDRAIntegration` is enabled (Beta, on by default since 0.18), `handleDRA` pre-computes a workload's DRA-backed resources and queues the workload with `workload.WithPreprocessedDRAResources(...)`, so the queued `Info` correctly reflects the workload's device/quota footprint.

If that same `Reconcile` call also handles a backoff-requeue for the workload (i.e. the workload's retry backoff timer has just elapsed), the requeue path calls `AddOrUpdateWorkload` again with **no** `InfoOption`s. Since `AddOrUpdateWorkload` always rebuilds the queued `Info` from scratch rather than merging with what's already there, this second call overwrites the correct DRA-adjusted entry with one built from the workload's raw pod-spec requests — silently dropping the DRA logical resources and leaving in any extended resources DRA was meant to replace.

This PR fixes it by having `handleDRA` return the `InfoOption`s it already computed, so `Reconcile` can pass the same options into the backoff-requeue `AddOrUpdateWorkload` call instead of dropping them.

#### Which issue(s) this PR fixes:
Fixes #13930

#### Special notes for your reviewer:

- The fix only changes what `AddOrUpdateWorkload` is called with at the backoff-requeue site; it does not change any admission/quota logic. For any workload that isn't simultaneously mid-DRA-preprocessing and past its backoff deadline in the same reconcile pass, the new `draQueueOptions` variable is `nil`, which is a no-op for the variadic call — behavior is unchanged.
- `handleDRA`'s return signature grew a 4th value (`queueOptions []workload.InfoOption`); all of its internal early-return branches (including the ones delegating to `markDRAInadmissible`) were updated accordingly.
- Added a regression test (`workload_controller_dra_test.go`) that sets an elapsed `RequeueState.RequeueAt` on a DRA `ResourceClaimTemplate` workload to exercise both code paths in one `Reconcile` call. Verified it fails on `main` before this fix (the DRA "gpu" resource is missing from the queued `Info`) and passes after.
- Verified with `make test` (unit/pkg tests only; no failures) and by running the integration suites separately: `go test ./test/integration/singlecluster/controller/dra/` and `go test ./test/integration/singlecluster/controller/core/` against a real envtest control plane.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed a bug where a workload requeued after backoff lost its DRA-preprocessed resources, causing the queue to fall back to raw pod-spec requests.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## AI summary

Fixed DRA resource accounting for workloads requeued after backoff. Requeued workloads retain DRA-preprocessed resources and do not double-charge replaced extended resources. Workloads waiting for backoff remain managed by the queue manager with pending resources counted. Added regression tests for `ResourceClaimTemplate` and extended-resource workloads.

### Suggested release note

DRA: Fixed a bug where workloads requeued after backoff could lose DRA resources and double-charge replaced extended resources. Kueue now preserves the correct resource accounting. This behavior is gated by the `KueueDRAIntegration` feature gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->