### PR TITLE
Validate pod overhead, and charge only what can be charged

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -505,7 +505,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 
 			// For elastic workloads detect a scale-down event and propagate changes to the remote.
 			if group.IsElasticWorkload() && workloadslicing.ScaledDown(workload.ExtractPodSetCountsFromWorkload(remWl), workload.ExtractPodSetCountsFromWorkload(group.local)) {
-				remWl.Spec = group.local.Spec
+				remWl.Spec = specWithChargeableOverhead(&group.local.Spec)
 				updateRemote = true
 			}
 
@@ -676,6 +676,16 @@ func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {
 	local.PodSets = podSetsWithChargeableOverhead(local.PodSets)
 	remote.PodSets = podSetsWithChargeableOverhead(remote.PodSets)
 	return !equality.Semantic.DeepEqual(local, remote)
+}
+
+// specWithChargeableOverhead copies the spec before taking the overhead off it,
+// so the source keeps what it is allowed to carry. A remote weighs anything the
+// manager sends it against what it already holds, and it never held these.
+func specWithChargeableOverhead(src *kueue.WorkloadSpec) kueue.WorkloadSpec {
+	var dst kueue.WorkloadSpec
+	src.DeepCopyInto(&dst)
+	chargeableOverhead(dst.PodSets)
+	return dst
 }
 
 // chargeableOverhead rewrites the overhead in place, for PodSets that are
@@ -1449,10 +1459,7 @@ func cloneForCreate(orig *kueue.Workload, origin string, preemptionGated bool) *
 		remoteWl.Labels = make(map[string]string, 1)
 	}
 	remoteWl.Labels[kueue.MultiKueueOriginLabel] = origin
-	orig.Spec.DeepCopyInto(&remoteWl.Spec)
-	// The worker sees this as a create, so it has no earlier state to weigh it
-	// against and refuses an overhead entry the manager is only carrying.
-	chargeableOverhead(remoteWl.Spec.PodSets)
+	remoteWl.Spec = specWithChargeableOverhead(&orig.Spec)
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) && preemptionGated {
 		// Preemption gates should be treated independently on the remotes and manager,

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -52,6 +52,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
 	"sigs.k8s.io/kueue/pkg/util/api"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
@@ -669,7 +670,39 @@ func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {
 	// so any differences should not be considered as out-of-sync.
 	local.PreemptionGates = nil
 	remote.PreemptionGates = nil
+	// The remote was created without the overhead entries that are not charged,
+	// so compare what both sides would carry rather than deleting and recreating
+	// it on every pass.
+	local.PodSets = podSetsWithChargeableOverhead(local.PodSets)
+	remote.PodSets = podSetsWithChargeableOverhead(remote.PodSets)
 	return !equality.Semantic.DeepEqual(local, remote)
+}
+
+// chargeableOverhead rewrites the overhead in place, for PodSets that are
+// already a copy.
+func chargeableOverhead(podSets []kueue.PodSet) {
+	for i := range podSets {
+		podSets[i].Template.Spec.Overhead = resources.ChargeableOverhead(podSets[i].Template.Spec.Overhead)
+	}
+}
+
+// podSetsWithChargeableOverhead returns podSets, or a shallow copy of it whose
+// overhead is the chargeable part, leaving the caller's slice alone.
+func podSetsWithChargeableOverhead(podSets []kueue.PodSet) []kueue.PodSet {
+	changed := false
+	out := make([]kueue.PodSet, len(podSets))
+	copy(out, podSets)
+	for i := range out {
+		charged := resources.ChargeableOverhead(out[i].Template.Spec.Overhead)
+		if len(charged) != len(out[i].Template.Spec.Overhead) {
+			changed = true
+			out[i].Template.Spec.Overhead = charged
+		}
+	}
+	if !changed {
+		return podSets
+	}
+	return out
 }
 
 func (w *wlReconciler) listComponentWorkloads(ctx context.Context, wl *kueue.Workload) (*kueue.WorkloadList, error) {
@@ -1417,6 +1450,9 @@ func cloneForCreate(orig *kueue.Workload, origin string, preemptionGated bool) *
 	}
 	remoteWl.Labels[kueue.MultiKueueOriginLabel] = origin
 	orig.Spec.DeepCopyInto(&remoteWl.Spec)
+	// The worker sees this as a create, so it has no earlier state to weigh it
+	// against and refuses an overhead entry the manager is only carrying.
+	chargeableOverhead(remoteWl.Spec.PodSets)
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) && preemptionGated {
 		// Preemption gates should be treated independently on the remotes and manager,

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -675,6 +675,9 @@ func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {
 	// it on every pass.
 	local.PodSets = podSetsWithChargeableOverhead(local.PodSets)
 	remote.PodSets = podSetsWithChargeableOverhead(remote.PodSets)
+	// The remote was created without the overhead entries that are not charged,
+	// so compare what both sides would carry rather than deleting and recreating
+	// it on every pass.
 	return !equality.Semantic.DeepEqual(local, remote)
 }
 

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -675,9 +675,6 @@ func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {
 	// it on every pass.
 	local.PodSets = podSetsWithChargeableOverhead(local.PodSets)
 	remote.PodSets = podSetsWithChargeableOverhead(remote.PodSets)
-	// The remote was created without the overhead entries that are not charged,
-	// so compare what both sides would carry rather than deleting and recreating
-	// it on every pass.
 	return !equality.Semantic.DeepEqual(local, remote)
 }
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -3329,8 +3329,27 @@ func TestSpecWithChargeableOverheadLeavesTheSourceAlone(t *testing.T) {
 // reads an entry arriving now as one being introduced, with nothing behind it
 // to grandfather it, and refuses the update for as long as the local carries it.
 func TestReconcileGroupScaleDownKeepsRemoteOverheadNormalized(t *testing.T) {
+	// Both kinds of entry the remote was created without: one Kueue never
+	// charges, and one it only tolerates on an object that predates the gate.
+	cases := map[string]struct {
+		key      corev1.ResourceName
+		quantity string
+		nonNeg   bool
+	}{
+		"a reserved name":                  {key: corev1.ResourcePods, quantity: "1"},
+		"a negative one, with the gate on": {key: corev1.ResourceCPU, quantity: "-1", nonNeg: true},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			runScaleDownOverheadCase(t, tc.key, tc.quantity, tc.nonNeg)
+		})
+	}
+}
+
+func runScaleDownOverheadCase(t *testing.T, key corev1.ResourceName, quantity string, nonNeg bool) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	features.SetFeatureGateDuringTest(t, features.WorkloadValidateResourcesAreNonNegative, nonNeg)
 	now := time.Now()
 
 	const (
@@ -3359,7 +3378,7 @@ func TestReconcileGroupScaleDownKeepsRemoteOverheadNormalized(t *testing.T) {
 		}).
 		ClusterName(workerName).
 		Obj())
