### PR TITLE
Fix TAS flavor fallback by recomputing workload assignment

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -648,7 +648,19 @@ func New(
 func (a *FlavorAssigner) Assign(ctx context.Context, counts []int32) Assignment {
 	log := log.FromContext(ctx)
 
-	return a.assignFlavors(ctx, log, counts)
+	tasFlavorModes := make(tasFlavorModes)
+	for {
+		assignment := a.assignFlavors(ctx, log, counts, tasFlavorModes)
+		if !features.Enabled(features.TopologyAwareScheduling) || assignment.RepresentativeMode() == NoFit {
+			return assignment
+		}
+		if !a.assignTopology(ctx, log, &assignment, tasFlavorModes) {
+			if features.Enabled(features.UnadmittedWorkloadsObservability) {
+				assignment.resolveNoFitReason(a.cq)
+			}
+			return assignment
+		}
+	}
 }
 
 type indexedPodSet struct {
@@ -657,7 +669,80 @@ type indexedPodSet struct {
 	podSetAssignment *PodSetAssignment
 }
 
-func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, counts []int32) Assignment {
+type tasFlavorModeKey struct {
+	podSetName kueue.PodSetReference
+	flavor     kueue.ResourceFlavorReference
+}
+
+type tasFlavorMode struct {
+	preemptionMode preemptionMode
+	reasons        []string
+}
+
+type tasFlavorModes map[tasFlavorModeKey]tasFlavorMode
+
+func (m tasFlavorModes) modeForPodSets(
+	podSetIDs []int,
+	wl *workload.Info,
+	flavor kueue.ResourceFlavorReference,
+) (tasFlavorMode, bool) {
+	result := tasFlavorMode{preemptionMode: fit}
+	found := false
+	for _, podSetID := range podSetIDs {
+		mode, exists := m[tasFlavorModeKey{
+			podSetName: wl.Obj.Spec.PodSets[podSetID].Name,
+			flavor:     flavor,
+		}]
+		if !exists {
+			continue
+		}
+		found = true
+		if mode.preemptionMode < result.preemptionMode {
+			result.preemptionMode = mode.preemptionMode
+		}
+		result.reasons = mergeUnique(result.reasons, mode.reasons)
+	}
+	return result, found
+}
+
+func (a *FlavorAssigner) downgradeTASFlavorMode(
+	modes tasFlavorModes,
+	failure *schdcache.FailureInfo,
+	mode preemptionMode,
+) bool {
+	failedPodSetIndex := slices.IndexFunc(a.wl.Obj.Spec.PodSets, func(podSet kueue.PodSet) bool {
+		return podSet.Name == failure.PodSetName
+	})
+	if failedPodSetIndex < 0 {
+		return false
+	}
+
+	failedGroupName := podSetGroupName(&a.wl.Obj.Spec.PodSets[failedPodSetIndex])
+	changed := false
+	for i := range a.wl.Obj.Spec.PodSets {
+		podSet := &a.wl.Obj.Spec.PodSets[i]
+		belongsToFailedGroup := podSet.Name == failure.PodSetName
+		if failedGroupName != nil {
+			groupName := podSetGroupName(podSet)
+			belongsToFailedGroup = groupName != nil && *groupName == *failedGroupName
+		}
+		if !belongsToFailedGroup {
+			continue
+		}
+
+		key := tasFlavorModeKey{podSetName: podSet.Name, flavor: failure.Flavor}
+		current, found := modes[key]
+		if !found || mode < current.preemptionMode {
+			current.preemptionMode = mode
+			changed = true
+		}
+		current.reasons = mergeUnique(current.reasons, []string{failure.Reason})
+		modes[key] = current
+	}
+	return changed
+}
+
+func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, counts []int32, tasFlavorModes tasFlavorModes) Assignment {
 	requests := make([]workload.PodSetResources, len(a.wl.TotalRequests))
 	if len(counts) == 0 {
 		for i, ps := range a.wl.TotalRequests {
@@ -774,7 +859,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 				continue
 			}
 
-			flavors, status, considered := a.findFlavorForPodSets(ctx, log, psIDs, requests, resName, assignment.Usage.Quota.Assigned)
+			flavors, status, considered := a.findFlavorForPodSets(ctx, log, psIDs, requests, resName, assignment.Usage.Quota.Assigned, tasFlavorModes)
 			mergeFlavorAttemptsForResource(consideredFlavors, considered, resName, a.cq)
 			if status.IsError() || (len(flavors) == 0 && requests.Len() > 0) {
 				groupFlavors = nil
@@ -813,49 +898,6 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 		return assignment
 	}
 
-	if features.Enabled(features.TopologyAwareScheduling) {
-		tasRequests := assignment.WorkloadsTopologyRequests(log, a.wl, a.cq)
-		if assignment.RepresentativeMode() == Fit {
-			result := a.cq.FindTopologyAssignmentsForWorkload(ctx, tasRequests, schdcache.WithWorkload(a.wl.Obj))
-			if failure := result.Failure(); failure != nil {
-				// There is at least one PodSet which does not fit
-				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
-				psAssignment.reason(failure.Reason)
-				// update the mode for all flavors and the representative mode
-				assignment.updateMode(failure.PodSetName, Preempt)
-			} else {
-				// All PodSets fit, we just update the TopologyAssignments
-				assignment.UpdateForTASResult(log, a.cq, a.wl, result)
-			}
-		}
-		if assignment.RepresentativeMode() == Preempt && !workload.HasUnhealthyNodes(a.wl.Obj) {
-			// Don't preempt other workloads if looking for a failed node replacement
-			result := a.cq.FindTopologyAssignmentsForWorkload(
-				ctx,
-				tasRequests,
-				schdcache.WithSimulateEmpty(true),
-				schdcache.WithWorkload(a.wl.Obj),
-			)
-			if failure := result.Failure(); failure != nil {
-				// There is at least one PodSet which does not fit even if
-				// all workloads are preempted.
-				psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
-				if features.Enabled(features.UnadmittedWorkloadsObservability) {
-					psAssignment.markFlavorAttempt(failure.Flavor, NoFit, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
-				}
-				// update the mode for all flavors and the representative mode
-				assignment.updateMode(failure.PodSetName, NoFit)
-			} else {
-				// Update TAS-related assignments to Preempt because preemptions might be needed
-				// in resources in which total unused quota is sufficient (Fit), but the
-				// quota is fragmented.
-				assignment.updateModeForTASRequests(tasRequests, Preempt)
-			}
-		}
-	}
-	if features.Enabled(features.UnadmittedWorkloadsObservability) {
-		assignment.resolveNoFitReason(a.cq)
-	}
 	return assignment
 }
 
@@ -894,6 +936,77 @@ func (a *FlavorAssigner) resolvePodSetFlavors(log logr.Logger, idxPodSet indexed
 	}
 
 	return nil
+}
+
+func (a *FlavorAssigner) assignTopology(
+	ctx context.Context,
+	log logr.Logger,
+	assignment *Assignment,
+	tasFlavorModes tasFlavorModes,
+) bool {
+	tasRequests := assignment.WorkloadsTopologyRequests(log, a.wl, a.cq)
+	if assignment.RepresentativeMode() == Fit {
+		result := a.cq.FindTopologyAssignmentsForWorkload(ctx, tasRequests, schdcache.WithWorkload(a.wl.Obj))
+		failure := result.Failure()
+		if failure == nil {
+			assignment.UpdateForTASResult(log, a.cq, a.wl, result)
+			return false
+		}
+
+		if a.shouldRetryFlavorAssignmentAfterTASFailure() &&
+			a.downgradeTASFlavorMode(tasFlavorModes, failure, preempt) {
+			return true
+		}
+
+		psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
+		psAssignment.reason(failure.Reason)
+		assignment.updateMode(failure.PodSetName, Preempt)
+	}
+
+	if assignment.RepresentativeMode() != Preempt || workload.HasUnhealthyNodes(a.wl.Obj) {
+		return false
+	}
+
+	// Don't preempt other workloads if looking for a failed node replacement.
+	tasRequests = assignment.WorkloadsTopologyRequests(log, a.wl, a.cq)
+	result := a.cq.FindTopologyAssignmentsForWorkload(
+		ctx,
+		tasRequests,
+		schdcache.WithSimulateEmpty(true),
+		schdcache.WithWorkload(a.wl.Obj),
+	)
+	failure := result.Failure()
+	if failure == nil {
+		// Update TAS-related assignments to Preempt because preemptions might be needed
+		// in resources in which total unused quota is sufficient (Fit), but the
+		// quota is fragmented.
+		assignment.updateModeForTASRequests(tasRequests, Preempt)
+		return false
+	}
+
+	if a.shouldRetryFlavorAssignmentAfterTASFailure() &&
+		a.downgradeTASFlavorMode(
+			tasFlavorModes,
+			failure,
+			noFit,
+		) {
+		return true
+	}
+
+	psAssignment := assignment.podSetAssignmentByName(failure.PodSetName)
+	if features.Enabled(features.UnadmittedWorkloadsObservability) {
+		psAssignment.markFlavorAttempt(failure.Flavor, NoFit, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
+	}
+	psAssignment.Status.reasons = mergeUnique(psAssignment.Status.reasons, []string{failure.Reason})
+	assignment.updateMode(failure.PodSetName, NoFit)
+	return false
+}
+
+func (a *FlavorAssigner) shouldRetryFlavorAssignmentAfterTASFailure() bool {
+	return features.Enabled(features.FlavorFungibility) &&
+		features.Enabled(features.FlavorFungibilityPreserveScanProgress) &&
+		!a.shouldRespectNominationMapping() &&
+		!workload.HasUnhealthyNodes(a.wl.Obj)
 }
 
 func (a *Assignment) resolveNoFitReason(cq *schdcache.ClusterQueueSnapshot) {
@@ -1021,6 +1134,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 	requests resources.Requests,
 	resName corev1.ResourceName,
 	assignmentUsage resources.FlavorResourceQuantities,
+	tasFlavorModes tasFlavorModes,
 ) (ResourceAssignment, *Status, FlavorAssignmentAttempts) {
 	resourceGroup := a.cq.RGByResource(resName)
 	if resourceGroup == nil {
@@ -1038,6 +1152,8 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 	var bestAssignment ResourceAssignment
 	bestAssignmentMode := worstGranularMode()
 	consideredFlavors := newFlavorAssignmentAttempts(len(resourceGroup.Flavors))
+	var bestStatus *Status
+	bestHasTASFlavorMode := false
 
 	// We will only check against the flavors' labels for the resource.
 	attemptedFlavorIdx := -1
@@ -1123,17 +1239,37 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 			}
 		})
 
+		tasMode, flavorHasTASFlavorMode := tasFlavorModes.modeForPodSets(psIDs, a.wl, fName)
+		if flavorHasTASFlavorMode {
+			if tasMode.preemptionMode < representativeMode.preemptionMode {
+				representativeMode.preemptionMode = tasMode.preemptionMode
+				for _, assignment := range assignments {
+					assignment.Mode = tasMode.preemptionMode.flavorAssignmentMode()
+				}
+			}
+			flavorQuotaReasons = mergeUnique(flavorQuotaReasons, tasMode.reasons)
+			status.reasons = mergeUnique(status.reasons, tasMode.reasons)
+			if tasMode.preemptionMode == noFit {
+				flavorNoFitReason = mostSevereReason(flavorNoFitReason, kueue.WorkloadQuotaReservedReasonTopologyPlacementFailed)
+			}
+		}
+
 		consideredFlavors.AddRepresentativeModeFlavorAttempt(fName, representativeMode.preemptionMode, maxBorrow, flavorQuotaReasons, flavorNoFitReason)
+		flavorStatus := &Status{reasons: slices.Clone(flavorQuotaReasons), noFitReason: flavorNoFitReason}
 
 		if features.Enabled(features.FlavorFungibility) {
 			if !shouldTryNextFlavor(representativeMode, a.cq.FlavorFungibility) {
 				bestAssignment = assignments
 				bestAssignmentMode = representativeMode
+				bestStatus = flavorStatus
+				bestHasTASFlavorMode = flavorHasTASFlavorMode
 				break
 			}
 			if isPreferred(representativeMode, bestAssignmentMode, a.cq.FlavorFungibility) {
 				bestAssignment = assignments
 				bestAssignmentMode = representativeMode
+				bestStatus = flavorStatus
+				bestHasTASFlavorMode = flavorHasTASFlavorMode
 			}
 		} else if representativeMode.preemptionMode > bestAssignmentMode.preemptionMode {
 			bestAssignment = assignments
@@ -1156,6 +1292,9 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 		}
 		if bestAssignmentMode.preemptionMode == fit {
 			return bestAssignment, nil, consideredFlavors
+		}
+		if bestHasTASFlavorMode && bestStatus != nil {
+			return bestAssignment, bestStatus, consideredFlavors
 		}
 	}
 	return bestAssignment, status, consideredFlavors

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -6174,6 +6174,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 
 		wantMode           FlavorAssignmentMode
 		wantTriedFlavorIdx int
+		wantNoBookmark     bool
 		// wantPlan is whether nomination produced a TopologyAssignment. Only an
 		// assignment that carries a plan can later be invalidated mid-cycle, which is
 		// what the in-cycle recomputation is triggered by.
@@ -6192,7 +6193,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			wantTriedFlavorIdx: 0,
 			wantPlan:           true,
 		},
