### PR TITLE
fix(debugger): prevent signal handler leak on context cancellation

### DIFF
--- a/pkg/debugger/debugger.go
+++ b/pkg/debugger/debugger.go
@@ -43,6 +43,7 @@ func (d *Dumper) ListenForSignal(ctx context.Context) {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, syscall.SIGUSR2)
 	go func() {
+		defer signal.Stop(signalCh)
 		for {
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
In `pkg/debugger/debugger.go`, `ListenForSignal` registers for `syscall.SIGUSR2` via `signal.Notify(signalCh, syscall.SIGUSR2)`. When `ctx.Done()` is received and the goroutine exits, `signal.Stop(signalCh)` was never called, leaving the signal registered in the runtime signal table.

This PR adds `defer signal.Stop(signalCh)` so the signal listener properly cleans up when the context is cancelled.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
NONE

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of signal notification handling when debugger monitoring stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->