### PR TITLE
Do not read the admission because the condition says it is there

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -91,6 +91,11 @@ func (w *WorkloadWebhook) ValidateCreate(ctx context.Context, wl *kueue.Workload
 func (w *WorkloadWebhook) ValidateUpdate(ctx context.Context, oldWL, newWL *kueue.Workload) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
 	log.V(5).Info("Validating update")
+	if reservesQuotaWithoutAdmission(oldWL) && reservesQuotaWithoutAdmission(newWL) {
+		// An update that introduces this is refused and says so, so the one
+		// worth a trace is the one that was already like this and goes through.
+		log.V(3).Info("Workload already reserves quota with no admission recorded, letting the update through so it can converge")
+	}
 	return nil, ValidateWorkloadUpdate(newWL, oldWL).ToAggregate()
 }
 
@@ -125,7 +130,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 
 	statusPath := field.NewPath("status")
 	if workload.HasQuotaReservation(obj) {
-		allErrs = append(allErrs, validateAdmission(obj, statusPath.Child("admission"))...)
+		allErrs = append(allErrs, validateAdmission(obj, oldObj, statusPath.Child("admission"))...)
 	}
 
 	allErrs = append(allErrs, metav1validation.ValidateConditions(obj.Status.Conditions, statusPath.Child("conditions"))...)
@@ -267,8 +272,24 @@ func validateTolerations(tolerations []corev1.Toleration, fldPath *field.Path) f
 	return allErrors
 }
 
-func validateAdmission(obj *kueue.Workload, path *field.Path) field.ErrorList {
+// reservesQuotaWithoutAdmission reports a Workload carrying the QuotaReserved
+// condition with no status.admission.
+func reservesQuotaWithoutAdmission(wl *kueue.Workload) bool {
+	return wl != nil && workload.HasQuotaReservation(wl) && wl.Status.Admission == nil
+}
+
+// validateAdmission is reached on the QuotaReserved condition rather than on the
+// field, so it has to answer for a Workload that carries one without the other.
+func validateAdmission(obj, oldObj *kueue.Workload, path *field.Path) field.ErrorList {
 	admission := obj.Status.Admission
+	if admission == nil {
+		// One that was already like this goes through, so it can converge and be
+		// removed, the way validateReclaimablePods lets a stale count through.
+		if reservesQuotaWithoutAdmission(oldObj) {
+			return nil
+		}
+		return field.ErrorList{field.Required(path, "must be set while the QuotaReserved condition is true")}
+	}
 	var allErrs field.ErrorList
 
 	names := sets.New[kueue.PodSetReference]()

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -47,6 +47,21 @@ const (
 	testWorkloadNamespace = "test-ns"
 )
 
+// quotaReservedWithoutAdmission builds a Workload with the QuotaReserved
+// condition and no status.admission.
+func quotaReservedWithoutAdmission(now time.Time) *kueue.Workload {
+	wl := utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+		PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).Obj()
+	wl.Status.Conditions = []metav1.Condition{{
+		Type:               kueue.WorkloadQuotaReserved,
+		Status:             metav1.ConditionTrue,
+		Reason:             "AdmittedByTest",
+		Message:            "admitted",
+		LastTransitionTime: metav1.NewTime(now),
+	}}
+	return wl
+}
+
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")
@@ -66,6 +81,12 @@ func TestValidateWorkload(t *testing.T) {
 				*utiltestingapi.MakePodSet("driver", 1).Obj(),
 				*utiltestingapi.MakePodSet("workers", 100).Obj(),
 			).Obj(),
+		},
+		"quota reserved without an admission is refused, not a panic": {
+			workload: quotaReservedWithoutAdmission(now),
+			wantErr: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "status.admission"},
+			}.ToAggregate(),
 		},
 		"should have a valid podSet name in status assignment": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
@@ -715,6 +736,18 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		wantErr       error
 		wantWarnings  admission.Warnings
 	}{
+		"an update may not put a workload in quota reserved with no admission": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).Obj(),
+			after: quotaReservedWithoutAdmission(now),
+			wantErr: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "status.admission"},
+			}.ToAggregate(),
+		},
+		"a workload already in that state stays updatable so it can be removed": {
+			before: quotaReservedWithoutAdmission(now),
+			after:  quotaReservedWithoutAdmission(now),
+		},
 		"reclaimable pod count can change up": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
@@ -1392,6 +1425,16 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				}).
 				PodSets(*utiltestingapi.MakePodSet("main", 1).Obj()).
 				Obj(),
+			wantErr: nil,
+		},
+		// Refusing this update would leave the object undeletable.
+		"a workload whose quota reservation lost its admission can still drop its finalizer": {
+			before: func() *kueue.Workload {
+				wl := quotaReservedWithoutAdmission(now)
+				wl.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+				return wl
+			}(),
+			after:   quotaReservedWithoutAdmission(now),
 			wantErr: nil,
 		},
 	}

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -591,6 +591,23 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			gomega.Expect(k8sClient.Delete(ctx, priorityClass)).To(gomega.Succeed())
 		})
 
