### PR TITLE
kueueviz: add WebSocket heartbeat support

### DIFF
--- a/cmd/kueueviz/backend/handlers/handlers.go
+++ b/cmd/kueueviz/backend/handlers/handlers.go
@@ -37,6 +37,10 @@ type Handlers struct {
 	// tokenRevalidationInterval controls how often a live WebSocket connection
 	// re-verifies the bearer token. Defaults to 30 s; overridable in tests.
 	tokenRevalidationInterval time.Duration
+
+	// heartbeatInterval controls how often a WebSocket ping control frame is sent.
+	// Defaults to 30 s; overridable in tests.
+	heartbeatInterval time.Duration
 }
 
 func New(client Client, validator TokenValidator) *Handlers {
@@ -44,6 +48,7 @@ func New(client Client, validator TokenValidator) *Handlers {
 		client:                    client,
 		validator:                 validator,
 		tokenRevalidationInterval: 30 * time.Second,
+		heartbeatInterval:         30 * time.Second,
 	}
 }
 

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -210,6 +210,15 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		authTickerC = authTicker.C
 	}
 
+	var heartbeatTicker *time.Ticker
+	var heartbeatTickerC <-chan time.Time
+
+	if h.heartbeatInterval > 0 {
+		heartbeatTicker = time.NewTicker(h.heartbeatInterval)
+		defer heartbeatTicker.Stop()
+		heartbeatTickerC = heartbeatTicker.C
+	}
+
 	// Handle updates from the informers
 	for {
 		select {
@@ -238,6 +247,16 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		case <-updateChan:
 			if err := h.sendData(ctx, conn, dataFetcher); err != nil {
 				slog.Error("Error sending update", "error", err)
+				return
+			}
+
+		case <-heartbeatTickerC:
+			if err := conn.WriteControl(
+				websocket.PingMessage,
+				nil,
+				time.Now().Add(writeDeadlineExtension),
+			); err != nil {
+				slog.Warn("Failed to send WebSocket heartbeat", "error", err)
 				return
 			}
 		}

--- a/cmd/kueueviz/backend/handlers/websocket_handler.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler.go
@@ -210,6 +210,9 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		authTickerC = authTicker.C
 	}
 
+	heartbeatTicker := time.NewTicker(h.heartbeatInterval)
+	defer heartbeatTicker.Stop()
+
 	// Handle updates from the informers
 	for {
 		select {
@@ -238,6 +241,16 @@ func (h *Handlers) handleInformerUpdates(ctx context.Context, conn *websocket.Co
 		case <-updateChan:
 			if err := h.sendData(ctx, conn, dataFetcher); err != nil {
 				slog.Error("Error sending update", "error", err)
+				return
+			}
+
+		case <-heartbeatTicker.C:
+			if err := conn.WriteControl(
+				websocket.PingMessage,
+				nil,
+				time.Now().Add(writeDeadlineExtension),
+			); err != nil {
+				slog.Debug("Failed to send WebSocket heartbeat", "error", err)
 				return
 			}
 		}

--- a/cmd/kueueviz/backend/handlers/websocket_handler_test.go
+++ b/cmd/kueueviz/backend/handlers/websocket_handler_test.go
@@ -47,6 +47,9 @@ const (
 	// trigger the token re-validation ticker without waiting 30 seconds.
 	testTokenRevalidationInterval = 100 * time.Millisecond
 
+	// testHeartbeatInterval is a short interval used in tests to quickly
+	// trigger WebSocket heartbeat pings without waiting 30 seconds.
+	testHeartbeatInterval = 100 * time.Millisecond
 	// testPollInterval is the polling frequency used in waitUntil calls.
 	testPollInterval = 10 * time.Millisecond
 
@@ -245,7 +248,8 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]int64{"call": fetchCalls.Add(1)}, nil
 				}
 
-				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvkA, gvkB)
+				h := New(client, nil)
+				conn, closeServer := newTestWebSocketConnection(t, h, dataFetcher, gvkA, gvkB)
 				defer closeServer()
 				defer conn.Close()
 
