### PR TITLE
Give each non-leading request its own decoding destination

### DIFF
--- a/pkg/controller/core/leader_aware_reconciler.go
+++ b/pkg/controller/core/leader_aware_reconciler.go
@@ -52,16 +52,16 @@ func WithLeadingManager(mgr ctrl.Manager, reconciler reconcile.Reconciler, obj c
 		elected:         mgr.Elected(),
 		client:          mgr.GetClient(),
 		delegate:        reconciler,
-		object:          obj,
+		objectPrototype: obj,
 		requeueDuration: cfg.LeaderElection.LeaseDuration.Duration,
 	}
 }
 
 type leaderAwareReconciler struct {
-	elected  <-chan struct{}
-	client   client.Client
-	delegate reconcile.Reconciler
-	object   client.Object
+	elected         <-chan struct{}
+	client          client.Client
+	delegate        reconcile.Reconciler
+	objectPrototype client.Object
 	// the duration used by non-leading replicas to requeue events,
 	// so no events are missed over the period it takes for
 	// leader election to fail over a new replica.
@@ -76,7 +76,10 @@ func (r *leaderAwareReconciler) Reconcile(ctx context.Context, request reconcile
 		// The manager has been elected leader, delegate reconciliation to the provided reconciler.
 		return r.delegate.Reconcile(ctx, request)
 	default:
-		if err := r.client.Get(ctx, request.NamespacedName, r.object); err != nil {
+		// The client writes what it read into the object it is given, and the decorated controllers
+		// run with more than one worker, so the prototype is copied rather than reused.
+		object := r.objectPrototype.DeepCopyObject().(client.Object)
+		if err := r.client.Get(ctx, request.NamespacedName, object); err != nil {
 			// Discard request if not found, to prevent from re-enqueueing indefinitely.
 			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}

--- a/pkg/controller/core/leader_aware_reconciler_test.go
+++ b/pkg/controller/core/leader_aware_reconciler_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+// The controllers this decorates run with more than one worker, so several requests reach the
+// non-leading branch at once. The client writes what it read into the object it is handed, so each
+// request needs a destination of its own.
+func TestLeaderAwareReconcilerNonLeadingDestinations(t *testing.T) {
+	const requests = 2
+
+	var (
+		mu           sync.Mutex
+		destinations []client.Object
+	)
+	inGet := make(chan struct{}, requests)
+	release := make(chan struct{})
+
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(
+			utiltestingapi.MakeWorkload("first", "ns").Obj(),
+			utiltestingapi.MakeWorkload("second", "ns").Obj(),
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				mu.Lock()
+				destinations = append(destinations, obj)
+				mu.Unlock()
+				// Hold both requests inside Get so they overlap the way two workers would.
+				inGet <- struct{}{}
+				<-release
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := &leaderAwareReconciler{
+		elected:         make(chan struct{}), // never closed, so the replica never leads
+		client:          cl,
+		objectPrototype: &kueue.Workload{},
+		requeueDuration: time.Second,
+	}
+
+	var wg sync.WaitGroup
+	for _, name := range []string{"first", "second"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: "ns", Name: name},
+			}); err != nil {
+				t.Errorf("Reconcile(%q) returned %v", name, err)
+			}
+		}()
+	}
+	for range requests {
+		<-inGet
+	}
+	close(release)
+	wg.Wait()
+
+	if len(destinations) != requests {
+		t.Fatalf("Get was called %d times, want %d", len(destinations), requests)
+	}
+	if destinations[0] == destinations[1] {
+		t.Errorf("both requests decoded into %p, want a destination per request", destinations[0])
+	}
+}

--- a/pkg/controller/core/leader_aware_reconciler_test.go
+++ b/pkg/controller/core/leader_aware_reconciler_test.go
@@ -72,15 +72,13 @@ func TestLeaderAwareReconcilerNonLeadingDestinations(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for _, name := range []string{"first", "second"} {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := reconciler.Reconcile(t.Context(), reconcile.Request{
 				NamespacedName: types.NamespacedName{Namespace: "ns", Name: name},
 			}); err != nil {
 				t.Errorf("Reconcile(%q) returned %v", name, err)
 			}
-		}()
+		})
 	}
 	for range requests {
 		<-inGet


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`WithLeadingManager` stores one `client.Object` and passes it as the destination for every `Get` taken on the non-leading branch:

```go
if err := r.client.Get(ctx, request.NamespacedName, r.object); err != nil {
```

The controllers it decorates start with `NeedLeaderElection: false` so they keep draining their queues in non-leading replicas, and each runs with the concurrency configured for its kind. `pkg/controller/core/workload_controller.go` is the clearest case: `NeedLeaderElection: false`, `MaxConcurrentReconciles` taken from `Workload.kueue.x-k8s.io` (10 by default), and `WithLeadingManager(mgr, r, &kueue.Workload{}, cfg)`. Fourteen call sites use the decorator today.

The client writes what it read into the object it is handed, so two workers on that branch write the same struct. The window is not only multi-replica HA: a single replica takes this branch from startup until `mgr.Elected()` closes.

This copies the prototype per request instead, and renames the field to say that is what it holds.

#### Which issue(s) this PR fixes:

None filed. Found while reviewing another change that uses this decorator.

#### Special notes for your reviewer:

The test asserts the invariant directly rather than depending on the race detector: it holds two requests inside `Get` and checks each was given a different destination, so it fails deterministically without `-race`. The shared destination is reportable as a data race too, but only once enough requests overlap for the writes to collide, which is not something a regression should rely on.

Reproduced on `main` by driving the non-leading branch from eight goroutines over two keys:

```
WARNING: DATA RACE
Write at 0x00c001298488 by goroutine 72:
  reflect.Value.SetString()
  ...
  sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Get()
  sigs.k8s.io/kueue/pkg/controller/core.(*leaderAwareReconciler).Reconcile()
      pkg/controller/core/leader_aware_reconciler.go:79
```

The same form reports no race after this change, and `go test -race ./pkg/controller/core/...` is green.

#13682 also touches this file, so this may be easier to take first.

#### Does this PR introduce a user-facing change?

```release-note
HA: Fix a data race between concurrent reconciles in non-leading replicas, where the leader-aware decorator used one shared object as the destination for every lookup.
```


#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent reconciliation by ensuring parallel operations use separate object instances.
  * Prevented data from being overwritten or mixed between simultaneous non-leading reconciliation tasks.

* **Tests**
  * Added coverage verifying that concurrent reconciliation requests receive distinct destination objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
