### PR TITLE
Don't ungate TAS pods onto a node awaiting replacement

### DIFF
--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -268,13 +268,22 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				}
 			}
 			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], rankOffsets[psa.Name], maxRank[psa.Name])
-			if unhealthy := unhealthyDomainIDs(wl, &psa); len(unhealthy) > 0 {
+			// While a node is recorded in Status.UnhealthyNodes the assignment still
+			// points at it until the scheduler's second pass swaps in a replacement
+			// domain. Gated pods must not be ungated onto such a node in the
+			// meantime: they can never schedule there, and the node controller then
+			// terminates them with UnschedulableOnAssignedNode, so every recreated
+			// pod is killed again immediately. Leaving them gated lets them wait for
+			// the replacement domain and be ungated onto a healthy node instead.
+			if workload.HasUnhealthyNodes(wl) {
+				levels := psa.TopologyAssignment.Levels
 				gatedPodsToDomains = slices.DeleteFunc(gatedPodsToDomains, func(pd podWithDomain) bool {
-					if !unhealthy[pd.domainID] {
+					nodeName, ok := utiltas.NodeNameFromDomainID(levels, pd.domainID)
+					if !ok || !workload.HasUnhealthyNode(wl, nodeName) {
 						return false
 					}
-					log.V(2).Info("skipping ungate; the assigned domain's node is unhealthy and awaiting replacement",
-						"pod", klog.KObj(pd.pod), "domain", pd.domainID)
+					log.V(3).Info("skipping ungate; the assigned node is unhealthy and awaiting replacement",
+						"pod", klog.KObj(pd.pod), "domain", pd.domainID, "node", nodeName)
 					return true
 				})
 			}
@@ -362,36 +371,6 @@ func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, workloadSliceNa
 		result = append(result, pod)
 	}
 	return result, nil
-}
-
-// unhealthyDomainIDs returns the assignment's domains whose node is recorded in
-// the Workload's Status.UnhealthyNodes.
-//
-// With TASFailedNodeReplacementFailFast disabled the assignment deliberately
-// keeps pointing at an unhealthy node while the scheduler's second pass looks
-// for a replacement domain. Gated pods must not be ungated onto those domains
-// in the meantime: they can never schedule there, and the node controller then
-// terminates them with UnschedulableOnAssignedNode, so each recreated pod is
-// killed again immediately. Leaving them gated lets them wait for either a
-// replacement domain or the recovery timeout.
-func unhealthyDomainIDs(wl *kueue.Workload, psa *kueue.PodSetAssignment) map[utiltas.TopologyDomainID]bool {
-	if !workload.HasUnhealthyNodes(wl) || psa.TopologyAssignment == nil ||
-		!utiltas.IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
-		return nil
-	}
-	var ids map[utiltas.TopologyDomainID]bool
-	for domain := range utiltas.InternalSeqFrom(psa.TopologyAssignment) {
-		if len(domain.Values) == 0 {
-			continue
-		}
-		if workload.HasUnhealthyNode(wl, domain.Values[len(domain.Values)-1]) {
-			if ids == nil {
-				ids = make(map[utiltas.TopologyDomainID]bool)
-			}
-			ids[utiltas.DomainID(domain.Values)] = true
-		}
-	}
-	return ids
 }
 
 func podsToUngateInfo(

--- a/pkg/controller/tas/topology_ungater.go
+++ b/pkg/controller/tas/topology_ungater.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -267,6 +268,16 @@ func (r *topologyUngater) Reconcile(ctx context.Context, req reconcile.Request) 
 				}
 			}
 			gatedPodsToDomains := assignGatedPodsToDomains(log, &psa, pods, psNameToTopologyRequest[psa.Name], rankOffsets[psa.Name], maxRank[psa.Name])
