### PR TITLE
Cherry pick 14046 to release 0.19:  Replace ptr.To with the new builtin

### DIFF
--- a/apis/config/v1beta1/defaults.go
+++ b/apis/config/v1beta1/defaults.go
@@ -101,8 +101,8 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		cfg.WaitForPodsReady.BlockAdmission = cmp.Or(cfg.WaitForPodsReady.BlockAdmission, &cfg.WaitForPodsReady.Enable)
 		cfg.WaitForPodsReady.RequeuingStrategy = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy, &RequeuingStrategy{})
 		cfg.WaitForPodsReady.RequeuingStrategy.Timestamp = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.Timestamp, new(EvictionTimestamp))
-		cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds, ptr.To[int32](DefaultRequeuingBackoffBaseSeconds))
-		cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds, ptr.To[int32](DefaultRequeuingBackoffMaxSeconds))
+		cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds, new(int32(DefaultRequeuingBackoffBaseSeconds)))
+		cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds, new(int32(DefaultRequeuingBackoffMaxSeconds)))
 	}
 
 	cfg.Integrations = cmp.Or(cfg.Integrations, &Integrations{})

--- a/apis/config/v1beta1/defaults_test.go
+++ b/apis/config/v1beta1/defaults_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -329,8 +328,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable: new(false),
 				},
 				ClientConnection: &ClientConnection{
-					QPS:   ptr.To[float32](123.0),
-					Burst: ptr.To[int32](456),
+					QPS:   new(float32(123.0)),
+					Burst: new(int32(456)),
 				},
 			},
 			want: &Configuration{
@@ -340,8 +339,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable: new(false),
 				},
 				ClientConnection: &ClientConnection{
-					QPS:   ptr.To[float32](123.0),
-					Burst: ptr.To[int32](456),
+					QPS:   new(float32(123.0)),
+					Burst: new(int32(456)),
 				},
 				Integrations:                 overwriteNamespaceIntegrations,
 				MultiKueue:                   defaultMultiKueue,
@@ -387,8 +386,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					RecoveryTimeout: &podsReadyTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
-						BackoffMaxSeconds:  ptr.To[int32](DefaultRequeuingBackoffMaxSeconds),
+						BackoffBaseSeconds: new(int32(DefaultRequeuingBackoffBaseSeconds)),
+						BackoffMaxSeconds:  new(int32(DefaultRequeuingBackoffMaxSeconds)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -433,8 +432,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Timeout: &podsReadyTimeoutOverwrite,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(CreationTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](63),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						BackoffBaseSeconds: new(int32(63)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 				},
@@ -450,8 +449,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(CreationTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](63),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						BackoffBaseSeconds: new(int32(63)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -643,7 +642,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Transformations: []ResourceTransformation{
 						{Input: corev1.ResourceCPU},
 						{Input: corev1.ResourceMemory, Strategy: new(Replace)},
-						{Input: corev1.ResourceEphemeralStorage, Strategy: ptr.To[ResourceTransformationStrategy]("")},
+						{Input: corev1.ResourceEphemeralStorage, Strategy: new(ResourceTransformationStrategy(""))},
 					},
 				},
 			},

--- a/apis/config/v1beta2/defaults.go
+++ b/apis/config/v1beta2/defaults.go
@@ -112,8 +112,8 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		cfg.WaitForPodsReady.RecoveryTimeout = cmp.Or(cfg.WaitForPodsReady.RecoveryTimeout, &cfg.WaitForPodsReady.Timeout)
 		cfg.WaitForPodsReady.RequeuingStrategy = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy, &RequeuingStrategy{})
 		cfg.WaitForPodsReady.RequeuingStrategy.Timestamp = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.Timestamp, new(EvictionTimestamp))
-		cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds, ptr.To[int32](DefaultRequeuingBackoffBaseSeconds))
-		cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds, ptr.To[int32](DefaultRequeuingBackoffMaxSeconds))
+		cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffBaseSeconds, new(int32(DefaultRequeuingBackoffBaseSeconds)))
+		cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds = cmp.Or(cfg.WaitForPodsReady.RequeuingStrategy.BackoffMaxSeconds, new(int32(DefaultRequeuingBackoffMaxSeconds)))
 	}
 
 	cfg.Integrations = cmp.Or(cfg.Integrations, &Integrations{})
@@ -146,7 +146,7 @@ func SetDefaults_Configuration(cfg *Configuration) {
 		afs.UsageSamplingInterval.Duration = cmp.Or(afs.UsageSamplingInterval.Duration, 5*time.Minute)
 	}
 	cfg.VisibilityServer = cmp.Or(cfg.VisibilityServer, &VisibilityServerConfiguration{})
-	cfg.VisibilityServer.BindPort = cmp.Or(cfg.VisibilityServer.BindPort, ptr.To[int32](DefaultVisibilityBindPort))
+	cfg.VisibilityServer.BindPort = cmp.Or(cfg.VisibilityServer.BindPort, new(int32(DefaultVisibilityBindPort)))
 
 	if cfg.Resources != nil {
 		for idx := range cfg.Resources.Transformations {

--- a/apis/config/v1beta2/defaults_test.go
+++ b/apis/config/v1beta2/defaults_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	"k8s.io/utils/ptr"
 )
 
 const (
@@ -101,7 +100,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 	}
 
 	defaultVisibilityServer := &VisibilityServerConfiguration{
-		BindPort: ptr.To[int32](8082),
+		BindPort: new(int32(8082)),
 	}
 	defaultWaitForPodsReady := &WaitForPodsReady{
 		Timeout: metav1.Duration{
@@ -113,8 +112,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 		},
 		RequeuingStrategy: &RequeuingStrategy{
 			Timestamp:          new(EvictionTimestamp),
-			BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
-			BackoffMaxSeconds:  ptr.To[int32](DefaultRequeuingBackoffMaxSeconds),
+			BackoffBaseSeconds: new(int32(DefaultRequeuingBackoffBaseSeconds)),
+			BackoffMaxSeconds:  new(int32(DefaultRequeuingBackoffMaxSeconds)),
 		},
 	}
 
@@ -354,8 +353,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable: new(false),
 				},
 				ClientConnection: &ClientConnection{
-					QPS:   ptr.To[float32](123.0),
-					Burst: ptr.To[int32](456),
+					QPS:   new(float32(123.0)),
+					Burst: new(int32(456)),
 				},
 			},
 			want: &Configuration{
@@ -365,8 +364,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Enable: new(false),
 				},
 				ClientConnection: &ClientConnection{
-					QPS:   ptr.To[float32](123.0),
-					Burst: ptr.To[int32](456),
+					QPS:   new(float32(123.0)),
+					Burst: new(int32(456)),
 				},
 				Integrations:                 overwriteNamespaceIntegrations,
 				MultiKueue:                   defaultMultiKueue,
@@ -415,8 +414,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					},
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
-						BackoffMaxSeconds:  ptr.To[int32](DefaultRequeuingBackoffMaxSeconds),
+						BackoffBaseSeconds: new(int32(DefaultRequeuingBackoffBaseSeconds)),
+						BackoffMaxSeconds:  new(int32(DefaultRequeuingBackoffMaxSeconds)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -447,8 +446,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					RecoveryTimeout: &customTimeout,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
-						BackoffMaxSeconds:  ptr.To[int32](DefaultRequeuingBackoffMaxSeconds),
+						BackoffBaseSeconds: new(int32(DefaultRequeuingBackoffBaseSeconds)),
+						BackoffMaxSeconds:  new(int32(DefaultRequeuingBackoffMaxSeconds)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -469,8 +468,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Timeout: podsReadyTimeoutOverwrite,
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(CreationTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](63),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						BackoffBaseSeconds: new(int32(63)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 				},
@@ -485,8 +484,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					RecoveryTimeout: &metav1.Duration{Duration: time.Minute},
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(CreationTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](63),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						BackoffBaseSeconds: new(int32(63)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -518,8 +517,8 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					RecoveryTimeout: &metav1.Duration{Duration: 0},
 					RequeuingStrategy: &RequeuingStrategy{
 						Timestamp:          new(EvictionTimestamp),
-						BackoffBaseSeconds: ptr.To[int32](DefaultRequeuingBackoffBaseSeconds),
-						BackoffMaxSeconds:  ptr.To[int32](DefaultRequeuingBackoffMaxSeconds),
+						BackoffBaseSeconds: new(int32(DefaultRequeuingBackoffBaseSeconds)),
+						BackoffMaxSeconds:  new(int32(DefaultRequeuingBackoffMaxSeconds)),
 					},
 				},
 				Namespace:         new(DefaultNamespace),
@@ -694,7 +693,7 @@ func TestSetDefaults_Configuration(t *testing.T) {
 					Transformations: []ResourceTransformation{
 						{Input: corev1.ResourceCPU},
 						{Input: corev1.ResourceMemory, Strategy: new(Replace)},
-						{Input: corev1.ResourceEphemeralStorage, Strategy: ptr.To[ResourceTransformationStrategy]("")},
+						{Input: corev1.ResourceEphemeralStorage, Strategy: new(ResourceTransformationStrategy(""))},
 					},
 				},
 			},

--- a/apis/kueue/v1beta1/workload_conversion_test.go
+++ b/apis/kueue/v1beta1/workload_conversion_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta2"
 )
@@ -54,13 +53,13 @@ func TestWorkloadConvertTo(t *testing.T) {
 			input: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: WorkloadStatus{
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](0),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(0)),
 				},
 			},
 			expected: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: v1beta2.WorkloadStatus{
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](0),
+					AccumulatedPastExecutionTimeSeconds: new(int32(0)),
 				},
 			},
 		},
@@ -68,13 +67,13 @@ func TestWorkloadConvertTo(t *testing.T) {
 			input: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: WorkloadStatus{
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](3600),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(3600)),
 				},
 			},
 			expected: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: v1beta2.WorkloadStatus{
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](3600),
+					AccumulatedPastExecutionTimeSeconds: new(int32(3600)),
 				},
 			},
 		},
@@ -89,7 +88,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 							Reason: "AdmittedByClusterQueue",
 						},
 					},
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](7200),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(7200)),
 				},
 			},
 			expected: &v1beta2.Workload{
@@ -102,7 +101,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 							Reason: "AdmittedByClusterQueue",
 						},
 					},
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](7200),
+					AccumulatedPastExecutionTimeSeconds: new(int32(7200)),
 				},
 			},
 		},
@@ -110,7 +109,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 			input: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: PodPriorityClassSource,
 					PriorityClassName:   "low",
 				},
@@ -118,7 +117,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 			expected: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: v1beta2.WorkloadSpec{
-					Priority: ptr.To[int32](100),
+					Priority: new(int32(100)),
 					PriorityClassRef: &v1beta2.PriorityClassRef{
 						Group: v1beta2.PodPriorityClassGroup,
 						Kind:  v1beta2.PodPriorityClassKind,
@@ -131,7 +130,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 			input: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: WorkloadPriorityClassSource,
 					PriorityClassName:   "low",
 				},
@@ -139,7 +138,7 @@ func TestWorkloadConvertTo(t *testing.T) {
 			expected: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: v1beta2.WorkloadSpec{
-					Priority: ptr.To[int32](100),
+					Priority: new(int32(100)),
 					PriorityClassRef: &v1beta2.PriorityClassRef{
 						Group: v1beta2.WorkloadPriorityClassGroup,
 						Kind:  v1beta2.WorkloadPriorityClassKind,
@@ -250,13 +249,13 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			input: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: v1beta2.WorkloadStatus{
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](0),
+					AccumulatedPastExecutionTimeSeconds: new(int32(0)),
 				},
 			},
 			expected: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: WorkloadStatus{
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](0),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(0)),
 				},
 			},
 		},
@@ -264,13 +263,13 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			input: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: v1beta2.WorkloadStatus{
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](3600),
+					AccumulatedPastExecutionTimeSeconds: new(int32(3600)),
 				},
 			},
 			expected: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: WorkloadStatus{
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](3600),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(3600)),
 				},
 			},
 		},
@@ -285,7 +284,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 							Reason: "JobFinished",
 						},
 					},
-					AccumulatedPastExecutionTimeSeconds: ptr.To[int32](1800),
+					AccumulatedPastExecutionTimeSeconds: new(int32(1800)),
 				},
 			},
 			expected: &Workload{
@@ -298,7 +297,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 							Reason: "JobFinished",
 						},
 					},
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](1800),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(1800)),
 				},
 			},
 		},
@@ -306,7 +305,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			input: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: v1beta2.WorkloadSpec{
-					Priority: ptr.To[int32](100),
+					Priority: new(int32(100)),
 					PriorityClassRef: &v1beta2.PriorityClassRef{
 						Group: v1beta2.PodPriorityClassGroup,
 						Kind:  v1beta2.PodPriorityClassKind,
@@ -317,7 +316,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			expected: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: PodPriorityClassSource,
 					PriorityClassName:   "low",
 				},
@@ -327,7 +326,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			input: &v1beta2.Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: v1beta2.WorkloadSpec{
-					Priority: ptr.To[int32](100),
+					Priority: new(int32(100)),
 					PriorityClassRef: &v1beta2.PriorityClassRef{
 						Group: v1beta2.WorkloadPriorityClassGroup,
 						Kind:  v1beta2.WorkloadPriorityClassKind,
@@ -338,7 +337,7 @@ func TestWorkloadConvertFrom(t *testing.T) {
 			expected: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: WorkloadPriorityClassSource,
 					PriorityClassName:   "low",
 				},
@@ -522,7 +521,7 @@ func TestWorkloadConversion_RoundTrip(t *testing.T) {
 							Reason: "AdmittedByClusterQueue",
 						},
 					},
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](5400),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(5400)),
 				},
 			},
 		},
@@ -538,7 +537,7 @@ func TestWorkloadConversion_RoundTrip(t *testing.T) {
 			v1beta1Obj: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Status: WorkloadStatus{
-					AccumulatedPastExexcutionTimeSeconds: ptr.To[int32](0),
+					AccumulatedPastExexcutionTimeSeconds: new(int32(0)),
 				},
 			},
 		},
@@ -546,7 +545,7 @@ func TestWorkloadConversion_RoundTrip(t *testing.T) {
 			v1beta1Obj: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: PodPriorityClassSource,
 					PriorityClassName:   "low",
 				},
@@ -556,7 +555,7 @@ func TestWorkloadConversion_RoundTrip(t *testing.T) {
 			v1beta1Obj: &Workload{
 				ObjectMeta: defaultObjectMeta,
 				Spec: WorkloadSpec{
-					Priority:            ptr.To[int32](100),
+					Priority:            new(int32(100)),
 					PriorityClassSource: WorkloadPriorityClassSource,
 					PriorityClassName:   "low",
 				},

--- a/cmd/importer/pod/import.go
+++ b/cmd/importer/pod/import.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -192,7 +191,7 @@ func admitWorkload(ctx context.Context, c client.Client, wl *kueue.Workload, cq 
 					Name:          info.TotalRequests[0].Name,
 					Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
 					ResourceUsage: info.TotalRequests[0].Requests.ToResourceList(resourceFormatter),
-					Count:         ptr.To[int32](1),
+					Count:         new(int32(1)),
 				},
 			},
 		}

--- a/cmd/importer/pod/import_test.go
+++ b/cmd/importer/pod/import_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -52,7 +51,7 @@ func TestImportNamespace(t *testing.T) {
 		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 			Image("img").
 			Request(corev1.ResourceCPU, "1").
-			PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+			PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 			Obj()).
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq1").
 			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).

--- a/cmd/kueuectl/app/resume/resume_clusterqueue.go
+++ b/cmd/kueuectl/app/resume/resume_clusterqueue.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -128,7 +127,7 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 	}
 
 	cqOriginal := cq.DeepCopy()
-	cq.Spec.StopPolicy = ptr.To(kueue.None)
+	cq.Spec.StopPolicy = new(kueue.None)
 
 	if o.DryRunStrategy != dryrun.Client {
 		opts := metav1.PatchOptions{}

--- a/cmd/kueuectl/app/resume/resume_localqueue.go
+++ b/cmd/kueuectl/app/resume/resume_localqueue.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -138,7 +137,7 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 	}
 
 	lqOriginal := lq.DeepCopy()
-	lq.Spec.StopPolicy = ptr.To(kueue.None)
+	lq.Spec.StopPolicy = new(kueue.None)
 
 	if o.DryRunStrategy != dryrun.Client {
 		opts := metav1.PatchOptions{}

--- a/cmd/kueuectl/app/stop/stop_clusterqueue.go
+++ b/cmd/kueuectl/app/stop/stop_clusterqueue.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -159,8 +158,8 @@ func (o *ClusterQueueOptions) Run(ctx context.Context) error {
 
 func (o *ClusterQueueOptions) stopClusterQueue(cq *kueue.ClusterQueue) {
 	if o.KeepAlreadyRunning {
-		cq.Spec.StopPolicy = ptr.To(kueue.Hold)
+		cq.Spec.StopPolicy = new(kueue.Hold)
 	} else {
-		cq.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+		cq.Spec.StopPolicy = new(kueue.HoldAndDrain)
 	}
 }

--- a/cmd/kueuectl/app/stop/stop_localqueue.go
+++ b/cmd/kueuectl/app/stop/stop_localqueue.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericiooptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubectl/pkg/util/templates"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -169,8 +168,8 @@ func (o *LocalQueueOptions) Run(ctx context.Context) error {
 
 func (o *LocalQueueOptions) stopLocalQueue(lq *kueue.LocalQueue) {
 	if o.KeepAlreadyRunning {
-		lq.Spec.StopPolicy = ptr.To(kueue.Hold)
+		lq.Spec.StopPolicy = new(kueue.Hold)
 	} else {
-		lq.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+		lq.Spec.StopPolicy = new(kueue.HoldAndDrain)
 	}
 }

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -86,7 +85,7 @@ func Test_PushOrUpdate(t *testing.T) {
 		},
 		"workload is still under the backoff waiting time": {
 			workload: wlBase.Clone().
-				RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteLater))).
+				RequeueState(new(int32(10)), new(metav1.NewTime(minuteLater))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
 					Reason: kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -99,7 +98,7 @@ func Test_PushOrUpdate(t *testing.T) {
 			wantInAdmissibleWorkloads: inadmissibleWorkloads{
 				"default/workload-1": workload.NewInfo(wlBase.Clone().
 					ResourceVersion("1").
-					RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteLater))).
+					RequeueState(new(int32(10)), new(metav1.NewTime(minuteLater))).
 					Condition(metav1.Condition{
 						Type:   kueue.WorkloadEvicted,
 						Reason: kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -265,7 +264,7 @@ func TestPushOrUpdateGenerationChanged(t *testing.T) {
 		"stays inadmissible when generation changed but backoff unexpired": {
 			updatedWorkload: utiltestingapi.MakeWorkload("workload-1", defaultNamespace).
 				Creation(now).Generation(2).ResourceVersion("2").Priority(300).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(time.Hour)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(time.Hour)))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadRequeued,
 					Status: metav1.ConditionFalse,
@@ -385,11 +384,11 @@ func TestSnapshotDeterministicOrder(t *testing.T) {
 			},
 			inadmissibleWorkloads: []*kueue.Workload{
 				utiltestingapi.MakeWorkload("wl3", defaultNamespace).Queue(lqName).Creation(now).UID(types.UID("uid-3")).
-					RequeueState(ptr.To[int32](1), new(metav1.NewTime(backoffUntil))).
+					RequeueState(new(int32(1)), new(metav1.NewTime(backoffUntil))).
 					Condition(metav1.Condition{Type: kueue.WorkloadRequeued, Status: metav1.ConditionFalse}).
 					Obj(),
 				utiltestingapi.MakeWorkload("wl4", defaultNamespace).Queue(lqName).Creation(now).UID(types.UID("uid-4")).
-					RequeueState(ptr.To[int32](1), new(metav1.NewTime(backoffUntil))).
+					RequeueState(new(int32(1)), new(metav1.NewTime(backoffUntil))).
 					Condition(metav1.Condition{Type: kueue.WorkloadRequeued, Status: metav1.ConditionFalse}).
 					Obj(),
 			},
@@ -984,7 +983,7 @@ func TestClusterQueueImpl(t *testing.T) {
 		utiltestingapi.MakeWorkload("w2", "ns2").Queue("q2").Obj(),
 		utiltestingapi.MakeWorkload("w3", "ns3").Queue("q3").Obj(),
 		utiltestingapi.MakeWorkload("w4-requeue-state", "ns1").
-			RequeueState(ptr.To[int32](1), new(metav1.NewTime(minuteLater))).
+			RequeueState(new(int32(1)), new(metav1.NewTime(minuteLater))).
 			Queue("q1").
 			Condition(metav1.Condition{
 				Type:   kueue.WorkloadEvicted,
@@ -1228,12 +1227,12 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 		},
 		"workload doesn't have an evicted condition with reason=PodsReadyTimeout": {
 			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
-				RequeueState(ptr.To[int32](10), nil).Obj()),
+				RequeueState(new(int32(10)), nil).Obj()),
 			want: true,
 		},
 		"now already has exceeded requeueAt": {
 			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
-				RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteAgo))).
+				RequeueState(new(int32(10)), new(metav1.NewTime(minuteAgo))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
 					Status: metav1.ConditionTrue,
@@ -1243,7 +1242,7 @@ func TestBackoffWaitingTimeExpired(t *testing.T) {
 		},
 		"now hasn't yet exceeded requeueAt": {
 			workloadInfo: workload.NewInfo(utiltestingapi.MakeWorkload("wl", "ns").
-				RequeueState(ptr.To[int32](10), new(metav1.NewTime(minuteLater))).
+				RequeueState(new(int32(10)), new(metav1.NewTime(minuteLater))).
 				Condition(metav1.Condition{
 					Type:   kueue.WorkloadEvicted,
 					Status: metav1.ConditionTrue,

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
@@ -365,7 +364,7 @@ func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
 
-	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: ptr.To(configapi.SourceKindLocalQueue)}})
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: new(configapi.SourceKindLocalQueue)}})
 	fakeClient := utiltesting.NewFakeClient(
 		utiltesting.MakeNamespace(defaultNamespace),
 		utiltestingapi.MakeWorkload("done", defaultNamespace).Queue("foo").Finished().Obj(),

--- a/pkg/cache/scheduler/cache_resync_metrics_test.go
+++ b/pkg/cache/scheduler/cache_resync_metrics_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -103,7 +102,7 @@ func TestResyncCohortGaugeMetricsUsesUpdatedCustomLabels(t *testing.T) {
 	defer metrics.InitMetricVectors(nil)
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
 
-	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: ptr.To(configapi.SourceKindCohort)}})
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: new(configapi.SourceKindCohort)}})
 	cache := New(utiltesting.NewFakeClient(), WithCustomLabels(customLabels), WithFairSharing(true))
 
 	cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -428,7 +427,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				Obj(),
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
-				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
+				topologyRequest: &kueue.PodSetTopologyRequest{Required: new(corev1.LabelHostname)},
 				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
@@ -466,7 +465,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				Obj(),
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
-				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
+				topologyRequest: &kueue.PodSetTopologyRequest{Required: new(corev1.LabelHostname)},
 				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
@@ -505,7 +504,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				Obj(),
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
-				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
+				topologyRequest: &kueue.PodSetTopologyRequest{Required: new(corev1.LabelHostname)},
 				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
@@ -544,7 +543,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				Obj(),
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
-				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
+				topologyRequest: &kueue.PodSetTopologyRequest{Required: new(corev1.LabelHostname)},
 				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
@@ -582,7 +581,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				Obj(),
 			podSets: []PodSetTestCase{{
 				podSetName:      "main",
-				topologyRequest: &kueue.PodSetTopologyRequest{Required: ptr.To(corev1.LabelHostname)},
+				topologyRequest: &kueue.PodSetTopologyRequest{Required: new(corev1.LabelHostname)},
 				requests:        map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 				count:           1,
 				wantAssignment: &tas.TopologyAssignment{
@@ -666,7 +665,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -744,7 +743,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -860,7 +859,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -902,7 +901,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -926,7 +925,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -951,7 +950,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -976,7 +975,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1001,7 +1000,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1051,7 +1050,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: []string{tasBlockLabel},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasBlockLabel),
+					Preferred: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1081,7 +1080,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1106,7 +1105,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1120,7 +1119,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1148,7 +1147,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1183,7 +1182,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1215,7 +1214,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 4000,
@@ -1229,7 +1228,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1243,7 +1242,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceMemory: 1024,
@@ -1268,7 +1267,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasRackLabel),
+					Preferred: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1300,7 +1299,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasRackLabel),
+					Preferred: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1339,7 +1338,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasBlockLabel),
+					Preferred: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1378,7 +1377,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasBlockLabel),
+					Preferred: new(tasBlockLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1402,7 +1401,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1430,7 +1429,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1469,7 +1468,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasRackLabel),
+					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1499,7 +1498,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 600,
@@ -1543,7 +1542,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 600,
@@ -1584,7 +1583,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 600,
@@ -1615,7 +1614,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 600,
@@ -1676,7 +1675,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 0,
@@ -1716,7 +1715,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 600,
@@ -1755,7 +1754,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1784,7 +1783,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1820,7 +1819,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1875,7 +1874,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1902,7 +1901,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU:                     1000,
@@ -1934,7 +1933,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -1988,7 +1987,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 300,
@@ -2013,7 +2012,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "one",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(corev1.LabelHostname),
+						Required: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -2032,7 +2031,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "two",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(corev1.LabelHostname),
+						Required: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -2062,7 +2061,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 300,
@@ -2094,7 +2093,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 300,
@@ -2138,7 +2137,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultOneLevel,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -2202,8 +2201,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2287,8 +2286,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2362,8 +2361,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2471,8 +2470,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2515,8 +2514,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Preferred:                   new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2590,8 +2589,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2670,8 +2669,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Preferred:                   new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(3)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -2737,7 +2736,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasRackLabel),
+					Preferred: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -2802,7 +2801,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasRackLabel),
+					Preferred: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -2868,9 +2867,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(tasRackLabel),
+					Preferred:                   new(tasRackLabel),
 					PodSetSliceSize:             new(int32(5)),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -2945,7 +2944,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:       ptr.To(tasRackLabel),