-	local.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}
+	local.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{key: resource.MustParse(quantity)}
 
 	remote := elastic(utiltestingapi.MakeWorkload("wl1", TestNamespace).
 		PodSets(*utiltestingapi.MakePodSet("main", 2).Request(corev1.ResourceCPU, "1").Obj()).
@@ -3406,7 +3425,7 @@ func TestReconcileGroupScaleDownKeepsRemoteOverheadNormalized(t *testing.T) {
 		t.Errorf("remote overhead = %v, want none: the scale-down put back what the create left out",
 			got.Spec.PodSets[0].Template.Spec.Overhead)
 	}
-	if _, ok := local.Spec.PodSets[0].Template.Spec.Overhead[corev1.ResourcePods]; !ok {
+	if _, ok := local.Spec.PodSets[0].Template.Spec.Overhead[key]; !ok {
 		t.Error("the local workload lost its overhead, so the normalization reached the caller's slice")
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -45,6 +45,7 @@ import (
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	kueueconstants "sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	"sigs.k8s.io/kueue/pkg/controller/jobs"
@@ -3320,5 +3321,92 @@ func TestSpecWithChargeableOverheadLeavesTheSourceAlone(t *testing.T) {
 	}
 	if diff := cmp.Diff(want.PodSets, src.PodSets); diff != "" {
 		t.Errorf("the source was modified (-want +got):\n%s", diff)
+	}
+}
+
+// A scale-down writes the local spec over the remote one. The remote was
+// created without the overhead entries Kueue will not charge, so the worker
+// reads an entry arriving now as one being introduced, with nothing behind it
+// to grandfather it, and refuses the update for as long as the local carries it.
+func TestReconcileGroupScaleDownKeepsRemoteOverheadNormalized(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	now := time.Now()
+
+	const (
+		acName     = kueue.AdmissionCheckReference("ac1")
+		workerName = "worker1"
+	)
+
+	elastic := func(wl *kueue.Workload) *kueue.Workload {
+		if wl.Annotations == nil {
+			wl.Annotations = map[string]string{}
+		}
+		wl.Annotations[kueueconstants.ElasticJobAnnotation] = "true"
+		return wl
+	}
+
+	// The manager still carries what it was admitted with, one replica fewer
+	// than the remote now that it has scaled down.
+	local := elastic(utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").Obj(), now).
+		AdmittedAt(true, now).
+		AdmissionCheck(kueue.AdmissionCheckState{
+			Name:               acName,
+			State:              kueue.CheckStateReady,
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		ClusterName(workerName).
+		Obj())
+	local.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}
+
+	remote := elastic(utiltestingapi.MakeWorkload("wl1", TestNamespace).
+		PodSets(*utiltestingapi.MakePodSet("main", 2).Request(corev1.ResourceCPU, "1").Obj()).
+		Condition(metav1.Condition{
+			Type:               kueue.WorkloadAdmitted,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Admitted",
+			LastTransitionTime: metav1.NewTime(now),
+		}).
+		Obj())
+
+	managerClient := getClientBuilder(ctx).WithObjects(local).WithStatusSubresource(local).Build()
+	workerClient := NewNeverCachingClient(getClientBuilder(ctx).WithObjects(remote).WithStatusSubresource(remote).Build())
+
+	group := &wlGroup{
+		local:       local,
+		localClient: managerClient,
+		remotes:     map[string]*kueue.Workload{workerName: remote},
+		remoteClients: map[string]*remoteClient{
+			workerName: {client: workerClient, origin: defaultOrigin},
+		},
+		acName:        acName,
+		jobAdapter:    &deferredSyncStubAdapter{},
+		controllerKey: types.NamespacedName{Name: "job1", Namespace: TestNamespace},
+	}
+	reconciler := &wlReconciler{
+		client:            managerClient,
+		clock:             testingclock.NewFakeClock(now),
+		origin:            defaultOrigin,
+		workerLostTimeout: defaultWorkerLostTimeout,
+		recorder:          &utiltesting.EventRecorder{},
+		dispatcherName:    config.MultiKueueDispatcherModeAllAtOnce,
+	}
+
+	if _, err := reconciler.reconcileGroup(ctx, group); err != nil {
+		t.Fatalf("reconcileGroup: %v", err)
+	}
+
+	got := &kueue.Workload{}
+	if err := workerClient.Get(ctx, client.ObjectKeyFromObject(remote), got); err != nil {
+		t.Fatalf("reading the remote back: %v", err)
+	}
+	if len(got.Spec.PodSets[0].Template.Spec.Overhead) != 0 {
+		t.Errorf("remote overhead = %v, want none: the scale-down put back what the create left out",
+			got.Spec.PodSets[0].Template.Spec.Overhead)
+	}
+	if _, ok := local.Spec.PodSets[0].Template.Spec.Overhead[corev1.ResourcePods]; !ok {
+		t.Error("the local workload lost its overhead, so the normalization reached the caller's slice")
 	}
 }

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -3289,3 +3289,36 @@ func TestRemoteCloneNormalizesOverheadWithoutChurn(t *testing.T) {
 		})
 	}
 }
+
+// The remote never held these entries, so it weighs them as newly introduced
+// and refuses them, whatever the manager is allowed to keep carrying.
+func TestSpecWithChargeableOverheadLeavesTheSourceAlone(t *testing.T) {
+	src := kueue.WorkloadSpec{PodSets: []kueue.PodSet{{
+		Name:  "main",
+		Count: 2,
+		Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Overhead: corev1.ResourceList{
+				corev1.ResourcePods: resource.MustParse("1"),
+				corev1.ResourceCPU:  resource.MustParse("-1"),
+				"example.com/keep":  resource.MustParse("2"),
+			},
+		}},
+	}}}
+	want := src.DeepCopy()
+
+	got := specWithChargeableOverhead(&src)
+
+	oh := got.PodSets[0].Template.Spec.Overhead
+	if _, found := oh[corev1.ResourcePods]; found {
+		t.Errorf("the copy kept the pods overhead: %v", oh)
+	}
+	if _, found := oh[corev1.ResourceCPU]; found {
+		t.Errorf("the copy kept the negative overhead: %v", oh)
+	}
+	if q := oh["example.com/keep"]; q.Value() != 2 {
+		t.Errorf("the copy lost the valid overhead: %v", oh)
+	}
+	if diff := cmp.Diff(want.PodSets, src.PodSets); diff != "" {
+		t.Errorf("the source was modified (-want +got):\n%s", diff)
+	}
+}

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -3220,5 +3221,71 @@ func TestReconcileGroup_SyncDeferred_ShortRequeue(t *testing.T) {
 	if gotResult.RequeueAfter != syncDeferredRequeueAfter {
 		t.Fatalf("reconcileGroup result has RequeueAfter=%v; want %v (sync was deferred)",
 			gotResult.RequeueAfter, syncDeferredRequeueAfter)
+	}
+}
+
+// The remote copy is created without the overhead entries Kueue will not
+// charge, so the comparison that decides whether to replace it has to read both
+// sides the same way. Otherwise the remote it just created is out of sync with
+// the local one on the next pass, for as long as the entry is there.
+func TestRemoteCloneNormalizesOverheadWithoutChurn(t *testing.T) {
+	withOverhead := func(o corev1.ResourceList) *kueue.Workload {
+		wl := utiltestingapi.MakeWorkload("wl", TestNamespace).
+			PodSets(*utiltestingapi.MakePodSet("main", 1).
+				Request(corev1.ResourceCPU, "1").Obj()).
+			Obj()
+		wl.Spec.PodSets[0].Template.Spec.Overhead = o
+		return wl
+	}
+
+	cases := map[string]struct {
+		local            corev1.ResourceList
+		wantRemote       corev1.ResourceList
+		remoteAfterClone corev1.ResourceList
+		wantOutOfSync    bool
+	}{
+		"an entry that is not charged is dropped on the way and does not read as a difference": {
+			local:      corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")},
+			wantRemote: corev1.ResourceList{},
+		},
+		"a negative one goes the same way": {
+			local:      corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
+			wantRemote: corev1.ResourceList{},
+		},
+		"an overhead that is charged reaches the remote unchanged": {
+			local:      corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
+			wantRemote: corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
+		},
+		"a remote carrying a different charged overhead is still out of sync": {
+			local:            corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
+			wantRemote:       corev1.ResourceList{"example.com/gpu": resource.MustParse("2")},
+			remoteAfterClone: corev1.ResourceList{"example.com/gpu": resource.MustParse("3")},
+			wantOutOfSync:    true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			local := withOverhead(tc.local)
+			before := local.Spec.PodSets[0].Template.Spec.Overhead.DeepCopy()
+
+			remote := cloneForCreate(local, "origin1", false)
+			if diff := cmp.Diff(tc.wantRemote, remote.Spec.PodSets[0].Template.Spec.Overhead); diff != "" {
+				t.Errorf("remote overhead (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(before, local.Spec.PodSets[0].Template.Spec.Overhead); diff != "" {
+				t.Errorf("the local workload was modified (-before +after):\n%s", diff)
+			}
+
+			if tc.remoteAfterClone != nil {
+				remote.Spec.PodSets[0].Template.Spec.Overhead = tc.remoteAfterClone
+			}
+			if got := isRemoteSpecOutOfSync(local.Spec, remote.Spec); got != tc.wantOutOfSync {
+				t.Errorf("out of sync = %v, want %v", got, tc.wantOutOfSync)
+			}
+			if diff := cmp.Diff(before, local.Spec.PodSets[0].Template.Spec.Overhead); diff != "" {
+				t.Errorf("comparing modified the local workload (-before +after):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -19,6 +19,7 @@ package concurrentadmission
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
 	"time"
 
@@ -48,6 +49,7 @@ import (
 	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
+	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
 	"sigs.k8s.io/kueue/pkg/workload/concurrentadmission"
@@ -358,12 +360,19 @@ func generateVariant(parent *kueue.Workload, flavor kueue.ResourceFlavorReferenc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:          jobframework.GetWorkloadNameForVariant(parent.Name, parent.UID, parent.GroupVersionKind(), string(flavor)),
 			Namespace:     parent.Namespace,
-			Labels:        parent.Labels,
-			Annotations:   parent.Annotations,
+			Labels:        maps.Clone(parent.Labels),
+			Annotations:   maps.Clone(parent.Annotations),
 			ManagedFields: parent.ManagedFields,
 		},
-		Spec:   parent.Spec,
-		Status: parent.Status,
+	}
+	// A variant is a create, so the webhook has no earlier state to weigh an
+	// overhead entry against and refuses one the parent is only carrying. The
+	// copy also keeps the edits below off the parent's own maps and slices.
+	parent.Spec.DeepCopyInto(&variant.Spec)
+	parent.Status.DeepCopyInto(&variant.Status)
+	for i := range variant.Spec.PodSets {
+		variant.Spec.PodSets[i].Template.Spec.Overhead =
+			resources.ChargeableOverhead(variant.Spec.PodSets[i].Template.Spec.Overhead)
 	}
 	variant.Spec.PreemptionGates = slices.Clone(variant.Spec.PreemptionGates)
 	workload.EnsurePreemptionGateOnSpec(variant, controllerconsts.ConcurrentAdmissionPreemptionGate)

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -18,6 +18,7 @@ package concurrentadmission
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -2501,5 +2502,45 @@ func TestCreateVariantsAlreadyExists(t *testing.T) {
 
 	if err := cl.Get(t.Context(), client.ObjectKeyFromObject(existing), &kueue.Workload{}); err != nil {
 		t.Fatalf("pre-existing variant should still exist: %v", err)
+	}
+}
+
+// A variant is a create, so the webhook has nothing earlier to weigh an
+// overhead entry against and refuses one the parent is only allowed to keep.
+func TestGenerateVariantNormalizesOverheadWithoutTouchingTheParent(t *testing.T) {
+	parent := utiltestingapi.MakeWorkload("parent-wl", "default").
+		Queue("lq").
+		Request(corev1.ResourceCPU, "1").
+		Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+		Obj()
+	parent.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+		corev1.ResourcePods: resource.MustParse("1"),
+		corev1.ResourceCPU:  resource.MustParse("-1"),
+		"example.com/keep":  resource.MustParse("2"),
+	}
+	parentLabels := maps.Clone(parent.Labels)
+	parentOverhead := parent.Spec.PodSets[0].Template.Spec.Overhead.DeepCopy()
+
+	variant := generateVariant(parent, "spot")
+
+	got := variant.Spec.PodSets[0].Template.Spec.Overhead
+	if _, found := got[corev1.ResourcePods]; found {
+		t.Errorf("variant kept the pods overhead: %v", got)
+	}
+	if _, found := got[corev1.ResourceCPU]; found {
+		t.Errorf("variant kept the negative overhead: %v", got)
+	}
+	if q := got["example.com/keep"]; q.Value() != 2 {
+		t.Errorf("variant lost the valid overhead: %v", got)
+	}
+
+	if diff := cmp.Diff(parentOverhead, parent.Spec.PodSets[0].Template.Spec.Overhead); diff != "" {
+		t.Errorf("generating the variant changed the parent's overhead (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(parentLabels, parent.Labels); diff != "" {
+		t.Errorf("generating the variant changed the parent's labels (-want +got):\n%s", diff)
+	}
+	if _, found := parent.Annotations[constants.WorkloadAllowedResourceFlavorAnnotation]; found {
+		t.Error("generating the variant wrote its flavor annotation onto the parent")
 	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -475,8 +475,8 @@ const (
 
 	// owner: @vladikkuzn
 	//
-	// Rejects Workloads with negative container, pod-level, or PodSpec overhead
-	// resource requests/limits.
+	// Rejects negative container and pod-level resource requests or limits, and
+	// negative PodSpec overhead quantities.
 	WorkloadValidateResourcesAreNonNegative featuregate.Feature = "WorkloadValidateResourcesAreNonNegative"
 
 	// owner: mszadkow

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -475,7 +475,8 @@ const (
 
 	// owner: @vladikkuzn
 	//
-	// Rejects Workloads with negative container or pod-level resource requests/limits.
+	// Rejects Workloads with negative container, pod-level, or PodSpec overhead
+	// resource requests/limits.
 	WorkloadValidateResourcesAreNonNegative featuregate.Feature = "WorkloadValidateResourcesAreNonNegative"
 
 	// owner: mszadkow

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -17,9 +17,10 @@ limitations under the License.
 package resources
 
 import (
+	"maps"
+
 	corev1 "k8s.io/api/core/v1"
 	resourcehelpers "k8s.io/component-helpers/resource"
-	"maps"
 
 	"sigs.k8s.io/kueue/pkg/features"
 )

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -19,6 +19,7 @@ package resources
 import (
 	corev1 "k8s.io/api/core/v1"
 	resourcehelpers "k8s.io/component-helpers/resource"
+	"maps"
 
 	"sigs.k8s.io/kueue/pkg/features"
 )
@@ -89,14 +90,19 @@ func PodRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
 
 // ChargeableOverhead drops the overhead entries Kueue will not charge.
 func ChargeableOverhead(overhead corev1.ResourceList) corev1.ResourceList {
-	charged := make(corev1.ResourceList, len(overhead))
+	// Most overhead is chargeable, and this sits on the path every PodSet takes
+	// through quota, TAS and the LimitRange checks, so wait for a reason to copy.
+	var charged corev1.ResourceList
 	for name, quantity := range overhead {
-		if name == corev1.ResourcePods || quantity.Sign() < 0 {
+		if name != corev1.ResourcePods && quantity.Sign() >= 0 {
 			continue
 		}
-		charged[name] = quantity
+		if charged == nil {
+			charged = maps.Clone(overhead)
+		}
+		delete(charged, name)
 	}
-	if len(charged) == len(overhead) {
+	if charged == nil {
 		return overhead
 	}
 	return charged

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -72,8 +72,34 @@ func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
 		return NewRequests()
 	}
-	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
-	return NewRequestsFromResourceList(rl)
+	return NewRequestsFromResourceList(PodRequests(podSpec))
+}
+
+// PodRequests aggregates what a PodSpec asks for, less the overhead entries
+// that cannot be charged. `pods` is written from the PodSet count during flavor
+// assignment, and a negative quantity cancels a request the PodSet did make,
+// which nothing downstream can tell apart from nothing having been asked for.
+// Every place Kueue computes requests from a spec goes through here, so quota,
+// topology assignment and LimitRange all read one view of the same Workload.
+func PodRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
+	spec := *podSpec
+	spec.Overhead = ChargeableOverhead(spec.Overhead)
+	return resourcehelpers.PodRequests(&corev1.Pod{Spec: spec}, resourcehelpers.PodResourcesOptions{})
+}
+
+// ChargeableOverhead drops the overhead entries Kueue will not charge.
+func ChargeableOverhead(overhead corev1.ResourceList) corev1.ResourceList {
+	charged := make(corev1.ResourceList, len(overhead))
+	for name, quantity := range overhead {
+		if name == corev1.ResourcePods || quantity.Sign() < 0 {
+			continue
+		}
+		charged[name] = quantity
+	}
+	if len(charged) == len(overhead) {
+		return overhead
+	}
+	return charged
 }
 
 // ToMap converts any Requests instance into a MapRequests map.

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
@@ -53,7 +52,7 @@ func NewMapRequests(rl corev1.ResourceList) MapRequests {
 }
 
 func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
-	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+	return NewMapRequests(PodRequests(podSpec))
 }
 
 func (r MapRequests) Clone() Requests {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -948,10 +948,10 @@ func TestPodRequestsDropsOverheadThatIsNotCharged(t *testing.T) {
 	if diff := cmp.Diff(before, spec.Overhead); diff != "" {
 		t.Errorf("the caller's overhead was modified (-before +after):\n%s", diff)
 	}
-	if v := NewRequestsFromPodSpec(spec).GetValue(corev1.ResourceCPU); v != 1000 {
+	if v := NewRequestsFromPodSpec(spec).ResourceValue(corev1.ResourceCPU); v != 1000 {
 		t.Errorf("NewRequestsFromPodSpec disagrees: cpu %d, want 1000 milli", v)
 	}
-	if v := NewMapRequestsFromPodSpec(spec).GetValue(corev1.ResourceCPU); v != 1000 {
+	if v := NewMapRequestsFromPodSpec(spec).ResourceValue(corev1.ResourceCPU); v != 1000 {
 		t.Errorf("NewMapRequestsFromPodSpec disagrees: cpu %d, want 1000 milli", v)
 	}
 }

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -915,3 +915,43 @@ func TestRequestsEqual(t *testing.T) {
 		})
 	}
 }
+
+// One view: quota, topology assignment and LimitRange all reach a spec through
+// here, so an overhead entry that is not charged must not be visible to any of
+// them, and the spec they were handed must come back unchanged.
+func TestPodRequestsDropsOverheadThatIsNotCharged(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "c",
+			Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			}},
+		}},
+		Overhead: corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("-1"),
+			corev1.ResourcePods: resource.MustParse("8"),
+			"example.com/gpu":   resource.MustParse("2"),
+		},
+	}
+	before := spec.Overhead.DeepCopy()
+
+	got := PodRequests(spec)
+	if cpu := got[corev1.ResourceCPU]; cpu.Value() != 1 {
+		t.Errorf("cpu charged %s, want the container's 1 with the negative overhead left out", cpu.String())
+	}
+	if _, ok := got[corev1.ResourcePods]; ok {
+		t.Errorf("pods reached the charge from overhead: %v", got)
+	}
+	if gpu := got["example.com/gpu"]; gpu.Value() != 2 {
+		t.Errorf("a positive overhead was charged %s, want 2", gpu.String())
+	}
+	if diff := cmp.Diff(before, spec.Overhead); diff != "" {
+		t.Errorf("the caller's overhead was modified (-before +after):\n%s", diff)
+	}
+	if v := NewRequestsFromPodSpec(spec).GetValue(corev1.ResourceCPU); v != 1000 {
+		t.Errorf("NewRequestsFromPodSpec disagrees: cpu %d, want 1000 milli", v)
+	}
+	if v := NewMapRequestsFromPodSpec(spec).GetValue(corev1.ResourceCPU); v != 1000 {
+		t.Errorf("NewMapRequestsFromPodSpec disagrees: cpu %d, want 1000 milli", v)
+	}
+}

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -111,10 +111,20 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	var allErrs field.ErrorList
 	specPath := field.NewPath("spec")
 
+	// On an update, what a PodSet already carried is not this workload's to
+	// refuse again; only what it is asking for now.
+	var previousOverhead map[kueue.PodSetReference]corev1.ResourceList
+	if oldObj != nil {
+		previousOverhead = make(map[kueue.PodSetReference]corev1.ResourceList, len(oldObj.Spec.PodSets))
+		for i := range oldObj.Spec.PodSets {
+			previousOverhead[oldObj.Spec.PodSets[i].Name] = oldObj.Spec.PodSets[i].Template.Spec.Overhead
+		}
+	}
+
 	variableCountPodSets := 0
 	for i := range obj.Spec.PodSets {
 		ps := &obj.Spec.PodSets[i]
-		allErrs = append(allErrs, validatePodSet(ps, specPath.Child("podSets").Index(i))...)
+		allErrs = append(allErrs, validatePodSet(ps, previousOverhead[ps.Name], specPath.Child("podSets").Index(i))...)
 		if ps.MinCount != nil {
 			variableCountPodSets++
 		}
@@ -157,7 +167,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 	return allErrs
 }
 
-func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
+func validatePodSet(ps *kueue.PodSet, oldOverhead corev1.ResourceList, path *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
 	// validate metadata labels and annotations
@@ -177,9 +187,12 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], cPath.Index(ci))...)
 	}
 	// Pod overhead is added to the request PodRequests computes, so it is charged
