### PR TITLE
docs: fix issue number for tainted-node eviction in README roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ High-level overview of the main priorities for 2026:
 - Improve user experience for [Topology Aware Scheduling](https://kueue.sigs.k8s.io/docs/concepts/topology_aware_scheduling/), in particular:
   * Support for ResourceTransformations [#8860](https://github.com/kubernetes-sigs/kueue/issues/8860)
   * Support for [Elastic Workloads](https://kueue.sigs.k8s.io/docs/concepts/elastic_workload/) [#8160](https://github.com/kubernetes-sigs/kueue/issues/8160)
-  * Evict workloads which are running on nodes which become tainted [#8838](https://github.com/kubernetes-sigs/kueue/issues/8828)
+  * Evict workloads which are running on nodes which become tainted [#8828](https://github.com/kubernetes-sigs/kueue/issues/8828)
 - Integration with the k8s native Workload-Aware Scheduler (WAS) and Topology-Aware Scheduling [#8871](https://github.com/kubernetes-sigs/kueue/issues/8871)
 - Support for Concurrent Workload Admission [#8691](https://github.com/kubernetes-sigs/kueue/issues/8691)
 - Support for running hero workloads [#8826](https://github.com/kubernetes-sigs/kueue/issues/8826)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Fixes the displayed issue number in `README.md` for the tainted-node eviction roadmap item so the visible text `#8828` matches the link target (`https://github.com/kubernetes-sigs/kueue/issues/8828`).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the roadmap issue reference for tainted-node workload eviction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->