### PR TITLE
Do not let a negative request spend another charge under the same name

### DIFF
--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -18,7 +18,6 @@ package resources
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	resourcehelpers "k8s.io/component-helpers/resource"
 
 	"sigs.k8s.io/kueue/pkg/features"
 )
@@ -72,8 +71,7 @@ func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
 		return NewRequests()
 	}
-	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
-	return NewRequestsFromResourceList(rl)
+	return NewRequestsFromResourceList(PodRequests(podSpec))
 }
 
 // ToMap converts any Requests instance into a MapRequests map.

--- a/pkg/resources/podrequests.go
+++ b/pkg/resources/podrequests.go
@@ -1,0 +1,138 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	resourcehelpers "k8s.io/component-helpers/resource"
+)
+
+// PodRequests totals a PodSpec the way a Pod's own requests are totalled, with
+// every list read as chargeable first. Zeroing the sum instead would let a
+// negative request in one container spend what another asked for under the same
+// name, and the aggregation hides that the sum ever went there.
+//
+// Every reader of a PodSpec goes through here, so quota, Topology Aware
+// Scheduling and the pod-level LimitRange see one total. The spec is borrowed,
+// and nothing here writes to it.
+func PodRequests(spec *corev1.PodSpec) corev1.ResourceList {
+	if spec == nil {
+		return nil
+	}
+	if !hasNegativeRequest(spec) {
+		return resourcehelpers.PodRequests(&corev1.Pod{Spec: *detachPodLevelRequests(spec)}, resourcehelpers.PodResourcesOptions{})
+	}
+	requests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *chargeableSpec(spec)}, resourcehelpers.PodResourcesOptions{})
+	// A dropped override leaves the name unset where no container asked for it,
+	// and a multiplyBy that reads it then scales by one. Only the names
+	// component-helpers reads at the pod level: no other was in the untreated
+	// total, and a name the ClusterQueue covers picks a flavor at any quantity.
+	if spec.Resources != nil {
+		for name, q := range spec.Resources.Requests {
+			if q.Sign() >= 0 || !resourcehelpers.IsSupportedPodLevelResource(name) {
+				continue
+			}
+			if _, found := requests[name]; !found {
+				requests[name] = resource.Quantity{}
+			}
+		}
+	}
+	return requests
+}
+
+// detachPodLevelRequests gives the helper its own pod-level list, which it adds
+// the overhead into in place. A decimal quantity is held behind a pointer, so
+// the borrowed spec would otherwise grow by the overhead on every read.
+func detachPodLevelRequests(spec *corev1.PodSpec) *corev1.PodSpec {
+	if spec.Resources == nil {
+		return spec
+	}
+	out := *spec
+	out.Resources = spec.Resources.DeepCopy()
+	return &out
+}
+
+// hasNegativeRequest reports whether any list the charge is built from holds one.
+func hasNegativeRequest(spec *corev1.PodSpec) bool {
+	negative := func(rl corev1.ResourceList) bool {
+		for _, q := range rl {
+			if q.Sign() < 0 {
+				return true
+			}
+		}
+		return false
+	}
+	for _, containers := range [][]corev1.Container{spec.InitContainers, spec.Containers} {
+		for _, c := range containers {
+			if negative(c.Resources.Requests) {
+				return true
+			}
+		}
+	}
+	if spec.Resources != nil && negative(spec.Resources.Requests) {
+		return true
+	}
+	return negative(spec.Overhead)
+}
+
+// chargeableSpec copies the spec rather than editing the one the caller is only
+// borrowing.
+func chargeableSpec(spec *corev1.PodSpec) *corev1.PodSpec {
+	out := spec.DeepCopy()
+	for i := range out.InitContainers {
+		out.InitContainers[i].Resources.Requests = chargeableRequests(out.InitContainers[i].Resources.Requests)
+	}
+	for i := range out.Containers {
+		out.Containers[i].Resources.Requests = chargeableRequests(out.Containers[i].Resources.Requests)
+	}
+	if out.Resources != nil {
+		// A pod-level request replaces the container total instead of adding to it,
+		// so a zero left here would spend what the containers asked for.
+		out.Resources.Requests = dropNegativeRequests(out.Resources.Requests)
+	}
+	// PodRequests adds the overhead only where the field is set, so a nil one is
+	// left alone rather than handed back as an empty map.
+	if out.Overhead != nil {
+		out.Overhead = chargeableRequests(out.Overhead)
+	}
+	return out
+}
+
+// chargeableRequests keeps a name it cannot charge, at zero.
+func chargeableRequests(input corev1.ResourceList) corev1.ResourceList {
+	res := make(corev1.ResourceList, len(input))
+	for name, quantity := range input {
+		if quantity.Sign() < 0 {
+			quantity = resource.Quantity{}
+		}
+		res[name] = quantity
+	}
+	return res
+}
+
+// dropNegativeRequests removes the names it cannot charge, rather than keeping
+// them at zero as chargeableRequests does.
+func dropNegativeRequests(requests corev1.ResourceList) corev1.ResourceList {
+	out := make(corev1.ResourceList, len(requests))
+	for name, quantity := range requests {
+		if quantity.Sign() >= 0 {
+			out[name] = quantity
+		}
+	}
+	return out
+}

--- a/pkg/resources/podrequests_test.go
+++ b/pkg/resources/podrequests_test.go
@@ -91,23 +91,35 @@ func TestPodRequests(t *testing.T) {
 	}
 }
 
-// The helper adds the overhead into the pod-level list in place, and a decimal
-// quantity is held behind a pointer, so a borrowed spec grows on every read.
+// The helper adds the overhead into the pod-level list in place, and only a
+// decimal quantity is held behind a pointer, so the whole-unit row is the
+// control: on its own the other one could pass for the wrong reason.
 func TestPodRequestsIsIdempotent(t *testing.T) {
-	spec := &corev1.PodSpec{
-		Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")})},
-		Resources:  &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1.5Gi")}},
-		Overhead:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
+	cases := map[string]struct {
+		podLevel string
+	}{
+		"a pod-level request carrying a decimal": {podLevel: "1.5Gi"},
+		"a pod-level request in whole units":     {podLevel: "1Gi"},
 	}
-	before := spec.DeepCopy()
 
-	first := PodRequests(spec)
-	second := PodRequests(spec)
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")})},
+				Resources:  &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(tc.podLevel)}},
+				Overhead:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
+			}
+			before := spec.DeepCopy()
 
