### PR TITLE
Automated cherry pick of #13244: MultiKueue: reject in-tree autoscaling for elastic RayClusters until worker-driven resizes are supported

### DIFF
--- a/pkg/controller/jobs/raycluster/raycluster_webhook.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook.go
@@ -214,6 +214,18 @@ func validateElasticJob(job *rayv1.RayCluster) field.ErrorList {
 		)
 	}
 
+	// MultiKueue does not support Ray autoscaling yet.
+	if ptr.Deref(job.Spec.EnableInTreeAutoscaling, false) &&
+		ptr.Deref(job.Spec.ManagedBy, "") == kueue.MultiKueueControllerName {
+		allErrors = append(
+			allErrors,
+			field.Forbidden(
+				specPath.Child("enableInTreeAutoscaling"),
+				"in-tree autoscaling is not supported for a MultiKueue-managed elastic RayCluster",
+			),
+		)
+	}
+
 	return allErrors
 }
 

--- a/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_webhook_test.go
@@ -157,6 +157,30 @@ func TestValidateCreate(t *testing.T) {
 				),
 			}.ToAggregate(),
 		},
+		"invalid managed - elastic MultiKueue job with auto scaler": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				ManagedBy(kueue.MultiKueueControllerName).
+				SchedulingGate(kueue.ElasticJobSchedulingGate).
+				WithEnableAutoscaling(new(true)).
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(
+					field.NewPath("spec", "enableInTreeAutoscaling"),
+					"in-tree autoscaling is not supported for a MultiKueue-managed elastic RayCluster",
+				),
+			}.ToAggregate(),
+		},
+		"valid managed - elastic MultiKueue job without auto scaler": {
+			featureGates: map[featuregate.Feature]bool{features.ElasticJobsViaWorkloadSlices: true},
+			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").
+				SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				ManagedBy(kueue.MultiKueueControllerName).
+				SchedulingGate(kueue.ElasticJobSchedulingGate).
+				Obj(),
+			wantErr: nil,
+		},
 		"invalid managed - too many worker groups": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			job: testingrayutil.MakeCluster("job", "ns").Queue("queue").

--- a/pkg/util/testingjobs/raycluster/wrappers.go
+++ b/pkg/util/testingjobs/raycluster/wrappers.go
@@ -168,6 +168,17 @@ func (j *ClusterWrapper) WithAutoscalerOptions(value *rayv1.AutoscalerOptions) *
 	return j
 }
 
+// SchedulingGate adds a scheduling gate to the head group and every worker group template.
+func (j *ClusterWrapper) SchedulingGate(name string) *ClusterWrapper {
+	gate := corev1.PodSchedulingGate{Name: name}
+	j.Spec.HeadGroupSpec.Template.Spec.SchedulingGates = append(j.Spec.HeadGroupSpec.Template.Spec.SchedulingGates, gate)
+	for i := range j.Spec.WorkerGroupSpecs {
+		wgs := &j.Spec.WorkerGroupSpecs[i]
+		wgs.Template.Spec.SchedulingGates = append(wgs.Template.Spec.SchedulingGates, gate)
+	}
+	return j
+}
+
 func (j *ClusterWrapper) ScaleFirstWorkerGroup(replicas int32) *ClusterWrapper {
 	j.Spec.WorkerGroupSpecs[0].Replicas = &replicas
 	return j


### PR DESCRIPTION
Cherry pick of #13244 on release-0.18.

#13244: MultiKueue: reject in-tree autoscaling for elastic RayClusters until worker-driven resizes are supported

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

/area release

```release-note
MultiKueue: an elastic RayCluster (ElasticJobsViaWorkloadSlices) managed by MultiKueue is now rejected at admission if `enableInTreeAutoscaling` is set, as MultiKueue does not support Ray autoscaling yet. Previously such a RayCluster was accepted but deleted right after admission due to inconsistent autoscaler-sidecar accounting between the manager and the worker.
```