### PR TITLE
Update AFS KEP with second-pass scheduling

### DIFF
--- a/keps/4136-admission-fair-sharing/README.md
+++ b/keps/4136-admission-fair-sharing/README.md
@@ -206,21 +206,22 @@ usageSamplingInterval: 5mins
 Here, all Jobs submitted by Tenant B  within the next 5min get scheduled.
 Even if Tenant B submitted a job that consumed 1000 CPUs, consecutive jobs would still be prioritized because of the delay in updating the status.
 
-Hence, since v0.13 Kueue adds an entry penalty when it first assumes a Workload for a quota
-reservation in a ClusterQueue that uses `UsageBasedAdmissionFairSharing`. The penalty should be
-calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
+Hence, since v0.13 Kueue adds an entry penalty to FairSharingStatus every time it admits a Workload. The penalty should be calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
 
 `A = 1 - 0.5 ^ (sampling/half_life_decay)`. 
 
 This an equivalent of a job's usage that has been admitted `samplingInterval` ago. The value of penalty is an arbitrary decision for now.
 After we collect customers' feedback, we'll consider introducing an API that allows to configure it.
 
+Starting with Kueue v0.18.5 and v0.19.1, entry penalties are applied only when Kueue first assumes
+a Workload for a quota reservation in a ClusterQueue that uses `UsageBasedAdmissionFairSharing`.
 Each quota reservation contributes at most one entry penalty. A Workload that needs a second
-scheduling pass, such as one using a [ProvisioningRequest AdmissionCheck](../2724-topology-aware-scheduling/README.md#support-for-provisioningrequests)
+scheduling pass, such as one using a
+[ProvisioningRequest AdmissionCheck](../2724-topology-aware-scheduling/README.md#support-for-provisioningrequests)
 or the [`TASFailedNodeReplacement` feature gate](../2724-topology-aware-scheduling/README.md#node-failures),
 is re-assumed while keeping its existing quota reservation. The second-pass assumption does not
-add another entry penalty. The penalty added during the first pass is settled when the Workload is
-admitted.
+add another entry penalty. The penalty added during the first pass is settled on the transition to
+admission, unless the Workload is deactivated in the same update.
 
 ### User Stories (Optional)
 #### Story 1

--- a/keps/4136-admission-fair-sharing/README.md
+++ b/keps/4136-admission-fair-sharing/README.md
@@ -206,12 +206,21 @@ usageSamplingInterval: 5mins
 Here, all Jobs submitted by Tenant B  within the next 5min get scheduled.
 Even if Tenant B submitted a job that consumed 1000 CPUs, consecutive jobs would still be prioritized because of the delay in updating the status.
 
-Hence, since v0.13 Kueue adds an entry penalty to FairSharingStatus every time it admits a Workload. The penalty should be calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
+Hence, since v0.13 Kueue adds an entry penalty when it first assumes a Workload for a quota
+reservation in a ClusterQueue that uses `UsageBasedAdmissionFairSharing`. The penalty should be
+calculated with the formula: `penalty = A * requested_resource`, where `A` is as above:
 
 `A = 1 - 0.5 ^ (sampling/half_life_decay)`. 
 
 This an equivalent of a job's usage that has been admitted `samplingInterval` ago. The value of penalty is an arbitrary decision for now.
 After we collect customers' feedback, we'll consider introducing an API that allows to configure it.
+
+Each quota reservation contributes at most one entry penalty. A Workload that needs a second
+scheduling pass, such as one using a [ProvisioningRequest AdmissionCheck](../2724-topology-aware-scheduling/README.md#support-for-provisioningrequests)
+or the [`TASFailedNodeReplacement` feature gate](../2724-topology-aware-scheduling/README.md#node-failures),
+is re-assumed while keeping its existing quota reservation. The second-pass assumption does not
+add another entry penalty. The penalty added during the first pass is settled when the Workload is
+admitted.
 
 ### User Stories (Optional)
 #### Story 1
@@ -294,4 +303,3 @@ for configuration examples.
 
 * Not having the feature.
 * Modifying/replacing the existing preemptive fair sharing algorithm.
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I reflected https://github.com/kubernetes-sigs/kueue/issues/13495 changes on AFS KEP.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that entry penalties apply when a workload first reserves ClusterQueue quota under usage-based admission fair sharing.
  * Documented that each reservation adds at most one penalty, settled upon admission unless the workload is deactivated in the same update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->