### PR TITLE
docs: add post-admission startup and eviction latency queries

### DIFF
--- a/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
+++ b/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
@@ -117,6 +117,39 @@ histogram_quantile(0.99,
 )
 ```
 
+## Post-admission startup latency
+
+For workloads using the Pod integration, monitor the time from Workload admission
+until Kueue removes a scheduling gate from the associated Pods. For example, the
+following query shows the 95th percentile (P95) by ClusterQueue, gate name, and
+whether the Pods belong to a group:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, cluster_queue, name, is_group) (
+    rate(kueue_pod_scheduling_gate_removal_seconds_bucket[5m])
+  )
+)
+```
+
+This latency isolates the controller handoff after admission. It does not include
+the time that Kubernetes takes to schedule or start the Pods.
+
+When `waitForPodsReady` is enabled, monitor the time from Workload admission until
+the Workload reaches `PodsReady=True`. For example, the following query shows the
+P95 by ClusterQueue and priority class:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, cluster_queue, priority_class) (
+    rate(kueue_admitted_until_ready_wait_time_seconds_bucket[5m])
+  )
+)
+```
+
+This latency includes Kubernetes scheduling, container startup, and Pod readiness.
+It does not establish that the application has started useful work.
+
 ## Workload throughput
 
 To monitor how many workloads are being admitted per hour:
@@ -154,6 +187,20 @@ sum by (cluster_queue, reason) (
 ```
 
 See [Prometheus Metrics](/docs/reference/metrics) for the full list of `reason` label values.
+
+## Eviction recovery latency
+
+To monitor the time from Workload eviction until quota is released and the
+Workload returns to Pending, use the workload eviction latency histogram. For
+example, the following query shows the P95 by ClusterQueue and eviction reason:
+
+```promql
+histogram_quantile(0.95,
+  sum by (le, cluster_queue, reason) (
+    rate(kueue_workload_eviction_latency_seconds_bucket[5m])
+  )
+)
+```
 
 ## ClusterQueue status
 

--- a/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
+++ b/site/content/en/docs/tasks/manage/observability/common_grafana_queries.md
@@ -119,10 +119,13 @@ histogram_quantile(0.99,
 
 ## Post-admission startup latency
 
-For workloads using the Pod integration, monitor the time from Workload admission
-until Kueue removes a scheduling gate from the associated Pods. For example, the
-following query shows the 95th percentile (P95) by ClusterQueue, gate name, and
-whether the Pods belong to a group:
+Monitor the time from Workload admission until Kueue removes one of its scheduling
+gates from the associated Pods. Kueue records this latency for the
+`kueue.x-k8s.io/admission` (Pod integration), the `kueue.x-k8s.io/topology`
+ (Topology-Aware Scheduling, for any supported job framework), and the
+`kueue.x-k8s.io/elastic-job` scheduling gates (elastic jobs). For example, the following query
+shows the 95th percentile (P95) by ClusterQueue, gate name, and whether the Pods
+belong to a group:
 
 ```promql
 histogram_quantile(0.95,


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

/area website

#### What this PR does / why we need it:

Adds example PromQL queries for three existing Kueue lifecycle metrics:

- admission to Pod scheduling-gate removal;
- admission to `PodsReady=True`;
- eviction to Pending/quota release.

The docs also clarify what each interval represents. In particular, gate-removal latency covers the Kueue controller handoff rather than Kubernetes scheduling or Pod startup, and `PodsReady` should not be interpreted as application readiness or useful work.

This is documentation only and does not change any metrics, APIs, or scheduling behavior.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

I checked the metric names and labels against the generated Prometheus metrics reference and `pkg/metrics/metrics.go`. `git diff --check` passes.

I wasn’t able to run the full `make` verification locally because the macOS environment is missing GNU `sed`.

I used an AI coding assistant while researching the existing metrics and drafting the docs. I reviewed the queries and final changes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Grafana queries for measuring post-admission startup latency.
  * Added P95 metrics for scheduling-gate removal and time until pods are ready.
  * Documented eviction recovery latency, grouped by ClusterQueue and eviction reason.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->