### PR TITLE
[release-0.18] Saturate Add and Sub in both Requests implementations

### DIFF
--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -27,7 +27,12 @@ type Requests interface {
 	Clone() Requests
 	ScaledUp(f int64) Requests
 	ScaledDown(f int64) Requests
+	// Add adds other into the receiver, element-wise. Values saturate at
+	// math.MaxInt64 and math.MinInt64 instead of wrapping, so a total too large
+	// to represent is never returned with the opposite sign. Implementations
+	// have to agree on this, since the one in use is chosen by feature gate.
 	Add(other Requests)
+	// Sub subtracts other from the receiver, element-wise, saturating like Add.
 	Sub(other Requests)
 	Divide(f int64)
 	Mul(f int64)

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -133,13 +133,13 @@ func (r MapRequests) FloorToZero() {
 
 func (r MapRequests) Add(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
-		r[k] += v
+		r[k] = utilmath.SaturatingAdd(r[k], v)
 	})
 }
 
 func (r MapRequests) Sub(other Requests) {
 	other.ForEach(func(k corev1.ResourceName, v int64) {
-		r[k] -= v
+		r[k] = utilmath.SaturatingSub(r[k], v)
 	})
 }
 

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -251,9 +251,7 @@ func (sr *SliceRequests) Add(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
-		return a + b
-	})
+	sr.mergeWithInPlace(toSliceRequests(other), utilmath.SaturatingAdd)
 }
 
 // Sub performs an element-wise subtraction.
