### PR TITLE
Automated cherry pick of #12589: Fix ray-mini image by pinning Python 3.13 and re-enable for presubmits

### DIFF
--- a/hack/testing/ray-mini/Dockerfile
+++ b/hack/testing/ray-mini/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim
+FROM python:3.13-slim@sha256:2b7445fb71ca9cb15e9aab053fe8cb3162796f8e1d92ada12a49c766a811bc1e
 
 # Set environment variable to avoid interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Cherry pick of #12589 on release-0.18.

#12589: Fix ray-mini image by pinning Python 3.13 and re-enable for presubmits

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

/area release

```release-note
NONE
```