-	// like the rest and has to be validated with them.
+	// like the rest and has to be validated with them. Entries a workload was
+	// already carrying are left alone, since an update is how it writes a
+	// condition, deactivates, releases quota and drops its finalizer, and its
+	// PodSets are immutable once it has reserved.
 	if ps.Template.Spec.Overhead != nil {
-		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Overhead, path.Child("template", "spec", "overhead"))...)
+		allErrs = append(allErrs, validateResourceList(newOverhead(ps.Template.Spec.Overhead, oldOverhead), path.Child("template", "spec", "overhead"))...)
 	}
 	// validate pod-level resources
 	if ps.Template.Spec.Resources != nil {
@@ -223,6 +236,22 @@ func validateAdmissionChecks(obj *kueue.Workload, basePath *field.Path) field.Er
 		allErrs = append(allErrs, validatePodSetUpdates(&obj.Status.AdmissionChecks[i], obj, basePath.Index(i).Child("podSetUpdates"))...)
 	}
 	return allErrs
+}
+
+// newOverhead drops the entries that are already on the workload unchanged, so
+// what is left is what this request introduces.
+func newOverhead(overhead, old corev1.ResourceList) corev1.ResourceList {
+	if len(old) == 0 {
+		return overhead
+	}
+	introduced := make(corev1.ResourceList, len(overhead))
+	for name, quantity := range overhead {
+		if before, carried := old[name]; carried && before.Cmp(quantity) == 0 {
+			continue
+		}
+		introduced[name] = quantity
+	}
+	return introduced
 }
 
 func validatePodSetUpdates(acs *kueue.AdmissionCheckState, obj *kueue.Workload, basePath *field.Path) field.ErrorList {

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -176,6 +176,11 @@ func validatePodSet(ps *kueue.PodSet, path *field.Path) field.ErrorList {
 	for ci := range ps.Template.Spec.Containers {
 		allErrs = append(allErrs, validateContainer(&ps.Template.Spec.Containers[ci], cPath.Index(ci))...)
 	}
+	// Pod overhead is added to the request PodRequests computes, so it is charged
+	// like the rest and has to be validated with them.
+	if ps.Template.Spec.Overhead != nil {
+		allErrs = append(allErrs, validateResourceList(ps.Template.Spec.Overhead, path.Child("template", "spec", "overhead"))...)
+	}
 	// validate pod-level resources
 	if ps.Template.Spec.Resources != nil {
 		resPath := path.Child("template", "spec", "resources")

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -782,23 +782,48 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		// container and pod-level lists beside it already do, and the two are
 		// only worth having together, but it has to be a decision rather than
 		// something a later reader relaxes for this one field.
-		"a reserved workload keeping a reserved-name overhead cannot be updated": {
+		// A workload that already carries one has to be able to leave. Its
+		// PodSets are immutable once it has reserved, and an update is how it
+		// writes a condition, deactivates, releases quota and drops its
+		// finalizer, so refusing the entry it is not changing would strand it
+		// in Terminating still holding the quota.
+		"a reserved workload keeps a reserved-name overhead it is not changing": {
+			before: reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}),
+			after: func() *kueue.Workload {
+				wl := reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
+				wl.Finalizers = nil
+				wl.Status.Conditions = append(wl.Status.Conditions, metav1.Condition{
+					Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue,
+					Reason: "Succeeded", Message: "done", LastTransitionTime: metav1.NewTime(now),
+				})
+				return wl
+			}(),
+			wantErr: nil,
+		},
+		// Before it reserves, the PodSets can still change, which is where an
+		// entry can actually be introduced. Adding or changing one is refused.
+		"a reserved-name overhead added before reserving is refused": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
-				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
-					corev1.ResourcePods: resource.MustParse("1"),
-				})).
-				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
-					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
-				Obj(),
+				PodSets(*podSetWithOverhead("main", nil)).Obj(),
 			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
 					corev1.ResourcePods: resource.MustParse("1"),