+			if unhealthy := unhealthyDomainIDs(wl, &psa); len(unhealthy) > 0 {
+				gatedPodsToDomains = slices.DeleteFunc(gatedPodsToDomains, func(pd podWithDomain) bool {
+					if !unhealthy[pd.domainID] {
+						return false
+					}
+					log.V(2).Info("skipping ungate; the assigned domain's node is unhealthy and awaiting replacement",
+						"pod", klog.KObj(pd.pod), "domain", pd.domainID)
+					return true
+				})
+			}
 			if len(gatedPodsToDomains) > 0 {
 				toUngate := podsToUngateInfo(&psa, gatedPodsToDomains)
 				log.V(2).Info("identified pods to ungate for podset", "podset", psa.Name, "count", len(toUngate))
@@ -351,6 +362,36 @@ func (r *topologyUngater) podsForPodSet(ctx context.Context, ns, workloadSliceNa
 		result = append(result, pod)
 	}
 	return result, nil
+}
+
+// unhealthyDomainIDs returns the assignment's domains whose node is recorded in
+// the Workload's Status.UnhealthyNodes.
+//
+// With TASFailedNodeReplacementFailFast disabled the assignment deliberately
+// keeps pointing at an unhealthy node while the scheduler's second pass looks
+// for a replacement domain. Gated pods must not be ungated onto those domains
+// in the meantime: they can never schedule there, and the node controller then
+// terminates them with UnschedulableOnAssignedNode, so each recreated pod is
+// killed again immediately. Leaving them gated lets them wait for either a
+// replacement domain or the recovery timeout.
+func unhealthyDomainIDs(wl *kueue.Workload, psa *kueue.PodSetAssignment) map[utiltas.TopologyDomainID]bool {
+	if !workload.HasUnhealthyNodes(wl) || psa.TopologyAssignment == nil ||
+		!utiltas.IsLowestLevelHostname(psa.TopologyAssignment.Levels) {
+		return nil
+	}
+	var ids map[utiltas.TopologyDomainID]bool
+	for domain := range utiltas.InternalSeqFrom(psa.TopologyAssignment) {
+		if len(domain.Values) == 0 {
+			continue
+		}
+		if workload.HasUnhealthyNode(wl, domain.Values[len(domain.Values)-1]) {
+			if ids == nil {
+				ids = make(map[utiltas.TopologyDomainID]bool)
+			}
+			ids[utiltas.DomainID(domain.Values)] = true
+		}
+	}
+	return ids
 }
 
 func podsToUngateInfo(

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -165,6 +165,110 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		"does not ungate a replacement pod onto the unhealthy domain of a two-pod group": {
+			// Closer to production than the single-pod case below: one pod of the
+			// group survives on a healthy domain and holds its slot, so the only
+			// slot the replacement could take is the one on the unhealthy node.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "2").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domains(
+										utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj(),
+										utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj(),
+									).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					UnhealthyNodes("x1").
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				// Survivor: already ungated on the healthy domain, holding x2's slot.
+				*testingpod.MakePod("pod-survivor", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(corev1.LabelHostname, "x2").
+					Obj(),
+				// Replacement for the pod that was on the unhealthy node.
+				*testingpod.MakePod("pod-replacement", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					TopologySchedulingGate().
+					Obj(),
+			},
+			nodeSelectorAssertMode: nodeSelectorAssertCountsOnly,
+			// Listed name-sorted, which is the order the comparison uses.
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-replacement", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					TopologySchedulingGate().
+					Obj(),
+				*testingpod.MakePod("pod-survivor", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					NodeSelector(corev1.LabelHostname, "x2").
+					Obj(),
+			},
+			wantCounts: []counts{
+				{
+					NodeSelector: map[string]string{corev1.LabelHostname: "x2"},
+					Count:        1,
+				},
+			},
+		},
+		"does not ungate a pod onto a node marked unhealthy": {
+			// With TASFailedNodeReplacementFailFast=false the workload keeps its
+			// admission and its TopologyAssignment while it waits for a
+			// replacement node (see the "should update workload
+			// TopologyAssignment after a node becomes available" integration
+			// test, which asserts the assignment is retained). A replacement pod
+			// created during that window must NOT be ungated onto the domain of
+			// the node already recorded in Status.UnhealthyNodes: it can never
+			// schedule there, and the node controller then terminates it with
+			// UnschedulableOnAssignedNode, so every recreation burns a retry.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("unit-test", "ns").Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "unit-test-flavor", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+									Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					UnhealthyNodes("x1").
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					TopologySchedulingGate().
+					Obj(),
+			},
+			nodeSelectorAssertMode: nodeSelectorAssertCountsOnly,
+			// The pod must stay gated: no node selector applied, nothing ungated.
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "unit-test").
+					Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+					TopologySchedulingGate().
+					Obj(),
+			},
+			wantCounts: []counts{},
+		},
 		"ungate single pod with sub group index label but no sub group count": {
 			// Regression test: a PodSet with SubGroupIndexLabel set but SubGroupCount
 			// nil (e.g. from an unvalidated user-supplied annotation) must not panic

--- a/pkg/controller/tas/topology_ungater_test.go
+++ b/pkg/controller/tas/topology_ungater_test.go
@@ -225,9 +225,8 @@ func TestReconcile(t *testing.T) {
 			},
 		},
 		"does not ungate a pod onto a node marked unhealthy": {
-			// With TASFailedNodeReplacementFailFast=false the workload keeps its
-			// admission and its TopologyAssignment while it waits for a
-			// replacement node (see the "should update workload
+			// The workload keeps its admission and its TopologyAssignment while it
+			// waits for a replacement node (see the "should update workload
 			// TopologyAssignment after a node becomes available" integration
 			// test, which asserts the assignment is retained). A replacement pod
 			// created during that window must NOT be ungated onto the domain of

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -26,8 +26,26 @@ import (
 
 type TopologyDomainID string
 
+// domainIDSeparator joins the level values encoded in a TopologyDomainID.
+const domainIDSeparator = ","
+
 func DomainID(levelValues []string) TopologyDomainID {
-	return TopologyDomainID(strings.Join(levelValues, ","))
+	return TopologyDomainID(strings.Join(levelValues, domainIDSeparator))
+}
+
+// NodeNameFromDomainID returns the node name encoded as the lowest level of the
+// domain ID. It reports false when the domain does not identify a single node,
+// i.e. when the lowest level of levels is not the hostname label, or when
+// domainID does not encode exactly one value per level.
+func NodeNameFromDomainID(levels []string, domainID TopologyDomainID) (string, bool) {
+	if len(levels) == 0 || !IsLowestLevelHostname(levels) {
+		return "", false
+	}
+	values := strings.Split(string(domainID), domainIDSeparator)
+	if len(values) != len(levels) {
+		return "", false
+	}
+	return values[len(values)-1], true
 }
 
 func IsTAS(pod *corev1.Pod) bool {

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -26,26 +26,22 @@ import (
 
 type TopologyDomainID string
 
-// domainIDSeparator joins the level values encoded in a TopologyDomainID.
-const domainIDSeparator = ","
-
 func DomainID(levelValues []string) TopologyDomainID {
-	return TopologyDomainID(strings.Join(levelValues, domainIDSeparator))
+	return TopologyDomainID(strings.Join(levelValues, ","))
 }
 
-// NodeNameFromDomainID returns the node name encoded as the lowest level of the
-// domain ID. It reports false when the domain does not identify a single node,
-// i.e. when the lowest level of levels is not the hostname label, or when
-// domainID does not encode exactly one value per level.
+// NodeNameFromDomainID returns the node name identified by the domain ID. It
+// reports false when the domain does not identify a single node, i.e. when the
+// lowest level of levels is not the hostname label.
+//
+// When the hostname is the lowest level, an assignment is built for that level
+// alone, so the domain ID holds the node name verbatim with no level values
+// concatenated into it.
 func NodeNameFromDomainID(levels []string, domainID TopologyDomainID) (string, bool) {
 	if len(levels) == 0 || !IsLowestLevelHostname(levels) {
 		return "", false
 	}
-	values := strings.Split(string(domainID), domainIDSeparator)
-	if len(values) != len(levels) {
-		return "", false
-	}
-	return values[len(values)-1], true
+	return string(domainID), true
 }
 
 func IsTAS(pod *corev1.Pod) bool {

--- a/pkg/util/tas/tas_test.go
+++ b/pkg/util/tas/tas_test.go
@@ -35,9 +35,12 @@ func TestNodeNameFromDomainID(t *testing.T) {
 			wantNodeName: "x1",
 			wantOK:       true,
 		},
+		// When the hostname is the lowest level, the assignment covers that level
+		// alone, so the domain ID holds only the node name even for a deeper
+		// topology. See buildAssignment in pkg/cache/scheduler/tas_flavor_snapshot.go.
 		"hostname is the lowest of multiple levels": {
 			levels:       []string{"cloud.com/topology-block", "cloud.com/topology-rack", corev1.LabelHostname},
-			domainID:     DomainID([]string{"b1", "r1", "x1"}),
+			domainID:     DomainID([]string{"x1"}),
 			wantNodeName: "x1",
 			wantOK:       true,
 		},
@@ -56,37 +59,13 @@ func TestNodeNameFromDomainID(t *testing.T) {
 			domainID: DomainID([]string{"x1"}),
 			wantOK:   false,
 		},
-		"fewer values than levels": {
-			levels:   []string{"cloud.com/topology-rack", corev1.LabelHostname},
-			domainID: DomainID([]string{"x1"}),
-			wantOK:   false,
-		},
-		"more values than levels": {
-			levels:   []string{corev1.LabelHostname},
-			domainID: DomainID([]string{"r1", "x1"}),
-			wantOK:   false,
-		},
+		// The domain ID is returned verbatim, so an empty one maps to the empty
+		// node name, which matches no UnhealthyNodes entry.
 		"empty domain ID": {
-			levels:   []string{corev1.LabelHostname, "cloud.com/topology-rack"},
-			domainID: "",
-			wantOK:   false,
-		},
-		// A single-level hostname topology encodes the node name verbatim, so an
-		// empty domain ID is indistinguishable from a node with an empty name. It
-		// maps to the empty node name, which matches no UnhealthyNodes entry.
-		"empty domain ID for a single hostname level": {
 			levels:       []string{corev1.LabelHostname},
 			domainID:     "",
 			wantNodeName: "",
 			wantOK:       true,
-		},
-		"node name containing the separator is not representable": {
-			// DomainID joins level values with ",", so a value containing a comma
-			// cannot be recovered. Node names cannot contain commas (RFC 1123),
-			// so this only guards against malformed input.
-			levels:   []string{corev1.LabelHostname},
-			domainID: DomainID([]string{"x1,x2"}),
-			wantOK:   false,
 		},
 	}
 	for name, tc := range cases {

--- a/pkg/util/tas/tas_test.go
+++ b/pkg/util/tas/tas_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tas
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNodeNameFromDomainID(t *testing.T) {
+	cases := map[string]struct {
+		levels       []string
+		domainID     TopologyDomainID
+		wantNodeName string
+		wantOK       bool
+	}{
+		"hostname is the only level": {
+			levels:       []string{corev1.LabelHostname},
+			domainID:     DomainID([]string{"x1"}),
+			wantNodeName: "x1",
+			wantOK:       true,
+		},
+		"hostname is the lowest of multiple levels": {
+			levels:       []string{"cloud.com/topology-block", "cloud.com/topology-rack", corev1.LabelHostname},
+			domainID:     DomainID([]string{"b1", "r1", "x1"}),
+			wantNodeName: "x1",
+			wantOK:       true,
+		},
+		"hostname is not the lowest level": {
+			levels:   []string{corev1.LabelHostname, "cloud.com/topology-rack"},
+			domainID: DomainID([]string{"x1", "r1"}),
+			wantOK:   false,
+		},
+		"lowest level is not hostname": {
+			levels:   []string{"cloud.com/topology-block", "cloud.com/topology-rack"},
+			domainID: DomainID([]string{"b1", "r1"}),
+			wantOK:   false,
+		},
+		"no levels": {
+			levels:   nil,
+			domainID: DomainID([]string{"x1"}),
+			wantOK:   false,
+		},
+		"fewer values than levels": {
+			levels:   []string{"cloud.com/topology-rack", corev1.LabelHostname},
+			domainID: DomainID([]string{"x1"}),
+			wantOK:   false,
+		},
+		"more values than levels": {
+			levels:   []string{corev1.LabelHostname},
+			domainID: DomainID([]string{"r1", "x1"}),
+			wantOK:   false,
+		},
+		"empty domain ID": {
+			levels:   []string{corev1.LabelHostname, "cloud.com/topology-rack"},
+			domainID: "",
+			wantOK:   false,
+		},
+		// A single-level hostname topology encodes the node name verbatim, so an
+		// empty domain ID is indistinguishable from a node with an empty name. It
+		// maps to the empty node name, which matches no UnhealthyNodes entry.
+		"empty domain ID for a single hostname level": {
+			levels:       []string{corev1.LabelHostname},
+			domainID:     "",
+			wantNodeName: "",
+			wantOK:       true,
+		},
+		"node name containing the separator is not representable": {
+			// DomainID joins level values with ",", so a value containing a comma
+			// cannot be recovered. Node names cannot contain commas (RFC 1123),
+			// so this only guards against malformed input.
+			levels:   []string{corev1.LabelHostname},
+			domainID: DomainID([]string{"x1,x2"}),
+			wantOK:   false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotNodeName, gotOK := NodeNameFromDomainID(tc.levels, tc.domainID)
+			if gotOK != tc.wantOK {
+				t.Errorf("NodeNameFromDomainID() ok = %v, want %v", gotOK, tc.wantOK)
+			}
+			if gotNodeName != tc.wantNodeName {
+				t.Errorf("NodeNameFromDomainID() nodeName = %q, want %q", gotNodeName, tc.wantNodeName)
+			}
+		})
+	}
+}

--- a/test/e2e/tas/baseline/hotswap_test.go
+++ b/test/e2e/tas/baseline/hotswap_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -425,9 +426,12 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(ut
 			// In this test we use a job with RequiredTopology = Block.
 			// Each pod requires 1 "extraResource" so the job will use three nodes from a Block.
 			// We simulate a node failure by making it NotReady while the pods are Pending (gated).
-			// The NodeController should identify the pending pods assigned to the failed node and terminate them.
-			// The replacement mechanism should then find the available node in the same Block and replace the failed one.
-			// Note: This test verifies that NodeController can act on pending pods that are assigned to the node (by the nodeSelector) but not scheduled yet.
+			// The pod assigned to the failed node stays gated: the ungater does not
+			// place it onto a node already recorded in Status.UnhealthyNodes, since
+			// it could never schedule there and would only be terminated with
+			// UnschedulableOnAssignedNode and recreated. The replacement mechanism
+			// then finds the available node in the same Block, and the same pod is
+			// ungated onto it.
 			ginkgo.It("Should replace a node when it becomes NotReady and pods are Pending", func() {
 				parallelism := 3
 				numPods := parallelism
@@ -495,6 +499,14 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(ut
 					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
+				// Recorded before the failure so the assertions below can prove the
+				// original pods survive: none is terminated on the failed node and
+				// recreated, they are simply ungated once a replacement exists.
+				initialPodUIDs := make([]types.UID, 0, numPods)
+				for _, p := range pods.Items {
+					initialPodUIDs = append(initialPodUIDs, p.UID)
+				}
+
 				node := &corev1.Node{}
 				nodeName := initialNodes[0]
 				ginkgo.By(fmt.Sprintf("Simulate failure of node %s", nodeName), func() {
@@ -523,34 +535,40 @@ var _ = ginkgo.Describe("Hotswap for Topology Aware Scheduling", ginkgo.Label(ut
 					}
 				})
 
-				var victimPodName string
-				ginkgo.By("Wait for the victim pod to be Failed", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						victimPod := findPod(ctx, k8sClient, g, ns.Name, jobName, "0", nodeName, false)
-						g.Expect(victimPod).NotTo(gomega.BeNil(), "Victim pod should still exist")
-						victimPodName = victimPod.Name
-					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-					util.ExpectPodTerminatedByKueueCondition(ctx, k8sClient, client.ObjectKey{Name: victimPodName, Namespace: ns.Name}, "UnschedulableOnAssignedNode")
-				})
-
-				var replacementPodName string
-				ginkgo.By("Wait for the replacement pod to be created", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						replacementPod := findPod(ctx, k8sClient, g, ns.Name, jobName, "0", nodeName, true)
-						g.Expect(replacementPod).NotTo(gomega.BeNil(), "Replacement pod should appear")
-						replacementPodName = replacementPod.Name
-					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
-				})
-
-				ginkgo.By("Removing the artificial scheduling gate from the replacement pod", func() {
-					gomega.Eventually(func(g gomega.Gomega) {
-						updatedPod := &corev1.Pod{}
-						g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: replacementPodName, Namespace: ns.Name}, updatedPod)).To(gomega.Succeed())
-						if utilpod.Ungate(updatedPod, artificialGate) {
-							g.Expect(k8sClient.Update(ctx, updatedPod)).To(gomega.Succeed())
-							g.Expect(utilpod.HasGate(updatedPod, artificialGate)).To(gomega.BeFalse(), "Still found artificial gate, retrying...")
+				ginkgo.By(fmt.Sprintf("No pod is ungated onto the failed node %s", nodeName), func() {
+					// The pod whose domain is the failed node keeps the topology gate
+					// while the second pass looks for a replacement domain, so it is
+					// never assigned to that node and never terminated there.
+					gomega.Consistently(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), client.MatchingLabels{
+							"job-name": jobName,
+						})).To(gomega.Succeed())
+						for _, p := range pods.Items {
+							g.Expect(p.Spec.NodeName).NotTo(gomega.Equal(nodeName),
+								"pod %s must not be scheduled onto the failed node", p.Name)
+							if utilpod.HasGate(&p, kueue.TopologySchedulingGate) {
+								g.Expect(p.Spec.NodeSelector).NotTo(gomega.HaveKeyWithValue(corev1.LabelHostname, nodeName),
+									"gated pod %s must not carry a node selector for the failed node", p.Name)
+							}
 						}
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+					}, util.LongConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("The original pods are ungated onto the replacement node instead of being recreated", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						g.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name), client.MatchingLabels{
+							"job-name": jobName,
+						})).To(gomega.Succeed())
+						g.Expect(pods.Items).To(gomega.HaveLen(numPods))
+						gotUIDs := make([]types.UID, 0, numPods)
+						for _, p := range pods.Items {
+							g.Expect(utilpod.HasGate(&p, kueue.TopologySchedulingGate)).To(gomega.BeFalse(),
+								"pod %s should no longer be topology-gated", p.Name)
+							gotUIDs = append(gotUIDs, p.UID)
+						}
+						g.Expect(gotUIDs).To(gomega.ConsistOf(initialPodUIDs),
+							"no pod should have been terminated and recreated")
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
 				})
 
 				ginkgo.By("Check that the topology assignment is updated with the new node in the same block", func() {
@@ -701,27 +719,6 @@ func expectPodsOnNodes(ctx context.Context, k8sClient client.Client, nsName stri
 		g.Expect(gotNodes).To(gomega.HaveLen(numPods))
 		g.Expect(gotNodes).To(gomega.ConsistOf(expectedNodes))
 	}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
-}
-
-func findPod(ctx context.Context, k8sClient client.Client, g gomega.Gomega, nsName, jobName, index string, failedNodeName string, isReplacement bool) *corev1.Pod {
-	pods := &corev1.PodList{}
-	g.Expect(k8sClient.List(ctx, pods, client.InNamespace(nsName), client.MatchingLabels{
-		"job-name": jobName,
-	})).To(gomega.Succeed())
-
-	for i := range pods.Items {
-		p := &pods.Items[i]
-		if p.Labels["batch.kubernetes.io/job-completion-index"] == index {
-			nodeName := p.Spec.NodeName
-			if nodeName == "" && p.Spec.NodeSelector != nil {
-				nodeName = p.Spec.NodeSelector[corev1.LabelHostname]
-			}
-			if (nodeName == failedNodeName) != isReplacement {
-				return p
-			}
-		}
-	}
-	return nil
 }
 
 func findPodOnNode(pods []corev1.Pod, nodeName string) corev1.Pod {

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -3323,12 +3323,15 @@ var _ = ginkgo.Describe("Pod controller with TASFailedNodeReplacementFailFast di
 	})
 
 	ginkgo.It("should not ungate a replacement pod onto the failed node while no replacement domain is available", framework.SlowSpec, func() {
-		// With fail-fast disabled the workload keeps its admission and its
-		// TopologyAssignment while the second pass looks for a replacement
-		// domain, so the assignment still names the failed node. A replacement
-		// pod created in that window must stay gated rather than be ungated
-		// onto that node: it could never schedule there, and the node
-		// controller would terminate it again immediately.
+		// The ungater skips the failed node regardless of the fail-fast gate;
+		// the gate is disabled here only to keep the window open long enough to
+		// observe it. With fail-fast enabled and no replacement domain the
+		// workload is evicted right away, whereas with it disabled the workload
+		// keeps its admission and its TopologyAssignment while the second pass
+		// looks for a replacement domain, so the assignment still names the
+		// failed node. A replacement pod created in that window must stay gated
+		// rather than be ungated onto that node: it could never schedule there,
+		// and the node controller would terminate it again immediately.
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASFailedNodeReplacementFailFast, false)
 
 		podGroupName := "pod-group"

--- a/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go
@@ -18,6 +18,7 @@ package pod
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strconv"
 	"testing"
@@ -43,6 +44,7 @@ import (
 	podcontroller "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	podconstants "sigs.k8s.io/kueue/pkg/controller/jobs/pod/constants"
 	"sigs.k8s.io/kueue/pkg/features"
+	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -3220,6 +3222,291 @@ var _ = ginkgo.Describe("Pod controller with TASReplaceNodeOnPodTermination", gi
 				g.Expect(nodeNames).To(gomega.HaveLen(1))
 				g.Expect(nodeNames[0]).ShouldNot(gomega.Equal(nodeName))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+})
+
+var _ = ginkgo.Describe("Pod controller with TASFailedNodeReplacementFailFast disabled", ginkgo.Label("job:pod", "area:jobs", "feature:tas"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
+	const (
+		nodeGroupLabel = "node-group"
+	)
+
+	var (
+		ns           *corev1.Namespace
+		nodes        []corev1.Node
+		topology     *kueue.Topology
+		tasFlavor    *kueue.ResourceFlavor
+		clusterQueue *kueue.ClusterQueue
+		localQueue   *kueue.LocalQueue
+	)
+	nsSelector := &metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      corev1.LabelMetadataName,
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"kube-system", "kueue-system"},
+			},
+		},
+	}
+	mjnsSelector, err := metav1.LabelSelectorAsSelector(nsSelector)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	ginkgo.BeforeAll(func() {
+		fwk.StartManager(ctx, cfg, managerSetup(true, true, nil,
+			jobframework.WithManagedJobsNamespaceSelector(mjnsSelector),
+			jobframework.WithEnabledFrameworks([]string{"pod"}),
+		))
+	})
+
+	ginkgo.AfterAll(func() {
+		fwk.StopManager(ctx)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ns = util.CreateNamespaceFromPrefixWithLog(ctx, k8sClient, "tas-pod-")
+
+		// Two nodes with room for exactly one 1-CPU pod each, so a two-pod
+		// group fills both and no domain has a spare slot for a replacement.
+		nodes = []corev1.Node{
+			*testingnode.MakeNode("x1").
+				Label(nodeGroupLabel, "tas").
+				Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+				Label(utiltesting.DefaultRackTopologyLevel, "r1").
+				Label(corev1.LabelHostname, "x1").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+			*testingnode.MakeNode("x2").
+				Label(nodeGroupLabel, "tas").
+				Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+				Label(utiltesting.DefaultRackTopologyLevel, "r1").
+				Label(corev1.LabelHostname, "x2").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+					corev1.ResourcePods:   resource.MustParse("10"),
+				}).
+				Ready().
+				Obj(),
+		}
+		util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+		topology = utiltestingapi.MakeDefaultThreeLevelTopology("default")
+		util.MustCreate(ctx, k8sClient, topology)
+
+		tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+			NodeLabel(nodeGroupLabel, "tas").
+			TopologyName(topology.Name).Obj()
+		util.MustCreate(ctx, k8sClient, tasFlavor)
+
+		clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "2").Obj()).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+		util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+		localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+	})
+
+	ginkgo.AfterEach(func() {
+		gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+		util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+		for _, node := range nodes {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+		}
+	})
+
+	ginkgo.It("should not ungate a replacement pod onto the failed node while no replacement domain is available", framework.SlowSpec, func() {
+		// With fail-fast disabled the workload keeps its admission and its
+		// TopologyAssignment while the second pass looks for a replacement
+		// domain, so the assignment still names the failed node. A replacement
+		// pod created in that window must stay gated rather than be ungated
+		// onto that node: it could never schedule there, and the node
+		// controller would terminate it again immediately.
+		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASFailedNodeReplacementFailFast, false)
+
+		podGroupName := "pod-group"
+		var failedNode string
+		podToNode := make(map[string]string, 2)
+		podgroup := testingpod.MakePod(podGroupName, ns.Name).
+			Queue(localQueue.Name).
+			Annotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
+			Request(corev1.ResourceCPU, "1").
+			MakeIndexedGroup(2)
+
+		ginkgo.By("Creating the Pod group", func() {
+			for _, p := range podgroup {
+				util.MustCreate(ctx, k8sClient, p)
+				gomega.Expect(p.Spec.SchedulingGates).To(gomega.ContainElements(
+					corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName},
+					corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate},
+				))
+			}
+		})
+
+		wlKey := types.NamespacedName{Namespace: ns.Name, Name: podGroupName}
+		wl := &kueue.Workload{}
+
+		ginkgo.By("checking that the workload is created", func() {
+			// Also populates wl, whose name/namespace ExpectWorkloadsToBeAdmitted
+			// below uses as the lookup key.
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).Should(gomega.Succeed())
+				g.Expect(wl.Spec.PodSets).To(gomega.HaveLen(1))
+				g.Expect(wl.Spec.PodSets[0].Count).To(gomega.Equal(int32(2)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the workload is admitted onto both nodes", func() {
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+			nodeNames := slices.Collect(tas.LowestLevelValues(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment))
+			gomega.Expect(nodeNames).To(gomega.ConsistOf("x1", "x2"))
+		})
+
+		ginkgo.By("wait for pods to be ungated and bind each to its assigned node", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				for _, p := range podgroup {
+					pod := &corev1.Pod{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(p), pod)).To(gomega.Succeed())
+					g.Expect(pod.Spec.SchedulingGates).Should(gomega.BeEmpty())
+					g.Expect(pod.Spec.NodeSelector).Should(gomega.HaveKey(corev1.LabelHostname))
+					podToNode[pod.Name] = pod.Spec.NodeSelector[corev1.LabelHostname]
+				}
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Expect(slices.Sorted(maps.Values(podToNode))).To(gomega.Equal([]string{"x1", "x2"}))
+			for _, p := range podgroup {
+				util.BindPodWithNode(ctx, k8sClient, podToNode[p.Name], p)
+			}
+			util.SetPodsPhase(ctx, k8sClient, corev1.PodRunning, podgroup...)
+		})
+
+		failedNode = podToNode[podgroup[0].Name]
+
+		ginkgo.By("making the node of the first pod NotReady", func() {
+			nodeToUpdate := &corev1.Node{}
+			gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: failedNode}, nodeToUpdate)).Should(gomega.Succeed())
+			util.SetNodeCondition(ctx, k8sClient, nodeToUpdate, &corev1.NodeCondition{
+				Type:   corev1.NodeReady,
+				Status: corev1.ConditionFalse,
+			})
+		})
+
+		ginkgo.By("terminating the pod on the failed node", func() {
+			podKey := client.ObjectKeyFromObject(podgroup[0])
+			gomega.Eventually(func(g gomega.Gomega) {
+				pod := &corev1.Pod{}
+				g.Expect(k8sClient.Get(ctx, podKey, pod)).To(gomega.Succeed())
+				pod.Status.Phase = corev1.PodFailed
+				g.Expect(k8sClient.Status().Update(ctx, pod)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the node is marked unhealthy and the assignment still names it", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(workload.UnhealthyNodeNames(wl)).To(gomega.ConsistOf(failedNode))
+				// Retained on purpose while a replacement is sought; see the
+				// "should update workload TopologyAssignment after a node
+				// becomes available" TAS integration test.
+				nodeNames := slices.Collect(tas.LowestLevelValues(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment))
+				g.Expect(nodeNames).To(gomega.ContainElement(failedNode))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		// Carries the same group index as the pod it replaces. The PodSet has a
+		// PodIndexLabel, so the ungater takes the rank-based path
+		// (readRanksIfAvailable): rank 0 maps to the assignment's first domain,
+		// which is the node podgroup[0] was ungated onto and therefore the node
+		// this test fails. Without an index the ungater falls back to greedy
+		// assignment, and whether it lands on the failed domain depends on
+		// ordering rather than on the behaviour under test.
+		replacementPod := testingpod.MakePod("replacement-pod", ns.Name).
+			GroupNameLabel(podGroupName).
+			GroupTotalCount("2").
+			GroupIndex("0").
+			Queue(localQueue.Name).
+			Annotation(kueue.PodSetPreferredTopologyAnnotation, utiltesting.DefaultRackTopologyLevel).
+			Request(corev1.ResourceCPU, "1").
+			Obj()
+		replacementKey := client.ObjectKeyFromObject(replacementPod)
+
+		ginkgo.By("creating a replacement pod in the group", func() {
+			util.MustCreate(ctx, k8sClient, replacementPod)
+		})
+
+		ginkgo.By("verify Kueue observes the replacement pod", func() {
+			// Guards the assertion below against passing vacuously: the group
+			// is whole again, so the replacement is genuinely being tracked
+			// and is a candidate for ungating.
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+				g.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusFalse(kueue.WorkloadWaitingForReplacementPods))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the replacement pod is enrolled in the podset the ungater reads", func() {
+			// Without this the test can pass for the wrong reason: the ungater
+			// only considers pods carrying constants.PodSetLabel, so a
+			// replacement missing it would stay gated no matter what the
+			// ungater does, and the assertion below would be vacuous.
+			originalPod := &corev1.Pod{}
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(podgroup[1]), originalPod)).To(gomega.Succeed())
+			wantPodSet := originalPod.Labels[constants.PodSetLabel]
+			gomega.Expect(wantPodSet).ToNot(gomega.BeEmpty())
+			gomega.Eventually(func(g gomega.Gomega) {
+				pod := &corev1.Pod{}
+				g.Expect(k8sClient.Get(ctx, replacementKey, pod)).To(gomega.Succeed())
+				g.Expect(pod.Labels).To(gomega.HaveKeyWithValue(constants.PodSetLabel, wantPodSet))
+				g.Expect(pod.Spec.SchedulingGates).ToNot(gomega.ContainElement(
+					corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}),
+					"the replacement must be past the managed-by gate to be an ungate candidate")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the unhealthy domain still has a free slot for the replacement", func() {
+			// The ungater only ungates into a domain with remaining capacity. If
+			// the failed pod still occupied the domain, the replacement would
+			// stay gated regardless of the fix.
+			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+			ungatedOnFailedNode := 0
+			pods := &corev1.PodList{}
+			gomega.Expect(k8sClient.List(ctx, pods, client.InNamespace(ns.Name))).To(gomega.Succeed())
+			for _, p := range pods.Items {
+				if utilpod.IsTerminated(&p) || utilpod.HasGate(&p, kueue.TopologySchedulingGate) {
+					continue
+				}
+				if p.Spec.NodeSelector[corev1.LabelHostname] == failedNode {
+					ungatedOnFailedNode++
+				}
+			}
+			gomega.Expect(ungatedOnFailedNode).To(gomega.Equal(0),
+				"the failed node's slot must be free, otherwise the ungater has nowhere to place the replacement and the assertion below is vacuous")
+		})
+
+		ginkgo.By("verify the replacement pod stays gated and is never pinned to the failed node", func() {
+			// LongConsistentDuration, not ConsistentDuration: the ungater reacts
+			// to pod and workload events within a few hundred milliseconds of the
+			// replacement becoming visible, so a 300ms window can close before it
+			// has acted and pass whatever the ungater decides.
+			gomega.Consistently(func(g gomega.Gomega) {
+				pod := &corev1.Pod{}
+				g.Expect(k8sClient.Get(ctx, replacementKey, pod)).To(gomega.Succeed())
+				g.Expect(pod.Spec.SchedulingGates).To(gomega.ContainElement(
+					corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}))
+				g.Expect(pod.Spec.NodeSelector).ShouldNot(gomega.HaveKeyWithValue(corev1.LabelHostname, failedNode))
+			}, util.LongConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the workload kept its admission rather than being evicted", func() {
+			gomega.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
+			gomega.Expect(wl.Status.Conditions).To(utiltesting.HaveConditionStatusTrue(kueue.WorkloadAdmitted))
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

With `TASFailedNodeReplacementFailFast` disabled, a workload whose assigned node goes unhealthy intentionally keeps its admission and its `TopologyAssignment` while the second pass looks for a replacement domain. That retention is by design — `test/integration/singlecluster/tas/tas_test.go` ("should update workload TopologyAssignment after a node becomes available") asserts the assignment is kept until capacity frees up.

The topology ungater, however, never consults `Status.UnhealthyNodes`. It ungates gated pods straight from the retained assignment, so a replacement pod is pinned to the very node Kueue has already decided to replace. `kube-scheduler` cannot place it there, and Kueue's own node controller then terminates it with `UnschedulableOnAssignedNode` — Kueue both creates and punishes the condition, in a loop:

```
scheduler             SecondPassFailed      couldn't assign flavors to pod set <podset>:
                                            topology "<topology>" doesn't allow to fit any of 1 pod(s)
tas-topology-ungater  "ungating pod"        nodeLabels={"kubernetes.io/hostname":"<unhealthy-node>"}
events                PodTerminatedByKueue  "Pod terminated by Kueue NodeController due to node taint"
```

Each cycle consumes one pod recreation, so an integration with a bounded retry budget fails the job within minutes — long before `RecoveryTimeout` can expire and let the workload be requeued for fresh placement. That inverts the intent of `TASFailedNodeReplacementFailFast=false`, which exists to keep waiting for a replacement node rather than failing fast.

This PR skips ungating a pod whose assigned domain resolves to a node in `Status.UnhealthyNodes`, leaving it gated until either a replacement domain appears or the recovery timeout expires. The filter is per domain, so a multi-domain workload still ungates pods onto its healthy domains. It reuses the existing `workload.HasUnhealthyNodes` / `workload.HasUnhealthyNode` / `utiltas.IsLowestLevelHostname` helpers and is scoped to hostname-lowest-level topologies, matching `utiltas.HasNodeInPodSetAssignment`.

#### Which issue(s) this PR fixes:

Fixes #14092

#### Special notes for your reviewer:

This is only reachable with the non-default `TASFailedNodeReplacementFailFast=false`. With the default `true`, the scheduler catches the case first and evicts the workload, which clears the admission and stops the ungater — which is why it has not shown up in CI.

Tests, all three failing without the guard and passing with it:

* Two `TestReconcile` cases in `pkg/controller/tas/topology_ungater_test.go` — a single-pod PodSet where the unhealthy node is the only domain, and a two-pod group whose surviving pod holds the healthy domain's slot, so the only slot a replacement could take is the one on the unhealthy node.
* A pods-based integration spec in `test/integration/singlecluster/controller/jobs/pod/pod_controller_test.go`. The existing coverage for this feature gate uses bare `Workload` objects, so the ungater never runs against a real gated pod; that is the gap this closes. Two details worth knowing if you touch it: the replacement pod carries the same pod index as the pod it replaces, so the ungater takes its rank-based path and rank 0 resolves to the unhealthy domain; and it asserts over `LongConsistentDuration`, because the second pass is deferred with backoff and the ungate lands roughly 0.8s after the replacement becomes visible, which a 300ms window misses either way.

If you would rather see this solved in the scheduler — dropping the unhealthy domain from the assignment on `SecondPassFailed` — I am happy to rework it; the requirement is just that the ungater stops acting on a domain the scheduler has already excluded.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where, with TASFailedNodeReplacementFailFast disabled, replacement pods for a workload whose node became unhealthy were ungated onto that same unhealthy node and immediately terminated, exhausting the pod recreation budget instead of waiting for a replacement domain.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented replacement pods from being scheduled onto unhealthy nodes.
  * Replacement pods now remain topology-gated until a suitable healthy domain is available.
  * Preserved workload admission and existing pod identity during failed-node replacement.

* **Tests**
  * Added coverage for unhealthy-node replacement scenarios, topology mapping, pending pods, and multi-node topology failover behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->