### PR TITLE
Fix TAS domain ID collision between leaf and root domains

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -791,7 +791,7 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 // in Node's NodeReady condition
 func (s *TASFlavorSnapshot) IsTopologyAssignmentStale(ta *utiltas.TopologyAssignment) (bool, string) {
 	for _, domain := range ta.Domains {
-		if _, found := s.domains[utiltas.DomainID(domain.Values)]; !found {
+		if _, found := s.leaves[utiltas.DomainID(domain.Values)]; !found {
 			return true, domain.Values[0]
 		}
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -221,7 +221,7 @@ func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name stri
 		if failure := result.Failure(); failure != nil {
 			b.Fatalf("balanced placement preflight failed: %s", failure.Reason)
 		}
-		if len(snapshot.state) == len(snapshot.domains) {
+		if len(snapshot.state) == snapshot.domainCount {
 			b.Fatal("balanced placement preflight did not clone domain state")
 		}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -148,6 +148,89 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 	}
 }
 
+func TestIsTopologyAssignmentStale(t *testing.T) {
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+
+	hostnameLowest := newTopologyTree(
+		[]string{blockLabel, corev1.LabelHostname},
+		[]*corev1.Node{
+			node.MakeNode("n1").
+				Label(blockLabel, "b1").
+				Label(corev1.LabelHostname, "n1").
+				Obj(),
+		},
+		0,
+	)
+	rackLowest := newTopologyTree(
+		[]string{blockLabel, rackLabel},
+		[]*corev1.Node{
+			node.MakeNode("n1").
+				Label(blockLabel, "b1").
+				Label(rackLabel, "r1").
+				Obj(),
+		},
+		0,
+	)
+
+	cases := map[string]struct {
+		tree            *topologyTree
+		assignment      *tas.TopologyAssignment
+		wantStale       bool
+		wantStaleDomain string
+	}{
+		"existing hostname leaf is not stale": {
+			tree: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n1"}}},
+			},
+		},
+		"missing hostname leaf is stale": {
+			tree: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n2"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "n2",
+		},
+		"deleted node is stale even when its hostname matches an existing root domain ID": {
+			tree: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "b1",
+		},
+		"existing non-hostname leaf is not stale": {
+			tree: rackLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r1"}}},
+			},
+		},
+		"missing non-hostname leaf is stale": {
+			tree: rackLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r2"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "b1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			snapshot := &TASFlavorSnapshot{topologyTree: tc.tree}
+			gotStale, gotStaleDomain := snapshot.IsTopologyAssignmentStale(tc.assignment)
+			if gotStale != tc.wantStale {
+				t.Errorf("IsTopologyAssignmentStale() stale = %t, want %t", gotStale, tc.wantStale)
+			}
+			if gotStaleDomain != tc.wantStaleDomain {
+				t.Errorf("IsTopologyAssignmentStale() stale domain = %q, want %q", gotStaleDomain, tc.wantStaleDomain)
+			}
+		})
+	}
+}
+
 func TestMergeTopologyAssignments(t *testing.T) {
 	nodes := []*corev1.Node{
 		node.MakeNode("x").Label("level-1", "a").Label("level-2", "b").Obj(),

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -30,7 +30,7 @@ import (
 // Its per-snapshot mutable state lives in TASFlavorSnapshot.state,
 // addressed by idx.
 type domain struct {
-	// id is the globally unique id of the domain
+	// id identifies the domain within its topology level
 	id utiltas.TopologyDomainID
 
 	// idx is the dense index of the domain within its topologyTree, used to
@@ -89,11 +89,8 @@ type topologyTree struct {
 	// roots maps domainID to domains that are at the highest level of topology structure
 	roots domainByID
 
-	// domains maps domainID to every domain available in the topology structure
-	domains domainByID
-
-	// domainCount is the number of allocated domains. It can exceed len(domains)
-	// when domains at different topology levels have colliding IDs.
+	// domainCount is the number of allocated domains. Domain IDs are not unique
+	// across levels, so it counts domains rather than distinct IDs.
 	domainCount int
 
 	// domainsPerLevel stores the static tree information
@@ -123,7 +120,6 @@ func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *t
 		generation:        generation,
 		levelKeys:         slices.Clone(levels),
 		leaves:            make(leafDomainByID),
-		domains:           make(domainByID),
 		roots:             make(domainByID),
 		domainsPerLevel:   domainsPerLevel,
 		isLowestLevelNode: len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
@@ -196,7 +192,6 @@ func (t *topologyTree) initialize() {
 	for _, leafDomain := range t.leaves {
 		domain := &leafDomain.domain
 		t.indexDomain(domain)
-		t.domains[domain.id] = domain
 		t.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
 		t.initializeHelper(domain)
 	}
@@ -210,14 +205,13 @@ func (t *topologyTree) initializeHelper(dom *domain) {
 	}
 	parentValues := dom.levelValues[:len(dom.levelValues)-1]
 	parentID := utiltas.DomainID(parentValues)
-	parent, parentFound := t.domains[parentID]
+	parent, parentFound := t.domainsPerLevel[len(parentValues)-1][parentID]
 	if !parentFound {
 		// create parent
 		parent = &domain{id: parentID, levelValues: parentValues}
 		t.indexDomain(parent)
 
 		t.domainsPerLevel[len(parentValues)-1][parentID] = parent
-		t.domains[parentID] = parent
 		t.initializeHelper(parent)
 	}
 	// connect parent and child

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -83,12 +84,30 @@ func TestNewTopologyTreeCopiesAndRightSizesNodeSlice(t *testing.T) {
 	}
 }
 
+// domainKey identifies a domain in the dumps below. A leaf and root can share
+// an ID, so the level is part of the key.
+type domainKey struct {
+	Level int
+	ID    utiltas.TopologyDomainID
+}
+
+func domainKeyOf(dom *domain) domainKey {
+	return domainKey{Level: len(dom.levelValues) - 1, ID: dom.id}
+}
+
+func (k domainKey) compare(other domainKey) int {
+	if k.Level != other.Level {
+		return k.Level - other.Level
+	}
+	return strings.Compare(string(k.ID), string(other.ID))
+}
+
 // snapshotDomainDump is a comparison representation of one domain of a
 // TASFlavorSnapshot, used to verify that snapshots sharing a cached topology
 // tree behave exactly like snapshots built from scratch.
 type snapshotDomainDump struct {
-	Parent       utiltas.TopologyDomainID
-	Children     []utiltas.TopologyDomainID
+	Parent       domainKey
+	Children     []domainKey
 	LevelValues  []string
 	Root         bool
 	Leaf         bool
@@ -97,42 +116,44 @@ type snapshotDomainDump struct {
 	TASUsage     resources.Requests
 }
 
-func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[utiltas.TopologyDomainID]snapshotDomainDump {
+func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[domainKey]snapshotDomainDump {
 	t.Helper()
 	perLevelCount := 0
 	for _, level := range s.domainsPerLevel {
 		perLevelCount += len(level)
 	}
-	if perLevelCount != len(s.domains) {
-		t.Errorf("domainsPerLevel holds %d domains, want %d", perLevelCount, len(s.domains))
+	if perLevelCount != s.domainCount {
+		t.Errorf("domainsPerLevel holds %d domains, want %d", perLevelCount, s.domainCount)
 	}
-	dump := make(map[utiltas.TopologyDomainID]snapshotDomainDump, len(s.domains))
-	for id, dom := range s.domains {
-		d := snapshotDomainDump{
-			LevelValues: dom.levelValues,
-			Root:        s.roots[id] == dom,
-		}
-		if dom.parent != nil {
-			d.Parent = dom.parent.id
-		}
-		for _, child := range dom.children {
-			d.Children = append(d.Children, child.id)
-		}
-		slices.Sort(d.Children)
-		if leaf, found := s.leaves[id]; found {
-			d.Leaf = true
-			leafState := s.leafStateOf(leaf)
-			if leafState.freeCapacity != nil {
-				d.FreeCapacity = leafState.freeCapacity.Clone()
+	dump := make(map[domainKey]snapshotDomainDump, perLevelCount)
+	for _, level := range s.domainsPerLevel {
+		for id, dom := range level {
+			d := snapshotDomainDump{
+				LevelValues: dom.levelValues,
+				Root:        s.roots[id] == dom,
 			}
-			if leafState.tasUsage != nil {
-				d.TASUsage = leafState.tasUsage.Clone()
+			if dom.parent != nil {
+				d.Parent = domainKeyOf(dom.parent)
 			}
-			if leaf.node != nil {
-				d.NodeName = leaf.node.Name
+			for _, child := range dom.children {
+				d.Children = append(d.Children, domainKeyOf(child))
 			}
+			slices.SortFunc(d.Children, domainKey.compare)
+			if leaf, found := s.leaves[id]; found && &leaf.domain == dom {
+				d.Leaf = true
+				leafState := s.leafStateOf(leaf)
+				if leafState.freeCapacity != nil {
+					d.FreeCapacity = leafState.freeCapacity.Clone()
+				}
+				if leafState.tasUsage != nil {
+					d.TASUsage = leafState.tasUsage.Clone()
+				}
+				if leaf.node != nil {
+					d.NodeName = leaf.node.Name
+				}
+			}
+			dump[domainKeyOf(dom)] = d
 		}
-		dump[id] = d
 	}
 	return dump
 }
@@ -260,8 +281,8 @@ func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
 	if failure := first.Failure(); failure != nil {
 		t.Fatalf("first assignment failed: %s", failure.Reason)
 	}
-	if len(snapshot.state) <= len(snapshot.domains) {
-		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.state), len(snapshot.domains))
+	if len(snapshot.state) <= snapshot.domainCount {
+		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.state), snapshot.domainCount)
 	}
 
 	second := snapshot.FindTopologyAssignmentsForFlavor(ctx, requests)
@@ -360,7 +381,7 @@ func TestTopologyTreeInvalidation(t *testing.T) {
 				tasCache.SyncNode(makeTreeTestNode("n3", "b3", "r3"))
 			},
 			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
-				if _, found := snapshot.domains[utiltas.DomainID([]string{"b3"})]; !found {
+				if _, found := snapshot.domainsPerLevel[0][utiltas.DomainID([]string{"b3"})]; !found {
 					t.Error("snapshot does not contain the added node's block domain")
 				}
 			},
@@ -370,7 +391,7 @@ func TestTopologyTreeInvalidation(t *testing.T) {
 				tasCache.DeleteNodeByName("n2")
 			},
 			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
-				if _, found := snapshot.domains[utiltas.DomainID([]string{"b2"})]; found {
+				if _, found := snapshot.domainsPerLevel[0][utiltas.DomainID([]string{"b2"})]; found {
 					t.Error("snapshot still contains the deleted node's block domain")
 				}
 			},
@@ -425,20 +446,49 @@ func TestTopologyTreeInvalidation(t *testing.T) {
 	}
 }
 
-func makeTopologyTreeWithCollidingLeafAndRootIDs() *topologyTree {
-	return newTopologyTree(
-		[]string{treeTestBlockLabel, corev1.LabelHostname},
-		[]*corev1.Node{
-			makeTreeTestNode("block-a", "block-b", "r1"),
-			makeTreeTestNode("block-b", "block-a", "r1"),
-		},
-		0,
-	)
+type topologyTreeDomainDump struct {
+	LevelValues []string
+	Parent      domainKey
+	Children    []domainKey
+	Root        bool
+	Leaf        bool
+	NodeName    string
+	CPUCapacity int64
 }
 
-func TestTopologyTreeStateIndexesWhenDomainIDsCollide(t *testing.T) {
+func dumpTopologyTree(tree *topologyTree) map[domainKey]topologyTreeDomainDump {
+	dump := make(map[domainKey]topologyTreeDomainDump, tree.domainCount)
+	for _, levelDomains := range tree.domainsPerLevel {
+		for id, dom := range levelDomains {
+			d := topologyTreeDomainDump{
+				LevelValues: dom.levelValues,
+				Root:        tree.roots[id] == dom,
+			}
+			if dom.parent != nil {
+				d.Parent = domainKeyOf(dom.parent)
+			}
+			for _, child := range dom.children {
+				d.Children = append(d.Children, domainKeyOf(child))
+			}
+			slices.SortFunc(d.Children, domainKey.compare)
+			if leaf, found := tree.leaves[id]; found && &leaf.domain == dom {
+				d.Leaf = true
+				d.CPUCapacity = leaf.capacity.GetValue(corev1.ResourceCPU)
+				if leaf.node != nil {
+					d.NodeName = leaf.node.Name
+				}
+			}
+			dump[domainKeyOf(dom)] = d
+		}
+	}
+	return dump
+}
+
+func validateTopologyTreeStateIndexes(t *testing.T, tree *topologyTree) {
+	t.Helper()
 	_, log := utiltesting.ContextWithLog(t)
-	tree := makeTopologyTreeWithCollidingLeafAndRootIDs()
+	// Validate each domain's index against the per-snapshot domain state addressed
+	// by domain.idx.
 	snapshot := newTASFlavorSnapshot(log, "default", tree, nil, &defaultChecker{})
 	seen := make(map[int]*domain, tree.domainCount)
 	for _, levelDomains := range tree.domainsPerLevel {
@@ -455,5 +505,117 @@ func TestTopologyTreeStateIndexesWhenDomainIDsCollide(t *testing.T) {
 	}
 	if got := len(seen); got != tree.domainCount {
 		t.Errorf("domains with state indexes = %d, want %d", got, tree.domainCount)
+	}
+}
+
+func TestNewTopologyTree(t *testing.T) {
+	tests := map[string]struct {
+		levels []string
+		nodes  []*corev1.Node
+		want   map[domainKey]topologyTreeDomainDump
+	}{
+		"lowest level is hostname": {
+			levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname},
+			nodes: []*corev1.Node{
+				makeTreeTestNode("n1", "b1", "r1"),
+				makeTreeTestNode("n2", "b1", "r1"),
+				makeTreeTestNode("n3", "b1", "r2"),
+			},
+			want: map[domainKey]topologyTreeDomainDump{
+				{Level: 0, ID: "b1"}: {
+					LevelValues: []string{"b1"},
+					Children:    []domainKey{{Level: 1, ID: "b1,r1"}, {Level: 1, ID: "b1,r2"}},
+					Root:        true,
+				},
+				{Level: 1, ID: "b1,r1"}: {
+					LevelValues: []string{"b1", "r1"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Children:    []domainKey{{Level: 2, ID: "n1"}, {Level: 2, ID: "n2"}},
+				},
+				{Level: 1, ID: "b1,r2"}: {
+					LevelValues: []string{"b1", "r2"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Children:    []domainKey{{Level: 2, ID: "n3"}},
+				},
+				{Level: 2, ID: "n1"}: {
+					LevelValues: []string{"b1", "r1", "n1"},
+					Parent:      domainKey{Level: 1, ID: "b1,r1"},
+					Leaf:        true,
+					NodeName:    "n1",
+					CPUCapacity: 4000,
+				},
+				{Level: 2, ID: "n2"}: {
+					LevelValues: []string{"b1", "r1", "n2"},
+					Parent:      domainKey{Level: 1, ID: "b1,r1"},
+					Leaf:        true,
+					NodeName:    "n2",
+					CPUCapacity: 4000,
+				},
+				{Level: 2, ID: "n3"}: {
+					LevelValues: []string{"b1", "r2", "n3"},
+					Parent:      domainKey{Level: 1, ID: "b1,r2"},
+					Leaf:        true,
+					NodeName:    "n3",
+					CPUCapacity: 4000,
+				},
+			},
+		},
+		"lowest level is not hostname": {
+			levels: []string{treeTestBlockLabel, treeTestRackLabel},
+			nodes: []*corev1.Node{
+				makeTreeTestNode("n1", "b1", "r1"),
+				makeTreeTestNode("n2", "b1", "r1"),
+				makeTreeTestNode("n3", "b1", "r2"),
+			},
+			want: map[domainKey]topologyTreeDomainDump{
+				{Level: 0, ID: "b1"}: {
+					LevelValues: []string{"b1"},
+					Children:    []domainKey{{Level: 1, ID: "b1,r1"}, {Level: 1, ID: "b1,r2"}},
+					Root:        true,
+				},
+				{Level: 1, ID: "b1,r1"}: {
+					LevelValues: []string{"b1", "r1"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Leaf:        true,
+					CPUCapacity: 8000,
+				},
+				{Level: 1, ID: "b1,r2"}: {
+					LevelValues: []string{"b1", "r2"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Leaf:        true,
+					CPUCapacity: 4000,
+				},
+			},
+		},
+		"leaf and root IDs collide": {
+			levels: []string{treeTestBlockLabel, corev1.LabelHostname},
+			nodes: []*corev1.Node{
+				makeTreeTestNode("b1", "b1", "r1"),
+			},
+			want: map[domainKey]topologyTreeDomainDump{
+				{Level: 0, ID: "b1"}: {
+					LevelValues: []string{"b1"},
+					Children:    []domainKey{{Level: 1, ID: "b1"}},
+					Root:        true,
+				},
+				{Level: 1, ID: "b1"}: {
+					LevelValues: []string{"b1", "b1"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Leaf:        true,
+					NodeName:    "b1",
+					CPUCapacity: 4000,
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			tree := newTopologyTree(tc.levels, tc.nodes, 0)
+			validateTopologyTreeStateIndexes(t, tree)
+			if diff := cmp.Diff(tc.want, dumpTopologyTree(tree)); diff != "" {
+				t.Errorf("unexpected topology tree (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When a Topology uses `kubernetes.io/hostname` as its lowest level, a leaf domain is keyed by the bare hostname while every ancestor is keyed by its level values joined with `,`. Both live in `TASFlavorSnapshot.domains`, so a node whose hostname equals a top-level topology value shares a key with that root domain.

`initializeHelper` then resolves the ancestor lookup to the leaf, which becomes its own parent and never reaches the branch that registers a root. The node keeps its capacity in the tree but is unreachable from the root-driven traversal in `fillInCounts`, so no workload is ever placed on it — with no error and nothing in the logs.

This change drops the flat map `TASFlavorSnapshot.domains` and uses `TASFlavorSnapshot.domainsPerLevel` and `TASFlavorSnapshot.leaves` instead, so the parent lookup can no longer resolve to a leaf.

#### Which issue(s) this PR fixes:

Fixes #14009

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where a node whose hostname matched the value of the topology's top level was silently excluded from placement. The node stayed Ready with free capacity but never received pods, because its domain was recorded as its own parent and never registered as a topology root.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology handling when leaf and root domains share the same identifier.
  * Strengthened stale-assignment detection across hostname and non-hostname leaves.
  * Improved validation and cleanup across topology levels.

* **Tests**
  * Added regression coverage for overlapping identifiers, missing leaves, parent relationships, and root-domain registration.
  * Expanded validation of topology snapshots and stale-domain reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->