### PR TITLE
MultiKueue: forward RayService serveConfigV2 in-place updates to the worker

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1132,8 +1132,7 @@ func multiKueueConfigName(ac *kueue.AdmissionCheck) string {
 // alter the workload's PodSets (e.g. a RayService serveConfigV2 edit) leaves the
 // workload untouched, so that path never fires and this controller would only
 // reconcile on the next periodic requeue. This handler bridges that gap by watching
-// the job directly, so such a change promptly re-runs SyncJob
-// (e.g. to forward the serveConfigV2 edit to the worker).
+// the job directly, so such a change promptly re-runs SyncJob.
 type localJobHandler struct {
 	client            client.Client
 	gvk               schema.GroupVersionKind
@@ -1143,7 +1142,6 @@ type localJobHandler struct {
 var _ handler.EventHandler = (*localJobHandler)(nil)
 
 func (h *localJobHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	// no-op as the workload is synced through its own watch on creation
 }
 
 func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -1156,8 +1154,6 @@ func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q wor
 }
 
 func (h *localJobHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	// no-op as a manager-job deletion needs no sync trigger: the owning workload is
-	// being finalized regardless.
 }
 
 func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1137,6 +1137,7 @@ type localJobHandler struct {
 var _ handler.EventHandler = (*localJobHandler)(nil)
 
 func (h *localJobHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// no-op as the workload is synced through its own watch on creation
 }
 
 func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -1149,16 +1150,22 @@ func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q wor
 }
 
 func (h *localJobHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// no-op as a manager-job deletion needs no sync trigger: the owning workload is
+	// being finalized regardless.
 }
 
 func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// no-op as we don't need to react to generic
 }
 
 func (h *localJobHandler) queue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// Resolve owned workloads via the owner-reference index rather than the adapter's
+	// WorkloadKeysFor: this handler is generic over adapters (it only holds the GVK)
+	// and the index does not depend on the prebuilt-workload annotation being set.
 	wls := &kueue.WorkloadList{}
 	if err := h.client.List(ctx, wls, client.InNamespace(obj.GetNamespace()),
 		client.MatchingFields{indexer.OwnerReferenceIndexKey(h.gvk): obj.GetName()}); err != nil {
-		ctrl.LoggerFrom(ctx).V(3).Error(err, "Listing workloads for manager job", "job", klog.KObj(obj))
+		ctrl.LoggerFrom(ctx).V(2).Error(err, "Listing workloads for manager job", "job", klog.KObj(obj))
 		return
 	}
 	for i := range wls.Items {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1147,6 +1147,10 @@ func (h *localJobHandler) Create(context.Context, event.CreateEvent, workqueue.T
 func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	// React to spec changes only; a status-only update (e.g. status synced back
 	// from the worker) neither needs nor should re-trigger a sync.
+	//
+	// TODO: generation bumps only on spec changes, so metadata-only edits (labels,
+	// annotations) are filtered out here. Revisit if a future adapter needs to forward
+	// such metadata to the worker.
 	if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
 		return
 	}

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1124,6 +1124,48 @@ func multiKueueConfigName(ac *kueue.AdmissionCheck) string {
 	return ac.Spec.Parameters.Name
 }
 
+// localJobHandler enqueues the workload(s) owned by a manager-side job when the
+// job's spec changes, so MultiKueue promptly re-runs SyncJob (e.g. to forward a
+// RayService serveConfigV2 edit to the worker) instead of waiting for the next
+// periodic requeue.
+type localJobHandler struct {
+	client            client.Client
+	gvk               schema.GroupVersionKind
+	eventsBatchPeriod time.Duration
+}
+
+var _ handler.EventHandler = (*localJobHandler)(nil)
+
+func (h *localJobHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// React to spec changes only; a status-only update (e.g. status synced back
+	// from the worker) neither needs nor should re-trigger a sync.
+	if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
+		return
+	}
+	h.queue(ctx, e.ObjectNew, q)
+}
+
+func (h *localJobHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) queue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	wls := &kueue.WorkloadList{}
+	if err := h.client.List(ctx, wls, client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{indexer.OwnerReferenceIndexKey(h.gvk): obj.GetName()}); err != nil {
+		ctrl.LoggerFrom(ctx).V(3).Error(err, "Listing workloads for manager job", "job", klog.KObj(obj))
+		return
+	}
+	for i := range wls.Items {
+		q.AddAfter(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&wls.Items[i])}, h.eventsBatchPeriod)
+	}
+}
+
 func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	syncHndl := handler.Funcs{
 		GenericFunc: func(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -1134,12 +1176,33 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
 		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
-		Watches(&kueue.AdmissionCheck{}, &admissionCheckHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
+		Watches(&kueue.AdmissionCheck{}, &admissionCheckHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod})
+
+	// Watch the local (manager) job objects of adapters that forward spec changes
+	// after admission, so an edit (e.g. RayService serveConfigV2) promptly triggers
+	// a sync instead of waiting for the next periodic requeue.
+	for _, adapter := range w.adapters {
+		lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
+		if !ok {
+			continue
+		}
+		emptyJob := lw.NewEmptyLocalJob()
+		if emptyJob == nil {
+			continue
+		}
+		builder = builder.Watches(emptyJob, &localJobHandler{
+			client:            w.client,
+			gvk:               adapter.GVK(),
+			eventsBatchPeriod: w.eventsBatchPeriod,
+		})
+	}
+
+	return builder.
 		WithEventFilter(w).
 		WithOptions(controller.Options{
 			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload"),

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1197,20 +1197,22 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	// workload CR, so it does not reconcile this controller through the usual path;
 	// watching the job directly lets it promptly trigger a sync instead of waiting for
 	// the next periodic requeue.
-	for _, adapter := range w.adapters {
-		lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
-		if !ok {
-			continue
+	if features.Enabled(features.MultiKueueRemoteSpecSync) {
+		for _, adapter := range w.adapters {
+			lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
+			if !ok {
+				continue
+			}
+			emptyJob := lw.NewEmptyLocalJob()
+			if emptyJob == nil {
+				continue
+			}
+			builder = builder.Watches(emptyJob, &localJobHandler{
+				client:            w.client,
+				gvk:               adapter.GVK(),
+				eventsBatchPeriod: w.eventsBatchPeriod,
+			})
 		}
-		emptyJob := lw.NewEmptyLocalJob()
-		if emptyJob == nil {
-			continue
-		}
-		builder = builder.Watches(emptyJob, &localJobHandler{
-			client:            w.client,
-			gvk:               adapter.GVK(),
-			eventsBatchPeriod: w.eventsBatchPeriod,
-		})
 	}
 
 	return builder.

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1131,8 +1131,8 @@ func multiKueueConfigName(ac *kueue.AdmissionCheck) string {
 // turn reconciles this admission-check controller. But a spec change that does not
 // alter the workload's PodSets (e.g. a RayService serveConfigV2 edit) leaves the
 // workload untouched, so that path never fires and this controller would only
-// reconcile on the next periodic requeue (~workerLostTimeout). This handler bridges
-// that gap by watching the job directly, so such a change promptly re-runs SyncJob
+// reconcile on the next periodic requeue. This handler bridges that gap by watching
+// the job directly, so such a change promptly re-runs SyncJob
 // (e.g. to forward the serveConfigV2 edit to the worker).
 type localJobHandler struct {
 	client            client.Client

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1164,9 +1164,6 @@ func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue
 }
 
 func (h *localJobHandler) queue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	// Resolve owned workloads via the owner-reference index rather than the adapter's
-	// WorkloadKeysFor: this handler is generic over adapters (it only holds the GVK)
-	// and the index does not depend on the prebuilt-workload annotation being set.
 	wls := &kueue.WorkloadList{}
 	if err := h.client.List(ctx, wls, client.InNamespace(obj.GetNamespace()),
 		client.MatchingFields{indexer.OwnerReferenceIndexKey(h.gvk): obj.GetName()}); err != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1125,9 +1125,15 @@ func multiKueueConfigName(ac *kueue.AdmissionCheck) string {
 }
 
 // localJobHandler enqueues the workload(s) owned by a manager-side job when the
-// job's spec changes, so MultiKueue promptly re-runs SyncJob (e.g. to forward a
-// RayService serveConfigV2 edit to the worker) instead of waiting for the next
-// periodic requeue.
+// job's spec changes.
+//
+// Normally a job spec edit makes the job controller update the workload, which in
+// turn reconciles this admission-check controller. But a spec change that does not
+// alter the workload's PodSets (e.g. a RayService serveConfigV2 edit) leaves the
+// workload untouched, so that path never fires and this controller would only
+// reconcile on the next periodic requeue (~workerLostTimeout). This handler bridges
+// that gap by watching the job directly, so such a change promptly re-runs SyncJob
+// (e.g. to forward the serveConfigV2 edit to the worker).
 type localJobHandler struct {
 	client            client.Client
 	gvk               schema.GroupVersionKind

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1193,8 +1193,10 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Watches(&kueue.AdmissionCheck{}, &admissionCheckHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod})
 
 	// Watch the local (manager) job objects of adapters that forward spec changes
-	// after admission, so an edit (e.g. RayService serveConfigV2) promptly triggers
-	// a sync instead of waiting for the next periodic requeue.
+	// after admission. Such an edit (e.g. RayService serveConfigV2) does not alter the
+	// workload CR, so it does not reconcile this controller through the usual path;
+	// watching the job directly lets it promptly trigger a sync instead of waiting for
+	// the next periodic requeue.
 	for _, adapter := range w.adapters {
 		lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
 		if !ok {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -1192,11 +1193,27 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
 		Watches(&kueue.AdmissionCheck{}, &admissionCheckHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod})
 
+	c, err := builder.
+		WithEventFilter(w).
+		WithOptions(controller.Options{
+			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload"),
+		}).
+		Build(w)
+	if err != nil {
+		return err
+	}
+
 	// Watch the local (manager) job objects of adapters that forward spec changes
 	// after admission. Such an edit (e.g. RayService serveConfigV2) does not alter the
 	// workload CR, so it does not reconcile this controller through the usual path;
 	// watching the job directly lets it promptly trigger a sync instead of waiting for
 	// the next periodic requeue.
+	//
+	// The watch is added on the built controller (not the builder) and only once the
+	// job's CRD is served (jobframework.WaitForAPI). A job CRD may be installed after
+	// Kueue starts (e.g. KubeRay), so adding it to the builder would make this
+	// controller's cache sync fail and crash-loop the manager; deferring degrades
+	// gracefully and picks the watch up when the CRD appears.
 	if features.Enabled(features.MultiKueueRemoteSpecSync) {
 		for _, adapter := range w.adapters {
 			lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
@@ -1207,20 +1224,23 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 			if emptyJob == nil {
 				continue
 			}
-			builder = builder.Watches(emptyJob, &localJobHandler{
-				client:            w.client,
-				gvk:               adapter.GVK(),
-				eventsBatchPeriod: w.eventsBatchPeriod,
-			})
+			gvk := adapter.GVK()
+			h := &localJobHandler{client: w.client, gvk: gvk, eventsBatchPeriod: w.eventsBatchPeriod}
+			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				log := ctrl.LoggerFrom(ctx).WithName("multikueue-workload")
+				jobframework.WaitForAPI(ctx, mgr, log, gvk, func() {
+					if err := c.Watch(source.Kind(mgr.GetCache(), emptyJob, h)); err != nil {
+						log.Error(err, "Unable to watch local job for MultiKueue spec sync", "gvk", gvk)
+					}
+				})
+				return nil
+			})); err != nil {
+				return err
+			}
 		}
 	}
 
-	return builder.
-		WithEventFilter(w).
-		WithOptions(controller.Options{
-			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload"),
-		}).
-		Complete(w)
+	return nil
 }
 
 func findPodSetAssignment(assignments []kueue.PodSetAssignment, name kueue.PodSetReference) *kueue.PodSetAssignment {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1157,7 +1157,6 @@ func (h *localJobHandler) Delete(context.Context, event.DeleteEvent, workqueue.T
 }
 
 func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	// no-op as we don't need to react to generic
 }
 
 func (h *localJobHandler) queue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -66,6 +66,18 @@ type MultiKueueWatcher interface {
 	WorkloadKeysFor(runtime.Object) ([]types.NamespacedName, error)
 }
 
+// MultiKueueLocalJobWatcher is implemented by MultiKueueAdapters whose local
+// (manager) job object should be watched, so that a manager-side spec change
+// promptly triggers a workload reconcile (and thus SyncJob) instead of waiting for
+// the next periodic requeue. Only adapters that forward manager spec changes to
+// the worker after admission need this (see the Ray adapter's RemoteSpecSyncer);
+// create-once adapters do not implement it, or return nil below.
+type MultiKueueLocalJobWatcher interface {
+	// NewEmptyLocalJob returns an empty job object of the adapter's type for the
+	// local watch, or nil if this adapter does not need one.
+	NewEmptyLocalJob() client.Object
+}
+
 // MultiKueueMultiWorkloadAdapter is an optional interface for MultiKueue adapters
 // whose jobs create multiple workloads (e.g., LeaderWorkerSet creates one workload per replica).
 type MultiKueueMultiWorkloadAdapter interface {

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -66,15 +66,15 @@ type MultiKueueWatcher interface {
 	WorkloadKeysFor(runtime.Object) ([]types.NamespacedName, error)
 }
 
-// MultiKueueLocalJobWatcher is implemented by MultiKueueAdapters whose local
-// (manager) job object should be watched, so that a manager-side spec change
-// promptly triggers a workload reconcile (and thus SyncJob) instead of waiting for
-// the next periodic requeue. Only adapters that forward manager spec changes to
-// the worker after admission need this (see the Ray adapter's RemoteSpecSyncer);
-// create-once adapters do not implement it, or return nil below.
+// MultiKueueLocalJobWatcher is an optional interface for MultiKueue adapters that
+// forward manager-side spec changes to the worker after admission (see the Ray
+// adapter's RemoteSpecSyncer). Watching the local (manager) job lets a spec change
+// promptly trigger a workload reconcile (and thus SyncJob) instead of waiting for
+// the next periodic requeue. Adapters that don't forward spec changes simply do not
+// implement it.
 type MultiKueueLocalJobWatcher interface {
-	// NewEmptyLocalJob returns an empty job object of the adapter's type for the
-	// local watch, or nil if this adapter does not need one.
+	// NewEmptyLocalJob returns an empty job object of the adapter's type to watch,
+	// or nil when this adapter does not currently need a local watch.
 	NewEmptyLocalJob() client.Object
 }
 

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -94,7 +94,7 @@ func (m *IntegrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, deferring setting up controller")
-				go waitForAPI(ctx, mgr, log, gvk, func() {
+				go WaitForAPI(ctx, mgr, log, gvk, func() {
 					log.Info("API now available, starting controller", "gvk", gvk)
 					if err := m.setupControllerAndWebhook(ctx, mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller for job framework")
@@ -147,7 +147,12 @@ func (m *IntegrationManager) setupControllerAndWebhook(ctx context.Context, mgr 
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+// WaitForAPI runs action once the CRD for gvk is served by the API server: it invokes
+// action immediately if the CRD is already installed, otherwise it polls (with backoff)
+// until the CRD appears, then invokes action. It returns early if ctx is cancelled. This
+// lets callers set up watches on optional CRDs without hard-depending on the CRD being
+// present at manager start.
+func WaitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
 	rateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[string](baseBackoffWaitForIntegration, maxBackoffWaitForIntegration)
 	item := gvk.String()
 	for {

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -202,7 +202,7 @@ func (a *adapter[PtrT, T]) SyncJob(
 		if a.needElasticSync(ctx, workloadName, localJob, remoteJob) {
 			return false, a.syncElastic(ctx, remoteClient, workloadName, localJob, remoteJob)
 		}
-		if a.remoteSpecSync != nil && a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
+		if a.remoteSpecSync != nil && features.Enabled(features.MultiKueueRemoteSpecSync) && a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
 			return false, a.syncRemoteSpec(ctx, remoteClient, localJob, remoteJob)
 		}
 		return false, nil

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -55,19 +55,18 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	// on the worker cluster. It is left unset for job types that do not support
 	// this (see ElasticReplicaSync).
 	elastic *ElasticReplicaSync[PtrT, T]
-	// remoteSpecSync is optional. When set, the adapter forwards admission-safe,
-	// quota-neutral spec changes from the manager copy onto the remote copy on the
-	// worker cluster after admission (see RemoteSpecSyncer). It is left unset for
-	// job types that keep the create-once behavior.
+	// remoteSpecSync is optional. When set, the adapter forwards spec changes that
+	// do not alter the workload's PodSets from the manager copy onto the remote copy
+	// on the worker cluster after admission (see RemoteSpecSyncer). It is left unset
+	// for job types that keep the create-once behavior.
 	remoteSpecSync RemoteSpecSyncer[PtrT]
 }
 
-// RemoteSpecSyncer lets a job type forward admission-safe, quota-neutral spec
-// changes from the manager copy onto its worker copy after the job is admitted.
-// The adapter owns the mechanism (detect on reconcile, patch the remote); each
-// job type owns the policy: which fields are safe to forward, and when a sync is
-// needed. Fields that change the PodSets/quota, or that require re-admission,
-// must not be forwarded here.
+// RemoteSpecSyncer lets a job type forward spec changes that do not alter the
+// workload's PodSets from the manager copy to its worker copy after admission
+// (e.g. RayService's serveConfigV2). Such changes need no quota change and no
+// re-admission. Each job type decides which fields to forward and when; fields
+// that change the PodSets must not be forwarded here.
 type RemoteSpecSyncer[PtrT any] interface {
 	// NeedsSync reports whether a manager-side change must be forwarded to the
 	// worker copy. It must be side-effect free.
@@ -116,9 +115,9 @@ func WithElasticReplicaSync[PtrT objAsPtr[T], T any](e *ElasticReplicaSync[PtrT,
 	}
 }
 
-// WithRemoteSpecSync enables forwarding admission-safe, quota-neutral spec changes
-// from the manager copy to the worker copy for job types that support it (see
-// RemoteSpecSyncer).
+// WithRemoteSpecSync enables forwarding spec changes that do not alter the
+// workload's PodSets from the manager copy to the worker copy for job types that
+// support it (see RemoteSpecSyncer).
 func WithRemoteSpecSync[PtrT objAsPtr[T], T any](s RemoteSpecSyncer[PtrT]) Option[PtrT, T] {
 	return func(a *adapter[PtrT, T]) {
 		a.remoteSpecSync = s
@@ -271,9 +270,9 @@ func (a *adapter[PtrT, T]) syncElastic(ctx context.Context, remoteClient client.
 	return nil
 }
 
-// syncRemoteSpec patches the remote object's admission-safe spec fields to match
-// the local (manager) object via the configured RemoteSpecSyncer. It should only
-// be called when the syncer's NeedsSync returns true.
+// syncRemoteSpec patches the remote object's spec fields to match the local
+// (manager) object via the configured RemoteSpecSyncer. It should only be called
+// when the syncer's NeedsSync returns true.
 func (a *adapter[PtrT, T]) syncRemoteSpec(ctx context.Context, remoteClient client.Client, localJob, remoteJob PtrT) error {
 	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
 		if !a.remoteSpecSync.NeedsSync(remoteJob, localJob) {

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -55,18 +55,16 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	// on the worker cluster. It is left unset for job types that do not support
 	// this (see ElasticReplicaSync).
 	elastic *ElasticReplicaSync[PtrT, T]
-	// remoteSpecSync is optional. When set, the adapter forwards spec changes that
-	// do not alter the workload's PodSets from the manager copy onto the remote copy
-	// on the worker cluster after admission (see RemoteSpecSyncer). It is left unset
-	// for job types that keep the create-once behavior.
+	// remoteSpecSync is optional. When set, the adapter forwards manager-side spec
+	// changes onto the remote copy on the worker cluster after admission (see
+	// RemoteSpecSyncer). It is left unset for job types that keep the create-once
+	// behavior.
 	remoteSpecSync RemoteSpecSyncer[PtrT]
 }
 
-// RemoteSpecSyncer lets a job type forward spec changes that do not alter the
-// workload's PodSets from the manager copy to its worker copy after admission
-// (e.g. RayService's serveConfigV2). Such changes need no quota change and no
-// re-admission. Each job type decides which fields to forward and when; fields
-// that change the PodSets must not be forwarded here.
+// RemoteSpecSyncer lets a job type forward selected spec changes from the manager
+// copy to its worker copy after the job is admitted, via an in-place patch of the
+// remote. Each job type decides which fields to forward and when a sync is needed.
 type RemoteSpecSyncer[PtrT any] interface {
 	// NeedsSync reports whether a manager-side change must be forwarded to the
 	// worker copy. It must be side-effect free.
@@ -115,9 +113,8 @@ func WithElasticReplicaSync[PtrT objAsPtr[T], T any](e *ElasticReplicaSync[PtrT,
 	}
 }
 
-// WithRemoteSpecSync enables forwarding spec changes that do not alter the
-// workload's PodSets from the manager copy to the worker copy for job types that
-// support it (see RemoteSpecSyncer).
+// WithRemoteSpecSync enables forwarding manager-side spec changes to the worker copy
+// for job types that support it (see RemoteSpecSyncer).
 func WithRemoteSpecSync[PtrT objAsPtr[T], T any](s RemoteSpecSyncer[PtrT]) Option[PtrT, T] {
 	return func(a *adapter[PtrT, T]) {
 		a.remoteSpecSync = s

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -124,6 +124,7 @@ func WithRemoteSpecSync[PtrT objAsPtr[T], T any](s RemoteSpecSyncer[PtrT]) Optio
 type fullInterface interface {
 	jobframework.MultiKueueAdapter
 	jobframework.MultiKueueWatcher
+	jobframework.MultiKueueLocalJobWatcher
 }
 
 // NewMKAdapter creates a generic MultiKueue adapter for Ray job types.

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -302,6 +302,17 @@ func (a *adapter[PtrT, T]) GetEmptyList() client.ObjectList {
 	return a.emptyList()
 }
 
+// NewEmptyLocalJob lets the MultiKueue controller watch the manager job so a spec
+// change promptly triggers a sync. It is wired only for types that forward spec
+// changes after admission (remoteSpecSync); create-once types return nil and are
+// not watched.
+func (a *adapter[PtrT, T]) NewEmptyLocalJob() client.Object {
+	if a.remoteSpecSync == nil {
+		return nil
+	}
+	return PtrT(new(T))
+}
+
 func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {
 	job, isTheJob := o.(PtrT)
 	if !isTheJob {

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -55,6 +55,26 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	// on the worker cluster. It is left unset for job types that do not support
 	// this (see ElasticReplicaSync).
 	elastic *ElasticReplicaSync[PtrT, T]
+	// remoteSpecSync is optional. When set, the adapter forwards admission-safe,
+	// quota-neutral spec changes from the manager copy onto the remote copy on the
+	// worker cluster after admission (see RemoteSpecSyncer). It is left unset for
+	// job types that keep the create-once behavior.
+	remoteSpecSync RemoteSpecSyncer[PtrT]
+}
+
+// RemoteSpecSyncer lets a job type forward admission-safe, quota-neutral spec
+// changes from the manager copy onto its worker copy after the job is admitted.
+// The adapter owns the mechanism (detect on reconcile, patch the remote); each
+// job type owns the policy: which fields are safe to forward, and when a sync is
+// needed. Fields that change the PodSets/quota, or that require re-admission,
+// must not be forwarded here.
+type RemoteSpecSyncer[PtrT any] interface {
+	// NeedsSync reports whether a manager-side change must be forwarded to the
+	// worker copy. It must be side-effect free.
+	NeedsSync(remote, local PtrT) bool
+	// Apply copies the safe fields from local onto remote. It is invoked only when
+	// NeedsSync returned true, and must be idempotent.
+	Apply(remote, local PtrT)
 }
 
 // ElasticReplicaSync carries the type-specific hooks that let the MultiKueue
@@ -93,6 +113,15 @@ type Option[PtrT objAsPtr[T], T any] func(*adapter[PtrT, T])
 func WithElasticReplicaSync[PtrT objAsPtr[T], T any](e *ElasticReplicaSync[PtrT, T]) Option[PtrT, T] {
 	return func(a *adapter[PtrT, T]) {
 		a.elastic = e
+	}
+}
+
+// WithRemoteSpecSync enables forwarding admission-safe, quota-neutral spec changes
+// from the manager copy to the worker copy for job types that support it (see
+// RemoteSpecSyncer).
+func WithRemoteSpecSync[PtrT objAsPtr[T], T any](s RemoteSpecSyncer[PtrT]) Option[PtrT, T] {
+	return func(a *adapter[PtrT, T]) {
+		a.remoteSpecSync = s
 	}
 }
 
@@ -177,6 +206,9 @@ func (a *adapter[PtrT, T]) SyncJob(
 		if a.needElasticSync(ctx, workloadName, localJob, remoteJob) {
 			return false, a.syncElastic(ctx, remoteClient, workloadName, localJob, remoteJob)
 		}
+		if a.remoteSpecSync != nil && a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
+			return false, a.syncRemoteSpec(ctx, remoteClient, localJob, remoteJob)
+		}
 		return false, nil
 	}
 
@@ -235,6 +267,22 @@ func (a *adapter[PtrT, T]) syncElastic(ctx context.Context, remoteClient client.
 		return changed, nil
 	}); err != nil {
 		return fmt.Errorf("failed to patch remote %s: %w", a.gvk.Kind, err)
+	}
+	return nil
+}
+
+// syncRemoteSpec patches the remote object's admission-safe spec fields to match
+// the local (manager) object via the configured RemoteSpecSyncer. It should only
+// be called when the syncer's NeedsSync returns true.
+func (a *adapter[PtrT, T]) syncRemoteSpec(ctx context.Context, remoteClient client.Client, localJob, remoteJob PtrT) error {
+	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
+		if !a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
+			return false, nil
+		}
+		a.remoteSpecSync.Apply(remoteJob, localJob)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("failed to sync remote %s spec: %w", a.gvk.Kind, err)
 	}
 	return nil
 }

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -57,8 +57,7 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	elastic *ElasticReplicaSync[PtrT, T]
 	// remoteSpecSync is optional. When set, the adapter forwards manager-side spec
 	// changes onto the remote copy on the worker cluster after admission (see
-	// RemoteSpecSyncer). It is left unset for job types that keep the create-once
-	// behavior.
+	// RemoteSpecSyncer).
 	remoteSpecSync RemoteSpecSyncer[PtrT]
 }
 

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -60,7 +60,7 @@ func RegisterIntegration(m *jobframework.IntegrationManager) error {
 		JobType:       &rayv1.RayService{},
 		AddToScheme:   rayv1.AddToScheme,
 		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
-			ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](serveConfigV2Syncer{}),
+			ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](remoteSpecSyncer{}),
 		),
 	})
 }

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -53,13 +53,15 @@ const (
 
 func RegisterIntegration(m *jobframework.IntegrationManager) error {
 	return m.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:      SetupIndexes,
-		NewJob:            newJob,
-		NewReconciler:     NewReconciler,
-		SetupWebhook:      SetupRayServiceWebhook,
-		JobType:           &rayv1.RayService{},
-		AddToScheme:       rayv1.AddToScheme,
-		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
+		SetupIndexes:  SetupIndexes,
+		NewJob:        newJob,
+		NewReconciler: NewReconciler,
+		SetupWebhook:  SetupRayServiceWebhook,
+		JobType:       &rayv1.RayService{},
+		AddToScheme:   rayv1.AddToScheme,
+		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+			ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](serveConfigV2Syncer{}),
+		),
 	})
 }
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
@@ -27,16 +27,16 @@ import (
 
 var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
-// remoteSpecSyncer is RayService's RemoteSpecSyncer for MultiKueue. It forwards
-// serveConfigV2 from the manager copy onto the worker copy, so an operator editing
-// the Serve application config on the manager reaches the worker's KubeRay (an
-// in-place Serve update). serveConfigV2 changes no PodSet, so no quota change or
-// re-admission is involved. rayClusterConfig and upgradeStrategy, which drive a
-// pod-affecting zero-downtime upgrade, are intentionally not forwarded here.
+// remoteSpecSyncer is RayService's RemoteSpecSyncer for MultiKueue.
 type remoteSpecSyncer struct{}
 
 var _ ray.RemoteSpecSyncer[*rayv1.RayService] = remoteSpecSyncer{}
 
+// NeedsSync reports whether the manager's serveConfigV2 differs from the worker's.
+// serveConfigV2 is the Ray Serve application config; forwarding it performs an
+// in-place Serve update on the worker's KubeRay. It changes no PodSet, so no quota
+// change or re-admission is involved. rayClusterConfig and upgradeStrategy, which
+// drive a pod-affecting zero-downtime upgrade, are intentionally not forwarded.
 func (remoteSpecSyncer) NeedsSync(remote, local *rayv1.RayService) bool {
 	return remote.Spec.ServeConfigV2 != local.Spec.ServeConfigV2
 }

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
@@ -27,21 +27,21 @@ import (
 
 var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
-// serveConfigV2Syncer realizes RayService's in-place Serve update over MultiKueue:
-// it forwards serveConfigV2 from the manager copy onto the worker copy, so an
-// operator editing the Serve application config on the manager reaches the worker's
-// KubeRay. serveConfigV2 is quota-neutral (it changes no PodSet), so no
+// remoteSpecSyncer is RayService's RemoteSpecSyncer for MultiKueue. It forwards
+// serveConfigV2 from the manager copy onto the worker copy, so an operator editing
+// the Serve application config on the manager reaches the worker's KubeRay (an
+// in-place Serve update). serveConfigV2 changes no PodSet, so no quota change or
 // re-admission is involved. rayClusterConfig and upgradeStrategy, which drive a
 // pod-affecting zero-downtime upgrade, are intentionally not forwarded here.
-type serveConfigV2Syncer struct{}
+type remoteSpecSyncer struct{}
 
-var _ ray.RemoteSpecSyncer[*rayv1.RayService] = serveConfigV2Syncer{}
+var _ ray.RemoteSpecSyncer[*rayv1.RayService] = remoteSpecSyncer{}
 
-func (serveConfigV2Syncer) NeedsSync(remote, local *rayv1.RayService) bool {
+func (remoteSpecSyncer) NeedsSync(remote, local *rayv1.RayService) bool {
 	return remote.Spec.ServeConfigV2 != local.Spec.ServeConfigV2
 }
 
-func (serveConfigV2Syncer) Apply(remote, local *rayv1.RayService) {
+func (remoteSpecSyncer) Apply(remote, local *rayv1.RayService) {
 	remote.Spec.ServeConfigV2 = local.Spec.ServeConfigV2
 }
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
@@ -27,6 +27,24 @@ import (
 
 var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
+// serveConfigV2Syncer realizes RayService's in-place Serve update over MultiKueue:
+// it forwards serveConfigV2 from the manager copy onto the worker copy, so an
+// operator editing the Serve application config on the manager reaches the worker's
+// KubeRay. serveConfigV2 is quota-neutral (it changes no PodSet), so no
+// re-admission is involved. rayClusterConfig and upgradeStrategy, which drive a
+// pod-affecting zero-downtime upgrade, are intentionally not forwarded here.
+type serveConfigV2Syncer struct{}
+
+var _ ray.RemoteSpecSyncer[*rayv1.RayService] = serveConfigV2Syncer{}
+
+func (serveConfigV2Syncer) NeedsSync(remote, local *rayv1.RayService) bool {
+	return remote.Spec.ServeConfigV2 != local.Spec.ServeConfigV2
+}
+
+func (serveConfigV2Syncer) Apply(remote, local *rayv1.RayService) {
+	remote.Spec.ServeConfigV2 = local.Spec.ServeConfigV2
+}
+
 func copyJobStatus(dst, src *rayv1.RayService) {
 	dst.Status = src.Status
 }

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
@@ -34,9 +34,7 @@ var _ ray.RemoteSpecSyncer[*rayv1.RayService] = remoteSpecSyncer{}
 
 // NeedsSync reports whether the manager's serveConfigV2 differs from the worker's.
 // serveConfigV2 is the Ray Serve application config; forwarding it performs an
-// in-place Serve update on the worker's KubeRay. It changes no PodSet, so no quota
-// change or re-admission is involved. rayClusterConfig and upgradeStrategy, which
-// drive a pod-affecting zero-downtime upgrade, are intentionally not forwarded.
+// in-place Serve update on the worker cluster's RayService.
 func (remoteSpecSyncer) NeedsSync(remote, local *rayv1.RayService) bool {
 	return remote.Spec.ServeConfigV2 != local.Spec.ServeConfigV2
 }

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -82,6 +82,34 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync forwards a serveConfigV2 change to the existing remote rayservice": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
+			},
+			workerRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					WithServeConfigV2("old-config").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
+			},
+			wantWorkerRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					WithServeConfigV2("new-config").
+					Obj(),
+			},
+		},
 		"sync status from remote rayservice": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
@@ -264,7 +292,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+				ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](serveConfigV2Syncer{}))
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -83,7 +83,10 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync forwards a serveConfigV2 change to the existing remote rayservice": {
-			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			featureGates: map[featuregate.Feature]bool{
+				features.WorkloadIdentifierAnnotations: false,
+				features.MultiKueueRemoteSpecSync:      true,
+			},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
 			},

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -293,7 +293,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 
 			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
-				ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](serveConfigV2Syncer{}))
+				ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](remoteSpecSyncer{}))
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -83,10 +83,7 @@ func TestMultiKueueAdapter(t *testing.T) {
 			},
 		},
 		"sync forwards a serveConfigV2 change to the existing remote rayservice": {
-			featureGates: map[featuregate.Feature]bool{
-				features.WorkloadIdentifierAnnotations: false,
-				features.MultiKueueRemoteSpecSync:      true,
-			},
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
 				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
 			},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -546,6 +546,13 @@ const (
 	// begun, and suspend defaulting only ever adds suspend, so no path exists to
 	// unsuspend an object or bypass quota via create-then-delete.
 	SkipAncestorCheckForDeletedWorkloads featuregate.Feature = "SkipAncestorCheckForDeletedWorkloads"
+
+	// owner: @kevin85421
+	//
+	// Enables MultiKueue to forward manager-side spec changes (currently a RayService
+	// serveConfigV2 edit) onto the worker copy after admission, and to watch the manager
+	// job so such a change is forwarded promptly instead of on the next periodic requeue.
+	MultiKueueRemoteSpecSync featuregate.Feature = "MultiKueueRemoteSpecSync"
 )
 
 func init() {
@@ -851,6 +858,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	SkipAncestorCheckForDeletedWorkloads: {
 		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	MultiKueueRemoteSpecSync: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -861,7 +861,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	MultiKueueRemoteSpecSync: {
-		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -257,9 +257,9 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: PartialAdmission
   versionedSpecs:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -255,6 +255,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: MultiKueueRemoteSpecSync
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: PartialAdmission
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -257,9 +257,9 @@
     version: "0.17"
 - name: MultiKueueRemoteSpecSync
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: PartialAdmission
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -255,6 +255,12 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.17"
+- name: MultiKueueRemoteSpecSync
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: PartialAdmission
   versionedSpecs:
   - default: false

--- a/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
@@ -38,7 +38,6 @@ featureGates:
   ElasticJobsViaWorkloadSlices: true
   ConcurrentAdmission: true
   MultiKueueManagerQuotaAutomation: true
-  MultiKueueRemoteSpecSync: true
 tls:
   minVersion: "VersionTLS12"
   # this is the default ciphersuite for golang 1.26

--- a/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
+++ b/test/e2e/config/multikueue/extended-shard-1/controller_manager_config.yaml
@@ -38,6 +38,7 @@ featureGates:
   ElasticJobsViaWorkloadSlices: true
   ConcurrentAdmission: true
   MultiKueueManagerQuotaAutomation: true
+  MultiKueueRemoteSpecSync: true
 tls:
   minVersion: "VersionTLS12"
   # this is the default ciphersuite for golang 1.26

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -1001,6 +1001,19 @@ app = HelloWorld.bind()`,
         ray_actor_options:
           num_cpus: 0.2`
 
+				gomega.Expect(updatedServeConfigV2).NotTo(gomega.Equal(serveConfigV2), "the updated serveConfigV2 must differ from the initial config so the forward assertion is meaningful")
+
+				workerClient := kubernetesClients[admittedWorker].client
+				var workerRayServiceUID types.UID
+				ginkgo.By("Recording the existing worker copy and its initial serveConfigV2", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						workerRayService := &rayv1.RayService{}
+						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
+						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(serveConfigV2))
+						workerRayServiceUID = workerRayService.UID
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
 				ginkgo.By("Updating serveConfigV2 on the manager", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						createdRayService := &rayv1.RayService{}
@@ -1010,12 +1023,12 @@ app = HelloWorld.bind()`,
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				ginkgo.By("Checking the serveConfigV2 change is promptly forwarded to the worker cluster", func() {
-					workerClient := kubernetesClients[admittedWorker].client
+				ginkgo.By("Checking the change is promptly forwarded to the same worker copy (in-place, no re-admission)", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						workerRayService := &rayv1.RayService{}
 						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
 						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(updatedServeConfigV2))
+						g.Expect(workerRayService.UID).To(gomega.Equal(workerRayServiceUID))
 					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 				})
 			})

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -1010,10 +1010,6 @@ app = HelloWorld.bind()`,
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
 
-				// The forward must be driven by the prompt local-job watch, not the
-				// ~workerLostTimeout periodic requeue, so this uses a moderate timeout on
-				// purpose: a broken/missing trigger (which would only sync minutes later)
-				// fails here rather than passing under a very long timeout.
 				ginkgo.By("Checking the serveConfigV2 change is promptly forwarded to the worker cluster", func() {
 					workerClient := kubernetesClients[admittedWorker].client
 					gomega.Eventually(func(g gomega.Gomega) {

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -986,6 +986,37 @@ app = HelloWorld.bind()`,
 						g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 				})
+
+				// An in-place serveConfigV2 change is quota-neutral (no PodSet change),
+				// so MultiKueue forwards it to the worker copy without re-admission.
+				updatedServeConfigV2 := `applications:
+  - name: hello_app
+    import_path: hello_serve:app
+    route_prefix: /
+    deployments:
+      - name: HelloWorld
+        num_replicas: 2
+        max_replicas_per_node: 1
+        ray_actor_options:
+          num_cpus: 0.2`
+
+				ginkgo.By("Updating serveConfigV2 on the manager", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayService := &rayv1.RayService{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+						createdRayService.Spec.ServeConfigV2 = updatedServeConfigV2
+						g.Expect(k8sManagerClient.Update(ctx, createdRayService)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking the serveConfigV2 change propagates to the RayService on the worker cluster", func() {
+					workerClient := kubernetesClients[admittedWorker].client
+					gomega.Eventually(func(g gomega.Gomega) {
+						workerRayService := &rayv1.RayService{}
+						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
+						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(updatedServeConfigV2))
+					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
+				})
 			})
 		})
 	})

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -986,6 +986,42 @@ app = HelloWorld.bind()`,
 						g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 				})
+
+				// An in-place serveConfigV2 edit is quota-neutral, so MultiKueue forwards it
+				// to the worker copy without re-admission. num_replicas 1 -> 2 is a clear,
+				// observable change within serveConfigV2.
+				updatedServeConfigV2 := `applications:
+  - name: hello_app
+    import_path: hello_serve:app
+    route_prefix: /
+    deployments:
+      - name: HelloWorld
+        num_replicas: 2
+        max_replicas_per_node: 1
+        ray_actor_options:
+          num_cpus: 0.2`
+
+				ginkgo.By("Updating serveConfigV2 on the manager", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayService := &rayv1.RayService{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+						createdRayService.Spec.ServeConfigV2 = updatedServeConfigV2
+						g.Expect(k8sManagerClient.Update(ctx, createdRayService)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				// The forward must be driven by the prompt local-job watch, not the
+				// ~workerLostTimeout periodic requeue, so this uses a moderate timeout on
+				// purpose: a broken/missing trigger (which would only sync minutes later)
+				// fails here rather than passing under a very long timeout.
+				ginkgo.By("Checking the serveConfigV2 change is promptly forwarded to the worker cluster", func() {
+					workerClient := kubernetesClients[admittedWorker].client
+					gomega.Eventually(func(g gomega.Gomega) {
+						workerRayService := &rayv1.RayService{}
+						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
+						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(updatedServeConfigV2))
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				})
 			})
 		})
 	})

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -986,37 +986,6 @@ app = HelloWorld.bind()`,
 						g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 				})
-
-				// An in-place serveConfigV2 change is quota-neutral (no PodSet change),
-				// so MultiKueue forwards it to the worker copy without re-admission.
-				updatedServeConfigV2 := `applications:
-  - name: hello_app
-    import_path: hello_serve:app
-    route_prefix: /
-    deployments:
-      - name: HelloWorld
-        num_replicas: 2
-        max_replicas_per_node: 1
-        ray_actor_options:
-          num_cpus: 0.2`
-
-				ginkgo.By("Updating serveConfigV2 on the manager", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						createdRayService := &rayv1.RayService{}
-						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
-						createdRayService.Spec.ServeConfigV2 = updatedServeConfigV2
-						g.Expect(k8sManagerClient.Update(ctx, createdRayService)).To(gomega.Succeed())
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("Checking the serveConfigV2 change propagates to the RayService on the worker cluster", func() {
-					workerClient := kubernetesClients[admittedWorker].client
-					gomega.Eventually(func(g gomega.Gomega) {
-						workerRayService := &rayv1.RayService{}
-						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
-						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(updatedServeConfigV2))
-					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
-				})
 			})
 		})
 	})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1796,6 +1796,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should forward a serveConfigV2 update to the RayService on the worker if admitted", func() {
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueRemoteSpecSync, true)
 		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -58,6 +58,7 @@ import (
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
@@ -72,6 +73,7 @@ import (
 	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 	testingtfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
 	testingxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
@@ -83,7 +85,7 @@ import (
 )
 
 var defaultEnabledIntegrations = sets.New(
-	"batch/job", "kubeflow.org/mpijob", "ray.io/rayjob", "ray.io/raycluster",
+	"batch/job", "kubeflow.org/mpijob", "ray.io/rayjob", "ray.io/raycluster", "ray.io/rayservice",
 	"jobset.x-k8s.io/jobset", "kubeflow.org/paddlejob",
 	"kubeflow.org/pytorchjob", "kubeflow.org/tfjob", "kubeflow.org/xgboostjob", "kubeflow.org/jaxjob",
 	"pod", "workload.codeflare.dev/appwrapper", "trainer.kubeflow.org/trainjob")
@@ -1789,6 +1791,45 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should forward a serveConfigV2 update to the RayService on the worker if admitted", func() {
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
+			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
+		)
+		rayService := testingrayservice.MakeService("rayservice1", managerNs.Name).
+			Queue(managerLq.Name).
+			WithServeConfigV2("serve-config-v1").
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, rayService)
+		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
+		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
+
+		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+
+		ginkgo.By("checking the remote RayService is created with the initial serveConfigV2", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.ServeConfigV2).To(gomega.Equal("serve-config-v1"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("updating serveConfigV2 on the manager, the change is forwarded to the remote RayService", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				createdRayService.Spec.ServeConfigV2 = "serve-config-v2"
+				g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, &createdRayService)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.ServeConfigV2).To(gomega.Equal("serve-config-v2"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -1796,7 +1796,6 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should forward a serveConfigV2 update to the RayService on the worker if admitted", func() {
-		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueRemoteSpecSync, true)
 		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -54,6 +54,7 @@ import (
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 	"sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
 	"sigs.k8s.io/kueue/pkg/dra"
@@ -214,6 +215,7 @@ func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.Integr
 		workloadpod.FrameworkName,
 		workloadrayjob.FrameworkName,
 		workloadraycluster.FrameworkName,
+		workloadrayservice.FrameworkName,
 		workloadaw.FrameworkName,
 		workloadtrainjob.FrameworkName,
 	} {
@@ -400,6 +402,21 @@ func setupManager(ctx context.Context, mgr manager.Manager) *jobframework.Integr
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadraycluster.SetupRayClusterWebhook(mgr, jobOptions...)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = workloadrayservice.SetupIndexes(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	rayServiceReconciler, err := workloadrayservice.NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		mgr.GetFieldIndexer(),
+		mgr.GetEventRecorder(constants.JobControllerName), jobOptions...)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = rayServiceReconciler.SetupWithManager(mgr)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = workloadrayservice.SetupRayServiceWebhook(mgr, jobOptions...)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadaw.SetupIndexes(ctx, mgr.GetFieldIndexer())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/area multikueue

#### What this PR does / why we need it:

**Background — RayService in-place updates.** KubeRay's `RayService` supports an *in-place update* of the Serve application config: when you edit `serveConfigV2` (the Serve app definition) and re-apply the CR, KubeRay applies the new config to the **existing** RayCluster rather than creating a new one — affected deployments transition `UPDATING → HEALTHY`. It changes no pods and needs no new cluster; it is the normal way to roll out a new model/app version on a running service. See the [KubeRay RayService guide](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/rayservice.html#kuberay-rayservice) for details.

**Problem — MultiKueue does not forward these changes today.** A `RayService` dispatched to a worker cluster is **create-once**: the adapter's `SyncJob` copies status back from the worker but never re-applies the manager's spec to the worker copy. So editing `serveConfigV2` on the **manager** `RayService` currently has **no effect** — the change is silently dropped and never reaches the worker's KubeRay, where the service actually runs. Operators cannot perform an in-place Serve update on a MultiKueue-dispatched `RayService`.

**This PR** adds a small, generic hook to the shared Ray MultiKueue adapter that lets a job type forward selected manager-side spec changes to its worker copy after admission:

- **`RemoteSpecSyncer[PtrT]` interface** (`NeedsSync` / `Apply`) plus a `WithRemoteSpecSync` adapter option. The adapter owns the mechanism (detect on reconcile, in-place patch the remote); each job type owns the policy — which fields to forward, and when. The interface itself is field-agnostic.
- **`RayService`** provides the only implementation today: it forwards **only** `serveConfigV2` (the Ray Serve application config).

**Prompt trigger — forward in ~1s, not up to `workerLostTimeout`.** A `serveConfigV2` edit does not change the manager `RayService`'s `Workload` (it is PodSet-neutral, quota-neutral). The MultiKueue admission-check controller reconciles `Workload`s, so without an extra signal the edit would only be forwarded on the next *periodic* requeue (`workerLostTimeout`, default **15 min**). To close that gap this PR adds an opt-in local-job watch:

- **`MultiKueueLocalJobWatcher` optional adapter interface** (`NewEmptyLocalJob`). An adapter that forwards spec changes returns an empty job object to watch; create-once adapters return `nil` and are unaffected.
- **`localJobHandler`** enqueues the owning `Workload` (resolved via the owner-reference index) whenever the watched manager job's spec `generation` bumps, so the edit promptly re-runs `SyncJob`. Status-only updates are filtered out to avoid a status-sync feedback loop.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

- AI tools were used to help prepare this change, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Forwarded in-place `serveConfigV2` (Ray Serve application config) updates on a `RayService` from the manager to the worker cluster, so editing the Serve config on the manager now takes effect on the worker promptly. Changes to `rayClusterConfig`/`upgradeStrategy` (zero-downtime upgrade) are not yet propagated.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RayService configurations can now synchronize from the manager to existing worker jobs without requiring re-admission.
  * Serve configuration updates are applied in place while preserving existing MultiKueue metadata.
  * Added the `MultiKueueRemoteSpecSync` beta feature gate, enabled by default.
* **Bug Fixes**
  * Workloads now reconcile promptly when watched manager-side job specifications change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->