### PR TITLE
Add CustomLabel test builder for the metrics config

### DIFF
--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3156,6 +3156,50 @@ func TestValidateCustomLabels(t *testing.T) {
 				},
 			},
 		},
+		"too many custom labels for local queue": {
+			cfg: &configapi.Configuration{
+				ControllerManager: configapi.ControllerManager{
+					Metrics: configapi.ControllerMetrics{
+						CustomLabels: []configapi.ControllerMetricsCustomLabel{
+							{Name: "lq1", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq2", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq3", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq4", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq5", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq6", SourceKind: new(configapi.SourceKindLocalQueue)},
+							{Name: "lq7", SourceKind: new(configapi.SourceKindLocalQueue)},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "metrics.customLabels",
+					Detail: "too many custom labels for source kind LocalQueue: found 7, expected <= 6",
+				},
+			},
+		},
+		"too many custom labels for workload": {
+			cfg: &configapi.Configuration{
+				ControllerManager: configapi.ControllerManager{
+					Metrics: configapi.ControllerMetrics{
+						CustomLabels: []configapi.ControllerMetricsCustomLabel{
+							{Name: "wl1", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"v"}},
+							{Name: "wl2", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"v"}},
+							{Name: "wl3", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"v"}},
+						},
+					},
+				},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "metrics.customLabels",
+					Detail: "too many custom labels for source kind Workload: found 3, expected <= 2",
+				},
+			},
+		},
 		"workload without tracked values": {
 			cfg: &configapi.Configuration{
 				ControllerManager: configapi.ControllerManager{

--- a/pkg/metrics/custom_labels_test.go
+++ b/pkg/metrics/custom_labels_test.go
@@ -26,6 +26,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 )
 
 func TestCustomLabels(t *testing.T) {
@@ -54,7 +55,7 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"name only (defaults to label key)": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team"},
+				utiltestingapi.MakeCustomLabel("team").Obj(),
 			},
 			labels:      map[string]string{"team": "infra"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -63,7 +64,7 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"sourceLabelKey": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team", SourceLabelKey: "org/team"},
+				utiltestingapi.MakeCustomLabel("team").SourceLabelKey("org/team").Obj(),
 			},
 			labels:      map[string]string{"org/team": "platform"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -72,7 +73,7 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"sourceAnnotationKey": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "cost_center", SourceAnnotationKey: "billing/cost-center"},
+				utiltestingapi.MakeCustomLabel("cost_center").SourceAnnotationKey("billing/cost-center").Obj(),
 			},
 			annotations: map[string]string{"billing/cost-center": "cc-123"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -81,7 +82,7 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"missing key returns empty string": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team"},
+				utiltestingapi.MakeCustomLabel("team").Obj(),
 			},
 			labels:      map[string]string{"other": "value"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -90,9 +91,9 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"multiple entries": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team"},
-				{Name: "env", SourceLabelKey: "environment"},
-				{Name: "cost", SourceAnnotationKey: "billing/cost"},
+				utiltestingapi.MakeCustomLabel("team").Obj(),
+				utiltestingapi.MakeCustomLabel("env").SourceLabelKey("environment").Obj(),
+				utiltestingapi.MakeCustomLabel("cost").SourceAnnotationKey("billing/cost").Obj(),
 			},
 			labels:      map[string]string{"team": "ml", "environment": "prod"},
 			annotations: map[string]string{"billing/cost": "high"},
@@ -102,10 +103,10 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"entries with specified source kinds": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "cohort", SourceAnnotationKey: "cohort", SourceKind: new(configapi.SourceKindCohort)},
-				{Name: "team", SourceKind: new(configapi.SourceKindClusterQueue)},
-				{Name: "env", SourceLabelKey: "environment", SourceKind: new(configapi.SourceKindLocalQueue)},
-				{Name: "cost", SourceAnnotationKey: "billing/cost", SourceKind: new(configapi.SourceKindClusterQueue)},
+				utiltestingapi.MakeCustomLabel("cohort").SourceAnnotationKey("cohort").SourceKind(configapi.SourceKindCohort).Obj(),
+				utiltestingapi.MakeCustomLabel("team").SourceKind(configapi.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("env").SourceLabelKey("environment").SourceKind(configapi.SourceKindLocalQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("cost").SourceAnnotationKey("billing/cost").SourceKind(configapi.SourceKindClusterQueue).Obj(),
 			},
 			labels:      map[string]string{"team": "ml", "environment": "prod"},
 			annotations: map[string]string{"billing/cost": "high", "cohort": "c1"},
@@ -115,9 +116,9 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"all values tracked": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team", TrackedValues: []string{"infra", "platform"}},
-				{Name: "env", SourceLabelKey: "environment", TrackedValues: []string{"prod", "staging"}},
-				{Name: "cost", TrackedValues: []string{}},
+				utiltestingapi.MakeCustomLabel("team").TrackedValues("infra", "platform").Obj(),
+				utiltestingapi.MakeCustomLabel("env").SourceLabelKey("environment").TrackedValues("prod", "staging").Obj(),
+				utiltestingapi.MakeCustomLabel("cost").Obj(),
 			},
 			labels:      map[string]string{"team": "infra", "environment": "prod", "cost": "high"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -126,9 +127,9 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"some values not tracked": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "team", TrackedValues: []string{"infra", "platform"}},
