### PR TITLE
Fix the cherry_pick_pull.sh script

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -162,7 +162,6 @@ For details on the cherry pick process, see the [cherry pick requests](https://g
 
 #### What type of PR is this?
 ${kind_commands}
-/area release
 
 \`\`\`release-note
 $(printf '%s\n' "${RELEASE_NOTES[@]}")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup
/area release

#### What this PR does / why we need it:

- the use of area/release label is for release-process automation, not cherrypicks
- the PRs targeting the main branch will also be released, so labeling only cherrypicks creates assymetric labeling

Fixing some aspects of https://github.com/kubernetes-sigs/kueue/issues/12763

#### Special notes for your reviewer:

This was added by mistake in https://github.com/kubernetes-sigs/kueue/pull/13457

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `/area release` label directive from generated cherry-pick pull request descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->