-				})).
-				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
-					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
-				Obj(),
+				})).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "overhead").Key(string(corev1.ResourcePods)), nil, ""),
+			}.ToAggregate(),
+		},
+		"changing a negative overhead to another negative one is refused": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				})).Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-2"),
+				})).Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "overhead").Key("example.com/gpu"), nil, ""),
 			}.ToAggregate(),
 		},
 		// The negative half has a gate, so an operator caught out by it has a
@@ -1539,6 +1564,18 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 
 // podSetWithOverhead builds a PodSet carrying pod overhead, which the wrappers do
 // not otherwise reach.
+// reservedWithOverhead is a workload that already holds quota and a finalizer,
+// which is the shape an existing one takes when the rules change under it.
+func reservedWithOverhead(now time.Time, overhead corev1.ResourceList) *kueue.Workload {
+	wl := utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+		PodSets(*podSetWithOverhead("main", overhead)).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+			PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
+		Obj()
+	wl.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+	return wl
+}
+
 func podSetWithOverhead(name kueue.PodSetReference, overhead corev1.ResourceList) *kueue.PodSet {
 	ps := utiltestingapi.MakePodSet(name, 1).Obj()
 	ps.Template.Spec.Overhead = overhead

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -802,6 +802,15 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		},
 		// Before it reserves, the PodSets can still change, which is where an
 		// entry can actually be introduced. Adding or changing one is refused.
