### PR TITLE
fix(webhook): correct typos and grammar in webhook error messages

### DIFF
--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -184,7 +184,7 @@ func (w *JobWebhook) validateSyncCompletionCreate(job *Job) field.ErrorList {
 					field.Invalid(
 						field.NewPath("spec", "completions"),
 						job.Spec.Completions,
-						fmt.Sprintf("should be equal to parallelism when %s is annotation is true", JobCompletionsEqualParallelismAnnotation),
+						fmt.Sprintf("should be equal to parallelism when %s annotation is true", JobCompletionsEqualParallelismAnnotation),
 					),
 				)
 			}

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -136,7 +136,7 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec", "completions"),
 					ptr.To[int32](6),
-					fmt.Sprintf("should be equal to parallelism when %s is annotation is true", JobCompletionsEqualParallelismAnnotation),
+					fmt.Sprintf("should be equal to parallelism when %s annotation is true", JobCompletionsEqualParallelismAnnotation),
 				),
 			},
 		},

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -410,7 +410,7 @@ func validateReclaimablePodsUpdate(newObj, oldObj *kueue.Workload, basePath *fie
 		}
 		oldCount, found := knowPodSets[newCount.Name]
 		if found && newCount.Count < oldCount.Count && !scaledDownPodSets.Has(newCount.Name) {
-			ret = append(ret, field.Invalid(basePath.Key(string(newCount.Name)).Child("count"), newCount.Count, fmt.Sprintf("cannot be less then %d", oldCount.Count)))
+			ret = append(ret, field.Invalid(basePath.Key(string(newCount.Name)).Child("count"), newCount.Count, fmt.Sprintf("cannot be less than %d", oldCount.Count)))
 		}
 	}
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
This PR fixes minor grammatical errors and typos in webhook validation messages:
- In `pkg/webhooks/workload_webhook.go`, fixes `"cannot be less then %d"` -> `"cannot be less than %d"`.
- In `pkg/controller/jobs/job/job_webhook.go`, fixes `"should be equal to parallelism when %s is annotation is true"` -> `"should be equal to parallelism when %s annotation is true"`.
- Updates the corresponding test expectation in `pkg/controller/jobs/job/job_webhook_test.go`.

Which issue(s) this PR fixes:
NONE

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation error messages for mismatched completions and parallelism when synchronization is enabled.
  * Fixed a grammatical error in the reclaimable pods update validation message.
  * Updated related validation test expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```
```release-note
NONE
```