### PR TITLE
[release-0.18] Separate what a transformation generates from what the PodSet requested

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -561,7 +561,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -558,7 +558,9 @@ type ResourceTransformation struct {
 	// MultiplyBy indicates the resource name requested by a workload, if
 	// specified.
 	// The requested amount of the resource is used to multiply the requested
-	// amount of the resource indicated by the "input" field.
+	// amount of the resource indicated by the "input" field when computing
+	// "outputs". It does not change the quantity retained under "input" when
+	// "strategy" is Retain.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/keps/2937-resource-transformer/README.md
+++ b/keps/2937-resource-transformer/README.md
@@ -391,11 +391,15 @@ Based on the example in Story 3, the following content can be defined in the Kue
 resources:
   transformations:
   - input: nvidia.com/gpumem
-    strategy: Retain
+    strategy: Replace
     multiplyBy: nvidia.com/gpu
     outputs:
       nvidia.com/total-gpumem: 1
 ```
+
+`multiplyBy` scales the outputs. It does not change what `Retain` keeps under the
+input's own name, so with `Retain` here the effective request above would also
+carry `nvidia.com/gpumem: 1024` and the ClusterQueue would have to cover it.
 
 ### Observability
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -547,32 +547,47 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	if !match {
 		return input
 	}
-	output := make(corev1.ResourceList)
+	// What the transformations produce is kept apart from what the PodSet asked
+	// for until the end. A negative output factor is how an allowance is
+	// written, so outputs still cancel each other, but the total one resource
+	// generates cannot go on to reduce a request that was never part of that
+	// arithmetic: an ordinary request under the same name, or the DRA charge
+	// merged in after this returns.
+	retained := make(corev1.ResourceList)
+	generated := make(corev1.ResourceList)
 	for inputName, inputQuantity := range input {
-		if mapping, ok := transforms[inputName]; ok {
-			// If MultiplyBy is specified, multiply the input quantity by
-			// the value of the resource specified in MultiplyBy.
-			if mapping.MultiplyBy != "" {
-				if q, ok := input[mapping.MultiplyBy]; ok {
-					inputQuantity = multiplyResourceQuantities(inputQuantity, q)
-				}
+		mapping, ok := transforms[inputName]
+		if !ok {
+			retained[inputName] = inputQuantity
+			continue
+		}
+		// MultiplyBy scales the value the outputs are computed from by the
+		// quantity of the resource it names. Retain keeps the input as it was
+		// requested, so the multiplier does not reach that as well.
+		outputInputVal := inputQuantity
+		if mapping.MultiplyBy != "" {
+			if q, ok := input[mapping.MultiplyBy]; ok {
+				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
 			}
+		}
 
-			for outputName, baseFactor := range mapping.Outputs {
-				outputQuantity := multiplyResourceQuantities(inputQuantity, baseFactor)
-				if accumulated, ok := output[outputName]; ok {
-					outputQuantity.Add(accumulated)
-				}
-				output[outputName] = outputQuantity
-			}
-			if ptr.Deref(mapping.Strategy, config.Retain) == config.Retain {
-				output[inputName] = inputQuantity
-			}
-		} else {
-			output[inputName] = inputQuantity
+		outputs := make(corev1.ResourceList, len(mapping.Outputs))
+		for outputName, baseFactor := range mapping.Outputs {
+			outputs[outputName] = multiplyResourceQuantities(outputInputVal, baseFactor)
+		}
+		// Summed rather than assigned, so which order the input map is walked
+		// in does not decide which contribution to a name survives.
+		generated = resource.MergeResourceListKeepSum(generated, outputs)
+		if ptr.Deref(mapping.Strategy, config.Retain) == config.Retain {
+			retained[inputName] = inputQuantity
 		}
 	}
-	return output
+	for name, quantity := range generated {
+		if quantity.Sign() < 0 {
+			generated[name] = apiresource.Quantity{}
+		}
+	}
+	return resource.MergeResourceListKeepSum(retained, generated)
 }
 
 func multiplyResourceQuantities(value, mul apiresource.Quantity) apiresource.Quantity {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -724,6 +724,265 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		// A negative output factor is how a per-unit allowance is written: the
+		// charge is what the request exceeds it by. These three are the same
+		// configuration at, above and below the allowance.
+		"transformAllowanceAboveIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "2048").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 2048,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformAllowanceExactlyAtIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "1024").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 0,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformAllowanceUnderIt": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("nvidia.com/gpumem", "512").
+					Request("nvidia.com/gpu", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "nvidia.com/gpumem",
+					Strategy:   ptr.To(config.Replace),
+					MultiplyBy: "nvidia.com/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
+				},
+				{
+					Input:    "nvidia.com/gpu",
+					Strategy: ptr.To(config.Retain),
+					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/gpu-memory-overage"): 0,
+						corev1.ResourceName("nvidia.com/gpu"):                       2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An allowance is spent against what the transformations generate, and
+		// nothing else. Here it would otherwise come off a request the PodSet
+		// made directly under the same name.
+		"transformAllowanceDoesNotReachADirectRequest": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "8").
+					Request("example.com/credit", "3").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: ptr.To(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An output sharing a name with something the PodSet requests directly
+		// used to be kept or dropped by the order the input map was walked.
+		"transformOutputSharingANameWithARequestIsAdded": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					Request("example.com/credit", "1").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: ptr.To(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// And one naming its own retained input used to be overwritten by the
+		// retain assignment every time.
+		"transformOutputSharingANameWithItsRetainedInputIsAdded": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/gpu",
+				Strategy: ptr.To(config.Retain),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("5")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 6,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformRetainWithMultiplyBy": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request("example.com/gpu", "2").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:      "example.com/gpumem",
+					Strategy:   ptr.To(config.Retain),
+					MultiplyBy: "example.com/gpu",
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							// Retain keeps gpumem as requested (1024), not the multiplyBy
+							// product (2048); the multiplier only scales the quota output.
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 2048,
+							corev1.ResourceName("example.com/gpu"):          2,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
+		// A multiplier below one scales the generated output but leaves the
+		// retained input unchanged: 1024 is retained while the output is 512.
+		"transformRetainWithMultiplyByUnderOne": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(
+					*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/gpumem", "1024").
+						Request(corev1.ResourceCPU, "500m").
+						Obj(),
+				).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input: "example.com/gpumem",
+					// Strategy left unset: nil defaults to Retain in production,
+					// so this covers the path an operator gets without asking.
+					MultiplyBy: corev1.ResourceCPU,
+					Outputs: corev1.ResourceList{
+						"example.com/gpumem-quota": resource.MustParse("1"),
+					},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{
+					{
+						Name: "a",
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							corev1.ResourceName("example.com/gpumem"):       1024,
+							corev1.ResourceName("example.com/gpumem-quota"): 512,
+							corev1.ResourceCPU:                              500,
+						}),
+						Count: 1,
+					},
+				},
+			},
+		},
+		// MultiplyBy scales the value the outputs are computed from. Retain keeps
+		// the input as it was requested, so a request of 1 against a multiplier
+		// of 2 leaves 2 generated and 1 retained rather than 2 and 2.
+		"transformOutputSharingANameWithItsRetainedInputIsAddedToTheAmountRequested": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					Request("example.com/node", "2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:      "example.com/gpu",
+				Strategy:   ptr.To(config.Retain),
+				MultiplyBy: "example.com/node",
+				Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):  3,
+						corev1.ResourceName("example.com/node"): 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1142,7 +1142,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1201,7 +1201,9 @@ Defaults to Retain</p>
    <p>MultiplyBy indicates the resource name requested by a workload, if
 specified.
 The requested amount of the resource is used to multiply the requested
-amount of the resource indicated by the &quot;input&quot; field.</p>
+amount of the resource indicated by the &quot;input&quot; field when computing
+&quot;outputs&quot;. It does not change the quantity retained under &quot;input&quot; when
+&quot;strategy&quot; is Retain.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>


### PR DESCRIPTION
This is a manual cherry-pick of #13986. The automated one could not apply.

`pkg/util/resource` is imported unaliased on this branch and apimachinery is aliased as `apiresource`, the reverse of main, so the import the commit adds is dropped, `MergeResourceListKeepSum` is called through the existing `resource`, and the zeroed quantity is `apiresource.Quantity{}`. `applyResourceTransformations` is otherwise byte-identical to the commit on main, and the file set matches #14032.

`pkg/workload` passes and the package is lint clean here.

/assign tenzen-y

```release-note
ResourceTransformations × DRA: Fixed negative generated totals so they no longer reduce retained Pod requests or DRA logical-resource charges. Negative outputs can still offset other generated outputs, and contributions to the same resource are now summed deterministically. Also fixed `multiplyBy` to scale generated outputs only; with `Retain`, the original input quantity remains unchanged.
```

/kind bug

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
