### PR TITLE
Automated cherry pick of #14095: Rename "out-scope" to standard "out-of-scope" in SECURITY-INSIGHTS.yaml

### DIFF
--- a/SECURITY-INSIGHTS.yaml
+++ b/SECURITY-INSIGHTS.yaml
@@ -71,7 +71,7 @@ vulnerability-reporting:
       (for example, quota borrowing or preemption affecting workloads of another
       tenant)
     - Insecure RBAC defaults in the shipped manifests or Helm chart
-  out-scope:
+  out-of-scope:
     - Vulnerabilities in Kubernetes core, which are delegated to the upstream
       Kubernetes security process at https://kubernetes.io/security/
     - Issues that only affect unsupported Kueue releases


### PR DESCRIPTION
Cherry pick of #14095 on release-0.19.

#14095: Rename "out-scope" to standard "out-of-scope" in SECURITY-INSIGHTS.yaml

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```