-	if diff := cmp.Diff(first, second); diff != "" {
-		t.Errorf("the second read differs from the first (-first,+second):\n%s", diff)
-	}
-	if diff := cmp.Diff(before, spec); diff != "" {
-		t.Errorf("PodRequests() wrote to the spec it was lent (-before,+after):\n%s", diff)
+			first := PodRequests(spec)
+			second := PodRequests(spec)
+
+			if diff := cmp.Diff(first, second); diff != "" {
+				t.Errorf("the second read differs from the first (-first,+second):\n%s", diff)
+			}
+			if diff := cmp.Diff(before, spec); diff != "" {
+				t.Errorf("PodRequests() wrote to the spec it was lent (-before,+after):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/resources/podrequests_test.go
+++ b/pkg/resources/podrequests_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func container(requests corev1.ResourceList) corev1.Container {
+	return corev1.Container{Resources: corev1.ResourceRequirements{Requests: requests}}
+}
+
+func restartableInit(requests corev1.ResourceList) corev1.Container {
+	always := corev1.ContainerRestartPolicyAlways
+	c := container(requests)
+	c.RestartPolicy = &always
+	return c
+}
+
+func TestPodRequests(t *testing.T) {
+	cases := map[string]struct {
+		spec *corev1.PodSpec
+		want corev1.ResourceList
+	}{
+		"a negative sidecar does not spend what a container asked for": {
+			spec: &corev1.PodSpec{
+				Containers:     []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")})},
+				InitContainers: []corev1.Container{restartableInit(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-3")})},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+		},
+		"a negative ordinary init container is read at zero": {
+			spec: &corev1.PodSpec{
+				Containers:     []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")})},
+				InitContainers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-3")})},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+		},
+		"a negative pod-level override leaves the container total standing": {
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")})},
+				Resources:  &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-3")}},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+		},
+		"a negative overhead cannot take back the container's charge": {
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")})},
+				Overhead:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-3")},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+		},
+		"a spec with nothing negative is totalled as it always was": {
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")})},
+				Overhead:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+			want: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("3")},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			before := tc.spec.DeepCopy()
+			got := PodRequests(tc.spec)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("PodRequests() (-want,+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(before, tc.spec); diff != "" {
+				t.Errorf("PodRequests() wrote to the spec it was lent (-before,+after):\n%s", diff)
+			}
+		})
+	}
+}
+
+// The helper adds the overhead into the pod-level list in place, and a decimal
+// quantity is held behind a pointer, so a borrowed spec grows on every read.
+func TestPodRequestsIsIdempotent(t *testing.T) {
+	spec := &corev1.PodSpec{
+		Containers: []corev1.Container{container(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")})},
+		Resources:  &corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1.5Gi")}},
+		Overhead:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
+	}
+	before := spec.DeepCopy()
+
+	first := PodRequests(spec)
+	second := PodRequests(spec)
+
+	if diff := cmp.Diff(first, second); diff != "" {
+		t.Errorf("the second read differs from the first (-first,+second):\n%s", diff)
+	}
+	if diff := cmp.Diff(before, spec); diff != "" {
+		t.Errorf("PodRequests() wrote to the spec it was lent (-before,+after):\n%s", diff)
+	}
+}

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
@@ -53,7 +52,7 @@ func NewMapRequests(rl corev1.ResourceList) MapRequests {
 }
 
 func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
-	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+	return NewMapRequests(PodRequests(podSpec))
 }
 
 func (r MapRequests) Clone() Requests {

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4865,6 +4865,51 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 		prevAdmission *kueue.Admission
 		want          workload.TASUsage
 	}{
+		// The net usage reads the PodSpec again, so a negative sidecar must not
+		// leave a domain accounted for less than the quota the assignment took.
+		"a negative sidecar does not shrink the per-domain usage": {
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name:     kueue.DefaultPodSetName,
+					Flavors:  ResourceAssignment{corev1.ResourceCPU: {Name: "tas"}},
+					Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")},
+					Count:    1,
+					TopologyAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Values: []string{"node-a"},
+							Count:  1,
+						}},
+					},
+				}},
+			},
+			wl: workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							Request(corev1.ResourceCPU, "8").
+							InitContainers(*utiltesting.MakeContainer().Name("sidecar").AsSidecar().
+								WithResourceReq(corev1.ResourceCPU, "-3").Obj()).
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			cq: &schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+					"tas": {},
+				},
+			},
+			want: workload.TASUsage{
+				"tas": []workload.TopologyDomainRequests{{
+					Values: []string{"node-a"},
+					SinglePodRequests: resources.NewRequestsFromResourceList(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("8"),
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"records actual pod requests when assignment requests differ": {
 			assignment: Assignment{
 				PodSets: []PodSetAssignment{{

--- a/pkg/util/limitrange/limitrange_test.go
+++ b/pkg/util/limitrange/limitrange_test.go
@@ -217,6 +217,25 @@ func TestValidatePodSpec(t *testing.T) {
 				field.Invalid(podSpecPath, []corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotBeAboveLimitRangeMaxMessage),
 			},
 		},
+		// The Pod-level range reads the same total quota does, so a negative
+		// sidecar cannot bring a container's request under the maximum.
+		"a negative sidecar does not bring the pod under the maximum": {
+			summary: Summarize(*testingutil.MakeLimitRange("", "").
+				WithType(corev1.LimitTypePod).
+				WithValue("Max", corev1.ResourceCPU, "5").
+				Obj()),
+			podSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					*testingutil.MakeContainer().WithResourceReq(corev1.ResourceCPU, "8").Obj(),
+				},
+				InitContainers: []corev1.Container{
+					*testingutil.MakeContainer().AsSidecar().WithResourceReq(corev1.ResourceCPU, "-3").Obj(),
+				},
+			},
+			want: field.ErrorList{
+				field.Invalid(podSpecPath, []corev1.ResourceName{corev1.ResourceCPU}, RequestsMustNotBeAboveLimitRangeMaxMessage),
+			},
+		},
 		"pod under": {
 			summary: Summarize(*testingutil.MakeLimitRange("", "").
 				WithType(corev1.LimitTypePod).

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -493,12 +493,13 @@ func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
 		return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
 	}
 	requests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *chargeableSpec(spec)}, resourcehelpers.PodResourcesOptions{})
-	// A dropped pod-level override with no container total to fall back to leaves
-	// the name unset, which a multiplyBy that reads it treats as one. Put it back
-	// at zero so it still overrides at zero.
+	// A dropped override leaves the name unset where no container asked for it,
+	// and a multiplyBy that reads it then scales by one. Only the names
+	// component-helpers reads at the pod level: no other was in the untreated
+	// total, and a name the ClusterQueue covers picks a flavor at any quantity.
 	if spec.Resources != nil {
 		for name, q := range spec.Resources.Requests {
-			if q.Sign() >= 0 {
+			if q.Sign() >= 0 || !resourcehelpers.IsSupportedPodLevelResource(name) {
 				continue
 			}
 			if _, found := requests[name]; !found {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -489,10 +489,24 @@ func chargeableRequests(input corev1.ResourceList) corev1.ResourceList {
 // would let a negative request in one container spend what another asked for
 // under the same name, and the aggregation hides that the sum ever went there.
 func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
-	if hasNegativeRequest(spec) {
-		spec = chargeableSpec(spec)
+	if !hasNegativeRequest(spec) {
+		return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
 	}
-	return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
+	requests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *chargeableSpec(spec)}, resourcehelpers.PodResourcesOptions{})
+	// A dropped pod-level override with no container total to fall back to leaves
+	// the name unset, which a multiplyBy that reads it treats as one. Put it back
+	// at zero so it still overrides at zero.
+	if spec.Resources != nil {
+		for name, q := range spec.Resources.Requests {
+			if q.Sign() >= 0 || !resourcehelpers.IsSupportedPodLevelResource(name) {
+				continue
+			}
+			if _, found := requests[name]; !found {
+				requests[name] = resource.Quantity{}
+			}
+		}
+	}
+	return requests
 }
 
 func hasNegativeRequest(spec *corev1.PodSpec) bool {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -498,7 +498,7 @@ func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
 	// at zero so it still overrides at zero.
 	if spec.Resources != nil {
 		for name, q := range spec.Resources.Requests {
-			if q.Sign() >= 0 || !resourcehelpers.IsSupportedPodLevelResource(name) {
+			if q.Sign() >= 0 {
 				continue
 			}
 			if _, found := requests[name]; !found {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/util/sets"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -468,106 +467,6 @@ func (i *Info) ResourceUsage() ResourceUsage {
 	return ru
 }
 
-// chargeableRequests zeroes the quantities a PodSet cannot be charged for,
-// which today means the negative ones. It runs before the transformations and
-// the DRA merge, since a negative left in place is spent against what those
-// generate under the same name.
-func chargeableRequests(input corev1.ResourceList) corev1.ResourceList {
-	res := make(corev1.ResourceList, len(input))
-	for name, quantity := range input {
-		if quantity.Sign() < 0 {
-			// Zeroed rather than dropped, so the resource stays named.
-			quantity = resource.Quantity{}
-		}
-		res[name] = quantity
-	}
-	return res
-}
-
-// chargeablePodRequests totals a PodSet the way a Pod's own requests are
-// totalled, with each list read as chargeable first. Zeroing the sum instead
-// would let a negative request in one container spend what another asked for
-// under the same name, and the aggregation hides that the sum ever went there.
-func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
-	if !hasNegativeRequest(spec) {
-		return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
-	}
-	requests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *chargeableSpec(spec)}, resourcehelpers.PodResourcesOptions{})
-	// A dropped override leaves the name unset where no container asked for it,
-	// and a multiplyBy that reads it then scales by one. Only the names
-	// component-helpers reads at the pod level: no other was in the untreated
-	// total, and a name the ClusterQueue covers picks a flavor at any quantity.
-	if spec.Resources != nil {
-		for name, q := range spec.Resources.Requests {
-			if q.Sign() >= 0 || !resourcehelpers.IsSupportedPodLevelResource(name) {
-				continue
-			}
-			if _, found := requests[name]; !found {
-				requests[name] = resource.Quantity{}
-			}
-		}
-	}
-	return requests
-}
-
-// hasNegativeRequest reports whether any list the charge is built from holds one.
-func hasNegativeRequest(spec *corev1.PodSpec) bool {
-	negative := func(rl corev1.ResourceList) bool {
-		for _, q := range rl {
-			if q.Sign() < 0 {
-				return true
-			}
-		}
-		return false
-	}
-	for _, containers := range [][]corev1.Container{spec.InitContainers, spec.Containers} {
-		for _, c := range containers {
-			if negative(c.Resources.Requests) {
-				return true
-			}
-		}
-	}
-	if spec.Resources != nil && negative(spec.Resources.Requests) {
-		return true
-	}
-	return negative(spec.Overhead)
-}
-
-// chargeableSpec copies the spec rather than editing the one the Workload
-// holds, which the caller is only borrowing.
-func chargeableSpec(spec *corev1.PodSpec) *corev1.PodSpec {
-	out := spec.DeepCopy()
-	for i := range out.InitContainers {
-		out.InitContainers[i].Resources.Requests = chargeableRequests(out.InitContainers[i].Resources.Requests)
-	}
-	for i := range out.Containers {
-		out.Containers[i].Resources.Requests = chargeableRequests(out.Containers[i].Resources.Requests)
-	}
-	if out.Resources != nil {
-		// A pod-level request replaces the container total instead of adding to it,
-		// so a zero left here would spend what the containers asked for.
-		out.Resources.Requests = dropNegativeRequests(out.Resources.Requests)
-	}
-	// PodRequests adds the overhead only where the field is set, so a nil one is
-	// left alone rather than handed back as an empty map.
-	if out.Overhead != nil {
-		out.Overhead = chargeableRequests(out.Overhead)
-	}
-	return out
-}
-
-// dropNegativeRequests removes the names it cannot charge, rather than keeping
-// them at zero as chargeableRequests does.
-func dropNegativeRequests(requests corev1.ResourceList) corev1.ResourceList {
-	out := make(corev1.ResourceList, len(requests))
-	for name, quantity := range requests {
-		if quantity.Sign() >= 0 {
-			out[name] = quantity
-		}
-	}
-	return out
-}
-
 func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string) corev1.ResourceList {
 	res := corev1.ResourceList{}
 	for inputName, inputQuantity := range input {
@@ -793,7 +692,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Name:  ps.Name,
 			Count: count,
 		}
-		specRequests := chargeablePodRequests(&ps.Template.Spec)
+		specRequests := resources.PodRequests(&ps.Template.Spec)
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -547,7 +547,11 @@ func chargeableSpec(spec *corev1.PodSpec) *corev1.PodSpec {
 		// so a zero left here would spend what the containers asked for.
 		out.Resources.Requests = dropNegativeRequests(out.Resources.Requests)
 	}
-	out.Overhead = chargeableRequests(out.Overhead)
+	// PodRequests adds the overhead only where the field is set, so a nil one is
+	// left alone rather than handed back as an empty map.
+	if out.Overhead != nil {
+		out.Overhead = chargeableRequests(out.Overhead)
+	}
 	return out
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -468,6 +468,72 @@ func (i *Info) ResourceUsage() ResourceUsage {
 	return ru
 }
 
+// chargeableRequests zeroes the quantities a PodSet cannot be charged for,
+// which today means the negative ones. It runs before the transformations and
+// the DRA merge, since a negative left in place is spent against what those
+// generate under the same name.
+func chargeableRequests(input corev1.ResourceList) corev1.ResourceList {
+	res := make(corev1.ResourceList, len(input))
+	for name, quantity := range input {
+		if quantity.Sign() < 0 {
+			// Zeroed rather than dropped, so the resource stays named.
+			quantity = resource.Quantity{}
+		}
+		res[name] = quantity
+	}
+	return res
+}
+
+// chargeablePodRequests totals a PodSet the way a Pod's own requests are
+// totalled, with each list read as chargeable first. Zeroing the sum instead
+// would let a negative request in one container spend what another asked for
+// under the same name, and the aggregation hides that the sum ever went there.
+func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
+	if hasNegativeRequest(spec) {
+		spec = zeroNegativeRequests(spec)
+	}
+	return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
+}
+
+func hasNegativeRequest(spec *corev1.PodSpec) bool {
+	negative := func(rl corev1.ResourceList) bool {
+		for _, q := range rl {
+			if q.Sign() < 0 {
+				return true
+			}
+		}
+		return false
+	}
+	for _, containers := range [][]corev1.Container{spec.InitContainers, spec.Containers} {
+		for _, c := range containers {
+			if negative(c.Resources.Requests) {
+				return true
+			}
+		}
+	}
+	if spec.Resources != nil && negative(spec.Resources.Requests) {
+		return true
+	}
+	return negative(spec.Overhead)
+}
+
+// zeroNegativeRequests copies the spec rather than editing the one the Workload
+// holds, which the caller is only borrowing.
+func zeroNegativeRequests(spec *corev1.PodSpec) *corev1.PodSpec {
+	out := spec.DeepCopy()
+	for i := range out.InitContainers {
+		out.InitContainers[i].Resources.Requests = chargeableRequests(out.InitContainers[i].Resources.Requests)
+	}
+	for i := range out.Containers {
+		out.Containers[i].Resources.Requests = chargeableRequests(out.Containers[i].Resources.Requests)
+	}
+	if out.Resources != nil {
+		out.Resources.Requests = chargeableRequests(out.Resources.Requests)
+	}
+	out.Overhead = chargeableRequests(out.Overhead)
+	return out
+}
+
 func dropExcludedResources(input corev1.ResourceList, excludedPrefixes []string) corev1.ResourceList {
 	res := corev1.ResourceList{}
 	for inputName, inputQuantity := range input {
@@ -693,7 +759,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Name:  ps.Name,
 			Count: count,
 		}
-		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
+		specRequests := chargeablePodRequests(&ps.Template.Spec)
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -490,7 +490,7 @@ func chargeableRequests(input corev1.ResourceList) corev1.ResourceList {
 // under the same name, and the aggregation hides that the sum ever went there.
 func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
 	if hasNegativeRequest(spec) {
-		spec = zeroNegativeRequests(spec)
+		spec = chargeableSpec(spec)
 	}
 	return resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec}, resourcehelpers.PodResourcesOptions{})
 }
@@ -517,9 +517,9 @@ func hasNegativeRequest(spec *corev1.PodSpec) bool {
 	return negative(spec.Overhead)
 }
 
-// zeroNegativeRequests copies the spec rather than editing the one the Workload
+// chargeableSpec copies the spec rather than editing the one the Workload
 // holds, which the caller is only borrowing.
-func zeroNegativeRequests(spec *corev1.PodSpec) *corev1.PodSpec {
+func chargeableSpec(spec *corev1.PodSpec) *corev1.PodSpec {
 	out := spec.DeepCopy()
 	for i := range out.InitContainers {
 		out.InitContainers[i].Resources.Requests = chargeableRequests(out.InitContainers[i].Resources.Requests)
@@ -528,9 +528,21 @@ func zeroNegativeRequests(spec *corev1.PodSpec) *corev1.PodSpec {
 		out.Containers[i].Resources.Requests = chargeableRequests(out.Containers[i].Resources.Requests)
 	}
 	if out.Resources != nil {
-		out.Resources.Requests = chargeableRequests(out.Resources.Requests)
+		// A pod-level request replaces the container total instead of adding to it,
+		// so a zero left here would spend what the containers asked for.
+		out.Resources.Requests = dropNegativeRequests(out.Resources.Requests)
 	}
 	out.Overhead = chargeableRequests(out.Overhead)
+	return out
+}
+
+func dropNegativeRequests(requests corev1.ResourceList) corev1.ResourceList {
+	out := make(corev1.ResourceList, len(requests))
+	for name, quantity := range requests {
+		if quantity.Sign() >= 0 {
+			out[name] = quantity
+		}
+	}
 	return out
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -510,6 +510,7 @@ func chargeablePodRequests(spec *corev1.PodSpec) corev1.ResourceList {
 	return requests
 }
 
+// hasNegativeRequest reports whether any list the charge is built from holds one.
 func hasNegativeRequest(spec *corev1.PodSpec) bool {
 	negative := func(rl corev1.ResourceList) bool {
 		for _, q := range rl {
@@ -555,6 +556,8 @@ func chargeableSpec(spec *corev1.PodSpec) *corev1.PodSpec {
 	return out
 }
 
+// dropNegativeRequests removes the names it cannot charge, rather than keeping
+// them at zero as chargeableRequests does.
 func dropNegativeRequests(requests corev1.ResourceList) corev1.ResourceList {
 	out := make(corev1.ResourceList, len(requests))
 	for name, quantity := range requests {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -330,6 +330,54 @@ func TestNewInfo(t *testing.T) {
 				},
 			},
 		},
+		// The quota reader normalizes the sidecar away, and TAS rebuilds
+		// SinglePodRequests from the same spec, so the two have to agree.
+		"admitted with TAS and a negative sidecar": {
+			workload: *utiltestingapi.MakeWorkload("tas-negative", "").
+				PodSets(
+					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "8").
+						InitContainers(*utiltesting.MakeContainer().Name("sidecar").AsSidecar().
+							WithResourceReq(corev1.ResourceCPU, "-3").Obj()).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Obj(),
+				).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("tas-cq").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "tas", "8").
+							Count(1).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(utiltestingapi.MakeDefaultOneLevelTopology("default"))).
+								Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 1).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now,
+				).
+				Obj(),
+			wantInfo: Info{
+				ClusterQueue: "tas-cq",
+				TotalRequests: []PodSetResources{
+					{
+						Name:    kueue.DefaultPodSetName,
+						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{corev1.ResourceCPU: "tas"},
+						Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+							corev1.ResourceCPU: 8000,
+						}),
+						Count: 1,
+						TopologyRequest: &TopologyRequest{
+							Levels: []string{corev1.LabelHostname},
+							DomainRequests: []TopologyDomainRequests{{
+								Values: []string{"node-a"},
+								SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+									corev1.ResourceCPU: 8000,
+								}),
+								Count: 1,
+							}},
+						},
+					},
+				},
+			},
+		},
 		"admitted with TAS and transformed resources": {
 			workload: *utiltestingapi.MakeWorkload("tas", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1378,6 +1378,41 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// A multiplier reads the aggregate by name, so the name a zeroed overhead
+		// leaves behind multiplies by zero. Dropping the entry instead would leave
+		// it missing, which is a multiplier of one, and the negative output would
+		// land: gpu would come out at 5.
+		"negativeOverheadReadAsAMultiplierIsZeroRatherThanAbsent": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "8").
+					Request("example.com/slot", "3").
+					PodOverHead(corev1.ResourceList{"example.com/node": resource.MustParse("-2")}).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:    "example.com/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+				{
+					Input:      "example.com/slot",
+					Strategy:   new(config.Replace),
+					MultiplyBy: "example.com/node",
+					Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):  8,
+						corev1.ResourceName("example.com/node"): 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// The charge here is one preprocessing already produced, not one this
 		// resolves: the PodSet carries no claim. What is pinned is the merge.
 		"negativeOrdinaryRequestDoesNotSpendPreprocessedDRACharge": {
@@ -1472,7 +1507,13 @@ func TestNewInfo(t *testing.T) {
 			for fg, enabled := range tc.featureGates {
 				features.SetFeatureGateDuringTest(t, fg, enabled)
 			}
+			// The caller is lending this Workload, not handing it over: it is the
+			// one the informer holds, and the charge is built from a copy.
+			borrowed := tc.workload.DeepCopy()
 			info := NewInfo(&tc.workload, tc.infoOptions...)
+			if diff := cmp.Diff(borrowed, &tc.workload); diff != "" {
+				t.Errorf("NewInfo(_) changed the Workload it was given (-before,+after):\n%s", diff)
+			}
 			if diff := cmp.Diff(info, &tc.wantInfo, cmpopts.IgnoreFields(Info{}, "Obj", "SchedulingHash"), cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("NewInfo(_) = (-want,+got):\n%s", diff)
 			}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1079,10 +1079,37 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// A sidecar runs beside the regular containers, so its request is added
-		// Only cpu and memory reach the pod-level override, and it replaces the
-		// container total rather than adding to it, so an invalid entry has to go
-		// rather than become a zero.
+		// A sidecar runs beside the regular containers rather than before them, so
+		// its request joins their sum instead of being compared with it. That sum
+		// is where a negative one would be spent.
+		"negativeRestartableInitRequestDoesNotSpendTheRegularOne": {
+			workload: *utiltestingapi.MakeWorkload("sidecar", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						*utiltesting.MakeContainer().Name("asks").WithResourceReq("example.com/credit", "8").Obj(),
+					).
+					InitContainers(
+						*utiltesting.MakeContainer().Name("beside").AsSidecar().WithResourceReq("example.com/credit", "-3").Obj(),
+					).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// cpu, memory and hugepages are the names a pod-level entry is read for,
+		// and it replaces the container total rather than adding to it, so an
+		// invalid entry has to go rather than become a zero.
 		"negativePodLevelCPUFallsBackToTheContainerAggregate": {
 			workload: withPodLevelRequests(
 				utiltestingapi.MakeWorkload("podlevelcpu", "").
@@ -1117,7 +1144,28 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// A zero is a legitimate pod-level answer and still wins over the containers.
+		"negativePodLevelHugepagesFallsBackToTheContainerAggregate": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelhuge", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("hugepages-2Mi", "8Mi").Obj()).
+					Obj(),
+				corev1.ResourceList{"hugepages-2Mi": resource.MustParse("-4Mi")}),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"hugepages-2Mi": 8 * 1024 * 1024,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An explicit zero is a value, not an absent entry, so it still replaces
+		// the container total. The apiserver would refuse this shape on a Pod,
+		// since a pod-level request may not sit below the containers it covers,
+		// but a Workload written directly is not checked against that, and what
+		// is charged then is whatever the aggregation returns.
 		"zeroPodLevelRequestStillOverridesTheContainerAggregate": {
 			workload: withPodLevelRequests(
 				utiltestingapi.MakeWorkload("podlevelzero", "").

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1135,6 +1135,74 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// A negative pod-level override read by a multiplyBy has no container to
+		// fall back to, so it stays named at zero rather than vanish and read as one.
+		"negativePodLevelMultiplierWithoutContainerFallbackStaysZero": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelmultiplier", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/credit", "8").
+						Request("example.com/slot", "3").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-2")}),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:    "example.com/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+				{
+					Input:      "example.com/slot",
+					Strategy:   new(config.Replace),
+					MultiplyBy: corev1.ResourceCPU,
+					Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+						corev1.ResourceCPU:                     0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The same with a negative output factor is the quota-safety case: the slot
+		// contribution must be zero, not spent against the credit output.
+		"negativePodLevelMultiplierDoesNotUnderchargeWithNegativeFactor": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelmultiplierneg", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/credit", "8").
+						Request("example.com/slot", "3").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-2")}),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:    "example.com/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+				{
+					Input:      "example.com/slot",
+					Strategy:   new(config.Replace),
+					MultiplyBy: corev1.ResourceCPU,
+					Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+						corev1.ResourceCPU:                     0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"negativeOverheadDoesNotSpendTheRequest": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1191,10 +1191,12 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// component-helpers only reads cpu, memory and hugepages at the pod level,
-		// so an invalid entry under any other name leaves nothing behind for a
-		// multiplyBy to find, and a missing multiplier is read as one.
-		"negativeUnsupportedPodLevelNameIsStillNamedAtZero": {
+		// component-helpers only reads cpu, memory and hugepages at the pod level.
+		// The normalization has no business naming any other one: it was never in
+		// the total, and flavor assignment matches on the name rather than on the
+		// quantity, so a zero under a name the ClusterQueue covers would pick that
+		// resource's flavor and put its node labels and tolerations on the Job.
+		"unsupportedPodLevelNameStaysOutOfTheCharge": {
 			workload: withPodLevelRequests(
 				utiltestingapi.MakeWorkload("podlevelunsup", "").
 					PodSets(*utiltestingapi.MakePodSet("a", 1).
@@ -1212,8 +1214,7 @@ func TestNewInfo(t *testing.T) {
 				TotalRequests: []PodSetResources{{
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
-						corev1.ResourceName("example.com/gpu"):  8,
-						corev1.ResourceName("example.com/node"): 0,
+						corev1.ResourceName("example.com/gpu"): 5,
 					}),
 					Count: 1,
 				}},

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1107,6 +1107,36 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// An ordinary init container is measured with the sidecars declared before
+		// it already running, and that sum is compared with the regular one rather
+		// than added to it. It is a different branch from the case above, and a
+		// negative sidecar reaches the ordinary init container through it.
+		"negativeSidecarDoesNotSpendAnOrdinaryInitThatFollowsIt": {
+			workload: *utiltestingapi.MakeWorkload("sidecar-then-init", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Containers(
+						*utiltesting.MakeContainer().Name("asks").WithResourceReq("example.com/credit", "1").Obj(),
+					).
+					InitContainers(
+						*utiltesting.MakeContainer().Name("beside").AsSidecar().WithResourceReq("example.com/credit", "-3").Obj(),
+						*utiltesting.MakeContainer().Name("before").WithResourceReq("example.com/credit", "8").Obj(),
+					).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// cpu, memory and hugepages are the names a pod-level entry is read for,
 		// and it replaces the container total rather than adding to it, so an
 		// invalid entry has to go rather than become a zero.

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1212,6 +1212,27 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// The case below never reaches the normalization, since nothing in it is
+		// negative. A zero has to survive the filter that removes the invalid
+		// entries, so bring that filter in with an unrelated negative.
+		"explicitPodLevelZeroSurvivesTheNormalization": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelzeroslow", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/trigger", "-1").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")}),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:                         0,
+						corev1.ResourceName("example.com/trigger"): 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// An explicit zero is a value, not an absent entry, so it still replaces
 		// the container total. The apiserver would refuse this shape on a Pod,
 		// since a pod-level request may not sit below the containers it covers,

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1022,6 +1022,39 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// A negative reaching multiplyBy flips the sign of every output its input
+		// generates, which then comes off what another input generated.
+		"transformNegativeMultiplierDoesNotSpendAGeneratedOutput": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "8").
+					Request("example.com/slot", "3").
+					Request("example.com/node", "-2").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{
+					Input:    "example.com/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+				{
+					Input:      "example.com/slot",
+					Strategy:   new(config.Replace),
+					MultiplyBy: "example.com/node",
+					Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):  8,
+						corev1.ResourceName("example.com/node"): 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// The Pod aggregation adds the containers together, so a negative left
 		// until after it is spent before anything can see it.
 		"negativeRequestInAnotherContainerDoesNotSpendTheFirst": {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1161,6 +1161,34 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// component-helpers only reads cpu, memory and hugepages at the pod level,
+		// so an invalid entry under any other name leaves nothing behind for a
+		// multiplyBy to find, and a missing multiplier is read as one.
+		"negativeUnsupportedPodLevelNameIsStillNamedAtZero": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelunsup", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/credit", "8").
+						Request("example.com/slot", "3").Obj()).
+					Obj(),
+				corev1.ResourceList{"example.com/node": resource.MustParse("-2")}),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{Input: "example.com/credit", Strategy: new(config.Replace),
+					Outputs: corev1.ResourceList{"example.com/gpu": resource.MustParse("1")}},
+				{Input: "example.com/slot", Strategy: new(config.Replace), MultiplyBy: "example.com/node",
+					Outputs: corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")}},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):  8,
+						corev1.ResourceName("example.com/node"): 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// Dropping an invalid entry must not take a valid one with it. The
 		// normalization only runs when the spec holds a negative somewhere, so
 		// the negative here is what brings it in; the pod-level request is one

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1161,6 +1161,29 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// Dropping an invalid entry must not take a valid one with it. The
+		// normalization only runs when the spec holds a negative somewhere, so
+		// the negative here is what brings it in; the pod-level request is one
+		// the apiserver would have accepted and has to survive.
+		"normalizationKeepsAPodLevelRequestTheApiserverWouldAccept": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelkeep", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request(corev1.ResourceCPU, "8").
+						Request(corev1.ResourceMemory, "-1").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("12")}),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceCPU:    12000,
+						corev1.ResourceMemory: 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// An explicit zero is a value, not an absent entry, so it still replaces
 		// the container total. The apiserver would refuse this shape on a Pod,
 		// since a pod-level request may not sit below the containers it covers,

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -135,6 +135,12 @@ func TestIsOnHold(t *testing.T) {
 	}
 }
 
+// The PodSet builders do not reach pod-level resources, and only one case needs them.
+func withPodLevelRequests(wl *kueue.Workload, rl corev1.ResourceList) kueue.Workload {
+	wl.Spec.PodSets[0].Template.Spec.Resources = &corev1.ResourceRequirements{Requests: rl}
+	return *wl
+}
+
 func TestNewInfo(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	cases := map[string]struct {
@@ -989,6 +995,171 @@ func TestNewInfo(t *testing.T) {
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceName("example.com/gpu"): math.MaxInt64,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A negative predating the webhook guard still reaches the accounting.
+		"transformNegativeRequestDoesNotSpendAGeneratedOutput": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "-3").
+					Request("example.com/credit", "8").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The Pod aggregation adds the containers together, so a negative left
+		// until after it is spent before anything can see it.
+		"negativeRequestInAnotherContainerDoesNotSpendTheFirst": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).Containers(
+					*utiltesting.MakeContainer().Name("asks").WithResourceReq("example.com/credit", "8").Obj(),
+					*utiltesting.MakeContainer().Name("gives-back").WithResourceReq("example.com/credit", "-3").Obj(),
+				).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A sidecar runs beside the regular containers, so its request is added
+		// to theirs rather than compared against them.
+		"negativeRestartableInitRequestDoesNotSpendTheRegularOne": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					InitContainers(*utiltesting.MakeContainer().Name("sidecar").
+						AsSidecar().WithResourceReq("example.com/credit", "-3").Obj()).
+					Containers(*utiltesting.MakeContainer().Name("asks").
+						WithResourceReq("example.com/credit", "8").Obj()).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A pod-level request zeroed here does not take the container aggregate
+		// down with it: the aggregation still answers 8. Pinned because dropping
+		// the key instead would be a different answer.
+		"negativePodLevelRequestLeavesTheContainerAggregate": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevel", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request("example.com/credit", "8").Obj()).
+					Obj(),
+				corev1.ResourceList{"example.com/credit": resource.MustParse("-3")}),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"negativeOverheadDoesNotSpendTheRequest": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "8").
+					PodOverHead(corev1.ResourceList{"example.com/credit": resource.MustParse("-3")}).Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The charge here is one preprocessing already produced, not one this
+		// resolves: the PodSet carries no claim. What is pinned is the merge.
+		"negativeOrdinaryRequestDoesNotSpendPreprocessedDRACharge": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "-3").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{
+						"a": {"example.com/gpu": resource.MustParse("8")},
+					},
+					nil,
+				),
+			},
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformNegativeRequestOnItsOwnIsZero": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "-3").
+					Request("example.com/credit", "1").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/other": resource.MustParse("1")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"):   0,
+						corev1.ResourceName("example.com/other"): 1,
 					}),
 					Count: 1,
 				}},
@@ -3715,5 +3886,22 @@ func TestTotalExecutionTime(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// NewInfo is handed Workloads straight out of the informer cache, so it borrows
+// the PodSpec rather than owning it.
+func TestNewInfoLeavesTheWorkloadAlone(t *testing.T) {
+	wl := utiltestingapi.MakeWorkload("negative", "ns").
+		PodSets(*utiltestingapi.MakePodSet("a", 1).
+			Request("example.com/credit", "-3").
+			PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")}).Obj()).
+		Obj()
+	want := wl.DeepCopy()
+
+	NewInfo(wl)
+
+	if diff := cmp.Diff(want.Spec, wl.Spec); diff != "" {
+		t.Errorf("NewInfo() rewrote the Workload it was given (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1047,50 +1047,56 @@ func TestNewInfo(t *testing.T) {
 			},
 		},
 		// A sidecar runs beside the regular containers, so its request is added
-		// to theirs rather than compared against them.
-		"negativeRestartableInitRequestDoesNotSpendTheRegularOne": {
-			workload: *utiltestingapi.MakeWorkload("transform", "").
-				PodSets(*utiltestingapi.MakePodSet("a", 1).
-					InitContainers(*utiltesting.MakeContainer().Name("sidecar").
-						AsSidecar().WithResourceReq("example.com/credit", "-3").Obj()).
-					Containers(*utiltesting.MakeContainer().Name("asks").
-						WithResourceReq("example.com/credit", "8").Obj()).Obj()).
-				Obj(),
-			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
-				Input:    "example.com/credit",
-				Strategy: new(config.Replace),
-				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
-			}})},
+		// Only cpu and memory reach the pod-level override, and it replaces the
+		// container total rather than adding to it, so an invalid entry has to go
+		// rather than become a zero.
+		"negativePodLevelCPUFallsBackToTheContainerAggregate": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelcpu", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request(corev1.ResourceCPU, "8").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("-3")}),
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
-						corev1.ResourceName("example.com/gpu"): 8,
+						corev1.ResourceCPU: 8000,
 					}),
 					Count: 1,
 				}},
 			},
 		},
