### PR TITLE
docs: link SIG Scheduling contributor guide in coding guidelines

### DIFF
--- a/site/content/en/community/contribution_guidelines/coding_guidelines.md
+++ b/site/content/en/community/contribution_guidelines/coding_guidelines.md
@@ -13,6 +13,9 @@ these when writing new code or reviewing pull requests.
 Kueue is a Kubernetes project and follows the upstream Kubernetes conventions.
 Be familiar with these core guidelines:
 
+- [SIG Scheduling Contributor Guide](https://git.k8s.io/community/sig-scheduling/CONTRIBUTING.md)
+  — contribution guidance specific to the Kubernetes scheduling ecosystem that
+  Kueue is part of.
 - [Kubernetes Deprecation Policy](https://kubernetes.io/docs/reference/using-api/deprecation-policy/)
   — rules for API version lifetimes (alpha, beta, GA) and removal timelines.
 - [Kubernetes API Changes](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area website

#### What this PR does / why we need it:

Adds a reference to the SIG Scheduling contributor guide near the existing
upstream Kubernetes guidance in the coding guidelines, so contributors have
a direct pointer to the scheduling-specific contribution process.

#### Which issue(s) this PR fixes:

Fixes #14059

#### Special notes for your reviewer:

Requested by @tenzen-y in review of #11514.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the Kubernetes SIG Scheduling Contributor Guide.
  * Included a description of the guide’s scheduling-specific contribution guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->