### PR TITLE
Cleanup: Remove SchedulerLongRequeueInterval

### DIFF
--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -30,7 +30,6 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -40,9 +40,6 @@ const (
 )
 
 func getRequeueBatchPeriod() time.Duration {
-	if features.Enabled(features.SchedulerLongRequeueInterval) {
-		return requeueLongBatchPeriod
-	}
 	return requeueBatchPeriod
 }
 

--- a/pkg/cache/queue/inadmissible_workloads_test.go
+++ b/pkg/cache/queue/inadmissible_workloads_test.go
@@ -43,26 +43,6 @@ func TestNewRequeuer(t *testing.T) {
 		args args
 		want want
 	}{
-		"SchedulerLongRequeueInterval feature disabled": {
-			args: args{
-				featureGates: map[featuregate.Feature]bool{
-					features.SchedulerLongRequeueInterval: false,
-				},
-			},
-			want: want{
-				batchPeriod: time.Second,
-			},
-		},
-		"SchedulerLongRequeueInterval feature enabled": {
-			args: args{
-				featureGates: map[featuregate.Feature]bool{
-					features.SchedulerLongRequeueInterval: true,
-				},
-			},
-			want: want{
-				batchPeriod: 10 * time.Second,
-			},
-		},
 		"custom batch period": {
 			args: args{
 				opts: []RequeuerOption{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -291,12 +291,6 @@ const (
 	// owner: @mbobrovskyi
 	//
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
-	// Use 10s interval for scheduler requeuing.
-	SchedulerLongRequeueInterval featuregate.Feature = "SchedulerLongRequeueInterval"
-
-	// owner: @mbobrovskyi
-	//
-	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
 	// Use a 5min buffer so that workloads with scheduling timestamps within this
 	// buffer do not preempt each other based on LowerOrNewerEqualPriority.
 	SchedulerTimestampPreemptionBuffer featuregate.Feature = "SchedulerTimestampPreemptionBuffer"
@@ -724,9 +718,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
-	},
-	SchedulerLongRequeueInterval: {
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 	SchedulerTimestampPreemptionBuffer: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -238,3 +238,8 @@
   stage: GA
   from: "0.18"
   to: "0.20"
+- feature: SchedulerLongRequeueInterval
+  default: false
+  stage: Alpha
+  from: "0.17"
+  to: "0.20"

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -311,12 +311,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-- name: SchedulerLongRequeueInterval
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
 - name: SchedulerTimestampPreemptionBuffer
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -311,12 +311,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-- name: SchedulerLongRequeueInterval
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
 - name: SchedulerTimestampPreemptionBuffer
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Part of #13697

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Removed Features**
  * Removed the `SchedulerLongRequeueInterval` feature gate.
  * Scheduler requeue intervals now consistently use the one-second default.
  * Updated feature-gate and compatibility documentation to reflect its removal.
  * Preserved historical lifecycle information for the retired alpha feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->