-				{Name: "env", SourceLabelKey: "environment", TrackedValues: []string{"prod", "staging"}},
-				{Name: "cost", TrackedValues: []string{}},
+				utiltestingapi.MakeCustomLabel("team").TrackedValues("infra", "platform").Obj(),
+				utiltestingapi.MakeCustomLabel("env").SourceLabelKey("environment").TrackedValues("prod", "staging").Obj(),
+				utiltestingapi.MakeCustomLabel("cost").Obj(),
 			},
 			labels:      map[string]string{"team": "other", "environment": "prod", "cost": "high"},
 			sourceKinds: []configapi.SourceKind{configapi.SourceKindClusterQueue},
@@ -193,10 +194,10 @@ func TestStoreCustomLabels(t *testing.T) {
 					}
 			},
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "a"},
-				{Name: "b"},
-				{Name: "c", SourceAnnotationKey: "c"},
-				{Name: "d", SourceAnnotationKey: "d"},
+				utiltestingapi.MakeCustomLabel("a").Obj(),
+				utiltestingapi.MakeCustomLabel("b").Obj(),
+				utiltestingapi.MakeCustomLabel("c").SourceAnnotationKey("c").Obj(),
+				utiltestingapi.MakeCustomLabel("d").SourceAnnotationKey("d").Obj(),
 			},
 			initialLabels: map[string]string{
 				"a": "a",
@@ -234,10 +235,10 @@ func TestStoreCustomLabels(t *testing.T) {
 					}
 			},
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "cq-label"},
-				{Name: "wl-label", SourceKind: new(configapi.SourceKindWorkload)},
-				{Name: "cq-annotation", SourceAnnotationKey: "cq-annotation"},
-				{Name: "wl-annotation", SourceAnnotationKey: "wl-annotation", SourceKind: new(configapi.SourceKindWorkload)},
+				utiltestingapi.MakeCustomLabel("cq_label").SourceLabelKey("cq-label").Obj(),
+				utiltestingapi.MakeCustomLabel("wl_label").SourceLabelKey("wl-label").SourceKind(configapi.SourceKindWorkload).TrackedValues("wl-label-value").Obj(),
+				utiltestingapi.MakeCustomLabel("cq_annotation").SourceAnnotationKey("cq-annotation").Obj(),
+				utiltestingapi.MakeCustomLabel("wl_annotation").SourceAnnotationKey("wl-annotation").SourceKind(configapi.SourceKindWorkload).TrackedValues("wl-annot-value", "wl-annot-value2").Obj(),
 			},
 			initialLabels: map[string]string{
 				"cq-label":    "cq-label-value",
@@ -314,7 +315,7 @@ func TestUpdateRequired(t *testing.T) {
 		nilReceiver bool
 	}{
 		"nil receiver": {
-			entries:     []configapi.ControllerMetricsCustomLabel{{Name: "team"}},
+			entries:     []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()},
 			kind:        configapi.SourceKindClusterQueue,
 			ref:         "cq1",
 			testLabels:  map[string]string{"team": "infra"},
@@ -322,28 +323,28 @@ func TestUpdateRequired(t *testing.T) {
 			nilReceiver: true,
 		},
 		"unsupported kind": {
-			entries:    []configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: new(configapi.SourceKindClusterQueue)}},
+			entries:    []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").SourceKind(configapi.SourceKindClusterQueue).Obj()},
 			kind:       configapi.SourceKindLocalQueue,
 			ref:        "lq1",
 			testLabels: map[string]string{"team": "infra"},
 			want:       false,
 		},
 		"not stored, new values empty": {
-			entries:    []configapi.ControllerMetricsCustomLabel{{Name: "team"}},
+			entries:    []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()},
 			kind:       configapi.SourceKindClusterQueue,
 			ref:        "cq1",
 			testLabels: map[string]string{"other": "value"},
 			want:       false,
 		},
 		"not stored, new values not empty": {
-			entries:    []configapi.ControllerMetricsCustomLabel{{Name: "team"}},
+			entries:    []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()},
 			kind:       configapi.SourceKindClusterQueue,
 			ref:        "cq1",
 			testLabels: map[string]string{"team": "infra"},
 			want:       true,
 		},
 		"stored, values equal": {
-			entries:     []configapi.ControllerMetricsCustomLabel{{Name: "team"}},
+			entries:     []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()},
 			kind:        configapi.SourceKindClusterQueue,
 			ref:         "cq1",
 			storeLabels: map[string]string{"team": "infra"},