-		// A pod-level request zeroed here does not take the container aggregate
-		// down with it: the aggregation still answers 8. Pinned because dropping
-		// the key instead would be a different answer.
-		"negativePodLevelRequestLeavesTheContainerAggregate": {
+		"negativePodLevelMemoryFallsBackToTheContainerAggregate": {
 			workload: withPodLevelRequests(
-				utiltestingapi.MakeWorkload("podlevel", "").
+				utiltestingapi.MakeWorkload("podlevelmem", "").
 					PodSets(*utiltestingapi.MakePodSet("a", 1).
-						Request("example.com/credit", "8").Obj()).
+						Request(corev1.ResourceMemory, "8").Obj()).
 					Obj(),
-				corev1.ResourceList{"example.com/credit": resource.MustParse("-3")}),
-			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
-				Input:    "example.com/credit",
-				Strategy: new(config.Replace),
-				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
-			}})},
+				corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("-3")}),
 			wantInfo: Info{
 				TotalRequests: []PodSetResources{{
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
-						corev1.ResourceName("example.com/gpu"): 8,
+						corev1.ResourceMemory: 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A zero is a legitimate pod-level answer and still wins over the containers.
+		"zeroPodLevelRequestStillOverridesTheContainerAggregate": {
+			workload: withPodLevelRequests(
+				utiltestingapi.MakeWorkload("podlevelzero", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).
+						Request(corev1.ResourceCPU, "8").Obj()).
+					Obj(),
+				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")}),
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 0,
 					}),
 					Count: 1,
 				}},

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -135,7 +135,7 @@ func TestIsOnHold(t *testing.T) {
 	}
 }
 