+		ginkgo.It("Should refuse a status update reserving quota with no admission", func() {
+			wl := utiltestingapi.MakeWorkload(workloadName, ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				wl.Status.Conditions = append(wl.Status.Conditions, metav1.Condition{
+					Type:               kueue.WorkloadQuotaReserved,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Admitted",
+					Message:            "admitted",
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				})
+				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(utiltesting.BeForbiddenError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.DescribeTable("Validate Workload on update",
 			func(w func() *kueue.Workload, setQuotaReservation bool, updateWl func(newWL *kueue.Workload), matcher gomegatypes.GomegaMatcher) {
 				ginkgo.By("Creating a new Workload")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ValidateWorkload` decides whether to look at the admission from the condition, and `validateAdmission` then reads the field:

```go
if workload.HasQuotaReservation(obj) {
    allErrs = append(allErrs, validateAdmission(obj, statusPath.Child("admission"))...)
}
```

```go
admission := obj.Status.Admission
...
for i, ps := range admission.PodSetAssignments {
```

`HasQuotaReservation` reads the `QuotaReserved` condition, not `status.admission`, so a Workload carrying the condition without the field dereferences a nil pointer inside the validating webhook:

```
PANIC in the validating webhook: runtime error: invalid memory address or nil pointer dereference
```

The webhook is registered with `failurePolicy: Fail` over `workloads` and `workloads/status`, so the request is refused. controller-runtime recovers the panic rather than taking the process down, which means the cost is an internal error the caller cannot act on, not a crash.

Kueue writes the condition and the field together, and the write that would separate them is the one that panics and is refused, so the API server will not produce this state. It is reachable by anything that puts an object in etcd without passing through admission: a restore, a migration, or a window with the webhook unavailable under a policy other than `Fail`.

This refuses the state as a validation error naming the field, so the message says what is wrong. An update that leaves a Workload in the state it was already in is allowed through, so an object that got there without the webhook can converge and be removed. That mirrors how `validateReclaimablePods` treats a count left over from an elastic scale down.

#### Which issue(s) this PR fixes:

Fixes #14012

#### Special notes for your reviewer:

The tolerate-what-was-already-there half is the part worth a second look. Without it, refusing the state strands the object: an update that leaves the inconsistency in place is refused, and dropping a finalizer is such an update, so the Workload cannot be removed until something repairs it first. `ValidateWorkload` already takes `oldObj` for exactly this kind of question, and its doc comment points at `validateReclaimablePods` as the reason.

Measured rather than assumed, on unmodified main. A repairing update is not refused today:

```
bad -> repaired : no panic, errs=<nil>
bad -> bad      : PANIC, so the request is refused
```

So the object was always repairable. What it could not do was lose the finalizer that keeps it around while still carrying the inconsistency, and that is the case this changes. An earlier revision of this description said such an object could be neither repaired nor deleted, which was wrong on the first half.

The five transitions are covered as unit cases: create introducing the state, an update introducing it, an update leaving a pre-existing one in place, an update repairing it, and a consistent object. The first two are refused and the rest are not.

There is an integration test for the update that is refused, since that one is reachable through the API server. Against unmodified `main` it reproduces the panic in a live webhook rather than in a unit test:

```
Observed a panic ... "runtime error: invalid memory address or nil pointer dereference"
sigs.k8s.io/kueue/pkg/webhooks.validateAdmission(...)  workload_webhook.go:279
Ran 1 of 253 Specs  FAIL!  0 Passed | 1 Failed
```

and with the change:

```
Ran 1 of 253 Specs  SUCCESS!  1 Passed | 0 Failed
```

The tolerated case has no integration test because the API server will not produce the state to begin with, which is the same reason it needs tolerating. Getting an object into it inside envtest means bypassing the webhook that the test exists to exercise, so those transitions are unit cases where the previous state can be handed in directly.

On whether anything in the tree produces the state: `UnsetQuotaReservationWithCondition` is the only writer that sets `status.admission` to nil, and it sets the condition to false in the same call, so the two never separate. A Workload that reaches the validator with one and not the other did not come from Kueue.

While writing them I checked the rest of the update path for the same shape and it is clean. `validateReclaimablePodsUpdate` and `validateImmutablePodSetUpdates` read slices, which range fine when empty, `validateClusterNameUpdate` reads `status.clusterName`, and `validateAdmissionUpdate` takes the two pointers and already returns early when either is nil. One guard in the callee is enough rather than one per caller.

`ValidateDelete` returns no error unconditionally, so a delete request was always accepted. What the object could not do was lose its finalizer, and that is an update.

#### Does this PR introduce a user-facing change?

```release-note
The Workload validating webhook panicked when the `QuotaReserved` condition was set while `status.admission` was absent, so the API server refused the request with an internal error rather than one naming the field. It is now refused as a validation error. An update that leaves a Workload in the state it was already in is allowed through, so an object that entered etcd without passing through admission, from a restore or a migration, can still be updated and removed.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