@@ -351,7 +352,7 @@ func TestUpdateRequired(t *testing.T) {
 			want:        false,
 		},
 		"stored, values not equal": {
-			entries:     []configapi.ControllerMetricsCustomLabel{{Name: "team"}},
+			entries:     []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()},
 			kind:        configapi.SourceKindClusterQueue,
 			ref:         "cq1",
 			storeLabels: map[string]string{"team": "infra"},
@@ -383,7 +384,7 @@ func TestUpdateRequired(t *testing.T) {
 
 func TestCustomLabelsDisabled(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, false)
-	entries := []configapi.ControllerMetricsCustomLabel{{Name: "team"}}
+	entries := []configapi.ControllerMetricsCustomLabel{utiltestingapi.MakeCustomLabel("team").Obj()}
 	cl := NewCustomLabels(entries)
 	if cl != nil {
 		t.Error("expected nil CustomLabels when feature gate is disabled")

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -30,6 +30,7 @@ import (
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/util/csv"
@@ -1806,4 +1807,48 @@ func (cpw *ClusterProfileWrapper) ClusterManager(clusterManagerName string) *Clu
 		Name: clusterManagerName,
 	}
 	return cpw
+}
+
+// CustomLabelWrapper builds a ControllerMetricsCustomLabel. The label is a named field
+// (not embedded) so the setters can mirror the API field names.
+type CustomLabelWrapper struct {
+	label configapi.ControllerMetricsCustomLabel
+}
+
+// MakeCustomLabel starts a wrapper for the label with the given name.
+func MakeCustomLabel(name string) *CustomLabelWrapper {
+	return &CustomLabelWrapper{label: configapi.ControllerMetricsCustomLabel{Name: name}}
+}
+
+func (w *CustomLabelWrapper) SourceLabelKey(key string) *CustomLabelWrapper {
+	w.label.SourceLabelKey = key
+	return w
+}
+
+func (w *CustomLabelWrapper) SourceAnnotationKey(key string) *CustomLabelWrapper {
+	w.label.SourceAnnotationKey = key
+	return w
+}
+
+func (w *CustomLabelWrapper) SourceKind(kind configapi.SourceKind) *CustomLabelWrapper {
+	w.label.SourceKind = new(kind)
+	return w
+}
+
+func (w *CustomLabelWrapper) TrackedValues(values ...string) *CustomLabelWrapper {
+	w.label.TrackedValues = values
+	return w
+}
+
+// Obj returns the built ControllerMetricsCustomLabel. Like the ResourceGroup and
+// FlavorQuotas builders, it panics on local construction mistakes; the full API
+// validation lives in pkg/config.
+func (w *CustomLabelWrapper) Obj() configapi.ControllerMetricsCustomLabel {
+	if w.label.SourceLabelKey != "" && w.label.SourceAnnotationKey != "" {
+		panic(fmt.Sprintf("CustomLabel %q: sourceLabelKey and sourceAnnotationKey are mutually exclusive", w.label.Name))
+	}
+	if w.label.SourceKind != nil && *w.label.SourceKind == configapi.SourceKindWorkload && len(w.label.TrackedValues) == 0 {
+		panic(fmt.Sprintf("CustomLabel %q: trackedValues are required when sourceKind is Workload", w.label.Name))
+	}
+	return w.label
 }

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -1809,13 +1809,11 @@ func (cpw *ClusterProfileWrapper) ClusterManager(clusterManagerName string) *Clu
 	return cpw
 }
 
