### PR TITLE
Charge the DeviceClass the scheduler will allocate from

### DIFF
--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -67,12 +67,38 @@ func NeedsDRAReconcile(wl *kueue.Workload, erCache *ExtendedResourceCache) bool 
 	return false
 }
 
+// selectedDeviceClass returns the DeviceClass Kubernetes uses when more than one
+// declares the same extendedResourceName. Quoting the field's documentation:
+//
+//	It should be unique among all the device classes in a cluster. If two device
+//	classes have the same name, then the class created later is picked to satisfy
+//	a pod's extended resource requests. If two classes are created at the same
+//	time, then the name of the class lexicographically sorted first is picked.
+//
+// Ties are the common case, since a creation timestamp carries seconds. items
+// is non-empty and already filtered to one extendedResourceName.
+func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceClass {
+	selected := &items[0]
+	for i := range items[1:] {
+		candidate := &items[i+1]
+		switch candidate.CreationTimestamp.Compare(selected.CreationTimestamp.Time) {
+		case 1:
+			selected = candidate
+		case 0:
+			if candidate.Name < selected.Name {
+				selected = candidate
+			}
+		}
+	}
+	return selected
+}
+
 // resolveContainerExtendedResources converts DRA-backed extended resources in a
 // container's requests into logical quota keys. For each extended resource, it looks
-// up DeviceClasses by spec.extendedResourceName. If a DeviceClass is found in
-// deviceClassMappings, the mapped name is used as quota key; otherwise the
-// extendedResourceName itself is used. Returns the converted resources and the set
-// of original resource names that were replaced (for double-count prevention).
+// up DeviceClasses by spec.extendedResourceName, selects the one the scheduler would
+// allocate from, and uses that class's deviceClassMappings entry as the quota key;
+// otherwise the extendedResourceName itself is used. Returns the converted resources
+// and the set of original resource names that were replaced (for double-count prevention).
 func resolveContainerExtendedResources(
 	ctx context.Context,
 	cl client.Client,
@@ -118,38 +144,35 @@ func resolveContainerExtendedResources(
 			continue
 		}
 
+		// The class the scheduler will allocate from, not whichever List returned first.
+		selected := selectedDeviceClass(dcList.Items)
+
 		// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
 		// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
 		// Otherwise, use the extendedResourceName directly.
 		quotaKey := resourceName
-		for _, dc := range dcList.Items {
-			if logicalName, found := mapper.Lookup(corev1.ResourceName(dc.Name)); found {
-				quotaKey = logicalName
-				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(dc.Name))) > 0 {
-					errs = append(errs, field.Invalid(
-						containerPath,
-						resourceName,
-						fmt.Sprintf(
-							"extended resource %s resolves to DeviceClass %s with counters configured;"+
-								" use ResourceClaimTemplates with CEL selectors for counter-based quota",
-							resourceName, dc.Name,
-						),
-					))
-					continue
-				}
-				if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(dc.Name))) > 0 {
-					errs = append(errs, field.Invalid(
-						containerPath,
-						resourceName,
-						fmt.Sprintf(
-							"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
-								" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
-							resourceName, dc.Name,
-						),
-					))
-					continue
-				}
-				break
+		if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
+			quotaKey = logicalName
+			if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(selected.Name))) > 0 {
+				errs = append(errs, field.Invalid(
+					containerPath,
+					resourceName,
+					fmt.Sprintf(
+						"extended resource %s resolves to DeviceClass %s with counters configured;"+
+							" use ResourceClaimTemplates with CEL selectors for counter-based quota",
+						resourceName, selected.Name,
+					),
+				))
+			} else if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(selected.Name))) > 0 {
+				errs = append(errs, field.Invalid(
+					containerPath,
+					resourceName,
+					fmt.Sprintf(
+						"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
+							" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
+						resourceName, selected.Name,
+					),
+				))
 			}
 		}
 