+					Preferred:       new(tasRackLabel),
 					PodSetSliceSize: new(int32(1)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -3021,7 +3020,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:       ptr.To(tasRackLabel),
+					Preferred:       new(tasRackLabel),
 					PodSetSliceSize: new(int32(1)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -3098,9 +3097,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(tasRackLabel),
+					Preferred:                   new(tasRackLabel),
 					PodSetSliceSize:             new(int32(5)),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3193,9 +3192,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: []string{tasBlockLabel, tasSubBlockLabel, tasRackLabel, corev1.LabelHostname},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(string(tasSubBlockLabel)),
+					Preferred:                   new(string(tasSubBlockLabel)),
 					PodSetSliceSize:             new(int32(2)),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3291,9 +3290,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: []string{tasBlockLabel, tasSubBlockLabel, tasRackLabel, corev1.LabelHostname},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(string(tasSubBlockLabel)),
+					Preferred:                   new(string(tasSubBlockLabel)),
 					PodSetSliceSize:             new(int32(2)),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3379,9 +3378,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: []string{tasBlockLabel, tasSubBlockLabel, tasRackLabel},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(string(tasSubBlockLabel)),
+					Preferred:                   new(string(tasSubBlockLabel)),
 					PodSetSliceSize:             new(int32(2)),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3467,9 +3466,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred:                   ptr.To(string(corev1.LabelHostname)),
+					Preferred:                   new(string(corev1.LabelHostname)),
 					PodSetSliceSize:             new(int32(2)),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3554,7 +3553,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(string(corev1.LabelHostname)),
+					Preferred: new(string(corev1.LabelHostname)),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3623,8 +3622,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(string(tasRackLabel)),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						Preferred:                   new(string(tasRackLabel)),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -3644,9 +3643,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(string(tasRackLabel)),
+						Preferred:                   new(string(tasRackLabel)),
 						PodSetSliceSize:             new(int32(5)),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -3733,7 +3732,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(string(tasRackLabel)),
+					Preferred: new(string(tasRackLabel)),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3822,7 +3821,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(string(tasRackLabel)),
+					Preferred: new(string(tasRackLabel)),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -3904,7 +3903,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: []string{tasRackLabel, corev1.LabelHostname},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(string(tasRackLabel)),
+					Preferred: new(string(tasRackLabel)),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -4039,7 +4038,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Preferred: ptr.To(tasRackLabel),
+					Preferred: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
 					"example.com/gpu": 1,
@@ -4105,8 +4104,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(string(tasRackLabel)),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						Preferred:                   new(string(tasRackLabel)),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -4126,7 +4125,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(string(tasRackLabel)),
+						Preferred: new(string(tasRackLabel)),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -4186,8 +4185,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(string(tasRackLabel)),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						Preferred:                   new(string(tasRackLabel)),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -4207,7 +4206,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(string(tasRackLabel)),
+						Preferred: new(string(tasRackLabel)),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -4287,8 +4286,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(tasBlockLabel),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						Preferred:                   new(tasBlockLabel),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 5,
@@ -4308,7 +4307,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(tasBlockLabel),
+						Preferred: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						"example.com/gpu": 1,
@@ -4377,8 +4376,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4440,8 +4439,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4513,8 +4512,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(3)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4545,8 +4544,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(corev1.LabelHostname),
-					PodSetSliceRequiredTopology: ptr.To(tasBlockLabel),
+					Required:                    new(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(tasBlockLabel),
 					PodSetSliceSize:             new(int32(1)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4561,8 +4560,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -4576,7 +4575,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
+					Required:                    new(tasBlockLabel),
 					PodSetSliceRequiredTopology: new("not-existing-topology-level"),
 					PodSetSliceSize:             new(int32(1)),
 				},
@@ -4629,7 +4628,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4666,7 +4665,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4697,7 +4696,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				requests: map[corev1.ResourceName]int64{
@@ -4761,7 +4760,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "podset1",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(tasBlockLabel),
+						Preferred: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -4788,7 +4787,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "podset2",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(tasBlockLabel),
+						Preferred: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -4850,7 +4849,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -4872,7 +4871,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -4929,7 +4928,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
@@ -4949,7 +4948,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2000,
@@ -5011,7 +5010,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
@@ -5031,8 +5030,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required:                    ptr.To(tasRackLabel),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						Required:                    new(tasRackLabel),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 						PodSetSliceSize:             new(int32(2)),
 					},
 					requests: resources.MapRequests{
@@ -5084,7 +5083,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(corev1.LabelHostname),
+						Preferred: new(corev1.LabelHostname),
 					},
 					requests: resources.MapRequests{
 						corev1.ResourceCPU: 1000,
@@ -5104,7 +5103,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(corev1.LabelHostname),
+						Preferred: new(corev1.LabelHostname),
 					},
 					requests: resources.MapRequests{
 						corev1.ResourceCPU: 2000,
@@ -5217,8 +5216,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required:                    ptr.To(tasRackLabel),
-						PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+						Required:                    new(tasRackLabel),
+						PodSetSliceRequiredTopology: new(tasRackLabel),
 						PodSetSliceSize:             new(int32(1)),
 					},
 					requests: resources.MapRequests{
@@ -5239,8 +5238,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required:                    ptr.To(tasRackLabel),
-						PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+						Required:                    new(tasRackLabel),
+						PodSetSliceRequiredTopology: new(tasRackLabel),
 						PodSetSliceSize:             new(int32(1)),
 					},
 					requests: resources.MapRequests{
@@ -5295,7 +5294,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5315,7 +5314,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5380,7 +5379,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 2500,
@@ -5397,7 +5396,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 2500,
@@ -5458,7 +5457,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 2500,
@@ -5475,7 +5474,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 500,
@@ -5536,7 +5535,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5553,7 +5552,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5595,7 +5594,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5608,7 +5607,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5647,7 +5646,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5669,7 +5668,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5755,7 +5754,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(tasBlockLabel),
+						Preferred: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5775,9 +5774,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Preferred:                   ptr.To(tasBlockLabel),
+						Preferred:                   new(tasBlockLabel),
 						PodSetSliceSize:             new(int32(2)),
-						PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+						PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5827,7 +5826,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 10000,
@@ -5839,7 +5838,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -5931,7 +5930,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 2000,
@@ -5953,7 +5952,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -6083,7 +6082,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "leader",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -6106,7 +6105,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "workers",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -6141,7 +6140,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "podset1",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -6160,7 +6159,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "podset2",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceMemory: 1024,
@@ -6186,7 +6185,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "podset1",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 					},
 					requests: map[corev1.ResourceName]int64{
 						corev1.ResourceCPU: 1000,
@@ -6846,7 +6845,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 					PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 						{Topology: tasRackLabel, Size: 4},
 						{Topology: corev1.LabelHostname, Size: 2},
@@ -6922,8 +6921,8 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required:                    ptr.To(tasBlockLabel),
-					PodSetSliceRequiredTopology: ptr.To(tasRackLabel),
+					Required:                    new(tasBlockLabel),
+					PodSetSliceRequiredTopology: new(tasRackLabel),
 					PodSetSliceSize:             new(int32(4)),
 					// Without the feature gate, only two-level fields are used;
 					// PodsetSliceRequiredTopologyConstraints would not be populated by the parser.
@@ -6991,7 +6990,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			},
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasDataCenterLabel),
+					Required: new(tasDataCenterLabel),
 					PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 						{Topology: tasAIZoneLabel, Size: 48},
 						{Topology: tasRackLabel, Size: 16},
@@ -7063,7 +7062,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{
 				{
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasBlockLabel),
+						Required: new(tasBlockLabel),
 						PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 							{Topology: tasRackLabel, Size: 6},
 							{Topology: corev1.LabelHostname, Size: 2},
@@ -7130,7 +7129,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 					PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 						{Topology: tasRackLabel, Size: 8},
 						{Topology: corev1.LabelHostname, Size: 4},
@@ -7186,7 +7185,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(tasBlockLabel),
+					Required: new(tasBlockLabel),
 					PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 						{Topology: tasRackLabel, Size: 6},
 						{Topology: corev1.LabelHostname, Size: 2},
@@ -7311,7 +7310,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			podSets: []PodSetTestCase{
 				{
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasDataCenterLabel),
+						Required: new(tasDataCenterLabel),
 						PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 							{Topology: tasBlockLabel, Size: 12},
 							{Topology: tasRackLabel, Size: 6},
@@ -7799,7 +7798,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				podSetName: "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Preferred:                   new("kubernetes.io/hostname"),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				nodeAffinity: &corev1.NodeAffinity{
@@ -7869,7 +7868,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				podSetName: "main",
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained:               new(true),
-					PodSetSliceRequiredTopology: ptr.To(corev1.LabelHostname),
+					PodSetSliceRequiredTopology: new(corev1.LabelHostname),
 					PodSetSliceSize:             new(int32(2)),
 				},
 				nodeAffinity: &corev1.NodeAffinity{
@@ -8082,7 +8081,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 				{
 					podSetName: "main",
 					topologyRequest: &kueue.PodSetTopologyRequest{
-						Required: ptr.To(tasRackLabel),
+						Required: new(tasRackLabel),
 					},
 					requests: map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000},
 					count:    1,
@@ -8173,7 +8172,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -8219,7 +8218,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -8265,7 +8264,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -8311,7 +8310,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			levels: defaultThreeLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
-					Required: ptr.To(corev1.LabelHostname),
+					Required: new(corev1.LabelHostname),
 				},
 				requests: map[corev1.ResourceName]int64{
 					corev1.ResourceCPU: 1000,
@@ -8511,7 +8510,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			admissionCount: 4,
 			unhealthyNode:  "x3",
 			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
+				Required: new(tasBlockLabel),
 				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 					{Topology: tasRackLabel, Size: 2},
 				},
@@ -8561,7 +8560,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			admissionCount: 4,
 			unhealthyNode:  "x3",
 			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
+				Required: new(tasBlockLabel),
 				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 					{Topology: tasRackLabel, Size: 2},
 				},
@@ -8646,7 +8645,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			admissionCount: 16,
 			unhealthyNode:  "x3",
 			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
+				Required: new(tasBlockLabel),
 				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 					{Topology: tasRackLabel, Size: 8},
 					{Topology: tasSwitchLabel, Size: 4},
@@ -8723,7 +8722,7 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 			admissionCount: 8,
 			unhealthyNode:  "x3",
 			topologyRequest: &kueue.PodSetTopologyRequest{
-				Required: ptr.To(tasBlockLabel),
+				Required: new(tasBlockLabel),
 				PodsetSliceRequiredTopologyConstraints: []kueue.PodsetSliceRequiredTopologyConstraint{
 					{Topology: tasRackLabel, Size: 4},
 					{Topology: corev1.LabelHostname, Size: 2},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1084,27 +1084,27 @@ webhook:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
 				WaitForPodsReady: defaultWaitForPodsReady,
 
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+					QPS:   new(configapi.DefaultClientConnectionQPS),
+					Burst: new(configapi.DefaultClientConnectionBurst),
 				},
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1190,26 +1190,26 @@ webhook:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
 				WaitForPodsReady: defaultWaitForPodsReady,
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+					QPS:   new(configapi.DefaultClientConnectionQPS),
+					Burst: new(configapi.DefaultClientConnectionBurst),
 				},
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1237,27 +1237,27 @@ webhook:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
 				WaitForPodsReady: defaultWaitForPodsReady,
 
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+					QPS:   new(configapi.DefaultClientConnectionQPS),
+					Burst: new(configapi.DefaultClientConnectionBurst),
 				},
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,9 +66,9 @@ var defaultWaitForPodsReady = &configapi.WaitForPodsReady{
 		Duration: 30 * time.Minute,
 	},
 	RequeuingStrategy: &configapi.RequeuingStrategy{
-		Timestamp:          ptr.To(configapi.EvictionTimestamp),
-		BackoffBaseSeconds: ptr.To[int32](configapi.DefaultRequeuingBackoffBaseSeconds),
-		BackoffMaxSeconds:  ptr.To[int32](configapi.DefaultRequeuingBackoffMaxSeconds),
+		Timestamp:          new(configapi.EvictionTimestamp),
+		BackoffBaseSeconds: new(int32(configapi.DefaultRequeuingBackoffBaseSeconds)),
+		BackoffMaxSeconds:  new(int32(configapi.DefaultRequeuingBackoffMaxSeconds)),
 	},
 }
 
@@ -96,9 +95,9 @@ func defaultControlOptions(namespace string) ctrl.Options {
 		LeaderElectionID:              configapi.DefaultLeaderElectionID,
 		LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 		LeaderElectionReleaseOnCancel: true,
-		LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-		RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-		RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+		LeaseDuration:                 new(configapi.DefaultLeaderElectionLeaseDuration),
+		RenewDeadline:                 new(configapi.DefaultLeaderElectionRenewDeadline),
+		RetryPeriod:                   new(configapi.DefaultLeaderElectionRetryPeriod),
 	}
 }
 
@@ -406,8 +405,8 @@ objectRetentionPolicies:
 
 	enableDefaultInternalCertManagement := &configapi.InternalCertManagement{
 		Enable:             new(true),
-		WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-		WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+		WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+		WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 	}
 
 	ctrlOptsCmpOpts := cmp.Options{
@@ -429,8 +428,8 @@ objectRetentionPolicies:
 	}
 
 	defaultClientConnection := &configapi.ClientConnection{
-		QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-		Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+		QPS:   new(configapi.DefaultClientConnectionQPS),
+		Burst: new(configapi.DefaultClientConnectionBurst),
 	}
 
 	defaultIntegrations := &configapi.Integrations{
@@ -449,13 +448,13 @@ objectRetentionPolicies:
 
 	defaultMultiKueue := &configapi.MultiKueue{
 		GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-		Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+		Origin:            new(configapi.DefaultMultiKueueOrigin),
 		WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-		DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+		DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 	}
 
 	defaultVisibility := &configapi.VisibilityServerConfiguration{
-		BindPort: ptr.To[int32](configapi.DefaultVisibilityBindPort),
+		BindPort: new(int32(configapi.DefaultVisibilityBindPort)),
 	}
 
 	testcases := []struct {
@@ -471,7 +470,7 @@ objectRetentionPolicies:
 			name:       "default config",
 			configFile: "",
 			wantConfiguration: configapi.Configuration{
-				Namespace:                    ptr.To(configapi.DefaultNamespace),
+				Namespace:                    new(configapi.DefaultNamespace),
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
@@ -490,7 +489,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                    ptr.To(configapi.DefaultNamespace),
+				Namespace:                    new(configapi.DefaultNamespace),
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
 				Integrations:                 defaultIntegrations,
@@ -548,7 +547,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                    ptr.To(configapi.DefaultNamespace),
+				Namespace:                    new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName:   false,
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
@@ -568,9 +567,9 @@ objectRetentionPolicies:
 				LeaderElectionID:              "test-id",
 				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 				LeaderElectionReleaseOnCancel: true,
-				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaseDuration:                 new(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 new(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   new(configapi.DefaultLeaderElectionRetryPeriod),
 			},
 		},
 		{
@@ -581,7 +580,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
@@ -605,7 +604,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable: new(false),
@@ -646,9 +645,9 @@ objectRetentionPolicies:
 				LeaderElectionID:              configapi.DefaultLeaderElectionID,
 				LeaderElectionResourceLock:    resourcelock.LeasesResourceLock,
 				LeaderElectionReleaseOnCancel: false,
-				LeaseDuration:                 ptr.To(configapi.DefaultLeaderElectionLeaseDuration),
-				RenewDeadline:                 ptr.To(configapi.DefaultLeaderElectionRenewDeadline),
-				RetryPeriod:                   ptr.To(configapi.DefaultLeaderElectionRetryPeriod),
+				LeaseDuration:                 new(configapi.DefaultLeaderElectionLeaseDuration),
+				RenewDeadline:                 new(configapi.DefaultLeaderElectionRenewDeadline),
+				RetryPeriod:                   new(configapi.DefaultLeaderElectionRetryPeriod),
 				LeaderElection:                false,
 			},
 		},
@@ -660,7 +659,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				WaitForPodsReady: &configapi.WaitForPodsReady{
@@ -668,10 +667,10 @@ objectRetentionPolicies:
 					Timeout:         metav1.Duration{Duration: 50 * time.Second},
 					RecoveryTimeout: &metav1.Duration{Duration: 3 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp:          ptr.To(configapi.CreationTimestamp),
-						BackoffLimitCount:  ptr.To[int32](10),
-						BackoffBaseSeconds: ptr.To[int32](30),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						Timestamp:          new(configapi.CreationTimestamp),
+						BackoffLimitCount:  new(int32(10)),
+						BackoffBaseSeconds: new(int32(30)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 				},
 				ClientConnection:             defaultClientConnection,
@@ -690,12 +689,12 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To[float32](50),
-					Burst: ptr.To[int32](100),
+					QPS:   new(float32(50)),
+					Burst: new(int32(100)),
 				},
 				Integrations:                 defaultIntegrations,
 				MultiKueue:                   defaultMultiKueue,
@@ -713,12 +712,12 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To[float32](50),
-					Burst: ptr.To[int32](100),
+					QPS:   new(float32(50)),
+					Burst: new(int32(100)),
 				},
 				Integrations:                 defaultIntegrations,
 				MultiKueue:                   defaultMultiKueue,
@@ -740,9 +739,9 @@ objectRetentionPolicies:
 				LeaderElectionNamespace:       "namespace",
 				LeaderElectionResourceLock:    "lock",
 				LeaderElectionReleaseOnCancel: true,
-				LeaseDuration:                 ptr.To(time.Second * 100),
-				RenewDeadline:                 ptr.To(time.Second * 15),
-				RetryPeriod:                   ptr.To(time.Second * 30),
+				LeaseDuration:                 new(time.Second * 100),
+				RenewDeadline:                 new(time.Second * 15),
+				RetryPeriod:                   new(time.Second * 30),
 				Controller: runtimeconfig.Controller{
 					GroupKindConcurrency: map[string]int{
 						"workload": 5,
@@ -759,7 +758,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection:           defaultClientConnection,
@@ -785,7 +784,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection:           defaultClientConnection,
@@ -794,7 +793,7 @@ objectRetentionPolicies:
 					GCInterval:        &metav1.Duration{Duration: 90 * time.Second},
 					Origin:            new("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: 10 * time.Minute},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeIncremental),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeIncremental),
 					IncrementalDispatcherConfig: &configapi.IncrementalDispatcherConfig{
 						StepSize: new(int32(3)),
 					},
@@ -829,7 +828,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement:     enableDefaultInternalCertManagement,
 				ClientConnection:           defaultClientConnection,
@@ -838,7 +837,7 @@ objectRetentionPolicies:
 					GCInterval:        &metav1.Duration{Duration: 90 * time.Second},
 					Origin:            new("multikueue-manager1"),
 					WorkerLostTimeout: &metav1.Duration{Duration: 10 * time.Minute},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeIncremental),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeIncremental),
 					IncrementalDispatcherConfig: &configapi.IncrementalDispatcherConfig{
 						StepSize: new(int32(3)),
 					},
@@ -869,7 +868,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                    ptr.To(configapi.DefaultNamespace),
+				Namespace:                    new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName:   false,
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
@@ -882,7 +881,7 @@ objectRetentionPolicies:
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    corev1.ResourceName("nvidia.com/mig-1g.5gb"),
-							Strategy: ptr.To(configapi.Replace),
+							Strategy: new(configapi.Replace),
 							Outputs: corev1.ResourceList{
 								corev1.ResourceName("example.com/accelerator-memory"): resourcev1.MustParse("5Gi"),
 								corev1.ResourceName("example.com/credits"):            resourcev1.MustParse("10"),
@@ -890,7 +889,7 @@ objectRetentionPolicies:
 						},
 						{
 							Input:    corev1.ResourceName("nvidia.com/mig-2g.10gb"),
-							Strategy: ptr.To(configapi.Replace),
+							Strategy: new(configapi.Replace),
 							Outputs: corev1.ResourceList{
 								corev1.ResourceName("example.com/accelerator-memory"): resourcev1.MustParse("10Gi"),
 								corev1.ResourceName("example.com/credits"):            resourcev1.MustParse("15"),
@@ -898,7 +897,7 @@ objectRetentionPolicies:
 						},
 						{
 							Input:    corev1.ResourceCPU,
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 							Outputs: corev1.ResourceList{
 								corev1.ResourceName("example.com/credits"): resourcev1.MustParse("1"),
 							},
@@ -924,7 +923,7 @@ objectRetentionPolicies:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                    ptr.To(configapi.DefaultNamespace),
+				Namespace:                    new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName:   false,
 				InternalCertManagement:       enableDefaultInternalCertManagement,
 				ClientConnection:             defaultClientConnection,
@@ -1034,26 +1033,26 @@ webhook:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
 				WaitForPodsReady: defaultWaitForPodsReady,
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+					QPS:   new(configapi.DefaultClientConnectionQPS),
+					Burst: new(configapi.DefaultClientConnectionBurst),
 				},
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1137,27 +1136,27 @@ webhook:
 					APIVersion: configapi.SchemeGroupVersion.String(),
 					Kind:       "Configuration",
 				},
-				Namespace:                  ptr.To(configapi.DefaultNamespace),
+				Namespace:                  new(configapi.DefaultNamespace),
 				ManageJobsWithoutQueueName: false,
 				InternalCertManagement: &configapi.InternalCertManagement{
 					Enable:             new(true),
-					WebhookServiceName: ptr.To(configapi.DefaultWebhookServiceName),
-					WebhookSecretName:  ptr.To(configapi.DefaultWebhookSecretName),
+					WebhookServiceName: new(configapi.DefaultWebhookServiceName),
+					WebhookSecretName:  new(configapi.DefaultWebhookSecretName),
 				},
 				WaitForPodsReady: defaultWaitForPodsReady,
 
 				ClientConnection: &configapi.ClientConnection{
-					QPS:   ptr.To(configapi.DefaultClientConnectionQPS),
-					Burst: ptr.To(configapi.DefaultClientConnectionBurst),
+					QPS:   new(configapi.DefaultClientConnectionQPS),
+					Burst: new(configapi.DefaultClientConnectionBurst),
 				},
 				Integrations: &configapi.Integrations{
 					Frameworks: []string{job.FrameworkName},
 				},
 				MultiKueue: &configapi.MultiKueue{
 					GCInterval:        &metav1.Duration{Duration: configapi.DefaultMultiKueueGCInterval},
-					Origin:            ptr.To(configapi.DefaultMultiKueueOrigin),
+					Origin:            new(configapi.DefaultMultiKueueOrigin),
 					WorkerLostTimeout: &metav1.Duration{Duration: configapi.DefaultMultiKueueWorkerLostTimeout},
-					DispatcherName:    ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName:    new(configapi.MultiKueueDispatcherModeAllAtOnce),
 				},
 				ManagedJobsNamespaceSelector: &metav1.LabelSelector{
 					MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1541,7 +1540,7 @@ func TestConfigureClusterProfileCacheWithClient(t *testing.T) {
 				Cache: defaultControlCacheOptions(configapi.DefaultNamespace),
 			}
 			cfg := &configapi.Configuration{
-				Namespace: ptr.To(configapi.DefaultNamespace),
+				Namespace: new(configapi.DefaultNamespace),
 			}
 
 			var objects []runtime.Object
@@ -1602,7 +1601,7 @@ func TestConfigureClusterProfileCache(t *testing.T) {
 			opts := &ctrl.Options{
 				Cache: ctrlcache.Options{},
 			}
-			cfg := configapi.Configuration{Namespace: ptr.To(configapi.DefaultNamespace)}
+			cfg := configapi.Configuration{Namespace: new(configapi.DefaultNamespace)}
 			err := ConfigureClusterProfileCache(ctx, log, opts, tc.kubeConfig, cfg)
 
 			if err == nil {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -33,7 +33,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -241,7 +240,7 @@ func TestValidate(t *testing.T) {
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Timeout: metav1.Duration{Duration: 5 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp: ptr.To[configapi.RequeuingTimestamp]("NoSupported"),
+						Timestamp: new(configapi.RequeuingTimestamp("NoSupported")),
 					},
 				},
 			},
@@ -311,10 +310,10 @@ func TestValidate(t *testing.T) {
 					},
 					BlockAdmission: new(false),
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						Timestamp:          ptr.To(configapi.CreationTimestamp),
-						BackoffLimitCount:  ptr.To[int32](10),
-						BackoffBaseSeconds: ptr.To[int32](30),
-						BackoffMaxSeconds:  ptr.To[int32](1800),
+						Timestamp:          new(configapi.CreationTimestamp),
+						BackoffLimitCount:  new(int32(10)),
+						BackoffBaseSeconds: new(int32(30)),
+						BackoffMaxSeconds:  new(int32(1800)),
 					},
 				},
 			},
@@ -325,7 +324,7 @@ func TestValidate(t *testing.T) {
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Timeout: metav1.Duration{Duration: 5 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						BackoffLimitCount: ptr.To[int32](-1),
+						BackoffLimitCount: new(int32(-1)),
 					},
 				},
 			},
@@ -342,7 +341,7 @@ func TestValidate(t *testing.T) {
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Timeout: metav1.Duration{Duration: 5 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						BackoffBaseSeconds: ptr.To[int32](-1),
+						BackoffBaseSeconds: new(int32(-1)),
 					},
 				},
 			},
@@ -359,7 +358,7 @@ func TestValidate(t *testing.T) {
 				WaitForPodsReady: &configapi.WaitForPodsReady{
 					Timeout: metav1.Duration{Duration: 5 * time.Minute},
 					RequeuingStrategy: &configapi.RequeuingStrategy{
-						BackoffMaxSeconds: ptr.To[int32](-1),
+						BackoffMaxSeconds: new(int32(-1)),
 					},
 				},
 			},
@@ -434,7 +433,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				MultiKueue: &configapi.MultiKueue{
-					DispatcherName: ptr.To(configapi.MultiKueueDispatcherModeIncremental),
+					DispatcherName: new(configapi.MultiKueueDispatcherModeIncremental),
 					IncrementalDispatcherConfig: &configapi.IncrementalDispatcherConfig{
 						StepSize: new(int32(2)),
 					},
@@ -445,7 +444,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				MultiKueue: &configapi.MultiKueue{
-					DispatcherName: ptr.To(configapi.MultiKueueDispatcherModeAllAtOnce),
+					DispatcherName: new(configapi.MultiKueueDispatcherModeAllAtOnce),
 					IncrementalDispatcherConfig: &configapi.IncrementalDispatcherConfig{
 						StepSize: new(int32(2)),
 					},
@@ -462,7 +461,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				MultiKueue: &configapi.MultiKueue{
-					DispatcherName: ptr.To(configapi.MultiKueueDispatcherModeIncremental),
+					DispatcherName: new(configapi.MultiKueueDispatcherModeIncremental),
 					IncrementalDispatcherConfig: &configapi.IncrementalDispatcherConfig{
 						StepSize: new(int32(0)),
 					},
@@ -881,7 +880,7 @@ func TestValidate(t *testing.T) {
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    corev1.ResourceCPU,
-							Strategy: ptr.To(configapi.ResourceTransformationStrategy("invalid")),
+							Strategy: new(configapi.ResourceTransformationStrategy("invalid")),
 						},
 					},
 				},
@@ -901,15 +900,15 @@ func TestValidate(t *testing.T) {
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    corev1.ResourceCPU,
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 						},
 						{
 							Input:    corev1.ResourceMemory,
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 						},
 						{
 							Input:    corev1.ResourceCPU,
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 						},
 					},
 				},
@@ -929,11 +928,11 @@ func TestValidate(t *testing.T) {
 					Transformations: []configapi.ResourceTransformation{
 						{
 							Input:    corev1.ResourceCPU,
-							Strategy: ptr.To(configapi.Retain),
+							Strategy: new(configapi.Retain),
 						},
 						{
 							Input:    corev1.ResourceMemory,
-							Strategy: ptr.To(configapi.Replace),
+							Strategy: new(configapi.Replace),
 						},
 					},
 				},
@@ -1145,7 +1144,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				VisibilityServer: &configapi.VisibilityServerConfiguration{
-					BindPort: ptr.To[int32](0),
+					BindPort: new(int32(0)),
 				},
 			},
 			wantErr: field.ErrorList{
@@ -1159,7 +1158,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				VisibilityServer: &configapi.VisibilityServerConfiguration{
-					BindPort: ptr.To[int32](8080),
+					BindPort: new(int32(8080)),
 				},
 			},
 		},
@@ -1167,7 +1166,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
-					QuotaCheckStrategy:      ptr.To(configapi.QuotaCheckIgnoreUndeclared),
+					QuotaCheckStrategy:      new(configapi.QuotaCheckIgnoreUndeclared),
 					ExcludeResourcePrefixes: []string{"foo.com/device"},
 				},
 			},
@@ -1183,7 +1182,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
-					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckIgnoreUndeclared),
+					QuotaCheckStrategy: new(configapi.QuotaCheckIgnoreUndeclared),
 				},
 			},
 		},
@@ -1191,7 +1190,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
-					QuotaCheckStrategy:      ptr.To(configapi.QuotaCheckBlockUndeclared),
+					QuotaCheckStrategy:      new(configapi.QuotaCheckBlockUndeclared),
 					ExcludeResourcePrefixes: []string{"foo.com/device"},
 				},
 			},
@@ -1200,7 +1199,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
-					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckStrategy("test")),
+					QuotaCheckStrategy: new(configapi.QuotaCheckStrategy("test")),
 				},
 			},
 			wantErr: field.ErrorList{
@@ -1214,7 +1213,7 @@ func TestValidate(t *testing.T) {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
 				Resources: &configapi.Resources{
-					QuotaCheckStrategy: ptr.To(configapi.QuotaCheckStrategy("test")),
+					QuotaCheckStrategy: new(configapi.QuotaCheckStrategy("test")),
 				},
 			},
 			featureGates: map[featuregate.Feature]bool{
@@ -3130,7 +3129,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:          "team",
-								SourceKind:    ptr.To(configapi.SourceKindWorkload),
+								SourceKind:    new(configapi.SourceKindWorkload),
 								TrackedValues: []string{"a"},
 							},
 						},
@@ -3145,7 +3144,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:          "team",
-								SourceKind:    ptr.To(configapi.SourceKindCohort),
+								SourceKind:    new(configapi.SourceKindCohort),
 								TrackedValues: []string{"a"},
 							},
 						},
@@ -3291,7 +3290,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:       "team",
-								SourceKind: ptr.To(configapi.SourceKind("Unknown")),
+								SourceKind: new(configapi.SourceKind("Unknown")),
 							},
 						},
 					},
@@ -3337,15 +3336,15 @@ func TestValidateCustomLabels(t *testing.T) {
 				ControllerManager: configapi.ControllerManager{
 					Metrics: configapi.ControllerMetrics{
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
-							{Name: "c1", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c2", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c3", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c4", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c5", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c6", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c7", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c8", SourceKind: ptr.To(configapi.SourceKindCohort)},
-							{Name: "c9", SourceKind: ptr.To(configapi.SourceKindCohort)},
+							{Name: "c1", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c2", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c3", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c4", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c5", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c6", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c7", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c8", SourceKind: new(configapi.SourceKindCohort)},
+							{Name: "c9", SourceKind: new(configapi.SourceKindCohort)},
 						},
 					},
 				},
@@ -3365,7 +3364,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:       "team",
-								SourceKind: ptr.To(configapi.SourceKindWorkload),
+								SourceKind: new(configapi.SourceKindWorkload),
 							},
 						},
 					},
@@ -3386,7 +3385,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:          "team",
-								SourceKind:    ptr.To(configapi.SourceKindCohort),
+								SourceKind:    new(configapi.SourceKindCohort),
 								TrackedValues: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17"},
 							},
 						},
@@ -3408,7 +3407,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:          "team",
-								SourceKind:    ptr.To(configapi.SourceKindWorkload),
+								SourceKind:    new(configapi.SourceKindWorkload),
 								TrackedValues: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"},
 							},
 						},