@@ -276,11 +280,8 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]int64{"call": fetchCalls.Add(1)}, nil
 				}
 
-				h := &Handlers{
-					client:                    client,
-					validator:                 validator,
-					tokenRevalidationInterval: testTokenRevalidationInterval,
-				}
+				h := New(client, validator)
+				h.tokenRevalidationInterval = testTokenRevalidationInterval
 				conn, closeServer := newTestWebSocketConnectionWithToken(t, h, "test-token", dataFetcher, gvk)
 				defer closeServer()
 
@@ -336,7 +337,8 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]string{"status": "ok"}, nil
 				}
 
-				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvkA, gvkB)
+				h := New(client, nil)
+				conn, closeServer := newTestWebSocketConnection(t, h, dataFetcher, gvkA, gvkB)
 				defer closeServer()
 
 				readMessage(t, conn)
@@ -366,7 +368,8 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]int64{"call": fetchCalls.Add(1)}, nil
 				}
 
-				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvk)
+				h := New(client, nil)
+				conn, closeServer := newTestWebSocketConnection(t, h, dataFetcher, gvk)
 				defer closeServer()
 				defer conn.Close()
 
@@ -413,6 +416,65 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 				}
 			},
 		},
+		"sends websocket heartbeat ping": {
+			run: func(t *testing.T) {
+				gvk := schema.GroupVersionKind{
+					Group:   "group",
+					Version: "v1",
+					Kind:    "Kind",
+				}
+
+				informer := newMockInformer()
+				client := newMockClient(
+					map[schema.GroupVersionKind]*mockInformer{
+						gvk: informer,
+					},
+				)
+
+				dataFetcher := func(_ context.Context) (any, error) {
+					return map[string]string{"status": "ok"}, nil
+				}
+
+				h := New(client, nil)
+				h.heartbeatInterval = testHeartbeatInterval
+				conn, closeServer := newTestWebSocketConnection(t, h, dataFetcher, gvk)
+				defer closeServer()
+				defer conn.Close()
+
+				// Consume the initial data snapshot.
+				readMessage(t, conn)
+
+				pingReceived := make(chan struct{}, 1)
+				defaultPingHandler := conn.PingHandler()
+
+				conn.SetPingHandler(func(appData string) error {
+					select {
+					case pingReceived <- struct{}{}:
+					default:
+					}
+
+					return defaultPingHandler(appData)
+				})
+
+				readErr := make(chan error, 1)
+				go func() {
+					for {
+						if _, _, err := conn.ReadMessage(); err != nil {
+							readErr <- err
+							return
+						}
+					}
+				}()
+
+				select {
+				case <-pingReceived:
+				case err := <-readErr:
+					t.Fatalf("read websocket message: %v", err)
+				case <-time.After(testTimeout):
+					t.Fatalf("timeout waiting for WebSocket heartbeat ping")
+				}
+			},
+		},
 		"enforces websocket read limit": {
 			run: func(t *testing.T) {
 				gvk := schema.GroupVersionKind{Group: "group", Version: "v1", Kind: "Kind"}
@@ -424,7 +486,8 @@ func TestWebSocketHandleInformerUpdates(t *testing.T) {
 					return map[string]string{"status": "ok"}, nil
 				}
 
-				conn, closeServer := newTestWebSocketConnection(t, &Handlers{client: client}, dataFetcher, gvk)
+				h := New(client, nil)
+				conn, closeServer := newTestWebSocketConnection(t, h, dataFetcher, gvk)
 				defer closeServer()
 				defer conn.Close()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Adds periodic WebSocket heartbeat pings to the KueueViz backend.

This change sends WebSocket ping control frames every 30 seconds to keep connections active. It also adds  a regression test verifying that heartbeat ping frames are sent.

#### Which issue(s) this PR fixes:

Fixes #13961

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
KueueViz: support WebSocket heartbeat
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection reliability by sending periodic heartbeat signals.
  * Connections are now closed when heartbeat delivery fails.

* **Tests**
  * Added coverage verifying that heartbeat signals are sent over WebSocket connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->