-// CustomLabelWrapper builds a ControllerMetricsCustomLabel. The label is a named field
-// (not embedded) so the setters can mirror the API field names.
+// CustomLabelWrapper wraps a ControllerMetricsCustomLabel.
 type CustomLabelWrapper struct {
 	label configapi.ControllerMetricsCustomLabel
 }
 
-// MakeCustomLabel starts a wrapper for the label with the given name.
 func MakeCustomLabel(name string) *CustomLabelWrapper {
 	return &CustomLabelWrapper{label: configapi.ControllerMetricsCustomLabel{Name: name}}
 }
@@ -1840,15 +1838,7 @@ func (w *CustomLabelWrapper) TrackedValues(values ...string) *CustomLabelWrapper
 	return w
 }
 
-// Obj returns the built ControllerMetricsCustomLabel. Like the ResourceGroup and
-// FlavorQuotas builders, it panics on local construction mistakes; the full API
-// validation lives in pkg/config.
+// Obj returns the built ControllerMetricsCustomLabel.
 func (w *CustomLabelWrapper) Obj() configapi.ControllerMetricsCustomLabel {
-	if w.label.SourceLabelKey != "" && w.label.SourceAnnotationKey != "" {
-		panic(fmt.Sprintf("CustomLabel %q: sourceLabelKey and sourceAnnotationKey are mutually exclusive", w.label.Name))
-	}
-	if w.label.SourceKind != nil && *w.label.SourceKind == configapi.SourceKindWorkload && len(w.label.TrackedValues) == 0 {
-		panic(fmt.Sprintf("CustomLabel %q: trackedValues are required when sourceKind is Workload", w.label.Name))
-	}
 	return w.label
 }

