### PR TITLE
RayCluster: make the autoscaling validation error name the elastic-job annotation

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -149,7 +149,9 @@ func (w *RayClusterWebhook) validateCreate(ctx context.Context, job *rayv1.RayCl
 				field.Invalid(
 					specPath.Child("enableInTreeAutoscaling"),
 					spec.EnableInTreeAutoscaling,
-					"a kueue managed job can use autoscaling only when the ElasticJobsViaWorkloadSlices feature gate is on and the job is an elastic job",
+					fmt.Sprintf("a kueue-managed RayCluster can use in-tree autoscaling only as an elastic job: "+
+						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
+						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),
 			)
 		}

--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -149,7 +149,7 @@ func (w *RayClusterWebhook) validateCreate(ctx context.Context, job *rayv1.RayCl
 				field.Invalid(
 					specPath.Child("enableInTreeAutoscaling"),
 					spec.EnableInTreeAutoscaling,
-					fmt.Sprintf("a kueue-managed RayCluster can use in-tree autoscaling only as an elastic job: "+
+					fmt.Sprintf("a kueue-managed RayCluster can use autoscaling only as an elastic job: "+
 						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
 						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -151,7 +151,9 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec", "enableInTreeAutoscaling"),
 					new(true),
-					"a kueue managed job can use autoscaling only when the ElasticJobsViaWorkloadSlices feature gate is on and the job is an elastic job",
+					fmt.Sprintf("a kueue-managed RayCluster can use in-tree autoscaling only as an elastic job: "+
+						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
+						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),
 			}.ToAggregate(),
 		},

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -151,7 +151,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec", "enableInTreeAutoscaling"),
 					new(true),
-					fmt.Sprintf("a kueue-managed RayCluster can use in-tree autoscaling only as an elastic job: "+
+					fmt.Sprintf("a kueue-managed RayCluster can use autoscaling only as an elastic job: "+
 						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
 						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

When a Kueue-managed `RayCluster` sets `spec.enableInTreeAutoscaling: true` but is not an elastic job, the create webhook rejects it. The old error message ended with "…and the job is an elastic job", which states the constraint but does not tell the user how to satisfy it.

This makes the message actionable by naming the exact requirements:

> a kueue-managed RayCluster can use in-tree autoscaling only as an elastic job: enable the ElasticJobsViaWorkloadSlices feature gate and set the "kueue.x-k8s.io/elastic-job": "true" annotation

The annotation key/value are built from `workloadslicing.EnabledAnnotationKey` / `EnabledAnnotationValue`, so the message can't drift from the constant that actually gates the behavior. No behavior change — only the message text.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Message text and the `TestValidateCreate` expectation are generated from the same constants. AI tools were used to help draft this change, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
RayCluster: Fixed an unclear validation error for Kueue-managed RayClusters that enable in-tree autoscaling without being configured as elastic jobs. The error explains that "ElasticJobsViaWorkloadSlices" and the "kueue.x-k8s.io/elastic-job: "true"" annotation are required.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscaling validation messages for Kueue-managed RayClusters.
  * Errors now clearly identify the required feature gate and workload annotation for elastic-job autoscaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->