-// The PodSet builders do not reach pod-level resources, and only one case needs them.
+// The PodSet builders do not reach pod-level resources.
 func withPodLevelRequests(wl *kueue.Workload, rl corev1.ResourceList) kueue.Workload {
 	wl.Spec.PodSets[0].Template.Spec.Resources = &corev1.ResourceRequirements{Requests: rl}
 	return *wl
@@ -1017,6 +1017,31 @@ func TestNewInfo(t *testing.T) {
 					Name: "a",
 					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 						corev1.ResourceName("example.com/gpu"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The reproducer Kueue#14015 was filed with. Both contributions are
+		// generated, and outputs cancelling each other is deliberate, so nothing
+		// downstream separates these two: the source is the only place to act.
+		"transformNegativeInputDoesNotSpendWhatAnotherInputGenerated": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/real-gpu", "8").
+					Request("example.com/credit", "-3").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
+				{Input: "example.com/real-gpu", Strategy: new(config.Replace),
+					Outputs: corev1.ResourceList{"example.com/gpu-quota": resource.MustParse("1")}},
+				{Input: "example.com/credit", Strategy: new(config.Replace),
+					Outputs: corev1.ResourceList{"example.com/gpu-quota": resource.MustParse("1")}},
+			})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu-quota"): 8,
 					}),
 					Count: 1,
 				}},

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1233,28 +1233,6 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// An explicit zero is a value, not an absent entry, so it still replaces
-		// the container total. The apiserver would refuse this shape on a Pod,
-		// since a pod-level request may not sit below the containers it covers,
-		// but a Workload written directly is not checked against that, and what
-		// is charged then is whatever the aggregation returns.
-		"zeroPodLevelRequestStillOverridesTheContainerAggregate": {
-			workload: withPodLevelRequests(
-				utiltestingapi.MakeWorkload("podlevelzero", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).
-						Request(corev1.ResourceCPU, "8").Obj()).
-					Obj(),
-				corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("0")}),
-			wantInfo: Info{
-				TotalRequests: []PodSetResources{{
-					Name: "a",
-					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
-						corev1.ResourceCPU: 0,
-					}),
-					Count: 1,
-				}},
-			},
-		},
 		// A negative pod-level override read by a multiplyBy has no container to
 		// fall back to, so it stays named at zero rather than vanish and read as one.
 		"negativePodLevelMultiplierWithoutContainerFallbackStaysZero": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

