### PR TITLE
docs: Clarify device class uniqueness enforcement for count-based mappings in DRA documentation

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -304,7 +304,7 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
 - The `ResourceClaims` and `ResourceClaimTemplates` APIs for DRA in k8s are immutable.
 - ResourceClaims are not supported in alpha - workloads must use ResourceClaimTemplates.
   Direct ResourceClaim references will result in inadmissible workloads.
-- Device class uniqueness is enforced - each device class can only map to one resource name to prevent quota ambiguity.
+- Device class uniqueness is enforced for count-based mappings - each device class can only map to one resource name to prevent quota ambiguity.
 - Configuration-based approach - device class mappings are configured through the Kueue Configuration API
 - This design does not work with Kueue's Topology Aware Scheduling feature and will be addressed in future work.
 - DRA resource preprocessing is not scoped by ResourceFlavor node constraints. Counter
@@ -575,7 +575,8 @@ complex runtime resolution logic, ensuring predictable and efficient workload ad
 **Note**: A single mapping can have multiple capacity sources that sum into one quota
 resource, which does not violate this constraint. Tracking independent capacity
 dimensions as separate quota resources (same DeviceClass, different resource names)
-requires relaxing this uniqueness constraint and is deferred to beta.
+remains deferred to beta, while count-based mappings already relax this constraint
+for distinct counter names.
 
 ### RBAC Requirements
 
@@ -1639,8 +1640,8 @@ capacity sources cannot be mixed within the same mapping. This means a unified
 quota pool across both device types (e.g., partitioned and time-sliced GPUs both
 charging `gpu.memory`) is not supported. Relaxing the resource name uniqueness
 to allow separate counter and capacity mappings to share a quota resource is to
-be evaluated for [Beta](#beta). The same DeviceClass cannot appear in two different
-mappings due to the DeviceClass uniqueness constraint across mappings.
+be evaluated for [Beta](#beta). For count-based mappings, the same DeviceClass
+cannot appear in two different mappings unless the counter names differ.
 
 **Extended resources and capacity sources are not supported together:**
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -304,7 +304,7 @@ GPU memory quota, while a team requesting a 7g.80gb profile should consume 80Gi.
 - The `ResourceClaims` and `ResourceClaimTemplates` APIs for DRA in k8s are immutable.
 - ResourceClaims are not supported in alpha - workloads must use ResourceClaimTemplates.
   Direct ResourceClaim references will result in inadmissible workloads.
-- Device class uniqueness is enforced for count-based mappings - each device class can only map to one resource name to prevent quota ambiguity.
+- Device class uniqueness is enforced. Each device class can only map to one resource name to prevent quota ambiguity. Counter-based mappings relax this when counter names differ.
 - Configuration-based approach - device class mappings are configured through the Kueue Configuration API
 - This design does not work with Kueue's Topology Aware Scheduling feature and will be addressed in future work.
 - DRA resource preprocessing is not scoped by ResourceFlavor node constraints. Counter

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -1640,8 +1640,7 @@ capacity sources cannot be mixed within the same mapping. This means a unified
 quota pool across both device types (e.g., partitioned and time-sliced GPUs both
 charging `gpu.memory`) is not supported. Relaxing the resource name uniqueness
 to allow separate counter and capacity mappings to share a quota resource is to
-be evaluated for [Beta](#beta). For counter-based mappings, the same DeviceClass
-cannot appear in two different mappings unless the counter names differ.
+be evaluated for [Beta](#beta). For counter-based mappings, the same DeviceClass can appear in different mappings when the counter names differ. For device-count and capacity-based mappings, DeviceClass uniqueness remains enforced. 
 
 **Extended resources and capacity sources are not supported together:**
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -575,7 +575,7 @@ complex runtime resolution logic, ensuring predictable and efficient workload ad
 **Note**: A single mapping can have multiple capacity sources that sum into one quota
 resource, which does not violate this constraint. Tracking independent capacity
 dimensions as separate quota resources (same DeviceClass, different resource names)
-remains deferred to beta, while count-based mappings already relax this constraint
+remains deferred to beta, while counter-based mappings already relax this constraint
 for distinct counter names.
 
 ### RBAC Requirements
@@ -1640,7 +1640,7 @@ capacity sources cannot be mixed within the same mapping. This means a unified
 quota pool across both device types (e.g., partitioned and time-sliced GPUs both
 charging `gpu.memory`) is not supported. Relaxing the resource name uniqueness
 to allow separate counter and capacity mappings to share a quota resource is to
-be evaluated for [Beta](#beta). For count-based mappings, the same DeviceClass
+be evaluated for [Beta](#beta). For counter-based mappings, the same DeviceClass
 cannot appear in two different mappings unless the counter names differ.
 
 **Extended resources and capacity sources are not supported together:**


### PR DESCRIPTION
Align the DRA KEP with the current validator behavior. This qualifies DeviceClass uniqueness for count-based mappings, clarifies the remaining beta-only capacity tracking case, and moves the already-delivered multi-counter item into the alpha list.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind documentation

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13987 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that count-based mappings can reuse a DeviceClass when counter names differ.
  * Documented the distinction between multiple capacity sources in one mapping and separate quota resources.
  * Noted that independent capacity dimensions remain deferred to Beta.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->