### PR TITLE
Automated cherry pick of #12436: fix(tas): account for elastic workload leaders

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -6642,6 +6642,155 @@ func TestFindTopologyAssignments(t *testing.T) {
 				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
 			},
 		},
+		"elastic workload scale down with leader: truncates workers, reuses leader": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           3,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 3, Values: []string{"x1"}},
+							{Count: 2, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 3, Values: []string{"x1"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
+		"elastic workload same count with leader: reuses both assignments exactly": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("4"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			levels: defaultOneLevel,
+			podSets: []PodSetTestCase{
+				{
+					podSetName: "leader",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           1,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+				{
+					podSetName: "workers",
+					topologyRequest: &kueue.PodSetTopologyRequest{
+						Unconstrained: new(true),
+					},
+					requests: map[corev1.ResourceName]int64{
+						corev1.ResourceCPU: 1000,
+					},
+					count:           3,
+					podSetGroupName: new("elastic-group"),
+					previousAssignment: tas.V1Beta2From(&tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 1, Values: []string{"x2"}},
+						},
+					}),
+					wantAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{
+							{Count: 2, Values: []string{"x1"}},
+							{Count: 1, Values: []string{"x2"}},
+						},
+					},
+				},
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.ElasticJobsViaWorkloadSlices:        true,
+				features.ElasticJobsViaWorkloadSlicesWithTAS: true,
+			},
+		},
 		"multi-layer topology: block required; rack slices of 4; host slices of 2; TASMultiLayerTopology": {
 			// 4-level topology: block → rack → hostname
 			//              b1

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -61,18 +61,15 @@ func (s *TASFlavorSnapshot) handleElasticWorkload(
 	}
 
 	previousCount := utiltas.CountPodsInAssignment(prevAssignment)
-	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 
 	switch {
 	case workers.Count > previousCount:
 		return s.handleScaleUp(workers, leader, prevAssignment, previousCount, assumedUsage, opts)
 	case workers.Count < previousCount:
-		return s.handleScaleDown(workers, prevAssignment, assumedUsage)
+		return s.handleScaleDown(workers, leader, prevAssignment, assumedUsage)
 	default:
 		// Same count: reuse previous assignment
-		result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: prevAssignment}
-		addAssumedUsage(assumedUsage, prevAssignment, &workers)
-		return elasticPlacementResult{applied: true, assignments: result}
+		return s.finalizeElasticAssignment(workers, prevAssignment, leader, assumedUsage)
 	}
 }
 
@@ -133,13 +130,32 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 // handleScaleDown truncates the previous assignment to fit fewer pods.
 func (s *TASFlavorSnapshot) handleScaleDown(
 	workers TASPodSetRequests,
+	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 ) elasticPlacementResult {
-	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
-
 	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
-	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: truncatedAssignment}
-	addAssumedUsage(assumedUsage, truncatedAssignment, &workers)
+	return s.finalizeElasticAssignment(workers, truncatedAssignment, leader, assumedUsage)
+}
+
+// finalizeElasticAssignment builds a result with the workers' assignment and, when
+// present, the leader's previous assignment. It also accounts for the resource usage
+// of both.
+func (s *TASFlavorSnapshot) finalizeElasticAssignment(
+	workers TASPodSetRequests,
+	workersAssignment *utiltas.TopologyAssignment,
+	leader *TASPodSetRequests,
+	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+) elasticPlacementResult {
+	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
+	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: workersAssignment}
+	addAssumedUsage(assumedUsage, workersAssignment, &workers)
+
+	if leader != nil {
+		leaderPrevAssignment := utiltas.InternalFrom(leader.PreviousAssignment)
+		result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: leaderPrevAssignment}
+		addAssumedUsage(assumedUsage, leaderPrevAssignment, leader)
+	}
+
 	return elasticPlacementResult{applied: true, assignments: result}
 }


### PR DESCRIPTION
Cherry pick of #12436 on release-0.18.

#12436: fix(tas): account for elastic workload leaders

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug

/area release

```release-note
TAS: Fixed elastic workload placement to preserve leader pod set assignments and capacity accounting when worker counts stay the same or scale down.
```