### PR TITLE
docs: correct Event RBAC for external integrations

### DIFF
--- a/site/content/en/docs/tasks/dev/integrate_a_custom_job.md
+++ b/site/content/en/docs/tasks/dev/integrate_a_custom_job.md
@@ -137,7 +137,7 @@ Extend your existing RBAC Authorizations to include the privileges needed by
 Kueue's JobReconciler:
 ```go
 // +kubebuilder:rbac:groups=scheduling.k8s.io,resources=priorityclasses,verbs=list;get;watch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;watch;update;patch
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;watch;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kueue.x-k8s.io,resources=workloads/finalizers,verbs=update


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area integrations
/area website

#### What this PR does / why we need it:

Updates the external integration guide to grant `events.k8s.io` Event permissions, matching the `events.EventRecorder` used by Kueue's `JobReconciler`. This prevents event writes from being denied for integrations that follow the documented RBAC markers.

#### Which issue(s) this PR fixes:

Fixes #13933

#### Special notes for your reviewer:

Integrations that separately use the deprecated Event recorder still need their existing core Event RBAC rule.

Validated with `git diff --check` and a full Hugo `--gc --minify` site build.

The final diff was manually implemented and validated. AI tools were used to assist with code review.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```