@@ -157,7 +180,7 @@ func resolveContainerExtendedResources(
 
 		log.V(4).Info("Resolved extended resource to DRA quota key",
 			"resource", resourceName, "quotaKey", quotaKey, "quantity", chargeQuantity.String(),
-			"deviceClass", dcList.Items[0].Name)
+			"deviceClass", selected.Name)
 
 		replaced.Insert(resourceName)
 		result = utilresource.MergeResourceListKeepSum(result, corev1.ResourceList{

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -111,6 +111,53 @@ func TestIsExtendedResourceName(t *testing.T) {
 	}
 }
 
+func TestSelectedDeviceClass(t *testing.T) {
+	at := func(sec int64) metav1.Time { return metav1.Unix(sec, 0) }
+	class := func(name string, created metav1.Time) resourceapi.DeviceClass {
+		return resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: name, CreationTimestamp: created}}
+	}
+	cases := map[string]struct {
+		items []resourceapi.DeviceClass
+		want  string
+	}{
+		"one class is the one": {
+			items: []resourceapi.DeviceClass{class("a", at(100))},
+			want:  "a",
+		},
+		"the class created later wins": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("b", at(200))},
+			want:  "b",
+		},
+		"and wins from either end of the list": {
+			items: []resourceapi.DeviceClass{class("b", at(200)), class("a", at(100))},
+			want:  "b",
+		},
+		"created together, the lexicographically first name wins": {
+			items: []resourceapi.DeviceClass{class("b", at(100)), class("a", at(100))},
+			want:  "a",
+		},
+		"and that tie does not depend on the list order either": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("b", at(100))},
+			want:  "a",
+		},
+		"a later class beats an earlier one with a smaller name": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("z", at(200))},
+			want:  "z",
+		},
+		"the tie-break applies among the latest only": {
+			items: []resourceapi.DeviceClass{class("a", at(300)), class("z", at(100)), class("b", at(300))},
+			want:  "a",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := selectedDeviceClass(tc.items); got.Name != tc.want {
+				t.Errorf("selectedDeviceClass() = %q, want %q", got.Name, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveExtendedResourceQuota(t *testing.T) {
 	gpuDeviceClass := &resourceapi.DeviceClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -135,6 +182,28 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			Name: "plain.nvidia.com",
 		},
 		Spec: resourceapi.DeviceClassSpec{},
+	}
+
+	// Two classes on one extendedResourceName. The names sort against the
+	// timestamps, so only the creation order can explain the class picked.
+	alphaDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "alpha.example.com",
+			CreationTimestamp: metav1.Unix(100, 0),
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("example.com/gpu"),
+		},
+	}
+
+	omegaDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "omega.example.com",
+			CreationTimestamp: metav1.Unix(200, 0),
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("example.com/gpu"),
+		},
 	}
 
 	tests := []struct {
@@ -533,6 +602,90 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "containers").Index(0),
 					"", "",
 				),
+			},
+		},
+		{
+			name: "the mapping of the later DeviceClass decides the quota key",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{alphaDeviceClass, omegaDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "alpha-claims",
+					DeviceClassNames: []corev1.ResourceName{"alpha.example.com"},
+				},
+				{
+					Name:             "omega-claims",
+					DeviceClassNames: []corev1.ResourceName{"omega.example.com"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"omega-claims": resource.MustParse("1"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
+			name: "an unmapped later DeviceClass leaves the extended resource name as the quota key",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{alphaDeviceClass, omegaDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "alpha-claims",
+					DeviceClassNames: []corev1.ResourceName{"alpha.example.com"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("1"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
 			},
 		},
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When several DeviceClasses declare the same `spec.extendedResourceName`, Kueue has to charge the one the scheduler will allocate from. It charges the first one the List returns that happens to have a `deviceClassMappings` entry instead:

```go
quotaKey := resourceName
for _, dc := range dcList.Items {
	if logicalName, found := mapper.Lookup(corev1.ResourceName(dc.Name)); found {
		quotaKey = logicalName
		...
		break
	}
}
```

Kubernetes documents which one it picks. Quoting the `extendedResourceName` field:

> It should be unique among all the device classes in a cluster. If two device classes have the same name, then the class created later is picked to satisfy a pod's extended resource requests. If two classes are created at the same time, then the name of the class lexicographically sorted first is picked.

and `updateResourceName2class` in `dynamic-resource-allocation/deviceclass/extendedresourcecache` implements exactly that, keeping the newer class and breaking a tie on the lower name.

This selects the class first, the way Kubernetes does, and then asks the mapper about that one class. Where the two disagreed, the charge landed in a resource group the allocation had nothing to do with: a ClusterQueue covering the class actually used was not debited, and one that did not cover it was.

## Why the tie matters more than it reads

`metav1.Time` carries seconds, so two classes applied together share a creation timestamp and the name decides. A single `kubectl apply -f` with both classes in it is enough to reach the tie-break, which is why the test table pins it from both list orders rather than only pinning the timestamp comparison.

## The log said a third thing

The log line below the loop reported `dcList.Items[0].Name`, which is neither the class that produced the quota key nor necessarily the one Kubernetes uses. Anyone reading it to work out where a charge went was told the wrong class. It now names the class that was selected.

## Scope

The selection is per extended resource, inside the resolver that already lists by `spec.extendedResourceName`, so nothing else changes shape. This does not touch the upstream cache's own behaviour under deletes and updates, which I filed separately as kubernetes/kubernetes#141103; Kueue lists live rather than reading that cache, so the two are independent.

#### Which issue(s) this PR fixes:

Fixes #14043

#### Special notes for your reviewer:

`selectedDeviceClass` is a small pure function so the rule can be pinned on its own: reverting it to `items[0]` turns three cases red, the later-class one, the name tie-break, and a later class with a larger name.

The doc comment quotes the upstream wording rather than paraphrasing it, since the rule is not obvious from the code and a future reader should not have to guess whether the newer or the older class wins.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed a bug where extended resource quota could be charged against a DeviceClass the scheduler would not allocate from when multiple DeviceClasses share the same `extendedResourceName`.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Extended-resource quota handling now consistently uses the newest matching device class.
  - Selection remains deterministic when device classes share the same creation time, regardless of their listing order.
  - Quota mapping, validation, logging, and charging now consistently reference the selected device class.
  - Quota validation and charging report only one applicable configuration error at a time, making configuration issues clearer and easier to resolve.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->