### PR TITLE
Separate what a transformation generates from what the PodSet requested

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -569,7 +569,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -621,7 +621,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/keps/2937-resource-transformer/README.md
+++ b/keps/2937-resource-transformer/README.md
@@ -391,11 +391,15 @@ Based on the example in Story 3, the following content can be defined in the Kue
 resources:
   transformations:
   - input: nvidia.com/gpumem
-    strategy: Retain
+    strategy: Replace
     multiplyBy: nvidia.com/gpu
     outputs:
       nvidia.com/total-gpumem: 1
 ```
+
+`multiplyBy` scales the outputs. It does not change what `Retain` keeps under the
+input's own name, so with `Retain` here the effective request above would also
+carry `nvidia.com/gpumem: 1024` and the ClusterQueue would have to cover it.
 
 ### Observability
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -60,6 +60,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	utilptr "sigs.k8s.io/kueue/pkg/util/ptr"
 	"sigs.k8s.io/kueue/pkg/util/queue"
+	utilresource "sigs.k8s.io/kueue/pkg/util/resource"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	"sigs.k8s.io/kueue/pkg/util/wait"
@@ -584,40 +585,37 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	for inputName, inputQuantity := range input {
 		mapping, ok := transforms[inputName]
 		if !ok {
-			addResourceQuantity(retained, inputName, inputQuantity)
+			retained[inputName] = inputQuantity
 			continue
 		}
-		// If MultiplyBy is specified, multiply the input quantity by
-		// the value of the resource specified in MultiplyBy.
+		// If MultiplyBy is specified, multiply the input quantity by the value
+		// of the resource specified in MultiplyBy. It scales the value the
+		// outputs are computed from; Retain keeps the input as it was
+		// requested, so the multiplier does not reach that as well.
+		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {
 			if q, ok := input[mapping.MultiplyBy]; ok {
-				inputQuantity = multiplyResourceQuantities(inputQuantity, q)
+				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
 			}
 		}
 
+		outputs := make(corev1.ResourceList, len(mapping.Outputs))
 		for outputName, baseFactor := range mapping.Outputs {
-			addResourceQuantity(generated, outputName, multiplyResourceQuantities(inputQuantity, baseFactor))
+			outputs[outputName] = multiplyResourceQuantities(outputInputVal, baseFactor)
 		}
+		// Summed rather than assigned, so which order the input map is walked
+		// in does not decide which contribution to a name survives.
+		generated = utilresource.MergeResourceListKeepSum(generated, outputs)
 		if ptr.Deref(mapping.Strategy, config.Retain) == config.Retain {
-			addResourceQuantity(retained, inputName, inputQuantity)
+			retained[inputName] = inputQuantity
 		}
 	}
 	for name, quantity := range generated {
 		if quantity.Sign() < 0 {
-			quantity = resource.Quantity{}
+			generated[name] = resource.Quantity{}
 		}
-		addResourceQuantity(retained, name, quantity)
 	}
-	return retained
-}
-
-// addResourceQuantity accumulates rather than assigns, so which order the input
-// map is walked in does not decide which contribution to a name survives.
-func addResourceQuantity(list corev1.ResourceList, name corev1.ResourceName, quantity resource.Quantity) {
-	if existing, ok := list[name]; ok {
-		quantity.Add(existing)
-	}
-	list[name] = quantity
+	return utilresource.MergeResourceListKeepSum(retained, generated)
 }
 
 func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -588,9 +588,8 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 			retained[inputName] = inputQuantity
 			continue
 		}
-		// If MultiplyBy is specified, multiply the input quantity by the value
-		// of the resource specified in MultiplyBy. It scales the value the
-		// outputs are computed from; Retain keeps the input as it was
+		// MultiplyBy scales the value the outputs are computed from by the
+		// quantity of the resource it names. Retain keeps the input as it was
 		// requested, so the multiplier does not reach that as well.
 		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -573,32 +573,51 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	if !match {
 		return input
 	}
-	output := make(corev1.ResourceList)
+	// What the transformations produce is kept apart from what the PodSet asked
+	// for until the end. A negative output factor is how an allowance is
+	// written, so outputs still cancel each other, but the total one resource
+	// generates cannot go on to reduce a request that was never part of that
+	// arithmetic: an ordinary request under the same name, or the DRA charge
+	// merged in after this returns.
+	retained := make(corev1.ResourceList)
+	generated := make(corev1.ResourceList)
 	for inputName, inputQuantity := range input {
-		if mapping, ok := transforms[inputName]; ok {
-			// If MultiplyBy is specified, multiply the input quantity by
-			// the value of the resource specified in MultiplyBy.
-			if mapping.MultiplyBy != "" {
-				if q, ok := input[mapping.MultiplyBy]; ok {
-					inputQuantity = multiplyResourceQuantities(inputQuantity, q)
-				}
+		mapping, ok := transforms[inputName]
+		if !ok {
+			addResourceQuantity(retained, inputName, inputQuantity)
+			continue
+		}
+		// If MultiplyBy is specified, multiply the input quantity by
+		// the value of the resource specified in MultiplyBy.
+		if mapping.MultiplyBy != "" {
+			if q, ok := input[mapping.MultiplyBy]; ok {
+				inputQuantity = multiplyResourceQuantities(inputQuantity, q)
 			}
+		}
 
-			for outputName, baseFactor := range mapping.Outputs {
-				outputQuantity := multiplyResourceQuantities(inputQuantity, baseFactor)
-				if accumulated, ok := output[outputName]; ok {
-					outputQuantity.Add(accumulated)
-				}
-				output[outputName] = outputQuantity
-			}
-			if ptr.Deref(mapping.Strategy, config.Retain) == config.Retain {
-				output[inputName] = inputQuantity
-			}
-		} else {
-			output[inputName] = inputQuantity
+		for outputName, baseFactor := range mapping.Outputs {
+			addResourceQuantity(generated, outputName, multiplyResourceQuantities(inputQuantity, baseFactor))
+		}
+		if ptr.Deref(mapping.Strategy, config.Retain) == config.Retain {
+			addResourceQuantity(retained, inputName, inputQuantity)
 		}
 	}
-	return output
+	for name, quantity := range generated {
+		if quantity.Sign() < 0 {
+			quantity = resource.Quantity{}
+		}
+		addResourceQuantity(retained, name, quantity)
+	}
+	return retained
+}
+
+// addResourceQuantity accumulates rather than assigns, so which order the input
+// map is walked in does not decide which contribution to a name survives.
+func addResourceQuantity(list corev1.ResourceList, name corev1.ResourceName, quantity resource.Quantity) {
+	if existing, ok := list[name]; ok {
+		quantity.Add(existing)
+	}
+	list[name] = quantity
 }
 
 func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -713,6 +713,132 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		// A negative output factor is how a per-unit allowance is written: the
+		// charge is what the request exceeds it by. These three are the same
+		// configuration at, above and below the allowance.
+		"transformAllowanceAboveIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "2048").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 2048,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformAllowanceExactlyAtIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "1024").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 0,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformAllowanceUnderIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "512").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 0,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An allowance is spent against what the transformations generate, and
+		// nothing else. Here it would otherwise come off a request the PodSet
+		// made directly under the same name.
+		"transformAllowanceDoesNotReachADirectRequest": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "8").
+					Request("example.com/credit", "3").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: ptr.To(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An output sharing a name with something the PodSet requests directly
+		// used to be kept or dropped by the order the input map was walked.
+		"transformOutputSharingANameWithARequestIsAdded": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					Request("example.com/credit", "1").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: ptr.To(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// And one naming its own retained input used to be overwritten by the
+		// retain assignment every time.
+		"transformOutputSharingANameWithItsRetainedInputIsAdded": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/gpu",
+				Strategy: ptr.To(config.Retain),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("5")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 6,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(
@@ -3434,5 +3560,23 @@ func TestTotalExecutionTime(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// allowanceTransformations charges the memory a Workload asks for beyond a
+// per-GPU allowance, which is what a negative output factor expresses.
+func allowanceTransformations() []config.ResourceTransformation {
+	return []config.ResourceTransformation{
+		{
+			Input:      "nvidia.com/gpumem",
+			Strategy:   ptr.To(config.Replace),
+			MultiplyBy: "nvidia.com/gpu",
+			Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+		},
+		{
+			Input:    "nvidia.com/gpu",
+			Strategy: ptr.To(config.Retain),
+			Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+		},
 	}
 }

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -910,10 +910,9 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
-		// A multiplier below one is the direction that undercharges: the old
-		// behaviour retained 512 for a PodSet that asked for 1024, and every
-		// check on the way past reads a positive, exactly representable number
-		// that arrives once.
+		// A multiplier below one is the direction that undercharges, and nothing
+		// downstream can see it: the retained 512 for a PodSet that asked for
+		// 1024 is positive and reads like a smaller request.
 		"transformRetainWithMultiplyByUnderOne": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -910,9 +910,8 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
-		// A multiplier below one is the direction that undercharges, and nothing
-		// downstream can see it: the retained 512 for a PodSet that asked for
-		// 1024 is positive and reads like a smaller request.
+		// A multiplier below one scales the generated output but leaves the
+		// retained input unchanged: 1024 is retained while the output is 512.
 		"transformRetainWithMultiplyByUnderOne": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -722,7 +722,19 @@ func TestNewInfo(t *testing.T) {
 					Request("nvidia.com/gpumem", "2048").
 					Request("nvidia.com/gpu", "2").Obj()).
 				Obj(),
-			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
@@ -740,7 +752,19 @@ func TestNewInfo(t *testing.T) {
 					Request("nvidia.com/gpumem", "1024").
 					Request("nvidia.com/gpu", "2").Obj()).
 				Obj(),
-			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
@@ -758,7 +782,19 @@ func TestNewInfo(t *testing.T) {
 					Request("nvidia.com/gpumem", "512").
 					Request("nvidia.com/gpu", "2").Obj()).
 				Obj(),
-			infoOptions: []InfoOption{WithResourceTransformations(allowanceTransformations())},
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
@@ -834,6 +870,105 @@ func TestNewInfo(t *testing.T) {
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceName("example.com/gpu"): 6,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformRetainWithMultiplyBy": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request("example.com/gpu", "2").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "example.com/gpumem",
+					Strategy:   ptr.To(config.Retain),
+					MultiplyBy: "example.com/gpu",
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							// Retain keeps gpumem as requested (1024), not the multiplyBy
+							// product (2048); the multiplier only scales the quota output.
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 2048,
+							corev1.ResourceName("example.com/gpu"):          2,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
+		// A multiplier below one is the direction that undercharges: the old
+		// behaviour retained 512 for a PodSet that asked for 1024, and every
+		// check on the way past reads a positive, exactly representable number
+		// that arrives once.
+		"transformRetainWithMultiplyByUnderOne": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request(corev1.ResourceCPU, "500m").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input: "example.com/gpumem",
+					// Strategy left unset: nil defaults to Retain in production,
+					// so this covers the path an operator gets without asking.
+					MultiplyBy: corev1.ResourceCPU,
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 512,
+							corev1.ResourceCPU:                              500,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
+		// MultiplyBy scales the value the outputs are computed from. Retain keeps
+		// the input as it was requested, so a request of 1 against a multiplier
+		// of 2 leaves 2 generated and 1 retained rather than 2 and 2.
+		"transformOutputSharingANameWithItsRetainedInputIsAddedToTheAmountRequested": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					Request("example.com/node", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:      "example.com/gpu",
+				Strategy:   ptr.To(config.Retain),
+				MultiplyBy: "example.com/node",
+				Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):  3,
+						corev1.ResourceName("example.com/node"): 2,
 					}),
 					Count: 1,
 				}},
@@ -3560,23 +3695,5 @@ func TestTotalExecutionTime(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-// allowanceTransformations charges the memory a Workload asks for beyond a
-// per-GPU allowance, which is what a negative output factor expresses.
-func allowanceTransformations() []config.ResourceTransformation {
-	return []config.ResourceTransformation{
-		{
-			Input:      "nvidia.com/gpumem",
-			Strategy:   ptr.To(config.Replace),
-			MultiplyBy: "nvidia.com/gpu",
-			Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
-		},
-		{
-			Input:    "nvidia.com/gpu",
-			Strategy: ptr.To(config.Retain),
-			Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
-		},
 	}
 }

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1149,7 +1149,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1341,7 +1341,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A negative output factor writes a per-unit allowance, and the charge is what the request exceeds it by. On the configuration from #13985's discussion:

```yaml
resources:
  transformations:
  - input: nvidia.com/gpumem
    strategy: Replace
    multiplyBy: nvidia.com/gpu
    outputs:
      quota.platform.example/gpu-memory-overage: "1"
  - input: nvidia.com/gpu
    strategy: Retain
    outputs:
      quota.platform.example/gpu-memory-overage: "-1024"