+		"a reserved workload with a legacy overhead can still be deactivated": {
+			before: reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}),
+			after: func() *kueue.Workload {
+				wl := reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
+				wl.Spec.Active = ptr.To(false)
+				return wl
+			}(),
+			wantErr: nil,
+		},
 		"a reserved-name overhead added before reserving is refused": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*podSetWithOverhead("main", nil)).Obj(),

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -806,7 +806,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			before: reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}),
 			after: func() *kueue.Workload {
 				wl := reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
-				wl.Spec.Active = ptr.To(false)
+				wl.Spec.Active = new(bool)
 				return wl
 			}(),
 			wantErr: nil,

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -776,6 +776,51 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		wantErr       error
 		wantWarnings  admission.Warnings
 	}{
+		// A workload that already exists carries its overhead into every update
+		// it takes afterwards, and its PodSets are immutable once it holds
+		// quota, so it cannot be corrected in place. Refusing it is what the
+		// container and pod-level lists beside it already do, and the two are
+		// only worth having together, but it has to be a decision rather than
+		// something a later reader relaxes for this one field.
+		"a reserved workload keeping a reserved-name overhead cannot be updated": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					corev1.ResourcePods: resource.MustParse("1"),
+				})).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					corev1.ResourcePods: resource.MustParse("1"),
+				})).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(podSetsPath.Index(0).Child("template", "spec", "overhead").Key(string(corev1.ResourcePods)), nil, ""),
+			}.ToAggregate(),
+		},
+		// The negative half has a gate, so an operator caught out by it has a
+		// way to keep a reserved workload moving while they fix the source.
+		"the gate lets a reserved workload keep a negative overhead": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: false},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				})).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
+				Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				})).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+					PodSets(kueue.PodSetAssignment{Name: "main"}).Obj(), now).
+				Obj(),
+			wantErr: nil,
+		},
 		"an update may not put a workload in quota reserved with no admission": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).Obj(),

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -776,12 +776,6 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		wantErr       error
 		wantWarnings  admission.Warnings
 	}{
-		// A workload that already exists carries its overhead into every update
-		// it takes afterwards, and its PodSets are immutable once it holds
-		// quota, so it cannot be corrected in place. Refusing it is what the
-		// container and pod-level lists beside it already do, and the two are
-		// only worth having together, but it has to be a decision rather than
-		// something a later reader relaxes for this one field.
 		// A workload that already carries one has to be able to leave. Its
 		// PodSets are immutable once it has reserved, and an update is how it
 		// writes a condition, deactivates, releases quota and drops its
@@ -807,6 +801,44 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			after: func() *kueue.Workload {
 				wl := reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")})
 				wl.Spec.Active = new(bool)
+				return wl
+			}(),
+			wantErr: nil,
+		},
+		// The gate is on here, so this is the ratchet doing the work rather than
+		// the gate not looking.
+		"a reserved workload keeps a negative overhead it is not changing": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       reservedWithOverhead(now, corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")}),
+			after: func() *kueue.Workload {
+				wl := reservedWithOverhead(now, corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")})
+				wl.Status.Conditions = append(wl.Status.Conditions, metav1.Condition{
+					Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue,
+					Reason: "Succeeded", Message: "done", LastTransitionTime: metav1.NewTime(now),
+				})
+				return wl
+			}(),
+			wantErr: nil,
+		},
+		"removing a legacy overhead is how it gets fixed": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					corev1.ResourcePods: resource.MustParse("1"),
+				})).Obj(),
+			after: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", nil)).Obj(),
+			wantErr: nil,
+		},
+		"a reserved workload with a legacy overhead can release its quota": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			before:       reservedWithOverhead(now, corev1.ResourceList{corev1.ResourcePods: resource.MustParse("1")}),
+			after: func() *kueue.Workload {
+				wl := utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+					PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+						corev1.ResourcePods: resource.MustParse("1"),
+					})).Obj()
+				wl.Finalizers = []string{kueue.ResourceInUseFinalizerName}
 				return wl
 			}(),
 			wantErr: nil,

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -130,6 +130,46 @@ func TestValidateWorkload(t *testing.T) {
 				field.Invalid(firstPodSetSpecPath.Child("containers").Index(0).Child("resources", "requests").Key(string(corev1.ResourcePods)), nil, ""),
 			}.ToAggregate(),
 		},
