### PR TITLE
docs: fix Coding Guidelines link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 - [Contributor Cheat Sheet](https://k8s.dev/cheatsheet) - Common resources for existing developers
 - [AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance) - 🤖 Guidelines for using AI tools when contributing.
 - [SIG Scheduling Contributor's Guide](https://git.k8s.io/community/sig-scheduling/CONTRIBUTING.md) - Guidelines specific to SIG Scheduling.
-- [Coding Guidelines](https://kueue.sigs.k8s.io/docs/contribution_guidelines/coding_guidelines/) - Coding conventions and patterns for Kueue product and test code.
+- [Coding Guidelines](https://kueue.sigs.k8s.io/community/contribution_guidelines/coding_guidelines/) - Coding conventions and patterns for Kueue product and test code.
 
 ## Mentorship
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Corrects the Coding Guidelines URL in `CONTRIBUTING.md` so it points to the published page under `/community/contribution_guidelines/`. The previous `/docs/contribution_guidelines/` path returns 404.

#### Which issue(s) this PR fixes:

Fixes #14058

#### Special notes for your reviewer:

AI tools were used to assist with implementation. The final diff was manually reviewed and validated.

Validation:

- The corrected URL returns HTTP 200; the previous URL returns HTTP 404.
- A focused production Hugo build generated the expected route, canonical URL, title, and page content.
- `git diff --check` passes.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```