### PR TITLE
fix(kueueviz): safely render error details and handle circular error …

### DIFF
--- a/cmd/kueueviz/frontend/src/ErrorMessage.jsx
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.jsx
@@ -28,7 +28,8 @@ export const errorToString = (error) => {
   if (typeof error === 'string') return error;
   if (error && typeof error.message === 'string' && error.message.length > 0) return error.message;
   try {
-    return JSON.stringify(error);
+    const stringified = JSON.stringify(error);
+    return stringified !== undefined ? stringified : String(error);
   } catch {
     return String(error);
   }
@@ -40,7 +41,7 @@ const ErrorMessage = ({ error }) => {
   if (!error) return null;
 
   // Extract the first line as the summary
-  const errorString = errorToString(error);
+  const errorString = errorToString(error) || '';
   const lines = errorString.split('\n');
   const errorSummary = lines[0];
   

--- a/cmd/kueueviz/frontend/src/ErrorMessage.jsx
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.jsx
@@ -27,7 +27,11 @@ import './App.css';
 export const errorToString = (error) => {
   if (typeof error === 'string') return error;
   if (error && typeof error.message === 'string' && error.message.length > 0) return error.message;
-  return JSON.stringify(error);
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 };
 
 const ErrorMessage = ({ error }) => {
@@ -42,9 +46,6 @@ const ErrorMessage = ({ error }) => {
   
   // The rest is considered details
   const errorDetails = lines.slice(1).join('\n');
-  
-  // Format for HTML display
-  const formattedDetails = errorDetails.replace(/\n/g, '<br />');
 
   return (
     <Paper className="error-message" elevation={2}>
@@ -74,8 +75,10 @@ const ErrorMessage = ({ error }) => {
                 color="textSecondary" 
                 component="div"
                 className="error-details-text"
-                dangerouslySetInnerHTML={{ __html: formattedDetails }} 
-              />
+                sx={{ whiteSpace: 'pre-wrap' }}
+              >
+                {errorDetails}
+              </Typography>
             </Box>
           </Collapse>
         </Box>

--- a/cmd/kueueviz/frontend/src/ErrorMessage.jsx
+++ b/cmd/kueueviz/frontend/src/ErrorMessage.jsx
@@ -25,6 +25,7 @@ import './App.css';
  * Handles plain strings, Error objects, and arbitrary objects/events.
  */
 export const errorToString = (error) => {
+  if (error === undefined) return undefined;
   if (typeof error === 'string') return error;
   if (error && typeof error.message === 'string' && error.message.length > 0) return error.message;
   try {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dashboard

#### What this PR does / why we need it:

1. Replaces `dangerouslySetInnerHTML` in `ErrorMessage.jsx` with plain text using `sx={{ whiteSpace: 'pre-wrap' }}` to prevent potential HTML injection.
2. Wraps `JSON.stringify(error)` in a `try/catch` block inside `errorToString` so circular or non-serializable error objects don't throw an uncaught `TypeError` and crash the UI.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
KueueViz: Fixed crashes that occurred when the UI displayed error details containing values that could not be serialized.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when error details cannot be serialized or are unavailable.
  * Error messages now preserve whitespace and line breaks while displaying content safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->