@@ -3430,7 +3429,7 @@ func TestValidateCustomLabels(t *testing.T) {
 						CustomLabels: []configapi.ControllerMetricsCustomLabel{
 							{
 								Name:          "team",
-								SourceKind:    ptr.To(configapi.SourceKindCohort),
+								SourceKind:    new(configapi.SourceKindCohort),
 								TrackedValues: []string{"a", "b", "a"},
 							},
 						},
@@ -3461,30 +3460,30 @@ func TestValidateCustomLabels(t *testing.T) {
 			ControllerManager: configapi.ControllerManager{
 				Metrics: configapi.ControllerMetrics{
 					CustomLabels: []configapi.ControllerMetricsCustomLabel{
-						{Name: "c1", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c2", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c3", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c4", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c5", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c6", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c7", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c8", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "c9", SourceKind: ptr.To(configapi.SourceKindCohort)},
-						{Name: "l1", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l2", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l3", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l4", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l5", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l6", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l7", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l8", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l9", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "l10", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-						{Name: "w1", SourceKind: ptr.To(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
-						{Name: "w2", SourceKind: ptr.To(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
-						{Name: "w3", SourceKind: ptr.To(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
-						{Name: "w4", SourceKind: ptr.To(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
-						{Name: "w5", SourceKind: ptr.To(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
+						{Name: "c1", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c2", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c3", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c4", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c5", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c6", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c7", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c8", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "c9", SourceKind: new(configapi.SourceKindCohort)},
+						{Name: "l1", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l2", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l3", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l4", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l5", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l6", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l7", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l8", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l9", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "l10", SourceKind: new(configapi.SourceKindLocalQueue)},
+						{Name: "w1", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
+						{Name: "w2", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
+						{Name: "w3", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
+						{Name: "w4", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
+						{Name: "w5", SourceKind: new(configapi.SourceKindWorkload), TrackedValues: []string{"a"}},
 					},
 				},
 			},

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -1185,7 +1185,7 @@ func updateDelayedTopologyRequest(local, remote *kueue.Workload) {
 
 		if localPSA.DelayedTopologyRequest != nil &&
 			*localPSA.DelayedTopologyRequest == kueue.DelayedTopologyRequestStatePending {
-			localPSA.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
+			localPSA.DelayedTopologyRequest = new(kueue.DelayedTopologyRequestStateReady)
 		}
 	}
 }

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -35,7 +35,6 @@ import (
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -123,7 +122,7 @@ func TestReconcile(t *testing.T) {
 				ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU: resource.MustParse("4"),
 				},
-				Count: ptr.To[int32](4),
+				Count: new(int32(4)),
 			},
 			kueue.PodSetAssignment{
 				Name: "ps2",
@@ -133,7 +132,7 @@ func TestReconcile(t *testing.T) {
 				ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU: resource.MustParse("3M"),
 				},
-				Count: ptr.To[int32](3),
+				Count: new(int32(3)),
 			},
 		).
 			Obj(), now).
@@ -232,9 +231,9 @@ func TestReconcile(t *testing.T) {
 
 	var backoffBaseSeconds int32 = 60
 	baseConfigWithRetryStrategy := baseConfig.Clone().RetryStrategy(&kueue.ProvisioningRequestRetryStrategy{
-		BackoffLimitCount:  ptr.To[int32](3),
+		BackoffLimitCount:  new(int32(3)),
 		BackoffBaseSeconds: new(backoffBaseSeconds),
-		BackoffMaxSeconds:  ptr.To[int32](1800),
+		BackoffMaxSeconds:  new(int32(1800)),
 	})
 
 	baseConfigWithPodSetUpdates := baseConfigWithRetryStrategy.Clone().PodSetUpdate(kueue.ProvisioningRequestPodSetUpdates{
@@ -260,7 +259,7 @@ func TestReconcile(t *testing.T) {
 			ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU: resource.MustParse("1"),
 			},
-			Count: ptr.To[int32](1),
+			Count: new(int32(1)),
 		},
 		{
 			Name: "ps2",
@@ -270,7 +269,7 @@ func TestReconcile(t *testing.T) {
 			ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU: resource.MustParse("1"),
 			},
-			Count: ptr.To[int32](2),
+			Count: new(int32(2)),
 		},
 		{
 			Name: "ps3",
@@ -280,7 +279,7 @@ func TestReconcile(t *testing.T) {
 			ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("1M"),
 			},
-			Count: ptr.To[int32](2),
+			Count: new(int32(2)),
 		},
 		{
 			Name: "ps4",
@@ -290,7 +289,7 @@ func TestReconcile(t *testing.T) {
 			ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("1M"),
 			},
-			Count: ptr.To[int32](1),
+			Count: new(int32(1)),
 		},
 		{
 			Name: "ps5",
@@ -300,7 +299,7 @@ func TestReconcile(t *testing.T) {
 			ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceMemory: resource.MustParse("1M"),
 			},
-			Count: ptr.To[int32](1),
+			Count: new(int32(1)),
 		},
 	}
 
@@ -618,7 +617,7 @@ func TestReconcile(t *testing.T) {
 				AdmissionChecks(kueue.AdmissionCheckState{
 					Name:       "check1",
 					State:      kueue.CheckStatePending,
-					RetryCount: ptr.To[int32](1),
+					RetryCount: new(int32(1)),
 				}, kueue.AdmissionCheckState{
 					Name:  "not-provisioning",
 					State: kueue.CheckStatePending,
@@ -632,7 +631,7 @@ func TestReconcile(t *testing.T) {
 					AdmissionChecks(kueue.AdmissionCheckState{
 						Name:       "check1",
 						State:      kueue.CheckStatePending,
-						RetryCount: ptr.To[int32](1),
+						RetryCount: new(int32(1)),
 					}, kueue.AdmissionCheckState{
 						Name:  "not-provisioning",
 						State: kueue.CheckStatePending,
@@ -2079,7 +2078,7 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 				ResourceUsage: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU: resource.MustParse("4"),
 				},
-				Count: ptr.To[int32](4),
+				Count: new(int32(4)),
 			},
 		).
 			Obj(), now).

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -815,7 +814,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "spot",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1108,7 +1107,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "spot",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1200,7 +1199,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "on-demand",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1292,7 +1291,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "reservation",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1391,7 +1390,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "spot",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1474,7 +1473,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "on-demand",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1566,7 +1565,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "reservation",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -1665,7 +1664,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "spot",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{
@@ -2051,7 +2050,7 @@ func TestReconcile(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "spot",
 						},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
 					}).Obj()).
 				Condition(metav1.Condition{

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -261,7 +260,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 			// The full interval pins that the tick ran; the sampling-interval
 			// guard short-circuit would return interval minus the (negative)
 			// sinceLastUpdate instead.
-			wantRequeueAfter: ptr.To(5 * time.Minute),
+			wantRequeueAfter: new(5 * time.Minute),
 		},
 		"local queue decaying usage sums the previous state and running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -592,7 +591,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantRequeueAfter: ptr.To(time.Minute),
+			wantRequeueAfter: new(time.Minute),
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
@@ -892,7 +891,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				}).
 				Obj(),
 			// 5s interval - 1s elapsed = 4s remaining
-			wantRequeueAfter: ptr.To(4 * time.Second),
+			wantRequeueAfter: new(4 * time.Second),
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 60 * time.Second},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Second},

--- a/pkg/controller/core/workload_controller_eviction_test.go
+++ b/pkg/controller/core/workload_controller_eviction_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -509,7 +508,7 @@ func TestReconcileEviction(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                    3 * time.Second,
-					requeuingBackoffLimitCount: ptr.To[int32](1),
+					requeuingBackoffLimitCount: new(int32(1)),
 					requeuingBackoffJitter:     0,
 				}),
 			},
@@ -527,7 +526,7 @@ func TestReconcileEviction(t *testing.T) {
 					Message:            "Admitted by ClusterQueue q1",
 				}).
 				AdmittedAt(true, now).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(-1*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(-1*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -542,7 +541,7 @@ func TestReconcileEviction(t *testing.T) {
 					Reason:  kueue.WorkloadRequeuingLimitExceeded,
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(1*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(1*time.Second).Truncate(time.Second)))).
 				Obj(),
 		},
 		"should set the Evicted condition with Deactivated reason when the .spec.active=False": {
@@ -652,7 +651,7 @@ func TestReconcileEviction(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](0),
+					requeuingBackoffLimitCount:  new(int32(0)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 				}),
@@ -743,7 +742,7 @@ func TestReconcileEviction(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](0),
+					requeuingBackoffLimitCount:  new(int32(0)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 				}),
@@ -834,7 +833,7 @@ func TestReconcileEviction(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 				}),
@@ -855,7 +854,7 @@ func TestReconcileEviction(t *testing.T) {
 					Reason:  kueue.WorkloadRequeuingLimitExceeded,
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
-				RequeueState(ptr.To[int32](100), nil).
+				RequeueState(new(int32(100)), nil).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(false).
@@ -881,7 +880,7 @@ func TestReconcileEviction(t *testing.T) {
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
 				// The requeueState should be reset in the real cluster, but the fake client doesn't allow us to do it.
-				RequeueState(ptr.To[int32](100), nil).
+				RequeueState(new(int32(100)), nil).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          "Deactivated",
@@ -928,7 +927,7 @@ func TestReconcileEviction(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 				}),
@@ -949,7 +948,7 @@ func TestReconcileEviction(t *testing.T) {
 					Reason:  kueue.WorkloadRequeuingLimitExceeded,
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
-				RequeueState(ptr.To[int32](100), nil).
+				RequeueState(new(int32(100)), nil).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(false).
@@ -975,7 +974,7 @@ func TestReconcileEviction(t *testing.T) {
 					Message: "exceeding the maximum number of re-queuing retries",
 				}).
 				// The requeueState should be reset in the real cluster, but the fake client doesn't allow us to do it.
-				RequeueState(ptr.To[int32](100), nil).
+				RequeueState(new(int32(100)), nil).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          "Deactivated",

--- a/pkg/controller/core/workload_controller_requeue_test.go
+++ b/pkg/controller/core/workload_controller_requeue_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -43,7 +42,7 @@ func TestReconcileRequeue(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 					requeuingBackoffMaxDuration: time.Duration(3600) * time.Second,
@@ -63,7 +62,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Message:            "Admitted by ClusterQueue q1",
 				}).
 				AdmittedAt(true, now).
-				RequeueState(ptr.To[int32](3), nil).
+				RequeueState(new(int32(3)), nil).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -97,7 +96,7 @@ func TestReconcileRequeue(t *testing.T) {
 					ObservedGeneration: 1,
 				}).
 				// 10s * 2^(4-1) = 80s
-				RequeueState(ptr.To[int32](4), new(metav1.NewTime(now.Add(80*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(4)), new(metav1.NewTime(now.Add(80*time.Second).Truncate(time.Second)))).
 				// check EvictionState mergeStrategy
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
@@ -127,7 +126,7 @@ func TestReconcileRequeue(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     3 * time.Second,
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 					requeuingBackoffMaxDuration: time.Duration(7200) * time.Second,
@@ -148,7 +147,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Message:            "Admitted by ClusterQueue q1",
 				}).
 				AdmittedAt(true, now).
-				RequeueState(ptr.To[int32](10), new(metav1.NewTime(now.Add(-1*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(10)), new(metav1.NewTime(now.Add(-1*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -167,7 +166,7 @@ func TestReconcileRequeue(t *testing.T) {
 					ObservedGeneration: 1,
 				}).
 				//  10s * 2^(11-1) = 10240s > requeuingBackoffMaxSeconds; then wait time should be limited to requeuingBackoffMaxSeconds
-				RequeueState(ptr.To[int32](11), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(11)), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -189,8 +188,8 @@ func TestReconcileRequeue(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     5 * time.Minute,
-					recoveryTimeout:             ptr.To(3 * time.Second),
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					recoveryTimeout:             new(3 * time.Second),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 					requeuingBackoffMaxDuration: time.Duration(7200) * time.Second,
@@ -243,7 +242,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Message:            "At least one pod has failed, waiting for recovery",
 				}).
 				//  10s * 2^(11-1) = 10240s > requeuingBackoffMaxSeconds; then wait time should be limited to requeuingBackoffMaxSeconds
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -265,8 +264,8 @@ func TestReconcileRequeue(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWaitForPodsReady(&waitForPodsReadyConfig{
 					timeout:                     5 * time.Minute,
-					recoveryTimeout:             ptr.To(3 * time.Second),
-					requeuingBackoffLimitCount:  ptr.To[int32](100),
+					recoveryTimeout:             new(3 * time.Second),
+					requeuingBackoffLimitCount:  new(int32(100)),
 					requeuingBackoffBaseSeconds: 10,
 					requeuingBackoffJitter:      0,
 					requeuingBackoffMaxDuration: time.Duration(7200) * time.Second,
@@ -321,7 +320,7 @@ func TestReconcileRequeue(t *testing.T) {
 				}).
 				AdmittedAt(true, now).
 				UnhealthyNodes("xyz").
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -354,7 +353,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Message:            "At least one pod has failed, waiting for recovery",
 				}).
 				AdmittedAt(true, now).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(7200*time.Second).Truncate(time.Second)))).
 				SchedulingStatsEviction(
 					kueue.WorkloadSchedulingStatsEviction{
 						Reason:          kueue.WorkloadEvictedByPodsReadyTimeout,
@@ -401,7 +400,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
 					Message: "Exceeded the PodsReady timeout ns",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -411,7 +410,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  kueue.WorkloadEvictedByPodsReadyTimeout,
 					Message: "Exceeded the PodsReady timeout ns",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantResult: reconcile.Result{RequeueAfter: time.Minute},
 		},
@@ -444,7 +443,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  kueue.WorkloadEvictedByAdmissionCheck,
 					Message: "Exceeded the AdmissionCheck timeout ns",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -454,7 +453,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  kueue.WorkloadEvictedByAdmissionCheck,
 					Message: "Exceeded the AdmissionCheck timeout ns",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Add(60*time.Second).Truncate(time.Second)))).
 				Obj(),
 			wantResult: reconcile.Result{RequeueAfter: time.Minute},
 		},
@@ -510,7 +509,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  "JobFinished",
 					Message: "Job finished successfully",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Truncate(time.Second)))).
 				Obj(),
 			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
 				Active(true).
@@ -526,7 +525,7 @@ func TestReconcileRequeue(t *testing.T) {
 					Reason:  "JobFinished",
 					Message: "Job finished successfully",
 				}).
-				RequeueState(ptr.To[int32](1), new(metav1.NewTime(now.Truncate(time.Second)))).
+				RequeueState(new(int32(1)), new(metav1.NewTime(now.Truncate(time.Second)))).
 				Obj(),
 		},
 		"should set the WorkloadRequeued condition to true on ClusterQueue started": {

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -189,7 +188,7 @@ func TestAdmittedNotReadyWorkload(t *testing.T) {
 					},
 				},
 			},
-			waitForPodsReady:    &waitForPodsReadyConfig{recoveryTimeout: ptr.To(3 * time.Minute)},
+			waitForPodsReady:    &waitForPodsReadyConfig{recoveryTimeout: new(3 * time.Minute)},
 			wantUnderlyingCause: kueue.WorkloadWaitForRecovery,
 			wantRecheckAfter:    3 * time.Minute,
 		},
@@ -966,7 +965,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: ptr.To(util.MediumTimeout),
+						afterFinished: new(util.MediumTimeout),
 					},
 				),
 			},
@@ -989,7 +988,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: ptr.To(util.MediumTimeout),
+						afterFinished: new(util.MediumTimeout),
 					},
 				),
 			},
@@ -1018,7 +1017,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: ptr.To(util.MediumTimeout),
+						afterFinished: new(util.MediumTimeout),
 					},
 				),
 			},
@@ -1045,7 +1044,7 @@ func TestReconcile(t *testing.T) {
 			reconcilerOpts: []Option{
 				WithWorkloadRetention(
 					&workloadRetentionConfig{
-						afterFinished: ptr.To(util.MediumTimeout),
+						afterFinished: new(util.MediumTimeout),
 					},
 				),
 			},

--- a/pkg/controller/jobframework/defaults.go
+++ b/pkg/controller/jobframework/defaults.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -140,7 +139,7 @@ func ApplyDefaultForManagedBy(job GenericJob, queues *qcache.Manager, cache *sch
 			for _, admissionCheck := range cache.AdmissionChecksForClusterQueue(clusterQueueName) {
 				if admissionCheck.Controller == kueue.MultiKueueControllerName {
 					log.V(5).Info("Defaulting ManagedBy", "oldManagedBy", managedJob.ManagedBy(), "managedBy", kueue.MultiKueueControllerName)
-					managedJob.SetManagedBy(ptr.To(kueue.MultiKueueControllerName))
+					managedJob.SetManagedBy(new(kueue.MultiKueueControllerName))
 					return
 				}
 			}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -386,7 +386,7 @@ func TestReconcileGenericJob(t *testing.T) {
 								Name:          "main",
 								Flavors:       nil,
 								ResourceUsage: nil,
-								Count:         ptr.To[int32](1),
+								Count:         new(int32(1)),
 							},
 						},
 					}).

--- a/pkg/controller/jobframework/tas_test.go
+++ b/pkg/controller/jobframework/tas_test.go
@@ -25,7 +25,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -58,19 +57,19 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 					kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
 				},
 			},
-			podIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+			podIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 			wantReq: &kueue.PodSetTopologyRequest{
 				Required:      new("cloud.com/block"),
-				PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+				PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 			},
 		},
 		"pod index label only": {
 			meta: &metav1.ObjectMeta{
 				Annotations: map[string]string{},
 			},
-			podIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+			podIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 			wantReq: &kueue.PodSetTopologyRequest{
-				PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+				PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 			},
 		},
 		"required annotation with sub group": {
@@ -80,12 +79,12 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 					kueue.PodSetGroupName:                  "block",
 				},
 			},
-			subGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-			subGroupCount:      ptr.To[int32](1),
+			subGroupIndexLabel: new(jobsetapi.JobIndexKey),
+			subGroupCount:      new(int32(1)),
 			wantReq: &kueue.PodSetTopologyRequest{
 				Required:           new("cloud.com/block"),
-				SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-				SubGroupCount:      ptr.To[int32](1),
+				SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+				SubGroupCount:      new(int32(1)),
 				PodSetGroupName:    new("block"),
 			},
 		},
@@ -96,12 +95,12 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 					kueue.PodSetGroupName:                  "block",
 				},
 			},
-			subGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-			subGroupCount:      ptr.To[int32](1),
+			subGroupIndexLabel: new(jobsetapi.JobIndexKey),
+			subGroupCount:      new(int32(1)),
 			wantReq: &kueue.PodSetTopologyRequest{
 				Required:           new("cloud.com/block"),
-				SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-				SubGroupCount:      ptr.To[int32](1),
+				SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+				SubGroupCount:      new(int32(1)),
 				PodSetGroupName:    new("block"),
 			},
 		},
@@ -144,7 +143,7 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 			},
 			wantReq: &kueue.PodSetTopologyRequest{
 				PodSetSliceRequiredTopology: new("cloud.com/block"),
-				PodSetSliceSize:             ptr.To[int32](1),
+				PodSetSliceSize:             new(int32(1)),
 			},
 		},
 		"slice-only topology – only slice required annotation": {
@@ -169,13 +168,13 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 					kueue.PodSetGroupName:                       "block",
 				},
 			},
-			subGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-			subGroupCount:      ptr.To[int32](1),
+			subGroupIndexLabel: new(jobsetapi.JobIndexKey),
+			subGroupCount:      new(int32(1)),
 			wantReq: &kueue.PodSetTopologyRequest{
 				PodSetSliceRequiredTopology: new("cloud.com/block"),
-				PodSetSliceSize:             ptr.To[int32](1),
-				SubGroupIndexLabel:          ptr.To(jobsetapi.JobIndexKey),
-				SubGroupCount:               ptr.To[int32](1),
+				PodSetSliceSize:             new(int32(1)),
+				SubGroupIndexLabel:          new(jobsetapi.JobIndexKey),
+				SubGroupCount:               new(int32(1)),
 			},
 		},
 		"invalid unconstrained topology annotation value": {
@@ -267,7 +266,7 @@ func TestPodSetTopologyRequestBuilder(t *testing.T) {
 			wantReq: &kueue.PodSetTopologyRequest{
 				Required:                    new("cloud.com/block"),
 				PodSetSliceRequiredTopology: new("cloud.com/rack"),
-				PodSetSliceSize:             ptr.To[int32](16),
+				PodSetSliceSize:             new(int32(16)),
 			},
 		},
 		"multi-layer: invalid JSON in constraints annotation": {

--- a/pkg/controller/jobframework/validation_test.go
+++ b/pkg/controller/jobframework/validation_test.go
@@ -231,7 +231,7 @@ func TestValidateImmutablePodSpec(t *testing.T) {
 		"change priority": {
 			oldPodSpec: &corev1.PodSpec{},
 			newPodSpec: &corev1.PodSpec{
-				Priority: ptr.To[int32](1),
+				Priority: new(int32(1)),
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/pkg/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -121,13 +120,13 @@ func TestPodSets(t *testing.T) {
 					PodSpec(pytorchJobTAS.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 					RequiredTopologyRequest("cloud.com/rack").
-					PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+					PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 					Obj(),
 				*utiltestingapi.MakePodSet("aw-1", 4).
 					PodSpec(pytorchJobTAS.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+					PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 					Obj(),
 			},
 

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -363,7 +363,7 @@ func (j *Job) PodSets(ctx context.Context, _ client.Client) ([]kueue.PodSet, err
 	if features.Enabled(features.TopologyAwareScheduling) {
 		topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 			&j.Spec.Template.ObjectMeta).PodIndexLabel(
-			ptr.To(batchv1.JobCompletionIndexAnnotation)).Build()
+			new(batchv1.JobCompletionIndexAnnotation)).Build()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -62,8 +61,8 @@ func TestPodsReady(t *testing.T) {
 		"parallelism = completions; no progress": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{},
 			},
@@ -72,11 +71,11 @@ func TestPodsReady(t *testing.T) {
 		"parallelism = completions; not enough progress": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready:     ptr.To[int32](1),
+					Ready:     new(int32(1)),
 					Succeeded: 1,
 				},
 			},
@@ -85,11 +84,11 @@ func TestPodsReady(t *testing.T) {
 		"parallelism = completions; all ready": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready:     ptr.To[int32](3),
+					Ready:     new(int32(3)),
 					Succeeded: 0,
 				},
 			},
@@ -98,11 +97,11 @@ func TestPodsReady(t *testing.T) {
 		"parallelism = completions; some ready, some succeeded": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready:     ptr.To[int32](2),
+					Ready:     new(int32(2)),
 					Succeeded: 1,
 				},
 			},
@@ -111,8 +110,8 @@ func TestPodsReady(t *testing.T) {
 		"parallelism = completions; all succeeded": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
 					Succeeded: 3,
@@ -123,11 +122,11 @@ func TestPodsReady(t *testing.T) {
 		"parallelism < completions; reaching parallelism is enough": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](2),
-					Completions: ptr.To[int32](3),
+					Parallelism: new(int32(2)),
+					Completions: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready: ptr.To[int32](2),
+					Ready: new(int32(2)),
 				},
 			},
 			want: true,
@@ -135,11 +134,11 @@ func TestPodsReady(t *testing.T) {
 		"parallelism > completions; reaching completions is enough": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
-					Completions: ptr.To[int32](2),
+					Parallelism: new(int32(3)),
+					Completions: new(int32(2)),
 				},
 				Status: batchv1.JobStatus{
-					Ready: ptr.To[int32](2),
+					Ready: new(int32(2)),
 				},
 			},
 			want: true,
@@ -147,10 +146,10 @@ func TestPodsReady(t *testing.T) {
 		"parallelism specified only; not enough progress": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready: ptr.To[int32](2),
+					Ready: new(int32(2)),
 				},
 			},
 			want: false,
@@ -158,10 +157,10 @@ func TestPodsReady(t *testing.T) {
 		"parallelism specified only; all ready": {
 			job: Job{
 				Spec: batchv1.JobSpec{
-					Parallelism: ptr.To[int32](3),
+					Parallelism: new(int32(3)),
 				},
 				Status: batchv1.JobStatus{
-					Ready: ptr.To[int32](3),
+					Ready: new(int32(3)),
 				},
 			},
 			want: true,
@@ -408,7 +407,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					RequiredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
 		},
@@ -425,7 +424,7 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.Template.Spec).
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
 		},
@@ -445,7 +444,7 @@ func TestPodSets(t *testing.T) {
 						kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
 						kueue.PodSetSliceSizeAnnotation:             "1",
 					}).
-					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 					SliceRequiredTopologyRequest("cloud.com/block").
 					SliceSizeTopologyRequest(1).
 					Obj(),
@@ -484,7 +483,7 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{
 						kueue.PodSetSliceRequiredTopologyAnnotation: "cloud.com/block",
 					}).
-					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
 		},
@@ -502,7 +501,7 @@ func TestPodSets(t *testing.T) {
 					Annotations(map[string]string{
 						kueue.PodSetSliceSizeAnnotation: "1",
 					}).
-					PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+					PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 					Obj(),
 			},
 		},
@@ -4474,7 +4473,7 @@ func TestReconciler(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 						},
-						Count: ptr.To[int32](10),
+						Count: new(int32(10)),
 					}).Obj(), now).
 					AdmittedAt(true, now).
 					Obj(),
@@ -4503,7 +4502,7 @@ func TestReconciler(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 						},
-						Count: ptr.To[int32](10),
+						Count: new(int32(10)),
 					}).Obj(), now).
 					AdmittedAt(true, now).
 					Obj(),
@@ -4550,7 +4549,7 @@ func TestReconciler(t *testing.T) {
 						Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 							corev1.ResourceCPU: "default",
 						},
-						Count: ptr.To[int32](10),
+						Count: new(int32(10)),
 					}).Obj(), now).
 					Obj(),
 			},
@@ -5015,13 +5014,13 @@ func TestReclaimablePods(t *testing.T) {
 		j.Status.Failed = failed
 		j.Status.CompletedIndexes = completedIndexes
 		if failedIndexes != "" {
-			j.Spec.BackoffLimitPerIndex = ptr.To[int32](0)
+			j.Spec.BackoffLimitPerIndex = new(int32(0))
 			j.Status.FailedIndexes = new(failedIndexes)
 		}
 		return (*Job)(j)
 	}
 	retryableFailureJob := indexedJob(1, 1, "0", "")
-	retryableFailureJob.Spec.BackoffLimitPerIndex = ptr.To[int32](1)
+	retryableFailureJob.Spec.BackoffLimitPerIndex = new(int32(1))
 	cases := map[string]struct {
 		job  *Job
 		want []kueue.ReclaimablePod

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -137,7 +136,7 @@ func TestValidateCreate(t *testing.T) {
 			wantValidationErrs: field.ErrorList{
 				field.Invalid(
 					field.NewPath("spec", "completions"),
-					ptr.To[int32](6),
+					new(int32(6)),
 					fmt.Sprintf("should be equal to parallelism when %s annotation is true", JobCompletionsEqualParallelismAnnotation),
 				),
 			},

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -123,8 +123,8 @@ func (j *JobSet) PodSets(ctx context.Context, _ client.Client) ([]kueue.PodSet, 
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 				&replicatedJob.Template.Spec.Template.ObjectMeta).PodIndexLabel(
-				ptr.To(batchv1.JobCompletionIndexAnnotation)).SubGroup(
-				ptr.To(jobsetapi.JobIndexKey),
+				new(batchv1.JobCompletionIndexAnnotation)).SubGroup(
+				new(jobsetapi.JobIndexKey),
 				new(replicatedJob.Replicas)).Build()
 			if err != nil {
 				return nil, err

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -251,15 +250,15 @@ func TestPodSets(t *testing.T) {
 						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
 						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 						RequiredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](2)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(2))).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[1].Name), 6).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](3)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(3))).
 						Obj(),
 				}
 			},
@@ -284,17 +283,17 @@ func TestPodSets(t *testing.T) {
 				return []kueue.PodSet{
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[0].Name), 2).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[0].Template.Spec.Template.Spec.DeepCopy()).
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](2)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(2))).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(jobSet.Spec.ReplicatedJobs[1].Name), 6).
 						PodSpec(*jobSet.Spec.ReplicatedJobs[1].Template.Spec.Template.Spec.DeepCopy()).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](3)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(3))).
 						Obj(),
 				}
 			},
@@ -475,13 +474,13 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("replicated-job-1", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobset.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 						*utiltestingapi.MakePodSet("replicated-job-2", 4).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](2)).
+							SubGroupIndexLabel(new(jobset.JobIndexKey)).
+							SubGroupCount(new(int32(2))).
 							Obj(),
 					).
 					Obj(),
@@ -518,8 +517,8 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("replicated-job-1", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobset.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 					).
 					Obj(),
@@ -556,8 +555,8 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("replicated-job-1", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobset.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 					).
 					Obj(),
@@ -594,8 +593,8 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("replicated-job-1", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobset.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 					).
 					Obj(),

--- a/pkg/controller/jobs/jobset/jobset_webhook_test.go
+++ b/pkg/controller/jobs/jobset/jobset_webhook_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -404,7 +403,7 @@ func TestDefault(t *testing.T) {
 			name: "TestDefault_JobSetManagedBy_jobsetapi.JobSetControllerName",
 			jobSet: &jobset.JobSet{
 				Spec: jobset.JobSetSpec{
-					ManagedBy: ptr.To(jobset.JobSetControllerName),
+					ManagedBy: new(jobset.JobSetControllerName),
 				},
 				ObjectMeta: ctrl.ObjectMeta{
 					Labels: map[string]string{
@@ -428,7 +427,7 @@ func TestDefault(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
-			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
+			wantManagedBy: new(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -455,7 +454,7 @@ func TestDefault(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
-			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
+			wantManagedBy: new(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",

--- a/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/jaxjob/jaxjob_controller_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -128,7 +127,7 @@ func TestPodSets(t *testing.T) {
 				return []kueue.PodSet{
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.JAXJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.JAXReplicaSpecs[kftraining.JAXJobReplicaTypeWorker].Template.Spec).
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},
@@ -151,7 +150,7 @@ func TestPodSets(t *testing.T) {
 						PodSpec(job.Spec.JAXReplicaSpecs[kftraining.JAXJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/paddlejob/paddlejob_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -290,13 +289,13 @@ func TestPodSets(t *testing.T) {
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},
@@ -522,10 +521,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("paddlejob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("master", 1).
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							Obj(),
 					).
 					Obj(),
@@ -566,14 +565,14 @@ func TestReconciler(t *testing.T) {
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](1),
+								Count: new(int32(1)),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](10),
+								Count: new(int32(10)),
 							},
 						).
 						Obj(), now).
@@ -609,14 +608,14 @@ func TestReconciler(t *testing.T) {
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](1),
+								Count: new(int32(1)),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](10),
+								Count: new(int32(10)),
 							},
 						).
 						Obj(), now).

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -329,13 +328,13 @@ func TestPodSets(t *testing.T) {
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/tfjob/tfjob_controller_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -295,17 +294,17 @@ func TestPodSets(t *testing.T) {
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeChief].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypePS)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypePS].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeWorker].Template.Spec).
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},

--- a/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -288,13 +287,13 @@ func TestPodSets(t *testing.T) {
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/rack"}).
 						RequiredTopologyRequest("cloud.com/rack").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 					*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeWorker)), 1).
 						PodSpec(job.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker].Template.Spec).
 						Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj(),
 				}
 			},
@@ -531,10 +530,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("xgboostjob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("master", 1).
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							Obj(),
 					).
 					Obj(),
@@ -575,14 +574,14 @@ func TestReconciler(t *testing.T) {
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](1),
+								Count: new(int32(1)),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](10),
+								Count: new(int32(10)),
 							},
 						).
 						Obj(), now).
@@ -618,14 +617,14 @@ func TestReconciler(t *testing.T) {
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](1),
+								Count: new(int32(1)),
 							},
 							kueue.PodSetAssignment{
 								Name: "worker",
 								Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 									corev1.ResourceCPU: "default",
 								},
