### PR TITLE
[release-0.18] RayCluster: make the autoscaling validation error name the elastic-job annotation

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -147,7 +147,9 @@ func (w *RayClusterWebhook) validateCreate(ctx context.Context, job *rayv1.RayCl
 				field.Invalid(
 					specPath.Child("enableInTreeAutoscaling"),
 					spec.EnableInTreeAutoscaling,
-					"a kueue managed job can use autoscaling only when the ElasticJobsViaWorkloadSlices feature gate is on and the job is an elastic job",
+					fmt.Sprintf("a kueue-managed RayCluster can use autoscaling only as an elastic job: "+
+						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
+						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),
 			)
 		}

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -37,6 +37,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	testingrayutil "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
 
 func TestValidateDefault(t *testing.T) {
@@ -150,7 +151,9 @@ func TestValidateCreate(t *testing.T) {
 				field.Invalid(
 					field.NewPath("spec", "enableInTreeAutoscaling"),
 					new(true),
-					"a kueue managed job can use autoscaling only when the ElasticJobsViaWorkloadSlices feature gate is on and the job is an elastic job",
+					fmt.Sprintf("a kueue-managed RayCluster can use autoscaling only as an elastic job: "+
+						"enable the ElasticJobsViaWorkloadSlices feature gate and set the %q: %q annotation",
+						workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue),
 				),
 			}.ToAggregate(),
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

Cherry pick of #13996 onto `release-0.18`.

Makes the RayCluster autoscaling validation error actionable: when a Kueue-managed `RayCluster` sets `spec.enableInTreeAutoscaling: true` without being an elastic job, the message now names the exact requirements — the `ElasticJobsViaWorkloadSlices` feature gate and the `kueue.x-k8s.io/elastic-job: "true"` annotation — instead of only stating that the job must be "an elastic job". No behavior change; message text only.

The cherry-pick additionally adds the `workloadslicing` import to the webhook test, which the message change references (it is already imported by the test on `main`).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

Clean cherry-pick of the squashed commit `f90a84670` from #13996; the only extra change is the test import noted above. AI tools were used to help prepare this cherry-pick, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
RayCluster: Fixed an unclear validation error for Kueue-managed RayClusters that enable in-tree autoscaling without being configured as elastic jobs. The error explains that "ElasticJobsViaWorkloadSlices" and the "kueue.x-k8s.io/elastic-job: "true"" annotation are required.
```
