### PR TITLE
Encapsulate pending workload tracking structure in ClusterQueue

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -373,7 +373,7 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	key := workload.Key(wInfo.Obj)
 	// Skip if the scheduler is actively processing this workload.
 	// RequeueWorkload will handle placement with the latest version.
-	if c.workloads.IsInflight(key) {
+	if c.workloads.HasInflight(key) {
 		return
 	}
 	if oldInfo := c.workloads.GetInadmissible(key); oldInfo != nil {
@@ -453,7 +453,7 @@ func (c *ClusterQueue) RebuildHeap(log logr.Logger, lqName string) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
 	log.V(3).Info("Rebuilding heap after LocalQueue fair-sharing usage change", "clusterQueue", c.name, "localQueue", lqName)
-	c.workloads.RebuildLocalQueue(lqName)
+	c.workloads.RebuildActiveHeap()
 }
 
 // backoffWaitingTimeExpired returns true if the current time is after the requeueAt
@@ -646,7 +646,12 @@ func (c *ClusterQueue) Pop() *workload.Info {
 	defer c.rwm.Unlock()
 
 	if c.hasPendingPenalties() {
-		c.workloads.RebuildAll()
+		// A pending penalty can change the fair-sharing usage of several workloads from
+		// the same LocalQueue at once, so they all shift relative to other LocalQueues'
+		// workloads together. heap.Fix assumes a single element moved while the rest of
+		// the heap is valid, so fixing these entries one by one can leave the heap
+		// invalid; instead the whole invariant is re-established in O(n) with heap.Init.
+		c.workloads.RebuildActiveHeap()
 	}
 
 	c.popCycle++
@@ -915,5 +920,5 @@ func (c *ClusterQueue) UpdateLocalQueueWeight(lqKey utilqueue.LocalQueueReferenc
 		return
 	}
 	c.lqWeights[lqKey] = weight
-	c.heap.Init()
+	c.workloads.RebuildActiveHeap()
 }

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -19,7 +19,6 @@ package queue
 import (
 	"cmp"
 	"context"
-	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -145,34 +144,14 @@ func logStickyWorkloadSelectionIfVerbose(log logr.Logger, wl *kueue.Workload) {
 type ClusterQueue struct {
 	hierarchy.ClusterQueue[*cohort]
 	name              kueue.ClusterQueueReference
-	heap              heap.Heap[workload.Info, workload.Reference]
 	namespaceSelector labels.Selector
 	active            bool
-	customLabels      *metrics.CustomLabels
-
-	pendingWorkloadsTracker *metrics.LabelValsTracker
-
-	// inadmissibleWorkloads are workloads that have been tried at least once and couldn't be admitted.
-	//
-	// Invariant: a pending workload is tracked in exactly one of heap,
-	// inadmissibleWorkloads, or inflight at any time, and contributes to
-	// pendingResourcesTotal exactly once while in heap or inadmissibleWorkloads.
-	// All transitions between these places must go through the helpers next to
-	// addPendingResources (pushToHeapIfNotTracked, pushOrUpdateHeap,
-	// removeFromHeap, insertInadmissible, removeFromInadmissible,
-	// moveInadmissibleToHeap, moveHeapToInadmissible) so the accounting
-	// cannot drift.
-	inadmissibleWorkloads        inadmissibleWorkloads
-	inadmissibleWorkloadsTracker *metrics.LabelValsTracker
+	workloads         *pendingWorkloads
 
 	// hashToBulkMoveReason tracks scheduling equivalence classes and the reason
 	// why workloads with that hash were bulk-moved to inadmissibleWorkloads.
 	// Cleared when queueInadmissibleWorkloads runs.
 	hashToBulkMoveReason map[workload.EquivalenceHash]QuotaReservedReason
-
-	// schedulingHashes tracks the scheduling equivalence hashes of pending
-	// workloads for the pending_scheduling_hashes metric.
-	schedulingHashes *schedulingHashCounts
 
 	finishedWorkloads sets.Set[workload.Reference]
 
@@ -180,10 +159,6 @@ type ClusterQueue struct {
 	// popCycle and queueInadmissibleCycle are used to track when there is a requeuing
 	// of inadmissible workloads while a workload is being scheduled.
 	popCycle int64
-
-	// inflight is non-nil when a workload has been popped by the scheduler but
-	// not yet requeued or deleted.
-	inflight *workload.Info
 
 	// queueInadmissibleCycle stores the popId at the time when
 	// QueueInadmissibleWorkloads is called.
@@ -206,32 +181,6 @@ type ClusterQueue struct {
 	sw *stickyWorkload
 
 	ConcurrentAdmissionPolicy *kueue.ConcurrentAdmissionPolicy
-	// pendingResourcesTotal is the incremental sum of TotalRequests across workloads
-	// in heap and inadmissibleWorkloads (not inflight). Updated at each mutation site so
-	// pendingResources() is O(1) rather than O(N).
-	// Configured resources are seeded at 0 by Update() so they appear in metrics
-	// even when no workloads are pending; stale zero entries are pruned on Update().
-	pendingResourcesTotal map[corev1.ResourceName]int64
-}
-
-func (c *ClusterQueue) updateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
-	if oldInfo == nil {
-		oldInfo = c.inadmissibleWorkloads.get(key)
-	}
-	if oldInfo != nil {
-		metrics.UntrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, oldInfo.Obj)
-	}
-	c.inadmissibleWorkloads.insert(key, newInfo)
-	c.schedulingHashes.updateInadmissible(oldInfo, newInfo)
-	metrics.TrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, newInfo.Obj)
-}
-
-func (c *ClusterQueue) popPending() *workload.Info {
-	wInfo := c.heap.Pop()
-	if wInfo != nil {
-		metrics.UntrackWorkload(c.customLabels, c.pendingWorkloadsTracker, wInfo.Obj)
-	}
-	return wInfo
 }
 
 func (c *ClusterQueue) GetName() kueue.ClusterQueueReference {
@@ -323,23 +272,25 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
 	return &ClusterQueue{
-		customLabels:                 cl,
-		heap:                         *heap.New(workloadKey, lessFunc),
-		pendingWorkloadsTracker:      metrics.NewLabelValsTracker(),
-		inadmissibleWorkloads:        make(inadmissibleWorkloads),
-		inadmissibleWorkloadsTracker: metrics.NewLabelValsTracker(),
-		hashToBulkMoveReason:         make(map[workload.EquivalenceHash]QuotaReservedReason),
-		schedulingHashes:             newSchedulingHashCounts(),
-		finishedWorkloads:            sets.New[workload.Reference](),
-		queueInadmissibleCycle:       -1,
-		compareFunc:                  compareFunc,
-		snapshotSort:                 snapshotSort,
-		rwm:                          sync.RWMutex{},
-		clock:                        clock,
-		afsEntryPenalties:            options.afsEntryPenalties,
-		localQueuesInClusterQueue:    make(map[utilqueue.LocalQueueReference]bool),
-		sw:                           &sw,
-		pendingResourcesTotal:        make(map[corev1.ResourceName]int64),
+		workloads: &pendingWorkloads{
+			customLabels:          cl,
+			active:                *heap.New(workloadKey, lessFunc),
+			activeTracker:         metrics.NewLabelValsTracker(),
+			inadmissible:          make(inadmissibleWorkloads),
+			inadmissibleTracker:   metrics.NewLabelValsTracker(),
+			pendingResourcesTotal: make(map[corev1.ResourceName]int64),
+			schedulingHashes:      newSchedulingHashCounts(),
+		},
+		hashToBulkMoveReason:      make(map[workload.EquivalenceHash]QuotaReservedReason),
+		finishedWorkloads:         sets.New[workload.Reference](),
+		queueInadmissibleCycle:    -1,
+		compareFunc:               compareFunc,
+		snapshotSort:              snapshotSort,
+		rwm:                       sync.RWMutex{},
+		clock:                     clock,
+		afsEntryPenalties:         options.afsEntryPenalties,
+		localQueuesInClusterQueue: make(map[utilqueue.LocalQueueReference]bool),
+		sw:                        &sw,
 	}
 }
 
@@ -358,30 +309,8 @@ func (c *ClusterQueue) Update(apiCQ *kueue.ClusterQueue) error {
 	if features.Enabled(features.ConcurrentAdmission) {
 		c.ConcurrentAdmissionPolicy = apiCQ.Spec.ConcurrentAdmissionPolicy
 	}
-	c.updateConfiguredResources(apiCQ)
+	c.workloads.updateConfiguredResources(apiCQ)
 	return nil
-}
-
-// updateConfiguredResources seeds pendingResourcesTotal with 0 for newly configured
-// resources so they appear in metrics even when no workloads are pending, and prunes
-// zero entries for resources removed from the spec.
-func (c *ClusterQueue) updateConfiguredResources(apiCQ *kueue.ClusterQueue) {
-	newConfigured := sets.New[corev1.ResourceName]()
-	for _, rg := range apiCQ.Spec.ResourceGroups {
-		for _, fq := range rg.Flavors {
-			for _, r := range fq.Resources {
-				newConfigured.Insert(r.Name)
-				if _, exists := c.pendingResourcesTotal[r.Name]; !exists {
-					c.pendingResourcesTotal[r.Name] = 0
-				}
-			}
-		}
-	}
-	for r, v := range c.pendingResourcesTotal {
-		if v == 0 && !newConfigured.Has(r) {
-			delete(c.pendingResourcesTotal, r)
-		}
-	}
 }
 
 // AddFromLocalQueue pushes all workloads belonging to this queue to
@@ -398,7 +327,7 @@ func (c *ClusterQueue) AddFromLocalQueue(q *LocalQueue, roleTracker *roletracker
 		}
 		// A workload already tracked as inadmissible stays there; retrying it
 		// is owned by the requeue paths, which respect the backoff time.
-		if c.pushToHeapIfNotTracked(info) {
+		if c.workloads.pushActiveIfNotPresent(info) {
 			added = true
 		}
 	}
@@ -430,10 +359,10 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	key := workload.Key(wInfo.Obj)
 	// Skip if the scheduler is actively processing this workload.
 	// RequeueWorkload will handle placement with the latest version.
-	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
+	if c.workloads.isInflight(key) {
 		return
 	}
-	if oldInfo := c.inadmissibleWorkloads.get(key); oldInfo != nil {
+	if oldInfo := c.workloads.getInadmissible(key); oldInfo != nil {
 		specChangedSinceEval := oldInfo.LastEvaluatedGeneration != 0 &&
 			wInfo.Obj.Generation != oldInfo.LastEvaluatedGeneration
 
@@ -449,25 +378,25 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 				apimeta.FindStatusCondition(wInfo.Obj.Status.Conditions, kueue.WorkloadRequeued)) &&
 			workload.HasClosedPreemptionGate(oldInfo.Obj) == workload.HasClosedPreemptionGate(wInfo.Obj) &&
 			!draRequestsChanged(oldInfo, wInfo) {
-			c.updateInadmissible(key, oldInfo, wInfo)
+			c.workloads.updateInadmissible(key, oldInfo, wInfo)
 			return
 		}
 		// Workload is leaving inadmissible; account for its resources before moving.
-		c.removeFromInadmissible(key, oldInfo)
+		c.workloads.removeFromInadmissible(key, oldInfo)
 	}
-	if c.heap.GetByKey(key) == nil && !c.backoffWaitingTimeExpired(wInfo) {
-		c.insertInadmissible(key, wInfo)
+	if c.workloads.getActive(key) == nil && !c.backoffWaitingTimeExpired(wInfo) {
+		c.workloads.insertInadmissible(key, wInfo)
 		return
 	}
 	// Skip to inadmissible if the workload's equivalence class was already bulk-moved to inadmissible
 	// (only for BestEffortFIFO; StrictFIFO preserves strict ordering).
-	if c.queueingStrategy == kueue.BestEffortFIFO && c.heap.GetByKey(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
+	if c.queueingStrategy == kueue.BestEffortFIFO && c.workloads.getActive(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
 		if _, has := c.hashToBulkMoveReason[wInfo.SchedulingHash]; has {
-			c.insertInadmissible(key, wInfo)
+			c.workloads.insertInadmissible(key, wInfo)
 			return
 		}
 	}
-	c.pushOrUpdateHeap(wInfo)
+	c.workloads.pushOrUpdateActive(wInfo)
 }
 
 func priorityBoostAnnotationChanged(oldInfo, newInfo *workload.Info) bool {
@@ -490,7 +419,7 @@ func draRequestsChanged(oldInfo, newInfo *workload.Info) bool {
 func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	wlInfo := c.inadmissibleWorkloads.get(wl)
+	wlInfo := c.workloads.getInadmissible(wl)
 	if wlInfo == nil {
 		return "", false
 	}
@@ -501,11 +430,7 @@ func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	for _, wl := range c.heap.List() {
-		if string(wl.Obj.Spec.QueueName) == lqName {
-			c.heap.PushOrUpdate(wl)
-		}
-	}
+	c.workloads.rebuildLocalQueue(lqName)
 }
 
 // backoffWaitingTimeExpired returns true if the current time is after the requeueAt
@@ -523,118 +448,6 @@ func (c *ClusterQueue) backoffWaitingTimeExpired(wInfo *workload.Info) bool {
 		c.clock.Now().Equal(wInfo.Obj.Status.RequeueState.RequeueAt.Time)
 }
 
-func (c *ClusterQueue) addPendingResources(wInfo *workload.Info) {
-	for _, ps := range wInfo.TotalRequests {
-		if ps.Requests != nil {
-			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
-				c.pendingResourcesTotal[name] += q
-			})
-		}
-	}
-}
-
-func (c *ClusterQueue) subtractPendingResources(wInfo *workload.Info) {
-	for _, ps := range wInfo.TotalRequests {
-		if ps.Requests != nil {
-			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
-				c.pendingResourcesTotal[name] -= q
-			})
-		}
-	}
-}
-
-func (c *ClusterQueue) insertInadmissible(key workload.Reference, wInfo *workload.Info) {
-	c.inadmissibleWorkloads.insert(key, wInfo)
-	c.schedulingHashes.addInadmissible(wInfo)
-	metrics.TrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, wInfo.Obj)
-	c.addPendingResources(wInfo)
-}
-
-func (c *ClusterQueue) removeFromInadmissible(key workload.Reference, wInfo *workload.Info) {
-	c.schedulingHashes.removeInadmissible(wInfo)
-	c.subtractPendingResources(wInfo)
-	c.inadmissibleWorkloads.delete(key)
-	metrics.UntrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, wInfo.Obj)
-}
-
-// pushToHeapIfNotTracked pushes wInfo onto the heap and accounts for its
-// pending resources, unless the workload is already tracked in the heap, in
-// inadmissibleWorkloads, or as inflight. The inflight workload is skipped
-// because the scheduler owns its placement until requeue or deletion, and a
-// heap copy would double-count its resources next to the inflight one.
-// Returns true if the workload was pushed.
-func (c *ClusterQueue) pushToHeapIfNotTracked(wInfo *workload.Info) bool {
-	key := workloadKey(wInfo)
-	if c.inflight != nil && workloadKey(c.inflight) == key {
-		return false
-	}
-	if c.inadmissibleWorkloads.hasKey(key) {
-		return false
-	}
-	if !c.heap.PushIfNotPresent(wInfo) {
-		return false
-	}
-	c.schedulingHashes.addActive(wInfo)
-	metrics.TrackWorkload(c.customLabels, c.pendingWorkloadsTracker, wInfo.Obj)
-	c.addPendingResources(wInfo)
-	return true
-}
-
-// pushOrUpdateHeap pushes wInfo onto the heap, replacing any previous copy.
-// The old copy's resources are subtracted before the new copy's are added,
-// because the requests may have changed.
-func (c *ClusterQueue) pushOrUpdateHeap(wInfo *workload.Info) {
-	old := c.heap.GetByKey(workload.Key(wInfo.Obj))
-	if old != nil {
-		metrics.UntrackWorkload(c.customLabels, c.pendingWorkloadsTracker, old.Obj)
-		c.subtractPendingResources(old)
-	}
-	c.heap.PushOrUpdate(wInfo)
-	c.schedulingHashes.updateActive(old, wInfo)
-	metrics.TrackWorkload(c.customLabels, c.pendingWorkloadsTracker, wInfo.Obj)
-	c.addPendingResources(wInfo)
-}
-
-// removeFromHeap removes the workload from the heap and subtracts its pending
-// resources, if the heap holds it.
-func (c *ClusterQueue) removeFromHeap(key workload.Reference) {
-	if old := c.heap.GetByKey(key); old != nil {
-		c.schedulingHashes.removeActive(old)
-		c.subtractPendingResources(old)
-		c.heap.Delete(key)
-		metrics.UntrackWorkload(c.customLabels, c.pendingWorkloadsTracker, old.Obj)
-	}
-}
-
-// moveInadmissibleToHeap moves a workload tracked in inadmissibleWorkloads
-// onto the heap. The workload stays pending throughout, so
-// pendingResourcesTotal is unchanged. The workload is pushed before the
-// inadmissible entry is deleted, so a failed push (the heap unexpectedly
-// already holding a copy) keeps the workload tracked as inadmissible instead
-// of dropping it. Returns true if the workload was moved.
-func (c *ClusterQueue) moveInadmissibleToHeap(key workload.Reference, wInfo *workload.Info) bool {
-	if !c.heap.PushIfNotPresent(wInfo) {
-		return false
-	}
-	c.schedulingHashes.moveToActive(wInfo)
-	metrics.TrackWorkload(c.customLabels, c.pendingWorkloadsTracker, wInfo.Obj)
-
-	c.inadmissibleWorkloads.delete(key)
-	metrics.UntrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, wInfo.Obj)
-	return true
-}
-
-// moveHeapToInadmissible moves a workload from the heap into
-// inadmissibleWorkloads. The workload stays pending throughout, so
-// pendingResourcesTotal is unchanged.
-func (c *ClusterQueue) moveHeapToInadmissible(key workload.Reference, wInfo *workload.Info) {
-	c.heap.Delete(key)
-	metrics.UntrackWorkload(c.customLabels, c.pendingWorkloadsTracker, wInfo.Obj)
-	c.inadmissibleWorkloads.insert(key, wInfo)
-	c.schedulingHashes.moveToInadmissible(wInfo)
-	metrics.TrackWorkload(c.customLabels, c.inadmissibleWorkloadsTracker, wInfo.Obj)
-}
-
 // Delete removes the workload from ClusterQueue.
 func (c *ClusterQueue) Delete(log logr.Logger, wlKey workload.Reference) {
 	c.rwm.Lock()
@@ -648,12 +461,12 @@ func (c *ClusterQueue) delete(log logr.Logger, key workload.Reference) {
 	// inadmissibleWorkloads); each removal below is a no-op when the bucket does
 	// not hold the key, and self-consistent when it does.
 	// Inflight is skipped because its resources were already removed from pendingResourcesTotal at Pop time.
-	if old := c.inadmissibleWorkloads.get(key); old != nil {
-		c.removeFromInadmissible(key, old)
+	if old := c.workloads.getInadmissible(key); old != nil {
+		c.workloads.removeFromInadmissible(key, old)
 	}
 
-	c.removeFromHeap(key)
-	c.forgetInflightByKey(key)
+	c.workloads.removeActive(key)
+	c.workloads.forgetInflightByKey(key)
 	if c.sw.matches(key) {
 		if logV := log.V(5); logV.Enabled() {
 			logV.Info("Clearing sticky workload due to deletion", "clusterQueue", c.name, "workload", key)
@@ -712,28 +525,28 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 		}
 		c.sw.set(key)
 	}
-	c.forgetInflightByKey(key)
+	c.workloads.forgetInflightByKey(key)
 
-	inadmissibleWl := c.inadmissibleWorkloads.get(key)
+	inadmissibleWl := c.workloads.getInadmissible(key)
 
 	if c.backoffWaitingTimeExpired(wInfo) &&
 		(immediate || c.queueInadmissibleCycle >= c.popCycle || wInfo.LastAssignment.PendingFlavors()) {
 		// If the workload was inadmissible, move it back into the queue.
 		if inadmissibleWl != nil {
-			return c.moveInadmissibleToHeap(key, inadmissibleWl)
+			return c.workloads.moveToActive(key, inadmissibleWl)
 		}
-		return c.pushToHeapIfNotTracked(wInfo)
+		return c.workloads.pushActiveIfNotPresent(wInfo)
 	}
 
 	if inadmissibleWl != nil {
 		return false
 	}
 
-	if c.heap.GetByKey(key) != nil {
+	if c.workloads.getActive(key) != nil {
 		return false
 	}
 
-	c.insertInadmissible(key, wInfo)
+	c.workloads.insertInadmissible(key, wInfo)
 	logMsg := "Workload couldn't be admitted."
 	if c.queueingStrategy == kueue.BestEffortFIFO {
 		logMsg += " Moving the head of this ClusterQueue to the consecutive Workload."
@@ -750,13 +563,6 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 	return true
 }
 
-func (c *ClusterQueue) forgetInflightByKey(key workload.Reference) {
-	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
-		c.inflight = nil
-		c.schedulingHashes.clearInflight()
-	}
-}
-
 // handleInadmissibleHash bulk-moves all heap workloads matching the given
 // scheduling hash to inadmissibleWorkloads. Returns the number moved.
 // Only applies to BestEffortFIFO queues; in StrictFIFO the head workload
@@ -767,9 +573,9 @@ func (c *ClusterQueue) handleInadmissibleHash(hash workload.EquivalenceHash, rea
 	}
 	c.hashToBulkMoveReason[hash] = reason
 	moved := 0
-	for _, wInfo := range c.heap.List() {
-		if wInfo.SchedulingHash == hash {
-			c.moveHeapToInadmissible(workloadKey(wInfo), wInfo)
+	for wlInfo := range c.workloads.activeIterator() {
+		if wlInfo.SchedulingHash == hash {
+			c.workloads.moveToInadmissible(workloadKey(wlInfo), wlInfo)
 			moved++
 		}
 	}
@@ -781,17 +587,7 @@ func (c *ClusterQueue) handleInadmissibleHash(hash workload.EquivalenceHash, rea
 func (c *ClusterQueue) pendingResources() map[corev1.ResourceName]int64 {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	result := maps.Clone(c.pendingResourcesTotal)
-	if c.inflight != nil {
-		for _, ps := range c.inflight.TotalRequests {
-			if ps.Requests != nil {
-				ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
-					result[name] += q
-				})
-			}
-		}
-	}
-	return result
+	return c.workloads.pendingResources()
 }
 
 // PendingTotal returns the total number of pending workloads.
@@ -810,59 +606,14 @@ func (c *ClusterQueue) Pending() (int, int) {
 func (c *ClusterQueue) PendingBreakdown() (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.pendingActive(), c.pendingInadmissible()
-}
-
-// pendingActive returns the number of active pending workloads,
-// workloads that are in the admission queue.
-func (c *ClusterQueue) pendingActive() *metrics.LabelValsTracker {
-	result := metrics.Copy(c.pendingWorkloadsTracker)
-	if c.inflight != nil {
-		metrics.TrackWorkload(c.customLabels, result, c.inflight.Obj)
-	}
-	return result
-}
-
-// pendingInadmissible returns the number of inadmissible pending workloads,
-// workloads that were already tried and are waiting for cluster conditions
-// to change to potentially become admissible.
-func (c *ClusterQueue) pendingInadmissible() *metrics.LabelValsTracker {
-	return metrics.Copy(c.inadmissibleWorkloadsTracker)
+	return c.workloads.pendingBreakdown()
 }
 
 // PendingInLocalQueue returns the number of active and inadmissible pending workloads in LocalQueue.
 func (c *ClusterQueue) PendingInLocalQueue(lqRef utilqueue.LocalQueueReference) (int, int) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.pendingActiveInLocalQueue(lqRef), c.pendingInadmissibleInLocalQueue(lqRef)
-}
-
-// pendingActiveInLocalQueue returns the number of active pending workloads in LocalQueue,
-// workloads that are in the admission queue.
-func (c *ClusterQueue) pendingActiveInLocalQueue(lqRef utilqueue.LocalQueueReference) (active int) {
-	for _, wl := range c.heap.List() {
-		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
-		if wlLqKey == lqRef {
-			active++
-		}
-	}
-	if c.inflight != nil && utilqueue.KeyFromWorkload(c.inflight.Obj) == lqRef {
-		active++
-	}
-	return
-}
-
-// pendingInadmissibleInLocalQueue returns the number of inadmissible pending workloads in LocalQueue,
-// workloads that were already tried and are waiting for cluster conditions
-// to change to potentially become admissible.
-func (c *ClusterQueue) pendingInadmissibleInLocalQueue(lqRef utilqueue.LocalQueueReference) (inadmissible int) {
-	for _, wl := range c.inadmissibleWorkloads {
-		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
-		if wlLqKey == lqRef {
-			inadmissible++
-		}
-	}
-	return
+	return c.workloads.pendingActiveInLocalQueue(lqRef), c.workloads.pendingInadmissibleInLocalQueue(lqRef)
 }
 
 // Pop removes the head of the queue and returns it. It returns nil if the
@@ -872,28 +623,11 @@ func (c *ClusterQueue) Pop() *workload.Info {
 	defer c.rwm.Unlock()
 
 	if c.hasPendingPenalties() {
-		c.rebuildAll()
+		c.workloads.rebuildAll()
 	}
 
 	c.popCycle++
-	if c.heap.Len() == 0 {
-		c.inflight = nil
-		c.schedulingHashes.clearInflight()
-		return nil
-	}
-	wl := c.popPending()
-	c.schedulingHashes.moveActiveToInflight(wl)
-	c.subtractPendingResources(wl)
-	c.inflight = wl
-	c.inflight.LastEvaluatedGeneration = c.inflight.Obj.Generation
-	return c.inflight
-}
-
-// rebuildAll rebuilds the entire heap. Must be called with lock held.
-func (c *ClusterQueue) rebuildAll() {
-	for _, wl := range c.heap.List() {
-		c.heap.PushOrUpdate(wl)
-	}
+	return c.workloads.popActive()
 }
 
 func (c *ClusterQueue) hasPendingPenalties() bool {
@@ -916,27 +650,13 @@ func (c *ClusterQueue) hasPendingPenalties() bool {
 func (c *ClusterQueue) Dump() ([]workload.Reference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	if c.heap.Len() == 0 {
-		return nil, false
-	}
-	elements := make([]workload.Reference, c.heap.Len())
-	for i, info := range c.heap.List() {
-		elements[i] = workload.Key(info.Obj)
-	}
-	return elements, true
+	return c.workloads.dumpActive()
 }
 
 func (c *ClusterQueue) DumpInadmissible() ([]workload.Reference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	if c.inadmissibleWorkloads.empty() {
-		return nil, false
-	}
-	elements := make([]workload.Reference, 0, c.inadmissibleWorkloads.len())
-	for _, info := range c.inadmissibleWorkloads {
-		elements = append(elements, workload.Key(info.Obj))
-	}
-	return elements, true
+	return c.workloads.dumpInadmissible()
 }
 
 // Snapshot returns a copy of pending workloads in queue order.
@@ -1034,7 +754,7 @@ func buildSnapshotSort(
 func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.heap.GetByKey(key)
+	return c.workloads.getActive(key)
 }
 
 // totalElements returns all pending workloads (heap + inadmissible + inflight).
@@ -1042,16 +762,7 @@ func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 func (c *ClusterQueue) totalElements() []*workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	totalLen := c.heap.Len() + c.inadmissibleWorkloads.len()
-	elements := make([]*workload.Info, 0, totalLen)
-	elements = append(elements, c.heap.List()...)
-	for _, e := range c.inadmissibleWorkloads {
-		elements = append(elements, e)
-	}
-	if c.inflight != nil {
-		elements = append(elements, c.inflight)
-	}
-	return elements
+	return c.workloads.dumpAll()
 }
 
 // Active returns true if the queue is active

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -146,7 +146,7 @@ type ClusterQueue struct {
 	name              kueue.ClusterQueueReference
 	namespaceSelector labels.Selector
 	active            bool
-	workloads         *pendingWorkloads
+	workloads         *PendingWorkloads
 
 	// hashToBulkMoveReason tracks scheduling equivalence classes and the reason
 	// why workloads with that hash were bulk-moved to inadmissibleWorkloads.
@@ -272,7 +272,7 @@ func newClusterQueueImpl(ctx context.Context, client client.Client, cl *metrics.
 		options.afsEntryPenalties, options.afsConsumedResources,
 	)
 	return &ClusterQueue{
-		workloads: &pendingWorkloads{
+		workloads: &PendingWorkloads{
 			customLabels:          cl,
 			active:                *heap.New(workloadKey, lessFunc),
 			activeTracker:         metrics.NewLabelValsTracker(),
@@ -309,7 +309,7 @@ func (c *ClusterQueue) Update(apiCQ *kueue.ClusterQueue) error {
 	if features.Enabled(features.ConcurrentAdmission) {
 		c.ConcurrentAdmissionPolicy = apiCQ.Spec.ConcurrentAdmissionPolicy
 	}
-	c.workloads.updateConfiguredResources(apiCQ)
+	c.workloads.UpdateConfiguredResources(apiCQ)
 	return nil
 }
 
@@ -327,7 +327,7 @@ func (c *ClusterQueue) AddFromLocalQueue(q *LocalQueue, roleTracker *roletracker
 		}
 		// A workload already tracked as inadmissible stays there; retrying it
 		// is owned by the requeue paths, which respect the backoff time.
-		if c.workloads.pushActiveIfNotPresent(info) {
+		if c.workloads.PushActiveIfNotPresent(info) {
 			added = true
 		}
 	}
@@ -359,10 +359,10 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	key := workload.Key(wInfo.Obj)
 	// Skip if the scheduler is actively processing this workload.
 	// RequeueWorkload will handle placement with the latest version.
-	if c.workloads.isInflight(key) {
+	if c.workloads.IsInflight(key) {
 		return
 	}
-	if oldInfo := c.workloads.getInadmissible(key); oldInfo != nil {
+	if oldInfo := c.workloads.GetInadmissible(key); oldInfo != nil {
 		specChangedSinceEval := oldInfo.LastEvaluatedGeneration != 0 &&
 			wInfo.Obj.Generation != oldInfo.LastEvaluatedGeneration
 
@@ -378,25 +378,25 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 				apimeta.FindStatusCondition(wInfo.Obj.Status.Conditions, kueue.WorkloadRequeued)) &&
 			workload.HasClosedPreemptionGate(oldInfo.Obj) == workload.HasClosedPreemptionGate(wInfo.Obj) &&
 			!draRequestsChanged(oldInfo, wInfo) {
-			c.workloads.updateInadmissible(key, oldInfo, wInfo)
+			c.workloads.UpdateInadmissible(key, oldInfo, wInfo)
 			return
 		}
 		// Workload is leaving inadmissible; account for its resources before moving.
-		c.workloads.removeFromInadmissible(key, oldInfo)
+		c.workloads.RemoveFromInadmissible(key, oldInfo)
 	}
-	if c.workloads.getActive(key) == nil && !c.backoffWaitingTimeExpired(wInfo) {
-		c.workloads.insertInadmissible(key, wInfo)
+	if c.workloads.GetActive(key) == nil && !c.backoffWaitingTimeExpired(wInfo) {
+		c.workloads.InsertInadmissible(key, wInfo)
 		return
 	}
 	// Skip to inadmissible if the workload's equivalence class was already bulk-moved to inadmissible
 	// (only for BestEffortFIFO; StrictFIFO preserves strict ordering).
-	if c.queueingStrategy == kueue.BestEffortFIFO && c.workloads.getActive(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
+	if c.queueingStrategy == kueue.BestEffortFIFO && c.workloads.GetActive(key) == nil && wInfo.SchedulingHash != workload.SchedulingHashUnknown {
 		if _, has := c.hashToBulkMoveReason[wInfo.SchedulingHash]; has {
-			c.workloads.insertInadmissible(key, wInfo)
+			c.workloads.InsertInadmissible(key, wInfo)
 			return
 		}
 	}
-	c.workloads.pushOrUpdateActive(wInfo)
+	c.workloads.PushOrUpdateActive(wInfo)
 }
 
 func priorityBoostAnnotationChanged(oldInfo, newInfo *workload.Info) bool {
@@ -419,7 +419,7 @@ func draRequestsChanged(oldInfo, newInfo *workload.Info) bool {
 func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	wlInfo := c.workloads.getInadmissible(wl)
+	wlInfo := c.workloads.GetInadmissible(wl)
 	if wlInfo == nil {
 		return "", false
 	}
@@ -430,7 +430,7 @@ func (c *ClusterQueue) GetNoFitReason(wl workload.Reference) (string, bool) {
 func (c *ClusterQueue) RebuildLocalQueue(lqName string) {
 	c.rwm.Lock()
 	defer c.rwm.Unlock()
-	c.workloads.rebuildLocalQueue(lqName)
+	c.workloads.RebuildLocalQueue(lqName)
 }
 
 // backoffWaitingTimeExpired returns true if the current time is after the requeueAt
@@ -461,12 +461,12 @@ func (c *ClusterQueue) delete(log logr.Logger, key workload.Reference) {
 	// inadmissibleWorkloads); each removal below is a no-op when the bucket does
 	// not hold the key, and self-consistent when it does.
 	// Inflight is skipped because its resources were already removed from pendingResourcesTotal at Pop time.
-	if old := c.workloads.getInadmissible(key); old != nil {
-		c.workloads.removeFromInadmissible(key, old)
+	if old := c.workloads.GetInadmissible(key); old != nil {
+		c.workloads.RemoveFromInadmissible(key, old)
 	}
 
-	c.workloads.removeActive(key)
-	c.workloads.forgetInflightByKey(key)
+	c.workloads.RemoveActive(key)
+	c.workloads.ForgetInflightByKey(key)
 	if c.sw.matches(key) {
 		if logV := log.V(5); logV.Enabled() {
 			logV.Info("Clearing sticky workload due to deletion", "clusterQueue", c.name, "workload", key)
@@ -525,28 +525,28 @@ func (c *ClusterQueue) requeueIfNotPresent(log logr.Logger, wInfo *workload.Info
 		}
 		c.sw.set(key)
 	}
-	c.workloads.forgetInflightByKey(key)
+	c.workloads.ForgetInflightByKey(key)
 
-	inadmissibleWl := c.workloads.getInadmissible(key)
+	inadmissibleWl := c.workloads.GetInadmissible(key)
 
 	if c.backoffWaitingTimeExpired(wInfo) &&
 		(immediate || c.queueInadmissibleCycle >= c.popCycle || wInfo.LastAssignment.PendingFlavors()) {
 		// If the workload was inadmissible, move it back into the queue.
 		if inadmissibleWl != nil {
-			return c.workloads.moveToActive(key, inadmissibleWl)
+			return c.workloads.MoveToActive(key, inadmissibleWl)
 		}
-		return c.workloads.pushActiveIfNotPresent(wInfo)
+		return c.workloads.PushActiveIfNotPresent(wInfo)
 	}
 
 	if inadmissibleWl != nil {
 		return false
 	}
 
-	if c.workloads.getActive(key) != nil {
+	if c.workloads.GetActive(key) != nil {
 		return false
 	}
 
-	c.workloads.insertInadmissible(key, wInfo)
+	c.workloads.InsertInadmissible(key, wInfo)
 	logMsg := "Workload couldn't be admitted."
 	if c.queueingStrategy == kueue.BestEffortFIFO {
 		logMsg += " Moving the head of this ClusterQueue to the consecutive Workload."
@@ -575,7 +575,7 @@ func (c *ClusterQueue) handleInadmissibleHash(hash workload.EquivalenceHash, rea
 	moved := 0
 	for wlInfo := range c.workloads.activeIterator() {
 		if wlInfo.SchedulingHash == hash {
-			c.workloads.moveToInadmissible(workloadKey(wlInfo), wlInfo)
+			c.workloads.MoveToInadmissible(workloadKey(wlInfo), wlInfo)
 			moved++
 		}
 	}
@@ -587,7 +587,7 @@ func (c *ClusterQueue) handleInadmissibleHash(hash workload.EquivalenceHash, rea
 func (c *ClusterQueue) pendingResources() map[corev1.ResourceName]int64 {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.pendingResources()
+	return c.workloads.PendingResources()
 }
 
 // PendingTotal returns the total number of pending workloads.
@@ -606,14 +606,14 @@ func (c *ClusterQueue) Pending() (int, int) {
 func (c *ClusterQueue) PendingBreakdown() (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.pendingBreakdown()
+	return c.workloads.PendingBreakdown()
 }
 
 // PendingInLocalQueue returns the number of active and inadmissible pending workloads in LocalQueue.
 func (c *ClusterQueue) PendingInLocalQueue(lqRef utilqueue.LocalQueueReference) (int, int) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.pendingActiveInLocalQueue(lqRef), c.workloads.pendingInadmissibleInLocalQueue(lqRef)
+	return c.workloads.PendingActiveInLocalQueue(lqRef), c.workloads.PendingInadmissibleInLocalQueue(lqRef)
 }
 
 // Pop removes the head of the queue and returns it. It returns nil if the
@@ -623,11 +623,11 @@ func (c *ClusterQueue) Pop() *workload.Info {
 	defer c.rwm.Unlock()
 
 	if c.hasPendingPenalties() {
-		c.workloads.rebuildAll()
+		c.workloads.RebuildAll()
 	}
 
 	c.popCycle++
-	return c.workloads.popActive()
+	return c.workloads.PopActive()
 }
 
 func (c *ClusterQueue) hasPendingPenalties() bool {
@@ -650,13 +650,13 @@ func (c *ClusterQueue) hasPendingPenalties() bool {
 func (c *ClusterQueue) Dump() ([]workload.Reference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.dumpActive()
+	return c.workloads.DumpActive()
 }
 
 func (c *ClusterQueue) DumpInadmissible() ([]workload.Reference, bool) {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.dumpInadmissible()
+	return c.workloads.DumpInadmissible()
 }
 
 // Snapshot returns a copy of pending workloads in queue order.
@@ -754,13 +754,13 @@ func buildSnapshotSort(
 func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.getActive(key)
+	return c.workloads.GetActive(key)
 }
 
 func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.get(key)
+	return c.workloads.Get(key)
 }
 
 // totalElements returns all pending workloads (heap + inadmissible + inflight).
@@ -768,7 +768,7 @@ func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
 func (c *ClusterQueue) totalElements() []*workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	return c.workloads.dumpAll()
+	return c.workloads.DumpAll()
 }
 
 // Active returns true if the queue is active

--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -757,29 +757,10 @@ func (c *ClusterQueue) Info(key workload.Reference) *workload.Info {
 	return c.workloads.getActive(key)
 }
 
-// trackedInfo returns the workload.Info currently tracked for the key, wherever it is held:
-// the heap, inadmissibleWorkloads once the Workload has been tried and could not be admitted,
-// or inflight while the scheduler is processing it. Info covers only the heap.
-//
-// An update to the inflight Workload reaches the LocalQueue but not the heap, since
-// PushOrUpdate deliberately drops it in favour of the newer copy the scheduler requeues at
-// the end of the cycle. The inflight lookup is still worth doing, because the LocalQueue copy
-// is what AddFromLocalQueue replays if the ClusterQueue is reactivated.
-//
-// Users of this method should not modify the returned object.
 func (c *ClusterQueue) trackedInfo(key workload.Reference) *workload.Info {
 	c.rwm.RLock()
 	defer c.rwm.RUnlock()
-	if wInfo := c.heap.GetByKey(key); wInfo != nil {
-		return wInfo
-	}
-	if wInfo := c.inadmissibleWorkloads.get(key); wInfo != nil {
-		return wInfo
-	}
-	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
-		return c.inflight
-	}
-	return nil
+	return c.workloads.get(key)
 }
 
 // totalElements returns all pending workloads (heap + inadmissible + inflight).

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -811,14 +811,14 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 	}{
 		"the workload stays tracked as inadmissible": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.InsertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			wantInInadmissible: true,
 			wantCPU:            singleWorkloadCPU,
 		},
 		"requeuing all inadmissible workloads moves it to the heap": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.InsertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			afterResync: func(cq *ClusterQueue, _ *workload.Info) {
 				cq.namespaceSelector = labels.Everything()
@@ -830,7 +830,7 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 		},
 		"deleting the workload removes it and its resources": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.InsertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			afterResync: func(cq *ClusterQueue, wInfo *workload.Info) {
 				cq.Delete(log, workloadKey(wInfo))

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -188,7 +188,7 @@ func Test_PushOrUpdate(t *testing.T) {
 			if diff := cmp.Diff(tc.wantWorkload, newWl, cmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected workloads in heap (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantInAdmissibleWorkloads, cq.inadmissibleWorkloads, cmpOpts...); len(diff) != 0 {
+			if diff := cmp.Diff(tc.wantInAdmissibleWorkloads, cq.workloads.inadmissible, cmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected inadmissibleWorkloads (-want,+got):\n%s", diff)
 			}
 		})
@@ -812,14 +812,14 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 	}{
 		"the workload stays tracked as inadmissible": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			wantInInadmissible: true,
 			wantCPU:            singleWorkloadCPU,
 		},
 		"requeuing all inadmissible workloads moves it to the heap": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			afterResync: func(cq *ClusterQueue, _ *workload.Info) {
 				cq.namespaceSelector = labels.Everything()
@@ -831,7 +831,7 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 		},
 		"deleting the workload removes it and its resources": {
 			beforeResync: func(_ *testing.T, cq *ClusterQueue, wInfo *workload.Info) {
-				cq.insertInadmissible(workloadKey(wInfo), wInfo)
+				cq.workloads.insertInadmissible(workloadKey(wInfo), wInfo)
 			},
 			afterResync: func(cq *ClusterQueue, wInfo *workload.Info) {
 				cq.Delete(log, workloadKey(wInfo))
@@ -873,9 +873,9 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 				tc.afterResync(cq, wInfo)
 			}
 
-			inHeap := cq.heap.GetByKey(key) != nil
-			inInadmissible := cq.inadmissibleWorkloads.hasKey(key)
-			inInflight := cq.inflight != nil && workloadKey(cq.inflight) == key
+			inHeap := cq.workloads.active.GetByKey(key) != nil
+			inInadmissible := cq.workloads.inadmissible.hasKey(key)
+			inInflight := cq.workloads.inflight != nil && workloadKey(cq.workloads.inflight) == key
 			if inHeap != tc.wantInHeap {
 				t.Errorf("in heap = %v, want %v", inHeap, tc.wantInHeap)
 			}
@@ -885,7 +885,7 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 			if inInflight != tc.wantInInflight {
 				t.Errorf("in inflight = %v, want %v", inInflight, tc.wantInInflight)
 			}
-			if got := cq.pendingActive(); got.Total() != tc.wantPendingActive {
+			if got := cq.workloads.pendingActive(); got.Total() != tc.wantPendingActive {
 				t.Errorf("pending active workloads = %d, want %d", got.Total(), tc.wantPendingActive)
 			}
 			if gotCPU, wantCPU := cq.pendingResources()[corev1.ResourceCPU], tc.wantCPU(wInfo); gotCPU != wantCPU {
@@ -962,8 +962,8 @@ func Test_DeleteFromLocalQueue(t *testing.T) {
 	if cq.PendingTotal() != wantPending {
 		t.Errorf("clusterQueue's workload number not right, want %v, got %v", wantPending, cq.PendingTotal())
 	}
-	if cq.inadmissibleWorkloads.len() != len(inadmissibleWorkloads) {
-		t.Errorf("clusterQueue's workload number in inadmissibleWorkloads not right, want %v, got %v", len(inadmissibleWorkloads), cq.inadmissibleWorkloads.len())
+	if cq.workloads.inadmissible.len() != len(inadmissibleWorkloads) {
+		t.Errorf("clusterQueue's workload number in inadmissibleWorkloads not right, want %v, got %v", len(inadmissibleWorkloads), cq.workloads.inadmissible.len())
 	}
 
 	cq.DeleteFromLocalQueue(log, qImpl, nil, nil)
@@ -1350,7 +1350,7 @@ func TestBestEffortFIFORequeueIfNotPresent(t *testing.T) {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
-			gotInadmissible := cq.inadmissibleWorkloads.hasKey(workload.Key(wl))
+			gotInadmissible := cq.workloads.inadmissible.hasKey(workload.Key(wl))
 			if diff := cmp.Diff(tc.wantInadmissible, gotInadmissible); diff != "" {
 				t.Errorf("Unexpected inadmissible status (-want,+got):\n%s", diff)
 			}
@@ -1584,7 +1584,7 @@ func TestStrictFIFORequeueIfNotPresent(t *testing.T) {
 				t.Error("failed to requeue nonexistent workload")
 			}
 
-			gotInadmissible := cq.inadmissibleWorkloads.hasKey(workload.Key(wl))
+			gotInadmissible := cq.workloads.inadmissible.hasKey(workload.Key(wl))
 			if test.wantInadmissible != gotInadmissible {
 				t.Errorf("Got inadmissible after requeue %t, want %t", gotInadmissible, test.wantInadmissible)
 			}
@@ -2048,7 +2048,7 @@ func TestGetNoFitReason(t *testing.T) {
 			wlKey := workload.Key(wl)
 			if tc.deleteFromInadmissible {
 				cq.rwm.Lock()
-				cq.inadmissibleWorkloads.delete(wlKey)
+				cq.workloads.inadmissible.delete(wlKey)
 				cq.rwm.Unlock()
 			}
 

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -167,22 +167,22 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 	c.queueInadmissibleCycle = c.popCycle
 	// Clear bulk-move scheduling hashes so re-queued workloads are re-evaluated fresh.
 	c.hashToBulkMoveReason = make(map[workload.EquivalenceHash]QuotaReservedReason)
-	if c.inadmissibleWorkloads.empty() {
+	if c.workloads.inadmissible.empty() {
 		return 0
 	}
 	log.V(2).Info("Resetting the head of the ClusterQueue", "clusterQueue", c.name)
 	moved := 0
-	for key, wInfo := range c.inadmissibleWorkloads {
+	for key, wInfo := range c.workloads.inadmissible {
 		ns := corev1.Namespace{}
 		err := client.Get(ctx, types.NamespacedName{Name: wInfo.Obj.Namespace}, &ns)
 		if err != nil || !c.namespaceSelector.Matches(labels.Set(ns.Labels)) || !c.backoffWaitingTimeExpired(wInfo) {
 			continue
 		}
-		if c.moveInadmissibleToHeap(key, wInfo) {
+		if c.workloads.moveToActive(key, wInfo) {
 			moved++
 		}
 	}
-	log.V(5).Info("Moved workloads from inadmissibleWorkloads back to heap", "clusterQueue", c.name, "workloadsMoved", moved, "workloadsNotMoved", c.inadmissibleWorkloads.len())
+	log.V(5).Info("Moved workloads from inadmissibleWorkloads back to heap", "clusterQueue", c.name, "workloadsMoved", moved, "workloadsNotMoved", c.workloads.inadmissible.len())
 	return moved
 }
 

--- a/pkg/cache/queue/inadmissible_workloads.go
+++ b/pkg/cache/queue/inadmissible_workloads.go
@@ -167,7 +167,7 @@ func queueInadmissibleWorkloads(ctx context.Context, c *ClusterQueue, client cli
 		if err != nil || !c.namespaceSelector.Matches(labels.Set(ns.Labels)) || !c.backoffWaitingTimeExpired(wInfo) {
 			continue
 		}
-		if c.workloads.moveToActive(key, wInfo) {
+		if c.workloads.MoveToActive(key, wInfo) {
 			moved++
 		}
 	}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2535,7 +2535,7 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 				if !cqImpl.requeueIfNotPresent(log, tracked, false, RequeueReasonNoFit, "") {
 					t.Fatal("Requeueing the Workload failed")
 				}
-				if cqImpl.workloads.inadmissible.get(key) == nil {
+				if cqImpl.workloads.GetInadmissible(key) == nil {
 					t.Fatal("Workload is not held in inadmissibleWorkloads")
 				}
 			}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2535,7 +2535,7 @@ func TestAddOrUpdateWorkloadCarriesLastAssignment(t *testing.T) {
 				if !cqImpl.requeueIfNotPresent(log, tracked, false, RequeueReasonNoFit, "") {
 					t.Fatal("Requeueing the Workload failed")
 				}
-				if cqImpl.inadmissibleWorkloads.get(key) == nil {
+				if cqImpl.workloads.inadmissible.get(key) == nil {
 					t.Fatal("Workload is not held in inadmissibleWorkloads")
 				}
 			}

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -69,7 +69,7 @@ type PendingWorkloads struct {
 
 // get returns the workload.Info for the key, wherever it is held:
 // the active heap, inadmissible list once the Workload has been tried and could not be admitted,
-// or inflight while the scheduler is processing it. Info covers only the heap.
+// or inflight while the scheduler is processing it.
 //
 // An update to the inflight Workload reaches the LocalQueue but not the heap, since
 // PushOrUpdate deliberately drops it in favour of the newer copy the scheduler requeues at
@@ -81,14 +81,14 @@ func (c *PendingWorkloads) Get(key workload.Reference) *workload.Info {
 	c.RLock()
 	defer c.RUnlock()
 
+	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
+		return c.inflight
+	}
 	if wInfo := c.active.GetByKey(key); wInfo != nil {
 		return wInfo
 	}
 	if wInfo := c.inadmissible.get(key); wInfo != nil {
 		return wInfo
-	}
-	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
-		return c.inflight
 	}
 	return nil
 }

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -19,6 +19,7 @@ package queue
 import (
 	"iter"
 	"maps"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -29,7 +30,8 @@ import (
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
-type pendingWorkloads struct {
+type PendingWorkloads struct {
+	sync.RWMutex
 	customLabels *metrics.CustomLabels
 
 	// active workloads are workloads that are ready to be admitted
@@ -75,7 +77,10 @@ type pendingWorkloads struct {
 // is what AddFromLocalQueue replays if the ClusterQueue is reactivated.
 //
 // Users of this method should not modify the returned object.
-func (c *pendingWorkloads) get(key workload.Reference) *workload.Info {
+func (c *PendingWorkloads) Get(key workload.Reference) *workload.Info {
+	c.RLock()
+	defer c.RUnlock()
+
 	if wInfo := c.active.GetByKey(key); wInfo != nil {
 		return wInfo
 	}
@@ -88,7 +93,16 @@ func (c *pendingWorkloads) get(key workload.Reference) *workload.Info {
 	return nil
 }
 
-func (p *pendingWorkloads) popActive() *workload.Info {
+func (p *PendingWorkloads) GetActive(key workload.Reference) *workload.Info {
+	p.RLock()
+	defer p.RUnlock()
+	return p.active.GetByKey(key)
+}
+
+func (p *PendingWorkloads) PopActive() *workload.Info {
+	p.Lock()
+	defer p.Unlock()
+
 	if p.active.Len() == 0 {
 		p.inflight = nil
 		p.schedulingHashes.clearInflight()
@@ -104,11 +118,7 @@ func (p *pendingWorkloads) popActive() *workload.Info {
 	return p.inflight
 }
 
-func (p *pendingWorkloads) getActive(key workload.Reference) *workload.Info {
-	return p.active.GetByKey(key)
-}
-
-func (p *pendingWorkloads) activeIterator() iter.Seq[*workload.Info] {
+func (p *PendingWorkloads) activeIterator() iter.Seq[*workload.Info] {
 	return func(yield func(*workload.Info) bool) {
 		for _, w := range p.active.List() {
 			if !yield(w) {
@@ -124,7 +134,10 @@ func (p *pendingWorkloads) activeIterator() iter.Seq[*workload.Info] {
 // because the scheduler owns its placement until requeue or deletion, and an
 // active workloads heap copy would double-count its resources next to the inflight one.
 // Returns true if the workload was pushed.
-func (p *pendingWorkloads) pushActiveIfNotPresent(wInfo *workload.Info) bool {
+func (p *PendingWorkloads) PushActiveIfNotPresent(wInfo *workload.Info) bool {
+	p.Lock()
+	defer p.Unlock()
+
 	key := workloadKey(wInfo)
 	if p.inflight != nil && workloadKey(p.inflight) == key {
 		return false
@@ -144,7 +157,10 @@ func (p *pendingWorkloads) pushActiveIfNotPresent(wInfo *workload.Info) bool {
 // pushOrUpdateActive pushes wInfo onto the active workloads heap, replacing any previous copy.
 // The old copy's resources are subtracted before the new copy's are added,
 // because the requests may have changed.
-func (p *pendingWorkloads) pushOrUpdateActive(wInfo *workload.Info) {
+func (p *PendingWorkloads) PushOrUpdateActive(wInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
+
 	old := p.active.GetByKey(workload.Key(wInfo.Obj))
 	if old != nil {
 		p.subtractPendingResources(old)
@@ -158,7 +174,10 @@ func (p *pendingWorkloads) pushOrUpdateActive(wInfo *workload.Info) {
 
 // removeActive removes the workload from the active workloads heap and subtracts its pending
 // resources, if the active workloads heap holds it.
-func (p *pendingWorkloads) removeActive(key workload.Reference) {
+func (p *PendingWorkloads) RemoveActive(key workload.Reference) {
+	p.Lock()
+	defer p.Unlock()
+
 	if old := p.active.GetByKey(key); old != nil {
 		p.active.Delete(key)
 		p.subtractPendingResources(old)
@@ -167,29 +186,39 @@ func (p *pendingWorkloads) removeActive(key workload.Reference) {
 	}
 }
 
-func (p *pendingWorkloads) isInflight(key workload.Reference) bool {
+func (p *PendingWorkloads) IsInflight(key workload.Reference) bool {
+	p.RLock()
+	defer p.RUnlock()
 	return p.inflight != nil && workloadKey(p.inflight) == key
 }
 
-func (p *pendingWorkloads) getInadmissible(key workload.Reference) *workload.Info {
+func (p *PendingWorkloads) GetInadmissible(key workload.Reference) *workload.Info {
+	p.RLock()
+	defer p.RUnlock()
 	return p.inadmissible.get(key)
 }
 
-func (p *pendingWorkloads) updateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
+func (p *PendingWorkloads) UpdateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
 	p.inadmissible.insert(key, newInfo)
 	p.schedulingHashes.updateInadmissible(oldInfo, newInfo)
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, oldInfo.Obj)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, newInfo.Obj)
 }
 
-func (p *pendingWorkloads) insertInadmissible(key workload.Reference, wInfo *workload.Info) {
+func (p *PendingWorkloads) InsertInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
 	p.inadmissible.insert(key, wInfo)
 	p.addPendingResources(wInfo)
 	p.schedulingHashes.addInadmissible(wInfo)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
-func (p *pendingWorkloads) removeFromInadmissible(key workload.Reference, wInfo *workload.Info) {
+func (p *PendingWorkloads) RemoveFromInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
 	p.inadmissible.delete(key)
 	p.subtractPendingResources(wInfo)
 	p.schedulingHashes.removeInadmissible(wInfo)
@@ -197,13 +226,17 @@ func (p *pendingWorkloads) removeFromInadmissible(key workload.Reference, wInfo 
 }
 
 // rebuildAll rebuilds the active workloads heap. Must be called with lock held.
-func (p *pendingWorkloads) rebuildAll() {
+func (p *PendingWorkloads) RebuildAll() {
+	p.Lock()
+	defer p.Unlock()
 	for w := range p.activeIterator() {
 		p.active.PushOrUpdate(w)
 	}
 }
 
-func (p *pendingWorkloads) rebuildLocalQueue(lqName string) {
+func (p *PendingWorkloads) RebuildLocalQueue(lqName string) {
+	p.Lock()
+	defer p.Unlock()
 	for wl := range p.activeIterator() {
 		if string(wl.Obj.Spec.QueueName) == lqName {
 			p.active.PushOrUpdate(wl)
@@ -211,7 +244,7 @@ func (p *pendingWorkloads) rebuildLocalQueue(lqName string) {
 	}
 }
 
-func (p *pendingWorkloads) addPendingResources(wInfo *workload.Info) {
+func (p *PendingWorkloads) addPendingResources(wInfo *workload.Info) {
 	for _, ps := range wInfo.TotalRequests {
 		if ps.Requests != nil {
 			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
@@ -221,7 +254,7 @@ func (p *pendingWorkloads) addPendingResources(wInfo *workload.Info) {
 	}
 }
 
-func (p *pendingWorkloads) subtractPendingResources(wInfo *workload.Info) {
+func (p *PendingWorkloads) subtractPendingResources(wInfo *workload.Info) {
 	for _, ps := range wInfo.TotalRequests {
 		if ps.Requests != nil {
 			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
@@ -231,10 +264,13 @@ func (p *pendingWorkloads) subtractPendingResources(wInfo *workload.Info) {
 	}
 }
 
-// updateConfiguredResources seeds pendingResourcesTotal with 0 for newly configured
+// UpdateConfiguredResources seeds pendingResourcesTotal with 0 for newly configured
 // resources so they appear in metrics even when no workloads are pending, and prunes
 // zero entries for resources removed from the spec.
-func (p *pendingWorkloads) updateConfiguredResources(apiCQ *kueue.ClusterQueue) {
+func (p *PendingWorkloads) UpdateConfiguredResources(apiCQ *kueue.ClusterQueue) {
+	p.Lock()
+	defer p.Unlock()
+
 	newConfigured := sets.New[corev1.ResourceName]()
 	for _, rg := range apiCQ.Spec.ResourceGroups {
 		for _, fq := range rg.Flavors {
@@ -253,13 +289,16 @@ func (p *pendingWorkloads) updateConfiguredResources(apiCQ *kueue.ClusterQueue) 
 	}
 }
 
-// moveToActive moves a workload from the inadmissible workloads list onto the active workloads heap.
+// MoveToActive moves a workload from the inadmissible workloads list onto the active workloads heap.
 // The workload stays pending throughout, so
 // pendingResourcesTotal is unchanged. The workload is pushed before the
 // inadmissible entry is deleted, so a failed push (the active workloads heap unexpectedly
 // already holding a copy) keeps the workload tracked as inadmissible instead
 // of dropping it. Returns true if the workload was moved.
-func (p *pendingWorkloads) moveToActive(key workload.Reference, wInfo *workload.Info) bool {
+func (p *PendingWorkloads) MoveToActive(key workload.Reference, wInfo *workload.Info) bool {
+	p.Lock()
+	defer p.Unlock()
+
 	if !p.active.PushIfNotPresent(wInfo) {
 		return false
 	}
@@ -272,10 +311,13 @@ func (p *pendingWorkloads) moveToActive(key workload.Reference, wInfo *workload.
 	return true
 }
 
-// moveToInadmissible moves a workload from the active workloads heap into
+// MoveToInadmissible moves a workload from the active workloads heap into
 // the inadmissible workloads list. The workload stays pending throughout, so
 // pendingResourcesTotal is unchanged.
-func (p *pendingWorkloads) moveToInadmissible(key workload.Reference, wInfo *workload.Info) {
+func (p *PendingWorkloads) MoveToInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
+
 	p.active.Delete(key)
 	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
 
@@ -285,16 +327,22 @@ func (p *pendingWorkloads) moveToInadmissible(key workload.Reference, wInfo *wor
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
-func (p *pendingWorkloads) forgetInflightByKey(key workload.Reference) {
+func (p *PendingWorkloads) ForgetInflightByKey(key workload.Reference) {
+	p.Lock()
+	defer p.Unlock()
+
 	if p.inflight != nil && workload.Key(p.inflight.Obj) == key {
 		p.inflight = nil
 		p.schedulingHashes.clearInflight()
 	}
 }
 
-// pendingResources returns the total resources requested by all pending workloads,
+// PendingResources returns the total resources requested by all pending workloads,
 // aggregated by resource name. Pending workloads have not yet been assigned to flavors.
-func (p *pendingWorkloads) pendingResources() map[corev1.ResourceName]int64 {
+func (p *PendingWorkloads) PendingResources() map[corev1.ResourceName]int64 {
+	p.RLock()
+	defer p.RUnlock()
+
 	result := maps.Clone(p.pendingResourcesTotal)
 	if p.inflight != nil {
 		for _, ps := range p.inflight.TotalRequests {
@@ -308,9 +356,16 @@ func (p *pendingWorkloads) pendingResources() map[corev1.ResourceName]int64 {
 	return result
 }
 
+// PendingBreakdown returns the number of active and inadmissible pending workloads.
+func (p *PendingWorkloads) PendingBreakdown() (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
+	p.RLock()
+	defer p.RUnlock()
+	return p.pendingActive(), p.pendingInadmissible()
+}
+
 // pendingActive returns the number of active pending workloads,
 // workloads that are in the admission queue.
-func (p *pendingWorkloads) pendingActive() *metrics.LabelValsTracker {
+func (p *PendingWorkloads) pendingActive() *metrics.LabelValsTracker {
 	result := metrics.Copy(p.activeTracker)
 	if p.inflight != nil {
 		metrics.TrackWorkload(p.customLabels, result, p.inflight.Obj)
@@ -321,18 +376,15 @@ func (p *pendingWorkloads) pendingActive() *metrics.LabelValsTracker {
 // pendingInadmissible returns the number of inadmissible pending workloads,
 // workloads that were already tried and are waiting for cluster conditions
 // to change to potentially become admissible.
-func (p *pendingWorkloads) pendingInadmissible() *metrics.LabelValsTracker {
+func (p *PendingWorkloads) pendingInadmissible() *metrics.LabelValsTracker {
 	return metrics.Copy(p.inadmissibleTracker)
 }
 
-// pendingBreakdown returns the number of active and inadmissible pending workloads.
-func (p *pendingWorkloads) pendingBreakdown() (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
-	return p.pendingActive(), p.pendingInadmissible()
-}
-
-// pendingActiveInLocalQueue returns the number of active pending workloads in LocalQueue,
+// PendingActiveInLocalQueue returns the number of active pending workloads in LocalQueue,
 // workloads that are in the admission queue.
-func (p *pendingWorkloads) pendingActiveInLocalQueue(lqRef utilqueue.LocalQueueReference) (active int) {
+func (p *PendingWorkloads) PendingActiveInLocalQueue(lqRef utilqueue.LocalQueueReference) (active int) {
+	p.RLock()
+	defer p.RUnlock()
 	for _, wl := range p.active.List() {
 		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
 		if wlLqKey == lqRef {
@@ -345,10 +397,12 @@ func (p *pendingWorkloads) pendingActiveInLocalQueue(lqRef utilqueue.LocalQueueR
 	return
 }
 
-// pendingInadmissibleInLocalQueue returns the number of inadmissible pending workloads in LocalQueue,
+// PendingInadmissibleInLocalQueue returns the number of inadmissible pending workloads in LocalQueue,
 // workloads that were already tried and are waiting for cluster conditions
 // to change to potentially become admissible.
-func (p *pendingWorkloads) pendingInadmissibleInLocalQueue(lqRef utilqueue.LocalQueueReference) (inadmissible int) {
+func (p *PendingWorkloads) PendingInadmissibleInLocalQueue(lqRef utilqueue.LocalQueueReference) (inadmissible int) {
+	p.RLock()
+	defer p.RUnlock()
 	for _, wl := range p.inadmissible {
 		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
 		if wlLqKey == lqRef {
@@ -358,10 +412,13 @@ func (p *pendingWorkloads) pendingInadmissibleInLocalQueue(lqRef utilqueue.Local
 	return
 }
 
-// dumpActive produces a dump of the current active workloads of
+// DumpActive produces a dump of the current active workloads of
 // this ClusterQueue. It returns false if the queue is empty,
 // otherwise returns true.
-func (p *pendingWorkloads) dumpActive() ([]workload.Reference, bool) {
+func (p *PendingWorkloads) DumpActive() ([]workload.Reference, bool) {
+	p.RLock()
+	defer p.RUnlock()
+
 	if p.active.Len() == 0 {
 		return nil, false
 	}
@@ -372,7 +429,10 @@ func (p *pendingWorkloads) dumpActive() ([]workload.Reference, bool) {
 	return elements, true
 }
 
-func (p *pendingWorkloads) dumpInadmissible() ([]workload.Reference, bool) {
+func (p *PendingWorkloads) DumpInadmissible() ([]workload.Reference, bool) {
+	p.RLock()
+	defer p.RUnlock()
+
 	if p.inadmissible.empty() {
 		return nil, false
 	}
@@ -383,9 +443,12 @@ func (p *pendingWorkloads) dumpInadmissible() ([]workload.Reference, bool) {
 	return elements, true
 }
 
-// dumpAll returns all pending workloads (active heap + inadmissible list + inflight).
+// DumpAll returns all pending workloads (active heap + inadmissible list + inflight).
 // The returned order is non-deterministic; callers should sort if needed.
-func (p *pendingWorkloads) dumpAll() []*workload.Info {
+func (p *PendingWorkloads) DumpAll() []*workload.Info {
+	p.RLock()
+	defer p.RUnlock()
+
 	totalLen := p.active.Len() + p.inadmissible.len()
 	elements := make([]*workload.Info, 0, totalLen)
 	elements = append(elements, p.active.List()...)

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -187,10 +187,10 @@ func (p *PendingWorkloads) RemoveActive(key workload.Reference) {
 	}
 }
 
-func (p *PendingWorkloads) IsInflight(key workload.Reference) bool {
+func (p *PendingWorkloads) HasInflight(ref workload.Reference) bool {
 	p.RLock()
 	defer p.RUnlock()
-	return p.inflight != nil && workloadKey(p.inflight) == key
+	return p.inflight != nil && workloadKey(p.inflight) == ref
 }
 
 func (p *PendingWorkloads) GetInadmissible(key workload.Reference) *workload.Info {
@@ -226,23 +226,11 @@ func (p *PendingWorkloads) RemoveFromInadmissible(key workload.Reference, wInfo 
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
-// rebuildAll rebuilds the active workloads heap. Must be called with lock held.
-func (p *PendingWorkloads) RebuildAll() {
+// rebuildActiveHeap rebuilds the active workloads heap.
+func (p *PendingWorkloads) RebuildActiveHeap() {
 	p.Lock()
 	defer p.Unlock()
-	for w := range p.activeIterator() {
-		p.active.PushOrUpdate(w)
-	}
-}
-
-func (p *PendingWorkloads) RebuildLocalQueue(lqName string) {
-	p.Lock()
-	defer p.Unlock()
-	for wl := range p.activeIterator() {
-		if string(wl.Obj.Spec.QueueName) == lqName {
-			p.active.PushOrUpdate(wl)
-		}
-	}
+	p.active.Init()
 }
 
 func (p *PendingWorkloads) addPendingResources(wInfo *workload.Info) {

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -68,7 +68,7 @@ type PendingWorkloads struct {
 	pendingResourcesTotal map[corev1.ResourceName]int64
 }
 
-// get returns the workload.Info for the key, wherever it is held:
+// Get returns the workload.Info for the key, wherever it is held:
 // the active heap, inadmissible list once the Workload has been tried and could not be admitted,
 // or inflight while the scheduler is processing it.
 //
@@ -94,12 +94,14 @@ func (c *PendingWorkloads) Get(key workload.Reference) *workload.Info {
 	return nil
 }
 
+// GetActive returns the workload.Info for the key from the active workloads heap.
 func (p *PendingWorkloads) GetActive(key workload.Reference) *workload.Info {
 	p.RLock()
 	defer p.RUnlock()
 	return p.active.GetByKey(key)
 }
 
+// PopActive pops the first workload on the active workloads heap.
 func (p *PendingWorkloads) PopActive() *workload.Info {
 	p.Lock()
 	defer p.Unlock()
@@ -187,10 +189,22 @@ func (p *PendingWorkloads) RemoveActive(key workload.Reference) {
 	}
 }
 
+// HasInflight checks if the provided reference mathces the current inflight workload (if any exists).
 func (p *PendingWorkloads) HasInflight(ref workload.Reference) bool {
 	p.RLock()
 	defer p.RUnlock()
 	return p.inflight != nil && workloadKey(p.inflight) == ref
+}
+
+// ForgetInflightByKey forgets the current inflight workload if it matches the provided reference.
+func (p *PendingWorkloads) ForgetInflightByKey(ref workload.Reference) {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.inflight != nil && workloadKey(p.inflight) == ref {
+		p.inflight = nil
+		p.schedulingHashes.clearInflight()
+	}
 }
 
 func (p *PendingWorkloads) GetInadmissible(key workload.Reference) *workload.Info {
@@ -226,7 +240,7 @@ func (p *PendingWorkloads) RemoveFromInadmissible(key workload.Reference, wInfo 
 	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
 }
 
-// rebuildActiveHeap rebuilds the active workloads heap.
+// RebuildActiveHeap re-establishes the active workloads heap invariant across all entries.
 func (p *PendingWorkloads) RebuildActiveHeap() {
 	p.Lock()
 	defer p.Unlock()
@@ -314,16 +328,6 @@ func (p *PendingWorkloads) MoveToInadmissible(key workload.Reference, wInfo *wor
 
 	p.inadmissible.insert(key, wInfo)
 	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
-}
-
-func (p *PendingWorkloads) ForgetInflightByKey(key workload.Reference) {
-	p.Lock()
-	defer p.Unlock()
-
-	if p.inflight != nil && workload.Key(p.inflight.Obj) == key {
-		p.inflight = nil
-		p.schedulingHashes.clearInflight()
-	}
 }
 
 // PendingResources returns the total resources requested by all pending workloads,

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/util/heap"

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -65,6 +65,29 @@ type pendingWorkloads struct {
 	pendingResourcesTotal map[corev1.ResourceName]int64
 }
 
+// get returns the workload.Info for the key, wherever it is held:
+// the active heap, inadmissible list once the Workload has been tried and could not be admitted,
+// or inflight while the scheduler is processing it. Info covers only the heap.
+//
+// An update to the inflight Workload reaches the LocalQueue but not the heap, since
+// PushOrUpdate deliberately drops it in favour of the newer copy the scheduler requeues at
+// the end of the cycle. The inflight lookup is still worth doing, because the LocalQueue copy
+// is what AddFromLocalQueue replays if the ClusterQueue is reactivated.
+//
+// Users of this method should not modify the returned object.
+func (c *pendingWorkloads) get(key workload.Reference) *workload.Info {
+	if wInfo := c.active.GetByKey(key); wInfo != nil {
+		return wInfo
+	}
+	if wInfo := c.inadmissible.get(key); wInfo != nil {
+		return wInfo
+	}
+	if c.inflight != nil && workload.Key(c.inflight.Obj) == key {
+		return c.inflight
+	}
+	return nil
+}
+
 func (p *pendingWorkloads) popActive() *workload.Info {
 	if p.active.Len() == 0 {
 		p.inflight = nil

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -1,0 +1,376 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"iter"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/util/heap"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+type pendingWorkloads struct {
+	customLabels *metrics.CustomLabels
+
+	// active workloads are workloads that are ready to be admitted
+	active        heap.Heap[workload.Info, workload.Reference]
+	activeTracker *metrics.LabelValsTracker
+
+	// inadmissible are workloads that have been tried at least once and couldn't be admitted.
+	//
+	// Invariant: a pending workload is tracked in exactly one of active workloads heap,
+	// inadmissible workloads list, or inflight at any time, and contributes to
+	// pendingResourcesTotal exactly once while in active workloads heap or inadmissible workloads list.
+	// All transitions between these places must go through the helpers next to
+	// addPendingResources (pushActiveIfNotPresent, pushOrUpdateActive,
+	// removeActive, insertInadmissible, removeInadmissible,
+	// moveToActive, moveToInadmissible) so the accounting
+	// cannot drift.
+	inadmissible        inadmissibleWorkloads
+	inadmissibleTracker *metrics.LabelValsTracker
+
+	// inflight is non-nil when a workload has been popped by the scheduler but
+	// not yet requeued or deleted.
+	inflight *workload.Info
+
+	// schedulingHashes tracks the scheduling equivalence hashes of pending
+	// workloads for the pending_scheduling_hashes metric.
+	schedulingHashes *schedulingHashCounts
+
+	// pendingResourcesTotal is the incremental sum of TotalRequests across workloads
+	// in active workloads heap and inadmissible workloads list (not inflight). Updated at each mutation site so
+	// pendingResources() is O(1) rather than O(N).
+	// Configured resources are seeded at 0 by Update() so they appear in metrics
+	// even when no workloads are pending; stale zero entries are pruned on Update().
+	pendingResourcesTotal map[corev1.ResourceName]int64
+}
+
+func (p *pendingWorkloads) popActive() *workload.Info {
+	if p.active.Len() == 0 {
+		p.inflight = nil
+		p.schedulingHashes.clearInflight()
+		return nil
+	}
+
+	wl := p.active.Pop()
+	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wl.Obj)
+	p.schedulingHashes.moveActiveToInflight(wl)
+	p.subtractPendingResources(wl)
+	p.inflight = wl
+	p.inflight.LastEvaluatedGeneration = p.inflight.Obj.Generation
+	return p.inflight
+}
+
+func (p *pendingWorkloads) getActive(key workload.Reference) *workload.Info {
+	return p.active.GetByKey(key)
+}
+
+func (p *pendingWorkloads) activeIterator() iter.Seq[*workload.Info] {
+	return func(yield func(*workload.Info) bool) {
+		for _, w := range p.active.List() {
+			if !yield(w) {
+				return
+			}
+		}
+	}
+}
+
+// pushActiveIfNotPresent pushes wInfo onto the active workloads heap and accounts for its
+// pending resources, unless the workload is already tracked in the active workloads heap, in
+// the inadmissible workloads list, or as inflight. The inflight workload is skipped
+// because the scheduler owns its placement until requeue or deletion, and an
+// active workloads heap copy would double-count its resources next to the inflight one.
+// Returns true if the workload was pushed.
+func (p *pendingWorkloads) pushActiveIfNotPresent(wInfo *workload.Info) bool {
+	key := workloadKey(wInfo)
+	if p.inflight != nil && workloadKey(p.inflight) == key {
+		return false
+	}
+	if p.inadmissible.hasKey(key) {
+		return false
+	}
+	if !p.active.PushIfNotPresent(wInfo) {
+		return false
+	}
+	p.addPendingResources(wInfo)
+	p.schedulingHashes.addActive(wInfo)
+	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
+	return true
+}
+
+// pushOrUpdateActive pushes wInfo onto the active workloads heap, replacing any previous copy.
+// The old copy's resources are subtracted before the new copy's are added,
+// because the requests may have changed.
+func (p *pendingWorkloads) pushOrUpdateActive(wInfo *workload.Info) {
+	old := p.active.GetByKey(workload.Key(wInfo.Obj))
+	if old != nil {
+		p.subtractPendingResources(old)
+		metrics.UntrackWorkload(p.customLabels, p.activeTracker, old.Obj)
+	}
+	p.active.PushOrUpdate(wInfo)
+	p.addPendingResources(wInfo)
+	p.schedulingHashes.updateActive(old, wInfo)
+	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
+}
+
+// removeActive removes the workload from the active workloads heap and subtracts its pending
+// resources, if the active workloads heap holds it.
+func (p *pendingWorkloads) removeActive(key workload.Reference) {
+	if old := p.active.GetByKey(key); old != nil {
+		p.active.Delete(key)
+		p.subtractPendingResources(old)
+		p.schedulingHashes.removeActive(old)
+		metrics.UntrackWorkload(p.customLabels, p.activeTracker, old.Obj)
+	}
+}
+
+func (p *pendingWorkloads) isInflight(key workload.Reference) bool {
+	return p.inflight != nil && workloadKey(p.inflight) == key
+}
+
+func (p *pendingWorkloads) getInadmissible(key workload.Reference) *workload.Info {
+	return p.inadmissible.get(key)
+}
+
+func (p *pendingWorkloads) updateInadmissible(key workload.Reference, oldInfo, newInfo *workload.Info) {
+	p.inadmissible.insert(key, newInfo)
+	p.schedulingHashes.updateInadmissible(oldInfo, newInfo)
+	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, oldInfo.Obj)
+	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, newInfo.Obj)
+}
+
+func (p *pendingWorkloads) insertInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.inadmissible.insert(key, wInfo)
+	p.addPendingResources(wInfo)
+	p.schedulingHashes.addInadmissible(wInfo)
+	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
+}
+
+func (p *pendingWorkloads) removeFromInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.inadmissible.delete(key)
+	p.subtractPendingResources(wInfo)
+	p.schedulingHashes.removeInadmissible(wInfo)
+	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
+}
+
+// rebuildAll rebuilds the active workloads heap. Must be called with lock held.
+func (p *pendingWorkloads) rebuildAll() {
+	for w := range p.activeIterator() {
+		p.active.PushOrUpdate(w)
+	}
+}
+
+func (p *pendingWorkloads) rebuildLocalQueue(lqName string) {
+	for wl := range p.activeIterator() {
+		if string(wl.Obj.Spec.QueueName) == lqName {
+			p.active.PushOrUpdate(wl)
+		}
+	}
+}
+
+func (p *pendingWorkloads) addPendingResources(wInfo *workload.Info) {
+	for _, ps := range wInfo.TotalRequests {
+		if ps.Requests != nil {
+			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+				p.pendingResourcesTotal[name] += q
+			})
+		}
+	}
+}
+
+func (p *pendingWorkloads) subtractPendingResources(wInfo *workload.Info) {
+	for _, ps := range wInfo.TotalRequests {
+		if ps.Requests != nil {
+			ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+				p.pendingResourcesTotal[name] -= q
+			})
+		}
+	}
+}
+
+// updateConfiguredResources seeds pendingResourcesTotal with 0 for newly configured
+// resources so they appear in metrics even when no workloads are pending, and prunes
+// zero entries for resources removed from the spec.
+func (p *pendingWorkloads) updateConfiguredResources(apiCQ *kueue.ClusterQueue) {
+	newConfigured := sets.New[corev1.ResourceName]()
+	for _, rg := range apiCQ.Spec.ResourceGroups {
+		for _, fq := range rg.Flavors {
+			for _, r := range fq.Resources {
+				newConfigured.Insert(r.Name)
+				if _, exists := p.pendingResourcesTotal[r.Name]; !exists {
+					p.pendingResourcesTotal[r.Name] = 0
+				}
+			}
+		}
+	}
+	for r, v := range p.pendingResourcesTotal {
+		if v == 0 && !newConfigured.Has(r) {
+			delete(p.pendingResourcesTotal, r)
+		}
+	}
+}
+
+// moveToActive moves a workload from the inadmissible workloads list onto the active workloads heap.
+// The workload stays pending throughout, so
+// pendingResourcesTotal is unchanged. The workload is pushed before the
+// inadmissible entry is deleted, so a failed push (the active workloads heap unexpectedly
+// already holding a copy) keeps the workload tracked as inadmissible instead
+// of dropping it. Returns true if the workload was moved.
+func (p *pendingWorkloads) moveToActive(key workload.Reference, wInfo *workload.Info) bool {
+	if !p.active.PushIfNotPresent(wInfo) {
+		return false
+	}
+	metrics.TrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
+
+	p.schedulingHashes.moveToActive(wInfo)
+
+	p.inadmissible.delete(key)
+	metrics.UntrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
+	return true
+}
+
+// moveToInadmissible moves a workload from the active workloads heap into
+// the inadmissible workloads list. The workload stays pending throughout, so
+// pendingResourcesTotal is unchanged.
+func (p *pendingWorkloads) moveToInadmissible(key workload.Reference, wInfo *workload.Info) {
+	p.active.Delete(key)
+	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wInfo.Obj)
+
+	p.schedulingHashes.moveToInadmissible(wInfo)
+
+	p.inadmissible.insert(key, wInfo)
+	metrics.TrackWorkload(p.customLabels, p.inadmissibleTracker, wInfo.Obj)
+}
+
+func (p *pendingWorkloads) forgetInflightByKey(key workload.Reference) {
+	if p.inflight != nil && workload.Key(p.inflight.Obj) == key {
+		p.inflight = nil
+		p.schedulingHashes.clearInflight()
+	}
+}
+
+// pendingResources returns the total resources requested by all pending workloads,
+// aggregated by resource name. Pending workloads have not yet been assigned to flavors.
+func (p *pendingWorkloads) pendingResources() map[corev1.ResourceName]int64 {
+	result := maps.Clone(p.pendingResourcesTotal)
+	if p.inflight != nil {
+		for _, ps := range p.inflight.TotalRequests {
+			if ps.Requests != nil {
+				ps.Requests.ForEach(func(name corev1.ResourceName, q int64) {
+					result[name] += q
+				})
+			}
+		}
+	}
+	return result
+}
+
+// pendingActive returns the number of active pending workloads,
+// workloads that are in the admission queue.
+func (p *pendingWorkloads) pendingActive() *metrics.LabelValsTracker {
+	result := metrics.Copy(p.activeTracker)
+	if p.inflight != nil {
+		metrics.TrackWorkload(p.customLabels, result, p.inflight.Obj)
+	}
+	return result
+}
+
+// pendingInadmissible returns the number of inadmissible pending workloads,
+// workloads that were already tried and are waiting for cluster conditions
+// to change to potentially become admissible.
+func (p *pendingWorkloads) pendingInadmissible() *metrics.LabelValsTracker {
+	return metrics.Copy(p.inadmissibleTracker)
+}
+
+// pendingBreakdown returns the number of active and inadmissible pending workloads.
+func (p *pendingWorkloads) pendingBreakdown() (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
+	return p.pendingActive(), p.pendingInadmissible()
+}
+
+// pendingActiveInLocalQueue returns the number of active pending workloads in LocalQueue,
+// workloads that are in the admission queue.
+func (p *pendingWorkloads) pendingActiveInLocalQueue(lqRef utilqueue.LocalQueueReference) (active int) {
+	for _, wl := range p.active.List() {
+		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
+		if wlLqKey == lqRef {
+			active++
+		}
+	}
+	if p.inflight != nil && utilqueue.KeyFromWorkload(p.inflight.Obj) == lqRef {
+		active++
+	}
+	return
+}
+
+// pendingInadmissibleInLocalQueue returns the number of inadmissible pending workloads in LocalQueue,
+// workloads that were already tried and are waiting for cluster conditions
+// to change to potentially become admissible.
+func (p *pendingWorkloads) pendingInadmissibleInLocalQueue(lqRef utilqueue.LocalQueueReference) (inadmissible int) {
+	for _, wl := range p.inadmissible {
+		wlLqKey := utilqueue.KeyFromWorkload(wl.Obj)
+		if wlLqKey == lqRef {
+			inadmissible++
+		}
+	}
+	return
+}
+
+// dumpActive produces a dump of the current active workloads of
+// this ClusterQueue. It returns false if the queue is empty,
+// otherwise returns true.
+func (p *pendingWorkloads) dumpActive() ([]workload.Reference, bool) {
+	if p.active.Len() == 0 {
+		return nil, false
+	}
+	elements := make([]workload.Reference, p.active.Len())
+	for i, info := range p.active.List() {
+		elements[i] = workload.Key(info.Obj)
+	}
+	return elements, true
+}
+
+func (p *pendingWorkloads) dumpInadmissible() ([]workload.Reference, bool) {
+	if p.inadmissible.empty() {
+		return nil, false
+	}
+	elements := make([]workload.Reference, 0, p.inadmissible.len())
+	for _, info := range p.inadmissible {
+		elements = append(elements, workload.Key(info.Obj))
+	}
+	return elements, true
+}
+
+// dumpAll returns all pending workloads (active heap + inadmissible list + inflight).
+// The returned order is non-deterministic; callers should sort if needed.
+func (p *pendingWorkloads) dumpAll() []*workload.Info {
+	totalLen := p.active.Len() + p.inadmissible.len()
+	elements := make([]*workload.Info, 0, totalLen)
+	elements = append(elements, p.active.List()...)
+	for _, e := range p.inadmissible {
+		elements = append(elements, e)
+	}
+	if p.inflight != nil {
+		elements = append(elements, p.inflight)
+	}
+	return elements
+}

--- a/pkg/cache/queue/scheduling_hash_counts.go
+++ b/pkg/cache/queue/scheduling_hash_counts.go
@@ -194,12 +194,12 @@ func (s *schedulingHashCounts) pendingUnionLen() int {
 // ClusterQueue-wide lock. When SchedulingEquivalenceHashing is disabled the
 // counts are naturally empty, because hashes are never recorded.
 func (c *ClusterQueue) PendingSchedulingHashes() (int, int) {
-	return c.schedulingHashes.pendingLens()
+	return c.workloads.schedulingHashes.pendingLens()
 }
 
 // pendingSchedulingHashesForInactiveClusterQueue reports all pending hashes
 // as inadmissible, mirroring how inactive ClusterQueues report their pending
 // workloads.
 func (c *ClusterQueue) pendingSchedulingHashesForInactiveClusterQueue() (int, int) {
-	return 0, c.schedulingHashes.pendingUnionLen()
+	return 0, c.workloads.schedulingHashes.pendingUnionLen()
 }

--- a/pkg/cache/queue/scheduling_hash_counts_test.go
+++ b/pkg/cache/queue/scheduling_hash_counts_test.go
@@ -175,11 +175,11 @@ func TestPendingSchedulingHashes(t *testing.T) {
 	}
 
 	inadmissibleDuplicate := makeSchedulingHashInfo(now, "inadmissible-b", "hash-b", "1")
-	cq.insertInadmissible(workloadKey(inadmissibleDuplicate), inadmissibleDuplicate)
+	cq.workloads.insertInadmissible(workloadKey(inadmissibleDuplicate), inadmissibleDuplicate)
 	inadmissibleC := makeSchedulingHashInfo(now, "inadmissible-c", "hash-c", "1")
-	cq.insertInadmissible(workloadKey(inadmissibleC), inadmissibleC)
+	cq.workloads.insertInadmissible(workloadKey(inadmissibleC), inadmissibleC)
 	inadmissibleUnknown := makeSchedulingHashInfo(now, "inadmissible-unknown", workload.SchedulingHashUnknown, "1")
-	cq.insertInadmissible(workloadKey(inadmissibleUnknown), inadmissibleUnknown)
+	cq.workloads.insertInadmissible(workloadKey(inadmissibleUnknown), inadmissibleUnknown)
 
 	active, inadmissible := cq.PendingSchedulingHashes()
 	if active != 2 || inadmissible != 2 {
@@ -236,7 +236,7 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 		"updates inadmissible hash counts when workload hash changes in place": {
 			mutate: func(t *testing.T, cq *ClusterQueue) {
 				oldInfo := makeSchedulingHashInfo(now, "inadmissible", "old-hash", "1")
-				cq.insertInadmissible(workloadKey(oldInfo), oldInfo)
+				cq.workloads.insertInadmissible(workloadKey(oldInfo), oldInfo)
 				cq.PushOrUpdate(makeSchedulingHashInfo(now, "inadmissible", "new-hash", "1"))
 			},
 			wantInadmissibleCounts: map[workload.EquivalenceHash]int{"new-hash": 1},
@@ -249,7 +249,7 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 				cq.PushOrUpdate(makeSchedulingHashInfo(now, "active-b", "shared-hash", "1"))
 				cq.PushOrUpdate(makeSchedulingHashInfo(now, "active-c", "other-hash", "1"))
 				cq.Delete(log, "default/active-a")
-				if got := cq.schedulingHashes.active["shared-hash"]; got != 1 {
+				if got := cq.workloads.schedulingHashes.active["shared-hash"]; got != 1 {
 					t.Fatalf("shared-hash count after first delete = %d, want 1", got)
 				}
 				cq.Delete(log, "default/active-b")
@@ -281,7 +281,7 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 					t.Fatal("expected one workload to be inflight")
 				}
 				inadmissibleWl := makeSchedulingHashInfo(now, "inadmissible", "shared-hash", "1")
-				cq.insertInadmissible(workloadKey(inadmissibleWl), inadmissibleWl)
+				cq.workloads.insertInadmissible(workloadKey(inadmissibleWl), inadmissibleWl)
 			},
 			wantInadmissibleCounts: map[workload.EquivalenceHash]int{"shared-hash": 1},
 			wantActive:             1,
@@ -305,10 +305,10 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, nil, defaultOrdering, testingclock.NewFakeClock(now))
 			tc.mutate(t, cq)
 
-			if diff := cmp.Diff(tc.wantActiveCounts, cq.schedulingHashes.active, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantActiveCounts, cq.workloads.schedulingHashes.active, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("active hash counts (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantInadmissibleCounts, cq.schedulingHashes.inadmissible, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantInadmissibleCounts, cq.workloads.schedulingHashes.inadmissible, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("inadmissible hash counts (-want,+got):\n%s", diff)
 			}
 			active, inadmissible := cq.PendingSchedulingHashes()
@@ -337,9 +337,9 @@ func TestReportCQPendingSchedulingHashesInactiveClusterQueue(t *testing.T) {
 	}
 	cq.PushOrUpdate(makeSchedulingHashInfo(now, "active-only", "active-hash", "1"))
 	inadmissibleShared := makeSchedulingHashInfo(now, "inadmissible-shared", "shared-hash", "1")
-	cq.insertInadmissible(workloadKey(inadmissibleShared), inadmissibleShared)
+	cq.workloads.insertInadmissible(workloadKey(inadmissibleShared), inadmissibleShared)
 	inadmissibleOnly := makeSchedulingHashInfo(now, "inadmissible-only", "inadmissible-hash", "1")
-	cq.insertInadmissible(workloadKey(inadmissibleOnly), inadmissibleOnly)
+	cq.workloads.insertInadmissible(workloadKey(inadmissibleOnly), inadmissibleOnly)
 
 	m := NewManagerForUnitTests(nil, &fakeStatusChecker{}, WithCustomLabels(kueuemetrics.NewCustomLabels(nil)))
 	kueuemetrics.ClearClusterQueueMetrics(cq.name)
@@ -410,14 +410,14 @@ func TestSchedulingHashCountsInadmissibleTransitions(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, nil, defaultOrdering, testingclock.NewFakeClock(now))
 			storedInfo := makeSchedulingHashInfo(now, "workload", "stored-hash", "1")
 			resyncInfo := makeSchedulingHashInfo(now, "workload", "resync-hash", "2")
-			cq.insertInadmissible(workloadKey(storedInfo), storedInfo)
+			cq.workloads.insertInadmissible(workloadKey(storedInfo), storedInfo)
 			lq := &LocalQueue{items: map[workload.Reference]*workload.Info{
 				workloadKey(resyncInfo): resyncInfo,
 			}}
 			if added := cq.AddFromLocalQueue(lq, nil, kueuemetrics.NewCustomLabels(nil)); added {
 				t.Fatal("AddFromLocalQueue() = true, want false for a workload already tracked as inadmissible")
 			}
-			if diff := cmp.Diff(map[workload.EquivalenceHash]int{"stored-hash": 1}, cq.schedulingHashes.inadmissible); diff != "" {
+			if diff := cmp.Diff(map[workload.EquivalenceHash]int{"stored-hash": 1}, cq.workloads.schedulingHashes.inadmissible); diff != "" {
 				t.Fatalf("inadmissible hash counts after resync (-want,+got):\n%s", diff)
 			}
 
@@ -427,10 +427,10 @@ func TestSchedulingHashCountsInadmissibleTransitions(t *testing.T) {
 			if active != tc.wantActive || inadmissible != tc.wantInadmissible {
 				t.Errorf("Pending() active=%d inadmissible=%d, want active=%d inadmissible=%d", active, inadmissible, tc.wantActive, tc.wantInadmissible)
 			}
-			if diff := cmp.Diff(tc.wantActiveCounts, cq.schedulingHashes.active, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantActiveCounts, cq.workloads.schedulingHashes.active, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("active hash counts (-want,+got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantInadmissibleCounts, cq.schedulingHashes.inadmissible, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantInadmissibleCounts, cq.workloads.schedulingHashes.inadmissible, cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("inadmissible hash counts (-want,+got):\n%s", diff)
 			}
 			active, inadmissible = cq.PendingSchedulingHashes()

--- a/pkg/cache/queue/scheduling_hash_counts_test.go
+++ b/pkg/cache/queue/scheduling_hash_counts_test.go
@@ -175,11 +175,11 @@ func TestPendingSchedulingHashes(t *testing.T) {
 	}
 
 	inadmissibleDuplicate := makeSchedulingHashInfo(now, "inadmissible-b", "hash-b", "1")
-	cq.workloads.insertInadmissible(workloadKey(inadmissibleDuplicate), inadmissibleDuplicate)
+	cq.workloads.InsertInadmissible(workloadKey(inadmissibleDuplicate), inadmissibleDuplicate)
 	inadmissibleC := makeSchedulingHashInfo(now, "inadmissible-c", "hash-c", "1")
-	cq.workloads.insertInadmissible(workloadKey(inadmissibleC), inadmissibleC)
+	cq.workloads.InsertInadmissible(workloadKey(inadmissibleC), inadmissibleC)
 	inadmissibleUnknown := makeSchedulingHashInfo(now, "inadmissible-unknown", workload.SchedulingHashUnknown, "1")
-	cq.workloads.insertInadmissible(workloadKey(inadmissibleUnknown), inadmissibleUnknown)
+	cq.workloads.InsertInadmissible(workloadKey(inadmissibleUnknown), inadmissibleUnknown)
 
 	active, inadmissible := cq.PendingSchedulingHashes()
 	if active != 2 || inadmissible != 2 {
@@ -236,7 +236,7 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 		"updates inadmissible hash counts when workload hash changes in place": {
 			mutate: func(t *testing.T, cq *ClusterQueue) {
 				oldInfo := makeSchedulingHashInfo(now, "inadmissible", "old-hash", "1")
-				cq.workloads.insertInadmissible(workloadKey(oldInfo), oldInfo)
+				cq.workloads.InsertInadmissible(workloadKey(oldInfo), oldInfo)
 				cq.PushOrUpdate(makeSchedulingHashInfo(now, "inadmissible", "new-hash", "1"))
 			},
 			wantInadmissibleCounts: map[workload.EquivalenceHash]int{"new-hash": 1},
@@ -281,7 +281,7 @@ func TestPendingSchedulingHashesTracksMutations(t *testing.T) {
 					t.Fatal("expected one workload to be inflight")
 				}
 				inadmissibleWl := makeSchedulingHashInfo(now, "inadmissible", "shared-hash", "1")
-				cq.workloads.insertInadmissible(workloadKey(inadmissibleWl), inadmissibleWl)
+				cq.workloads.InsertInadmissible(workloadKey(inadmissibleWl), inadmissibleWl)
 			},
 			wantInadmissibleCounts: map[workload.EquivalenceHash]int{"shared-hash": 1},
 			wantActive:             1,
@@ -337,9 +337,9 @@ func TestReportCQPendingSchedulingHashesInactiveClusterQueue(t *testing.T) {
 	}
 	cq.PushOrUpdate(makeSchedulingHashInfo(now, "active-only", "active-hash", "1"))
 	inadmissibleShared := makeSchedulingHashInfo(now, "inadmissible-shared", "shared-hash", "1")
-	cq.workloads.insertInadmissible(workloadKey(inadmissibleShared), inadmissibleShared)
+	cq.workloads.InsertInadmissible(workloadKey(inadmissibleShared), inadmissibleShared)
 	inadmissibleOnly := makeSchedulingHashInfo(now, "inadmissible-only", "inadmissible-hash", "1")
-	cq.workloads.insertInadmissible(workloadKey(inadmissibleOnly), inadmissibleOnly)
+	cq.workloads.InsertInadmissible(workloadKey(inadmissibleOnly), inadmissibleOnly)
 
 	m := NewManagerForUnitTests(nil, &fakeStatusChecker{}, WithCustomLabels(kueuemetrics.NewCustomLabels(nil)))
 	kueuemetrics.ClearClusterQueueMetrics(cq.name)
@@ -410,7 +410,7 @@ func TestSchedulingHashCountsInadmissibleTransitions(t *testing.T) {
 			cq := newClusterQueueImpl(ctx, nil, nil, defaultOrdering, testingclock.NewFakeClock(now))
 			storedInfo := makeSchedulingHashInfo(now, "workload", "stored-hash", "1")
 			resyncInfo := makeSchedulingHashInfo(now, "workload", "resync-hash", "2")
-			cq.workloads.insertInadmissible(workloadKey(storedInfo), storedInfo)
+			cq.workloads.InsertInadmissible(workloadKey(storedInfo), storedInfo)
 			lq := &LocalQueue{items: map[workload.Reference]*workload.Info{
 				workloadKey(resyncInfo): resyncInfo,
 			}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area observability

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Extracts properties and functions managing the CQ's data storage and related meta-information tracking to a dedicated sub-structure.
This allows us to move some code from CQ to a separate file and better organize the logic.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13965

#### Special notes for your reviewer:
This is purely a refactor. All tests should continue working without any adjustments.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved tracking of active, inadmissible, and in-flight workloads.
  * Centralized resource accounting, workload transitions, queue reporting, and scheduling metrics for more consistent results.
  * Preserved existing queue operations, workload movement, filtering, backoff handling, and resource totals.
  * Enhanced workload lookups, snapshots, and reporting across queue states.
  * Improved consistency when rebuilding queues and aggregating pending resources.
  * Updated validation coverage to confirm reliable workload tracking and metric behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->