### PR TITLE
Read a multiplier from the requests, not from what is charged

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -543,10 +543,10 @@ type Resources struct {
 	// ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 	// Pod request view that Kueue charges quota against.
 	//
-	// A matching resource is not charged, and a transformation naming one as its
-	// input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
-	// which reads the request view from before this field is applied. Transformation
-	// outputs and DRA logical resources are added afterwards and are not filtered.
+	// An entry matching one of these prefixes is dropped from that view, so it is
+	// not charged, and a transformation naming it as its input does not run. The
+	// resource can still be read by ResourceTransformation.MultiplyBy, which reads
+	// the request view from before this field is applied.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`
 
 	// Transformations defines how to transform PodSpec resources into Workload resource requests.

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -544,7 +544,7 @@ type Resources struct {
 	// Pod request view that Kueue charges quota against.
 	//
 	// A matching resource is not charged, and a transformation naming one as its
-	// input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+	// input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
 	// which reads the request view from before this field is applied. Transformation
 	// outputs and DRA logical resources are added afterwards and are not filtered.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -540,7 +540,13 @@ type ClusterQueueVisibility struct {
 }
 
 type Resources struct {
-	// ExcludedResourcePrefixes defines which resources should be ignored by Kueue
+	// ExcludeResourcePrefixes defines the resource-name prefixes left out of the
+	// Pod request view that Kueue charges quota against.
+	//
+	// A matching resource is not charged, and a transformation naming one as its
+	// input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+	// which reads the request view from before this field is applied. Transformation
+	// outputs and DRA logical resources are added afterwards and are not filtered.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`
 
 	// Transformations defines how to transform PodSpec resources into Workload resource requests.
@@ -582,6 +588,8 @@ type ResourceTransformation struct {
 	// Disabling the ReservedResourceNameValidation feature gate lets such a
 	// configuration load for an upgrade; flavor assignment still overwrites the
 	// key with the PodSet count.
+	// The quantity is read from the request view before "excludeResourcePrefixes"
+	// is applied, so a resource kept out of quota can still be named here.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -595,10 +595,10 @@ type Resources struct {
 	// ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 	// Pod request view that Kueue charges quota against.
 	//
-	// A matching resource is not charged, and a transformation naming one as its
-	// input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
-	// which reads the request view from before this field is applied. Transformation
-	// outputs and DRA logical resources are added afterwards and are not filtered.
+	// An entry matching one of these prefixes is dropped from that view, so it is
+	// not charged, and a transformation naming it as its input does not run. The
+	// resource can still be read by ResourceTransformation.MultiplyBy, which reads
+	// the request view from before this field is applied.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`
 
 	// Transformations defines how to transform PodSpec resources into Workload resource requests.

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -592,7 +592,13 @@ type Resources struct {
 	// +optional
 	QuotaCheckStrategy *QuotaCheckStrategy `json:"quotaCheckStrategy,omitempty"`
 
-	// ExcludedResourcePrefixes defines which resources should be ignored by Kueue
+	// ExcludeResourcePrefixes defines the resource-name prefixes left out of the
+	// Pod request view that Kueue charges quota against.
+	//
+	// A matching resource is not charged, and a transformation naming one as its
+	// input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+	// which reads the request view from before this field is applied. Transformation
+	// outputs and DRA logical resources are added afterwards and are not filtered.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`
 
 	// Transformations defines how to transform PodSpec resources into Workload resource requests.
@@ -634,6 +640,8 @@ type ResourceTransformation struct {
 	// Disabling the ReservedResourceNameValidation feature gate lets such a
 	// configuration load for an upgrade; flavor assignment still overwrites the
 	// key with the PodSet count.
+	// The quantity is read from the request view before "excludeResourcePrefixes"
+	// is applied, so a resource kept out of quota can still be named here.
 	// +optional
 	MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -596,7 +596,7 @@ type Resources struct {
 	// Pod request view that Kueue charges quota against.
 	//
 	// A matching resource is not charged, and a transformation naming one as its
-	// input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+	// input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
 	// which reads the request view from before this field is applied. Transformation
 	// outputs and DRA logical resources are added afterwards and are not filtered.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`

--- a/keps/2937-resource-transformer/README.md
+++ b/keps/2937-resource-transformer/README.md
@@ -64,7 +64,7 @@ will enable Kueue to support simpler and more powerful definitions of resource q
 ### Non-Goals
 
 * Supporting complex numerical transformations of resource quantities
-* Supporting transformations that take multiple input resources
+* Supporting transformations that take multiple input resources beyond the single `input` and the optional `multiplyBy` operand
 * Performing any mutation of the resource requests/limits of Jobs
 * Ensuring that a Workload's resource requests is updated if the set of
 configured transformations functions changes after its resource requests are computed.
@@ -319,7 +319,9 @@ future extensions.
 The definitions below would be added to Kueue's `Configuration` types
 ```go
 type Resources struct {
-	// ExcludedResourcePrefixes defines which resources should be ignored by Kueue
+	// ExcludeResourcePrefixes lists the resource-name prefixes kept out of the Pod
+	// request view Kueue charges quota against. An excluded resource is still
+	// readable as a transformation multiplyBy source.
 	ExcludeResourcePrefixes []string `json:"excludeResourcePrefixes,omitempty"`
 
 	// Transformations defines how to transform PodSpec resources into Workload resource requests.
@@ -340,11 +342,12 @@ type ResourceTransformation struct {
 
   // Whether the input resource should be replaced or retained
   // +kubebuilder:default="Retain"
-  Strategy ResourceTransformationStrategy `json:"strategy"`
+  Strategy *ResourceTransformationStrategy `json:"strategy,omitempty"`
 
   // MultiplyBy defines a resource name, which performs a multiplication
-  // calculation on the resource name of the input.
-  MultiplyBy corev1.ResourceName `json:"multiplyBy"`
+  // calculation on the resource name of the input. The named resource is read
+  // from the request view before excludeResourcePrefixes is applied.
+  MultiplyBy corev1.ResourceName `json:"multiplyBy,omitempty"`
 
   // Output resources and quantities per unit of input resource
   Outputs corev1.ResourceList `json:"outputs,omitempty"`

--- a/keps/2937-resource-transformer/README.md
+++ b/keps/2937-resource-transformer/README.md
@@ -616,7 +616,9 @@ We should implement additional verification to flag overlaps between `resources.
 and `resources.transformations`.  The implementation applies the exclusions before
 the transformations, so if a resource both matches an exclusion prefix and is an input resource
 to a transformation the transformation will never apply.  This could be detected when validating
-the configuration and reported as a configuration error.
+the configuration and reported as a configuration error.  The overlap that is worth flagging is
+the one on `input`.  A `multiplyBy` naming an excluded resource is a supported combination: the
+resource is kept out of quota and is still read as a multiplier, so validation must not reject it.
 
 #### GA
 

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -940,6 +940,25 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		// The KEP asks for an overlap check between excludeResourcePrefixes and
+		// the transformations, scoped to the input. A multiplyBy naming an
+		// excluded resource is the deliberate combination, not the one to reject.
+		"valid .resources.transformations.multiplyBy naming an excluded prefix": {
+			cfg: &configapi.Configuration{
+				Integrations: defaultIntegrations,
+				Resources: &configapi.Resources{
+					ExcludeResourcePrefixes: []string{"vendor.example/"},
+					Transformations: []configapi.ResourceTransformation{
+						{
+							Input:      "example.com/mem",
+							Strategy:   new(configapi.Replace),
+							MultiplyBy: "vendor.example/gpu",
+							Outputs:    corev1.ResourceList{"quota.example.com/total-mem": resource.MustParse("1")},
+						},
+					},
+				},
+			},
+		},
 		"negative afterFinished in .objectRetentionPolicies.workloads": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -577,7 +577,10 @@ func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.R
 	return reqs.ToResourceList(formatter)
 }
 
-func applyResourceTransformations(input corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) corev1.ResourceList {
+// applyResourceTransformations charges input and reads a multiplyBy from
+// multiplierSource, which still holds the resources excludeResourcePrefixes
+// dropped from the charge.
+func applyResourceTransformations(input, multiplierSource corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) corev1.ResourceList {
 	match := false
 	for resourceName := range input {
 		if _, ok := transforms[resourceName]; ok {
@@ -607,7 +610,7 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		// requested, so the multiplier does not reach that as well.
 		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {
-			if q, ok := input[mapping.MultiplyBy]; ok {
+			if q, ok := multiplierSource[mapping.MultiplyBy]; ok {
 				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
 			}
 		}
@@ -701,7 +704,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 		}
 		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
-		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
+		effectiveRequests = applyResourceTransformations(effectiveRequests, specRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
 			// First, remove extended resources that were converted to DRA logical resources
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -611,6 +611,12 @@ func applyResourceTransformations(input, multiplierSource corev1.ResourceList, t
 		outputInputVal := inputQuantity
 		if mapping.MultiplyBy != "" {
 			if q, ok := multiplierSource[mapping.MultiplyBy]; ok {
+				// spec.overhead is not checked for sign, so a Workload can hand back a
+				// negative count here and turn this output into a credit against the
+				// same name. Zero is left alone; it is how an output scales to nothing.
+				if q.Sign() < 0 {
+					q = resource.Quantity{}
+				}
 				outputInputVal = multiplyResourceQuantities(inputQuantity, q)
 			}
 		}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -577,10 +577,9 @@ func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.R
 	return reqs.ToResourceList(formatter)
 }
 
-// applyResourceTransformations charges input and reads a multiplyBy from
-// multiplierSource, the same requests before excludeResourcePrefixes dropped
-// from them. Both must come from one chargeable view; a multiplier read from a
-// rawer list would scale by a quantity that cannot be charged at all.
+// applyResourceTransformations transforms input. A multiplyBy operand is read
+// from multiplierSource, the view from before excludeResourcePrefixes, and is
+// never merged in, so an excluded resource scales an output without being charged.
 func applyResourceTransformations(input, multiplierSource corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) corev1.ResourceList {
 	match := false
 	for resourceName := range input {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -578,8 +578,9 @@ func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.R
 }
 
 // applyResourceTransformations charges input and reads a multiplyBy from
-// multiplierSource, which still holds the resources excludeResourcePrefixes
-// dropped from the charge.
+// multiplierSource, the same requests before excludeResourcePrefixes dropped
+// from them. Both must come from one chargeable view; a multiplier read from a
+// rawer list would scale by a quantity that cannot be charged at all.
 func applyResourceTransformations(input, multiplierSource corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) corev1.ResourceList {
 	match := false
 	for resourceName := range input {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1048,6 +1048,43 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// A negative multiplier would turn this output into a credit against the one
+		// the other transformation generates under the same name, and the floor runs
+		// on the sum, so 8 would be charged as 2. Clamped rather than dropped: 8, not 11.
+		"transformNegativeMultiplierDoesNotCreditAnotherOutput": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/a", "8").
+					Request("example.com/b", "3").
+					PodOverHead(corev1.ResourceList{"vendor.example/gpu": resource.MustParse("-2")}).
+					Obj()).
+				Obj(),
+			infoOptions: []InfoOption{
+				WithExcludedResourcePrefixes([]string{"vendor.example/"}),
+				WithResourceTransformations([]config.ResourceTransformation{
+					{
+						Input:    "example.com/a",
+						Strategy: new(config.Replace),
+						Outputs:  corev1.ResourceList{"quota.example.com/total": resource.MustParse("1")},
+					},
+					{
+						Input:      "example.com/b",
+						Strategy:   new(config.Replace),
+						MultiplyBy: "vendor.example/gpu",
+						Outputs:    corev1.ResourceList{"quota.example.com/total": resource.MustParse("1")},
+					},
+				}),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/total"): 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// What a multiplier absent from the source does today, kept beside the
 		// excluded one so the two cases stay told apart. Nothing defines it: the
 		// field says which resource is read, not what happens when it is missing,

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -994,6 +994,32 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// An excluded resource is not charged, but can still be a multiplier.
+		"transformMultiplierSurvivesAnExcludedPrefix": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/mem", "1024").
+					Request("vendor.example/gpu", "4").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{
+				WithExcludedResourcePrefixes([]string{"vendor.example/"}),
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:      "example.com/mem",
+					Strategy:   new(config.Replace),
+					MultiplyBy: "vendor.example/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/total-mem": resource.MustParse("1")},
+				}}),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/total-mem"): 4096,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1020,9 +1020,9 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// The next two are a pair. A multiplier the lookup finds at zero and one it
-		// does not find at all are different answers, and which of the two an
-		// excluded resource becomes is decided upstream of here.
+		// A multiplier the lookup finds at zero and one it does not find at all are
+		// different answers, and which of the two an excluded resource becomes is
+		// decided upstream of here.
 		"transformExcludedMultiplierAtZeroIsNotAMissingMultiplier": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1020,6 +1020,58 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// The next two are a pair. A multiplier the lookup finds at zero and one it
+		// does not find at all are different answers, and which of the two an
+		// excluded resource becomes is decided upstream of here.
+		"transformExcludedMultiplierAtZeroIsNotAMissingMultiplier": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/mem", "1024").
+					Request("vendor.example/gpu", "0").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{
+				WithExcludedResourcePrefixes([]string{"vendor.example/"}),
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:      "example.com/mem",
+					Strategy:   new(config.Replace),
+					MultiplyBy: "vendor.example/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/total-mem": resource.MustParse("1")},
+				}}),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/total-mem"): 0,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		"transformMissingMultiplierScalesByOne": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/mem", "1024").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{
+				WithExcludedResourcePrefixes([]string{"vendor.example/"}),
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:      "example.com/mem",
+					Strategy:   new(config.Replace),
+					MultiplyBy: "vendor.example/gpu",
+					Outputs:    corev1.ResourceList{"quota.example.com/total-mem": resource.MustParse("1")},
+				}}),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("quota.example.com/total-mem"): 1024,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1048,7 +1048,11 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		"transformMissingMultiplierScalesByOne": {
+		// What a multiplier absent from the source does today, kept beside the
+		// excluded one so the two cases stay told apart. Nothing defines it: the
+		// field says which resource is read, not what happens when it is missing,
+		// so this records the current behavior and is not a contract to preserve.
+		"transformMultiplierMissingFromTheSourceIsNotScaledBy": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).
 					Request("example.com/mem", "1024").Obj()).

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1229,10 +1229,10 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
 <td>
    <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 Pod request view that Kueue charges quota against.</p>
-<p>A matching resource is not charged, and a transformation naming one as its
-input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
-which reads the request view from before this field is applied. Transformation
-outputs and DRA logical resources are added afterwards and are not filtered.</p>
+<p>An entry matching one of these prefixes is dropped from that view, so it is
+not charged, and a transformation naming it as its input does not run. The
+resource can still be read by ResourceTransformation.MultiplyBy, which reads
+the request view from before this field is applied.</p>
 </td>
 </tr>
 <tr><td><code>transformations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1175,7 +1175,9 @@ It must not be <code>pods</code>; that exact name is reserved for Kueue's intern
 Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
 Disabling the ReservedResourceNameValidation feature gate lets such a
 configuration load for an upgrade; flavor assignment still overwrites the
-key with the PodSet count.</p>
+key with the PodSet count.
+The quantity is read from the request view before &quot;excludeResourcePrefixes&quot;
+is applied, so a resource kept out of quota can still be named here.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1225,7 +1227,12 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
 <code>[]string</code>
 </td>
 <td>
-   <p>ExcludedResourcePrefixes defines which resources should be ignored by Kueue</p>
+   <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
+Pod request view that Kueue charges quota against.</p>
+<p>A matching resource is not charged, and a transformation naming one as its
+input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+which reads the request view from before this field is applied. Transformation
+outputs and DRA logical resources are added afterwards and are not filtered.</p>
 </td>
 </tr>
 <tr><td><code>transformations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -1230,7 +1230,7 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
    <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 Pod request view that Kueue charges quota against.</p>
 <p>A matching resource is not charged, and a transformation naming one as its
-input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
 which reads the request view from before this field is applied. Transformation
 outputs and DRA logical resources are added afterwards and are not filtered.</p>
 </td>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1428,10 +1428,10 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
 <td>
    <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 Pod request view that Kueue charges quota against.</p>
-<p>A matching resource is not charged, and a transformation naming one as its
-input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
-which reads the request view from before this field is applied. Transformation
-outputs and DRA logical resources are added afterwards and are not filtered.</p>
+<p>An entry matching one of these prefixes is dropped from that view, so it is
+not charged, and a transformation naming it as its input does not run. The
+resource can still be read by ResourceTransformation.MultiplyBy, which reads
+the request view from before this field is applied.</p>
 </td>
 </tr>
 <tr><td><code>transformations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1367,7 +1367,9 @@ It must not be <code>pods</code>; that exact name is reserved for Kueue's intern
 Pod-count accounting. A qualified name such as <code>example.com/pods</code> is allowed.
 Disabling the ReservedResourceNameValidation feature gate lets such a
 configuration load for an upgrade; flavor assignment still overwrites the
-key with the PodSet count.</p>
+key with the PodSet count.
+The quantity is read from the request view before &quot;excludeResourcePrefixes&quot;
+is applied, so a resource kept out of quota can still be named here.</p>
 </td>
 </tr>
 <tr><td><code>outputs</code> <B>[Required]</B><br/>
@@ -1424,7 +1426,12 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
 <code>[]string</code>
 </td>
 <td>
-   <p>ExcludedResourcePrefixes defines which resources should be ignored by Kueue</p>
+   <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
+Pod request view that Kueue charges quota against.</p>
+<p>A matching resource is not charged, and a transformation naming one as its
+input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+which reads the request view from before this field is applied. Transformation
+outputs and DRA logical resources are added afterwards and are not filtered.</p>
 </td>
 </tr>
 <tr><td><code>transformations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -1429,7 +1429,7 @@ An empty Outputs combined with a <code>Replace</code> Strategy causes the Input 
    <p>ExcludeResourcePrefixes defines the resource-name prefixes left out of the
 Pod request view that Kueue charges quota against.</p>
 <p>A matching resource is not charged, and a transformation naming one as its
-input does not run. It can still be read by ResourceTransformation.MultiplyBy,
+input does not run. The resource can still be read by ResourceTransformation.MultiplyBy,
 which reads the request view from before this field is applied. Transformation
 outputs and DRA logical resources are added afterwards and are not filtered.</p>
 </td>

--- a/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
+++ b/site/content/en/docs/tasks/manage/administer_cluster_quotas.md
@@ -403,6 +403,17 @@ resources:
 
 ## Transform resources for quota management
 
+{{% alert title="Interaction with excludeResourcePrefixes" color="primary" %}}
+Kueue applies `excludeResourcePrefixes` to the Pod requests before the
+transformations run, so a transformation whose `input` matches an excluded
+prefix does not run at all and produces no outputs. A resource matching an
+excluded prefix can still be named by `multiplyBy`, which reads the request
+view from before the prefixes are applied. Outputs are produced afterwards and
+are not filtered by `excludeResourcePrefixes`. For the same reason, a
+`multiplyBy` operand cannot name a transformation output: it is resolved from the
+Pod request view while the transformation runs, before any output exists.
+{{% /alert %}}
+
 {{< feature-state state="stable" for_version="v0.14" >}}
 
 An administrator may customize how the resources requested by Pods are


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`excludeResourcePrefixes` says a resource is not charged. A transformation naming that resource in `multiplyBy` is a different statement, and the two were answered with the same map:

```go
effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
```

By the time the transformation looks the multiplier up, the exclusion has already removed it, and a missing multiplier is not an error:

```go
if mapping.MultiplyBy != "" {
	if q, ok := input[mapping.MultiplyBy]; ok {
		inputQuantity = multipliedBy(inputQuantity, q)
	}
}
```

So the configured scaling silently becomes one. Measured on `main`, with a PodSet asking for `example.com/mem: 1024` and `vendor.example/gpu: 4`, and a transformation charging one unit of quota per unit of memory per GPU:

```
nothing excluded          quota.example.com/total-mem = 4096
vendor.example/ excluded  quota.example.com/total-mem = 1024
```

A quarter of the charge, with nothing reporting it.

I should be careful about how real that is, because I put it too strongly here at first. The multiplication is the documented one: the HAMi task multiplies a per-vGPU memory resource by the requested GPU count. Excluding that multiplier is not. HAMi's own ClusterQueue gives `nvidia.com/gpu` a `nominalQuota`, so an administrator following that page would not exclude it, and if they tried they could not: the match is a string prefix, and `nvidia.com/gpu` is a prefix of `nvidia.com/gpumem` and `nvidia.com/gpucores`, so the inputs would go with it and the transformation would have nothing to charge from.

Reaching this needs the input and the multiplier under different prefixes, which is what the reproducer and the test use. I found it by reading the path rather than from a report, and I know of no deployment carrying that combination.

## What the two arguments are

The transformation now charges what it is given and reads a multiplier from the requests as they were before the exclusion. That original list is only read: the excluded entry is not put back into the list the transformation charges and retains from, and only where a multiplier's quantity is read from changes.

Where nothing is excluded the two maps hold the same quantities, so the lookup finds what it found before.

## Not in this one

`multiplyBy: pods` never means the PodSet count, which is written from the count after the transformations have run. #13989 refuses it in configuration validation, which is why this says Part of rather than Fixes: #14007 records both triggers and only one of them is closed here.

I had this next part wrong here and am correcting it rather than leaving it. I wrote that `pods` is absent from both arguments. It is not: nothing rejects a `spec.overhead` naming `pods` until #13995, and `PodRequests` adds the overhead, so it arrives in the requests like any other name. **This change makes that value visible to `multiplyBy` again where an exclusion had removed it.** Measured with `example.com/mem: 1024`, an overhead of `pods: 4`, and a transformation multiplying by `pods`:

```
                  main    this PR
nothing excluded  4096    4096
pods excluded     1024    4096
```

The 4096 is not a Pod count. It is whatever quantity the user put in the overhead; the real count is written afterwards, by flavor assignment from the PodSet count (`flavorassigner.go:710`), long after the transformations have run.

Note also what the left column says: `main` already multiplies by that overhead quantity whenever `pods` is not excluded. The bogus multiplication is not new here. What this change removes is the accident that excluding `pods` used to hide it.

Both of the open fixes close the regression this PR makes, but they are not interchangeable and I should not have written them as though they were. #13995 stops `pods` reaching the requests from the overhead at all, so a multiplier naming it finds nothing and both numbers above become 1024. It leaves `multiplyBy: pods` accepted by configuration validation, still resolving to a missing multiplier, still silently scaling by one — which is the failure this PR exists to remove. #13989 refuses the name in `input`, `multiplyBy`, `outputs` and DRA mappings when the Configuration is loaded, so the path cannot be written.

So #13989 is the prerequisite this PR should be read against. #13995 is enough to stop this PR adding anything, and is worth having on its own terms, but it does not close the `pods` half of #14007 and this should not be merged on a claim that it does.

The prefix match is worth knowing about while reading a configuration that reaches this: `excludeResourcePrefixes: ["nvidia.com/gpu"]` also excludes `nvidia.com/gpumem`, since one name is a prefix of the other. That is the existing behaviour of the field and is not changed here.

The clamp is on the multiplier alone. A negative one no longer turns its output into a credit against whatever else generates the same name, and a zero still scales an output to nothing rather than reading as absent. Two things it does not close.

The same cancellation reached through the input rather than the multiplier. An input of `-6` under a `Replace` with no `multiplyBy` credits 6 back against another transformation's 8, and the name is charged 2. Measured rather than argued. That route is on `main` and needs nothing from this change, so it is #13995's, and that one has already settled it: `ChargeableOverhead` drops a negative entry rather than normalizing it, so the resource leaves `PodRequests` altogether and a `multiplyBy` naming it reads as absent, taking the identity fallback above rather than a zero. The clamp here stays as the second line for the paths that validation does not cover, an object written before the gate or a cluster with it off.

The list the multiplier is read from is not stable across rebuilds. `resourcehelpers.PodRequests` writes the overhead back into the PodSpec for a pod-level quantity that has to rescale, so `1.5Gi` beside an overhead of `1` reads 1610612737 on the second build and 1610612738 on the third. One Info build reads it once, so this PR does not compound it, but the multiplier is a number that drifts. That is #14407, which detaches `spec.Resources` before the call and pins it with `1.5Gi` against a `1Gi` control, asserting the total per pass and that the spec did not move.

## What the field's comment now says

`excludeResourcePrefixes` was documented as the resources that "should be ignored by Kueue". That is a claim about a precedence between two public configuration fields, and this change makes it false: an excluded resource is not charged, and is now read as a multiplier. Rather than leave the reader to find that out, both API versions now state the whole order. Measured, each line of it:

```
excluded resource, charged directly            no
excluded resource, read by multiplyBy          yes, after this change
excluded resource as a transformation input    transformation does not run at all
output named under an excluded prefix          charged; outputs are produced after the exclusion
DRA logical resource under one                 charged; merged after the transformations
```

The third line is #14204 and the fifth is the composition #14160 describes; neither is fixed here. What changes is that the field stops describing itself in a way that covers neither.

`multiplyBy` gains one sentence naming the view its quantity is read from, since that is the part this PR moves.

The reason to write this down rather than only fix the behaviour: KEP-2937's graduation criteria ask for a check flagging overlaps between the exclusions and the transformations. It already scopes that to the `input`, which is the overlap that silently loses work. A `multiplyBy` overlapping an exclusion is now the supported combination, and an implementer reaching for "reject transformations that overlap an exclusion" would make this fix unconfigurable. The KEP sentence says so, and `pkg/config/validation_test.go` has a case that goes red if validation ever rejects it — checked by adding such a rule and watching that one case, and only that one, fail.

#### Which issue(s) this PR fixes:

Part of #14007
Depends on #14047 and #13989

It also depends on #14407, or an equivalent immutable request reader. `specRequests` is now the multiplier source, and `component-helpers` `PodRequests` mutates a pod-level decimal quantity through overhead aliasing (kubernetes/kubernetes#141241), so repeated reads drift and the multiplier turns that drift into quota. A repeated-read and Workload-immutability regression should land with the rebase.

#### Special notes for your reviewer:

Reverting the lookup to the charge map turns the added case red on its own; the rest of `TestNewInfo` stays green either way, which is what says the no-exclusion path did not move.

Two more cases pin the distinction the lookup makes, because after this change an excluded resource can arrive in the multiplier view either way and which one it becomes is decided upstream:

```
multiplier present at 0   output 0
multiplier absent         output = input, the identity fallback
```

Each was checked by breaking the branch it covers. Folding a present zero into the missing arm fails the first and nothing else; making a missing multiplier produce zero instead of the input fails the second and nothing else — no case in the file pinned that fallback before. A third case for `Retain` under an excluded multiplier was written and then dropped: the mutation that would catch it already turns three existing cases red, so it was the product of two facts the file covers rather than a case of its own.

The added case uses a positive multiplier, and that is the half this PR can pin alone. A negative one needs #14047, and on its own this change moves it the wrong way, past zero. Measured on four trees, with a container asking `credit 8`, `slot 3` and `node -2`, `vendor.example/` excluded, and transformations generating one gpu per credit and one per slot multiplied by node:

```
main                 gpu = 11    the excluded multiplier is missing, so it is read as one
this PR alone        gpu = 2     the raw -2 is found, and 3 x -2 cancels 6 of the 8
14047 alone          gpu = 11    node is normalized to 0, then excluded, so still missing
this PR + 14047      gpu = 8     the multiplier source carries the normalized 0
```

Only the last is right, and the 2 is the part that matters. Contributions to one output name are summed before the floor is applied, so a negative contribution cancels a positive one that was charged legitimately and the floor only ever sees the total. Lowering `credit` to 6 in the same input takes the result to `0`: a legitimate generated charge can be cancelled outright.

An earlier version of this description showed a different combination of output signs, concluded the standalone result was an overcharge, and called that the safe direction. That held only for the combination it showed, and I have removed it rather than qualify it.

This PR is held until #14047 and #13989 merge, and until #14407 or an equivalent immutable request reader lands. That is not a preference about ordering: on its own this tree can charge less than the PodSet asked for, and an approval it happens to collect first should not be the only thing standing between that and `main`.

That one input is not the whole shape of it. Sweeping the multiplier's sign, the output factor's sign, and where the multiplier is written, this PR alone differs from the pair on **five of nine** cases, and every one of them is a case where the multiplier source is negative. It agrees with the pair wherever the multiplier is positive or zero, which is what the case added here covers.

One case the pair does not change, and it is worth being explicit rather than letting the table above be read as general: a multiplier written as an unsupported **pod-level** request stays at 11 on all four trees. `component-helpers` does not read an unsupported name at the pod level, so it never reaches the requests at all and `multiplyBy` goes on treating it as one. That is `main`'s behaviour and neither PR changes it.

The multiplier-source call site does not move: `specRequests` is already what is passed, and #14047 makes that the chargeable view. Its producer swaps to the immutable reader #14407 adds, but this call site stays. I ran the merge rather than assuming it. `workload.go` merges with no conflict, and git lands the call site on exactly the shape the pair needs:

```go
specRequests := chargeablePodRequests(&ps.Template.Spec)
effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
effectiveRequests = applyResourceTransformations(effectiveRequests, specRequests, info.resourceTransformations)
```

The helper's name may well move. What has to hold is that both views come from one normalized source, and that the second argument does not fall back to a raw `PodRequests`.

Only the test file collides, on two adjacent map entries, and both sides' cases have to survive that resolution. The rebase should also carry the negative case above, which no single tree passes: `main` and #14047 both give 11, this alone gives 2, and only the pair gives 8.

#13995 lands on the same `specRequests` line, and that is a third thing to compose rather than a second. It decides a number, not just a conflict marker, because the multiplier lookup tells a name present at zero apart from one that is absent:

```
multiplier present at 0   quota.example.com/out = 0
multiplier absent         quota.example.com/out = 1024
```

Measured on this branch, and the same on `main`: the asymmetry is `if q, ok := source[name]; ok` and neither PR introduces it. #14047 zeroes a negative and keeps the name, and re-adds a pod-level name it had to drop. #13995's `ChargeableOverhead` deletes the entry instead, both for `pods` and for any negative. They cannot both own that line: `chargeablePodRequests` and `resources.PodRequests` are alternatives there, and whichever survives decides whether a negative overhead read as a multiplier scales by zero or by one. One is the behaviour this PR removes elsewhere, so the composition should keep the name at zero and call through rather than pick: `chargeablePodRequests` calls `resources.PodRequests`, and that shared reader is where #14407's `spec.Resources.DeepCopy()` and #13995's `ChargeableOverhead` both live — neither is chosen against the other. #14289 helps by dropping the `len(podSpec.Overhead) == 0` guard on the RuntimeClass lookup, so a kept zero no longer decides whether the class is consulted at all, but it does not make the choice for anyone.

#14154 is a fourth thing to compose, and it collides on the signature rather than the `specRequests` line. It leaves `applyResourceTransformations` reading `input` and the transforms but changes the return to `(retained, generated)`, landing the DRA charge on the generated side once generated negatives are floored. This PR instead adds `multiplierSource` as a second parameter and keeps the single return. The two edits touch the same declaration in different places, so a mechanical resolution keeps one and drops the other: take this side and the split is gone; take #14154's and the excluded-multiplier lookup has no source to read. The shape that carries both is `applyResourceTransformations(input, multiplierSource, transforms) (retained, generated)` — the multiplier still feeds the lookup, the output still flows into `generated` — so whichever lands first, the later rebase restores the other half by hand rather than accepting the merge.

#### Does this PR introduce a user-facing change?

```release-note
ResourceTransformations: Fixed a transformation whose `multiplyBy` names a resource covered by `excludeResourcePrefixes` scaling by one instead of by that resource's quantity. The excluded resource stays out of the request list the transformation charges from, and is read only to answer what a multiplier names.

ACTION REQUIRED
The corrected charge can be larger or smaller than what the same configuration produced before, because the multiplier that was read as one is now read as it was written: a count of 4 quadruples the outputs it scales, `500m` halves them, and a zero takes them to zero. Check the quota on any ClusterQueue whose Workloads use a `multiplyBy` naming a resource an `excludeResourcePrefixes` entry covers, since a Workload that fitted before may no longer fit.

A Workload that already holds a quota reservation keeps the usage recorded in its admission status until that reservation is cleared, so the corrected figure applies the next time Kueue builds its requests from the PodSets.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected resource transformation calculations so excluded resources can still provide multiplier values.
  * Ensured derived resource totals remain accurate when source resources are filtered out.
  * Clarified handling of zero-valued and missing multiplier resources.

* **Documentation**
  * Clarified how excluded resources affect quota charging, transformations, and logical resources.
  * Documented that multiplier inputs are read before resource exclusion.
  * Clarified validation rules for transformation inputs and excluded resources.

* **Tests**
  * Added coverage for excluded, zero-valued, and missing transformation multipliers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->