A quantity a PodSet asked for can be negative. `validateResourceList` refuses one on the way in, and only while `WorkloadValidateResourcesAreNonNegative` is enabled; the gate is Beta and an administrator can turn it off, and a Workload written before the check existed still carries what it carries. Those are the same two doors #13991 describes for `spec.overhead`. What this changes for a Workload already in that state is its accounting view and nothing else: with the gate on, one of those cannot be updated, deactivated or deleted either, and that is #14373.

Nothing after that tells such a request apart from a resource nobody asked for. It is summed with whatever else is charged under the same name and pays for part of it, and because the total stays positive, the floor at the end sees nothing to correct. Measured on `main`, with a container requesting `example.com/gpu: -3` alongside `example.com/credit: 8` and a transformation generating one `example.com/gpu` per credit:

```
before   example.com/gpu = 5
after    example.com/gpu = 8
```

Three devices were admitted for nothing.

##### Why the source, and not where it is spent

#13986 already keeps what a transformation generates apart from what the PodSet asked for, and floors the generated side before merging them. Guarding the requested side there would look symmetric and would be wrong, because that function returns early:

```go
	if !match {
		return input
	}
```

A PodSet that only carries a `ResourceClaimTemplate` matches no transformation at all, so nothing inside one runs for it, while the DRA logical charge is merged a few lines later:

```go
effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
```

That is the ordinary shape for the workloads this matters most to. So each list the Pod aggregation reads is made chargeable before it reads them, rather than the sum afterwards. One container asking for 8 while another asks for -3 arrives as 5, and a floor on the sum has nothing left to catch. A restartable init container beside a regular one, and a negative pod overhead, land the same way.

Overhead is normalized here as well, and that half is not finished. `handlePodOverhead` decides whether to read the RuntimeClass before this runs, and it skips the read whenever the overhead is non-empty, so a Workload that already carries a negative one never picks the class value up. Measured with a container asking for 1 CPU, an embedded overhead of -1, and a RuntimeClass carrying 2:

```
no overhead        the class is read      charged 3000m
overhead -1        the class is skipped   charged 1000m
```

This change moves that second row up from 0, since the -1 no longer eats the container's 1, and the remaining 2 needs the decision moved ahead of it. That is #13991, and #13995 has the shape for it: dropping the entry rather than zeroing it is what lets `len(overhead) == 0` become true again. Zeroing keeps the key, which is the right rule for a request and the wrong one for this.

That treatment sits in one place. `pkg/resources/podrequests.go` is the only file outside `vendor/` that imports `component-helpers`, and everything building requests from a PodSpec goes through the `PodRequests` in it, either directly or through `NewRequestsFromPodSpec` and `NewMapRequestsFromPodSpec`. Quota calls it from `totalRequestsFromPodSets`. The admitted TAS domain rebuild, TAS placement, TAS net usage, the flavor overlap check, the TAS pod cache, the TAS pod usage controller and the pod-level LimitRange check reach it through `NewRequestsFromPodSpec`. An earlier revision normalized inside `pkg/workload` instead, which left quota reading one size and placement another for the same Workload, and putting it in the shared reader is what makes those agree. `TestNewInfo` gains an admitted TAS case where the two used to disagree, reading 8 for the quota and 8 for the domain, and `TestAssignment_ComputeTASNetUsage` and `TestValidatePodSpec` each carry one for a reader outside `pkg/workload`.