-								Count: ptr.To[int32](10),
+								Count: new(int32(10)),
 							},
 						).
 						Obj(), now).

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -121,7 +121,7 @@ func (j *KubeflowJob) PodSets(ctx context.Context, _ client.Client) ([]kueue.Pod
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 				&j.KFJobControl.ReplicaSpecs()[replicaType].Template.ObjectMeta).PodIndexLabel(
-				ptr.To(kftraining.ReplicaIndexLabel)).Build()
+				new(kftraining.ReplicaIndexLabel)).Build()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -381,7 +381,7 @@ func newPodSet(name kueue.PodSetReference, count int32, template *corev1.PodTemp
 	if features.Enabled(features.TopologyAwareScheduling) {
 		builder := jobframework.NewPodSetTopologyRequest(template.ObjectMeta.DeepCopy())
 		if podIndexLabel != nil {
-			builder.PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey))
+			builder.PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey))
 		}
 		topologyRequest, err := builder.Build()
 		if err != nil {
@@ -414,7 +414,7 @@ func podSets(lws *leaderworkersetv1.LeaderWorkerSet) ([]kueue.PodSet, error) {
 		defaultPodSetName,
 		defaultPodSetCount,
 		&lws.Spec.LeaderWorkerTemplate.WorkerTemplate,
-		ptr.To(leaderworkersetv1.WorkerIndexLabelKey),
+		new(leaderworkersetv1.WorkerIndexLabelKey),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -484,7 +483,7 @@ func TestReconciler(t *testing.T) {
 							Image(utiltestingjobs.TestDefaultContainerImage).
 							Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 							RequiredTopologyRequest("cloud.com/block").
-							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
 							Obj(),
 					).
 					Priority(0).

--- a/pkg/controller/jobs/mpijob/mpijob_controller.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller.go
@@ -122,7 +122,7 @@ func (j *MPIJob) PodSets(ctx context.Context, _ client.Client) ([]kueue.PodSet, 
 		if features.Enabled(features.TopologyAwareScheduling) {
 			topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 				&j.Spec.MPIReplicaSpecs[mpiReplicaType].Template.ObjectMeta).PodIndexLabel(
-				ptr.To(kfmpi.ReplicaIndexLabel)).Build()
+				new(kfmpi.ReplicaIndexLabel)).Build()
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_controller_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -232,13 +231,13 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					RequiredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 				*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block"}).
 					RequiredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
@@ -262,13 +261,13 @@ func TestPodSets(t *testing.T) {
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 				*utiltestingapi.MakePodSet(kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)), 3).
 					PodSpec(jobTemplate.Clone().Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker].Template.Spec).
 					Annotations(map[string]string{kueue.PodSetPreferredTopologyAnnotation: "cloud.com/block"}).
 					PreferredTopologyRequest("cloud.com/block").
-					PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+					PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 					Obj(),
 			},
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
@@ -526,10 +525,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("mpijob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 					).
 					Obj(),
@@ -549,10 +548,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("mpijob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 					).
 					WorkloadPriorityClassRef("test-wpc").
@@ -574,10 +573,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("mpijob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 					).
 					PodPriorityClassRef("test-pc").
@@ -601,10 +600,10 @@ func TestReconciler(t *testing.T) {
 				*utiltestingapi.MakeWorkload("mpijob", "ns").
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(kfmpi.ReplicaIndexLabel)).
+							PodIndexLabel(new(kfmpi.ReplicaIndexLabel)).
 							Obj(),
 					).
 					WorkloadPriorityClassRef("test-wpc").

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -356,7 +355,7 @@ func TestDefault(t *testing.T) {
 			mpiJob: &v2beta1.MPIJob{
 				Spec: v2beta1.MPIJobSpec{
 					RunPolicy: v2beta1.RunPolicy{
-						ManagedBy: ptr.To(v2beta1.KubeflowJobController),
+						ManagedBy: new(v2beta1.KubeflowJobController),
 					},
 				},
 				ObjectMeta: ctrl.ObjectMeta{
@@ -381,7 +380,7 @@ func TestDefault(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
-			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
+			wantManagedBy: new(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithQueueLabel",
@@ -408,7 +407,7 @@ func TestDefault(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			featureGates:  map[featuregate.Feature]bool{features.MultiKueue: true},
-			wantManagedBy: ptr.To(kueue.MultiKueueControllerName),
+			wantManagedBy: new(kueue.MultiKueueControllerName),
 		},
 		{
 			name: "TestDefault_WithoutQueueLabel",

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -751,7 +751,7 @@ func constructPodSet(p *corev1.Pod) (kueue.PodSet, error) {
 	if features.Enabled(features.TopologyAwareScheduling) {
 		topologyRequest, err := jobframework.NewPodSetTopologyRequest(
 			&p.ObjectMeta).PodIndexLabel(
-			ptr.To(kueue.PodGroupPodIndexLabel)).Build()
+			new(kueue.PodGroupPodIndexLabel)).Build()
 		if err != nil {
 			return kueue.PodSet{}, err
 		}

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -256,7 +255,7 @@ func TestPodSets(t *testing.T) {
 					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 						PodSpec(*pod.pod.Spec.DeepCopy()).
 						RequiredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 						Obj(),
 				}
 			},
@@ -272,7 +271,7 @@ func TestPodSets(t *testing.T) {
 					*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 						PodSpec(*pod.pod.Spec.DeepCopy()).
 						PreferredTopologyRequest("cloud.com/block").
-						PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 						Obj(),
 				}
 			},
@@ -500,7 +499,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -547,7 +546,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -564,7 +563,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName+"-changed").
@@ -627,7 +626,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -645,7 +644,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName+"-changed").
@@ -713,7 +712,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -731,7 +730,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -1060,7 +1059,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -1185,7 +1184,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 3).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -1256,7 +1255,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet("dc85db45", 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -1345,7 +1344,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet("dc85db45", 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -2599,7 +2598,7 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).Request(corev1.ResourceCPU, "1").
 							NodeName("test-node").
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -2859,7 +2858,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -3327,7 +3326,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -3775,7 +3774,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -4640,7 +4639,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -4700,7 +4699,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -4813,7 +4812,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localTestQueueName).
@@ -4876,7 +4875,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -4941,7 +4940,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).
@@ -5039,7 +5038,7 @@ func TestReconciler(t *testing.T) {
 						*utiltestingapi.MakePodSet(kueue.NewPodSetReference(podUID), 2).
 							Request(corev1.ResourceCPU, "1").
 							SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
-							PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+							PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 							Obj(),
 					).
 					Queue(localUserQueueName).

--- a/pkg/controller/jobs/raycluster/common_test.go
+++ b/pkg/controller/jobs/raycluster/common_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -66,7 +65,7 @@ func TestBuildPodSets(t *testing.T) {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName: "workers",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "worker"}},
@@ -100,7 +99,7 @@ func TestBuildPodSets(t *testing.T) {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName: "group1",
-						Replicas:  ptr.To[int32](2),
+						Replicas:  new(int32(2)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "worker1"}},
@@ -109,7 +108,7 @@ func TestBuildPodSets(t *testing.T) {
 					},
 					{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](5),
+						Replicas:  new(int32(5)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "worker2"}},
@@ -181,7 +180,7 @@ func TestBuildPodSets(t *testing.T) {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName:  "workers",
-						Replicas:   ptr.To[int32](3),
+						Replicas:   new(int32(3)),
 						NumOfHosts: 2,
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
@@ -230,7 +229,7 @@ func TestBuildPodSets(t *testing.T) {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName: "workers",
-						Replicas:  ptr.To[int32](1),
+						Replicas:  new(int32(1)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "worker"}},
@@ -321,7 +320,7 @@ func TestBuildPodSets(t *testing.T) {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName: "workers",
-						Replicas:  ptr.To[int32](1),
+						Replicas:  new(int32(1)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{
 								Containers: []corev1.Container{{Name: "worker"}},

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -82,7 +81,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},
@@ -132,7 +131,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},
@@ -181,7 +180,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -240,7 +239,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -252,7 +251,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group3",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
@@ -63,7 +62,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},
@@ -157,7 +156,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},
@@ -206,7 +205,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -265,7 +264,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -313,7 +312,7 @@ func TestPodSets(t *testing.T) {
 				WithWorkerGroups(
 					rayv1.WorkerGroupSpec{
 						GroupName: "group1",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -362,7 +361,7 @@ func TestPodSets(t *testing.T) {
 				WithWorkerGroups(
 					rayv1.WorkerGroupSpec{
 						GroupName: "group1",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							ObjectMeta: metav1.ObjectMeta{
 								Annotations: map[string]string{
@@ -429,7 +428,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName:  "group2",
-						Replicas:   ptr.To[int32](3),
+						Replicas:   new(int32(3)),
 						NumOfHosts: 4,
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
@@ -471,7 +470,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},
@@ -515,7 +514,7 @@ func TestPodSets(t *testing.T) {
 					},
 					rayv1.WorkerGroupSpec{
 						GroupName: "group2",
-						Replicas:  ptr.To[int32](3),
+						Replicas:  new(int32(3)),
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 						},

--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -86,7 +85,7 @@ func TestPodSets(t *testing.T) {
 							},
 							{
 								GroupName: "group2",
-								Replicas:  ptr.To[int32](3),
+								Replicas:  new(int32(3)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group2_c"}}},
 								},
@@ -176,7 +175,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName:  "group1",
-								Replicas:   ptr.To[int32](2),
+								Replicas:   new(int32(2)),
 								NumOfHosts: 3,
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
@@ -223,7 +222,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName: "group1",
-								Replicas:  ptr.To[int32](1),
+								Replicas:  new(int32(1)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 								},
@@ -276,7 +275,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName: "group1",
-								Replicas:  ptr.To[int32](1),
+								Replicas:  new(int32(1)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 								},
@@ -304,7 +303,7 @@ func TestPodSets(t *testing.T) {
 					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 						{
 							GroupName: "group1",
-							Replicas:  ptr.To[int32](5), // RayCluster has scaled to 5 replicas
+							Replicas:  new(int32(5)), // RayCluster has scaled to 5 replicas
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 							},
@@ -347,7 +346,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName: "group1",
-								Replicas:  ptr.To[int32](2),
+								Replicas:  new(int32(2)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 								},
@@ -370,7 +369,7 @@ func TestPodSets(t *testing.T) {
 					WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 						{
 							GroupName: "group1",
-							Replicas:  ptr.To[int32](10), // RayCluster has different count
+							Replicas:  new(int32(10)), // RayCluster has different count
 						},
 					},
 				},
@@ -410,7 +409,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName: "group1",
-								Replicas:  ptr.To[int32](3),
+								Replicas:  new(int32(3)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 								},
@@ -460,7 +459,7 @@ func TestPodSets(t *testing.T) {
 						WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 							{
 								GroupName: "group1",
-								Replicas:  ptr.To[int32](2),
+								Replicas:  new(int32(2)),
 								Template: corev1.PodTemplateSpec{
 									Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "group1_c"}}},
 								},

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -347,7 +347,7 @@ func (r *Reconciler) constructWorkload(sts *appsv1.StatefulSet) (*kueue.Workload
 
 	if features.Enabled(features.TopologyAwareScheduling) {
 		topologyRequest, err := jobframework.NewPodSetTopologyRequest(sts.Spec.Template.ObjectMeta.DeepCopy()).
-			PodIndexLabel(ptr.To(appsv1.PodIndexLabel)).
+			PodIndexLabel(new(appsv1.PodIndexLabel)).
 			Build()
 		if err != nil {
 			return nil, err

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -290,7 +289,7 @@ func TestReconciler(t *testing.T) {
 						},
 						TopologyRequest: &kueue.PodSetTopologyRequest{
 							Required:      new("cloud.com/block"),
-							PodIndexLabel: ptr.To(appsv1.PodIndexLabel),
+							PodIndexLabel: new(appsv1.PodIndexLabel),
 						},
 					}).
 					OwnerReference(gvk, "sts", "sts-uid").

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
@@ -73,7 +72,7 @@ func TestRunWithPodsetsInfo(t *testing.T) {
 	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
 		APIGroup: new(kftrainerapi.GroupVersion.Group),
 		Name:     "test",
-		Kind:     ptr.To(kftrainerapi.ClusterTrainingRuntimeKind),
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
 	})
 	testJobset := testingjobset.MakeJobSet("", "").ReplicatedJobs(
 		testingjobset.ReplicatedJobRequirements{
@@ -372,7 +371,7 @@ func TestReconciler(t *testing.T) {
 	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
 		APIGroup: new(kftrainerapi.GroupVersion.Group),
 		Name:     "test",
-		Kind:     ptr.To(kftrainerapi.ClusterTrainingRuntimeKind),
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
 	})
 	testJobset := testingjobset.MakeJobSet("", "").ReplicatedJobs(
 		testingjobset.ReplicatedJobRequirements{
@@ -411,13 +410,13 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("node", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobsetapi.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 						*utiltestingapi.MakePodSet("foo", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobsetapi.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 					).
 					Obj(),
@@ -435,13 +434,13 @@ func TestReconciler(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("node", 2).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobsetapi.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 						*utiltestingapi.MakePodSet("foo", 1).
 							PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
-							SubGroupIndexLabel(ptr.To(jobsetapi.JobIndexKey)).
-							SubGroupCount(ptr.To[int32](1)).
+							SubGroupIndexLabel(new(jobsetapi.JobIndexKey)).
+							SubGroupCount(new(int32(1))).
 							Obj(),
 					).
 					Obj(),

--- a/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_webhook_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -57,7 +56,7 @@ func TestValidateCreate(t *testing.T) {
 	testTrainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").RuntimeRef(kftrainerapi.RuntimeRef{
 		APIGroup: new(kftrainerapi.GroupVersion.Group),
 		Name:     "testCtr",
-		Kind:     ptr.To(kftrainerapi.ClusterTrainingRuntimeKind),
+		Kind:     new(kftrainerapi.ClusterTrainingRuntimeKind),
 	}).Suspend(false)
 	testcases := map[string]struct {
 		clusterTrainingRuntime  *kftrainerapi.ClusterTrainingRuntime

--- a/pkg/controller/tas/node_controller_test.go
+++ b/pkg/controller/tas/node_controller_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -508,7 +507,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 							Key:               "foo",
 							Effect:            corev1.TaintEffectNoExecute,
 							Operator:          corev1.TolerationOpExists,
-							TolerationSeconds: ptr.To[int64](300),
+							TolerationSeconds: new(int64(300)),
 						}).
 						Obj()).
 					ReserveQuotaAt(
@@ -544,7 +543,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 							Key:               "foo",
 							Effect:            corev1.TaintEffectNoExecute,
 							Operator:          corev1.TolerationOpExists,
-							TolerationSeconds: ptr.To[int64](300),
+							TolerationSeconds: new(int64(300)),
 						}).
 						Obj()).
 					ReserveQuotaAt(
@@ -648,7 +647,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 							Key:               "foo",
 							Effect:            corev1.TaintEffectNoExecute,
 							Operator:          corev1.TolerationOpExists,
-							TolerationSeconds: ptr.To[int64](300),
+							TolerationSeconds: new(int64(300)),
 						}).
 						Obj()).
 					ReserveQuotaAt(
@@ -688,7 +687,7 @@ func TestNodeFailureReconciler(t *testing.T) {
 							Key:               "foo",
 							Effect:            corev1.TaintEffectNoExecute,
 							Operator:          corev1.TolerationOpExists,
-							TolerationSeconds: ptr.To[int64](300),
+							TolerationSeconds: new(int64(300)),
 						}).
 						Obj()).
 					ReserveQuotaAt(

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -856,9 +855,9 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](1)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(1))).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -997,7 +996,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -1119,12 +1118,12 @@ func TestReconcile(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("workers", 4).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
 							PodSetGroup("lws-group").
 							Obj(),
 						*utiltestingapi.MakePodSet("leader", 1).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
 							PodSetGroup("lws-group").
 							Obj(),
 					).
@@ -1253,7 +1252,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -1376,12 +1375,12 @@ func TestReconcile(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("workers", 4).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
 							PodSetGroup("lws-group").
 							Obj(),
 						*utiltestingapi.MakePodSet("leader", 1).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(leaderworkersetv1.WorkerIndexLabelKey)).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
 							PodSetGroup("lws-group").
 							Obj(),
 					).
@@ -1672,9 +1671,9 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](2)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(2))).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -1796,9 +1795,9 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](2)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(2))).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -1922,9 +1921,9 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
-						SubGroupIndexLabel(ptr.To(jobset.JobIndexKey)).
-						SubGroupCount(ptr.To[int32](2)).
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						SubGroupIndexLabel(new(jobset.JobIndexKey)).
+						SubGroupCount(new(int32(2))).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -2026,12 +2025,12 @@ func TestReconcile(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							PodSetGroup("mpijob-group").
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 3).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							PodSetGroup("mpijob-group").
 							Obj(),
 					).
@@ -2327,12 +2326,12 @@ func TestReconcile(t *testing.T) {
 					PodSets(
 						*utiltestingapi.MakePodSet("launcher", 1).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							PodSetGroup("mpijob-group").
 							Obj(),
 						*utiltestingapi.MakePodSet("worker", 3).
 							Request(corev1.ResourceCPU, "1").
-							PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+							PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 							PodSetGroup("mpijob-group").
 							Obj(),
 					).
@@ -2436,7 +2435,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -2548,7 +2547,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(kftraining.ReplicaIndexLabel)).
+						PodIndexLabel(new(kftraining.ReplicaIndexLabel)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -2662,7 +2661,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -2768,7 +2767,7 @@ func TestReconcile(t *testing.T) {
 				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 4).
 						Request(corev1.ResourceCPU, "1").
-						PodIndexLabel(ptr.To(kueue.PodGroupPodIndexLabel)).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
 						Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").

--- a/pkg/metrics/custom_labels.go
+++ b/pkg/metrics/custom_labels.go
@@ -179,7 +179,7 @@ func parseLabels(targetKind configapi.SourceKind, labelSpecs []configapi.Control
 	specs = make([]configapi.ControllerMetricsCustomLabel, 0)
 	for _, spec := range labelSpecs {
 		if spec.SourceKind == nil {
-			spec.SourceKind = ptr.To(configapi.DefaultCustomMetricLabelSourceKind)
+			spec.SourceKind = new(configapi.DefaultCustomMetricLabelSourceKind)
 		}
 		if *spec.SourceKind == targetKind {
 			names = append(names, "custom_"+spec.Name)

--- a/pkg/metrics/custom_labels_test.go
+++ b/pkg/metrics/custom_labels_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -103,10 +102,10 @@ func TestCustomLabels(t *testing.T) {
 		},
 		"entries with specified source kinds": {
 			entries: []configapi.ControllerMetricsCustomLabel{
-				{Name: "cohort", SourceAnnotationKey: "cohort", SourceKind: ptr.To(configapi.SourceKindCohort)},
-				{Name: "team", SourceKind: ptr.To(configapi.SourceKindClusterQueue)},
-				{Name: "env", SourceLabelKey: "environment", SourceKind: ptr.To(configapi.SourceKindLocalQueue)},
-				{Name: "cost", SourceAnnotationKey: "billing/cost", SourceKind: ptr.To(configapi.SourceKindClusterQueue)},
+				{Name: "cohort", SourceAnnotationKey: "cohort", SourceKind: new(configapi.SourceKindCohort)},
+				{Name: "team", SourceKind: new(configapi.SourceKindClusterQueue)},
+				{Name: "env", SourceLabelKey: "environment", SourceKind: new(configapi.SourceKindLocalQueue)},
+				{Name: "cost", SourceAnnotationKey: "billing/cost", SourceKind: new(configapi.SourceKindClusterQueue)},
 			},
 			labels:      map[string]string{"team": "ml", "environment": "prod"},
 			annotations: map[string]string{"billing/cost": "high", "cohort": "c1"},
@@ -236,9 +235,9 @@ func TestStoreCustomLabels(t *testing.T) {
 			},
 			entries: []configapi.ControllerMetricsCustomLabel{
 				{Name: "cq-label"},
-				{Name: "wl-label", SourceKind: ptr.To(configapi.SourceKindWorkload)},
+				{Name: "wl-label", SourceKind: new(configapi.SourceKindWorkload)},
 				{Name: "cq-annotation", SourceAnnotationKey: "cq-annotation"},
-				{Name: "wl-annotation", SourceAnnotationKey: "wl-annotation", SourceKind: ptr.To(configapi.SourceKindWorkload)},
+				{Name: "wl-annotation", SourceAnnotationKey: "wl-annotation", SourceKind: new(configapi.SourceKindWorkload)},
 			},
 			initialLabels: map[string]string{
 				"cq-label":    "cq-label-value",
@@ -323,7 +322,7 @@ func TestUpdateRequired(t *testing.T) {
 			nilReceiver: true,
 		},
 		"unsupported kind": {
-			entries:    []configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: ptr.To(configapi.SourceKindClusterQueue)}},
+			entries:    []configapi.ControllerMetricsCustomLabel{{Name: "team", SourceKind: new(configapi.SourceKindClusterQueue)}},
 			kind:       configapi.SourceKindLocalQueue,
 			ref:        "lq1",
 			testLabels: map[string]string{"team": "infra"},

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -25,7 +25,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -81,7 +80,7 @@ func TestFromAssignment(t *testing.T) {
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 					corev1.ResourceCPU: kueue.ResourceFlavorReference(flavor1.Name),
 				},
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			},
 			defaultCount: 4,
 			flavors:      []kueue.ResourceFlavor{*flavor1.DeepCopy()},
@@ -102,7 +101,7 @@ func TestFromAssignment(t *testing.T) {
 					corev1.ResourceCPU:    kueue.ResourceFlavorReference(flavor1.Name),
 					corev1.ResourceMemory: kueue.ResourceFlavorReference(flavor2.Name),
 				},
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			},
 			defaultCount: 4,
 			flavors:      []kueue.ResourceFlavor{*flavor1.DeepCopy(), *flavor2.DeepCopy()},
@@ -125,7 +124,7 @@ func TestFromAssignment(t *testing.T) {
 					corev1.ResourceCPU:    kueue.ResourceFlavorReference(flavor1.Name),
 					corev1.ResourceMemory: kueue.ResourceFlavorReference(flavor1.Name),
 				},
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			},
 			defaultCount: 4,
 			flavors:      []kueue.ResourceFlavor{*flavor1.DeepCopy(), *flavor2.DeepCopy()},
@@ -145,7 +144,7 @@ func TestFromAssignment(t *testing.T) {
 				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 					corev1.ResourceCPU: kueue.ResourceFlavorReference(flavor1.Name),
 				},
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			},
 			defaultCount: 4,
 			wantError:    apierrors.NewNotFound(schema.GroupResource{Group: kueue.SchemeGroupVersion.Group, Resource: "resourceflavors"}, "flavor1"),

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1helpers "k8s.io/component-helpers/scheduling/corev1"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -89,7 +88,7 @@ func (a *Assignment) UpdateForTASResult(log logr.Logger, cq *schdcache.ClusterQu
 		psAssignment := a.podSetAssignmentByName(psName)
 		psAssignment.TopologyAssignment = psResult.TopologyAssignment
 		if psResult.TopologyAssignment != nil && psAssignment.DelayedTopologyRequest != nil {
-			psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStateReady)
+			psAssignment.DelayedTopologyRequest = new(kueue.DelayedTopologyRequestStateReady)
 		}
 	}
 	a.Usage.TAS = a.ComputeTASNetUsage(log, cq, wl, nil)
@@ -542,11 +541,11 @@ func fromPreemptionPossibility(preemptionPossibility preemptioncommon.Preemption
 func (mode preemptionMode) preemptionPossibility() *preemptioncommon.PreemptionPossibility {
 	switch mode {
 	case noPreemptionCandidates:
-		return ptr.To(preemptioncommon.NoCandidates)
+		return new(preemptioncommon.NoCandidates)
 	case preempt:
-		return ptr.To(preemptioncommon.Preempt)
+		return new(preemptioncommon.Preempt)
 	case reclaim:
-		return ptr.To(preemptioncommon.Reclaim)
+		return new(preemptioncommon.Reclaim)
 	case fit, noFit:
 		return nil
 	default:

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -359,7 +358,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "default",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor default, 1 more needed"},
 						},
 					},
@@ -835,7 +834,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "b_one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for example.com/gpu in flavor b_one, 1 more needed"},
 						},
 						{
@@ -847,7 +846,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "two",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for memory in flavor two, 5Mi more needed"},
 						},
@@ -1493,7 +1492,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
@@ -1536,7 +1535,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
@@ -1591,7 +1590,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
@@ -1649,7 +1648,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "two",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor two, 1 more needed"},
 						},
 					},
@@ -1707,7 +1706,7 @@ func TestAssignFlavors(t *testing.T) {
 							{
 								Flavor:                "one",
 								Mode:                  Preempt,
-								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+								PreemptionPossibility: new(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 							},
 							{
@@ -1741,7 +1740,7 @@ func TestAssignFlavors(t *testing.T) {
 							{
 								Flavor:                "tainted",
 								Mode:                  Preempt,
-								PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+								PreemptionPossibility: new(preemptioncommon.Preempt),
 								Reasons:               []string{"insufficient unused quota for cpu in flavor tainted, 3 more needed"},
 							},
 						},
@@ -2047,7 +2046,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
@@ -2097,7 +2096,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 					},
@@ -2145,7 +2144,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
 						{Flavor: "two", Mode: Fit},
@@ -2381,7 +2380,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -2448,7 +2447,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -2515,7 +2514,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -2582,7 +2581,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -2929,7 +2928,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
+							PreemptionPossibility: new(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
@@ -2996,7 +2995,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.NoCandidates),
+							PreemptionPossibility: new(preemptioncommon.NoCandidates),
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 2 more needed"},
 						},
 						{Flavor: "two", Mode: Fit, Borrow: 1},
@@ -3054,7 +3053,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 1 more needed"},
 						},
@@ -3116,7 +3115,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -3176,7 +3175,7 @@ func TestAssignFlavors(t *testing.T) {
 						{
 							Flavor:                "one",
 							Mode:                  Preempt,
-							PreemptionPossibility: ptr.To(preemptioncommon.Preempt),
+							PreemptionPossibility: new(preemptioncommon.Preempt),
 							Borrow:                1,
 							Reasons:               []string{"insufficient unused quota for cpu in flavor one, 10 more needed"},
 						},
@@ -4076,7 +4075,7 @@ func TestHierarchical(t *testing.T) {
 			flavorFungibility: &kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			simulationResult: map[resources.FlavorResource]simulationResultForFlavor{
 				{Flavor: "one", Resource: corev1.ResourceCPU}: {preemptioncommon.NoCandidates, 1},
@@ -6186,7 +6185,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			wantMode:           Fit,
 			wantTriedFlavorIdx: 0,
@@ -6199,7 +6198,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			// The quota scan stopped on flavor-1 and recorded it. TAS then rejected the
 			// flavor, and because the pod cannot fit a node even with every other
@@ -6219,7 +6218,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			// The real-state placement search fails, but the search that simulates every
 			// other Workload preempted succeeds, so the mode settles at Preempt. This is
@@ -6235,7 +6234,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.TryNextFlavor,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			// Borrowing is not optimal and WhenCanBorrow is TryNextFlavor, so the scan
 			// runs past flavor-1 and reaches the last flavor.
@@ -6250,7 +6249,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.MayStopSearch,
 				WhenCanPreempt: kueue.TryNextFlavor,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			wantMode:           Fit,
 			wantTriedFlavorIdx: 0,
@@ -6271,7 +6270,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.MayStopSearch,
 				WhenCanPreempt: kueue.MayStopSearch,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			wantMode:           Preempt,
 			wantTriedFlavorIdx: 0,
@@ -6294,7 +6293,7 @@ func TestFlavorScanRecordsLastTriedFlavorIdx(t *testing.T) {
 			fungibility: kueue.FlavorFungibility{
 				WhenCanBorrow:  kueue.MayStopSearch,
 				WhenCanPreempt: kueue.MayStopSearch,
-				Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+				Preference:     new(kueue.PreemptionOverBorrowing),
 			},
 			wantMode:           Preempt,
 			wantTriedFlavorIdx: -1,
@@ -6355,7 +6354,7 @@ func TestRecomputeRecordsLastTriedFlavorIdx(t *testing.T) {
 	fungibility := kueue.FlavorFungibility{
 		WhenCanBorrow:  kueue.TryNextFlavor,
 		WhenCanPreempt: kueue.TryNextFlavor,
-		Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+		Preference:     new(kueue.PreemptionOverBorrowing),
 	}
 
 	cases := map[string]struct {

--- a/pkg/scheduler/flavorassigner/tas_flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/tas_flavorassigner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
@@ -105,7 +104,7 @@ func podSetTopologyRequest(psAssignment *PodSetAssignment,
 	if cq.HasMultiKueueAdmissionCheck() || (!workload.HasQuotaReservation(wl.Obj) && cq.HasProvRequestAdmissionCheck(*tasFlvr)) {
 		// Delay TAS when MultiKueue is used (topology always assigned on worker cluster).
 		// For ProvisioningRequest, delay TAS on first scheduling pass only (topology assigned after provisioning).
-		psAssignment.DelayedTopologyRequest = ptr.To(kueue.DelayedTopologyRequestStatePending)
+		psAssignment.DelayedTopologyRequest = new(kueue.DelayedTopologyRequestStatePending)
 		return nil, nil
 	}
 	podSet := &wl.Obj.Spec.PodSets[podSetIndex]

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clocktesting "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -55,7 +54,7 @@ func TestFairPreemptions(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](-3),
+					MaxPriorityThreshold: new(int32(-3)),
 				},
 			}).
 			Obj(),
@@ -68,7 +67,7 @@ func TestFairPreemptions(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](-3),
+					MaxPriorityThreshold: new(int32(-3)),
 				},
 			}).
 			Obj(),
@@ -81,7 +80,7 @@ func TestFairPreemptions(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](-3),
+					MaxPriorityThreshold: new(int32(-3)),
 				},
 			}).
 			Obj(),

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clocktesting "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -364,7 +363,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](0),
+							MaxPriorityThreshold: new(int32(0)),
 						},
 					}).Obj(),
 				utiltestingapi.MakeClusterQueue("q_same_cohort").
@@ -579,7 +578,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](0),
+							MaxPriorityThreshold: new(int32(0)),
 						},
 					}).Obj(),
 				utiltestingapi.MakeClusterQueue("q_nominal").
@@ -800,7 +799,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](0),
+							MaxPriorityThreshold: new(int32(0)),
 						},
 					}).Obj(),
 				utiltestingapi.MakeClusterQueue("q_borrowing").
@@ -934,7 +933,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](0),
+							MaxPriorityThreshold: new(int32(0)),
 						},
 					}).Obj(),
 				utiltestingapi.MakeClusterQueue("q_borrowing").
@@ -1409,7 +1408,7 @@ func TestHierarchicalPreemptions(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](0),
+							MaxPriorityThreshold: new(int32(0)),
 						},
 					}).Obj(),
 				utiltestingapi.MakeClusterQueue("q_borrowing").

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
 	clocktesting "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -169,7 +168,7 @@ func TestPreemption(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](0),
+					MaxPriorityThreshold: new(int32(0)),
 				},
 			}).
 			Obj(),
@@ -185,7 +184,7 @@ func TestPreemption(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](0),
+					MaxPriorityThreshold: new(int32(0)),
 				},
 			}).
 			Obj(),
@@ -200,7 +199,7 @@ func TestPreemption(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](0),
+					MaxPriorityThreshold: new(int32(0)),
 				},
 			}).
 			Obj(),
@@ -215,7 +214,7 @@ func TestPreemption(t *testing.T) {
 				ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 				BorrowWithinCohort: &kueue.BorrowWithinCohort{
 					Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-					MaxPriorityThreshold: ptr.To[int32](0),
+					MaxPriorityThreshold: new(int32(0)),
 				},
 			}).
 			Obj(),
