### PR TITLE
Automated cherry pick of #13491: Sort GreaterKeys results alphabetically in both Requests implementations

### DIFF
--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -42,6 +42,10 @@ type Requests interface {
 	// FloorToZero replaces negative resource values with zero.
 	FloorToZero()
 	ToResourceList() corev1.ResourceList
+	// GreaterKeys returns the keys where the receiver is greater than other,
+	// sorted alphabetically for deterministic output.
 	GreaterKeys(other Requests) []corev1.ResourceName
+	// GreaterKeysRL returns the keys where the receiver is greater than the
+	// ResourceList value, sorted alphabetically for deterministic output.
 	GreaterKeysRL(rl corev1.ResourceList) []corev1.ResourceName
 }

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -20,6 +20,7 @@ import (
 	"iter"
 	"maps"
 	"math"
+	"slices"
 	"strings"
 	"sync"
 
@@ -209,7 +210,8 @@ func AmountQuantityString(name corev1.ResourceName, a Amount) string {
 	return ResourceQuantityString(name, a.Int64())
 }
 
-// GreaterKeys returns keys where the receiver is greater than other.
+// GreaterKeys returns keys where the receiver is greater than other,
+// sorted alphabetically for deterministic output.
 func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(r) == 0 || isEmpty(other) {
 		return nil
@@ -224,6 +226,7 @@ func (r MapRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if len(result) == 0 {
 		return nil
 	}
+	slices.Sort(result)
 	return result
 }
 

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -302,6 +302,17 @@ func TestGreaterKeys(t *testing.T) {
 			},
 			want: nil,
 		},
+		"multiple_greater_sorted": {
+			a: MapRequests{
+				"r2": 2,
+				"r1": 2,
+			},
+			b: MapRequests{
+				"r2": 1,
+				"r1": 1,
+			},
+			want: []corev1.ResourceName{"r1", "r2"},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -222,7 +222,8 @@ func (sr *SliceRequests) ToResourceList() corev1.ResourceList {
 	return ret
 }
 
-// GreaterKeys returns keys where the receiver is greater than other.
+// GreaterKeys returns keys where the receiver is greater than other,
+// sorted alphabetically for deterministic output.
 func (sr *SliceRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 	if sr.IsEmpty() || isEmpty(other) {
 		return nil
@@ -238,6 +239,7 @@ func (sr *SliceRequests) GreaterKeys(other Requests) []corev1.ResourceName {
 			result = append(result, entry.name)
 		}
 	}
+	slices.Sort(result)
 	return result
 }
 

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -725,6 +725,17 @@ func TestSliceRequests_GreaterKeys(t *testing.T) {
 			}),
 			want: []corev1.ResourceName{corev1.ResourceCPU},
 		},
+		"multiple greater keys sorted alphabetically": {
+			req: NewSliceRequests(MapRequests{
+				corev1.ResourceCPU:  2000,
+				corev1.ResourcePods: 10,
+			}),
+			other: MapRequests{
+				corev1.ResourceCPU:  1000,
+				corev1.ResourcePods: 5,
+			},
+			want: []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourcePods},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
+++ b/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("2a0910XBA20Z 0001020000")

--- a/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
+++ b/pkg/resources/testdata/fuzz/FuzzSliceRequestsEquivalence/2b2372b9b892381b
@@ -1,2 +1,0 @@
-go test fuzz v1
-[]byte("2a0910XBA20Z 0001020000")


### PR DESCRIPTION
Cherry pick of #13491 on release-0.18.

#13491: Sort GreaterKeys results alphabetically in both Requests implementations

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

/area release

```release-note
NONE
```