-		"quota fits but the pod is larger than any node: bookmark still names the first flavor": {
+		"all flavors fail TAS: no bookmark needed after exhaustive retry": {
 			nominalPerFlavor: "10",
 			cohortSpare:      "0",
 			request:          "6",
@@ -6201,14 +6202,13 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 				WhenCanPreempt: kueue.TryNextFlavor,
 				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
-			// The quota scan stopped on flavor-1 and recorded it. TAS then rejected the
-			// flavor, and because the pod cannot fit a node even with every other
-			// Workload preempted the mode ends at NoFit rather than Preempt. Either way
-			// the bookmark was already written and still points at flavor-1.
-			wantMode:           NoFit,
-			wantTriedFlavorIdx: 0,
+			// TAS rejects both flavors even after simulating preemption. The retry loop
+			// exhausts the ResourceGroup in this assignment, so no cross-cycle bookmark
+			// is needed.
+			wantMode:       NoFit,
+			wantNoBookmark: true,
 		},
-		"quota fits but the topology is fragmented: bookmark still names the first flavor": {
+		"fragmented first flavor: retries the second flavor in the same assignment": {
 			nominalPerFlavor: "10",
 			cohortSpare:      "0",
 			// The pod would fit node-1 on its own, so this is fragmentation rather than a
@@ -6221,12 +6221,12 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 				WhenCanPreempt: kueue.TryNextFlavor,
 				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
-			// The real-state placement search fails, but the search that simulates every
-			// other Workload preempted succeeds, so the mode settles at Preempt. This is
-			// the shape reported in #13658, and the bookmark written during the quota scan
-			// still points at flavor-1.
-			wantMode:           Preempt,
-			wantTriedFlavorIdx: 0,
+			// The real-state placement search rejects flavor-1. Flavor fallback reruns
+			// assignment immediately and places the pod on flavor-2, reaching the end of
+			// the ResourceGroup and recording "start over" for the next cycle.
+			wantMode:           Fit,
+			wantTriedFlavorIdx: -1,
+			wantPlan:           true,
 		},
 		"fits only by borrowing: bookmark says start over": {
 			nominalPerFlavor: "1",
@@ -6325,10 +6325,14 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 				t.Errorf("RepresentativeMode() = %s, want %s", gotMode, tc.wantMode)
 			}
 			got, ok := lastTriedFlavorIdx(assignment, corev1.ResourceCPU)
-			if !ok {
+			switch {
+			case tc.wantNoBookmark:
+				if ok {
+					t.Errorf("LastTriedFlavorIdx for cpu = %d, want no bookmark", got)
+				}
+			case !ok:
 				t.Fatalf("no bookmark recorded for cpu; mode was %s", assignment.RepresentativeMode())
-			}
-			if got != tc.wantTriedFlavorIdx {
+			case got != tc.wantTriedFlavorIdx:
 				t.Errorf("LastTriedFlavorIdx for cpu = %d, want %d", got, tc.wantTriedFlavorIdx)
 			}
 			if gotPlan := assignment.PodSets[0].TopologyAssignment != nil; gotPlan != tc.wantPlan {
@@ -6452,5 +6456,84 @@ func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
 				t.Errorf("recomputation RepresentativeMode() = %s, want %s", got, Preempt)
 			}
 		})
+	}
+}
+
+func TestDowngradeTASFlavorModeForPodSetGroup(t *testing.T) {
+	wl := workload.NewInfo(&kueue.Workload{
+		Spec: kueue.WorkloadSpec{
+			PodSets: []kueue.PodSet{
+				*utiltestingapi.MakePodSet("worker", 1).PodSetGroup("group1").Obj(),
+				*utiltestingapi.MakePodSet("leader", 1).PodSetGroup("group1").Obj(),
+				*utiltestingapi.MakePodSet("standalone", 1).Obj(),
+			},
+		},
+	})
+	assigner := FlavorAssigner{wl: wl}
+	modes := make(tasFlavorModes)
+	failure := &schdcache.FailureInfo{
+		PodSetName: "worker",
+		Flavor:     "tas-a",
+		Reason:     "tas-a has no fitting topology domain",
+	}
+
+	if changed := assigner.downgradeTASFlavorMode(modes, failure, preempt); !changed {
+		t.Fatal("expected the first downgrade to change the TAS flavor mode")
+	}
+	for _, podSetID := range []int{0, 1} {
+		got, found := modes.modeForPodSets([]int{podSetID}, wl, "tas-a")
+		if !found || got.preemptionMode != preempt {
+			t.Errorf("podSet %q mode = (%v, %t), want (preempt, true)", wl.Obj.Spec.PodSets[podSetID].Name, got.preemptionMode, found)
+		}
+	}
+	if _, found := modes.modeForPodSets([]int{2}, wl, "tas-a"); found {
+		t.Error("standalone PodSet unexpectedly inherited the group downgrade")
+	}
+
+	if changed := assigner.downgradeTASFlavorMode(
+		modes,
+		failure,
+		noFit,
+	); !changed {
+		t.Fatal("expected the second downgrade to change the TAS flavor mode")
+	}
+	got, found := modes.modeForPodSets([]int{0, 1}, wl, "tas-a")
+	if !found || got.preemptionMode != noFit {
+		t.Errorf("group mode = (%v, %t), want (noFit, true)", got.preemptionMode, found)
+	}
+}
+
+func TestAssignFlavorsPreservesRejectedTASReasonsForNonTASWinner(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+	features.SetFeatureGateDuringTest(t, features.FlavorFungibility, true)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	fungibility := kueue.FlavorFungibility{
+		WhenCanPreempt: kueue.TryNextFlavor,
+		Preference:     new(kueue.PreemptionOverBorrowing),
+	}
+	cqSnapshot := newBookmarkSnapshot(ctx, t, log, "2", "0", fungibility)
+	cqSnapshot.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{
+		{Flavor: "flavor-1", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+		{Flavor: "flavor-2", Resource: corev1.ResourceCPU}: resources.NewAmount(2_000),
+	}}})
+
+	wlInfo := bookmarkTestWorkload("2")
+	assigner := New(wlInfo, cqSnapshot, bookmarkTestFlavors(), false, &testOracle{}, nil,
+		configapi.QuotaCheckBlockUndeclared, resources.NewResourceFormatter(), bookmarkTestCycle)
+	const tasReason = "flavor-1 has no fitting topology domain"
+	modes := tasFlavorModes{
+		{podSetName: kueue.DefaultPodSetName, flavor: "flavor-1"}: {
+			preemptionMode: noFit,
+			reasons:        []string{tasReason},
+		},
+	}
+
+	assignment := assigner.assignFlavors(ctx, log, nil, modes)
+	if got := assignment.PodSets[0].Flavors[corev1.ResourceCPU].Name; got != "flavor-2" {
+		t.Fatalf("assigned flavor = %q, want %q", got, "flavor-2")
+	}
+	if got := assignment.PodSets[0].Status.Message(); !strings.Contains(got, tasReason) {
+		t.Errorf("status message = %q, want it to contain %q", got, tasReason)
 	}
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3911,6 +3911,374 @@ func TestScheduleForTASPreemption(t *testing.T) {
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]tasScheduleTestCase{
+		"TryNextFlavor falls back to preemption after TAS rejects a fit flavor": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-flavor", "a").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("y1").
+					Label("tas-flavor", "b").
+					Label(corev1.LabelHostname, "y1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+						corev1.ResourcePods:   resource.MustParse("10"),
+					}).
+					Ready().
+					Unschedulable().
+					Obj(),
+			},
+			topologies: []kueue.Topology{
+				*utiltestingapi.MakeTopology("two-flavor-topology").
+					Levels("tas-flavor", corev1.LabelHostname).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor-a").
+					NodeLabel("tas-flavor", "a").
+					TopologyName("two-flavor-topology").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("flavor-b").
+					NodeLabel("tas-flavor", "b").
+					TopologyName("two-flavor-topology").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.MayStopSearch,
+						WhenCanPreempt: kueue.TryNextFlavor,
+					}).
+					Preemption(kueue.ClusterQueuePreemption{WithinClusterQueue: kueue.PreemptionPolicyLowerPriority}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceCPU, "1").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "1").
+							Obj(),
+					).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceMemory, "1Gi").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceMemory, "1Gi").
+							Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								Assignment(corev1.ResourceMemory, "flavor-a", "1Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{"tas-flavor", corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"a", "x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor flavor-a, 1 more needed, insufficient unused quota for memory in flavor flavor-a, 1Gi more needed, no topology domains at level: tas-flavor, no topology domains at level: tas-flavor. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								Assignment(corev1.ResourceMemory, "flavor-a", "1Gi").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{"tas-flavor", corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"a", "x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Request(corev1.ResourceMemory, "1Gi").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/foo"},
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "foo", "PreemptedWorkload", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "foo", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, "Warning").Obj(),
+			},
+		},
+		"TAS flavor fallback recomputes quota for later PodSet groups": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-flavor", "a").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("3"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("y1").
+					Label("tas-flavor", "b").
+					Label(corev1.LabelHostname, "y1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{
+				*utiltestingapi.MakeTopology("two-flavor-topology").
+					Levels("tas-flavor", corev1.LabelHostname).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("flavor-a").
+					NodeLabel("tas-flavor", "a").
+					TopologyName("two-flavor-topology").
+					Obj(),
+				*utiltestingapi.MakeResourceFlavor("flavor-b").
+					NodeLabel("tas-flavor", "b").
+					TopologyName("two-flavor-topology").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					FlavorFungibility(kueue.FlavorFungibility{
+						WhenCanBorrow:  kueue.MayStopSearch,
+						WhenCanPreempt: kueue.TryNextFlavor,
+					}).
+					Preemption(kueue.ClusterQueuePreemption{WithinClusterQueue: kueue.PreemptionPolicyLowerPriority}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("flavor-a").
+							Resource(corev1.ResourceCPU, "3").
+							Obj(),
+						*utiltestingapi.MakeFlavorQuotas("flavor-b").
+							Resource(corev1.ResourceCPU, "5").
+							Obj(),
+					).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(
+						*utiltestingapi.MakePodSet("one", 1).
+							RequiredTopologyRequest("tas-flavor").
+							Request(corev1.ResourceCPU, "3").
+							Obj(),
+						*utiltestingapi.MakePodSet("two", 1).
+							RequiredTopologyRequest("tas-flavor").
+							Request(corev1.ResourceCPU, "2").
+							Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{"tas-flavor", corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"a", "x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("foo", "default").
+					UID("wl-foo").
+					JobUID("job-foo").
+					Queue("tas-main").
+					Priority(3).
+					PodSets(
+						*utiltestingapi.MakePodSet("one", 1).
+							RequiredTopologyRequest("tas-flavor").
+							Request(corev1.ResourceCPU, "3").
+							Obj(),
+						*utiltestingapi.MakePodSet("two", 1).
+							RequiredTopologyRequest("tas-flavor").
+							Request(corev1.ResourceCPU, "2").
+							Obj(),
+					).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            `couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor flavor-a, 1 more needed, topology "two-flavor-topology" doesn't allow to fit any of 1 pod(s). Total nodes: 1; excluded: resource "cpu": 1. Pending the preemption of 1 workload(s)`,
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(
+						kueue.PodSetRequest{
+							Name: "one",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("3"),
+							},
+						},
+						kueue.PodSetRequest{
+							Name: "two",
+							Resources: corev1.ResourceList{
+								corev1.ResourceCPU: resource.MustParse("2"),
+							},
+						},
+					).
+					Obj(),
+				*utiltestingapi.MakeWorkload("low-priority-admitted", "default").
+					UID("low-priority-admitted-uid").
+					Queue("tas-main").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "flavor-a", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{"tas-flavor", corev1.LabelHostname}).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"a", "x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest("tas-flavor").
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-foo, JobUID: job-foo) due to prioritization in the ClusterQueue; preemptor path: /tas-main; preemptee path: /tas-main",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-main": {"default/foo"},
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "EvictedDueToPreempted", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "low-priority-admitted", "Preempted", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "foo", "PreemptedWorkload", "Normal").Obj(),
+				utiltesting.MakeEventRecord("default", "foo", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, "Warning").Obj(),
+			},
+		},
 		"workload preempted due to quota is using deleted Node": {
 			// In this scenario the preemption target, based on quota, is a
 			// using an already deleted node (z).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When flavor fungibility is configured with `WhenCanPreempt: TryNextFlavor`, quota assignment can select a flavor that fits quota but later fails TAS placement.

Previously, the failed TAS result only changed the mode of the existing assignment to `Preempt` or `NoFit`. Flavor assignment was not recalculated, so Kueue could miss another viable flavor.

This PR:

- Records TAS failures as monotonic flavor downgrades: `Fit -> Preempt -> NoFit`.
- Recomputes the complete workload flavor assignment after a TAS downgrade.
- Recalculates quota usage, borrowing, and preemption for every PodSet group.
- Applies a TAS flavor downgrade consistently across resource groups in the same PodSet group.
- Supports workloads containing multiple PodSets and multiple resource groups.
- Preserves the status message associated with the selected flavor.

Recomputing the complete workload prevents stale quota accounting when an earlier PodSet changes flavor and avoids assigning multiple incompatible TAS flavors to one PodSet.

The retry loop terminates because each PodSet/flavor state can only move toward `NoFit`.

Tests cover:

- Falling back to a preemptible flavor after a quota-fit flavor fails TAS.
- Consistent fallback across multiple resource groups.
- Recomputing quota for later PodSets after an earlier PodSet changes flavor.
- Existing TAS preemption scenarios across the scheduler test matrix.

AI tools were used to assist with coding.

#### Which issue(s) this PR fixes:

Fixes #10824 

#### Special notes for your reviewer:

The implementation intentionally reruns the complete workload flavor assignment instead of caching full per-resource-group candidates. This ensures that quota usage remains consistent across PodSets after a TAS-driven flavor change.

#### Does this PR introduce a user-facing change?

No

```release-note
Fixed TAS flavor fallback so that Kueue can try alternative resource flavors after topology placement fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling when topology-aware constraints reject a flavor by retrying suitable alternatives.
  * Preserved and surfaced relevant topology failure reasons and assignment status.
  * Improved preemption decisions so lower-priority workloads are evicted only after fallback flavors are evaluated.
  * Recomputed quota correctly across subsequent workload groups when flavor fallback occurs.
  * Improved handling of grouped workloads during topology-aware flavor downgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->