### PR TITLE
Saturate Add and Sub in both Requests implementations

### DIFF
--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -27,7 +27,12 @@ type Requests interface {
 	Clone() Requests
 	ScaledUp(f int64) Requests
 	ScaledDown(f int64) Requests
+	// Add adds other into the receiver, element-wise. Values saturate at
+	// math.MaxInt64 and math.MinInt64 instead of wrapping, so a total too large
+	// to represent is never returned with the opposite sign. Implementations
+	// have to agree on this, since the one in use is chosen by feature gate.
 	Add(other Requests)
+	// Sub subtracts other from the receiver, element-wise, saturating like Add.
 	Sub(other Requests)
 	Divide(f int64)
 	Mul(f int64)

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -118,13 +118,13 @@ func (r MapRequests) FloorToZero() {
 
 func (r MapRequests) Add(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
-		r[k] += v
+		r[k] = utilmath.SaturatingAdd(r[k], v)
 	})
 }
 
 func (r MapRequests) Sub(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
-		r[k] -= v
+		r[k] = utilmath.SaturatingSub(r[k], v)
 	})
 }
 

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -253,9 +253,7 @@ func (sr *SliceRequests) Add(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
-		return a + b
-	})
+	sr.mergeWithInPlace(toSliceRequests(other), utilmath.SaturatingAdd)
 }
 
 // Sub performs an element-wise subtraction.
