### PR TITLE
Keep the retained input as requested when multiplyBy scales the outputs

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -569,7 +569,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -621,7 +621,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/keps/2937-resource-transformer/README.md
+++ b/keps/2937-resource-transformer/README.md
@@ -391,11 +391,15 @@ Based on the example in Story 3, the following content can be defined in the Kue
 resources:
   transformations:
   - input: nvidia.com/gpumem
-    strategy: Retain
+    strategy: Replace
     multiplyBy: nvidia.com/gpu
     outputs:
       nvidia.com/total-gpumem: 1
 ```
+
+`multiplyBy` scales the outputs. It does not change what `Retain` keeps under the
+input's own name, so with `Retain` here the effective request above would also
+carry `nvidia.com/gpumem: 1024` and the ClusterQueue would have to cover it.
 
 ### Observability
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -576,16 +576,18 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	output := make(corev1.ResourceList)
 	for inputName, inputQuantity := range input {
 		if mapping, ok := transforms[inputName]; ok {
-			// If MultiplyBy is specified, multiply the input quantity by
-			// the value of the resource specified in MultiplyBy.
+			// MultiplyBy scales the value the outputs are computed from. Retain
+			// still keeps the input as it was requested, so the multiplier only
+			// reaches the outputs and never inflates the retained charge.
+			scaledInput := inputQuantity
 			if mapping.MultiplyBy != "" {
 				if q, ok := input[mapping.MultiplyBy]; ok {
-					inputQuantity = multiplyResourceQuantities(inputQuantity, q)
+					scaledInput = multiplyResourceQuantities(inputQuantity, q)
 				}
 			}
 
 			for outputName, baseFactor := range mapping.Outputs {
-				outputQuantity := multiplyResourceQuantities(inputQuantity, baseFactor)
+				outputQuantity := multiplyResourceQuantities(scaledInput, baseFactor)
 				if accumulated, ok := output[outputName]; ok {
 					outputQuantity.Add(accumulated)
 				}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -578,7 +578,7 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		if mapping, ok := transforms[inputName]; ok {
 			// MultiplyBy scales the value the outputs are computed from. Retain
 			// still keeps the input as it was requested, so the multiplier only
-			// reaches the outputs and never inflates the retained charge.
+			// reaches the outputs and never changes the retained charge.
 			scaledInput := inputQuantity
 			if mapping.MultiplyBy != "" {
 				if q, ok := input[mapping.MultiplyBy]; ok {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -763,8 +763,9 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
-					Input:      "example.com/gpumem",
-					Strategy:   ptr.To(config.Retain),
+					Input: "example.com/gpumem",
+					// Strategy left unset: nil defaults to Retain in production,
+					// so this covers the path an operator gets without asking.
 					MultiplyBy: corev1.ResourceCPU,
 					Outputs: corev1.ResourceList{
 						"example.com/gpumem-quota": resource.MustParse("1"),

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -713,6 +713,41 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		"transformRetainWithMultiplyBy": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request("example.com/gpu", "2").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "example.com/gpumem",
+					Strategy:   ptr.To(config.Retain),
+					MultiplyBy: "example.com/gpu",
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							// Retain keeps gpumem as requested (1024), not the multiplyBy
+							// product (2048); the multiplier only scales the quota output.
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 2048,
+							corev1.ResourceName("example.com/gpu"):          2,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -748,6 +748,43 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		// A multiplier below one is the direction that undercharges: the old
+		// behaviour retained 512 for a PodSet that asked for 1024, and every
+		// check on the way past reads a positive, exactly representable number
+		// that arrives once.
+		"transformRetainWithMultiplyByUnderOne": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request(corev1.ResourceCPU, "500m").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "example.com/gpumem",
+					Strategy:   ptr.To(config.Retain),
+					MultiplyBy: corev1.ResourceCPU,
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 512,
+							corev1.ResourceCPU:                              500,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1149,7 +1149,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1341,7 +1341,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`multiplyBy` scales the value a transformation's outputs are computed from, by another resource the PodSet requests. The loop did that by reassigning the input's own quantity to the product:

```go
if mapping.MultiplyBy != "" {
	if q, ok := input[mapping.MultiplyBy]; ok {
		inputQuantity = multiplyResourceQuantities(inputQuantity, q)
	}
}
```

`Retain` then writes that same reassigned quantity back under the input's own name, so what is retained is the product rather than what was asked for.

Both directions are reachable. A PodSet requesting 1024 `example.com/gpumem` with `multiplyBy` on an `example.com/gpu` of 2 keeps 2048, charged for memory it never requested and scaled by a device count that has nothing to do with it. A multiplier below one goes the other way: the same request with `multiplyBy` on a `cpu` of 500m keeps 512, so the charge is smaller than the request.

The under-charging direction is the one that matters for quota. It is also invisible to the checks around it: 512 is positive, exactly representable, and reached the merge once.

The outputs now come from a separate quantity, and `Retain` keeps the input as it was requested.

##### What this leaves alone

A transformation without `multiplyBy` is unaffected, and so is `Replace`, which does not write the input back at all. Outputs whose names do not collide with a directly requested resource still scale exactly as before; #13990 covers the ones that do.

A `multiplyBy` naming a resource that is not in the list by the time transformations run is still treated as no scaling at all, which reads as multiplying by one. That is not only the absent case: `excludeResourcePrefixes` is applied first, so a multiplier the PodSet does request can be filtered out from under it. #14007 tracks that separately.

#### Which issue(s) this PR fixes:

Fixes #13992

#### Special notes for your reviewer:

The case is a table entry in `TestNewInfo`, so it goes through the same path a Workload's requests are built on. Putting the product back under the input's name turns it red.

This was on #13986 for a while. The two do not overlap: that one validates the sign of an output factor in the operator's configuration, this one is the transformer's own semantics, and they touch no file in common.

#### Does this PR introduce a user-facing change?

```release-note
ACTION REQUIRED: Fixed a bug where a resource transformation using `multiplyBy` with the `Retain` strategy kept the multiplied quantity under the input resource's own name instead of the quantity the PodSet requested.

New, pending and requeued Workloads using that combination are now charged the requested amount, which is more than before when the multiplier is below one and less when it is above, so a ClusterQueue covering the input resource may need more quota than it did. A Workload that already holds a quota reservation is rebuilt from the usage recorded in its admission rather than from the configuration, so it keeps the charge it was admitted with until that reservation is released.
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected resource transformation behavior so `MultiplyBy` scales derived output quantities without changing the original input quantity retained under the `Retain` strategy.
  - Added coverage for retained resources, fractional multipliers, and default transformation behavior.

- **Documentation**
  - Clarified `MultiplyBy` semantics across configuration references and transformation examples.
  - Updated examples to distinguish output scaling from retained input resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->