### PR TITLE
Clamp the resource conversion for every resource, not only cpu

### DIFF
--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -70,9 +70,8 @@ var maxNonCPUQuantityForAmount = *resource.NewQuantity(math.MaxInt64, resource.D
 // Unlimited when the canonical value would overflow int64.
 //
 // This is the safe constructor that all quota-side conversion (Nominal,
-// BorrowingLimit, LendingLimit) must use. ResourceValue is preserved for
-// non-quota call sites (workload requests) where the historical
-// truncate-on-overflow behavior is what existing tests document.
+// BorrowingLimit, LendingLimit) must use. ResourceValue is the equivalent for
+// workload requests, clamping to math.MaxInt64 rather than returning Unlimited.
 func AmountFromQuantity(name corev1.ResourceName, q resource.Quantity) Amount {
 	if name == corev1.ResourceCPU {
 		if q.Cmp(maxCPUQuantityForAmount) >= 0 {

--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -71,7 +71,8 @@ var maxNonCPUQuantityForAmount = *resource.NewQuantity(math.MaxInt64, resource.D
 //
 // This is the safe constructor that all quota-side conversion (Nominal,
 // BorrowingLimit, LendingLimit) must use. ResourceValue is the equivalent for
-// workload requests, clamping to math.MaxInt64 rather than returning Unlimited.
+// workload requests, clamping to math.MinInt64 or math.MaxInt64 rather than
+// returning Unlimited.
 func AmountFromQuantity(name corev1.ResourceName, q resource.Quantity) Amount {
 	if name == corev1.ResourceCPU {
 		if q.Cmp(maxCPUQuantityForAmount) >= 0 {

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -141,11 +141,13 @@ func (r MapRequests) ToResourceList(formatter *ResourceFormatter) corev1.Resourc
 
 // ResourceValue returns the integer value for the resource name.
 // It's milli-units for CPU and absolute units for everything else.
+// Both clamp: Quantity.Value and Quantity.MilliValue read a big.Int that need
+// not fit in an int64.
 func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 	if name == corev1.ResourceCPU {
 		return utilmath.SafeMilliValue(q)
 	}
-	return q.Value()
+	return utilmath.SafeValue(q)
 }
 
 // GreaterKeys returns keys where the receiver is greater than other,

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"maps"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -336,6 +337,72 @@ func TestGreaterKeysRL(t *testing.T) {
 	want := []corev1.ResourceName{corev1.ResourceCPU}
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected result (-want, +got)\n%s", diff)
+	}
+}
+
+// A quantity outside the int64 range reaches here from a resource
+// transformation, whose product is as large as the configuration asks for, and
+// from an extended resource a user can write by hand. Value reads a big.Int and
+// says nothing about what it returns when the value does not fit, so the result
+// used to be a number of another magnitude or another sign.
+func TestResourceValueClampsOutsideInt64(t *testing.T) {
+	cases := map[string]struct {
+		resource corev1.ResourceName
+		quantity string
+		want     int64
+	}{
+		"an ordinary extended resource is unchanged": {
+			resource: "example.com/gpu",
+			quantity: "8",
+			want:     8,
+		},
+		"the largest representable value is kept": {
+			resource: "example.com/gpu",
+			quantity: strconv.FormatInt(math.MaxInt64, 10),
+			want:     math.MaxInt64,
+		},
+		"one past it is clamped rather than wrapped": {
+			resource: "example.com/gpu",
+			quantity: "9223372036854775808",
+			want:     math.MaxInt64,
+		},
+		"far past it is clamped as well": {
+			resource: "example.com/gpu",
+			quantity: "100000000000000000000",
+			want:     math.MaxInt64,
+		},
+		"an ordinary negative value is unchanged": {
+			resource: "example.com/gpu",
+			quantity: "-3",
+			want:     -3,
+		},
+		"far below the range is clamped rather than wrapped": {
+			resource: "example.com/gpu",
+			quantity: "-100000000000000000000",
+			want:     math.MinInt64,
+		},
+		"memory past the range is clamped too": {
+			resource: corev1.ResourceMemory,
+			quantity: "100Ei",
+			want:     math.MaxInt64,
+		},
+		"cpu is still read in milli-units": {
+			resource: corev1.ResourceCPU,
+			quantity: "1500m",
+			want:     1500,
+		},
+		"cpu past the milli range is clamped": {
+			resource: corev1.ResourceCPU,
+			quantity: "10000000000000000",
+			want:     math.MaxInt64,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := ResourceValue(tc.resource, resource.MustParse(tc.quantity)); got != tc.want {
+				t.Errorf("ResourceValue(%s, %s) = %d, want %d", tc.resource, tc.quantity, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -340,11 +340,6 @@ func TestGreaterKeysRL(t *testing.T) {
 	}
 }
 
-// A quantity outside the int64 range reaches here from a resource
-// transformation, whose product is as large as the configuration asks for, and
-// from an extended resource a user can write by hand. Value reads a big.Int and
-// says nothing about what it returns when the value does not fit, so the result
-// used to be a number of another magnitude or another sign.
 func TestResourceValueClampsOutsideInt64(t *testing.T) {
 	cases := map[string]struct {
 		resource corev1.ResourceName

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -966,6 +967,28 @@ func TestNewInfo(t *testing.T) {
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceName("example.com/gpu"):  3,
 						corev1.ResourceName("example.com/node"): 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A transformation product past the range must not arrive negative and
+		// be floored away.
+		"transformProductPastTheRangeIsNotFlooredAway": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "10000000000").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("10000000000")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): math.MaxInt64,
 					}),
 					Count: 1,
 				}},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ResourceValue` converts a `resource.Quantity` into the `int64` the quota accounting works in. It clamps for CPU and does not clamp for anything else:

```go
func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
	if name == corev1.ResourceCPU {
		return utilmath.SafeMilliValue(q)
	}
	return q.Value()
}
```

Quoting `k8s.io/apimachinery/pkg/api/resource`, on `Quantity.Value`:

> Value returns the unscaled value of q rounded up to the nearest integer away from 0.

and, on the `int64Amount` path underneath it, the value is read out of a `big.Int` that does not have to fit. When it does not fit, what comes back is a number of another magnitude, and it can be of another sign. Nothing downstream can tell that apart from a small request: `FloorToZero` runs later and reads a negative charge as nothing having been asked for.

This is reachable without anyone writing an absurd number by hand. A resource transformation multiplies a request by a configured factor, so the product is as large as the configuration asks for rather than as large as the user wrote, and an extended resource is an ordinary quantity a user can put on a PodSet.

`utilmath.SafeValue` already exists for this, with the same shape as `SafeMilliValue`, and `pkg/dra/capacity.go` and `pkg/dra/counters.go` already convert through it. This uses it for the one conversion that was left on `Value`.

## What this does not fix

Two neighbouring things are out of scope here, and I would rather name them than let the title imply they are covered.

The first is addition. `MapRequests.Add` and `Sub` are plain `int64` arithmetic, so two quantities that each convert safely can still overflow when they are summed. That is a separate decision, since an accounting total and an admission envelope do not want the same answer: saturating quietly is defensible for the first and not for the second.

The second is the negative extreme, which is an upstream conversion defect rather than a range one. Measured against this tree:

```
-9223372036854775807  (MinInt64+1)   Value() = 1
-9223372036854775808  (MinInt64)     Value() = 0
 9223372036854775807  (MaxInt64)     Value() = 9223372036854775807
```

`MinInt64+1` is inside `int64`, so clamping cannot reach it; `Value` is simply wrong there. That belongs upstream in `apimachinery` and I have an open PR in that area already.

## The other caller

`ResourceValue` has a second caller, in `validateAdmission`, which checks that a `resourceUsage` divides by the PodSet count. A value past the range reached that check as an undefined number before and reaches it clamped now, so the divisibility verdict on such a value can change. Both readings are arbitrary for a quantity that cannot be represented; the clamped one is at least the same on every run.

#### Which issue(s) this PR fixes:

Fixes #13998

#### Special notes for your reviewer:

The added cases fail first: with `q.Value()` restored, `100000000000000000000` on an extended resource comes back as a number of the wrong magnitude rather than `MaxInt64`.

There is one case a level up as well, in `TestNewInfo`, because what the conversion returns and what a Workload is charged are different statements. A transformation whose product is larger than `int64` now reaches the requests as `MaxInt64`; before, it arrived with another sign and `FloorToZero` read that as nothing having been asked for. Reverting the conversion turns both levels red.

CPU keeps `SafeMilliValue`, so its milli-unit reading and its own clamp are unchanged, and the two cases at the end of the table pin that.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a quantity larger than `int64` on a resource other than `cpu` being converted to a number of another magnitude, or of another sign, when Kueue computes a Workload's requests. A large enough resource transformation product could arrive negative and then be floored to zero, so the Workload was admitted against no quota at all.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource quantities exceeding supported numeric limits are now safely clamped to the minimum or maximum representable values.
  * Large workload resource requests are preserved at their maximum supported value instead of incorrectly becoming zero.

* **Tests**
  * Added coverage for CPU, standard, and out-of-range resource quantities, including boundary values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->