+		// Overhead is added to the request PodRequests computes, so a negative one
+		// takes from the charge and the reserved key is discarded there too.
+		"should reject a negative pod overhead": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				})).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("overhead").Key("example.com/gpu"), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept a negative pod overhead while the gate is off": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: false},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				})).
+				Obj(),
+		},
+		"should reject the reserved pods key in overhead whatever the gate says": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: false},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					corev1.ResourcePods: resource.MustParse("1"),
+				})).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(firstPodSetSpecPath.Child("overhead").Key(string(corev1.ResourcePods)), nil, ""),
+			}.ToAggregate(),
+		},
+		"should accept an ordinary pod overhead": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadValidateResourcesAreNonNegative: true},
+			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*podSetWithOverhead("main", corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("100m"),
+				})).
+				Obj(),
+		},
 		"should reject reserved pods resource key in limits": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
@@ -1450,4 +1490,12 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// podSetWithOverhead builds a PodSet carrying pod overhead, which the wrappers do
+// not otherwise reach.
+func podSetWithOverhead(name kueue.PodSetReference, overhead corev1.ResourceList) *kueue.PodSet {
+	ps := utiltestingapi.MakePodSet(name, 1).Obj()
+	ps.Template.Spec.Overhead = overhead
+	return ps
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -58,6 +58,9 @@ func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload
 	var errs []error
 	for i := range wl.Spec.PodSets {
 		podSpec := &wl.Spec.PodSets[i].Template.Spec
+		// An entry that will not be charged must not stand in for one, or a
+		// RuntimeClass overhead is skipped here and then dropped downstream.
+		podSpec.Overhead = resources.ChargeableOverhead(podSpec.Overhead)
 		if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0 {
 			var runtimeClass nodev1.RuntimeClass
 			if err := cl.Get(ctx, types.NamespacedName{Name: *podSpec.RuntimeClassName}, &runtimeClass); err != nil {

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -116,6 +116,67 @@ func TestAdjustResources(t *testing.T) {
 				).
 				Obj(),
 		},
+		// An overhead Kueue will not charge leaves the PodSet with nothing, so
+		// the RuntimeClass it names is read instead of being passed over.
+		"Handle runtimeClass whose podOverHead is all uncharged entries": {
+			runtimeClasses: []nodev1.RuntimeClass{
+				utiltesting.MakeRuntimeClass("runtime-a", "handler-a").
+					PodOverhead(corev1.ResourceList{
+						corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
+						corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
+					}).
+					RuntimeClass,
+			},
+			wl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("reserved-name", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourcePods: defaultResourceQuantity(corev1.ResourcePods, 1),
+						}).
+						Obj(),
+					*utiltestingapi.MakePodSet("negative", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceCPU: defaultResourceQuantity(corev1.ResourceCPU, -1),
+						}).
+						Obj(),
+					// One charged entry alongside is still an overhead, so the
+					// RuntimeClass stays out of it.
+					*utiltestingapi.MakePodSet("partly-charged", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourcePods:   defaultResourceQuantity(corev1.ResourcePods, 1),
+							corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 2048),
+						}).
+						Obj(),
+				).
+				Obj(),
+			wantWl: utiltestingapi.MakeWorkload("foo", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("reserved-name", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
+							corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
+						}).
+						Obj(),
+					*utiltestingapi.MakePodSet("negative", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
+							corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
+						}).
+						Obj(),
+					*utiltestingapi.MakePodSet("partly-charged", 1).
+						RuntimeClass("runtime-a").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 2048),
+						}).
+						Obj(),
+				).
+				Obj(),
+		},
 		"Handle runtimeClass without podOverHead": {
 			runtimeClasses: []nodev1.RuntimeClass{
 				utiltesting.MakeRuntimeClass("runtime-a", "handler-a").

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -468,6 +468,28 @@ func (i *Info) ResourceUsage() ResourceUsage {
 	return ru
 }
 
+// podSpecForRequests drops the overhead entries that cannot be charged before
+// anything is summed. `pods` is written from the PodSet count during flavor
+// assignment, and a negative quantity cancels a request the PodSet did make,
+// which the floor afterwards cannot tell from nothing having been asked for.
+// The webhook refuses both, and refuses them only on the way in, so a workload
+// that predates it or was admitted while the check was off still reaches here.
+func podSpecForRequests(spec *corev1.PodSpec) corev1.PodSpec {
+	charged := make(corev1.ResourceList, len(spec.Overhead))
+	for name, quantity := range spec.Overhead {
+		if name == corev1.ResourcePods || quantity.Sign() < 0 {
+			continue
+		}
+		charged[name] = quantity
+	}
+	if len(charged) == len(spec.Overhead) {
+		return *spec
+	}
+	out := *spec
+	out.Overhead = charged
+	return out
+}
+
 func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string) corev1.ResourceList {
 	res := corev1.ResourceList{}
 	for inputName, inputQuantity := range input {
@@ -693,7 +715,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Name:  ps.Name,
 			Count: count,
 		}
-		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
+		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: podSpecForRequests(&ps.Template.Spec)}, resourcehelpers.PodResourcesOptions{})
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/util/sets"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -468,28 +467,6 @@ func (i *Info) ResourceUsage() ResourceUsage {
 	return ru
 }
 