@@ -261,9 +259,7 @@ func (sr *SliceRequests) Sub(other Requests) {
 	if isEmpty(other) || sr == nil {
 		return
 	}
-	sr.mergeWithInPlace(toSliceRequests(other), func(a, b int64) int64 {
-		return a - b
-	})
+	sr.mergeWithInPlace(toSliceRequests(other), utilmath.SaturatingSub)
 }
 
 // mergeFunc defines a computation lambda between matching or missing values in two SliceRequests.

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -41,16 +41,17 @@ var fuzzResourceNames = []corev1.ResourceName{
 //  1. Header (1 byte): data[0] is returned as opChoice to select the test operation (opAdd, opSub, opScaledUp, opCountIn).
 //  2. Map 1 parsing:
 //     - The next byte (data[0] % 5) defines len1, the number of resource entries to populate in m1 (0 to 4).
-//     - Each entry consumes 5 bytes:
+//     - Each entry consumes 9 bytes:
 //     - Byte 0: Resource name index into fuzzResourceNames array (data[0] % len(fuzzResourceNames)).
-//     - Bytes 1..4: 32-bit unsigned little-endian integer value for the resource quantity.
+//     - Bytes 1..8: 64-bit little-endian value for the resource quantity, taken as
+//     int64, so negative values and the saturation boundary are both reachable.
 //  3. Map 2 parsing:
 //     - If bytes remain, the next byte (data[0] % 5) defines len2 (0 to 4).
-//     - Up to len2 entries are parsed using 5 bytes each, exactly as in m1.
+//     - Up to len2 entries are parsed using 9 bytes each, exactly as in m1.
 //
 // Example:
 //
-//	Input data: []byte{0, 2, 0, 100, 0, 0, 0, 1, 50, 0, 0, 0}
+//	Input data: []byte{0, 2, 0, 100, 0, 0, 0, 0, 0, 0, 0, 1, 50, 0, 0, 0, 0, 0, 0, 0}
 //	- opChoice = 0 (opAdd)
 //	- m1 length = 2 % 5 = 2 entries
 //	  - Entry 1: index 0 -> fuzzResourceNames[0] ("cpu"), val = 100 -> m1["cpu"] = 100
@@ -76,13 +77,17 @@ func parseFuzzMap(data []byte) (MapRequests, []byte) {
 	m := make(MapRequests)
 	count := int(data[0] % 5)
 	data = data[1:]
-	for i := 0; i < count && len(data) >= 5; i++ {
+	for i := 0; i < count && len(data) >= 9; i++ {
 		res := fuzzResourceNames[int(data[0])%len(fuzzResourceNames)]
-		val := int64(data[1]) | int64(data[2])<<8 | int64(data[3])<<16 | int64(data[4])<<24
+		// Eight bytes rather than four: the values this fuzzer compares are int64,
+		// and a four-byte value can only reach 2^32 and is never negative, so the
+		// boundary where the two implementations could disagree was unreachable.
+		val := int64(uint64(data[1]) | uint64(data[2])<<8 | uint64(data[3])<<16 | uint64(data[4])<<24 |
+			uint64(data[5])<<32 | uint64(data[6])<<40 | uint64(data[7])<<48 | uint64(data[8])<<56)
 		if val != 0 {
 			m[res] = val
 		}
-		data = data[5:]
+		data = data[9:]
 	}
 	return m, data
 }
@@ -160,12 +165,16 @@ func (s fuzzSeed) encode() []byte {
 	buf := []byte{s.opChoice, byte(len(s.m1))}
 	for res, val := range s.m1 {
 		idx := resourceIndex(res)
-		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+		buf = append(buf, idx,
+			byte(val), byte(val>>8), byte(val>>16), byte(val>>24),
+			byte(val>>32), byte(val>>40), byte(val>>48), byte(val>>56))
 	}
 	buf = append(buf, byte(len(s.m2)))
 	for res, val := range s.m2 {
 		idx := resourceIndex(res)
-		buf = append(buf, idx, byte(val), byte(val>>8), byte(val>>16), byte(val>>24))
+		buf = append(buf, idx,
+			byte(val), byte(val>>8), byte(val>>16), byte(val>>24),
+			byte(val>>32), byte(val>>40), byte(val>>48), byte(val>>56))
 	}
 	return buf
 }
@@ -221,6 +230,24 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			opChoice: opCountIn,
 			m1:       MapRequests{corev1.ResourceMemory: 1},
 			m2:       MapRequests{corev1.ResourceMemory: math.MaxInt32 + 1},
+		},
+		// The int64 boundary, which the corpus could not encode while a value
+		// was four bytes wide. Both implementations saturate, so they have to
+		// saturate to the same place.
+		{
+			opChoice: opAdd,
+			m1:       MapRequests{corev1.ResourceCPU: math.MaxInt64},
+			m2:       MapRequests{corev1.ResourceCPU: 1},
+		},
+		{
+			opChoice: opSub,
+			m1:       MapRequests{corev1.ResourceCPU: math.MinInt64},
+			m2:       MapRequests{corev1.ResourceCPU: 1},
+		},
+		{
+			opChoice: opSub,
+			m1:       MapRequests{},
+			m2:       MapRequests{corev1.ResourceCPU: math.MinInt64},
 		},
 		{
 			opChoice: opSet,

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resources
 
 import (
+	"maps"
 	"math"
 	"testing"
 
@@ -271,6 +272,79 @@ func TestSliceRequests_AddAndSub(t *testing.T) {
 			t.Errorf("Sub MapRequests mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+// TestSliceRequests_SaturationMatchesMapRequests pins the two Requests
+// implementations to the same answer where int64 runs out. Which one runs is a
+// feature gate decision, so a difference here is the same cluster accounting two
+// ways.
+func TestSliceRequests_SaturationMatchesMapRequests(t *testing.T) {
+	const res = corev1.ResourceCPU
+	cases := map[string]struct {
+		start MapRequests
+		other MapRequests
+		sub   bool
+		want  MapRequests
+	}{
+		"adding past MaxInt64": {
+			start: MapRequests{res: math.MaxInt64},
+			other: MapRequests{res: 1},
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"adding past MinInt64": {
+			start: MapRequests{res: math.MinInt64},
+			other: MapRequests{res: -1},
+			want:  MapRequests{res: math.MinInt64},
+		},
+		"two halves that do not fit": {
+			start: MapRequests{res: math.MaxInt64/2 + 1},
+			other: MapRequests{res: math.MaxInt64/2 + 1},
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"subtracting a negative past MaxInt64": {
+			start: MapRequests{res: math.MaxInt64},
+			other: MapRequests{res: -1},
+			sub:   true,
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"subtracting past MinInt64": {
+			start: MapRequests{res: math.MinInt64},
+			other: MapRequests{res: 1},
+			sub:   true,
+			want:  MapRequests{res: math.MinInt64},
+		},
+		// A key the receiver does not hold takes a different route through
+		// SliceRequests: mergeInto reaches it as fn(0, b), which none of the
+		// cases above enter.
+		"subtracting MinInt64 from a key the receiver lacks": {
+			start: MapRequests{},
+			other: MapRequests{res: math.MinInt64},
+			sub:   true,
+			want:  MapRequests{res: math.MaxInt64},
+		},
+		"adding MinInt64 to a key the receiver lacks": {
+			start: MapRequests{},
+			other: MapRequests{res: math.MinInt64},
+			want:  MapRequests{res: math.MinInt64},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			mapReq := maps.Clone(tc.start)
+			sliceReq := NewSliceRequests(tc.start)
+			if tc.sub {
+				mapReq.Sub(tc.other)
+				sliceReq.Sub(tc.other)
+			} else {
+				mapReq.Add(tc.other)
+				sliceReq.Add(tc.other)
+			}
+			if diff := cmp.Diff(tc.want, mapReq); diff != "" {
+				t.Errorf("MapRequests mismatch (-want +got):\n%s", diff)
+			}
+			checkRequestsEquivalence(t, name, mapReq, sliceReq)
+		})
+	}
 }
 
 func TestSliceRequests_GetValue(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Manual cherry-pick of #14100 onto release-0.18, as asked for there.

`MapRequests` and `SliceRequests` both keep resource totals as `int64` and both already saturate in `Mul`, but `Add` and `Sub` were left as plain arithmetic. Two contributions that each convert intact can therefore sum past `MaxInt64` and come back negative, which `FloorToZero` then reads as nothing having been asked for. Both now go through `utilmath.SaturatingAdd` and `utilmath.SaturatingSub`, which already exist on this branch.

Which implementation runs is decided by the `VectorizedResourceRequests` feature gate, so both had to change together or the same cluster would account two ways depending on a gate.

#### Which issue(s) this PR fixes:

Part of #14045, which stays open on main for the admission envelope half.

#### Special notes for your reviewer:

Cherry-picked from the branch commit rather than the squashed one on main, so the subject carries no issue reference. The repository asks for that, since prow flags `#` mentions in commit messages.

The change applies unmodified, with no conflicts and nothing needing adjustment for this branch. Verified here rather than assumed from main: `go build ./...` and the `pkg/resources` and `pkg/workload` tests are green on this branch.

#### Does this PR introduce a user-facing change?

```release-note
Fixed resource totals wrapping to a negative number when two contributions to the same resource sum past the int64 range. Both Requests implementations now saturate in Add and Sub, as they already did in Mul, so an unrepresentable total is no longer read as an empty request.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