The DRA half is closed already. #14367 drops a negative extended-resource request before the logical charge is resolved, so nothing is left in front of this one.

##### Zero, not absent

A negative container request or pod overhead stays named and reaches zero rather than being dropped, since the aggregation adds those and a zero costs nothing. A pod-level override replaces the container total instead, so an invalid one is dropped rather than zeroed; that half is below. `TestNewInfo` already pins the zeroing for a negative that arrives on its own, with `corev1.ResourceCPU: 0` present in the expected requests, and dropping the key instead turns that case red. Where a resource is named is part of what the PodSet said.

A dropped pod-level name is put back at zero where no container recreates it, so a `multiplyBy` that reads it finds a zero rather than nothing, which would have scaled by one. That is limited to the names `component-helpers` reads at the pod level. It reads no others, so no other was ever in the total, and naming one here would add a resource the PodSet does not have. That is not a bookkeeping detail: the zero-quantity skip in flavor assignment only applies to a resource the ClusterQueue does not declare, so a name it does declare picks that resource's flavor whatever the quantity. An earlier revision of this PR restored those too. Measured against `main`, with a ClusterQueue covering that name:

```
main       flavors = {cpu: default}
that rev   flavors = {cpu: default, example.com/node: gpunode}
```

so the Job came out carrying `gpunode`'s node labels and tolerations, and where that flavor was tainted the Workload went from `Fit` to `NoFit`. With a second PodSet it was worse: the failed group returns early and the second assignment never gets appended, while the mode still reads `Fit`. The restore is limited to `IsSupportedPodLevelResource` now, which is the set the untreated spec would have named anyway.