--- a/test/e2e/sequential/baseline/custom_metrics_test.go
+++ b/test/e2e/sequential/baseline/custom_metrics_test.go
@@ -70,18 +70,8 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 				}
 				cfg.Integrations.LabelKeysToCopy = []string{"toCopyKeyIntegration"}
 				cfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-					{
-						Name:           "custom_label_key",
-						SourceLabelKey: "toCopyKeyCustom",
-						SourceKind:     new(config.SourceKindWorkload),
-						TrackedValues:  []string{"custom_value"},
-					},
-					{
-						Name:                "custom_annotation_key",
-						SourceAnnotationKey: "toCopyAnnotation",
-						SourceKind:          new(config.SourceKindWorkload),
-						TrackedValues:       []string{"annotation_value"},
-					},
+					utiltestingapi.MakeCustomLabel("custom_label_key").SourceLabelKey("toCopyKeyCustom").SourceKind(config.SourceKindWorkload).TrackedValues("custom_value").Obj(),
+					utiltestingapi.MakeCustomLabel("custom_annotation_key").SourceAnnotationKey("toCopyAnnotation").SourceKind(config.SourceKindWorkload).TrackedValues("annotation_value").Obj(),
 				}
 			})
 		})

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -51,8 +51,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_lq").SourceLabelKey("team").SourceKind(config.SourceKindLocalQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "cost_center", SourceLabelKey: "billing/cost-center", SourceKind: new(config.SourceKindClusterQueue)},
+				utiltestingapi.MakeCustomLabel("cost_center").SourceLabelKey("billing/cost-center").SourceKind(config.SourceKindClusterQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "budget", SourceAnnotationKey: "billing.co/budget", SourceKind: new(config.SourceKindClusterQueue)},
+				utiltestingapi.MakeCustomLabel("budget").SourceAnnotationKey("billing.co/budget").SourceKind(config.SourceKindClusterQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -295,8 +295,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, false)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_lq").SourceLabelKey("team").SourceKind(config.SourceKindLocalQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -403,8 +403,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_lq").SourceLabelKey("team").SourceKind(config.SourceKindLocalQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -466,8 +466,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_lq").SourceLabelKey("team").SourceKind(config.SourceKindLocalQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -627,7 +627,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				utiltestingapi.MakeCustomLabel("team").SourceKind(config.SourceKindClusterQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -724,8 +724,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			controllersCfg := &config.Configuration{}
 			controllersCfg.FairSharing = &config.FairSharing{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "team_cohort", SourceLabelKey: "team", SourceKind: new(config.SourceKindCohort)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("team_cohort").SourceLabelKey("team").SourceKind(config.SourceKindCohort).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -987,10 +987,10 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: new(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
-				{Name: "wl_anno", SourceAnnotationKey: "workload-anno", SourceKind: new(config.SourceKindWorkload), TrackedValues: []string{"anno1", "anno2"}},
-				{Name: "lq_label", SourceLabelKey: "lq-label", SourceKind: new(config.SourceKindLocalQueue)},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("wl_kind").SourceLabelKey("workload-kind").SourceKind(config.SourceKindWorkload).TrackedValues("kind1", "kind2").Obj(),
+				utiltestingapi.MakeCustomLabel("wl_anno").SourceAnnotationKey("workload-anno").SourceKind(config.SourceKindWorkload).TrackedValues("anno1", "anno2").Obj(),
+				utiltestingapi.MakeCustomLabel("lq_label").SourceLabelKey("lq-label").SourceKind(config.SourceKindLocalQueue).Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -1238,8 +1238,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
-				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: new(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
+				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),
+				utiltestingapi.MakeCustomLabel("wl_kind").SourceLabelKey("workload-kind").SourceKind(config.SourceKindWorkload).TrackedValues("kind1", "kind2").Obj(),
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind cleanup
/area testing

#### What this PR does / why we need it:

Adds a `MakeCustomLabel` test builder in `pkg/util/testing/v1beta2` and converts the
metrics, integration, and e2e call sites to use it.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13860 

#### Special notes for your reviewer:

Per review feedback, the builder is plain wrappers with no copy of the production validation

This PR was prepared with AI assistance.

#### Does this PR introduce a user-facing change?
N/A
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Tests

- Expanded custom metric-label validation coverage for source-specific label limits, including LocalQueue and Workload configurations.
- Updated controller, cluster, workload, and end-to-end test scenarios to use consistent custom-label configuration.
- Added coverage for custom-label mappings, tracked values, source keys, and annotations.
- Improved checks for invalid combinations and required workload configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->