### PR TITLE
Reject pods as a DRA logical resource name or anywhere in a transformation

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -597,8 +597,9 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
+	// reserved for Kueue's internal Pod-count accounting. A qualified name such
+	// as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -576,6 +576,7 @@ type ResourceTransformation struct {
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
+	// A resource must not be named `pods`, which Kueue writes itself from the PodSet count.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -590,6 +591,7 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
+	// It must not be `pods`, which Kueue writes itself from the PodSet count.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -576,7 +576,8 @@ type ResourceTransformation struct {
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// A resource must not be named `pods`, which Kueue writes itself from the PodSet count.
+	// Output resource names must not include `pods`, which is reserved for Kueue's
+	// internal Pod-count accounting.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -591,7 +592,7 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`, which Kueue writes itself from the PodSet count.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -572,6 +572,7 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -560,6 +560,7 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -560,7 +560,8 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -573,13 +574,15 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// Output resource names must not include `pods`, which is reserved for Kueue's
-	// internal Pod-count accounting.
+	// An output resource name must not be `pods`; that exact name is reserved for
+	// Kueue's internal Pod-count accounting. A qualified name such as
+	// `example.com/pods` is allowed.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -594,7 +597,8 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -612,6 +612,7 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -612,7 +612,8 @@ const Replace ResourceTransformationStrategy = "Replace"
 
 type ResourceTransformation struct {
 	// Input is the name of the input resource.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	Input corev1.ResourceName `json:"input"`
 
 	// Strategy specifies if the input resource should be replaced or retained.
@@ -625,13 +626,15 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// Output resource names must not include `pods`, which is reserved for Kueue's
-	// internal Pod-count accounting.
+	// An output resource name must not be `pods`; that exact name is reserved for
+	// Kueue's internal Pod-count accounting. A qualified name such as
+	// `example.com/pods` is allowed.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -646,7 +649,8 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
+	// It must not be `pods`; that exact name is reserved for Kueue's internal
+	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -628,6 +628,7 @@ type ResourceTransformation struct {
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
+	// A resource must not be named `pods`, which Kueue writes itself from the PodSet count.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -642,6 +643,7 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
+	// It must not be `pods`, which Kueue writes itself from the PodSet count.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -624,6 +624,7 @@ type ResourceTransformation struct {
 	// amount of the resource indicated by the "input" field when computing
 	// "outputs". It does not change the quantity retained under "input" when
 	// "strategy" is Retain.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -649,8 +649,9 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`; that exact name is reserved for Kueue's internal
-	// Pod-count accounting. A qualified name such as `example.com/pods` is allowed.
+	// With KueueDRAIntegration enabled it must not be `pods`; that exact name is
+	// reserved for Kueue's internal Pod-count accounting. A qualified name such
+	// as `example.com/pods` is allowed.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -628,7 +628,8 @@ type ResourceTransformation struct {
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
 	// Outputs specifies the output resources and quantities per unit of input resource.
-	// A resource must not be named `pods`, which Kueue writes itself from the PodSet count.
+	// Output resource names must not include `pods`, which is reserved for Kueue's
+	// internal Pod-count accounting.
 	// An empty Outputs combined with a `Replace` Strategy causes the Input resource to be ignored by Kueue.
 	Outputs corev1.ResourceList `json:"outputs,omitempty"`
 }
@@ -643,7 +644,7 @@ type DeviceClassMapping struct {
 	// and must start and end with an alphanumeric character.
 	// DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 	// The total length must not exceed 253 characters.
-	// It must not be `pods`, which Kueue writes itself from the PodSet count.
+	// It must not be `pods`, which is reserved for Kueue's internal Pod-count accounting.
 	Name corev1.ResourceName `json:"name"`
 
 	// DeviceClassNames enumerates the DeviceClasses represented by this resource name.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1544,21 +1544,23 @@ namespace: kueue-system
 }
 
 // A v1beta1 file reaches the same validator through generated conversion, so the
-// reservation covers the operators still writing that version only as long as
-// conversion carries these four fields.
+// reservation covers the operators still writing that version. One field is bare
+// per case, so each case pins the position that reported it. Only the mapping
+// name is converted field by field; the transformation list is reinterpreted
+// whole, so there is no per-field step there to hold.
 func TestReservedNameReachesAV1beta1Configuration(t *testing.T) {
 	const configuration = `apiVersion: config.kueue.x-k8s.io/v1beta1
 kind: Configuration
 resources:
   deviceClassMappings:
-  - name: %[1]spods
+  - name: %[1]s
     deviceClassNames: [gpu.example.com]
   transformations:
-  - input: %[1]spods
+  - input: %[2]s
     strategy: Retain
-    multiplyBy: %[1]spods
+    multiplyBy: %[3]s
     outputs:
-      %[1]spods: 1
+      %[4]s: 1
 `
 	scheme := runtime.NewScheme()
 	for _, addToScheme := range []func(*runtime.Scheme) error{
@@ -1568,24 +1570,54 @@ resources:
 			t.Fatal(err)
 		}
 	}
+	// Four distinct names, as the validator's own table uses, so a clean load
+	// says nothing about names that collide with one another.
+	const (
+		okMapping    = "dra.example.com/pods"
+		okInput      = "input.example.com/pods"
+		okMultiplier = "multiplier.example.com/pods"
+		okOutput     = "output.example.com/pods"
+	)
 	for name, tc := range map[string]struct {
-		prefix   string
-		wantErrs int
+		mapping, input, multiplyBy, output string
+		wantFields                         []string
 	}{
-		"the bare name in all four positions": {wantErrs: 4},
-		"a qualified name in all four":        {prefix: "example.com/", wantErrs: 0},
+		"qualified names in all four positions": {
+			mapping: okMapping, input: okInput, multiplyBy: okMultiplier, output: okOutput,
+		},
+		"a bare mapping name": {
+			mapping: "pods", input: okInput, multiplyBy: okMultiplier, output: okOutput,
+			wantFields: []string{"resources.deviceClassMappings[0].name"},
+		},
+		"a bare transformation input": {
+			mapping: okMapping, input: "pods", multiplyBy: okMultiplier, output: okOutput,
+			wantFields: []string{"resources.transformations[0].input"},
+		},
+		"a bare multiplier": {
+			mapping: okMapping, input: okInput, multiplyBy: "pods", output: okOutput,
+			wantFields: []string{"resources.transformations[0].multiplyBy"},
+		},
+		"a bare output key": {
+			mapping: okMapping, input: okInput, multiplyBy: okMultiplier, output: "pods",
+			wantFields: []string{"resources.transformations[0].outputs[pods]"},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "config.yaml")
-			if err := os.WriteFile(path, fmt.Appendf(nil, configuration, tc.prefix), 0o600); err != nil {
+			body := fmt.Appendf(nil, configuration, tc.mapping, tc.input, tc.multiplyBy, tc.output)
+			if err := os.WriteFile(path, body, 0o600); err != nil {
 				t.Fatal(err)
 			}
 			_, cfg, err := Load(scheme, path)
 			if err != nil {
 				t.Fatalf("loading the configuration: %v", err)
 			}
-			if errs := Validate(&cfg, scheme, jobs.NewIntegrationManager()); len(errs) != tc.wantErrs {
-				t.Errorf("%d errors, want %d: %v", len(errs), tc.wantErrs, errs)
+			var gotFields []string
+			for _, e := range Validate(&cfg, scheme, jobs.NewIntegrationManager()) {
+				gotFields = append(gotFields, e.Field)
+			}
+			if diff := cmp.Diff(tc.wantFields, gotFields); diff != "" {
+				t.Errorf("validation fields (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 	"net"
 	"os"
@@ -37,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -50,13 +48,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
-	configv1beta1 "sigs.k8s.io/kueue/apis/config/v1beta1"
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
-	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
+
+	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var defaultWaitForPodsReady = &configapi.WaitForPodsReady{
@@ -1538,89 +1536,6 @@ namespace: kueue-system
 			}
 			if diff := cmp.Diff(tc.wantPod, got); diff != "" {
 				t.Errorf("Unexpected pod after transform (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-// A v1beta1 file reaches the same validator through generated conversion, so the
-// reservation covers the operators still writing that version. One field is bare
-// per case, so each case pins the position that reported it. Only the mapping
-// name is converted field by field; the transformation list is reinterpreted
-// whole, so there is no per-field step there to hold.
-func TestReservedNameReachesAV1beta1Configuration(t *testing.T) {
-	const configuration = `apiVersion: config.kueue.x-k8s.io/v1beta1
-kind: Configuration
-resources:
-  deviceClassMappings:
-  - name: %[1]s
-    deviceClassNames: [gpu.example.com]
-  transformations:
-  - input: %[2]s
-    strategy: Retain
-    multiplyBy: %[3]s
-    outputs:
-      %[4]s: 1
-`
-	// The mapping half is only refused behind this gate, and its default is not
-	// this test's to depend on.
-	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, true)
-	scheme := runtime.NewScheme()
-	for _, addToScheme := range []func(*runtime.Scheme) error{
-		configapi.AddToScheme, configv1beta1.AddToScheme, clientgoscheme.AddToScheme,
-	} {
-		if err := addToScheme(scheme); err != nil {
-			t.Fatal(err)
-		}
-	}
-	// Four distinct names, as the validator's own table uses, so a clean load
-	// says nothing about names that collide with one another.
-	const (
-		okMapping    = "dra.example.com/pods"
-		okInput      = "input.example.com/pods"
-		okMultiplier = "multiplier.example.com/pods"
-		okOutput     = "output.example.com/pods"
-	)
-	for name, tc := range map[string]struct {
-		mapping, input, multiplyBy, output string
-		wantFields                         []string
-	}{
-		"qualified names in all four positions": {
-			mapping: okMapping, input: okInput, multiplyBy: okMultiplier, output: okOutput,
-		},
-		"a bare mapping name": {
-			mapping: "pods", input: okInput, multiplyBy: okMultiplier, output: okOutput,
-			wantFields: []string{"resources.deviceClassMappings[0].name"},
-		},
-		"a bare transformation input": {
-			mapping: okMapping, input: "pods", multiplyBy: okMultiplier, output: okOutput,
-			wantFields: []string{"resources.transformations[0].input"},
-		},
-		"a bare multiplier": {
-			mapping: okMapping, input: okInput, multiplyBy: "pods", output: okOutput,
-			wantFields: []string{"resources.transformations[0].multiplyBy"},
-		},
-		"a bare output key": {
-			mapping: okMapping, input: okInput, multiplyBy: okMultiplier, output: "pods",
-			wantFields: []string{"resources.transformations[0].outputs[pods]"},
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			path := filepath.Join(t.TempDir(), "config.yaml")
-			body := fmt.Appendf(nil, configuration, tc.mapping, tc.input, tc.multiplyBy, tc.output)
-			if err := os.WriteFile(path, body, 0o600); err != nil {
-				t.Fatal(err)
-			}
-			_, cfg, err := Load(scheme, path)
-			if err != nil {
-				t.Fatalf("loading the configuration: %v", err)
-			}
-			var gotFields []string
-			for _, e := range Validate(&cfg, scheme, jobs.NewIntegrationManager()) {
-				gotFields = append(gotFields, e.Field)
-			}
-			if diff := cmp.Diff(tc.wantFields, gotFields); diff != "" {
-				t.Errorf("validation fields (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"net"
 	"os"
@@ -36,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -48,13 +50,13 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	configv1beta1 "sigs.k8s.io/kueue/apis/config/v1beta1"
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var defaultWaitForPodsReady = &configapi.WaitForPodsReady{
@@ -1536,6 +1538,54 @@ namespace: kueue-system
 			}
 			if diff := cmp.Diff(tc.wantPod, got); diff != "" {
 				t.Errorf("Unexpected pod after transform (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// A v1beta1 file reaches the same validator through generated conversion, so the
+// reservation covers the operators still writing that version only as long as
+// conversion carries these four fields.
+func TestReservedNameReachesAV1beta1Configuration(t *testing.T) {
+	const configuration = `apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+resources:
+  deviceClassMappings:
+  - name: %[1]spods
+    deviceClassNames: [gpu.example.com]
+  transformations:
+  - input: %[1]spods
+    strategy: Retain
+    multiplyBy: %[1]spods
+    outputs:
+      %[1]spods: 1
+`
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		configapi.AddToScheme, configv1beta1.AddToScheme, clientgoscheme.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for name, tc := range map[string]struct {
+		prefix   string
+		wantErrs int
+	}{
+		"the bare name in all four positions": {wantErrs: 4},
+		"a qualified name in all four":        {prefix: "example.com/", wantErrs: 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(path, fmt.Appendf(nil, configuration, tc.prefix), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, cfg, err := Load(scheme, path)
+			if err != nil {
+				t.Fatalf("loading the configuration: %v", err)
+			}
+			if errs := Validate(&cfg, scheme, jobs.NewIntegrationManager()); len(errs) != tc.wantErrs {
+				t.Errorf("%d errors, want %d: %v", len(errs), tc.wantErrs, errs)
 			}
 		})
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1562,6 +1562,9 @@ resources:
     outputs:
       %[4]s: 1
 `
+	// The mapping half is only refused behind this gate, and its default is not
+	// this test's to depend on.
+	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, true)
 	scheme := runtime.NewScheme()
 	for _, addToScheme := range []func(*runtime.Scheme) error{
 		configapi.AddToScheme, configv1beta1.AddToScheme, clientgoscheme.AddToScheme,

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -526,11 +526,8 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		}
 
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
-		// A mapping is dormant until the gate is on, since that is where the mapper
-		// is built, so refusing it before then would fail a start that nothing else
-		// about the upgrade was going to fail. The rest of the checks below stay
-		// unconditional: a mapping that is malformed while dormant is still
-		// malformed the day it is switched on.
+		// Only behind the gate: the mapper is built there, so until then the name
+		// is dormant and refusing it would fail an unrelated upgrade.
 		if features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -478,7 +478,11 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			seenKeys.Insert(transform.Input)
 		}
 		// The same key, reached from the other side of the configuration, and
-		// discarded in the same place.
+		// discarded in the same place. When a check on the value lands next to
+		// this one, the reserved name is the error to give: changing the factor
+		// cannot make this output legal, so the name is what an operator has to
+		// act on, and it belongs in the same walk over the outputs so the whole
+		// list comes out in name order.
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -485,6 +485,12 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
 				corev1.ResourcePods, reservedResourceNameMsg))
 		}
+		// Not yet synthesized when transformations run, so it multiplies by one.
+		if transform.MultiplyBy == corev1.ResourcePods {
+			allErrs = append(allErrs, field.Invalid(
+				resourceTransformationPath.Index(idx).Child("multiplyBy"),
+				transform.MultiplyBy, reservedResourceNameMsg))
+		}
 	}
 	return allErrs
 }

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -455,6 +455,10 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
+// reservedResourceNameMsg matches what the Workload webhook reports for the same
+// key, so the two sides of the reservation read alike.
+const reservedResourceNameMsg = "the key is reserved for internal kueue use"
+
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {
 	res := c.Resources
 	if res == nil {
@@ -472,6 +476,12 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			allErrs = append(allErrs, field.Duplicate(resourceTransformationPath.Index(idx).Child("input"), transform.Input))
 		} else {
 			seenKeys.Insert(transform.Input)
+		}
+		// Same key, reached from the other side of the configuration.
+		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
+			allErrs = append(allErrs, field.Invalid(
+				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
+				corev1.ResourcePods, reservedResourceNameMsg))
 		}
 	}
 	return allErrs
@@ -502,6 +512,12 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 
 		if len(string(mapping.Name)) > 253 {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, "must not exceed 253 characters"))
+		}
+
+		// Flavor assignment writes this key from the PodSet count, replacing what
+		// is stored under it, so a mapped charge would be counted as one Pod.
+		if mapping.Name == corev1.ResourcePods {
+			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}
 
 		if seenResourceNames.Has(mapping.Name) {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -456,8 +456,6 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 }
 
 // reservedResourceNameMsg is the Workload webhook's message for the same key.
-// Only the message is shared, since the two validators do not refuse the same
-// set of things.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {
@@ -478,8 +476,7 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 		} else {
 			seenKeys.Insert(transform.Input)
 		}
-		// The same key, reached from the other side of the configuration, and
-		// discarded in the same place.
+		// Flavor assignment replaces this key with the PodSet count.
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
@@ -522,8 +519,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, "must not exceed 253 characters"))
 		}
 
-		// Flavor assignment replaces this key with the PodSet count, discarding
-		// whatever was stored under it.
+		// Flavor assignment replaces this key with the PodSet count.
 		if mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -455,7 +455,8 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
-// reservedResourceNameMsg is the Workload webhook's message for the same key.
+// reservedResourceNameMsg is worded as the Workload webhook words the same
+// refusal. Nothing holds the two together; the webhook spells its own out.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {
@@ -524,7 +525,7 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, "must not exceed 253 characters"))
 		}
 
-		// Flavor assignment replaces this key with the PodSet count.
+		// pods is reserved for the request Kueue synthesizes from the PodSet count.
 		if mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -456,9 +456,9 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 }
 
 // reservedResourceNameMsg is the Workload webhook's message for the same key.
-// That validator reports the reserved name and the sign of a negative quantity
-// as two errors, and this follows it: fixing either one leaves the other, and a
-// check the manager will not start past costs a restart to find the next.
+// Only the message is shared. A name that cannot be used and a factor that
+// cannot be used are separate things to fix, and both are reported: a check the
+// manager will not start past costs a restart to find the second one.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -477,7 +477,8 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 		} else {
 			seenKeys.Insert(transform.Input)
 		}
-		// Same key, reached from the other side of the configuration.
+		// The same key, reached from the other side of the configuration, and
+		// discarded in the same place.
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
@@ -514,8 +515,8 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, "must not exceed 253 characters"))
 		}
 
-		// Flavor assignment writes this key from the PodSet count, replacing what
-		// is stored under it, so a mapped charge would be counted as one Pod.
+		// Flavor assignment replaces this key with the PodSet count, discarding
+		// whatever was stored under it.
 		if mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -456,9 +456,8 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 }
 
 // reservedResourceNameMsg is the Workload webhook's message for the same key.
-// Only the message is shared. A name that cannot be used and a factor that
-// cannot be used are separate things to fix, and both are reported: a check the
-// manager will not start past costs a restart to find the second one.
+// Only the message is shared, since the two validators do not refuse the same
+// set of things.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {
@@ -480,10 +479,7 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 			seenKeys.Insert(transform.Input)
 		}
 		// The same key, reached from the other side of the configuration, and
-		// discarded in the same place. When a check on the value lands next to
-		// this one, both belong in one walk over the outputs, so the whole list
-		// comes out in name order and a name and a factor that are each wrong
-		// are each reported.
+		// discarded in the same place.
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -476,13 +476,18 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 		} else {
 			seenKeys.Insert(transform.Input)
 		}
-		// Flavor assignment replaces this key with the PodSet count.
+		// pods is reserved for the request Kueue synthesizes from the PodSet
+		// count, so a transformation must not name it in any position.
+		if transform.Input == corev1.ResourcePods {
+			allErrs = append(allErrs, field.Invalid(
+				resourceTransformationPath.Index(idx).Child("input"),
+				transform.Input, reservedResourceNameMsg))
+		}
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),
 				corev1.ResourcePods, reservedResourceNameMsg))
 		}
-		// Not yet synthesized when transformations run, so it multiplies by one.
 		if transform.MultiplyBy == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("multiplyBy"),

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -456,8 +456,9 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 }
 
 // reservedResourceNameMsg is the Workload webhook's message for the same key.
-// Only the message is shared: that validator reports the reserved name and the
-// sign of a negative quantity separately, where this one stops at the name.
+// That validator reports the reserved name and the sign of a negative quantity
+// as two errors, and this follows it: fixing either one leaves the other, and a
+// check the manager will not start past costs a restart to find the next.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {
@@ -480,10 +481,9 @@ func validateResourceTransformations(c *configapi.Configuration) field.ErrorList
 		}
 		// The same key, reached from the other side of the configuration, and
 		// discarded in the same place. When a check on the value lands next to
-		// this one, the reserved name is the error to give: changing the factor
-		// cannot make this output legal, so the name is what an operator has to
-		// act on, and it belongs in the same walk over the outputs so the whole
-		// list comes out in name order.
+		// this one, both belong in one walk over the outputs, so the whole list
+		// comes out in name order and a name and a factor that are each wrong
+		// are each reported.
 		if _, ok := transform.Outputs[corev1.ResourcePods]; ok {
 			allErrs = append(allErrs, field.Invalid(
 				resourceTransformationPath.Index(idx).Child("outputs").Key(string(corev1.ResourcePods)),

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -455,8 +455,7 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
-// reservedResourceNameMsg is worded as the Workload webhook words the same
-// refusal. Nothing holds the two together; the webhook spells its own out.
+// reservedResourceNameMsg repeats the Workload webhook's wording for the same refusal; the two are not linked.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -455,8 +455,9 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	return allErrs
 }
 
-// reservedResourceNameMsg matches what the Workload webhook reports for the same
-// key, so the two sides of the reservation read alike.
+// reservedResourceNameMsg is the Workload webhook's message for the same key.
+// Only the message is shared: that validator reports the reserved name and the
+// sign of a negative quantity separately, where this one stops at the name.
 const reservedResourceNameMsg = "the key is reserved for internal kueue use"
 
 func validateResourceTransformations(c *configapi.Configuration) field.ErrorList {

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -526,7 +526,12 @@ func validateDeviceClassMappings(c *configapi.Configuration) field.ErrorList {
 		}
 
 		// pods is reserved for the request Kueue synthesizes from the PodSet count.
-		if mapping.Name == corev1.ResourcePods {
+		// A mapping is dormant until the gate is on, since that is where the mapper
+		// is built, so refusing it before then would fail a start that nothing else
+		// about the upgrade was going to fail. The rest of the checks below stay
+		// unconditional: a mapping that is malformed while dormant is still
+		// malformed the day it is switched on.
+		if features.Enabled(features.KueueDRAIntegration) && mapping.Name == corev1.ResourcePods {
 			allErrs = append(allErrs, field.Invalid(mappingPath.Child("name"), mapping.Name, reservedResourceNameMsg))
 		}
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -28,6 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -3442,62 +3443,55 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 		},
 	}
 
-	var fields, refusedForItsFactor []string
-	reserved := map[string]int{}
-	refusedForItsFactorFirst := map[string]bool{}
+	// Whether the sign check is on this branch is settled on its own input, not
+	// on what the case below reports, so a fold that drops every factor error
+	// cannot pick the expectation that lets it pass.
+	signChecked := len(Validate(&configapi.Configuration{
+		Integrations: &configapi.Integrations{Frameworks: []string{"batch/job"}},
+		Resources: &configapi.Resources{
+			Transformations: []configapi.ResourceTransformation{{
+				Input:    "example.com/credits",
+				Strategy: ptr.To(configapi.Retain),
+				Outputs:  corev1.ResourceList{"example.com/one-negative": resource.MustParse("-1")},
+			}},
+		},
+	}, scheme, jobs.NewIntegrationManager())) > 0
+
+	reserved := func(idx int) reportedError {
+		return reportedError{fmt.Sprintf("resources.transformations[%d].outputs[pods]", idx), reservedResourceNameMsg}
+	}
+	negative := func(field string) reportedError {
+		return reportedError{field, apimachineryvalidation.IsNegativeErrorMsg}
+	}
+	// Transformations in the order they are configured, each one's outputs in
+	// name order, and an output refused for both named before it is weighed.
+	want := []reportedError{reserved(0), reserved(1)}
+	if signChecked {
+		want = []reportedError{
+			negative("resources.transformations[0].outputs[example.com/a-negative]"),
+			negative("resources.transformations[0].outputs[example.com/z-negative]"),
+			reserved(0),
+			negative("resources.transformations[0].outputs[pods]"),
+			negative("resources.transformations[0].outputs[zzz.example.com/negative]"),
+			negative("resources.transformations[1].outputs[example.com/b-negative]"),
+			reserved(1),
+		}
+	}
+
+	var got []reportedError
 	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
-		if !strings.Contains(e.Field, ".outputs[") {
-			continue
-		}
-		fields = append(fields, e.Field)
-		// Both checks reach a field with the same type, so only the reason says
-		// which of them refused it.
-		if e.Detail == reservedResourceNameMsg {
-			reserved[e.Field]++
-			// The webhook names the key before it judges the value, and one
-			// output refused for both has to read the same way round. Sorting
-			// the fields cannot see this, since the two share one.
-			if refusedForItsFactorFirst[e.Field] {
-				t.Errorf("%s was refused for its factor before its name", e.Field)
-			}
-			continue
-		}
-		refusedForItsFactorFirst[e.Field] = true
-		refusedForItsFactor = append(refusedForItsFactor, e.Field)
-	}
-	if len(fields) == 0 {
-		t.Fatal("no output was refused")
-	}
-	// The index sorts before the name in the path, so one comparison covers both
-	// the transformations keeping their order and each one's outputs being named
-	// in order.
-	if !slices.IsSorted(fields) {
-		t.Errorf("reported %v, want them in path order", fields)
-	}
-	for _, want := range []string{
-		"resources.transformations[0].outputs[pods]",
-		"resources.transformations[1].outputs[pods]",
-	} {
-		if reserved[want] != 1 {
-			t.Errorf("reported %v, want %s refused for its name exactly once, got %d", fields, want, reserved[want])
+		if strings.Contains(e.Field, ".outputs[") {
+			got = append(got, reportedError{e.Field, e.Detail})
 		}
 	}
-	if len(reserved) != 2 {
-		t.Errorf("reported %v, want the reserved name to be the only one refused for its name", fields)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("output errors (-want +got):\n%s", diff)
 	}
-	// Nothing here refuses a factor yet, so this stays empty. Once the check
-	// that does arrives every one of these has to be listed, the reserved name
-	// carrying a negative factor among them: the name and the factor are
-	// separate things to fix, and a walk that stops at the name would leave out
-	// both the factor under it and the output sorting after it.
-	wantFactor := []string{
-		"resources.transformations[0].outputs[example.com/a-negative]",
-		"resources.transformations[0].outputs[example.com/z-negative]",
-		"resources.transformations[0].outputs[pods]",
-		"resources.transformations[0].outputs[zzz.example.com/negative]",
-		"resources.transformations[1].outputs[example.com/b-negative]",
-	}
-	if len(refusedForItsFactor) != 0 && !slices.Equal(refusedForItsFactor, wantFactor) {
-		t.Errorf("refused for their factor: %v, want none of them or exactly %v", refusedForItsFactor, wantFactor)
-	}
+}
+
+// reportedError is a field path with the reason it was refused, which is the
+// only thing telling the two checks apart when they land on one output.
+type reportedError struct {
+	Field  string
+	Detail string
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1351,7 +1351,7 @@ func TestValidate(t *testing.T) {
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    "example.com/credits",
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
 						},
 					},
@@ -3417,7 +3417,7 @@ func TestValidateReportsAReservedOutputPerTransformation(t *testing.T) {
 			Transformations: []configapi.ResourceTransformation{
 				{
 					Input:    "example.com/credits",
-					Strategy: ptr.To(configapi.Retain),
+					Strategy: new(configapi.Retain),
 					Outputs: corev1.ResourceList{
 						corev1.ResourcePods: resource.MustParse("-1"),
 						"example.com/fine":  resource.MustParse("1"),
@@ -3425,7 +3425,7 @@ func TestValidateReportsAReservedOutputPerTransformation(t *testing.T) {
 				},
 				{
 					Input:    "example.com/tokens",
-					Strategy: ptr.To(configapi.Retain),
+					Strategy: new(configapi.Retain),
 					Outputs: corev1.ResourceList{
 						corev1.ResourcePods:     resource.MustParse("1"),
 						"example.com/also-fine": resource.MustParse("2"),

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3451,6 +3451,10 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 						"example.com/z-negative": resource.MustParse("-1"),
 						"example.com/a-negative": resource.MustParse("-1m"),
 						"example.com/fine":       resource.MustParse("1"),
+						// Sorts after `pods`, so an implementation that walks the
+						// ordinary outputs and appends the reserved one cannot come
+						// out in order by accident.
+						"zzz.example.com/negative": resource.MustParse("-1"),
 					},
 				},
 				{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3444,6 +3444,7 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 
 	var fields, refusedForItsFactor []string
 	reserved := map[string]int{}
+	refusedForItsFactorFirst := map[string]bool{}
 	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
 		if !strings.Contains(e.Field, ".outputs[") {
 			continue
@@ -3453,8 +3454,15 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 		// which of them refused it.
 		if e.Detail == reservedResourceNameMsg {
 			reserved[e.Field]++
+			// The webhook names the key before it judges the value, and one
+			// output refused for both has to read the same way round. Sorting
+			// the fields cannot see this, since the two share one.
+			if refusedForItsFactorFirst[e.Field] {
+				t.Errorf("%s was refused for its factor before its name", e.Field)
+			}
 			continue
 		}
+		refusedForItsFactorFirst[e.Field] = true
 		refusedForItsFactor = append(refusedForItsFactor, e.Field)
 	}
 	if len(fields) == 0 {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -18,7 +18,9 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -3420,4 +3422,100 @@ func TestValidateCustomLabels(t *testing.T) {
 			t.Errorf("unexpected error details (-want,+got):\n%s", diff)
 		}
 	})
+}
+
+// The sign check for output factors lands next to the reserved-name check, and
+// folding the two is what decides the order the errors come out in and whether a
+// negative `pods` output is reported once or twice. Asserting the properties
+// rather than a fixed list holds both before that check exists and after it
+// arrives. Two transformations, because the outputs of one are sorted by name
+// while the transformations themselves keep the order they were configured in.
+func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := configapi.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &configapi.Configuration{
+		Integrations: &configapi.Integrations{Frameworks: []string{"batch/job"}},
+		Resources: &configapi.Resources{
+			Transformations: []configapi.ResourceTransformation{
+				{
+					Input:    "example.com/credits",
+					Strategy: ptr.To(configapi.Retain),
+					Outputs: corev1.ResourceList{
+						corev1.ResourcePods:      resource.MustParse("-1"),
+						"example.com/z-negative": resource.MustParse("-1"),
+						"example.com/a-negative": resource.MustParse("-1m"),
+						"example.com/fine":       resource.MustParse("1"),
+					},
+				},
+				{
+					Input:    "example.com/tokens",
+					Strategy: ptr.To(configapi.Retain),
+					Outputs: corev1.ResourceList{
+						"example.com/b-negative": resource.MustParse("-2"),
+						corev1.ResourcePods:      resource.MustParse("1"),
+					},
+				},
+			},
+		},
+	}
+
+	// resources.transformations[<idx>].outputs[<name>]
+	pattern := regexp.MustCompile(`^resources\.transformations\[(\d+)\]\.outputs\[(.+)]$`)
+	type reported struct {
+		idx    int
+		name   string
+		detail string
+	}
+	var got []reported
+	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
+		m := pattern.FindStringSubmatch(e.Field)
+		if m == nil {
+			continue
+		}
+		idx, err := strconv.Atoi(m[1])
+		if err != nil {
+			t.Fatalf("parsing %q: %v", e.Field, err)
+		}
+		got = append(got, reported{idx: idx, name: m[2], detail: e.Detail})
+	}
+	if len(got) == 0 {
+		t.Fatal("no output was refused")
+	}
+
+	seenPods := make(map[int]int)
+	for i, r := range got {
+		if r.name == string(corev1.ResourcePods) {
+			seenPods[r.idx]++
+			// Both checks land on this field with the same type, so only the
+			// reason says which one refused it, and the reserved one has to. A
+			// factor told it is out of range invites a positive one, which is
+			// just as wrong.
+			if r.detail != reservedResourceNameMsg {
+				t.Errorf("transformation %d refused pods with %q, want %q", r.idx, r.detail, reservedResourceNameMsg)
+			}
+		}
+		if i == 0 {
+			continue
+		}
+		switch prev := got[i-1]; {
+		case r.idx < prev.idx:
+			t.Errorf("reported %v, want the transformations in the order they are configured", got)
+		case r.idx == prev.idx && r.name < prev.name:
+			t.Errorf("reported %v, want one transformation's outputs in name order", got)
+		}
+	}
+	for idx, n := range seenPods {
+		if n != 1 {
+			t.Errorf("reported %v, want the reserved name once under transformation %d, got %d", got, idx, n)
+		}
+	}
+	if len(seenPods) != 2 {
+		t.Errorf("reported %v, want the reserved name refused under both transformations", got)
+	}
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -1319,6 +1320,47 @@ func TestValidate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
 					Field: "resources.deviceClassMappings[1].deviceClassNames[0]",
+				},
+			},
+		},
+		// Kueue writes this key itself during flavor assignment, so a charge
+		// stored under it is replaced rather than counted.
+		"device class mapping named pods rejected": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             corev1.ResourcePods,
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.deviceClassMappings[0].name",
+				},
+			},
+		},
+		"transformation output named pods rejected": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:    "example.com/credits",
+							Strategy: ptr.To(configapi.Retain),
+							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].outputs[pods]",
 				},
 			},
 		},

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1349,6 +1349,32 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The case above rules out a match that only ends in the reserved name.
+		// These rule out one that only starts with it, and one that differs from
+		// it in case alone.
+		"names that merely resemble the reserved one accepted": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "pods.example.com/gpu",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+					},
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      "Pods",
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: "pods-per-node",
+							Outputs: corev1.ResourceList{
+								"PODS": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
 		"device class mapping named pods rejected": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1344,29 +1344,6 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		// The sign check that lands alongside this one has to leave a reserved key
-		// to this check alone, rather than reporting the name and the sign of the
-		// same output separately.
-		"negative transformation output named pods rejected once": {
-			cfg: &configapi.Configuration{
-				Integrations: defaultIntegrations,
-				Resources: &configapi.Resources{
-					Transformations: []configapi.ResourceTransformation{
-						{
-							Input:    "example.com/credits",
-							Strategy: ptr.To(configapi.Retain),
-							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("-1")},
-						},
-					},
-				},
-			},
-			wantErr: field.ErrorList{
-				&field.Error{
-					Type:  field.ErrorTypeInvalid,
-					Field: "resources.transformations[0].outputs[pods]",
-				},
-			},
-		},
 		"transformation output named pods rejected": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
@@ -3424,10 +3401,11 @@ func TestValidateCustomLabels(t *testing.T) {
 
 // The sign check for output factors lands next to the reserved-name check, and
 // folding the two decides the order the errors come out in, whether a reserved
-// output is reported once, and which of the two reasons a negative `pods` is
-// given. Asserting those as properties holds before that check exists and after
-// it arrives. Two transformations, and one output name sorting after `pods`, so
-// neither the grouping nor the order can come out right by accident.
+// output is named once, and whether a negative `pods` is refused for both its
+// name and its factor. Asserting those as properties holds before that check
+// exists and after it arrives. Two transformations, and one output name sorting
+// after `pods`, so neither the grouping nor the order can come out right by
+// accident.
 func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1364,8 +1364,26 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		// The multiplier is read while transformations run, before flavor
-		// assignment writes this key, so the lookup always misses.
+		"transformation taking pods as input rejected": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:    corev1.ResourcePods,
+							Strategy: new(configapi.Replace),
+							Outputs:  corev1.ResourceList{"example.com/license": resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].input",
+				},
+			},
+		},
 		"transformation multiplying by pods rejected": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1430,6 +1430,37 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// Reported per entry rather than once for the Configuration, and in the
+		// order the transformations are written.
+		"pods reported for each transformation naming it": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:    "example.com/credits",
+							Strategy: new(configapi.Retain),
+							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+						{
+							Input:    "example.com/tokens",
+							Strategy: new(configapi.Retain),
+							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].outputs[pods]",
+				},
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[1].outputs[pods]",
+				},
+			},
+		},
 		"multi-counter: whole-device and counter for same DeviceClass rejected": {
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
 			cfg: &configapi.Configuration{
@@ -3463,61 +3494,4 @@ func TestValidateCustomLabels(t *testing.T) {
 			t.Errorf("unexpected error details (-want,+got):\n%s", diff)
 		}
 	})
-}
-
-// TestValidateReportsAReservedOutputPerTransformation pins one error per
-// transformation, in configured order and not deduplicated across them.
-func TestValidateReportsAReservedOutputPerTransformation(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := clientgoscheme.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := configapi.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-
-	cfg := &configapi.Configuration{
-		Integrations: &configapi.Integrations{Frameworks: []string{"batch/job"}},
-		Resources: &configapi.Resources{
-			Transformations: []configapi.ResourceTransformation{
-				{
-					Input:    "example.com/credits",
-					Strategy: new(configapi.Retain),
-					Outputs: corev1.ResourceList{
-						corev1.ResourcePods: resource.MustParse("-1"),
-						"example.com/fine":  resource.MustParse("1"),
-					},
-				},
-				{
-					Input:    "example.com/tokens",
-					Strategy: new(configapi.Retain),
-					Outputs: corev1.ResourceList{
-						corev1.ResourcePods:     resource.MustParse("1"),
-						"example.com/also-fine": resource.MustParse("2"),
-					},
-				},
-			},
-		},
-	}
-
-	want := []reportedError{
-		{"resources.transformations[0].outputs[pods]", reservedResourceNameMsg},
-		{"resources.transformations[1].outputs[pods]", reservedResourceNameMsg},
-	}
-	var got []reportedError
-	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
-		if strings.Contains(e.Field, ".outputs[") {
-			got = append(got, reportedError{e.Field, e.Detail})
-		}
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("output errors (-want +got):\n%s", diff)
-	}
-}
-
-// reportedError is a field path with the reason it was refused, which is the
-// only thing telling the two checks apart when they land on one output.
-type reportedError struct {
-	Field  string
-	Detail string
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3498,4 +3498,24 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 			t.Errorf("reported %v, want %s exactly once, got %d", fields, want, reserved[want])
 		}
 	}
+	// Nothing here refuses a factor yet, so the outputs carrying a negative one
+	// go unreported. Once the check that does arrives they all have to be, and a
+	// fold that stops the walk at the reserved name rather than skipping past it
+	// would leave the one sorting after it out.
+	negative := []string{
+		"resources.transformations[0].outputs[example.com/a-negative]",
+		"resources.transformations[0].outputs[example.com/z-negative]",
+		"resources.transformations[0].outputs[zzz.example.com/negative]",
+		"resources.transformations[1].outputs[example.com/b-negative]",
+	}
+	reportedNegative := 0
+	for _, f := range negative {
+		if slices.Contains(fields, f) {
+			reportedNegative++
+		}
+	}
+	if reportedNegative != 0 && reportedNegative != len(negative) {
+		t.Errorf("reported %v, want every output with a negative factor or none of them, got %d of %d",
+			fields, reportedNegative, len(negative))
+	}
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -18,9 +18,7 @@ package config
 
 import (
 	"fmt"
-	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -3425,11 +3423,11 @@ func TestValidateCustomLabels(t *testing.T) {
 }
 
 // The sign check for output factors lands next to the reserved-name check, and
-// folding the two is what decides the order the errors come out in and whether a
-// negative `pods` output is reported once or twice. Asserting the properties
-// rather than a fixed list holds both before that check exists and after it
-// arrives. Two transformations, because the outputs of one are sorted by name
-// while the transformations themselves keep the order they were configured in.
+// folding the two decides the order the errors come out in, whether a reserved
+// output is reported once, and which of the two reasons a negative `pods` is
+// given. Asserting those as properties holds before that check exists and after
+// it arrives. Two transformations, and one output name sorting after `pods`, so
+// neither the grouping nor the order can come out right by accident.
 func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
@@ -3447,13 +3445,10 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 					Input:    "example.com/credits",
 					Strategy: ptr.To(configapi.Retain),
 					Outputs: corev1.ResourceList{
-						corev1.ResourcePods:      resource.MustParse("-1"),
-						"example.com/z-negative": resource.MustParse("-1"),
-						"example.com/a-negative": resource.MustParse("-1m"),
-						"example.com/fine":       resource.MustParse("1"),
-						// Sorts after `pods`, so an implementation that walks the
-						// ordinary outputs and appends the reserved one cannot come
-						// out in order by accident.
+						corev1.ResourcePods:        resource.MustParse("-1"),
+						"example.com/z-negative":   resource.MustParse("-1"),
+						"example.com/a-negative":   resource.MustParse("-1m"),
+						"example.com/fine":         resource.MustParse("1"),
 						"zzz.example.com/negative": resource.MustParse("-1"),
 					},
 				},
@@ -3469,57 +3464,38 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 		},
 	}
 
-	// resources.transformations[<idx>].outputs[<name>]
-	pattern := regexp.MustCompile(`^resources\.transformations\[(\d+)\]\.outputs\[(.+)]$`)
-	type reported struct {
-		idx    int
-		name   string
-		detail string
-	}
-	var got []reported
+	var fields []string
+	reserved := map[string]int{}
 	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
-		m := pattern.FindStringSubmatch(e.Field)
-		if m == nil {
+		if !strings.Contains(e.Field, ".outputs[") {
 			continue
 		}
-		idx, err := strconv.Atoi(m[1])
-		if err != nil {
-			t.Fatalf("parsing %q: %v", e.Field, err)
-		}
-		got = append(got, reported{idx: idx, name: m[2], detail: e.Detail})
-	}
-	if len(got) == 0 {
-		t.Fatal("no output was refused")
-	}
-
-	seenPods := make(map[int]int)
-	for i, r := range got {
-		if r.name == string(corev1.ResourcePods) {
-			seenPods[r.idx]++
-			// Both checks land on this field with the same type, so only the
-			// reason says which one refused it, and the reserved one has to. A
-			// factor told it is out of range invites a positive one, which is
-			// just as wrong.
-			if r.detail != reservedResourceNameMsg {
-				t.Errorf("transformation %d refused pods with %q, want %q", r.idx, r.detail, reservedResourceNameMsg)
+		fields = append(fields, e.Field)
+		if strings.HasSuffix(e.Field, ".outputs[pods]") {
+			reserved[e.Field]++
+			// Both checks reach this field with the same type, so only the reason
+			// says which refused it. Telling an operator to make the factor
+			// non-negative leaves the name just as wrong.
+			if e.Detail != reservedResourceNameMsg {
+				t.Errorf("%s refused with %q, want %q", e.Field, e.Detail, reservedResourceNameMsg)
 			}
 		}
-		if i == 0 {
-			continue
-		}
-		switch prev := got[i-1]; {
-		case r.idx < prev.idx:
-			t.Errorf("reported %v, want the transformations in the order they are configured", got)
-		case r.idx == prev.idx && r.name < prev.name:
-			t.Errorf("reported %v, want one transformation's outputs in name order", got)
-		}
 	}
-	for idx, n := range seenPods {
-		if n != 1 {
-			t.Errorf("reported %v, want the reserved name once under transformation %d, got %d", got, idx, n)
-		}
+	if len(fields) == 0 {
+		t.Fatal("no output was refused")
 	}
-	if len(seenPods) != 2 {
-		t.Errorf("reported %v, want the reserved name refused under both transformations", got)
+	// The index sorts before the name in the path, so one comparison covers both
+	// the transformations keeping their order and each one's outputs being named
+	// in order.
+	if !slices.IsSorted(fields) {
+		t.Errorf("reported %v, want them in path order", fields)
+	}
+	for _, want := range []string{
+		"resources.transformations[0].outputs[pods]",
+		"resources.transformations[1].outputs[pods]",
+	} {
+		if reserved[want] != 1 {
+			t.Errorf("reported %v, want %s exactly once, got %d", fields, want, reserved[want])
+		}
 	}
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1364,6 +1364,54 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The multiplier is read while transformations run, before flavor
+		// assignment writes this key, so the lookup always misses.
+		"transformation multiplying by pods rejected": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      "example.com/credits",
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: corev1.ResourcePods,
+							Outputs:    corev1.ResourceList{"example.com/charge": resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].multiplyBy",
+				},
+			},
+		},
+		"transformation naming pods twice reports both": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      "example.com/credits",
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: corev1.ResourcePods,
+							Outputs:    corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].outputs[pods]",
+				},
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].multiplyBy",
+				},
+			},
+		},
 		"multi-counter: whole-device and counter for same DeviceClass rejected": {
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegrationPartitionableDevices: true},
 			cfg: &configapi.Configuration{

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1323,9 +1323,9 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		// Kueue writes this key itself during flavor assignment, so a charge
-		// stored under it is replaced rather than counted.
-		// Only the bare name is reserved: one ending in /pods is a different resource.
+		// Kueue owns the bare pods key for Pod-count accounting.
+		// Only that exact name is reserved; a qualified name ending in /pods
+		// is a different resource.
 		"qualified names ending in pods accepted": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -28,7 +28,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -3400,14 +3399,10 @@ func TestValidateCustomLabels(t *testing.T) {
 	})
 }
 
-// The sign check for output factors lands next to the reserved-name check, and
-// folding the two decides the order the errors come out in, whether a reserved
-// output is named once, and whether a negative `pods` is refused for both its
-// name and its factor. Asserting those as properties holds before that check
-// exists and after it arrives. Two transformations, and one output name sorting
-// after `pods`, so neither the grouping nor the order can come out right by
-// accident.
-func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
+// One reserved output per transformation, in the order the transformations are
+// configured, and not deduplicated across them: the same name in two of them is
+// two separate things for an operator to fix.
+func TestValidateReportsAReservedOutputPerTransformation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {
 		t.Fatal(err)
@@ -3424,60 +3419,26 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 					Input:    "example.com/credits",
 					Strategy: ptr.To(configapi.Retain),
 					Outputs: corev1.ResourceList{
-						corev1.ResourcePods:        resource.MustParse("-1"),
-						"example.com/z-negative":   resource.MustParse("-1"),
-						"example.com/a-negative":   resource.MustParse("-1m"),
-						"example.com/fine":         resource.MustParse("1"),
-						"zzz.example.com/negative": resource.MustParse("-1"),
+						corev1.ResourcePods: resource.MustParse("-1"),
+						"example.com/fine":  resource.MustParse("1"),
 					},
 				},
 				{
 					Input:    "example.com/tokens",
 					Strategy: ptr.To(configapi.Retain),
 					Outputs: corev1.ResourceList{
-						"example.com/b-negative": resource.MustParse("-2"),
-						corev1.ResourcePods:      resource.MustParse("1"),
+						corev1.ResourcePods:     resource.MustParse("1"),
+						"example.com/also-fine": resource.MustParse("2"),
 					},
 				},
 			},
 		},
 	}
 
-	// Whether the sign check is on this branch is settled on its own input, not
-	// on what the case below reports, so a fold that drops every factor error
-	// cannot pick the expectation that lets it pass.
-	signChecked := len(Validate(&configapi.Configuration{
-		Integrations: &configapi.Integrations{Frameworks: []string{"batch/job"}},
-		Resources: &configapi.Resources{
-			Transformations: []configapi.ResourceTransformation{{
-				Input:    "example.com/credits",
-				Strategy: ptr.To(configapi.Retain),
-				Outputs:  corev1.ResourceList{"example.com/one-negative": resource.MustParse("-1")},
-			}},
-		},
-	}, scheme, jobs.NewIntegrationManager())) > 0
-
-	reserved := func(idx int) reportedError {
-		return reportedError{fmt.Sprintf("resources.transformations[%d].outputs[pods]", idx), reservedResourceNameMsg}
+	want := []reportedError{
+		{"resources.transformations[0].outputs[pods]", reservedResourceNameMsg},
+		{"resources.transformations[1].outputs[pods]", reservedResourceNameMsg},
 	}
-	negative := func(field string) reportedError {
-		return reportedError{field, apimachineryvalidation.IsNegativeErrorMsg}
-	}
-	// Transformations in the order they are configured, each one's outputs in
-	// name order, and an output refused for both named before it is weighed.
-	want := []reportedError{reserved(0), reserved(1)}
-	if signChecked {
-		want = []reportedError{
-			negative("resources.transformations[0].outputs[example.com/a-negative]"),
-			negative("resources.transformations[0].outputs[example.com/z-negative]"),
-			reserved(0),
-			negative("resources.transformations[0].outputs[pods]"),
-			negative("resources.transformations[0].outputs[zzz.example.com/negative]"),
-			negative("resources.transformations[1].outputs[example.com/b-negative]"),
-			reserved(1),
-		}
-	}
-
 	var got []reportedError
 	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
 		if strings.Contains(e.Field, ".outputs[") {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1325,8 +1325,7 @@ func TestValidate(t *testing.T) {
 		},
 		// Kueue writes this key itself during flavor assignment, so a charge
 		// stored under it is replaced rather than counted.
-		// Only the bare name is taken. A qualified one ending in the same word
-		// is somebody else's resource and has to keep working.
+		// Only the bare name is reserved: one ending in /pods is a different resource.
 		"qualified names ending in pods accepted": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3464,22 +3464,20 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 		},
 	}
 
-	var fields []string
+	var fields, refusedForItsFactor []string
 	reserved := map[string]int{}
 	for _, e := range Validate(cfg, scheme, jobs.NewIntegrationManager()) {
 		if !strings.Contains(e.Field, ".outputs[") {
 			continue
 		}
 		fields = append(fields, e.Field)
-		if strings.HasSuffix(e.Field, ".outputs[pods]") {
+		// Both checks reach a field with the same type, so only the reason says
+		// which of them refused it.
+		if e.Detail == reservedResourceNameMsg {
 			reserved[e.Field]++
-			// Both checks reach this field with the same type, so only the reason
-			// says which refused it. Telling an operator to make the factor
-			// non-negative leaves the name just as wrong.
-			if e.Detail != reservedResourceNameMsg {
-				t.Errorf("%s refused with %q, want %q", e.Field, e.Detail, reservedResourceNameMsg)
-			}
+			continue
 		}
+		refusedForItsFactor = append(refusedForItsFactor, e.Field)
 	}
 	if len(fields) == 0 {
 		t.Fatal("no output was refused")
@@ -3495,27 +3493,25 @@ func TestValidateReportsOutputProblemsOnceAndInOrder(t *testing.T) {
 		"resources.transformations[1].outputs[pods]",
 	} {
 		if reserved[want] != 1 {
-			t.Errorf("reported %v, want %s exactly once, got %d", fields, want, reserved[want])
+			t.Errorf("reported %v, want %s refused for its name exactly once, got %d", fields, want, reserved[want])
 		}
 	}
-	// Nothing here refuses a factor yet, so the outputs carrying a negative one
-	// go unreported. Once the check that does arrives they all have to be, and a
-	// fold that stops the walk at the reserved name rather than skipping past it
-	// would leave the one sorting after it out.
-	negative := []string{
+	if len(reserved) != 2 {
+		t.Errorf("reported %v, want the reserved name to be the only one refused for its name", fields)
+	}
+	// Nothing here refuses a factor yet, so this stays empty. Once the check
+	// that does arrives every one of these has to be listed, the reserved name
+	// carrying a negative factor among them: the name and the factor are
+	// separate things to fix, and a walk that stops at the name would leave out
+	// both the factor under it and the output sorting after it.
+	wantFactor := []string{
 		"resources.transformations[0].outputs[example.com/a-negative]",
 		"resources.transformations[0].outputs[example.com/z-negative]",
+		"resources.transformations[0].outputs[pods]",
 		"resources.transformations[0].outputs[zzz.example.com/negative]",
 		"resources.transformations[1].outputs[example.com/b-negative]",
 	}
-	reportedNegative := 0
-	for _, f := range negative {
-		if slices.Contains(fields, f) {
-			reportedNegative++
-		}
-	}
-	if reportedNegative != 0 && reportedNegative != len(negative) {
-		t.Errorf("reported %v, want every output with a negative factor or none of them, got %d of %d",
-			fields, reportedNegative, len(negative))
+	if len(refusedForItsFactor) != 0 && !slices.Equal(refusedForItsFactor, wantFactor) {
+		t.Errorf("refused for their factor: %v, want none of them or exactly %v", refusedForItsFactor, wantFactor)
 	}
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1325,6 +1325,31 @@ func TestValidate(t *testing.T) {
 		},
 		// Kueue writes this key itself during flavor assignment, so a charge
 		// stored under it is replaced rather than counted.
+		// Only the bare name is taken. A qualified one ending in the same word
+		// is somebody else's resource and has to keep working.
+		"qualified names ending in pods accepted": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             "dra.example.com/pods",
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+					},
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      "input.example.com/pods",
+							Strategy:   new(configapi.Retain),
+							MultiplyBy: "multiplier.example.com/pods",
+							Outputs: corev1.ResourceList{
+								"output.example.com/pods": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+		},
 		"device class mapping named pods rejected": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1375,7 +1375,8 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
-		"device class mapping named pods rejected": {
+		"device class mapping named pods rejected when DRA is enabled": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
@@ -1391,6 +1392,46 @@ func TestValidate(t *testing.T) {
 				&field.Error{
 					Type:  field.ErrorTypeInvalid,
 					Field: "resources.deviceClassMappings[0].name",
+				},
+			},
+		},
+		// The mapper is only built behind the gate, so nothing reads this name
+		// while it is off and refusing it would fail an upgrade about something
+		// else. It is refused the day the gate goes on, which is the case above.
+		"device class mapping named pods accepted when DRA is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					DeviceClassMappings: []configapi.DeviceClassMapping{
+						{
+							Name:             corev1.ResourcePods,
+							DeviceClassNames: []corev1.ResourceName{"gpu.nvidia.com"},
+						},
+					},
+				},
+			},
+		},
+		// Transformations are installed whatever the DRA gate says, so the name is
+		// refused there whatever it says too.
+		"transformation output named pods rejected when DRA is disabled": {
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:    "example.com/credits",
+							Strategy: new(configapi.Retain),
+							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].outputs[pods]",
 				},
 			},
 		},

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3447,9 +3447,8 @@ func TestValidateCustomLabels(t *testing.T) {
 	})
 }
 
-// One reserved output per transformation, in the order the transformations are
-// configured, and not deduplicated across them: the same name in two of them is
-// two separate things for an operator to fix.
+// TestValidateReportsAReservedOutputPerTransformation pins one error per
+// transformation, in configured order and not deduplicated across them.
 func TestValidateReportsAReservedOutputPerTransformation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := clientgoscheme.AddToScheme(scheme); err != nil {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1344,6 +1344,29 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The sign check that lands alongside this one has to leave a reserved key
+		// to this check alone, rather than reporting the name and the sign of the
+		// same output separately.
+		"negative transformation output named pods rejected once": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:    "example.com/credits",
+							Strategy: ptr.To(configapi.Retain),
+							Outputs:  corev1.ResourceList{corev1.ResourcePods: resource.MustParse("-1")},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "resources.transformations[0].outputs[pods]",
+				},
+			},
+		},
 		"transformation output named pods rejected": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -705,12 +705,11 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			}
 			// Then, add the DRA logical resources.
 			//
-			// No producer may name corev1.ResourcePods here. Claim-based charges
-			// key on mapping names, which configuration validation refuses that
-			// name; the extended-resource path takes only names
-			// IsExtendedResourceName accepts, and it reads pods as native. Flavor
-			// assignment sets pods from the PodSet count after this, so anything
-			// merged under it is overwritten and lost.
+			// No producer may name corev1.ResourcePods here: claim charges key on
+			// mapping names, which validation refuses under this same gate, and the
+			// extended-resource path reads pods as native. Flavor assignment sets
+			// pods from the PodSet count after this, so anything merged under it is
+			// lost.
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
 					q := effectiveRequests[resName]

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -703,7 +703,14 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 					delete(effectiveRequests, extRes)
 				}
 			}
-			// Then, add the DRA logical resources
+			// Then, add the DRA logical resources.
+			//
+			// No producer may name corev1.ResourcePods here. Claim-based charges
+			// key on mapping names, which configuration validation refuses that
+			// name; the extended-resource path takes only names
+			// IsExtendedResourceName accepts, and it reads pods as native. Flavor
+			// assignment sets pods from the PodSet count after this, so anything
+			// merged under it is overwritten and lost.
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
 					q := effectiveRequests[resName]

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -705,11 +705,11 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			}
 			// Then, add the DRA logical resources.
 			//
-			// No producer may name corev1.ResourcePods here: claim charges key on
-			// mapping names, which validation refuses under this same gate, and the
-			// extended-resource path reads pods as native. Flavor assignment sets
-			// pods from the PodSet count after this, so anything merged under it is
-			// lost.
+			// DRA producers must not emit corev1.ResourcePods here. Claim charges use
+			// mapping names, which validation rejects under this gate; the
+			// extended-resource path treats pods as native. Flavor assignment owns
+			// pod-count accounting for this key and, when the ClusterQueue tracks it,
+			// replaces any value merged here with PodSet.Count.
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
 					q := effectiveRequests[resName]

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -703,13 +703,12 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 					delete(effectiveRequests, extRes)
 				}
 			}
-			// Then, add the DRA logical resources.
+			// Then, add the DRA logical resources
 			//
-			// DRA producers must not emit corev1.ResourcePods here. Claim charges use
-			// mapping names, which validation rejects under this gate; the
-			// extended-resource path treats pods as native. Flavor assignment owns
-			// pod-count accounting for this key and, when the ClusterQueue tracks it,
-			// replaces any value merged here with PodSet.Count.
+			// A producer must not emit corev1.ResourcePods here: claim charges use
+			// mapping names, which validation refuses under this gate, and the
+			// extended-resource path treats pods as native. A ClusterQueue that
+			// tracks the key has it overwritten with PodSet.Count at assignment.
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
 				for resName, quantity := range draRes {
 					q := effectiveRequests[resName]

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -602,7 +602,7 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>, which Kueue writes itself from the PodSet count.</p>
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1168,7 +1168,8 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-A resource must not be named <code>pods</code>, which Kueue writes itself from the PodSet count.
+Output resource names must not include <code>pods</code>, which is reserved for Kueue's
+internal Pod-count accounting.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1160,7 +1160,8 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -602,8 +602,9 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -601,7 +601,8 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+It must not be <code>pods</code>, which Kueue writes itself from the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1167,6 +1168,7 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+A resource must not be named <code>pods</code>, which Kueue writes itself from the PodSet count.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -602,7 +602,8 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1141,7 +1142,8 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1162,7 +1164,8 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1170,8 +1173,9 @@ It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-cou
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-Output resource names must not include <code>pods</code>, which is reserved for Kueue's
-internal Pod-count accounting.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1140,7 +1140,8 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -770,7 +770,7 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>, which Kueue writes itself from the PodSet count.</p>
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1360,7 +1360,8 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-A resource must not be named <code>pods</code>, which Kueue writes itself from the PodSet count.
+Output resource names must not include <code>pods</code>, which is reserved for Kueue's
+internal Pod-count accounting.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1332,7 +1332,8 @@ re-queuing an evicted workload.</p>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcename-v1-core"><code>k8s.io/api/core/v1.ResourceName</code></a>
 </td>
 <td>
-   <p>Input is the name of the input resource.</p>
+   <p>Input is the name of the input resource.
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1352,7 +1352,8 @@ specified.
 The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
-&quot;strategy&quot; is Retain.</p>
+&quot;strategy&quot; is Retain.
+It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -770,7 +770,8 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1333,7 +1334,8 @@ re-queuing an evicted workload.</p>
 </td>
 <td>
    <p>Input is the name of the input resource.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>strategy</code> <B>[Required]</B><br/>
@@ -1354,7 +1356,8 @@ The requested amount of the resource is used to multiply the requested
 amount of the resource indicated by the &quot;input&quot; field when computing
 &quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
 &quot;strategy&quot; is Retain.
-It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-count accounting.</p>
+It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
+Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1362,8 +1365,9 @@ It must not be <code>pods</code>, which is reserved for Kueue's internal Pod-cou
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
-Output resource names must not include <code>pods</code>, which is reserved for Kueue's
-internal Pod-count accounting.
+An output resource name must not be <code>pods</code>; that exact name is reserved for
+Kueue's internal Pod-count accounting. A qualified name such as
+<code>example.com/pods</code> is allowed.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -769,7 +769,8 @@ followed by a slash and a DNS label, or just a DNS label.
 DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
-The total length must not exceed 253 characters.</p>
+The total length must not exceed 253 characters.
+It must not be <code>pods</code>, which Kueue writes itself from the PodSet count.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>
@@ -1359,6 +1360,7 @@ amount of the resource indicated by the &quot;input&quot; field when computing
 </td>
 <td>
    <p>Outputs specifies the output resources and quantities per unit of input resource.
+A resource must not be named <code>pods</code>, which Kueue writes itself from the PodSet count.
 An empty Outputs combined with a <code>Replace</code> Strategy causes the Input resource to be ignored by Kueue.</p>
 </td>
 </tr>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -770,8 +770,9 @@ DNS labels consist of lower-case alphanumeric characters or hyphens,
 and must start and end with an alphanumeric character.
 DNS subdomain prefixes follow the same rules as DNS labels but can contain periods.
 The total length must not exceed 253 characters.
-It must not be <code>pods</code>; that exact name is reserved for Kueue's internal
-Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.</p>
+With KueueDRAIntegration enabled it must not be <code>pods</code>; that exact name is
+reserved for Kueue's internal Pod-count accounting. A qualified name such
+as <code>example.com/pods</code> is allowed.</p>
 </td>
 </tr>
 <tr><td><code>deviceClassNames</code> <B>[Required]</B><br/>


### PR DESCRIPTION
**Current state**

- Safe to merge standalone: yes
- Remaining dependencies: none
- Out of scope: an invalid `spec.overhead`, which #13995 handles

---

#### What type of PR is this?

/kind bug
/area dra

#### What this PR does / why we need it:

`pods` is reserved for Kueue's own Pod-count accounting, and the Workload webhook says so when a user writes it:

```go
// pkg/webhooks/workload_webhook.go, validateResourceList
if name == corev1.ResourcePods {
	allErrs = append(allErrs, field.Invalid(path.Key(string(name)), corev1.ResourcePods, "the key is reserved for internal kueue use"))
}
```

The operator configuration did not apply the same reservation. `validateDeviceClassMappings` checked the mapping name for label-key syntax, length, and uniqueness only, so a DeviceClass could be mapped to a logical resource named `pods`, and `ResourceTransformation.Outputs` could name it too.

Either one lands in the same place. `totalRequestsFromPodSets` merges the preprocessed DRA resources into the PodSet's requests without filtering reserved names, and `dropExcludedResources` removes only the prefixes an administrator configured. Then flavor assignment replaces it:

```go
// pkg/scheduler/flavorassigner/flavorassigner.go, assignFlavors
if a.cq.RGByResource(corev1.ResourcePods) != nil {
	if podSet.Requests != nil {
		podSet.Requests.Set(corev1.ResourcePods, int64(podSet.Count))
	}
```

`Set` replaces rather than adds, in `MapRequests` and in `SliceRequests` alike. So a ClusterQueue tracking pod quota discards whatever was computed under that name: one Pod claiming eight devices of a mapped class is charged eight and reaches flavor assignment as one.

The Configuration reserves the name in the four transformation and DRA logical-resource positions that reach this accounting path: a mapping's `name`, and a transformation's `input`, `multiplyBy` and `outputs`. Two of those write. A mapping name and an output put another contribution under the key Kueue keeps for its own request, which is the collision above. The other two are operands, and the reason is different: a transformation runs before that request is synthesized, so neither can denote it, whatever the name suggests. All four report the message the webhook already uses. The string is repeated rather than shared, because the two validators do not refuse the same set of things and only the wording is common. Nothing else in the Configuration is touched: `admissionFairSharing.resourceWeights` and the like still take `pods`, where it means the Pod count and is the right name for it.

The webhook covers the container and pod-level resource lists. It does not reach `template.spec.overhead`, which `PodRequests` adds to the charge; that gap is #13991 rather than something this PR closes.

##### Where each half is refused

The mapping half sits behind `KueueDRAIntegration`. The mapper is built inside that gate check in `main.go`, so with the gate off nothing reads the name, nothing can collide with it, and a mapping carrying it is dormant. Refusing it anyway would have failed the manager at startup — a Configuration validation error is `os.Exit` — so a configuration that had been harmless for as long as the gate was off would have taken down an upgrade about something else entirely. It is refused the day the gate goes on, which is when the name starts meaning something.

Only that check moves. Count limits, name syntax and length, duplicate names, device class syntax and per-class conflicts stay unconditional: a mapping that is malformed while dormant is malformed the day it is switched on. This follows the shape #12134 already uses for `sources`, which is refused per check rather than by skipping the mapping validation.

The three transformation positions stay unconditional too. `main.go` installs transformations whenever they are configured, with no gate above them, so `pods` is as wrong there with DRA off as with it on. A case pins that, and it is what goes red if someone later folds the whole reservation behind the gate.

##### What this leaves alone

The reservation is about the one key Kueue writes for itself. Nothing else about mapping names or transformation outputs changes, and a configuration that does not name `pods` is unaffected.

This is not specific to prioritized lists: the existing `ExactCount` path charges through the same merge, so any mapping named `pods` was affected.

The multiplier and the input are the same collision read from the other side, so they are refused here too. What the multiplier finds is worth being precise about, because the first version of this said it always misses. It does not: `PodRequests` adds `spec.overhead` before the transformations run, and a Workload carrying `pods` there makes the lookup succeed. Measured on `main`, a PodSet asking for `example.com/gpumem: 1024` with an overhead of `pods: 4` is charged `4096`. That value is not the PodSet count either, since the count is applied to the whole set afterwards, so there is no reading under which the name means anything. #13991 and #13995 are what stop overhead carrying it in the first place.

The other half of #14007, where `excludeResourcePrefixes` removes a real multiplier and the missing lookup is read as one, is not addressed here.

#### Which issue(s) this PR fixes:

Fixes #13988
Part of #14007

#### Special notes for your reviewer:

Each of the four positions has its own case, written failing first and confirmed to fail because the expected error was absent, then mutation-checked on its own: removing one guard turns only the cases that reach it red.

All four are user-facing Configuration, so the reservation is in the field documentation and the generated references as well as the validator. Transformation uses are always rejected; a mapping use is rejected when `KueueDRAIntegration` is enabled.

A v1beta1 configuration reached the same validator through generated conversion, and there was a test that drove all four positions that way. @tenzen-y asked for it to go, and it is gone: the four positions are pinned in the validator's own table, and the conversion it went through is generated, so what the version-specific run added was those same assertions against a second serialisation. It was the only test driving these fields through decode and conversion, and the round-trip test beside the generated code populates FairSharing rather than these, so what is given up is a check that a generated slice copy keeps its order.

This no longer waits on #13986. That PR was going to refuse a negative output factor, and this branch's test was written to hold what the two checks would look like folded into one walk. @tenzen-y showed that a negative factor is how a per-unit allowance is written, so #13986 now changes where the allowance can be spent instead, and there is no sign check to fold with. What was left worth pinning is that the name is reported per entry and in configured order, and that is a case in the validator table rather than a test of its own: the table compares the whole error list, so it needs no scheme of its own and no field-name filter over the other validators' results. Reporting the output once per Configuration instead of per entry turns only that case red.

I have not added an integration test that drives a mapped `pods` charge through admission. Refusing the configuration means the state cannot be reached, and building a ClusterQueue that tracks pod quota alongside a DRA mapping to assert on the value that no longer exists seemed like the wrong place to spend the coverage.

The gate has a case on each side, and each was checked by breaking it. Ungating the mapping check turns only the disabled case red; gating the transformation checks alongside it turns only the transformation-with-DRA-off case red.

There is also a comment where the DRA charges are merged into the accounting view, `pkg/workload/workload.go`. Nothing reaches it with `pods` today: claim-based charges key on mapping names, which this validator now refuses, and the extended-resource path only takes names `IsExtendedResourceName` accepts, which excludes native ones. The reason to write it down is that the protection is spread across those producers, while what a future one sees is a merge into a map, and flavor assignment owns the `pods` key for Pod-count accounting, replacing any value merged there with the PodSet count when the ClusterQueue tracks pod quota. I have not added a runtime filter there: dropping the key would turn a producer bug into a quiet undercharge, and the function has no error channel to report one through.

#### Does this PR introduce a user-facing change?

```release-note
DRA & ResourceTransformation: Fixed a bug where DRA device-class mapping or a resource transformation under the reserved resource name `pods` was silently discarded or left the Workload permanently pending.

ACTION REQUIRED: Remove or rename those entries before upgrading, or the kueue-controller-manager will fail to start. Renaming a mapping name or an `outputs` key also requires updating the matching ClusterQueue `nominalQuota` entries in the same change.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the reserved `pods` resource name from being used in resource transformations, including multipliers and outputs, or device-class mappings.
  - Added clear validation errors for each invalid use, including configurations containing multiple violations.

- **Documentation**
  - Clarified across configuration references that `pods` is reserved for internal pod-count accounting and cannot be used in these configuration fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