```

```
gpumem 2048, gpu 2   overage 2048   above the allowance
gpumem 1024, gpu 2   overage 0      exactly at it
gpumem 512,  gpu 2   overage 0      under it
```

What goes wrong is not that the factor is negative, it is where the allowance can be spent. `applyResourceTransformations` puts the outputs and the requests the PodSet made into one map, so a total that goes negative carries on into whatever else holds that name. Two ways out of the transformation:

```go
setRes.Requests = resources.NewRequestsFromResourceList(effectiveRequests)
setRes.Requests.FloorToZero()
```

The floor runs after the DRA charge is merged in, not before, so a generated `-3` reduces it. Measured with an envelope of 8:

```
before   example.com/gpu = 5
after    example.com/gpu = 8
```

Three devices admitted for nothing, and the total is positive so the floor never sees anything wrong. The same value can also come off a request the PodSet made directly under that name.

So the two are accumulated apart and brought together at the end, with a generated total that went negative zeroed on the way. Outputs still cancel each other, which is what an allowance is, and they no longer reach anything else.

Summing rather than assigning also settles two collisions that were decided by the order the input map happened to be walked in, both in #13990: an output sharing a name with a request the PodSet made, and an output sharing a name with its own retained input. The second was not the walk order at all, the retain assignment overwrote it every time.

Separating the two also separates what `multiplyBy` reaches. It scales the value the outputs are computed from, and `Retain` keeps the input as it was requested, so a request of `1` with a multiplier of `2` is charged `2` generated and `1` retained rather than `2` and `2`. That was #13999 on its own; it is here now and that PR is closed.

#### Which issue(s) this PR fixes:

Fixes #13985
Fixes #13992

#### Special notes for your reviewer:

This replaces what the PR did before, which was to refuse a negative output factor during configuration validation. @tenzen-y pointed out that the allowance design is intended and that refusing it would take it away, and gave the shape this now follows. The earlier commits are gone.

Reverting either half turns cases red: the floor for the allowance reaching a direct request, the accumulation for the two collisions and for the allowance arithmetic itself.

It reaches into #13990, which @ranibharti385 has just picked up. Both shapes described there are covered by the summing here, so it is worth deciding between us which lands where before either of us writes more.

The `Retain` and `multiplyBy` combination has three cases, since it can go wrong from more than one side: an output under a name of its own, an output sharing the name of its retained input, and a multiplier below one with the strategy left unset. Reverting `outputInputVal` turns the second red on its own.

#### Does this PR introduce a user-facing change?

```release-note
ResourceTransformations × DRA: Fixed negative generated totals so they no longer reduce retained Pod requests or DRA logical-resource charges. Negative outputs can still offset other generated outputs, and contributions to the same resource are now summed deterministically. Also fixed `multiplyBy` to scale generated outputs only; with `Retain`, the original input quantity remains unchanged.
```


#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected resource transformation calculations so retained resources preserve their quantities while generated outputs are scaled appropriately.
  * Prevented negative generated resource totals from being reported.
  * Ensured duplicate and overlapping resource contributions are accumulated consistently.
  * Improved GPU memory allowance handling for usage above, at, and below configured limits.
  * Added coverage for interactions between transformed resources, direct requests, and retained inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



