### PR TITLE
Automated cherry pick of #12652: Fix: Clear Ungate Expectations on No-Op Elastic Pod Patch

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -166,8 +166,12 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		if e != nil {
 			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
 			log.Error(e, "failed ungating elastic pod", "pod", klog.KObj(pod))
+			return e
 		}
-		return e
+		if !ungated {
+			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+		}
+		return nil
 	})
 	return reconcile.Result{}, err
 }


### PR DESCRIPTION
Cherry pick of #12652 on release-0.18.

#12652: Fix: Clear Ungate Expectations on No-Op Elastic Pod Patch

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup

/area release

```release-note
ElasticJob: Added a defensive safeguard to avoid stale pending expectations in no-op pod ungate paths, following 
the pattern from the TAS topology ungater.
```