### PR TITLE
Automated cherry pick of #13051: test: wait for the reconciler to process the Job

### DIFF
--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5865,7 +5865,7 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 
 			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 
-			gomega.Consistently(func(g gomega.Gomega) {
+			gomega.Eventually(func(g gomega.Gomega) {
 				wls := &kueue.WorkloadList{}
 				gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
 				gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5865,11 +5865,11 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 
 			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 
-			gomega.Eventually(func(g gomega.Gomega) {
+			gomega.Consistently(func(g gomega.Gomega) {
 				wls := &kueue.WorkloadList{}
 				gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
 				gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
-			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5865,9 +5865,11 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 
 			gomega.Expect(k8sClient.Create(ctx, job)).To(gomega.Succeed())
 
-			wls := &kueue.WorkloadList{}
-			gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
-			gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
+			gomega.Consistently(func(g gomega.Gomega) {
+				wls := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
+				g.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
+			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 
 		ginkgo.It("should reconcile a job in managed namespace and create a workload", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5867,8 +5867,8 @@ var _ = ginkgo.Describe("Job reconciliation", ginkgo.Ordered, func() {
 
 			gomega.Consistently(func(g gomega.Gomega) {
 				wls := &kueue.WorkloadList{}
-				g.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
-				g.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
+				gomega.Expect(k8sClient.List(ctx, wls, client.InNamespace(unmanagedNs.Name))).To(gomega.Succeed())
+				gomega.Expect(wls.Items).To(gomega.BeEmpty(), "Expected no workload in unmanaged namespace")
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
 		})
 


### PR DESCRIPTION
Cherry pick of #13051 on release-0.18.

#13051: test: wait for the reconciler to process the Job

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake

/area release

```release-note
NONE
```