@@ -263,9 +261,7 @@ func (sr *SliceRequests) Sub(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
-		return a - b
-	})
+	sr.mergeWithInPlace(toSliceRequests(other), utilmath.SaturatingSub)
 }
 
 // mergeFunc defines a computation lambda between matching or missing values in two SliceRequests.

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -41,16 +41,17 @@ var fuzzResourceNames = []corev1.ResourceName{
 //  1. Header (1 byte): data[0] is returned as opChoice to select the test operation (opAdd, opSub, opScaledUp, opCountIn).
 //  2. Map 1 parsing:
 //     - The next byte (data[0] % 5) defines len1, the number of resource entries to populate in m1 (0 to 4).
-//     - Each entry consumes 5 bytes:
+//     - Each entry consumes 9 bytes:
 //     - Byte 0: Resource name index into fuzzResourceNames array (data[0] % len(fuzzResourceNames)).
-//     - Bytes 1..4: 32-bit unsigned little-endian integer value for the resource quantity.
+//     - Bytes 1..8: 64-bit little-endian value for the resource quantity, taken as
+//     int64, so negative values and the saturation boundary are both reachable.
 //  3. Map 2 parsing:
 //     - If bytes remain, the next byte (data[0] % 5) defines len2 (0 to 4).
-//     - Up to len2 entries are parsed using 5 bytes each, exactly as in m1.
+//     - Up to len2 entries are parsed using 9 bytes each, exactly as in m1.
 //
 // Example:
 //
-//	Input data: []byte{0, 2, 0, 100, 0, 0, 0, 1, 50, 0, 0, 0}
+//	Input data: []byte{0, 2, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 50, 0, 0, 0, 0, 0, 0, 0}
 //	- opChoice = 0 (opAdd)
 //	- m1 length = 2 % 5 = 2 entries
 //	  - Entry 1: index 0 -> fuzzResourceNames[0] ("cpu"), val = 100 -> m1["cpu"] = 100
@@ -76,13 +77,17 @@ func parseFuzzMap(data []byte) (MapRequests, []byte) {
 	m := make(MapRequests)
 	count := int(data[0] % 5)
 	data = data[1:]
-	for i := 0; i < count && len(data) >= 5; i++ {
+	for i := 0; i < count && len(data) >= 9; i++ {
 		res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
-		val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
+		// Eight bytes rather than four: the values this fuzzer compares are int64,
+		// and a four-byte value can only reach 2^32 and is never negative, so the
+		// boundary where the two implementations could disagree was unreachable.
+		val := int64(uint64(data[1]) | uint64(data[2])<<8 | uint64(data[3])<<16 | uint64(data[4])<<24 |
+			uint64(data[5])<<32 | uint64(data[6])<<40 | uint64(data[7])<<48 | uint64(data[8])<<56)
 		if val != 0 {
 			m[res] = val
 		}
-		data = data[5:]
+		data = data[9:]
 	}
 	return m, data
 }
@@ -160,12 +165,16 @@ func (s fuzzSeed) encode() []byte {
 	buf := []byte{s.opChoice, byte(len(s.m1))}
 	for res, val := range s.m1 {
 		idx := resourceIndex(res)
-		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+		buf = append(buf, idx,
+			byte(val), byte(val>>8), byte(val>>16), byte(val>>24),
+			byte(val>>32), byte(val>>40), byte(val>>48), byte(val>>56))
 	}
 	buf = append(buf, byte(len(s.m2)))
 	for res, val := range s.m2 {
 		idx := resourceIndex(res)
-		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+		buf = append(buf, idx,
+			byte(val), byte(val>>8), byte(val>>16), byte(val>>24),
+			byte(val>>32), byte(val>>40), byte(val>>48), byte(val>>56))
 	}
 	return buf
 }
@@ -221,6 +230,24 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			opChoice: opCountIn,
 			m1:       MapRequests{corev1.ResourceMemory: 1},
 			m2:       MapRequests{corev1.ResourceMemory: math.MaxInt32 + 1},
+		},
+		// The int64 boundary, which the corpus could not encode while a value
+		// was four bytes wide. Both implementations saturate, so they have to
+		// saturate to the same place.
+		{
+			opChoice: opAdd,
+			m1:       MapRequests{corev1.ResourceCPU: math.MaxInt64},
+			m2:       MapRequests{corev1.ResourceCPU: 1},
+		},
+		{
+			opChoice: opSub,
+			m1:       MapRequests{corev1.ResourceCPU: math.MinInt64},
+			m2:       MapRequests{corev1.ResourceCPU: 1},
+		},
+		{
+			opChoice: opSub,
+			m1:       MapRequests{},
+			m2:       MapRequests{corev1.ResourceCPU: math.MinInt64},
 		},
 		{
 			opChoice: opSet,

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"maps"
 	"math"
 	"testing"
 
@@ -271,6 +272,79 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 			t.Errorf("Sub MapRequests mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+// TestSliceRequests_SaturationMatchesMapRequests pins the two Requests
+// implementations to the same answer where int64 runs out. Which one runs is a
+// feature gate decision, so a difference here is the same cluster accounting two
+// ways.
+func TestSliceRequests_SaturationMatchesMapRequests(t *testing.T) {
+	const res = corev1.ResourceCPU
+	cases := map[string]struct {
+		start MapRequests
+		other MapRequests
+		sub   bool
+		want  MapRequests
+	}{
+		"adding past MaxInt64": {
+			start: MapRequests{res: math.MaxInt64},
+			other: MapRequests{res: 1},
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"adding past MinInt64": {
+			start: MapRequests{res: math.MinInt64},
+			other: MapRequests{res: -1},
+			want:  MapRequests{res: math.MinInt64},
+		},
+		"two halves that do not fit": {
+			start: MapRequests{res: math.MaxInt64/2 + 1},
+			other: MapRequests{res: math.MaxInt64/2 + 1},
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"subtracting a negative past MaxInt64": {
+			start: MapRequests{res: math.MaxInt64},
+			other: MapRequests{res: -1},
+			sub:   true,
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"subtracting past MinInt64": {
+			start: MapRequests{res: math.MinInt64},
+			other: MapRequests{res: 1},
+			sub:   true,
+			want:  MapRequests{res: math.MinInt64},
+		},
+		// A key the receiver does not hold takes a different route through
+		// SliceRequests: mergeInto reaches it as fn(0, b), which none of the
+		// cases above enter.
+		"subtracting MinInt64 from a key the receiver lacks": {
+			start: MapRequests{},
+			other: MapRequests{res: math.MinInt64},
+			sub:   true,
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"adding MinInt64 to a key the receiver lacks": {
+			start: MapRequests{},
+			other: MapRequests{res: math.MinInt64},
+			want:  MapRequests{res: math.MinInt64},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mapReq := maps.Clone(tc.start)
+			sliceReq := NewSliceRequests(tc.start)
+			if tc.sub {
+				mapReq.Sub(tc.other)
+				sliceReq.Sub(tc.other)
+			} else {
+				mapReq.Add(tc.other)
+				sliceReq.Add(tc.other)
+			}
+			if diff := cmp.Diff(tc.want, mapReq); diff != "" {
+				t.Errorf("MapRequests mismatch (-want +got):\n%s", diff)
+			}
+			checkRequestsEquivalence(t, name, mapReq, sliceReq)
+		})
+	}
 }
 
 func TestSliceRequests_GetValue(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`MapRequests` and `SliceRequests` both keep resource totals as `int64`, and both already saturate in `Mul`, but `Add` and `Sub` were left as plain arithmetic:

```go
func (r MapRequests) Add(other Requests) {
	other.ForEach(func(k corev1.ResourceName, v int64) {
		r[k] += v
	})
}
```

So two contributions that each convert to `int64` intact can still sum past `MaxInt64` and come back negative, and `FloorToZero` afterwards reads that as nothing having been asked for. Measured on this tree before the change, with each side at `MaxInt64/2 + 1`:

```
each side converts to  4611686018427387904
after Add             -9223372036854775808
MaxInt64 is            9223372036854775807
```

Both now go through `utilmath.SaturatingAdd` and `utilmath.SaturatingSub`. Those already exist, and their signature is already the merge function `SliceRequests` takes, so `SliceRequests` loses two lambdas rather than gaining anything.

## Why both implementations and not just the one in the issue

`factory.go` picks the implementation from the `VectorizedResourceRequests` feature gate. They are not old and new, they are two spellings of the same accounting, so fixing one would leave the same cluster charging two different totals depending on a gate. The contract is stated once on the `Requests` interface for that reason.

## What this does and does not promise

It bounds the representation, not the arithmetic. Saturating addition and subtraction are not associative, so a total that saturates and is then subtracted from does not return to where it started, and this PR does not claim otherwise. What it does guarantee is that adding a non-negative amount never lowers a total, and that no sum comes back with its sign reversed, which is what the accounting and `FloorToZero` rely on.

Fail-closed is the point of the direction. Wrapping turns a huge positive usage into a large negative one, which reads as free capacity; saturating leaves it at the ceiling, which reads as full.

#### Which issue(s) this PR fixes:

Part of #14045. Not `Fixes`, because that issue asks about two callers and this is one of them. The accounting total is what saturates well: a request that large is already past any quota, so clamping it and rejecting it come to the same thing. The admission envelope is the other half, and saturating there would quietly promise to charge `MaxInt64` instead of the number that was asked for, which is a field error rather than a clamp and a decision about the API surface. I would rather leave the issue open for that.

#### Special notes for your reviewer:

## The equivalence fuzzer could not see any of this

`FuzzSliceRequestsEquivalence` already compares the two implementations across `Add` and `Sub`, so it looks like the guard for exactly this. It is not, and it is worth saying why rather than letting it look covered. `parseFuzzMap` built each value out of four bytes:

```go
val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
```

which stops at 2^32 and is never negative, so the region where the two could disagree was unreachable, and 63 of the 64 bits were never explored. It reads eight bytes now, and the seed corpus carries the boundary cases it previously had no way to encode. I checked the seeds decode back to the values they name rather than assuming the encoder and the parser still agreed after widening both.

That widening is the one part of this diff that is not strictly the fix. It is here because without it the property that is supposed to hold the two implementations together silently stops short of the only place they could come apart.

## What the tests actually prove

Reverting just the two source files and rerunning turns six of the seven boundary cases red. The seventh, adding `MinInt64` to a key the receiver does not hold, passes either way by design: it does not overflow, and it is there to pin that saturation left the ordinary path alone.

The fuzzer does not go red on the unpatched tree, and that is expected rather than a gap. Both implementations wrapped identically before this, so they were equally wrong and still equivalent. What the widened fuzzer guards against is a later change that saturates one of them and not the other.

On this branch it ran clean over roughly 650k executions in a minute, and `go test ./pkg/...` is green. The failures in `cmd/experimental/*/test/{e2e,integration}` on my machine are `fork/exec /usr/local/kubebuilder/bin/etcd: no such file or directory`, so they never started a control plane.

## Deliberately not here

`Amount` stays out of this. `math.MaxInt64` is the live `Unlimited` sentinel on that side, and `amount.go` says bounded amounts must never equal it, so pulling the quota type into workload usage would conflate two domains that disagree about what the ceiling means.

`Divide` is also untouched. `MinInt64 / -1` is its own two's complement quirk with a different answer, and it is not what the issue is about.

No integration test. This is arithmetic in a leaf package, and reaching it from a real Workload means asking for a quantity that is rejected long before it matters. Happy to add one if you would rather see it end to end.

#### Does this PR introduce a user-facing change?

```release-note
Fixed resource totals wrapping to a negative number when two contributions to the same resource sum past the int64 range. Both Requests implementations now saturate in Add and Sub, as they already did in Mul, so an unrepresentable total is no longer read as an empty request.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource addition and subtraction now safely clamp values at the 64-bit integer limits, preventing overflow and underflow.
  * Map-based and slice-based resource calculations now produce consistent results, including for missing entries.

* **Tests**
  * Added coverage for boundary values and saturation behavior in resource calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->