### PR TITLE
Use resource/v1 for DeviceClass in the DRA fair-sharing test

### DIFF
--- a/test/integration/singlecluster/scheduler/fairsharing/dra_fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/dra_fair_sharing_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
-	resourceapi "k8s.io/api/resource/v1beta2"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,7 +41,7 @@ var _ = ginkgo.Describe("DRA with Admission Fair Sharing", ginkgo.Label("feature
 			defaultFlavor *kueue.ResourceFlavor
 			gpuFlavor     *kueue.ResourceFlavor
 			ns            *corev1.Namespace
-			deviceClass   *resourceapi.DeviceClass
+			deviceClass   *resourcev1.DeviceClass
 			rct           *resourcev1.ResourceClaimTemplate
 
 			cqs []*kueue.ClusterQueue
@@ -97,7 +96,7 @@ var _ = ginkgo.Describe("DRA with Admission Fair Sharing", ginkgo.Label("feature
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "dra-afs-")
 
 			// Create DeviceClass for DRA
-			deviceClass = &resourceapi.DeviceClass{
+			deviceClass = &resourcev1.DeviceClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "gpu.example.com",
 				},
@@ -297,7 +296,7 @@ var _ = ginkgo.Describe("DRA with Admission Fair Sharing", ginkgo.Label("feature
 			defaultFlavor *kueue.ResourceFlavor
 			gpuFlavor     *kueue.ResourceFlavor
 			ns            *corev1.Namespace
-			deviceClass   *resourceapi.DeviceClass
+			deviceClass   *resourcev1.DeviceClass
 			rct           *resourcev1.ResourceClaimTemplate
 
 			cqs []*kueue.ClusterQueue
@@ -330,7 +329,7 @@ var _ = ginkgo.Describe("DRA with Admission Fair Sharing", ginkgo.Label("feature
 			ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "dra-afs-")
 
 			// Create DeviceClass for DRA
-			deviceClass = &resourceapi.DeviceClass{
+			deviceClass = &resourcev1.DeviceClass{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "gpu.example.com",
 				},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

While reading through the DRA integration tests I noticed this one still builds its `DeviceClass` from `k8s.io/api/resource/v1beta2`, even though the `ResourceClaimTemplate` a few lines down already comes from `resource/v1`. `DeviceClass` graduated to GA in `resource/v1` in 1.34, so there is no reason for the test to keep reaching for the beta type.

The change is mechanical: point the two `DeviceClass` constructions at `resourcev1` and drop the now-unused `v1beta2` import. Both of them only set `ObjectMeta` (the `gpu.example.com` name), so the object the apiserver ends up storing is the same either way and the fair-sharing behavior the test actually exercises does not change.

This also turned out to be the last spot in the repository that imported `k8s.io/api/resource/v1beta2`, so the tree no longer references it at all after this. It is a tidy-up rather than anything urgent.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

Test-only, one file, `+4/-5`. I confirmed it type-checks with `go vet ./test/integration/singlecluster/scheduler/fairsharing/`; the integration job will cover the actual run.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated DRA integration tests to consistently use the current resource API version for device class objects.
  * Removed obsolete test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->