### PR TITLE
[release-0.18] Clamp the resource conversion for every resource, not only cpu

### DIFF
--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -70,9 +70,9 @@ var maxNonCPUQuantityForAmount = *resource.NewQuantity(math.MaxInt64, resource.D
 // Unlimited when the canonical value would overflow int64.
 //
 // This is the safe constructor that all quota-side conversion (Nominal,
-// BorrowingLimit, LendingLimit) must use. ResourceValue is preserved for
-// non-quota call sites (workload requests) where the historical
-// truncate-on-overflow behavior is what existing tests document.
+// BorrowingLimit, LendingLimit) must use. ResourceValue is the equivalent for
+// workload requests, clamping to math.MinInt64 or math.MaxInt64 rather than
+// returning Unlimited.
 func AmountFromQuantity(name corev1.ResourceName, q resource.Quantity) Amount {
 	if name == corev1.ResourceCPU {
 		if q.Cmp(maxCPUQuantityForAmount) >= 0 {

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -154,11 +154,13 @@ func (r MapRequests) ToResourceList() corev1.ResourceList {
 
 // ResourceValue returns the integer value for the resource name.
 // It's milli-units for CPU and absolute units for everything else.
+// Both clamp: Quantity.Value and Quantity.MilliValue read a big.Int that need
+// not fit in an int64.
 func ResourceValue(name corev1.ResourceName, q resource.Quantity) int64 {
 	if name == corev1.ResourceCPU {
 		return utilmath.SafeMilliValue(q)
 	}
-	return q.Value()
+	return utilmath.SafeValue(q)
 }
 
 func ResourceQuantity(name corev1.ResourceName, v int64) resource.Quantity {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"maps"
 	"math"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -342,6 +343,67 @@ func TestGreaterKeysRL(t *testing.T) {
 
 func resetBinaryFormattedResources() {
 	binaryFormattedResources = sync.Map{}
+}
+
+func TestResourceValueClampsOutsideInt64(t *testing.T) {
+	cases := map[string]struct {
+		resource corev1.ResourceName
+		quantity string
+		want     int64
+	}{
+		"an ordinary extended resource is unchanged": {
+			resource: "example.com/gpu",
+			quantity: "8",
+			want:     8,
+		},
+		"the largest representable value is kept": {
+			resource: "example.com/gpu",
+			quantity: strconv.FormatInt(math.MaxInt64, 10),
+			want:     math.MaxInt64,
+		},
+		"one past it is clamped rather than wrapped": {
+			resource: "example.com/gpu",
+			quantity: "9223372036854775808",
+			want:     math.MaxInt64,
+		},
+		"far past it is clamped as well": {
+			resource: "example.com/gpu",
+			quantity: "100000000000000000000",
+			want:     math.MaxInt64,
+		},
+		"an ordinary negative value is unchanged": {
+			resource: "example.com/gpu",
+			quantity: "-3",
+			want:     -3,
+		},
+		"far below the range is clamped rather than wrapped": {
+			resource: "example.com/gpu",
+			quantity: "-100000000000000000000",
+			want:     math.MinInt64,
+		},
+		"memory past the range is clamped too": {
+			resource: corev1.ResourceMemory,
+			quantity: "100Ei",
+			want:     math.MaxInt64,
+		},
+		"cpu is still read in milli-units": {
+			resource: corev1.ResourceCPU,
+			quantity: "1500m",
+			want:     1500,
+		},
+		"cpu past the milli range is clamped": {
+			resource: corev1.ResourceCPU,
+			quantity: "10000000000000000",
+			want:     math.MaxInt64,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := ResourceValue(tc.resource, resource.MustParse(tc.quantity)); got != tc.want {
+				t.Errorf("ResourceValue(%s, %s) = %d, want %d", tc.resource, tc.quantity, got, tc.want)
+			}
+		})
+	}
 }
 
 func TestResourceQuantityRoundTrips(t *testing.T) {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -983,6 +983,28 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// A transformation product past the range must not arrive negative and
+		// be floored away.
+		"transformProductPastTheRangeIsNotFlooredAway": {
+			workload: *utiltestingapi.MakeWorkload("transform", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "10000000000").Obj()).
+				Obj(),
+			infoOptions: []InfoOption{WithResourceTransformations([]config.ResourceTransformation{{
+				Input:    "example.com/credit",
+				Strategy: new(config.Replace),
+				Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("10000000000")},
+			}})},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						corev1.ResourceName("example.com/gpu"): math.MaxInt64,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		"transformMilliValues": {
 			workload: *utiltestingapi.MakeWorkload("transform", "").
 				PodSets(


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Cherry-pick of #14042 onto release-0.18, by hand because `k8s-infra-cherrypick-robot` could not apply it. #14112 covers release-0.19 and needed nothing.

`ResourceValue` reads a Quantity into the int64 the accounting works in. CPU went through `SafeMilliValue` and everything else through `Quantity.Value`, which reads a `big.Int` that does not have to fit. Past the range it returns a number of another magnitude, and it can be of another sign, which `FloorToZero` then reads as nothing having been asked for.

#### Which issue(s) this PR fixes:

Part of #13998, on this branch.

#### Special notes for your reviewer:

This is the plain cherry-pick with one conflict resolved, and the conflict is textual rather than semantic.

The robot tried while this branch was a few commits older, and hit `pkg/workload/workload_test.go` as well. That half resolves itself: #13986 has since been picked here as #14033, so the neighbourhood the new case lands in now matches main and the file applies untouched.

What is left is `pkg/resources/requests_test.go`. This branch carries a `resetBinaryFormattedResources` helper and the `sync` import it needs, in the same place the new test and its `strconv` import land, so the two additions collided. Both sides are kept: the helper and the new test are unrelated and neither replaces the other.

Verified here rather than assumed from main: `go build ./...`, `make ci-lint` and `go test ./pkg/...` are green on this branch, and the added cases run and pass on it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a quantity larger than `int64` on a resource other than `cpu` being converted to a number of another magnitude, or of another sign, when Kueue computes a Workload's requests. A large enough resource transformation product could arrive negative and then be floored to zero, so the Workload was admitted against no quota at all.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.