@@ -4842,7 +4841,7 @@ func TestPriorityInfo(t *testing.T) {
 		},
 		{
 			name:          "workload with priority only",
-			wl:            &kueue.Workload{Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](100)}},
+			wl:            &kueue.Workload{Spec: kueue.WorkloadSpec{Priority: new(int32(100))}},
 			wantEffective: 100,
 			wantBase:      100,
 			wantBoost:     0,
@@ -4854,7 +4853,7 @@ func TestPriorityInfo(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{controllerconstants.PriorityBoostAnnotationKey: "50"},
 				},
-				Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](200)},
+				Spec: kueue.WorkloadSpec{Priority: new(int32(200))},
 			},
 			wantEffective: 250,
 			wantBase:      200,
@@ -4867,7 +4866,7 @@ func TestPriorityInfo(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{controllerconstants.PriorityBoostAnnotationKey: "-30"},
 				},
-				Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](100)},
+				Spec: kueue.WorkloadSpec{Priority: new(int32(100))},
 			},
 			wantEffective: 70,
 			wantBase:      100,
@@ -4880,7 +4879,7 @@ func TestPriorityInfo(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{controllerconstants.PriorityBoostAnnotationKey: "not-a-number"},
 				},
-				Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](100)},
+				Spec: kueue.WorkloadSpec{Priority: new(int32(100))},
 			},
 			wantEffective: 100,
 			wantBase:      100,
@@ -4893,7 +4892,7 @@ func TestPriorityInfo(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{controllerconstants.PriorityBoostAnnotationKey: "1"},
 				},
-				Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](math.MaxInt32)},
+				Spec: kueue.WorkloadSpec{Priority: new(int32(math.MaxInt32))},
 			},
 			wantEffective: int64(math.MaxInt32) + 1,
 			wantBase:      math.MaxInt32,
@@ -4906,7 +4905,7 @@ func TestPriorityInfo(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{controllerconstants.PriorityBoostAnnotationKey: "50"},
 				},
-				Spec: kueue.WorkloadSpec{Priority: ptr.To[int32](100)},
+				Spec: kueue.WorkloadSpec{Priority: new(int32(100))},
 			},
 			wantEffective: 100,
 			wantBase:      100,

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -3469,7 +3468,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 					FlavorFungibility(kueue.FlavorFungibility{
 						WhenCanBorrow:  kueue.TryNextFlavor,
 						WhenCanPreempt: kueue.TryNextFlavor,
-						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+						Preference:     new(kueue.PreemptionOverBorrowing),
 					}).
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("on-demand").

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -3176,7 +3175,7 @@ func TestScheduleForTAS(t *testing.T) {
 		"workload with Resource Transformation (Retain CPU → cpu_credits)": {
 			resourceTransformations: []config.ResourceTransformation{{
 				Input:    corev1.ResourceCPU,
-				Strategy: ptr.To(config.Retain),
+				Strategy: new(config.Retain),
 				Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
 			}},
 			nodes:           defaultSingleNode,
@@ -3224,7 +3223,7 @@ func TestScheduleForTAS(t *testing.T) {
 		"workload with Resource Transformation (Retain CPU → cpu_credits, not enough credits)": {
 			resourceTransformations: []config.ResourceTransformation{{
 				Input:    corev1.ResourceCPU,
-				Strategy: ptr.To(config.Retain),
+				Strategy: new(config.Retain),
 				Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
 			}},
 			nodes:           defaultSingleNode,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/component-base/featuregate"
 	"k8s.io/component-base/metrics/testutil"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -6104,7 +6103,7 @@ func TestSchedule(t *testing.T) {
 					FlavorFungibility(kueue.FlavorFungibility{
 						WhenCanBorrow:  kueue.TryNextFlavor,
 						WhenCanPreempt: kueue.TryNextFlavor,
-						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+						Preference:     new(kueue.PreemptionOverBorrowing),
 					}).
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("on-demand").
@@ -6248,7 +6247,7 @@ func TestSchedule(t *testing.T) {
 					FlavorFungibility(kueue.FlavorFungibility{
 						WhenCanBorrow:  kueue.TryNextFlavor,
 						WhenCanPreempt: kueue.TryNextFlavor,
-						Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+						Preference:     new(kueue.PreemptionOverBorrowing),
 					}).
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("on-demand").
@@ -6352,7 +6351,7 @@ func TestSchedule(t *testing.T) {
 					FlavorFungibility(kueue.FlavorFungibility{
 						WhenCanBorrow:  kueue.TryNextFlavor,
 						WhenCanPreempt: kueue.TryNextFlavor,
-						Preference:     ptr.To(kueue.BorrowingOverPreemption),
+						Preference:     new(kueue.BorrowingOverPreemption),
 					}).
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("on-demand").
@@ -6809,7 +6808,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "high_pri_borrowing",
 					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}},
 			},
 			assignment: flavorassigner.Assignment{
@@ -6822,7 +6821,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "new_high_pri",
 					CreationTimestamp: metav1.NewTime(now.Add(4 * time.Second)),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}},
 			},
 		},
@@ -6886,7 +6885,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "high_pri_borrowing_more",
 					CreationTimestamp: metav1.NewTime(now.Add(3 * time.Second)),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}},
 			},
 			assignment: flavorassigner.Assignment{
@@ -6901,7 +6900,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "old-mid-recently-preempted-in-queue",
 					CreationTimestamp: metav1.NewTime(now),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}, Status: kueue.WorkloadStatus{
 					Conditions: []metav1.Condition{
 						{
@@ -6920,7 +6919,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "old-mid-recently-reclaimed-while-borrowing",
 					CreationTimestamp: metav1.NewTime(now),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}, Status: kueue.WorkloadStatus{
 					Conditions: []metav1.Condition{
 						{
@@ -6939,7 +6938,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "old-mid-more-recently-reclaimed-while-borrowing",
 					CreationTimestamp: metav1.NewTime(now),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}, Status: kueue.WorkloadStatus{
 					Conditions: []metav1.Condition{
 						{
@@ -6958,7 +6957,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "old-mid-not-preempted-yet",
 					CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](1),
+					Priority: new(int32(1)),
 				}},
 			},
 		},
@@ -6968,7 +6967,7 @@ func TestEntryOrdering(t *testing.T) {
 					Name:              "preemptor",
 					CreationTimestamp: metav1.NewTime(now.Add(7 * time.Second)),
 				}, Spec: kueue.WorkloadSpec{
-					Priority: ptr.To[int32](2),
+					Priority: new(int32(2)),
 				}},
 			},
 		},

--- a/pkg/util/tas/tas_assignment_test.go
+++ b/pkg/util/tas/tas_assignment_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -641,7 +640,7 @@ func TestCompactTopologyAssignmentEncodingWithHostnamePrefixRuns(t *testing.T) {
 					{
 						DomainCount: 2,
 						PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-							Universal: ptr.To[int32](3),
+							Universal: new(int32(3)),
 						},
 						ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 							{
@@ -1389,7 +1388,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 								{
 									DomainCount: 1,
 									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-										Universal: ptr.To[int32](1),
+										Universal: new(int32(1)),
 									},
 									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 										{
@@ -1417,7 +1416,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 								{
 									DomainCount: 1,
 									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-										Universal: ptr.To[int32](1),
+										Universal: new(int32(1)),
 									},
 									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 										{
@@ -1445,7 +1444,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 								{
 									DomainCount: 1,
 									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-										Universal: ptr.To[int32](1),
+										Universal: new(int32(1)),
 									},
 									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 										{
@@ -1503,7 +1502,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 								{
 									DomainCount: 1,
 									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-										Universal: ptr.To[int32](1),
+										Universal: new(int32(1)),
 									},
 									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 										{
@@ -1522,7 +1521,7 @@ func TestHasTASAssignmentOnNode(t *testing.T) {
 								{
 									DomainCount: 1,
 									PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-										Universal: ptr.To[int32](5),
+										Universal: new(int32(5)),
 									},
 									ValuesPerLevel: []kueue.TopologyAssignmentSliceLevelValues{
 										{

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -1431,7 +1430,7 @@ func MakePodSetAssignment(name kueue.PodSetReference) *PodSetAssignmentWrapper {
 			Name:          name,
 			Flavors:       make(map[corev1.ResourceName]kueue.ResourceFlavorReference),
 			ResourceUsage: make(corev1.ResourceList),
-			Count:         ptr.To[int32](1),
+			Count:         new(int32(1)),
 		},
 	}
 }

--- a/pkg/util/testing/wrappers.go
+++ b/pkg/util/testing/wrappers.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	utilResource "sigs.k8s.io/kueue/pkg/util/resource"
@@ -202,7 +201,7 @@ func (c *ContainerWrapper) WithEnvVar(envVar corev1.EnvVar) *ContainerWrapper {
 
 // AsSidecar makes the container a sidecar when used as an Init Container.
 func (c *ContainerWrapper) AsSidecar() *ContainerWrapper {
-	c.RestartPolicy = ptr.To(corev1.ContainerRestartPolicyAlways)
+	c.RestartPolicy = new(corev1.ContainerRestartPolicyAlways)
 
 	return c
 }

--- a/pkg/util/testingjobs/jaxjob/wrappers.go
+++ b/pkg/util/testingjobs/jaxjob/wrappers.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
@@ -78,7 +77,7 @@ func (j *JAXJobWrapper) JAXReplicaSpecs(replicaSpecs ...JAXReplicaSpecRequiremen
 
 func (j *JAXJobWrapper) JAXReplicaSpecsDefault() *JAXJobWrapper {
 	j.Spec.JAXReplicaSpecs[kftraining.JAXJobReplicaTypeWorker] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",

--- a/pkg/util/testingjobs/job/wrappers.go
+++ b/pkg/util/testingjobs/job/wrappers.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -45,7 +44,7 @@ func MakeJob(name, ns string) *JobWrapper {
 			Annotations: make(map[string]string, 1),
 		},
 		Spec: batchv1.JobSpec{
-			Parallelism: ptr.To[int32](1),
+			Parallelism: new(int32(1)),
 			Suspend:     new(true),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/pkg/util/testingjobs/jobset/wrappers.go
+++ b/pkg/util/testingjobs/jobset/wrappers.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	jobsetutil "sigs.k8s.io/jobset/pkg/util/testing"
 
@@ -93,12 +92,12 @@ func (j *JobSetWrapper) ReplicatedJobs(replicatedJobs ...ReplicatedJobRequiremen
 		if req.BackoffLimit != nil {
 			jt.Spec.BackoffLimit = req.BackoffLimit
 		} else if len(req.Image) > 0 {
-			jt.Spec.BackoffLimit = ptr.To[int32](0)
+			jt.Spec.BackoffLimit = new(int32(0))
 		}
 		if len(req.Image) > 0 {
 			spec := &jt.Spec.Template.Spec
 			spec.RestartPolicy = corev1.RestartPolicyNever
-			spec.TerminationGracePeriodSeconds = ptr.To[int64](0)
+			spec.TerminationGracePeriodSeconds = new(int64(0))
 			spec.Containers = []corev1.Container{
 				{
 					Name:  "c",

--- a/pkg/util/testingjobs/leaderworkerset/wrappers.go
+++ b/pkg/util/testingjobs/leaderworkerset/wrappers.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -46,7 +45,7 @@ func MakeLeaderWorkerSet(name, ns string) *LeaderWorkerSetWrapper {
 			Namespace: ns,
 		},
 		Spec: leaderworkersetv1.LeaderWorkerSetSpec{
-			Replicas:      ptr.To[int32](1),
+			Replicas:      new(int32(1)),
 			StartupPolicy: leaderworkersetv1.LeaderCreatedStartupPolicy,
 			LeaderWorkerTemplate: leaderworkersetv1.LeaderWorkerTemplate{
 				WorkerTemplate: corev1.PodTemplateSpec{
@@ -61,7 +60,7 @@ func MakeLeaderWorkerSet(name, ns string) *LeaderWorkerSetWrapper {
 						NodeSelector: map[string]string{},
 					},
 				},
-				Size: ptr.To[int32](1),
+				Size: new(int32(1)),
 			},
 		},
 	}}

--- a/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
+++ b/pkg/util/testingjobs/mpijob/wrappers_mpijob.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -79,7 +78,7 @@ func (j *MPIJobWrapper) MPIJobReplicaSpecs(replicaSpecs ...MPIJobReplicaSpecRequ
 func (j *MPIJobWrapper) GenericLauncherAndWorker() *MPIJobWrapper {
 	j.GenericLauncher()
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeWorker] = &kfmpi.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: corev1.RestartPolicyNever,
@@ -104,7 +103,7 @@ func (j *MPIJobWrapper) GenericLauncherAndWorker() *MPIJobWrapper {
 
 func (j *MPIJobWrapper) GenericLauncher() *MPIJobWrapper {
 	j.Spec.MPIReplicaSpecs[kfmpi.MPIReplicaTypeLauncher] = &kfmpi.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: corev1.RestartPolicyNever,

--- a/pkg/util/testingjobs/paddlejob/wrappers.go
+++ b/pkg/util/testingjobs/paddlejob/wrappers.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
@@ -74,7 +73,7 @@ func (j *PaddleJobWrapper) PaddleReplicaSpecs(replicaSpecs ...PaddleReplicaSpecR
 
 func (j *PaddleJobWrapper) PaddleReplicaSpecsDefault() *PaddleJobWrapper {
 	j.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeMaster] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -92,7 +91,7 @@ func (j *PaddleJobWrapper) PaddleReplicaSpecsDefault() *PaddleJobWrapper {
 	}
 
 	j.Spec.PaddleReplicaSpecs[kftraining.PaddleJobReplicaTypeWorker] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",

--- a/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
+++ b/pkg/util/testingjobs/pytorchjob/wrappers_pytorchjob.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
@@ -78,7 +77,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecs(replicaSpecs ...PyTorchReplicaSp
 
 func (j *PyTorchJobWrapper) PyTorchReplicaSpecsOnlyMasterDefault() *PyTorchJobWrapper {
 	j.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeMaster] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -94,7 +93,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecsOnlyMasterDefault() *PyTorchJobWr
 					},
 				},
 				NodeSelector:                  map[string]string{},
-				TerminationGracePeriodSeconds: ptr.To[int64](1),
+				TerminationGracePeriodSeconds: new(int64(1)),
 			},
 		},
 	}
@@ -106,7 +105,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecsDefault() *PyTorchJobWrapper {
 	j.PyTorchReplicaSpecsOnlyMasterDefault()
 
 	j.Spec.PyTorchReplicaSpecs[kftraining.PyTorchJobReplicaTypeWorker] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -122,7 +121,7 @@ func (j *PyTorchJobWrapper) PyTorchReplicaSpecsDefault() *PyTorchJobWrapper {
 					},
 				},
 				NodeSelector:                  map[string]string{},
-				TerminationGracePeriodSeconds: ptr.To[int64](1),
+				TerminationGracePeriodSeconds: new(int64(1)),
 			},
 		},
 	}

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -73,9 +72,9 @@ func MakeCluster(name, ns string) *ClusterWrapper {
 			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 				{
 					GroupName:      "workers-group-0",
-					Replicas:       ptr.To[int32](1),
-					MinReplicas:    ptr.To[int32](0),
-					MaxReplicas:    ptr.To[int32](10),
+					Replicas:       new(int32(1)),
+					MinReplicas:    new(int32(0)),
+					MaxReplicas:    new(int32(10)),
 					RayStartParams: map[string]string{},
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{

--- a/pkg/util/testingjobs/rayjob/wrappers.go
+++ b/pkg/util/testingjobs/rayjob/wrappers.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -66,9 +65,9 @@ func MakeJob(name, ns string) *JobWrapper {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName:      "workers-group-0",
-						Replicas:       ptr.To[int32](1),
-						MinReplicas:    ptr.To[int32](1),
-						MaxReplicas:    ptr.To[int32](5),
+						Replicas:       new(int32(1)),
+						MinReplicas:    new(int32(1)),
+						MaxReplicas:    new(int32(5)),
 						RayStartParams: map[string]string{},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{

--- a/pkg/util/testingjobs/rayservice/wrappers.go
+++ b/pkg/util/testingjobs/rayservice/wrappers.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -63,9 +62,9 @@ func MakeService(name, ns string) *ServiceWrapper {
 				WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
 					{
 						GroupName:      "workers-group-0",
-						Replicas:       ptr.To[int32](1),
-						MinReplicas:    ptr.To[int32](0),
-						MaxReplicas:    ptr.To[int32](10),
+						Replicas:       new(int32(1)),
+						MinReplicas:    new(int32(0)),
+						MaxReplicas:    new(int32(10)),
 						RayStartParams: map[string]string{},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{

--- a/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
+++ b/pkg/util/testingjobs/sparkapplication/wrappers_sparkapplication.go
@@ -18,7 +18,6 @@ import (
 	sparkappv1beta2 "github.com/kubeflow/spark-operator/v2/api/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 )
@@ -54,7 +53,7 @@ func MakeSparkApplication(name, ns string) *SparkApplicationWrapper {
 					ServiceAccount: new("spark-operator-spark"),
 				},
 				CoreRequest:         new("100m"),
-				Instances:           ptr.To[int32](1),
+				Instances:           new(int32(1)),
 				DeleteOnTermination: new(false),
 			},
 		},

--- a/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
+++ b/pkg/util/testingjobs/tfjob/wrappers_tfjob.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
@@ -74,7 +73,7 @@ func (j *TFJobWrapper) TFReplicaSpecs(replicaSpecs ...TFReplicaSpecRequirement) 
 
 func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 	j.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeChief] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -92,7 +91,7 @@ func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 	}
 
 	j.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypePS] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -110,7 +109,7 @@ func (j *TFJobWrapper) TFReplicaSpecsDefault() *TFJobWrapper {
 	}
 
 	j.Spec.TFReplicaSpecs[kftraining.TFJobReplicaTypeWorker] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",

--- a/pkg/util/testingjobs/xgboostjob/wrappers.go
+++ b/pkg/util/testingjobs/xgboostjob/wrappers.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	utiltestingjobs "sigs.k8s.io/kueue/pkg/util/testingjobs"
@@ -74,7 +73,7 @@ func (j *XGBoostJobWrapper) XGBReplicaSpecs(replicaSpecs ...XGBReplicaSpecRequir
 
 func (j *XGBoostJobWrapper) XGBReplicaSpecsDefault() *XGBoostJobWrapper {
 	j.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeMaster] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",
@@ -92,7 +91,7 @@ func (j *XGBoostJobWrapper) XGBReplicaSpecsDefault() *XGBoostJobWrapper {
 	}
 
 	j.Spec.XGBReplicaSpecs[kftraining.XGBoostJobReplicaTypeWorker] = &kftraining.ReplicaSpec{
-		Replicas: ptr.To[int32](1),
+		Replicas: new(int32(1)),
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				RestartPolicy: "Never",

--- a/pkg/webhooks/clusterqueue_webhook_test.go
+++ b/pkg/webhooks/clusterqueue_webhook_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -304,7 +303,7 @@ func TestValidateClusterQueue(t *testing.T) {
 						ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 						BorrowWithinCohort: &kueue.BorrowWithinCohort{
 							Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-							MaxPriorityThreshold: ptr.To[int32](10),
+							MaxPriorityThreshold: new(int32(10)),
 						},
 					},
 				},
@@ -329,7 +328,7 @@ func TestValidateClusterQueue(t *testing.T) {
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanBorrow:  kueue.TryNextFlavor,
 					WhenCanPreempt: kueue.MayStopSearch,
-					Preference:     ptr.To(kueue.BorrowingOverPreemption),
+					Preference:     new(kueue.BorrowingOverPreemption),
 				}).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(specPath.Child("flavorFungibility", "preference"), "", ""),
@@ -343,7 +342,7 @@ func TestValidateClusterQueue(t *testing.T) {
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanBorrow:  kueue.MayStopSearch,
 					WhenCanPreempt: kueue.MayStopSearch,
-					Preference:     ptr.To(kueue.BorrowingOverPreemption),
+					Preference:     new(kueue.BorrowingOverPreemption),
 				}).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(specPath.Child("flavorFungibility", "preference"), "", ""),
@@ -357,7 +356,7 @@ func TestValidateClusterQueue(t *testing.T) {
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanBorrow:  kueue.TryNextFlavor,
 					WhenCanPreempt: kueue.TryNextFlavor,
-					Preference:     ptr.To(kueue.BorrowingOverPreemption),
+					Preference:     new(kueue.BorrowingOverPreemption),
 				}).Obj(),
 		},
 		{
@@ -366,7 +365,7 @@ func TestValidateClusterQueue(t *testing.T) {
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanBorrow:  kueue.TryNextFlavor,
 					WhenCanPreempt: kueue.TryNextFlavor,
-					Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					Preference:     new(kueue.PreemptionOverBorrowing),
 				}).Obj(),
 		},
 		{
@@ -375,7 +374,7 @@ func TestValidateClusterQueue(t *testing.T) {
 				FlavorFungibility(kueue.FlavorFungibility{
 					WhenCanBorrow:  kueue.MayStopSearch,
 					WhenCanPreempt: kueue.TryNextFlavor,
-					Preference:     ptr.To(kueue.PreemptionOverBorrowing),
+					Preference:     new(kueue.PreemptionOverBorrowing),
 				}).Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(specPath.Child("flavorFungibility", "preference"), "", ""),

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -29,7 +29,6 @@ import (
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -413,7 +412,7 @@ func TestValidateWorkload(t *testing.T) {
 									Operator:          corev1.TolerationOpEqual,
 									Value:             "t1v",
 									Effect:            corev1.TaintEffectNoExecute,
-									TolerationSeconds: ptr.To[int64](5),
+									TolerationSeconds: new(int64(5)),
 								},
 							},
 							NodeSelector: map[string]string{"type": "first"},
@@ -428,7 +427,7 @@ func TestValidateWorkload(t *testing.T) {
 									Operator:          corev1.TolerationOpEqual,
 									Value:             "t2v",
 									Effect:            corev1.TaintEffectNoExecute,
-									TolerationSeconds: ptr.To[int64](10),
+									TolerationSeconds: new(int64(10)),
 								},
 							},
 							NodeSelector: map[string]string{"type": "second"},
@@ -905,7 +904,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 3).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(8))}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -917,7 +916,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 3).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(8))}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -937,7 +936,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 10).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](20)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(20))}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -949,7 +948,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 10).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](20)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(20))}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -995,7 +994,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 8).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(8))}).
 						Obj(), now,
 				).
 				ReclaimablePods(
@@ -1007,7 +1006,7 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 				PodSets(*utiltestingapi.MakePodSet("ps1", 1).Obj()).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("cluster-queue").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](8)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(8))}).
 						Obj(), now,
 				).
 				Obj(),

--- a/pkg/workload/admissionchecks_test.go
+++ b/pkg/workload/admissionchecks_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/featuregate"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -261,8 +260,8 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
 						Name:                   kueue.DefaultPodSetName,
-						Count:                  ptr.To[int32](1),
-						DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStatePending),
+						Count:                  new(int32(1)),
+						DelayedTopologyRequest: new(kueue.DelayedTopologyRequestStatePending),
 					},
 				},
 			},
@@ -302,8 +301,8 @@ func TestSyncAdmittedCondition(t *testing.T) {
 				PodSetAssignments: []kueue.PodSetAssignment{
 					{
 						Name:                   kueue.DefaultPodSetName,
-						Count:                  ptr.To[int32](1),
-						DelayedTopologyRequest: ptr.To(kueue.DelayedTopologyRequestStatePending),
+						Count:                  new(int32(1)),
+						DelayedTopologyRequest: new(kueue.DelayedTopologyRequestStatePending),
 					},
 				},
 			},
@@ -551,7 +550,7 @@ func TestGetMaxRetryTime(t *testing.T) {
 					Name:                "check1",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(time.Time{}),
-					RequeueAfterSeconds: ptr.To[int32](60),
+					RequeueAfterSeconds: new(int32(60)),
 				},
 			},
 			wantRetryTime: metav1.NewTime(time.Time{}),
@@ -562,7 +561,7 @@ func TestGetMaxRetryTime(t *testing.T) {
 					Name:                "check1",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](60),
+					RequeueAfterSeconds: new(int32(60)),
 				},
 			},
 			wantRetryTime: metav1.NewTime(baseTime.Add(60 * time.Second)),
@@ -573,19 +572,19 @@ func TestGetMaxRetryTime(t *testing.T) {
 					Name:                "check1",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](60),
+					RequeueAfterSeconds: new(int32(60)),
 				},
 				{
 					Name:                "check2",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](120),
+					RequeueAfterSeconds: new(int32(120)),
 				},
 				{
 					Name:                "check3",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](30),
+					RequeueAfterSeconds: new(int32(30)),
 				},
 			},
 			wantRetryTime: metav1.NewTime(baseTime.Add(120 * time.Second)),
@@ -602,13 +601,13 @@ func TestGetMaxRetryTime(t *testing.T) {
 					Name:                "check2",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](90),
+					RequeueAfterSeconds: new(int32(90)),
 				},
 				{
 					Name:                "check3",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(time.Time{}),
-					RequeueAfterSeconds: ptr.To[int32](180),
+					RequeueAfterSeconds: new(int32(180)),
 				},
 			},
 			wantRetryTime: metav1.NewTime(baseTime.Add(90 * time.Second)),
@@ -619,13 +618,13 @@ func TestGetMaxRetryTime(t *testing.T) {
 					Name:                "check1",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime),
-					RequeueAfterSeconds: ptr.To[int32](60),
+					RequeueAfterSeconds: new(int32(60)),
 				},
 				{
 					Name:                "check2",
 					State:               kueue.CheckStateRetry,
 					LastTransitionTime:  metav1.NewTime(baseTime.Add(30 * time.Second)),
-					RequeueAfterSeconds: ptr.To[int32](60),
+					RequeueAfterSeconds: new(int32(60)),
 				},
 			},
 			wantRetryTime: metav1.NewTime(baseTime.Add(90 * time.Second)),

--- a/pkg/workload/patching/patching_test.go
+++ b/pkg/workload/patching/patching_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -76,7 +75,7 @@ func TestSetCheckState(t *testing.T) {
 				Operator:          corev1.TolerationOpEqual,
 				Value:             "t1v",
 				Effect:            corev1.TaintEffectNoSchedule,
-				TolerationSeconds: ptr.To[int64](5),
+				TolerationSeconds: new(int64(5)),
 			},
 		},
 	}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
@@ -284,7 +283,7 @@ func TestNewInfo(t *testing.T) {
 								corev1.ResourceCPU:    resource.MustParse("10m"),
 								corev1.ResourceMemory: resource.MustParse("512Ki"),
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 						kueue.PodSetAssignment{
 							Name: "workers",
@@ -293,7 +292,7 @@ func TestNewInfo(t *testing.T) {
 								corev1.ResourceMemory: resource.MustParse("3Mi"),
 								"ex.com/gpu":          resource.MustParse("3"),
 							},
-							Count: ptr.To[int32](3),
+							Count: new(int32(3)),
 						},
 					).
 					Obj(), now).
@@ -632,7 +631,7 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:    "nvidia.com/mig-1g.5gb",
-					Strategy: ptr.To(config.Replace),
+					Strategy: new(config.Replace),
 					Outputs: corev1.ResourceList{
 						"example.com/accelerator-memory": resource.MustParse("5Ki"),
 						"example.com/credits":            resource.MustParse("10"),
@@ -640,7 +639,7 @@ func TestNewInfo(t *testing.T) {
 				},
 				{
 					Input:    "nvidia.com/mig-2g.10gb",
-					Strategy: ptr.To(config.Replace),
+					Strategy: new(config.Replace),
 					Outputs: corev1.ResourceList{
 						"example.com/accelerator-memory": resource.MustParse("10Ki"),
 						"example.com/credits":            resource.MustParse("15"),
@@ -648,7 +647,7 @@ func TestNewInfo(t *testing.T) {
 				},
 				{
 					Input:    "nvidia.com/gpu",
-					Strategy: ptr.To(config.Retain),
+					Strategy: new(config.Retain),
 					Outputs: corev1.ResourceList{
 						"example.com/accelerator-memory": resource.MustParse("40Ki"),
 						"example.com/credits":            resource.MustParse("100"),
@@ -656,7 +655,7 @@ func TestNewInfo(t *testing.T) {
 				},
 				{
 					Input:      "nvidia.com/vgpucores",
-					Strategy:   ptr.To(config.Replace),
+					Strategy:   new(config.Replace),
 					MultiplyBy: "nvidia.com/vgpu",
 					Outputs: corev1.ResourceList{
 						"nvidia.com/total-vgpucores": resource.MustParse("1"),
@@ -664,7 +663,7 @@ func TestNewInfo(t *testing.T) {
 				},
 				{
 					Input:      "nvidia.com/vgpumem",
-					Strategy:   ptr.To(config.Replace),
+					Strategy:   new(config.Replace),
 					MultiplyBy: "nvidia.com/vgpu",
 					Outputs: corev1.ResourceList{
 						"nvidia.com/total-vgpumem": resource.MustParse("1"),
@@ -725,13 +724,13 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:      "nvidia.com/gpumem",
-					Strategy:   ptr.To(config.Replace),
+					Strategy:   new(config.Replace),
 					MultiplyBy: "nvidia.com/gpu",
 					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
 				},
 				{
 					Input:    "nvidia.com/gpu",
-					Strategy: ptr.To(config.Retain),
+					Strategy: new(config.Retain),
 					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
 				},
 			})},
@@ -755,13 +754,13 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:      "nvidia.com/gpumem",
-					Strategy:   ptr.To(config.Replace),
+					Strategy:   new(config.Replace),
 					MultiplyBy: "nvidia.com/gpu",
 					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
 				},
 				{
 					Input:    "nvidia.com/gpu",
-					Strategy: ptr.To(config.Retain),
+					Strategy: new(config.Retain),
 					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
 				},
 			})},
@@ -785,13 +784,13 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:      "nvidia.com/gpumem",
-					Strategy:   ptr.To(config.Replace),
+					Strategy:   new(config.Replace),
 					MultiplyBy: "nvidia.com/gpu",
 					Outputs:    corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("1")},
 				},
 				{
 					Input:    "nvidia.com/gpu",
-					Strategy: ptr.To(config.Retain),
+					Strategy: new(config.Retain),
 					Outputs:  corev1.ResourceList{"quota.example.com/gpu-memory-overage": resource.MustParse("-1024")},
 				},
 			})},
