### PR TITLE
fix(kueuectl): fix grammar and formatting in list pods help text

### DIFF
--- a/cmd/kueuectl/app/list/list_pods.go
+++ b/cmd/kueuectl/app/list/list_pods.go
@@ -45,9 +45,9 @@ import (
 
 var (
 	podLong = templates.LongDesc(`
-		Lists all pods that matches the given criteria: should be part 
+		Lists all pods that match the given criteria: should be part 
 		of the specified Job kind, belonging to the specified namespace, 
-		matching the label selector or the field selector.)
+		matching the label selector or the field selector.
 
 		The --for=pod/pod-name option allows to find pods from the same 
 		pod group as the specified pod, including that pod itself. 

--- a/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_pods.md
+++ b/site/content/en/docs/reference/kubectl-kueue/commands/kueuectl_list/kueuectl_list_pods.md
@@ -13,7 +13,7 @@ The file is auto-generated from the Go source code of the component using the
 ## Synopsis
 
 
-Lists all pods that matches the given criteria: should be part of the specified Job kind, belonging to the specified namespace, matching the label selector or the field selector.)
+Lists all pods that match the given criteria: should be part of the specified Job kind, belonging to the specified namespace, matching the label selector or the field selector.
 
  The --for=pod/pod-name option allows to find pods from the same pod group as the specified pod, including that pod itself.
 


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
In `cmd/kueuectl/app/list/list_pods.go`, fixes the verb conjugation (`"matches"` -> `"match"`) and removes a stray closing parenthesis in the `podLong` description.

Which issue(s) this PR fixes:
NONE

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Corrected grammar and punctuation in the `kueuectl list pods` command description.
- Updated the command synopsis to accurately describe matching pods and remove an extraneous parenthesis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
```
```release-note
NONE
```