### PR TITLE
docs: fix ProvisioningClassDetails typo in ProvisioningRequest doc

### DIFF
--- a/site/content/en/docs/concepts/admission_check/provisioning_request.md
+++ b/site/content/en/docs/concepts/admission_check/provisioning_request.md
@@ -148,7 +148,7 @@ podSetUpdates:
 This snippet in ProvisioningRequestConfig instructs Kueue to update the Job's
 PodTemplate, after provisioning, to target the newly provisioned nodes which
 have the label: `autoscaling.cloud-provider.com/provisioning-request` with the
-value coming from the [ProvisiongClassDetails](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go#L169) map, under the "RequestKey" key.
+value coming from the [ProvisioningClassDetails](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1/types.go#L169) map, under the "RequestKey" key.
 
 Note that, this assumes the provisioning class (which can be cloud-provider
 specific) supports setting unique node label on the newly provisioned nodes.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes a small typo in the ProvisioningRequest concept documentation (`ProvisiongClassDetails` -> `ProvisioningClassDetails`).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the external `ProvisioningClassDetails` link in the PodSet updates documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
```


```release-note
NONE
```