### PR TITLE
test: set GOTRACEBACK=system for integration suites

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -159,6 +159,7 @@ test-integration-run:
 	ARTIFACTS=$(ARTIFACTS) \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \
 	GORACE="log_path=$(ARTIFACTS)/race" \
+	GOTRACEBACK=system \
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS) --race --json-report=integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/integration.json > $(ARTIFACTS)/integration-top.yaml
 
@@ -180,6 +181,7 @@ test-multikueue-integration: compile-crd-manifests envtest ginkgo dep-crds ginkg
 	ARTIFACTS=$(ARTIFACTS) \
 	TEST_LOG_LEVEL=$(TEST_LOG_LEVEL) API_LOG_LEVEL=$(INTEGRATION_API_LOG_LEVEL) \
 	GORACE="log_path=$(ARTIFACTS)/race" \
+	GOTRACEBACK=system \
 	$(GINKGO) $(INTEGRATION_FILTERS) $(GINKGO_ARGS) $(GOFLAGS) -procs=$(INTEGRATION_NPROCS_MULTIKUEUE) --race --json-report=multikueue-integration.json --output-interceptor-mode=none --output-dir=$(ARTIFACTS) -v $(INTEGRATION_TARGET_MULTIKUEUE)
 	$(BIN_DIR)/ginkgo-top -i $(ARTIFACTS)/multikueue-integration.json > $(ARTIFACTS)/multikueue-integration-top.yaml
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area testing

#### What this PR does / why we need it:

The integration test compilation has been observed to intermittently deadlock in `go vet`, producing no diagnostic output (the same SHA compiled fine on retry, pointing at a toolchain-level hang rather than a code defect).

This sets `GOTRACEBACK=system` on the `test-integration-run` and `test-multikueue-integration` recipes. If such a hang recurs, the Go runtime will then dump all goroutine stacks — including runtime internals — giving us actionable data to file an upstream Go report. It produces no output on successful runs and has negligible performance impact, so it is safe to leave on permanently.

This is the low-risk observability step suggested by @mimowo in the issue; it does not attempt to fix the root cause, only to capture it next time.

#### Which issue(s) this PR relates to:

Relates to #13934

#### Special notes for your reviewer:

Diff is two lines (one env var per integration recipe). Verified with `make -n test-integration-run` that `GOTRACEBACK=system` is injected into the generated Ginkgo command and the Makefile still parses.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