@@ -817,7 +816,7 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
 				Input:    "example.com/credit",
-				Strategy: ptr.To(config.Replace),
+				Strategy: new(config.Replace),
 				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("-1")},
 			}})},
 			wantInfo: Info{
@@ -840,7 +839,7 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
 				Input:    "example.com/credit",
-				Strategy: ptr.To(config.Replace),
+				Strategy: new(config.Replace),
 				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
 			}})},
 			wantInfo: Info{
@@ -862,7 +861,7 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
 				Input:    "example.com/gpu",
-				Strategy: ptr.To(config.Retain),
+				Strategy: new(config.Retain),
 				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("5")},
 			}})},
 			wantInfo: Info{
@@ -887,7 +886,7 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:      "example.com/gpumem",
-					Strategy:   ptr.To(config.Retain),
+					Strategy:   new(config.Retain),
 					MultiplyBy: "example.com/gpu",
 					Outputs: corev1.ResourceList{
 						"example.com/gpumem-quota": resource.MustParse("1"),
@@ -957,7 +956,7 @@ func TestNewInfo(t *testing.T) {
 				Obj(),
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
 				Input:      "example.com/gpu",
-				Strategy:   ptr.To(config.Retain),
+				Strategy:   new(config.Retain),
 				MultiplyBy: "example.com/node",
 				Outputs:    corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
 			}})},
@@ -984,14 +983,14 @@ func TestNewInfo(t *testing.T) {
 			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{
 				{
 					Input:    corev1.ResourceCPU,
-					Strategy: ptr.To(config.Replace),
+					Strategy: new(config.Replace),
 					Outputs: corev1.ResourceList{
 						"example.com/cpu-credits": resource.MustParse("3000"),
 					},
 				},
 				{
 					Input:    corev1.ResourceMemory,
-					Strategy: ptr.To(config.Replace),
+					Strategy: new(config.Replace),
 					Outputs: corev1.ResourceList{
 						"example.com/memory-credits": resource.MustParse("3m"),
 					},
@@ -1078,7 +1077,7 @@ func TestUpdateWithRebuild(t *testing.T) {
 					PodSets(kueue.PodSetAssignment{
 						Name:          kueue.DefaultPodSetName,
 						ResourceUsage: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
-						Count:         ptr.To[int32](1),
+						Count:         new(int32(1)),
 					}).Obj(), now).
 				Obj(),
 			wantRequests: []PodSetResources{{
@@ -2537,14 +2536,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: true,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(futureTime)),
-			wantCount:      ptr.To[int32](1),
+			wantCount:      new(int32(1)),
 		},
 		"should update time when existing requeue time is earlier": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(pastTime)),
-						Count:     ptr.To[int32](2),
+						Count:     new(int32(2)),
 					},
 				},
 			},
@@ -2552,14 +2551,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: false,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(futureTime)),
-			wantCount:      ptr.To[int32](2),
+			wantCount:      new(int32(2)),
 		},
 		"should not update time when existing requeue time is later": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(evenMoreFutureTime)),
-						Count:     ptr.To[int32](3),
+						Count:     new(int32(3)),
 					},
 				},
 			},
@@ -2567,14 +2566,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: false,
 			wantUpdated:    false,
 			wantRequeueAt:  new(metav1.NewTime(evenMoreFutureTime)),
-			wantCount:      ptr.To[int32](3),
+			wantCount:      new(int32(3)),
 		},
 		"should increment count but keep later requeue time": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(evenMoreFutureTime)),
-						Count:     ptr.To[int32](3),
+						Count:     new(int32(3)),
 					},
 				},
 			},
@@ -2582,14 +2581,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: true,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(evenMoreFutureTime)),
-			wantCount:      ptr.To[int32](4),
+			wantCount:      new(int32(4)),
 		},
 		"should increment count when requeue time is same": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(futureTime)),
-						Count:     ptr.To[int32](1),
+						Count:     new(int32(1)),
 					},
 				},
 			},
@@ -2597,14 +2596,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: true,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(futureTime)),
-			wantCount:      ptr.To[int32](2),
+			wantCount:      new(int32(2)),
 		},
 		"should increment from zero count": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(pastTime)),
-						Count:     ptr.To[int32](0),
+						Count:     new(int32(0)),
 					},
 				},
 			},
@@ -2612,14 +2611,14 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: true,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(futureTime)),
-			wantCount:      ptr.To[int32](1),
+			wantCount:      new(int32(1)),
 		},
 		"should handle zero time in requeue state": {
 			workload: &kueue.Workload{
 				Status: kueue.WorkloadStatus{
 					RequeueState: &kueue.RequeueState{
 						RequeueAt: new(metav1.NewTime(time.Time{})),
-						Count:     ptr.To[int32](0),
+						Count:     new(int32(0)),
 					},
 				},
 			},
@@ -2627,7 +2626,7 @@ func TestSetRequeueState(t *testing.T) {
 			incrementCount: true,
 			wantUpdated:    true,
 			wantRequeueAt:  new(metav1.NewTime(futureTime)),
-			wantCount:      ptr.To[int32](1),
+			wantCount:      new(int32(1)),
 		},
 	}
 
@@ -3167,7 +3166,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3198,7 +3197,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3240,7 +3239,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3271,7 +3270,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3290,7 +3289,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3321,7 +3320,7 @@ func TestUsedNodes(t *testing.T) {
 												}},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},
@@ -3353,7 +3352,7 @@ func TestUsedNodes(t *testing.T) {
 												{Universal: new("rack-1")},
 											},
 											PodCounts: kueue.TopologyAssignmentSlicePodCounts{
-												Universal: ptr.To[int32](1),
+												Universal: new(int32(1)),
 											},
 										},
 									},

--- a/test/e2e/dra/whole-device/dra_test.go
+++ b/test/e2e/dra/whole-device/dra_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -466,7 +465,7 @@ var _ = ginkgo.Describe("DRA", func() {
 						},
 					},
 					// This is the key field for Extended Resources backed by DRA
-					ExtendedResourceName: ptr.To(extendedResourceName),
+					ExtendedResourceName: new(extendedResourceName),
 				},
 			}
 			util.MustCreate(ctx, k8sClient, extendedResDevClass)
@@ -780,7 +779,7 @@ var _ = ginkgo.Describe("DRA", func() {
 							},
 						},
 					},
-					ExtendedResourceName: ptr.To(extendedResourceName),
+					ExtendedResourceName: new(extendedResourceName),
 				},
 			}
 			util.MustCreate(ctx, k8sClient, deviceClass)

--- a/test/e2e/multikueue/baseline/e2e_test.go
+++ b/test/e2e/multikueue/baseline/e2e_test.go
@@ -438,7 +438,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				createdDeployment := &appsv1.Deployment{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).To(gomega.Succeed())
-					createdDeployment.Spec.Replicas = ptr.To[int32](4)
+					createdDeployment.Spec.Replicas = new(int32(4))
 					g.Expect(k8sManagerClient.Update(ctx, createdDeployment)).To(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
@@ -459,7 +459,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				createdDeployment := &appsv1.Deployment{}
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(deployment), createdDeployment)).To(gomega.Succeed())
-					createdDeployment.Spec.Replicas = ptr.To[int32](2)
+					createdDeployment.Spec.Replicas = new(int32(2))
 					g.Expect(k8sManagerClient.Update(ctx, createdDeployment)).To(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
@@ -1326,7 +1326,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					cfg := &kueue.MultiKueueConfig{}
 					g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(multiKueueConfig), cfg)).To(gomega.Succeed())
-					cfg.Spec.QuotaManagement = ptr.To(kueue.QuotaManagementAutomated)
+					cfg.Spec.QuotaManagement = new(kueue.QuotaManagementAutomated)
 					g.Expect(k8sManagerClient.Update(ctx, cfg)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/multikueue/baseline/tas_test.go
+++ b/test/e2e/multikueue/baseline/tas_test.go
@@ -65,7 +65,7 @@ func waitForDelayedTopologyRequestReady(wlLookupKey types.NamespacedName) {
 		g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 		g.Expect(managerWl.Status.Admission).NotTo(gomega.BeNil())
 		g.Expect(managerWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
-		g.Expect(managerWl.Status.Admission.PodSetAssignments[0].DelayedTopologyRequest).To(gomega.Equal(ptr.To(kueue.DelayedTopologyRequestStateReady)))
+		g.Expect(managerWl.Status.Admission.PodSetAssignments[0].DelayedTopologyRequest).To(gomega.Equal(new(kueue.DelayedTopologyRequestStateReady)))
 	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 }
 

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -845,7 +845,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						createdRayCluster := &rayv1.RayCluster{}
 						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
-						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](3)
+						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(3))
 						g.Expect(k8sManagerClient.Update(ctx, createdRayCluster)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -862,7 +862,7 @@ var _ = ginkgo.Describe("MultiKueue", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						createdRayCluster := &rayv1.RayCluster{}
 						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(raycluster), createdRayCluster)).To(gomega.Succeed())