-// podSpecForRequests drops the overhead entries that cannot be charged before
-// anything is summed. `pods` is written from the PodSet count during flavor
-// assignment, and a negative quantity cancels a request the PodSet did make,
-// which the floor afterwards cannot tell from nothing having been asked for.
-// The webhook refuses both, and refuses them only on the way in, so a workload
-// that predates it or was admitted while the check was off still reaches here.
-func podSpecForRequests(spec *corev1.PodSpec) corev1.PodSpec {
-	charged := make(corev1.ResourceList, len(spec.Overhead))
-	for name, quantity := range spec.Overhead {
-		if name == corev1.ResourcePods || quantity.Sign() < 0 {
-			continue
-		}
-		charged[name] = quantity
-	}
-	if len(charged) == len(spec.Overhead) {
-		return *spec
-	}
-	out := *spec
-	out.Overhead = charged
-	return out
-}
-
 func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string) corev1.ResourceList {
 	res := corev1.ResourceList{}
 	for inputName, inputQuantity := range input {
@@ -715,7 +692,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Name:  ps.Name,
 			Count: count,
 		}
-		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: podSpecForRequests(&ps.Template.Spec)}, resourcehelpers.PodResourcesOptions{})
+		specRequests := resources.PodRequests(&ps.Template.Spec)
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -384,6 +384,61 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		// Quota keeps the usage the admission recorded, so upgrading the
+		// controller does not move a reservation that is already held. The
+		// topology domains are rebuilt from the PodSpec, so the same workload
+		// stops under-reporting what it takes from a node.
+		"admitted with TAS and a legacy overhead": {
+			workload: *utiltestingapi.MakeWorkload("tas-legacy", "").
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+						Request(corev1.ResourceCPU, "1").
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceCPU:  resource.MustParse("-750m"),
+							corev1.ResourcePods: resource.MustParse("8"),
+						}).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Obj(),
+				).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("tas-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							// What the overhead used to reduce it to: 250m a pod.
+							Assignment(corev1.ResourceCPU, "tas", "500m").
+							Count(2).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(utiltestingapi.MakeDefaultOneLevelTopology("default"))).
+								Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 2).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now,
+				).
+				Obj(),
+			wantInfo: Info{
+				ClusterQueue: "tas-cq",
+				TotalRequests: []PodSetResources{
+					{
+						Name: kueue.DefaultPodSetName,
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+							corev1.ResourceCPU: "tas",
+						},
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							corev1.ResourceCPU: 500,
+						}),
+						Count: 2,
+						TopologyRequest: &TopologyRequest{
+							Levels: []string{corev1.LabelHostname},
+							DomainRequests: []TopologyDomainRequests{{
+								Values: []string{"node-a"},
+								SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+									corev1.ResourceCPU: 1000,
+								}),
+								Count: 2,
+							}},
+						},
+					},
+				},
+			},
+		},
 		"admitted with reclaim; reclaimablePods on": {
 			workload: *utiltestingapi.MakeWorkload("", "").
 				PodSets(
@@ -1000,14 +1055,12 @@ func TestNewInfo(t *testing.T) {
 		// request the PodSet did make and the floor afterwards cannot tell that
 		// from nothing having been asked for.
 		"negativeOverheadDoesNotCancelTheRequest": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("legacy", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					"example.com/gpu": resource.MustParse("-1"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("legacy", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")}).
+					Obj()).
+				Obj(),
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
@@ -1019,14 +1072,12 @@ func TestNewInfo(t *testing.T) {
 			},
 		},
 		"podsOverheadDoesNotReachTheCount": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("legacy", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					corev1.ResourcePods: resource.MustParse("8"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("legacy", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{corev1.ResourcePods: resource.MustParse("8")}).
+					Obj()).
+				Obj(),
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
@@ -1038,14 +1089,12 @@ func TestNewInfo(t *testing.T) {
 			},
 		},
 		"positiveOverheadIsStillCharged": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("ok", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					"example.com/gpu": resource.MustParse("2"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("ok", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("2")}).
+					Obj()).
+				Obj(),
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -994,6 +994,68 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// The webhook refuses these on the way in, and only on the way in. A
+		// workload that predates it, or was admitted while the gate was off,
+		// still reaches the accounting, where a negative overhead cancels a
+		// request the PodSet did make and the floor afterwards cannot tell that
+		// from nothing having been asked for.
+		"negativeOverheadDoesNotCancelTheRequest": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("legacy", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("-1"),
+				}
+				return *wl
+			}(),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 1,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"podsOverheadDoesNotReachTheCount": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("legacy", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					corev1.ResourcePods: resource.MustParse("8"),
+				}
+				return *wl
+			}(),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 1,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"positiveOverheadIsStillCharged": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("ok", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("2"),
+				}
+				return *wl
+			}(),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 3,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -285,6 +285,32 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 						Obj()
 				},
 				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("should not allow a negative pod overhead",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("bad", 1).
+								PodOverHead(corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("-1"),
+								}).
+								Obj(),
+						).
+						Obj()
+				},
+				utiltesting.BeForbiddenError()),
+			ginkgo.Entry("should not allow the reserved pods name in a pod overhead",
+				func() *kueue.Workload {
+					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
+						PodSets(
+							*utiltestingapi.MakePodSet("bad", 1).
+								PodOverHead(corev1.ResourceList{
+									corev1.ResourcePods: resource.MustParse("1"),
+								}).
+								Obj(),
+						).
+						Obj()
+				},
+				utiltesting.BeForbiddenError()),
 			ginkgo.Entry("should not allow negative pod-level resource requests",
 				func() *kueue.Workload {
 					return utiltestingapi.MakeWorkload(workloadName, ns.Name).
@@ -1113,6 +1139,55 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(workload), &wl)).To(gomega.Succeed())
 				wl.Spec.QueueName = "" // omitempty omits the field → has(self.spec.queueName)==false
 				g.Expect(k8sClient.Update(ctx, &wl)).Should(utiltesting.BeInvalidError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// The webhook refuses these on the way in, and a Workload that predates it
+		// still has to be operable: its charge is already recorded, and every path
+		// that releases it, deactivation and finalizer removal among them, is an
+		// update that would be refused if the whole spec were validated again.
+		ginkgo.It("Should let a workload that already carries a refused overhead keep going", func() {
+			ginkgo.By("Creating a workload with a negative overhead while the gate is off")
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadValidateResourcesAreNonNegative, false)
+			wl := utiltestingapi.MakeWorkload(workloadName, ns.Name).
+				PodSets(
+					*utiltestingapi.MakePodSet("main", 1).
+						PodOverHead(corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("-1"),
+						}).
+						Obj(),
+				).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("Turning the gate back on")
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.WorkloadValidateResourcesAreNonNegative, true)
+
+			ginkgo.By("Refusing an update that changes the overhead to another refused value")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+				updated.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("-2"),
+				}
+				g.Expect(k8sClient.Update(ctx, &updated)).Should(utiltesting.BeForbiddenError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Allowing an update that leaves the overhead as it was")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+				updated.Labels = map[string]string{"example.com/test": "ratcheting"}
+				g.Expect(k8sClient.Update(ctx, &updated)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Deactivating it once it holds a quota reservation")
+			util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), utiltestingapi.MakeAdmission("cq").Obj())
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updated kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+				updated.Spec.Active = new(false)
+				g.Expect(k8sClient.Update(ctx, &updated)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`validatePodSet` walks the init containers, the containers, and the pod-level resources:

```go
	// validate initContainers
	icPath := path.Child("template", "spec", "initContainers")
	...
	// validate containers
	cPath := path.Child("template", "spec", "containers")
	...
	// validate pod-level resources
	if ps.Template.Spec.Resources != nil {
```

It stops there, and `spec.overhead` is part of the charge. `totalRequestsFromPodSets` calls `resourcehelpers.PodRequests` with a zero-valued options struct, so `ExcludeOverhead` is false and `component-helpers` adds it:

```go
	if !opts.ExcludeOverhead && pod.Spec.Overhead != nil {
		addResourceList(reqs, pod.Spec.Overhead)
	}
```

So overhead was the one place a quantity reached quota without passing the checks the rest of the PodSet's quantities pass. Two of them matter:

A negative overhead is subtracted from the request even with `WorkloadValidateResourcesAreNonNegative` enabled, and `Requests.FloorToZero` afterwards turns a large enough one into a clean zero. A container requesting `example.com/gpu: 1` alongside an overhead of `example.com/gpu: -1` reaches the queue at zero.

`pods`, which `validateResourceList` refuses in every list it does reach, was accepted in overhead. Flavor assignment replaces that key with the PodSet count, so the value is discarded rather than counted.

Sending overhead through `validateResourceList` closes both, each on the terms it already has: the reserved name unconditionally, the sign behind the feature gate.

##### What this leaves alone

Nothing else about overhead changes, and a PodSet without one is untouched. The reserved-name and non-negative rules are the existing ones; this only reaches them from a field that was missed.

#### Which issue(s) this PR fixes:

Fixes #13991

#### Special notes for your reviewer:

Four cases were written failing first: a negative overhead with the gate on, the same with the gate off, `pods` in overhead under a gate that is off, and an ordinary overhead. Removing the two lines turns exactly the two rejecting cases red.

Refusing it on every update instead would strand the Workloads that already have one. A reserved Workload with a `pods` overhead cannot write a Finished condition, cannot be deactivated, and cannot drop its `resource-in-use` finalizer after a delete, since that removal is an Update; it would sit in Terminating still holding the quota, and `pods` has no gate to turn off. So the check reads what the request introduces rather than what the object already had, which is also the only thing a reserved Workload can change, its PodSets being immutable by then.

Letting it stay means it would keep being charged, so the accounting stops reading it. Before anything is summed, an overhead entry naming `pods` or holding a negative quantity is dropped: the first is written from the PodSet count during flavor assignment, and the second cancels a request the PodSet did make, which `FloorToZero` afterwards cannot tell apart from nothing having been asked for. A request of 1 with an overhead of -1 is charged 1 rather than 0, `pods: 8` leaves the count alone, and a positive overhead is still added. That also makes turning the gate off a way through a rollout, which it was not before: the gate only ever stopped the value arriving, never stopped it cancelling.

MultiKueue and ConcurrentAdmission are here because each builds a Workload by copying one. That copy is a create, so there is no earlier state for the webhook to ratchet against, and a parent only carrying a legacy entry would have its copy refused. Both take the same view the accounting reads, `resources.ChargeableOverhead`, on a copy, so the source keeps what it is allowed to keep and the comparison against a remote does not churn on a difference neither side can act on.

The two halves of an admitted Workload are treated differently on purpose. Its quota reservation stays at the figure recorded when it was granted, because re-charging a Workload that already holds one is not this PR's to do. Its topology usage does not, because leaving TAS on the old figure would have it go on believing a node has room the Pods are not using.

The same trap exists for the container and pod-level lists this sits beside, which refuse an unchanged legacy value on every update today. That is worth deciding separately rather than copying.

Three integration cases sit beside the existing negative-request ones in the webhook suite. A negative overhead and one naming `pods` are refused on creation, and a Workload that already carries a negative one is refused when it changes it to another negative value, allowed through an update that leaves it alone, and still able to be deactivated once it holds a reservation. That last one is the reason for the ratchet, and it is the one a unit test on `validatePodSet` cannot show: what decides it is the webhook being registered on the update. Reverting the ratchet turns that case red and leaves the other two green.

The `pods` half of the ratchet has no integration case and cannot have one. Its refusal has no gate, so once this lands no such Workload can be created through the API and only an object that predates it can carry one. That half stays in the unit tests.

A Workload the webhook refuses leaves the Job that produced it without an event, the same as any other spec it refuses today, so an operator sees a Job that does not start rather than a reason. This adds a way to reach that, it does not add the behaviour, and improving it belongs with the rest of that path rather than here.

This is the remaining resource list on a Workload that was not passed through `validateResourceList`. It is not the last thing between a quantity and a DRA logical resource: #14004 shows a positive, validated overhead being deleted with the key it shares. #13985 and #13988 cover the two an administrator can supply through configuration; this is the one a user can put on a Workload.

#### Does this PR introduce a user-facing change?

```release-note
ACTION REQUIRED: Kueue now validates `spec.podSets[].template.spec.overhead` with the rest of a Workload's resource quantities: an entry named `pods` is rejected, and a negative quantity is rejected while `WorkloadValidateResourcesAreNonNegative` is enabled. A Workload that already carries such an entry keeps it, so it can still be updated, deactivated and deleted; introducing or changing one is rejected.

Such an entry no longer reaches the charge either. It cannot cancel a request the PodSet made, and it cannot stand in for Kueue's Pod count. Where it was the only overhead on a PodSet naming a `runtimeClassName`, the RuntimeClass overhead applies instead. A Workload holding a quota reservation keeps the quota usage recorded in its `status.admission` until that reservation is released. Its topology usage is not held the same way: `SinglePodRequests` is rebuilt from the PodSpec on every pass, so a TAS Workload admitted before this keeps its quota figure while its domains pick up the corrected one.

Where a cluster may still hold such a Workload, upgrade MultiKueue manager clusters before their workers, and roll workers back before their managers. A manager on this version normalizes the remote Workload it creates; an older one sends the entry as it is, to a worker that now validates creates and has no earlier state to weigh it against.

Fix the Job or controller producing the invalid specification, then recreate the affected Workload.
```




#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for Pod overhead resource requests and limits.
  * Positive, chargeable Pod overhead is included in total resource accounting.
  * Pod-count and other non-chargeable overhead are excluded from resource calculations.
  * Workload synchronization consistently normalizes overhead across environments.

* **Bug Fixes**
  * Negative overhead can no longer reduce requested resources.
  * Reserved Pod overhead resource entries are rejected.
  * Existing workloads with previously accepted overhead remain compatible during updates, while new or changed invalid overhead is rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