Keeping it to those names also takes out a discontinuity. A pod-level `example.com/node` of `-2` was reaching `multiplyBy` as zero while `0` and `4` both reached it as one, so making the value legal took the charge from 8 down to 5. All three read as one now, as they do on `main`.

#### Which issue(s) this PR fixes:

Fixes #14015

#### Special notes for your reviewer:

The cases that pin the fix fail without it: a transformation generating under the name, a DRA charge already under it, a negative pod-level cpu, memory or hugepages request, and a negative `multiplyBy` operand, which without this turns another input's `3 x 1` into `3 x -2` and spends 6 of a generated 8. A negative on a name nothing else touches passes either way, since `Requests.FloorToZero` further down already left it at zero; it is here because this moves where that zero comes from. A pod-level zero passes either way too, and guards the opposite mistake of dropping a legitimate override.

The reproducer the issue opens with is among them, and it is not the same shape as its neighbour. There the negative is on the requested side and reaches the generated total through the merge at the end; in the issue both contributions are generated, from two inputs whose factors are both `1`, so the sign is the Workload's alone and outputs cancelling each other is the behaviour that was asked for. Both land on 5 where 8 is wanted, but only the second is what was reported, and the source is the only place it can be caught.

`chargeableSpec` leaves a nil overhead nil rather than replacing it with an empty map. Nothing is charged differently, since adding an empty list adds nothing, but `PodRequests` guards its overhead branch on the field being set and the copy should not answer that differently from the spec it was taken from.

A pod-level request replaces the container aggregate rather than adding to it, so it does not take the same normalization as the rest. An earlier revision left an explicit zero there, which charged 0 for a cpu 8 with a pod-level -3: worse than the 5 the negative was meant to stop. The invalid entry is dropped instead, and the calculation falls back to the containers. Only cpu, memory and `hugepages-*` reach that path in `component-helpers`, which is why the case that first pinned it, written with an extended resource, passed with or without the change.

A negative transformation output factor is deliberately untouched. That is the intended way to write a per-unit allowance, and it stays confined to the generated bucket exactly as #13986 left it.

##### Who owns the overhead, once the other three land

Four PRs touch the overhead a Workload is charged, and each owns a different half. Writing them down so whoever resolves the conflict does it on purpose.

This one normalizes a negative entry where the accounting view is built, alongside the container and pod-level lists, because that is the list `PodRequests` adds last and a negative one there spends what the containers asked for. #13995 owns the validation and the `pkg/resources.ChargeableOverhead` helper, and drops an entry naming `pods` as well; it also moves that drop above the `runtimeClassName` check, which is what lets a Workload carrying only an invalid overhead reach the RuntimeClass at all. #14289 removes that `len(overhead) == 0` guard outright and takes the larger of the class and what the PodSet carries, so the class is consulted whatever the entry says. #14048 splits where `multiplyBy` reads from, which is the only one of the four that does not touch overhead.

Composed, the order is: drop what cannot be charged, resolve the class and take the larger, then build the charge view.

Three PRs add the same shared reader: #13995, #14407 and this one. The first two put a `PodRequests` in `pkg/resources/factory.go` and this one puts it in `pkg/resources/podrequests.go`. Merging #13995 into this one conflicts in `factory.go`, so git asks. Merging #14407 into it does not: `factory.go` comes out clean and the package is left declaring `PodRequests` twice, which only the build reports. #14407 has nothing left that is not here. Its half is in this one because the split makes it matter: `chargeableSpec` copies, so a spec carrying a negative was never written back, while one carrying none would have kept being written back on every read. `detachPodLevelRequests` closes that, and `TestPodRequestsIsIdempotent` now carries both of its rows, the decimal one and the whole-unit control that says why the decimal one is the case worth having. So #13995 is the only one this still has to be merged with by hand, and whichever of the two lands second belongs in the file the first one left.

##### One constraint outside that group

#14154 takes back what the containers asked for on a replaced extended resource, and reads that amount from the untreated spec. Today both sides read the same thing. Once this lands they do not: a container asking for 8 beside one asking for -3 is 8 in the charge and 5 in that read, so the subtraction leaves 3 behind and the DRA charge is added on top. Composed locally on this branch:

```
dra.example/gpu = 8
example.com/gpu = 3
```

where the second should be gone. #14154 has to read the same view when it rebases. #14048 already does, since it takes its multiplier source from `specRequests`. Clamping the subtracted amount at zero is right once this lands and wrong before it, so it belongs to whichever of the two lands second.

Two more things about that composition are measured rather than argued, and both are about a name surviving as a zero rather than disappearing. This PR turns a negative overhead entry into a zero and keeps the key; #13995 removes the key instead, because `handlePodOverhead` reads `len(overhead) == 0` to decide whether the RuntimeClass answers. Both are right for what they are doing, and they disagree about what is left for a transformation to read as a `multiplyBy` source: a zero multiplies to nothing, a missing one is read as one. #14289 removes that `len(overhead) == 0` guard, so once it lands the reason to remove rather than zero is gone, and the two can agree.

#### Does this PR introduce a user-facing change?

```release-note
ResourceTransformations × DRA: Fixed a negative resource request on a Workload paying for what is charged under the same name, whether that is a resource transformation output or a DRA logical-resource charge that has already been resolved. A request of `-3` against a charge of `8` was admitted for `5`, and the total stayed positive so nothing downstream reported it. Every list the Pod aggregation reads is now made chargeable before it reads them: a negative container request or pod overhead counts as zero, while a negative pod-level override is dropped instead, so the container total it would have replaced stands.

Reading a PodSpec no longer writes to it, so a pod-level request beside a pod overhead stops rising by that overhead on every read.

A Workload that already holds a quota reservation keeps the usage recorded in `status.admission` until that reservation is released and rebuilt.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Negative resource requests are now treated as zero rather than reducing calculated resource totals.
  * Resource calculations remain accurate across containers, init containers, pod-level resources, overhead, and device-related processing.
  * Workload specifications remain unchanged during resource calculation.

* **Tests**
  * Added coverage for negative requests across direct, transformed, preprocessed, and generated resource scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