-						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = ptr.To[int32](1)
+						createdRayCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(1))
 						g.Expect(k8sManagerClient.Update(ctx, createdRayCluster)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -958,8 +958,8 @@ app = HelloWorld.bind()`,
 					Obj()
 
 				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].GroupName = "small-group"
-				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas = ptr.To[int32](1)
-				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = ptr.To[int32](2)
+				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MinReplicas = new(int32(1))
+				rayService.Spec.RayClusterSpec.WorkerGroupSpecs[0].MaxReplicas = new(int32(2))
 
 				ginkgo.By("Creating the ConfigMap on all clusters", func() {
 					worker1ConfigMap := configMap.DeepCopy()

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -235,7 +235,7 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 					if cfg.MultiKueue == nil {
 						cfg.MultiKueue = &kueueconfig.MultiKueue{}
 					}
-					cfg.MultiKueue.DispatcherName = ptr.To(kueueconfig.MultiKueueDispatcherModeIncremental)
+					cfg.MultiKueue.DispatcherName = new(kueueconfig.MultiKueueDispatcherModeIncremental)
 				})
 			})
 		})

--- a/test/e2e/sequential/baseline/custom_metrics_test.go
+++ b/test/e2e/sequential/baseline/custom_metrics_test.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -74,13 +73,13 @@ var _ = ginkgo.Describe("Pod groups", ginkgo.Label("area:singlecluster", "featur
 					{
 						Name:           "custom_label_key",
 						SourceLabelKey: "toCopyKeyCustom",
-						SourceKind:     ptr.To(config.SourceKindWorkload),
+						SourceKind:     new(config.SourceKindWorkload),
 						TrackedValues:  []string{"custom_value"},
 					},
 					{
 						Name:                "custom_annotation_key",
 						SourceAnnotationKey: "toCopyAnnotation",
-						SourceKind:          ptr.To(config.SourceKindWorkload),
+						SourceKind:          new(config.SourceKindWorkload),
 						TrackedValues:       []string{"annotation_value"},
 					},
 				}

--- a/test/e2e/sequential/baseline/default_config_test.go
+++ b/test/e2e/sequential/baseline/default_config_test.go
@@ -29,7 +29,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -147,7 +146,7 @@ var _ = ginkgo.Describe("Default configuration tests", ginkgo.Label(util.Shard0)
 			ginkgo.By("verify the localQueue can be fetched and mutated", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), localQueue)).To(gomega.Succeed())
-					localQueue.Spec.StopPolicy = ptr.To(kueue.Hold)
+					localQueue.Spec.StopPolicy = new(kueue.Hold)
 					g.Expect(k8sClient.Update(ctx, localQueue)).Should(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/sequential/baseline/failure_recovery_policy_test.go
+++ b/test/e2e/sequential/baseline/failure_recovery_policy_test.go
@@ -25,7 +25,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -65,7 +64,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			RequestAndLimit(corev1.ResourceMemory, "40Mi").
 			Parallelism(1).
 			TerminationGracePeriod(podTerminationGracePeriodSeconds).
-			PodReplacementPolicy(ptr.To(batchv1.Failed)).
+			PodReplacementPolicy(new(batchv1.Failed)).
 			PodAnnotation(constants.SafeToForcefullyDeleteAnnotationKey, constants.SafeToForcefullyDeleteAnnotationValue).
 			PodAffinity(&corev1.Affinity{
 				PodAntiAffinity: &corev1.PodAntiAffinity{
@@ -85,7 +84,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 				Key:               corev1.TaintNodeUnreachable,
 				Operator:          corev1.TolerationOpExists,
 				Effect:            corev1.TaintEffectNoExecute,
-				TolerationSeconds: ptr.To[int64](1),
+				TolerationSeconds: new(int64(1)),
 			}).
 			Obj()
 	})
@@ -181,7 +180,7 @@ var _ = ginkgo.Describe("Failure Recovery Policy", ginkgo.Label("feature:failure
 			})
 
 			ginkgo.By("deleting the job with foreground propagation", func() {
-				gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationForeground)})).To(gomega.Succeed())
+				gomega.Expect(k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: new(metav1.DeletePropagationForeground)})).To(gomega.Succeed())
 			})
 
 			ginkgo.By("ensuring the job is deleted", func() {

--- a/test/e2e/sequential/baseline/ha_test.go
+++ b/test/e2e/sequential/baseline/ha_test.go
@@ -100,7 +100,7 @@ var _ = ginkgo.Describe("HA tests", ginkgo.Label("feature:ha", util.Shard0), gin
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, key, deployment)).To(gomega.Succeed())
 					oldReplicas = max(oldReplicas, ptr.Deref(deployment.Spec.Replicas, int32(0)))
-					deployment.Spec.Replicas = ptr.To[int32](0)
+					deployment.Spec.Replicas = new(int32(0))
 					g.Expect(k8sClient.Update(ctx, deployment)).Should(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -172,7 +172,7 @@ var _ = ginkgo.Describe("HA tests", ginkgo.Label("feature:ha", util.Shard0), gin
 			ginkgo.By("verify the localQueue can be fetched and mutated", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), localQueue)).To(gomega.Succeed())
-					localQueue.Spec.StopPolicy = ptr.To(kueue.Hold)
+					localQueue.Spec.StopPolicy = new(kueue.Hold)
 					g.Expect(k8sClient.Update(ctx, localQueue)).Should(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/sequential/baseline/objectretentionpolicies_test.go
+++ b/test/e2e/sequential/baseline/objectretentionpolicies_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -71,7 +70,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies", ginkgo.Label("feature:objectr
 			Timeout:         metav1.Duration{Duration: util.TinyTimeout},
 			RecoveryTimeout: nil,
 			RequeuingStrategy: &configapi.RequeuingStrategy{
-				Timestamp:          ptr.To(configapi.EvictionTimestamp),
+				Timestamp:          new(configapi.EvictionTimestamp),
 				BackoffBaseSeconds: new(int32(1)),
 				BackoffLimitCount:  new(int32(1)),
 			},
@@ -288,7 +287,7 @@ var _ = ginkgo.Describe("ObjectRetentionPolicies with TinyTimeout and RequeuingL
 				Timeout:         metav1.Duration{Duration: util.TinyTimeout},
 				RecoveryTimeout: nil,
 				RequeuingStrategy: &configapi.RequeuingStrategy{
-					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					Timestamp:          new(configapi.EvictionTimestamp),
 					BackoffBaseSeconds: new(int32(1)),
 					BackoffLimitCount:  new(int32(1)),
 				},

--- a/test/e2e/sequential/baseline/quota_check_strategy_test.go
+++ b/test/e2e/sequential/baseline/quota_check_strategy_test.go
@@ -24,7 +24,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -49,7 +48,7 @@ var _ = ginkgo.Describe("QuotaCheckStrategy", ginkgo.Label("feature:quotacheckst
 				cfg.FeatureGates = make(map[string]bool)
 			}
 			cfg.Resources = &configapi.Resources{
-				QuotaCheckStrategy: ptr.To(configapi.QuotaCheckIgnoreUndeclared),
+				QuotaCheckStrategy: new(configapi.QuotaCheckIgnoreUndeclared),
 			}
 			cfg.Metrics = configapi.ControllerMetrics{
 				EnableClusterQueueResources: true,

--- a/test/e2e/sequential/baseline/visibility_server_test.go
+++ b/test/e2e/sequential/baseline/visibility_server_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -48,7 +47,7 @@ var _ = ginkgo.Describe("Visibility Server", ginkgo.Label("feature:visibility", 
 		ginkgo.By("Updating the visibilityServer configuration and restarting Kueue")
 		util.UpdateKueueConfigurationAndRestart(ctx, k8sClient, defaultKueueCfg, kindClusterName, func(cfg *configapi.Configuration) {
 			cfg.VisibilityServer = &configapi.VisibilityServerConfiguration{
-				BindPort: ptr.To[int32](customVisibilityPort),
+				BindPort: new(int32(customVisibilityPort)),
 			}
 		})
 	})

--- a/test/e2e/sequential/baseline/waitforpodsready_test.go
+++ b/test/e2e/sequential/baseline/waitforpodsready_test.go
@@ -84,7 +84,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with tiny Timeout and no RecoveryTimeo
 				Timeout:         metav1.Duration{Duration: util.TinyTimeout},
 				RecoveryTimeout: nil,
 				RequeuingStrategy: &configapi.RequeuingStrategy{
-					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					Timestamp:          new(configapi.EvictionTimestamp),
 					BackoffBaseSeconds: new(int32(10)),
 					BackoffLimitCount:  new(int32(1)),
 				},
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a tiny Recove
 				BlockAdmission:  new(true),
 				RecoveryTimeout: &metav1.Duration{Duration: util.TinyTimeout},
 				RequeuingStrategy: &configapi.RequeuingStrategy{
-					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					Timestamp:          new(configapi.EvictionTimestamp),
 					BackoffBaseSeconds: new(int32(1)),
 					// Allow at least one requeue cycle before deactivation so the test
 					// can verify the requeue behavior.
@@ -388,7 +388,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 				BlockAdmission:  new(true),
 				RecoveryTimeout: &metav1.Duration{Duration: util.LongTimeout},
 				RequeuingStrategy: &configapi.RequeuingStrategy{
-					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					Timestamp:          new(configapi.EvictionTimestamp),
 					BackoffBaseSeconds: new(int32(1)),
 					BackoffLimitCount:  new(int32(1)),
 				},

--- a/test/e2e/singlecluster/baseline/job_test.go
+++ b/test/e2e/singlecluster/baseline/job_test.go
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 							Template: corev1.PodTemplateSpec{
 								Spec: corev1.PodSpec{
 									RestartPolicy:                 corev1.RestartPolicyNever,
-									TerminationGracePeriodSeconds: ptr.To[int64](1),
+									TerminationGracePeriodSeconds: new(int64(1)),
 									Containers: []corev1.Container{
 										{
 											Name:    "c",
@@ -909,7 +909,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			ginkgo.By("scaling up parallelism from 2 to 3", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
-					elasticJob.Spec.Parallelism = ptr.To[int32](3)
+					elasticJob.Spec.Parallelism = new(int32(3))
 					g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -1031,7 +1031,7 @@ var _ = ginkgo.Describe("Kueue", ginkgo.Label("area:singlecluster", "feature:job
 			ginkgo.By("scaling parallelism 4 -> 1: quota converges to the single running pod (200m)", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
-					elasticJob.Spec.Parallelism = ptr.To[int32](1)
+					elasticJob.Spec.Parallelism = new(int32(1))
 					g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/e2e/singlecluster/baseline/statefulset_test.go
+++ b/test/e2e/singlecluster/baseline/statefulset_test.go
@@ -26,7 +26,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -241,7 +240,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](0)
+					createdStatefulSet.Spec.Replicas = new(int32(0))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -280,7 +279,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](3)
+					createdStatefulSet.Spec.Replicas = new(int32(3))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -330,7 +329,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](0)
+					createdStatefulSet.Spec.Replicas = new(int32(0))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -348,7 +347,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](3)
+					createdStatefulSet.Spec.Replicas = new(int32(3))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -428,7 +427,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](1)
+					createdStatefulSet.Spec.Replicas = new(int32(1))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -793,7 +792,7 @@ var _ = ginkgo.Describe("StatefulSet integration", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdStatefulSet := &appsv1.StatefulSet{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(statefulSet), createdStatefulSet)).To(gomega.Succeed())
-					createdStatefulSet.Spec.Replicas = ptr.To[int32](0)
+					createdStatefulSet.Spec.Replicas = new(int32(0))
 					g.Expect(k8sClient.Update(ctx, createdStatefulSet)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/e2e/singlecluster/baseline/visibility_test.go
+++ b/test/e2e/singlecluster/baseline/visibility_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -166,7 +165,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdJob := &batchv1.Job{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(blockingJob), createdJob)).Should(gomega.Succeed())
-					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(ptr.To[int32](1)))
+					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(new(int32(1))))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -214,7 +213,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdJob := &batchv1.Job{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(blockingJob), createdJob)).Should(gomega.Succeed())
-					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(ptr.To[int32](1)))
+					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(new(int32(1))))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 
@@ -312,7 +311,7 @@ var _ = ginkgo.Describe("Kueue visibility server", ginkgo.Label("area:singleclus
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdJob := &batchv1.Job{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(blockingJob), createdJob)).Should(gomega.Succeed())
-					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(ptr.To[int32](1)))
+					g.Expect(createdJob.Status.Ready).Should(gomega.Equal(new(int32(1))))
 				}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/e2e/singlecluster/extended/jobset_test.go
+++ b/test/e2e/singlecluster/extended/jobset_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -192,7 +191,7 @@ var _ = ginkgo.Describe("JobSet", ginkgo.Label("area:singlecluster", "feature:jo
 			ginkgo.By("Stopping the ClusterQueue to make the JobSet be stopped and suspended")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
-				clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				clusterQueue.Spec.StopPolicy = new(kueue.HoldAndDrain)
 				g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
+++ b/test/e2e/singlecluster/extended/kuberay_autoscaling_test.go
@@ -161,14 +161,14 @@ var _ = ginkgo.Describe("KubeRay multi-PodSet autoscaling", ginkgo.Label("area:s
 			RequestAndLimit(rayv1.WorkerNode, corev1.ResourceCPU, "400m").
 			Image(rayv1.HeadNode, kuberayTestImage, []string{}).
 			Image(rayv1.WorkerNode, kuberayTestImage, []string{}).
-			WithAutoscalerOptions(&rayv1.AutoscalerOptions{IdleTimeoutSeconds: ptr.To[int32](1)}).
+			WithAutoscalerOptions(&rayv1.AutoscalerOptions{IdleTimeoutSeconds: new(int32(1))}).
 			Obj()
 
 		workerA := rayCluster.Spec.WorkerGroupSpecs[0].DeepCopy()
 		workerA.GroupName = workerGroupA
-		workerA.Replicas = ptr.To[int32](0)
-		workerA.MinReplicas = ptr.To[int32](0)
-		workerA.MaxReplicas = ptr.To[int32](1)
+		workerA.Replicas = new(int32(0))
+		workerA.MinReplicas = new(int32(0))
+		workerA.MaxReplicas = new(int32(1))
 		workerA.RayStartParams = map[string]string{
 			"num-cpus":            "0",
 			"object-store-memory": objectStoreMemory,

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -271,7 +270,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				ginkgo.By("Scale up LeaderWorkerSet", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-						createdLeaderWorkerSet.Spec.Replicas = ptr.To[int32](2)
+						createdLeaderWorkerSet.Spec.Replicas = new(int32(2))
 						g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -358,7 +357,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				ginkgo.By("Scale down LeaderWorkerSet", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-						createdLeaderWorkerSet.Spec.Replicas = ptr.To[int32](1)
+						createdLeaderWorkerSet.Spec.Replicas = new(int32(1))
 						g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -445,7 +444,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				ginkgo.By("Scale up LeaderWorkerSet", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-						createdLeaderWorkerSet.Spec.Replicas = ptr.To[int32](2)
+						createdLeaderWorkerSet.Spec.Replicas = new(int32(2))
 						g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -453,7 +452,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				ginkgo.By("Scale down LeaderWorkerSet", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLeaderWorkerSet)).To(gomega.Succeed())
-						createdLeaderWorkerSet.Spec.Replicas = ptr.To[int32](1)
+						createdLeaderWorkerSet.Spec.Replicas = new(int32(1))
 						g.Expect(k8sClient.Update(ctx, createdLeaderWorkerSet)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})

--- a/test/e2e/singlecluster/extended/trainjob_test.go
+++ b/test/e2e/singlecluster/extended/trainjob_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -205,7 +204,7 @@ var _ = ginkgo.Describe("TrainJob", ginkgo.Label("area:singlecluster", "feature:
 			ginkgo.By("Stopping the ClusterQueue to make the TrainJob be stopped and suspended")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
-				clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				clusterQueue.Spec.StopPolicy = new(kueue.HoldAndDrain)
 				g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/e2e/tas/extended/mpijob_test.go
+++ b/test/e2e/tas/extended/mpijob_test.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -343,7 +342,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for MPIJob", ginkgo.Label("area
 			// The MPIJob wrapper only pre-populates Launcher/Worker entries, so unknown replica types must be set on the spec map directly
 			delete(mpijob.Spec.MPIReplicaSpecs, kfmpi.MPIReplicaTypeLauncher)
 			mpijob.Spec.MPIReplicaSpecs[unknownReplicaType] = &kfmpi.ReplicaSpec{
-				Replicas: ptr.To[int32](1),
+				Replicas: new(int32(1)),
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: map[string]string{

--- a/test/e2e/tas/extended/rayjob_test.go
+++ b/test/e2e/tas/extended/rayjob_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/utils/ptr"
 	"k8s.io/utils/set"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -123,9 +122,9 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for RayJob", ginkgo.Ordered, gi
 				WithWorkerGroups(
 					rayv1.WorkerGroupSpec{
 						GroupName:      "workers-group-0",
-						Replicas:       ptr.To[int32](workerReplicas),
-						MinReplicas:    ptr.To[int32](workerReplicas),
-						MaxReplicas:    ptr.To[int32](10),
+						Replicas:       new(int32(workerReplicas)),
+						MinReplicas:    new(int32(workerReplicas)),
+						MaxReplicas:    new(int32(10)),
 						RayStartParams: map[string]string{},
 						Template: corev1.PodTemplateSpec{
 							Spec: corev1.PodSpec{

--- a/test/e2e/tas/extended/trainjob_test.go
+++ b/test/e2e/tas/extended/trainjob_test.go
@@ -25,7 +25,6 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -109,7 +108,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label("ar
 			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainer.RuntimeRef{
 				APIGroup: new(kftrainer.GroupVersion.Group),
 				Name:     "test-trainingruntime",
-				Kind:     ptr.To(kftrainer.TrainingRuntimeKind),
+				Kind:     new(kftrainer.TrainingRuntimeKind),
 			}).
 				Queue(localQueue.Name).
 				Obj()
@@ -181,7 +180,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label("ar
 			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainer.RuntimeRef{
 				APIGroup: new(kftrainer.GroupVersion.Group),
 				Name:     "test-trainingruntime",
-				Kind:     ptr.To(kftrainer.TrainingRuntimeKind),
+				Kind:     new(kftrainer.TrainingRuntimeKind),
 			}).
 				Queue(localQueue.Name).
 				Obj()
@@ -252,7 +251,7 @@ var _ = ginkgo.Describe("TopologyAwareScheduling for TrainJob", ginkgo.Label("ar
 			trainjob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainer.RuntimeRef{
 				APIGroup: new(kftrainer.GroupVersion.Group),
 				Name:     "test-trainingruntime",
-				Kind:     ptr.To(kftrainer.TrainingRuntimeKind),
+				Kind:     new(kftrainer.TrainingRuntimeKind),
 			}).
 				Queue(localQueue.Name).
 				Obj()

--- a/test/integration/multikueue/cluster_role_sharing_test.go
+++ b/test/integration/multikueue/cluster_role_sharing_test.go
@@ -284,7 +284,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(jobMk), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -303,7 +303,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(jobNonMk), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -334,7 +334,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 						Message:            reachedPodsReason,
 					}, completedJobCondition)
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				createdJob.Status.Succeeded = 1
 				createdJob.Status.CompletionTime = new(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
@@ -366,7 +366,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 						Message:            reachedPodsReason,
 					}, completedJobCondition)
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				createdJob.Status.Succeeded = 1
 				createdJob.Status.CompletionTime = new(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
@@ -467,7 +467,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(jobMk), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -486,7 +486,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(jobNonMk), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(managerTestCluster.client.Status().Update(managerTestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -517,7 +517,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 						Message:            reachedPodsReason,
 					}, completedJobCondition)
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				createdJob.Status.Succeeded = 1
 				createdJob.Status.CompletionTime = new(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
@@ -549,7 +549,7 @@ var _ = ginkgo.Describe("MultiKueue Cluster Role Sharing", ginkgo.Label("area:mu
 						Message:            reachedPodsReason,
 					}, completedJobCondition)
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				createdJob.Status.Succeeded = 1
 				createdJob.Status.CompletionTime = new(now)
 				g.Expect(managerTestCluster.client.Status().Update(managerTestCluster.ctx, &createdJob)).To(gomega.Succeed())

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -424,7 +424,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -463,7 +463,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 						Message:            reachedPodsReason,
 					}, completedJobCondition)
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				createdJob.Status.Succeeded = 1
 				createdJob.Status.CompletionTime = new(now)
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -262,7 +262,7 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(lowJob), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -303,7 +303,7 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(lowJob), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
@@ -395,7 +395,7 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(lowJob), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.StartTime = &startTime
 				createdJob.Status.Active = 1
-				createdJob.Status.Ready = ptr.To[int32](1)
+				createdJob.Status.Ready = new(int32(1))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -436,7 +436,7 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(worker1TestCluster.client.Get(worker1TestCluster.ctx, client.ObjectKeyFromObject(lowJob), &createdJob)).To(gomega.Succeed())
 				createdJob.Status.Active = 0
-				createdJob.Status.Ready = ptr.To[int32](0)
+				createdJob.Status.Ready = new(int32(0))
 				g.Expect(worker1TestCluster.client.Status().Update(worker1TestCluster.ctx, &createdJob)).To(gomega.Succeed())
 			}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/multikueue/setup_test.go
+++ b/test/integration/multikueue/setup_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/utils/ptr"
 	inventoryv1alpha1 "sigs.k8s.io/cluster-inventory-api/apis/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -814,7 +813,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			gomega.Eventually(func(g gomega.Gomega) {
 				mkc := &kueue.MultiKueueConfig{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerMultiKueueConfig), mkc)).To(gomega.Succeed())
-				mkc.Spec.QuotaManagement = ptr.To(kueue.QuotaManagementAutomated)
+				mkc.Spec.QuotaManagement = new(kueue.QuotaManagementAutomated)
 				g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, mkc)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -297,8 +296,8 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 						Name:  kueue.DefaultPodSetName,
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(string(corev1.LabelHostname)),
-							PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+							Required:      new(string(corev1.LabelHostname)),
+							PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 						},
 					}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -328,7 +327,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 					g.Expect(managerWl.Status.Admission).NotTo(gomega.BeNil())
 					g.Expect(managerWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
-					g.Expect(managerWl.Status.Admission.PodSetAssignments[0].DelayedTopologyRequest).To(gomega.Equal(ptr.To(kueue.DelayedTopologyRequestStateReady)))
+					g.Expect(managerWl.Status.Admission.PodSetAssignments[0].DelayedTopologyRequest).To(gomega.Equal(new(kueue.DelayedTopologyRequestStateReady)))
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})

--- a/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
+++ b/test/integration/singlecluster/controller/core/clusterqueue_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics/testutil"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -504,7 +503,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 						ResourceUsage: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("2"),
 						},
-						Count: ptr.To[int32](2),
+						Count: new(int32(2)),
 					},
 					kueue.PodSetAssignment{
 						Name: "workers",
@@ -514,7 +513,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 						ResourceUsage: corev1.ResourceList{
 							resourceGPU: resource.MustParse("5"),
 						},
-						Count: ptr.To[int32](5),
+						Count: new(int32(5)),
 					},
 				).Obj()
 
@@ -958,7 +957,7 @@ var _ = ginkgo.Describe("ClusterQueue controller", ginkgo.Label("controller:clus
 						ResourceUsage: corev1.ResourceList{
 							resourceGPU: resource.MustParse("5"),
 						},
-						Count: ptr.To[int32](5),
+						Count: new(int32(5)),
 					},
 				).Obj()
 				util.SetQuotaReservation(ctx, k8sClient, client.ObjectKeyFromObject(wl), admission)

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics/testutil"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -50,8 +49,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindLocalQueue)},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -194,7 +193,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "cost_center", SourceLabelKey: "billing/cost-center", SourceKind: ptr.To(config.SourceKindClusterQueue)},
+				{Name: "cost_center", SourceLabelKey: "billing/cost-center", SourceKind: new(config.SourceKindClusterQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -244,7 +243,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "budget", SourceAnnotationKey: "billing.co/budget", SourceKind: ptr.To(config.SourceKindClusterQueue)},
+				{Name: "budget", SourceAnnotationKey: "billing.co/budget", SourceKind: new(config.SourceKindClusterQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -294,8 +293,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, false)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindLocalQueue)},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -402,8 +401,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindLocalQueue)},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -465,8 +464,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "team_lq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindLocalQueue)},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "team_lq", SourceLabelKey: "team", SourceKind: new(config.SourceKindLocalQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -626,7 +625,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
+				{Name: "team", SourceKind: new(config.SourceKindClusterQueue)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -723,8 +722,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			controllersCfg := &config.Configuration{}
 			controllersCfg.FairSharing = &config.FairSharing{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "team_cohort", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindCohort)},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "team_cohort", SourceLabelKey: "team", SourceKind: new(config.SourceKindCohort)},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()
@@ -985,8 +984,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
-				{Name: "team_cq", SourceLabelKey: "team", SourceKind: ptr.To(config.SourceKindClusterQueue)},
-				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: ptr.To(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
+				{Name: "team_cq", SourceLabelKey: "team", SourceKind: new(config.SourceKindClusterQueue)},
+				{Name: "wl_kind", SourceLabelKey: "workload-kind", SourceKind: new(config.SourceKindWorkload), TrackedValues: []string{"kind1", "kind2"}},
 			}
 			fwk.StartManager(ctx, cfg, managerAndControllerSetup(controllersCfg, runScheduler))
 			defaultFlavor = utiltestingapi.MakeResourceFlavor("default").Obj()

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -738,7 +738,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 
 		ginkgo.It("should write granular conditions and reasons when localQueue is inactive", func() {
 			lq := utiltestingapi.MakeLocalQueue("inactive-q", ns.Name).ClusterQueue("cq").Obj()
-			lq.Spec.StopPolicy = ptr.To(kueue.Hold)
+			lq.Spec.StopPolicy = new(kueue.Hold)
 			gomega.Expect(k8sClient.Create(ctx, lq)).To(gomega.Succeed())
 
 			// Wait for LocalQueue to be reconciled and registered in the Queue Manager
@@ -772,7 +772,7 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 				ResourceGroup(*utiltestingapi.MakeFlavorQuotas(flavorOnDemand).
 					Resource(corev1.ResourceCPU, "1").Obj()).
 				Obj()
-			inactiveCq.Spec.StopPolicy = ptr.To(kueue.Hold)
+			inactiveCq.Spec.StopPolicy = new(kueue.Hold)
 			gomega.Expect(k8sClient.Create(ctx, inactiveCq)).To(gomega.Succeed())
 
 			lq := utiltestingapi.MakeLocalQueue("inactive-cq-q", ns.Name).ClusterQueue("inactive-cq").Obj()
@@ -1174,7 +1174,7 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			gomega.Eventually(func(g gomega.Gomega) {
 				var fetchedLq kueue.LocalQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
-				fetchedLq.Spec.StopPolicy = ptr.To(kueue.Hold)
+				fetchedLq.Spec.StopPolicy = new(kueue.Hold)
 				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1207,7 +1207,7 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 			gomega.Eventually(func(g gomega.Gomega) {
 				var fetchedLq kueue.LocalQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(localQueue), &fetchedLq)).To(gomega.Succeed())
-				fetchedLq.Spec.StopPolicy = ptr.To(kueue.None)
+				fetchedLq.Spec.StopPolicy = new(kueue.None)
 				g.Expect(k8sClient.Update(ctx, &fetchedLq)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -26,7 +26,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -1382,7 +1381,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			gomega.Eventually(func(g gomega.Gomega) {
 				var dc resourcev1.DeviceClass
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deviceClassName}, &dc)).To(gomega.Succeed())
-				dc.Spec.ExtendedResourceName = ptr.To(newExtendedResourceName)
+				dc.Spec.ExtendedResourceName = new(newExtendedResourceName)
 				g.Expect(k8sClient.Update(ctx, &dc)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1435,7 +1434,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			gomega.Eventually(func(g gomega.Gomega) {
 				var dc resourcev1.DeviceClass
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deviceClassName}, &dc)).To(gomega.Succeed())
-				dc.Spec.ExtendedResourceName = ptr.To(newExtendedResourceName)
+				dc.Spec.ExtendedResourceName = new(newExtendedResourceName)
 				g.Expect(k8sClient.Update(ctx, &dc)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -1472,7 +1471,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			gomega.Eventually(func(g gomega.Gomega) {
 				var dc resourcev1.DeviceClass
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: deviceClassName}, &dc)).To(gomega.Succeed())
-				dc.Spec.ExtendedResourceName = ptr.To(extendedResourceName)
+				dc.Spec.ExtendedResourceName = new(extendedResourceName)
 				g.Expect(k8sClient.Update(ctx, &dc)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/appwrapper/appwrapper_controller_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -935,8 +934,8 @@ var _ = ginkgo.Describe("AppWrapper controller with TopologyAwareScheduling", gi
 					Name:  wl.Spec.PodSets[0].Name,
 					Count: 1,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To(tasBlockLabel),
-						PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+						Required:      new(tasBlockLabel),
+						PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jaxjob/jaxjob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -660,8 +659,8 @@ var _ = ginkgo.Describe("JAXJob controller with TopologyAwareScheduling", ginkgo
 						Name:  kueue.NewPodSetReference(string(kftraining.JAXJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -1245,7 +1245,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("Single pod ready", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
 				Active: 1,
-				Ready:  ptr.To[int32](1),
+				Ready:  new(int32(1)),
 			},
 			wantCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
@@ -1268,7 +1268,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("All pods are ready", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
 				Active: 2,
-				Ready:  ptr.To[int32](2),
+				Ready:  new(int32(2)),
 			},
 			wantCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
@@ -1280,7 +1280,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("One pod ready, one terminating succeeded", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
 				Active: 1,
-				Ready:  ptr.To[int32](1),
+				Ready:  new(int32(1)),
 				UncountedTerminatedPods: &batchv1.UncountedTerminatedPods{
 					Succeeded: []types.UID{"foo"},
 				},
@@ -1295,7 +1295,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("One pod ready, one succeeded", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
 				Active:    1,
-				Ready:     ptr.To[int32](1),
+				Ready:     new(int32(1)),
 				Succeeded: 1,
 			},
 			wantCondition: &metav1.Condition{
@@ -1334,7 +1334,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		}),
 		ginkgo.Entry("All pods are succeeded", podsReadyTestSpec{
 			jobStatus: batchv1.JobStatus{
-				Ready:     ptr.To[int32](0),
+				Ready:     new(int32(0)),
 				Succeeded: 2,
 			},
 			wantCondition: &metav1.Condition{
@@ -1352,7 +1352,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 				Message: "Not all pods are ready or succeeded",
 			},
 			jobStatus: batchv1.JobStatus{
-				Ready:     ptr.To[int32](0),
+				Ready:     new(int32(0)),
 				Succeeded: 2,
 			},
 			wantCondition: &metav1.Condition{
@@ -1365,7 +1365,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("One ready pod, one failed; PodsReady=True before", podsReadyTestSpec{
 			beforeJobStatus: &batchv1.JobStatus{
 				Active: 2,
-				Ready:  ptr.To[int32](2),
+				Ready:  new(int32(2)),
 			},
 			beforeCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
@@ -1375,7 +1375,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 			},
 			jobStatus: batchv1.JobStatus{
 				Active: 1,
-				Ready:  ptr.To[int32](1),
+				Ready:  new(int32(1)),
 				Failed: 1,
 			},
 			wantCondition: &metav1.Condition{
@@ -1388,7 +1388,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("Job suspended without ready pods; but PodsReady=True before", podsReadyTestSpec{
 			beforeJobStatus: &batchv1.JobStatus{
 				Active: 2,
-				Ready:  ptr.To[int32](2),
+				Ready:  new(int32(2)),
 			},
 			beforeCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
@@ -1410,7 +1410,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 		ginkgo.Entry("Job suspended with all pods ready; PodsReady=True before", podsReadyTestSpec{
 			beforeJobStatus: &batchv1.JobStatus{
 				Active: 2,
-				Ready:  ptr.To[int32](2),
+				Ready:  new(int32(2)),
 			},
 			beforeCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
@@ -1420,7 +1420,7 @@ var _ = ginkgo.Describe("When waitForPodsReady enabled", ginkgo.Ordered, ginkgo.
 			},
 			jobStatus: batchv1.JobStatus{
 				Active: 2,
-				Ready:  ptr.To[int32](2),
+				Ready:  new(int32(2)),
 			},
 			suspended: true,
 			wantCondition: &metav1.Condition{
@@ -2488,7 +2488,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 			Completions(3).
 			BackoffLimitPerIndex(1).
 			Obj()
-		testJob.Spec.MaxFailedIndexes = ptr.To[int32](3)
+		testJob.Spec.MaxFailedIndexes = new(int32(3))
 
 		ginkgo.By("creating and admitting the job")
 		util.MustCreate(ctx, k8sClient, testJob)
@@ -2780,7 +2780,7 @@ var _ = ginkgo.Describe("Interacting with scheduler", ginkgo.Ordered, ginkgo.Con
 		ginkgo.By("updating the job", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-				createdJob.Spec.Parallelism = ptr.To[int32](1)
+				createdJob.Spec.Parallelism = new(int32(1))
 				g.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
@@ -3157,7 +3157,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			BlockAdmission: new(true),
 			Timeout:        waitForPodsReadyTimeout,
 			RequeuingStrategy: &configapi.RequeuingStrategy{
-				Timestamp:          ptr.To(configapi.EvictionTimestamp),
+				Timestamp:          new(configapi.EvictionTimestamp),
 				BackoffBaseSeconds: new(backoffBaseSeconds),
 				BackoffLimitCount:  backoffLimitCount,
 			},
@@ -3271,7 +3271,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 1
-				job.Status.Ready = ptr.To[int32](1)
+				job.Status.Ready = new(int32(1))
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -3291,7 +3291,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 0
-				job.Status.Ready = ptr.To[int32](0)
+				job.Status.Ready = new(int32(0))
 				job.Status.Failed = 1
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3330,7 +3330,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 1
-				job.Status.Ready = ptr.To[int32](1)
+				job.Status.Ready = new(int32(1))
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -3350,7 +3350,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 0
-				job.Status.Ready = ptr.To[int32](0)
+				job.Status.Ready = new(int32(0))
 				job.Status.Failed = 1
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3407,7 +3407,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 1
-				job.Status.Ready = ptr.To[int32](1)
+				job.Status.Ready = new(int32(1))
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -3427,7 +3427,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 0
-				job.Status.Ready = ptr.To[int32](0)
+				job.Status.Ready = new(int32(0))
 				job.Status.Failed = 1
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3448,7 +3448,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, jobKey, job)).Should(gomega.Succeed())
 				job.Status.Active = 1
-				job.Status.Ready = ptr.To[int32](1)
+				job.Status.Ready = new(int32(1))
 				job.Status.Failed = 1
 				g.Expect(k8sClient.Status().Update(ctx, job)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3477,7 +3477,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 	ginkgo.When("short backoffBaseSeconds and tiny .timeout", func() {
 		ginkgo.BeforeEach(func() {
 			backoffBaseSeconds = 1
-			backoffLimitCount = ptr.To[int32](1)
+			backoffLimitCount = new(int32(1))
 			waitForPodsReadyTimeout = metav1.Duration{Duration: util.TinyTimeout}
 		})
 
@@ -3507,7 +3507,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
+				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(new(int32(1))))
 				g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
 				g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 					gomega.BeComparableTo(metav1.Condition{
@@ -3646,7 +3646,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, lowJobKey, lowJob)).Should(gomega.Succeed())
 				lowJob.Status.Active = 1
-				lowJob.Status.Ready = ptr.To[int32](1)
+				lowJob.Status.Ready = new(int32(1))
 				g.Expect(k8sClient.Status().Update(ctx, lowJob)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -3666,7 +3666,7 @@ var _ = ginkgo.Describe("Job controller interacting with Workload controller whe
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, highJobKey, highJob)).Should(gomega.Succeed())
 				highJob.Status.Active = 1
-				highJob.Status.Ready = ptr.To[int32](1)
+				highJob.Status.Ready = new(int32(1))
 				g.Expect(k8sClient.Status().Update(ctx, highJob)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -3788,8 +3788,8 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 					Name:  kueue.DefaultPodSetName,
 					Count: 1,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To(tasBlockLabel),
-						PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+						Required:      new(tasBlockLabel),
+						PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3838,7 +3838,7 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 					Count: 1,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
 						Unconstrained: new(true),
-						PodIndexLabel: ptr.To(batchv1.JobCompletionIndexAnnotation),
+						PodIndexLabel: new(batchv1.JobCompletionIndexAnnotation),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -4029,7 +4029,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 				Timeout:         metav1.Duration{Duration: util.TinyTimeout},
 				RecoveryTimeout: nil,
 				RequeuingStrategy: &configapi.RequeuingStrategy{
-					Timestamp:          ptr.To(configapi.EvictionTimestamp),
+					Timestamp:          new(configapi.EvictionTimestamp),
 					BackoffBaseSeconds: new(int32(1)),
 					BackoffLimitCount:  new(int32(1)),
 				},
@@ -4234,7 +4234,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 						g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-						g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
+						g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(new(int32(1))))
 						g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
 						g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
@@ -4332,7 +4332,7 @@ var _ = ginkgo.Describe("Job controller with ObjectRetentionPolicies", ginkgo.Or
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 						g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-						g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
+						g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(new(int32(1))))
 						g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
 						g.Expect(wl.Status.Conditions).To(gomega.ContainElements(
 							gomega.BeComparableTo(metav1.Condition{
@@ -4686,8 +4686,8 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling the job down below the succeeded count")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](3)
-			testJob.Spec.Completions = ptr.To[int32](3)
+			testJob.Spec.Parallelism = new(int32(3))
+			testJob.Spec.Completions = new(int32(3))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -4755,8 +4755,8 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling down to 3; the stale failed index 4 is ignored so indexes 0-2 keep their quota (300m)")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](3)
-			testJob.Spec.Completions = ptr.To[int32](3)
+			testJob.Spec.Parallelism = new(int32(3))
+			testJob.Spec.Completions = new(int32(3))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -4815,7 +4815,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling parallelism 20 -> 10; the 5 still-running pods keep exactly their quota (500m), not the full podSet")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](10)
+			testJob.Spec.Parallelism = new(int32(10))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -4862,8 +4862,8 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling down to 10; completedIndexes is pruned to 5-9 but status.Succeeded stays stale at 15")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](10)
-			testJob.Spec.Completions = ptr.To[int32](10)
+			testJob.Spec.Parallelism = new(int32(10))
+			testJob.Spec.Completions = new(int32(10))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -5127,7 +5127,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("increasing the job's parallelism to 2 to emulate scale-up")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](2)
+			testJob.Spec.Parallelism = new(int32(2))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5564,7 +5564,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling the job up within quota")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(elasticJob), elasticJob)).Should(gomega.Succeed())
-			elasticJob.Spec.Parallelism = ptr.To[int32](2)
+			elasticJob.Spec.Parallelism = new(int32(2))
 			g.Expect(k8sClient.Update(ctx, elasticJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5607,7 +5607,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling the job up to create a replacement slice")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](2)
+			testJob.Spec.Parallelism = new(int32(2))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5680,7 +5680,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("scaling the job up to create a replacement slice")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
-			testJob.Spec.Parallelism = ptr.To[int32](2)
+			testJob.Spec.Parallelism = new(int32(2))
 			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5698,7 +5698,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("draining the ClusterQueue to evict the workload without deleting it")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).Should(gomega.Succeed())
-			clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+			clusterQueue.Spec.StopPolicy = new(kueue.HoldAndDrain)
 			g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5714,7 +5714,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		ginkgo.By("resuming the ClusterQueue")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).Should(gomega.Succeed())
-			clusterQueue.Spec.StopPolicy = ptr.To(kueue.None)
+			clusterQueue.Spec.StopPolicy = new(kueue.None)
 			g.Expect(k8sClient.Update(ctx, clusterQueue)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -5904,13 +5904,13 @@ var _ = ginkgo.Describe("Job controller with CustomMetricLabels", ginkgo.Label("
 						{
 							Name:           "custom_label_key",
 							SourceLabelKey: "job-label",
-							SourceKind:     ptr.To(configapi.SourceKindWorkload),
+							SourceKind:     new(configapi.SourceKindWorkload),
 							TrackedValues:  []string{"label-value"},
 						},
 						{
 							Name:                "custom_annotation_key",
 							SourceAnnotationKey: "job-annotation",
-							SourceKind:          ptr.To(configapi.SourceKindWorkload),
+							SourceKind:          new(configapi.SourceKindWorkload),
 							TrackedValues:       []string{"annotation-value"},
 						},
 					},

--- a/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/jobset/jobset_controller_test.go
@@ -426,7 +426,7 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Label("job:jobset", "area:jo
 							*utiltestingapi.MakePodSet("replicated-job-1", 4).
 								PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
 								SubGroupIndexLabel(new("jobset.sigs.k8s.io/job-index")).
-								SubGroupCount(ptr.To[int32](2)).
+								SubGroupCount(new(int32(2))).
 								Obj(),
 							checkPSOpts,
 						),
@@ -434,7 +434,7 @@ var _ = ginkgo.Describe("JobSet controller", ginkgo.Label("job:jobset", "area:jo
 							*utiltestingapi.MakePodSet("replicated-job-2-empty", 0).
 								PodIndexLabel(new("batch.kubernetes.io/job-completion-index")).
 								SubGroupIndexLabel(new("jobset.sigs.k8s.io/job-index")).
-								SubGroupCount(ptr.To[int32](1)).
+								SubGroupCount(new(int32(1))).
 								Obj(),
 							checkPSOpts,
 						),
@@ -1255,20 +1255,20 @@ var _ = ginkgo.Describe("JobSet controller with TopologyAwareScheduling", ginkgo
 						Name:  "rj1",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:           ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](1),
+							Required:           new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel:      new(batchv1.JobCompletionIndexAnnotation),
+							SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+							SubGroupCount:      new(int32(1)),
 						},
 					},
 					{
 						Name:  "rj2",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:          ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](1),
+							Preferred:          new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel:      new(batchv1.JobCompletionIndexAnnotation),
+							SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+							SubGroupCount:      new(int32(1)),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -1422,12 +1422,12 @@ var _ = ginkgo.Describe("JobSet controller with TopologyAwareScheduling", ginkgo
 
 				// job-a (completed, count=0) should have no topology assignment
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].Name).Should(gomega.Equal(kueue.NewPodSetReference("job-a")))
-				g.Expect(wl.Status.Admission.PodSetAssignments[0].Count).Should(gomega.Equal(ptr.To[int32](0)))
+				g.Expect(wl.Status.Admission.PodSetAssignments[0].Count).Should(gomega.Equal(new(int32(0))))
 				g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeNil())
 
 				// job-b (still running, count=1) should have a valid topology assignment
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].Name).Should(gomega.Equal(kueue.NewPodSetReference("job-b")))
-				g.Expect(wl.Status.Admission.PodSetAssignments[1].Count).Should(gomega.Equal(ptr.To[int32](1)))
+				g.Expect(wl.Status.Admission.PodSetAssignments[1].Count).Should(gomega.Equal(new(int32(1))))
 				g.Expect(wl.Status.Admission.PodSetAssignments[1].TopologyAssignment).ShouldNot(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/mpijob/mpijob_controller_test.go
@@ -984,16 +984,16 @@ var _ = ginkgo.Describe("MPIJob controller with TopologyAwareScheduling", ginkgo
 						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kfmpi.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kfmpi.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
@@ -1064,16 +1064,16 @@ var _ = ginkgo.Describe("MPIJob controller with TopologyAwareScheduling", ginkgo
 						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeLauncher)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kfmpi.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kfmpi.MPIReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kfmpi.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kfmpi.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/paddlejob/paddlejob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -390,16 +389,16 @@ var _ = ginkgo.Describe("PaddleJob controller with TopologyAwareScheduling", fra
 						Name:  kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kftraining.PaddleJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -826,14 +825,14 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 						kueue.PodSetAssignment{
 							Name: "bf90803c",
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -900,7 +899,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](2),
+							Count: new(int32(2)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -1283,14 +1282,14 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 						kueue.PodSetAssignment{
 							Name: "bf90803c",
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -1409,14 +1408,14 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 						kueue.PodSetAssignment{
 							Name: "bf90803c",
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](1),
+							Count: new(int32(1)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -1475,7 +1474,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](podCount),
+							Count: new(int32(podCount)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -1712,7 +1711,7 @@ var _ = ginkgo.Describe("Pod controller", ginkgo.Label("job:pod", "area:jobs"), 
 							Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
 								corev1.ResourceCPU: "default",
 							},
-							Count: ptr.To[int32](2),
+							Count: new(int32(2)),
 						},
 					).Obj()
 					util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
@@ -2395,9 +2394,9 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 		waitForPodsReady := &configapi.WaitForPodsReady{
 			Timeout: metav1.Duration{Duration: util.TinyTimeout},
 			RequeuingStrategy: &configapi.RequeuingStrategy{
-				Timestamp:          ptr.To(configapi.EvictionTimestamp),
-				BackoffLimitCount:  ptr.To[int32](1),
-				BackoffBaseSeconds: ptr.To[int32](1),
+				Timestamp:          new(configapi.EvictionTimestamp),
+				BackoffLimitCount:  new(int32(1)),
+				BackoffBaseSeconds: new(int32(1)),
 			},
 		}
 		nsSelector := &metav1.LabelSelector{
@@ -2493,7 +2492,7 @@ var _ = ginkgo.Describe("Pod controller interacting with Workload controller whe
 				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
 				g.Expect(workload.IsActive(wl)).Should(gomega.BeTrue())
 				g.Expect(wl.Status.RequeueState).ShouldNot(gomega.BeNil())
-				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(ptr.To[int32](1)))
+				g.Expect(wl.Status.RequeueState.Count).Should(gomega.Equal(new(int32(1))))
 				g.Expect(wl.Status.RequeueState.RequeueAt).Should(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectWorkloadToHaveConditions(ctx, k8sClient, wlKey,
@@ -2870,8 +2869,8 @@ var _ = ginkgo.Describe("Pod controller with TopologyAwareScheduling", ginkgo.La
 					Name:  kueue.DefaultPodSetName,
 					Count: 1,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To(tasBlockLabel),
-						PodIndexLabel: ptr.To(kueue.PodGroupPodIndexLabel),
+						Required:      new(tasBlockLabel),
+						PodIndexLabel: new(kueue.PodGroupPodIndexLabel),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -2921,8 +2920,8 @@ var _ = ginkgo.Describe("Pod controller with TopologyAwareScheduling", ginkgo.La
 					Name:  "5949e52e",
 					Count: 2,
 					TopologyRequest: &kueue.PodSetTopologyRequest{
-						Required:      ptr.To(tasBlockLabel),
-						PodIndexLabel: ptr.To(kueue.PodGroupPodIndexLabel),
+						Required:      new(tasBlockLabel),
+						PodIndexLabel: new(kueue.PodGroupPodIndexLabel),
 					},
 				}}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
@@ -3238,9 +3237,9 @@ var _ = ginkgo.Describe("Pod controller with deployment-owned pods and waitForPo
 			Timeout:        metav1.Duration{Duration: 3 * time.Second},
 			BlockAdmission: new(false),
 			RequeuingStrategy: &configapi.RequeuingStrategy{
-				Timestamp:          ptr.To(configapi.EvictionTimestamp),
-				BackoffBaseSeconds: ptr.To[int32](1),
-				BackoffMaxSeconds:  ptr.To[int32](5),
+				Timestamp:          new(configapi.EvictionTimestamp),
+				BackoffBaseSeconds: new(int32(1)),
+				BackoffMaxSeconds:  new(int32(5)),
 			},
 		}
 		nsSelector := &metav1.LabelSelector{

--- a/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -687,16 +686,16 @@ var _ = ginkgo.Describe("PyTorchJob controller with TopologyAwareScheduling", gi
 						Name:  kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kftraining.PyTorchJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -148,7 +148,7 @@ var _ = ginkgo.Describe("SparkApplication controller when waitForPodsReady enabl
 			},
 		}),
 		ginkgo.Entry("SparkApplication suspended; PodsReady=True before", PodsReadyTestSpec{
-			BeforeAppState: ptr.To(sparkv1beta2.ApplicationStateRunning),
+			BeforeAppState: new(sparkv1beta2.ApplicationStateRunning),
 			BeforeCondition: &metav1.Condition{
 				Type:    kueue.WorkloadPodsReady,
 				Status:  metav1.ConditionTrue,
@@ -337,14 +337,14 @@ var _ = ginkgo.Describe("SparkApplication controller with TopologyAwareSchedulin
 						Name:  kueue.NewPodSetReference("driver"),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+							Required: new(utiltesting.DefaultRackTopologyLevel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference("executor"),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+							Preferred: new(utiltesting.DefaultBlockTopologyLevel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/statefulset/statefulset_controller_test.go
@@ -23,7 +23,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -178,7 +177,7 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 		ginkgo.By("Scaling the StatefulSet to zero")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
-			createdSTS.Spec.Replicas = ptr.To[int32](0)
+			createdSTS.Spec.Replicas = new(int32(0))
 			g.Expect(k8sClient.Update(ctx, createdSTS)).Should(gomega.Succeed())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -204,7 +203,7 @@ var _ = ginkgo.Describe("StatefulSet controller", ginkgo.Label("job:statefulset"
 		ginkgo.By("Scaling the StatefulSet back up to 1")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sts), createdSTS)).Should(gomega.Succeed())
-			createdSTS.Spec.Replicas = ptr.To[int32](1)
+			createdSTS.Spec.Replicas = new(int32(1))
 			g.Expect(k8sClient.Update(ctx, createdSTS)).Should(gomega.Succeed())
 		}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/tfjob/tfjob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -412,24 +411,24 @@ var _ = ginkgo.Describe("TFJob controller with TopologyAwareScheduling", framewo
 						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeChief)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypePS)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kftraining.TFJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/trainjob/trainjob_controller_test.go
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("TrainJob controller for workloads when only jobs with q
 		trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "test",
-			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+			Kind:     new(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Suspend(false).
 			Obj()
@@ -446,7 +446,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 		trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "test",
-			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+			Kind:     new(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue(localQueue.Name).
 			Obj()
@@ -497,7 +497,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 		trainJob1 := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "tr-1",
-			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+			Kind:     new(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue(localQueue.Name).
 			Suspend(true).
@@ -536,7 +536,7 @@ var _ = ginkgo.Describe("TrainJob controller interacting with scheduler", ginkgo
 		trainJob2 := testingtrainjob.MakeTrainJob("trainjob-test-2", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "tr-2",
-			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+			Kind:     new(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue(localQueue.Name).
 			Suspend(true).
@@ -685,7 +685,7 @@ var _ = ginkgo.Describe("TrainJob controller with TopologyAwareScheduling", gink
 		trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "test",
-			Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+			Kind:     new(kftrainerapi.TrainingRuntimeKind),
 		}).
 			Queue(localQueue.Name).
 			Suspend(false).
@@ -710,20 +710,20 @@ var _ = ginkgo.Describe("TrainJob controller with TopologyAwareScheduling", gink
 						Name:  "node-1",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:           ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](1),
+							Required:           new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel:      new(batchv1.JobCompletionIndexAnnotation),
+							SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+							SubGroupCount:      new(int32(1)),
 						},
 					},
 					{
 						Name:  "node-2",
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:          ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel:      ptr.To(batchv1.JobCompletionIndexAnnotation),
-							SubGroupIndexLabel: ptr.To(jobsetapi.JobIndexKey),
-							SubGroupCount:      ptr.To[int32](1),
+							Preferred:          new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel:      new(batchv1.JobCompletionIndexAnnotation),
+							SubGroupIndexLabel: new(jobsetapi.JobIndexKey),
+							SubGroupCount:      new(int32(1)),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/xgboostjob/xgboostjob_controller_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -387,16 +386,16 @@ var _ = ginkgo.Describe("XGBoostJob controller with TopologyAwareScheduling", fr
 						Name:  kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeMaster)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Required:      ptr.To(utiltesting.DefaultRackTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Required:      new(utiltesting.DefaultRackTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 					{
 						Name:  kueue.NewPodSetReference(string(kftraining.XGBoostJobReplicaTypeWorker)),
 						Count: 1,
 						TopologyRequest: &kueue.PodSetTopologyRequest{
-							Preferred:     ptr.To(utiltesting.DefaultBlockTopologyLevel),
-							PodIndexLabel: ptr.To(kftraining.ReplicaIndexLabel),
+							Preferred:     new(utiltesting.DefaultBlockTopologyLevel),
+							PodIndexLabel: new(kftraining.ReplicaIndexLabel),
 						},
 					},
 				}, cmpopts.IgnoreFields(kueue.PodSet{}, "Template")))

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/metrics/testutil"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -991,7 +990,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			ginkgo.By("Pausing admissions to CQ")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq1), cq1)).To(gomega.Succeed())
-				cq1.Spec.StopPolicy = ptr.To(kueue.Hold)
+				cq1.Spec.StopPolicy = new(kueue.Hold)
 				g.Expect(k8sClient.Update(ctx, cq1)).Should(gomega.Succeed())
 			}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 
@@ -1020,7 +1019,7 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 			ginkgo.By("Resuming admissions to CQ")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq1), cq1)).To(gomega.Succeed())
-				cq1.Spec.StopPolicy = ptr.To(kueue.None)
+				cq1.Spec.StopPolicy = new(kueue.None)
 				g.Expect(k8sClient.Update(ctx, cq1)).Should(gomega.Succeed())
 			}, util.Timeout, util.ShortInterval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/podsready/scheduler_test.go
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 				RequeuingStrategy: &config.RequeuingStrategy{
 					Timestamp:          new(requeuingTimestamp),
 					BackoffLimitCount:  requeueingBackoffLimitCount,
-					BackoffBaseSeconds: ptr.To[int32](1),
+					BackoffBaseSeconds: new(int32(1)),
 				},
 			},
 		}
@@ -245,7 +245,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 	var _ = ginkgo.Context("Short PodsReady timeout", func() {
 		ginkgo.BeforeEach(func() {
 			podsReadyTimeout = util.ShortTimeout
-			requeueingBackoffLimitCount = ptr.To[int32](2)
+			requeueingBackoffLimitCount = new(int32(2))
 		})
 
 		ginkgo.It("Should requeue a workload which exceeded the timeout to reach PodsReady=True", framework.SlowSpec, func() {
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(prodWl1), prodWl1)).Should(gomega.Succeed())
 				g.Expect(ptr.Deref(prodWl1.Status.RequeueState, kueue.RequeueState{})).Should(gomega.BeComparableTo(kueue.RequeueState{
-					Count: ptr.To[int32](1),
+					Count: new(int32(1)),
 				}, cmpopts.IgnoreFields(kueue.RequeueState{}, "RequeueAt")))
 				g.Expect(prodWl1.Status.RequeueState.RequeueAt).ShouldNot(gomega.BeNil())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed(), "the workload should be evicted after the timeout expires")
@@ -305,7 +305,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			ginkgo.By("finish the eviction, and the workload is pending by backoff")
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
-				Count: ptr.To[int32](1),
+				Count: new(int32(1)),
 			}, false)
 			// To avoid flakiness, we don't verify if the workload has a QuotaReserved=false with pending reason here.
 
@@ -317,7 +317,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			util.SetRequeuedConditionWithPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl))
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			}, false)
 
 			ginkgo.By("the workload exceeded re-queue backoff limit should be deactivated")
@@ -353,7 +353,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			util.SetRequeuedConditionWithPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl))
 			util.FinishEvictionForWorkloads(ctx, k8sClient, prodWl)
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
-				Count: ptr.To[int32](1),
+				Count: new(int32(1)),
 			}, false)
 		})
 	})
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 	var _ = ginkgo.Context("Tiny PodsReady timeout", func() {
 		ginkgo.BeforeEach(func() {
 			podsReadyTimeout = util.TinyTimeout
-			requeueingBackoffLimitCount = ptr.To[int32](2)
+			requeueingBackoffLimitCount = new(int32(2))
 		})
 
 		ginkgo.It("Should unblock admission of new workloads in other ClusterQueues once the admitted workload exceeds timeout", func() {
@@ -455,7 +455,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 		// We wait 1 second between each workload creation call, including after the last one.
 		// Add this time to the timeout.
 		podsReadyTimeout = util.TinyTimeout + 3*time.Second
-		requeueingBackoffLimitCount = ptr.To[int32](2)
+		requeueingBackoffLimitCount = new(int32(2))
 
 		localQueueName := "eviction-lq"
 
@@ -510,13 +510,13 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReady", func() {
 			// Here, we focus on verifying if the requeuingTimestamp works well.
 			// So, we don't check if the .status.requeueState.requeueAt is reset.
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl1), &kueue.RequeueState{
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			}, true)
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl2), &kueue.RequeueState{
-				Count: ptr.To[int32](1),
+				Count: new(int32(1)),
 			}, true)
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl3), &kueue.RequeueState{
-				Count: ptr.To[int32](1),
+				Count: new(int32(1)),
 			}, true)
 		})
 	})
@@ -617,7 +617,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 				RequeuingStrategy: &config.RequeuingStrategy{
 					Timestamp:          new(requeuingTimestamp),
 					BackoffLimitCount:  requeueingBackoffLimitCount,
-					BackoffBaseSeconds: ptr.To[int32](1),
+					BackoffBaseSeconds: new(int32(1)),
 				},
 			},
 		}
@@ -718,7 +718,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 			util.AwaitWorkloadEvictionByPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), podsReadyTimeout)
 			util.SetRequeuedConditionWithPodsReadyTimeout(ctx, k8sClient, client.ObjectKeyFromObject(prodWl))
 			util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(prodWl), &kueue.RequeueState{
-				Count: ptr.To[int32](2),
+				Count: new(int32(2)),
 			}, false)
 			gomega.Expect(workload.IsActive(prodWl)).Should(gomega.BeTrue())
 		})
@@ -795,7 +795,7 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 				// - Count=1 (from the first eviction)
 				// - RequeueAt=nil (cleared after re-admission in nonblocking mode)
 				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl1), &kueue.RequeueState{
-					Count: ptr.To[int32](1),
+					Count: new(int32(1)),
 				}, false)
 			})
 			ginkgo.By("waiting for the first workload to be evicted again (second eviction)", func() {
@@ -808,10 +808,10 @@ var _ = ginkgo.Describe("SchedulerWithWaitForPodsReadyNonblockingMode", func() {
 				// because in nonblocking mode, after each backoff completes and re-admission happens,
 				// the controller clears RequeueAt to nil while preserving Count.
 				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl1), &kueue.RequeueState{
-					Count: ptr.To[int32](2),
+					Count: new(int32(2)),
 				}, false)
 				util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl2), &kueue.RequeueState{
-					Count: ptr.To[int32](1),
+					Count: new(int32(1)),
 				}, false)
 				ginkgo.By("wl3 had never been admitted", func() {
 					util.ExpectWorkloadToHaveRequeueState(ctx, k8sClient, client.ObjectKeyFromObject(wl3), nil, false)

--- a/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
+++ b/test/integration/singlecluster/scheduler/resourcetransformations/resource_transformations_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -45,7 +44,7 @@ var _ = ginkgo.Describe("Resource Transformations", ginkgo.Ordered, ginkgo.Conti
 		transformations := []config.ResourceTransformation{
 			{
 				Input:    "nvidia.com/mig-1g.5gb",
-				Strategy: ptr.To(config.Replace),
+				Strategy: new(config.Replace),
 				Outputs: corev1.ResourceList{
 					"example.com/accelerator-memory": resource.MustParse("5Ki"),
 					"example.com/credits":            resource.MustParse("10"),
@@ -53,7 +52,7 @@ var _ = ginkgo.Describe("Resource Transformations", ginkgo.Ordered, ginkgo.Conti
 			},
 			{
 				Input:      "nvidia.com/gpucores",
-				Strategy:   ptr.To(config.Replace),
+				Strategy:   new(config.Replace),
 				MultiplyBy: "nvidia.com/gpu",
 				Outputs: corev1.ResourceList{
 					"nvidia.com/total-gpucores": resource.MustParse("1"),
@@ -61,7 +60,7 @@ var _ = ginkgo.Describe("Resource Transformations", ginkgo.Ordered, ginkgo.Conti
 			},
 			{
 				Input:      "nvidia.com/gpumem",
-				Strategy:   ptr.To(config.Replace),
+				Strategy:   new(config.Replace),
 				MultiplyBy: "nvidia.com/gpu",
 				Outputs: corev1.ResourceList{
 					"nvidia.com/total-gpumem": resource.MustParse("1"),
@@ -203,7 +202,7 @@ var _ = ginkgo.Describe("Resource Transformation: Retain CPU → cpu_credits (Sh
 		// Starts the manager with a single retain transformation: 1 CPU → 1 cpu_credits
 		fwk.StartManager(ctx, cfg, managerAndSchedulerSetup([]config.ResourceTransformation{{
 			Input:    corev1.ResourceCPU,
-			Strategy: ptr.To(config.Retain),
+			Strategy: new(config.Retain),
 			Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
 		}}))
 	})
@@ -317,7 +316,7 @@ var _ = ginkgo.Describe("Resource Transformation: Retain CPU → cpu_credits (Sh
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admitted[0]), createdWl)).To(gomega.Succeed())
 					createdWl.Spec.PriorityClassRef.Name = lowPriorityClassName
-					createdWl.Spec.Priority = ptr.To[int32](lowPriority)
+					createdWl.Spec.Priority = new(int32(lowPriority))
 					g.Expect(k8sClient.Update(ctx, createdWl)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				util.FinishEvictionForWorkloads(ctx, k8sClient, admitted[0])

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -294,7 +294,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 						ResourceUsage: corev1.ResourceList{
 							corev1.ResourceCPU: resource.MustParse("0"),
 						},
-						Count: ptr.To[int32](0),
+						Count: new(int32(0)),
 					}).Obj()
 
 				util.ExpectWorkloadToBeAdmittedAs(ctx, k8sClient, emptyWl, emptyWlAdmission)
@@ -608,7 +608,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.When("Hold ClusterQueue at startup", func() {
 			ginkgo.BeforeEach(func() {
-				cqsStopPolicy = ptr.To(kueue.Hold)
+				cqsStopPolicy = new(kueue.Hold)
 			})
 			ginkgo.AfterEach(func() {
 				cqsStopPolicy = nil
@@ -706,7 +706,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 		ginkgo.When("Hold LocalQueue at startup", func() {
 			ginkgo.BeforeEach(func() {
-				lqsStopPolicy = ptr.To(kueue.Hold)
+				lqsStopPolicy = new(kueue.Hold)
 			})
 			ginkgo.AfterEach(func() {
 				lqsStopPolicy = nil
@@ -2158,7 +2158,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var cq kueue.ClusterQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cqTeamA), &cq)).To(gomega.Succeed())
-				cq.Spec.StopPolicy = ptr.To(kueue.Hold)
+				cq.Spec.StopPolicy = new(kueue.Hold)
 				g.Expect(k8sClient.Update(ctx, &cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -2183,7 +2183,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				var cq kueue.ClusterQueue
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cqTeamA), &cq)).To(gomega.Succeed())
-				cq.Spec.StopPolicy = ptr.To(kueue.None)
+				cq.Spec.StopPolicy = new(kueue.None)
 				g.Expect(k8sClient.Update(ctx, &cq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -2543,7 +2543,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			var clusterQueue kueue.ClusterQueue
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cq), &clusterQueue)).To(gomega.Succeed())
-				clusterQueue.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				clusterQueue.Spec.StopPolicy = new(kueue.HoldAndDrain)
 				g.Expect(k8sClient.Update(ctx, &clusterQueue)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
@@ -2645,7 +2645,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("Stopping the LocalQueue")
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lq), createdLq)).To(gomega.Succeed())
-				createdLq.Spec.StopPolicy = ptr.To(kueue.HoldAndDrain)
+				createdLq.Spec.StopPolicy = new(kueue.HoldAndDrain)
 				g.Expect(k8sClient.Update(ctx, createdLq)).Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/integration/singlecluster/scheduler/suite_test.go
+++ b/test/integration/singlecluster/scheduler/suite_test.go
@@ -27,7 +27,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/rest"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -107,7 +106,7 @@ func managerAndSchedulerSetup(ctx context.Context, mgr manager.Manager) {
 	transformations := []config.ResourceTransformation{
 		{
 			Input:    corev1.ResourceName(pseudoCPU),
-			Strategy: ptr.To(config.Replace),
+			Strategy: new(config.Replace),
 			Outputs:  corev1.ResourceList{corev1.ResourceCPU: resourcev1.MustParse("2")},
 		},
 	}

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -293,7 +293,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 
 		ginkgo.It("should not allow to update topologyName", func() {
 			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(tasFlavor), tasFlavor)).To(gomega.Succeed())
-			tasFlavor.Spec.TopologyName = ptr.To[kueue.TopologyReference]("invalid")
+			tasFlavor.Spec.TopologyName = new(kueue.TopologyReference("invalid"))
 			gomega.Expect(k8sClient.Update(ctx, tasFlavor)).Should(gomega.HaveOccurred())
 		})
 
@@ -899,7 +899,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 := utiltestingapi.MakeWorkload("wl1-inadmissible", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "2").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
@@ -916,7 +916,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].Count = 2
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+						Required: new(utiltesting.DefaultBlockTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
@@ -958,7 +958,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
@@ -993,7 +993,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl3 = utiltestingapi.MakeWorkload("wl3", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl3.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl3)
 				})
@@ -1028,7 +1028,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl4 = utiltestingapi.MakeWorkload("wl4", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl4.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl4)
 					util.ExpectWorkloadsToBePending(ctx, k8sClient, wl4)
@@ -1073,7 +1073,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].Count = 4
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Preferred: ptr.To(utiltesting.DefaultBlockTopologyLevel),
+						Preferred: new(utiltesting.DefaultBlockTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
@@ -1087,7 +1087,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl2 = utiltestingapi.MakeWorkload("wl2", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl2.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl2)
 				})
@@ -2697,7 +2697,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("creating a workload", func() {
 					wl1 = utiltestingapi.MakeWorkload("wl-greedy", ns.Name).
 						PodSets(*utiltestingapi.MakePodSet("worker", 2).
-							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 							RequiredTopologyRequest(utiltesting.DefaultBlockTopologyLevel).
 							Obj()).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
@@ -3806,7 +3806,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 				ginkgo.By("creating and admitting a rank-ordered slice-topology workload (count 3, slice size 2)", func() {
 					wl = utiltestingapi.MakeWorkload("wl-ungater-oob", ns.Name).
 						PodSets(*utiltestingapi.MakePodSet("worker", 3).
-							PodIndexLabel(ptr.To(batchv1.JobCompletionIndexAnnotation)).
+							PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
 							PreferredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
 							SliceRequiredTopologyRequest(corev1.LabelHostname).
 							SliceSizeTopologyRequest(2).
@@ -4149,7 +4149,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
@@ -4398,7 +4398,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 					wl1 = utiltestingapi.MakeWorkload("wl1", ns.Name).
 						Queue(kueue.LocalQueueName(localQueue.Name)).Request(corev1.ResourceCPU, "1").Obj()
 					wl1.Spec.PodSets[0].TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					util.MustCreate(ctx, k8sClient, wl1)
 				})
@@ -5862,13 +5862,13 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 						map[string]string{corev1.LabelInstanceTypeStable: "cpu-node"},
 					).Request(corev1.ResourceCPU, "5").Obj()
 					ps1.TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					ps2 := *utiltestingapi.MakePodSet("worker", 2).NodeSelector(
 						map[string]string{corev1.LabelInstanceTypeStable: "gpu-node"},
 					).Request(gpuResName, "2").Obj()
 					ps2.TopologyRequest = &kueue.PodSetTopologyRequest{
-						Required: ptr.To(utiltesting.DefaultRackTopologyLevel),
+						Required: new(utiltesting.DefaultRackTopologyLevel),
 					}
 					wl1.Spec.PodSets = []kueue.PodSet{ps1, ps2}
 					util.MustCreate(ctx, k8sClient, wl1)
@@ -7815,7 +7815,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling – Resource Transformation: 
 		// Starts the manager with a single retain transformation: 1 CPU → 1 cpu_credits
 		fwk.StartManager(ctx, cfg, managerSetup(config.ResourceTransformation{
 			Input:    corev1.ResourceCPU,
-			Strategy: ptr.To(config.Retain),
+			Strategy: new(config.Retain),
 			Outputs:  corev1.ResourceList{cpuCredits: resource.MustParse("1")},
 		}))
 	})
@@ -7965,7 +7965,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling – Resource Transformation: 
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(admitted[0]), createdWl)).To(gomega.Succeed())
 					createdWl.Spec.PriorityClassRef.Name = lowPriorityClassName
-					createdWl.Spec.Priority = ptr.To[int32](lowPriority)
+					createdWl.Spec.Priority = new(int32(lowPriority))
 					g.Expect(k8sClient.Update(ctx, createdWl)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				util.FinishEvictionForWorkloads(ctx, k8sClient, admitted[0])
@@ -8065,8 +8065,8 @@ var _ = ginkgo.Describe("Topology Aware Scheduling – WaitForPodsReady with Unh
 				Timeout:         metav1.Duration{Duration: 5 * time.Minute},
 				RecoveryTimeout: &metav1.Duration{Duration: 1 * time.Second},
 				RequeuingStrategy: &config.RequeuingStrategy{
-					BackoffLimitCount:  ptr.To[int32](100),
-					BackoffBaseSeconds: ptr.To[int32](1),
+					BackoffLimitCount:  new(int32(100)),
+					BackoffBaseSeconds: new(int32(1)),
 				},
 			},
 		}))

--- a/test/integration/singlecluster/webhook/core/clusterqueue_test.go
+++ b/test/integration/singlecluster/webhook/core/clusterqueue_test.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -79,7 +78,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 					},
 					Spec: kueue.ClusterQueueSpec{
 						QueueingStrategy:  kueue.BestEffortFIFO,
-						StopPolicy:        ptr.To(kueue.None),
+						StopPolicy:        new(kueue.None),
 						FlavorFungibility: defaultFlavorFungibility,
 						Preemption: &kueue.ClusterQueuePreemption{
 							WithinClusterQueue:  kueue.PreemptionPolicyNever,
@@ -103,7 +102,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 							ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 							BorrowWithinCohort: &kueue.BorrowWithinCohort{
 								Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-								MaxPriorityThreshold: ptr.To[int32](100),
+								MaxPriorityThreshold: new(int32(100)),
 							},
 						},
 					},
@@ -115,14 +114,14 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 					},
 					Spec: kueue.ClusterQueueSpec{
 						QueueingStrategy:  kueue.BestEffortFIFO,
-						StopPolicy:        ptr.To(kueue.None),
+						StopPolicy:        new(kueue.None),
 						FlavorFungibility: defaultFlavorFungibility,
 						Preemption: &kueue.ClusterQueuePreemption{
 							WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 							ReclaimWithinCohort: kueue.PreemptionPolicyAny,
 							BorrowWithinCohort: &kueue.BorrowWithinCohort{
 								Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-								MaxPriorityThreshold: ptr.To[int32](100),
+								MaxPriorityThreshold: new(int32(100)),
 							},
 						},
 					},
@@ -144,7 +143,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 					},
 					Spec: kueue.ClusterQueueSpec{
 						QueueingStrategy:  kueue.BestEffortFIFO,
-						StopPolicy:        ptr.To(kueue.None),
+						StopPolicy:        new(kueue.None),
 						FlavorFungibility: defaultFlavorFungibility,
 						Preemption: &kueue.ClusterQueuePreemption{
 							ReclaimWithinCohort: kueue.PreemptionPolicyNever,
@@ -532,7 +531,7 @@ var _ = ginkgo.Describe("ClusterQueue Webhook", func() {
 							ReclaimWithinCohort: kueue.PreemptionPolicyLowerPriority,
 							BorrowWithinCohort: &kueue.BorrowWithinCohort{
 								Policy:               kueue.BorrowWithinCohortPolicyLowerPriority,
-								MaxPriorityThreshold: ptr.To[int32](10),
+								MaxPriorityThreshold: new(int32(10)),
 							},
 						},
 					},

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueuev1beta1 "sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -323,7 +322,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 												Operator:          corev1.TolerationOpEqual,
 												Value:             "t1v",
 												Effect:            corev1.TaintEffectNoExecute,
-												TolerationSeconds: ptr.To[int64](5),
+												TolerationSeconds: new(int64(5)),
 											},
 										},
 										NodeSelector: map[string]string{"type": "first"},
@@ -338,7 +337,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 												Operator:          corev1.TolerationOpEqual,
 												Value:             "t2v",
 												Effect:            corev1.TaintEffectNoExecute,
-												TolerationSeconds: ptr.To[int64](10),
+												TolerationSeconds: new(int64(10)),
 											},
 										},
 										NodeSelector: map[string]string{"type": "second"},
@@ -820,7 +819,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				false,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.MaximumExecutionTimeSeconds = ptr.To[int32](1)
+					newWL.Spec.MaximumExecutionTimeSeconds = new(int32(1))
 				},
 				gomega.Succeed(),
 			),
@@ -842,7 +841,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				true,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.MaximumExecutionTimeSeconds = ptr.To[int32](1)
+					newWL.Spec.MaximumExecutionTimeSeconds = new(int32(1))
 				},
 				utiltesting.BeInvalidError(),
 			),
@@ -864,7 +863,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				false,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.Priority = ptr.To[int32](10)
+					newWL.Spec.Priority = new(int32(10))
 				},
 				gomega.Succeed(),
 			),
@@ -874,7 +873,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				false,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.Priority = ptr.To[int32](10)
+					newWL.Spec.Priority = new(int32(10))
 				},
 				gomega.Succeed(),
 			),
@@ -887,7 +886,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				false,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.Priority = ptr.To[int32](10)
+					newWL.Spec.Priority = new(int32(10))
 				},
 				gomega.Succeed(),
 			),
@@ -900,7 +899,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				},
 				false,
 				func(newWL *kueue.Workload) {
-					newWL.Spec.Priority = ptr.To[int32](10)
+					newWL.Spec.Priority = new(int32(10))
 				},
 				gomega.Succeed(),
 			),
@@ -911,7 +910,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("low")
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				gomega.Succeed(),
 			),
@@ -922,7 +921,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				true,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef = kueue.NewWorkloadPriorityClassRef("low")
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				utiltesting.BeInvalidError(),
 			),
@@ -936,7 +935,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef.Name = "low"
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				gomega.Succeed(),
 			),
@@ -950,7 +949,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				true,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef.Name = "low"
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				gomega.Succeed(),
 			),
@@ -989,7 +988,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef("low")
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				gomega.Succeed(),
 			),
@@ -1000,7 +999,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				true,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef = kueue.NewPodPriorityClassRef("low")
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				utiltesting.BeInvalidError(),
 			),
@@ -1014,7 +1013,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				false,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef.Name = "low"
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				gomega.Succeed(),
 			),
@@ -1028,7 +1027,7 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 				true,
 				func(newWL *kueue.Workload) {
 					newWL.Spec.PriorityClassRef.Name = "low"
-					newWL.Spec.Priority = ptr.To[int32](100)
+					newWL.Spec.Priority = new(int32(100))
 				},
 				utiltesting.BeInvalidError(),
 			),

--- a/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/job_webhook_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
-	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
@@ -192,7 +191,7 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 		createdJob := &batchv1.Job{}
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
-		createdJob.Spec.Parallelism = ptr.To[int32](4)
+		createdJob.Spec.Parallelism = new(int32(4))
 		createdJob.Spec.Suspend = new(false)
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 	})
@@ -214,7 +213,7 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 		createdJob := &batchv1.Job{}
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
-		createdJob.Spec.Parallelism = ptr.To[int32](3)
+		createdJob.Spec.Parallelism = new(int32(3))
 		createdJob.Spec.Suspend = new(false)
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 	})
@@ -232,7 +231,7 @@ var _ = ginkgo.Describe("Job Webhook with manageJobsWithoutQueueName disabled", 
 		updatedJob := &batchv1.Job{}
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, updatedJob)).Should(gomega.Succeed())
 
-		updatedJob.Spec.Parallelism = ptr.To[int32](6)
+		updatedJob.Spec.Parallelism = new(int32(6))
 		delete(updatedJob.Annotations, job.StoppingAnnotation)
 		gomega.Expect(k8sClient.Update(ctx, updatedJob)).Should(gomega.Succeed())
 	})

--- a/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/leaderworkerset_webhook_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
@@ -61,7 +60,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 			ginkgo.By("Increasing the size is rejected by the webhook", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
-					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+					createdLws.Spec.LeaderWorkerTemplate.Size = new(int32(10))
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.SatisfyAll(
 						utiltesting.BeForbiddenError(),
 						gomega.MatchError(gomega.ContainSubstring("spec.leaderWorkerTemplate.size")),
@@ -82,7 +81,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 			ginkgo.By("Decreasing the size is rejected by the webhook", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
-					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](1)
+					createdLws.Spec.LeaderWorkerTemplate.Size = new(int32(1))
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.SatisfyAll(
 						utiltesting.BeForbiddenError(),
 						gomega.MatchError(gomega.ContainSubstring("spec.leaderWorkerTemplate.size")),
@@ -104,7 +103,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 			ginkgo.By("Increasing replicas is accepted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
-					createdLws.Spec.Replicas = ptr.To[int32](3)
+					createdLws.Spec.Replicas = new(int32(3))
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
@@ -127,7 +126,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 				ginkgo.By("Increasing the size is accepted", func() {
 					gomega.Eventually(func(g gomega.Gomega) {
 						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
-						createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+						createdLws.Spec.LeaderWorkerTemplate.Size = new(int32(10))
 						g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 				})
@@ -147,7 +146,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet Webhook", func() {
 			ginkgo.By("Increasing the size is accepted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lws), createdLws)).To(gomega.Succeed())
-					createdLws.Spec.LeaderWorkerTemplate.Size = ptr.To[int32](10)
+					createdLws.Spec.LeaderWorkerTemplate.Size = new(int32(10))
 					g.Expect(k8sClient.Update(ctx, createdLws)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
+++ b/test/integration/singlecluster/webhook/jobs/trainjob_webhook_test.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 			trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 				APIGroup: new(kftrainerapi.GroupVersion.Group),
 				Name:     "test",
-				Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+				Kind:     new(kftrainerapi.TrainingRuntimeKind),
 			}).
 				Queue("queue").
 				Suspend(false).
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("Trainjob Webhook", func() {
 			trainJob := testingtrainjob.MakeTrainJob("trainjob-test", ns.Name).RuntimeRef(kftrainerapi.RuntimeRef{
 				APIGroup: new(kftrainerapi.GroupVersion.Group),
 				Name:     "test",
-				Kind:     ptr.To(kftrainerapi.TrainingRuntimeKind),
+				Kind:     new(kftrainerapi.TrainingRuntimeKind),
 			}).
 				Suspend(false).
 				Obj()

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
@@ -194,7 +193,7 @@ func KubeconfigForMultiKueueSA(ctx context.Context, c client.Client, restConfig 
 		Spec: authenticationv1.TokenRequestSpec{
 			// The 7d expiration duration matches the max expiration time value for this token
 			// and is configured in [hack/testing/multikueue/worker-cluster.kind.yaml].
-			ExpirationSeconds: ptr.To[int64](7 * 24 * 3600),
+			ExpirationSeconds: new(int64(7 * 24 * 3600)),
 		},
 	}
 	err = c.SubResource("token").Create(ctx, sa, token)

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -408,7 +408,7 @@ func UnholdClusterQueue(ctx context.Context, k8sClient client.Client, cq *kueue.
 		if ptr.Deref(cqCopy.Spec.StopPolicy, kueue.None) == kueue.None {
 			return
 		}
-		cqCopy.Spec.StopPolicy = ptr.To(kueue.None)
+		cqCopy.Spec.StopPolicy = new(kueue.None)
 		g.Expect(k8sClient.Update(ctx, &cqCopy)).To(gomega.Succeed())
 	}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Failed to unhold cluster queue", &cqCopy))
 }
@@ -420,7 +420,7 @@ func UnholdLocalQueue(ctx context.Context, k8sClient client.Client, lq *kueue.Lo
 		if ptr.Deref(lqCopy.Spec.StopPolicy, kueue.None) == kueue.None {
 			return
 		}
-		lqCopy.Spec.StopPolicy = ptr.To(kueue.None)
+		lqCopy.Spec.StopPolicy = new(kueue.None)
 		g.Expect(k8sClient.Update(ctx, &lqCopy)).To(gomega.Succeed())
 	}, Timeout, Interval).Should(gomega.Succeed(), AssertMsg("Failed to unhold local queue", &lqCopy))
 }
@@ -1679,7 +1679,7 @@ func waitForDummyWorkloadToRunOnNode(ctx context.Context, c client.Client, node 
 			SuccessPolicy(&batchv1.SuccessPolicy{
 				Rules: []batchv1.SuccessPolicyRule{
 					{
-						SucceededCount: ptr.To[int32](1),
+						SucceededCount: new(int32(1)),
 					},
 				},
 			}).


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Manual cherry pick of #14046 into `release-0.19`, as requested by the @tenzen-y .

`release-0.19` is on `go 1.26.0`, so the extended `new` builtin is available there.

Conflict resolution: three files conflicted because `main` has tests and fields for
features not present in `release-0.19`. In each case I kept the `release-0.19` side
and applied the rewrite to what that branch actually contains:

- `pkg/cache/queue/cluster_queue_test.go` — dropped incoming `TestClusterQueuePendingTrackers`
- `pkg/workload/workload_test.go` — dropped incoming `TestTotalExecutionTime`
- `test/integration/singlecluster/controller/core/custom_labels_test.go` — dropped the
  incoming `wl_anno` annotation entry and its metric assertions

The second commit converts 86 remaining `ptr.To` call sites that exist only on
`release-0.19` and so were never touched by the original patch. Without it the branch
is left partially converted. Happy to drop that commit if you'd prefer a strict
cherry-pick.

#### Special notes for your reviewer:

Verified on `release-0.19` with `go build ./...` and `go vet ./...`, both clean.

AI disclosure: assited by gemini-3.5-flash; reviewed by me.

#### Does this PR introduce a user-facing change?
No

```release-note
NONE