### PR TITLE
Cleanup : Removed SchedulerTimestampPreemptionBuffer

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -288,13 +288,6 @@ const (
 	// Skip equivalent inadmissible workloads in BestEffortFIFO scheduling.
 	SchedulingEquivalenceHashing featuregate.Feature = "SchedulingEquivalenceHashing"
 
-	// owner: @mbobrovskyi
-	//
-	// issue: https://github.com/kubernetes-sigs/kueue/issues/9799
-	// Use a 5min buffer so that workloads with scheduling timestamps within this
-	// buffer do not preempt each other based on LowerOrNewerEqualPriority.
-	SchedulerTimestampPreemptionBuffer featuregate.Feature = "SchedulerTimestampPreemptionBuffer"
-
 	// owner: @IrvingMg
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/7066-custom-metric-labels
 	//
@@ -718,9 +711,6 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	SchedulingEquivalenceHashing: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Beta},
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
-	},
-	SchedulerTimestampPreemptionBuffer: {
-		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha}, // remove in 0.20
 	},
 	CustomMetricLabels: {
 		{Version: version.MustParse("0.17"), Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/preemption/common/preemption_policy.go
+++ b/pkg/scheduler/preemption/common/preemption_policy.go
@@ -17,16 +17,12 @@ limitations under the License.
 package common
 
 import (
-	"time"
-
 	"github.com/go-logr/logr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
-
-const timestampPreemptionBuffer = 5 * time.Minute
 
 func SatisfiesPreemptionPolicy(log logr.Logger, preemptor, candidate *kueue.Workload, workloadOrdering workload.Ordering, policy kueue.PreemptionPolicy) bool {
 	preemptorPriority := priority.EffectivePriority(log, preemptor)

--- a/pkg/scheduler/preemption/common/preemption_policy.go
+++ b/pkg/scheduler/preemption/common/preemption_policy.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -41,9 +40,6 @@ func SatisfiesPreemptionPolicy(log logr.Logger, preemptor, candidate *kueue.Work
 		preemptorTS := workloadOrdering.GetQueueOrderTimestamp(preemptor)
 		candidateTS := workloadOrdering.GetQueueOrderTimestamp(candidate)
 		newerEqualPriority := (preemptorPriority == candidatePriority) && preemptorTS.Before(candidateTS)
-		if newerEqualPriority && features.Enabled(features.SchedulerTimestampPreemptionBuffer) {
-			newerEqualPriority = candidateTS.Sub(preemptorTS.Time) > timestampPreemptionBuffer
-		}
 		return lowerPriority || newerEqualPriority
 	}
 	return policy == kueue.PreemptionPolicyAny

--- a/pkg/scheduler/preemption/common/preemption_policy_test.go
+++ b/pkg/scheduler/preemption/common/preemption_policy_test.go
@@ -76,24 +76,6 @@ func TestSatisfiesPreemptionPolicy(t *testing.T) {
 			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
 			want:      true, // candidate is newer
 		},
-		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (within 5min buffer)": {
-			featureGates: map[featuregate.Feature]bool{
-				features.SchedulerTimestampPreemptionBuffer: true,
-			},
-			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
-			candidate: candidate.Clone().Priority(10).Creation(nowPlus1Min).Obj(),
-			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
-			want:      false, // candidate is newer but within buffer
-		},
-		"LowerOrNewerEqualPriority with SchedulerTimestampPreemptionBuffer: preemptor has same priority, older timestamp (outside 5min buffer)": {
-			featureGates: map[featuregate.Feature]bool{
-				features.SchedulerTimestampPreemptionBuffer: true,
-			},
-			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
-			candidate: candidate.Clone().Priority(10).Creation(nowPlus6Min).Obj(),
-			policy:    kueue.PreemptionPolicyLowerOrNewerEqualPriority,
-			want:      true, // candidate is newer and outside buffer
-		},
 		"PreemptionPolicyAny": {
 			preemptor: preemptor.Clone().Priority(10).Creation(now).Obj(),
 			candidate: candidate.Clone().Priority(10).Creation(nowPlus6Min).Obj(),

--- a/site/content/en/docs/getting-started/installation.md
+++ b/site/content/en/docs/getting-started/installation.md
@@ -300,7 +300,6 @@ spec:
 {{< feature-gates-table stage="alpha-beta" >}}
 
 {{% alert title="Note" color="primary" %}}
-The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3 to 0.20.0.
 The ShortWorkloadNames features are available starting from versions 0.15.7 and 0.16.4.
 {{% /alert %}}
 

--- a/site/content/en/docs/getting-started/installation.md
+++ b/site/content/en/docs/getting-started/installation.md
@@ -300,7 +300,7 @@ spec:
 {{< feature-gates-table stage="alpha-beta" >}}
 
 {{% alert title="Note" color="primary" %}}
-The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3.
+The SchedulerLongRequeueInterval and SchedulerTimestampPreemptionBuffer features are available starting from versions 0.15.6 and 0.16.3 to 0.20.0.
 The ShortWorkloadNames features are available starting from versions 0.15.7 and 0.16.4.
 {{% /alert %}}
 

--- a/site/data/featuregates/removed_feature_list.yaml
+++ b/site/data/featuregates/removed_feature_list.yaml
@@ -243,3 +243,8 @@
   stage: Alpha
   from: "0.17"
   to: "0.20"
+- feature: SchedulerTimestampPreemptionBuffer
+  default: false
+  stage: Alpha
+  from: "0.17"
+  to: "0.20"

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -311,12 +311,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-- name: SchedulerTimestampPreemptionBuffer
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -311,12 +311,6 @@
     lockToDefault: false
     preRelease: Alpha
     version: "0.19"
-- name: SchedulerTimestampPreemptionBuffer
-  versionedSpecs:
-  - default: false
-    lockToDefault: false
-    preRelease: Alpha
-    version: "0.17"
 - name: SchedulingEquivalenceHashing
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area testing


#### What this PR does / why we need it:
This PR is removing SchedulerTimestampPreemptionBuffer as it was reqd in v 0.20

#### Which issue(s) this PR fixes:

Fixes #13697

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Same-priority scheduler preemption now relies directly on queue timestamp ordering.
  * The previous five-minute timestamp buffer no longer affects preemption decisions.

* **Feature Lifecycle**
  * Removed the timestamp preemption buffer feature from active and versioned configurations.
  * Recorded the feature as removed for versions 0.17–0.20.

* **Documentation**
  * Updated feature lifecycle and availability documentation accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->