### PR TITLE
Keep the class sweep off Workloads MultiKueue created here

### DIFF
--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -98,7 +98,7 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
 		if !ownsPriority(wl) {
-			wlLog.V(3).Info("Workload's priority is not this cluster's to write")
+			wlLog.V(3).Info("Workload priority not owned by this controller")
 			continue
 		}
 
@@ -154,9 +154,10 @@ func (r *WorkloadPriorityClassReconciler) Generic(e event.TypedGenericEvent[*kue
 	return false
 }
 
-// ownsPriority reports whether this cluster decides the Workload's priority. A
-// Workload MultiKueue created here carries the manager's resolution, and a class
-// of the same name on this cluster is not the one it was resolved from.
+// ownsPriority reports whether this WorkloadPriorityClass controller owns
+// synchronizing the Workload's priority. A Workload MultiKueue created here
+// carries the manager's resolution, and a class of the same name on this
+// cluster is not the one it was resolved from.
 func ownsPriority(wl *kueue.Workload) bool {
 	_, isMultiKueueRemote := wl.Labels[kueue.MultiKueueOriginLabel]
 	return !isMultiKueueRemote && workload.IsWorkloadPriorityClass(wl)

--- a/pkg/controller/core/workloadpriorityclass_controller.go
+++ b/pkg/controller/core/workloadpriorityclass_controller.go
@@ -37,6 +37,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/core/indexer"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 // WorkloadPriorityClassReconciler reconciles a WorkloadPriorityClass object
@@ -96,6 +97,11 @@ func (r *WorkloadPriorityClassReconciler) Reconcile(ctx context.Context, req ctr
 		wl := &workloads.Items[i]
 		wlLog := log.WithValues("workload", klog.KObj(wl))
 
+		if !ownsPriority(wl) {
+			wlLog.V(3).Info("Workload's priority is not this cluster's to write")
+			continue
+		}
+
 		// Skip if priority is already up to date
 		if wl.Spec.Priority != nil && *wl.Spec.Priority == wpc.Value {
 			wlLog.V(3).Info("Workload priority already up to date")
@@ -146,6 +152,14 @@ func (r *WorkloadPriorityClassReconciler) Update(e event.TypedUpdateEvent[*kueue
 
 func (r *WorkloadPriorityClassReconciler) Generic(e event.TypedGenericEvent[*kueue.WorkloadPriorityClass]) bool {
 	return false
+}
+
+// ownsPriority reports whether this cluster decides the Workload's priority. A
+// Workload MultiKueue created here carries the manager's resolution, and a class
+// of the same name on this cluster is not the one it was resolved from.
+func ownsPriority(wl *kueue.Workload) bool {
+	_, isMultiKueueRemote := wl.Labels[kueue.MultiKueueOriginLabel]
+	return !isMultiKueueRemote && workload.IsWorkloadPriorityClass(wl)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -318,3 +318,41 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnsPriority(t *testing.T) {
+	cases := map[string]struct {
+		wl   *kueue.Workload
+		want bool
+	}{
+		"a local Workload referencing a WorkloadPriorityClass": {
+			wl:   utiltestingapi.MakeWorkload("wl", "default").WorkloadPriorityClassRef("high").Obj(),
+			want: true,
+		},
+		"a Workload MultiKueue created here carries the manager's resolution": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").
+				WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				Obj(),
+		},
+		"a PodPriorityClass of the same name is a different class": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").PodPriorityClassRef("high").Obj(),
+		},
+		"and one on a Workload MultiKueue created here is refused for both reasons": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").
+				PodPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				Obj(),
+		},
+		"no reference at all": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").Obj(),
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := ownsPriority(tc.wl); got != tc.want {
+				t.Errorf("ownsPriority() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -105,6 +105,31 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 		wantError     bool
 		clientFuncs   *interceptor.Funcs
 	}{
+		"reconcile leaves a Workload MultiKueue created here alone": {
+			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Obj(),
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("local", "default").
+					Priority(1000).
+					WorkloadPriorityClassRef("high").
+					Obj(),
+				*utiltestingapi.MakeWorkload("remote", "default").
+					Priority(100).
+					WorkloadPriorityClassRef("high").
+					Label(kueue.MultiKueueOriginLabel, "manager").
+					Obj(),
+			},
+		},
 		"reconcile updates workload priority when WPC priority changes": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads: []kueue.Workload{

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -108,22 +108,22 @@ func TestWorkloadPriorityClassReconcile(t *testing.T) {
 		"reconcile leaves a Workload MultiKueue created here alone": {
 			wpc: utiltestingapi.MakeWorkloadPriorityClass("high").PriorityValue(1000).Obj(),
 			workloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("remote", "default").
+				*utiltestingapi.MakeWorkload("a-remote", "default").
 					Priority(100).
 					WorkloadPriorityClassRef("high").
 					Label(kueue.MultiKueueOriginLabel, "manager").
 					Obj(),
-				*utiltestingapi.MakeWorkload("local", "default").
+				*utiltestingapi.MakeWorkload("z-local", "default").
 					Priority(100).
 					WorkloadPriorityClassRef("high").
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("local", "default").
+				*utiltestingapi.MakeWorkload("z-local", "default").
 					Priority(1000).
 					WorkloadPriorityClassRef("high").
 					Obj(),
-				*utiltestingapi.MakeWorkload("remote", "default").
+				*utiltestingapi.MakeWorkload("a-remote", "default").
 					Priority(100).
 					WorkloadPriorityClassRef("high").
 					Label(kueue.MultiKueueOriginLabel, "manager").

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -337,6 +337,22 @@ func TestOwnsPriority(t *testing.T) {
 		"a PodPriorityClass of the same name is a different class": {
 			wl: utiltestingapi.MakeWorkload("wl", "default").PodPriorityClassRef("high").Obj(),
 		},
+		// A PodPriorityClass differs in both the kind and the group, so it cannot say
+		// which of the two is being read. These can.
+		"the right group under some other kind": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").PriorityClassRef(&kueue.PriorityClassRef{
+				Group: kueue.WorkloadPriorityClassGroup,
+				Kind:  "SomeOtherKind",
+				Name:  "high",
+			}).Obj(),
+		},
+		"the right kind under some other group": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").PriorityClassRef(&kueue.PriorityClassRef{
+				Group: "other.example.com",
+				Kind:  kueue.WorkloadPriorityClassKind,
+				Name:  "high",
+			}).Obj(),
+		},
 		"and one on a Workload MultiKueue created here is refused for both reasons": {
 			wl: utiltestingapi.MakeWorkload("wl", "default").
 				PodPriorityClassRef("high").

--- a/pkg/controller/core/workloadpriorityclass_controller_test.go
+++ b/pkg/controller/core/workloadpriorityclass_controller_test.go
@@ -334,6 +334,14 @@ func TestOwnsPriority(t *testing.T) {
 				Label(kueue.MultiKueueOriginLabel, "manager").
 				Obj(),
 		},
+		// The label is read for its presence, not its value, so an origin that
+		// somehow arrived empty is still the manager's to answer for.
+		"an empty origin value still marks remote ownership": {
+			wl: utiltestingapi.MakeWorkload("wl", "default").
+				WorkloadPriorityClassRef("high").
+				Label(kueue.MultiKueueOriginLabel, "").
+				Obj(),
+		},
 		"a PodPriorityClass of the same name is a different class": {
 			wl: utiltestingapi.MakeWorkload("wl", "default").PodPriorityClassRef("high").Obj(),
 		},

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -555,6 +555,53 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 				g.Expect(finalQueueWorkload.Spec.Priority).To(gomega.Equal(&updatedPriority))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+		ginkgo.It("leaves a Workload MultiKueue created here alone", func() {
+			ginkgo.By("creating a local workload and one MultiKueue created here")
+			local := utiltestingapi.MakeWorkload("local", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+				WorkloadPriorityClassRef("workload-priority-class").
+				Priority(200).
+				Obj()
+			util.MustCreate(ctx, k8sClient, local)
+
+			remote := utiltestingapi.MakeWorkload("remote", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+				WorkloadPriorityClassRef("workload-priority-class").
+				Label(kueue.MultiKueueOriginLabel, "manager").
+				Priority(200).
+				Obj()
+			util.MustCreate(ctx, k8sClient, remote)
+
+			// The class update has to arrive after both are in the cache the
+			// controller lists from, or this would be testing the ordering in
+			// #13866 rather than the ownership guard.
+			ginkgo.By("waiting for both to be reconciled")
+			gomega.Eventually(func(g gomega.Gomega) {
+				for _, wl := range []*kueue.Workload{local, remote} {
+					got := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &got)).To(gomega.Succeed())
+					g.Expect(got.Status.Conditions).ShouldNot(gomega.BeNil())
+				}
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("updating workloadPriorityClass")
+			updatedPriority := int32(150)
+			workloadPriorityClass.Value = updatedPriority
+			gomega.Expect(k8sClient.Update(ctx, workloadPriorityClass)).To(gomega.Succeed())
+
+			ginkgo.By("the local workload follows the class")
+			gomega.Eventually(func(g gomega.Gomega) {
+				got := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(local), &got)).To(gomega.Succeed())
+				g.Expect(got.Spec.Priority).To(gomega.Equal(&updatedPriority))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("the remote one keeps what the manager resolved")
+			managerPriority := int32(200)
+			gomega.Consistently(func(g gomega.Gomega) {
+				got := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(remote), &got)).To(gomega.Succeed())
+				g.Expect(got.Spec.Priority).To(gomega.Equal(&managerPriority))
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
 	})
 
 	ginkgo.When("the workload has a maximum execution time set", func() {

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -557,13 +557,13 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 		})
 		ginkgo.It("leaves a Workload MultiKueue created here alone", func() {
 			ginkgo.By("creating a local workload and one MultiKueue created here")
-			local := utiltestingapi.MakeWorkload("local", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			local := utiltestingapi.MakeWorkload("z-local", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
 				WorkloadPriorityClassRef("workload-priority-class").
 				Priority(200).
 				Obj()
 			util.MustCreate(ctx, k8sClient, local)
 
-			remote := utiltestingapi.MakeWorkload("remote", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
+			remote := utiltestingapi.MakeWorkload("a-remote", ns.Name).Queue("lq").Request(corev1.ResourceCPU, "1").
 				WorkloadPriorityClassRef("workload-priority-class").
 				Label(kueue.MultiKueueOriginLabel, "manager").
 				Priority(200).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`WorkloadPriorityClassReconciler` answers a class event by listing every Workload that references the class and writing the class value to each one:

```go
for i := range workloads.Items {
	wl := &workloads.Items[i]
	...
	wl.Spec.Priority = new(wpc.Value)
```

A Workload that MultiKueue created on this cluster is in that list like any other. It carries the priority the manager resolved, from a class on the manager, and a class of the same name here is not the policy it was resolved from. So a worker cluster that happens to define `high` overwrites the value a remote Workload was admitted with, and the manager's decision is lost on a cluster that was never asked.

The sweep now asks whether the priority is this controller's to write before it writes.

`ownsPriority` states both halves of that question. The MultiKueue half is what changes behaviour here. The kind and group half is already true for everything this caller sees, since `indexer.WorkloadPriorityClassKey` restricts the list to references that are a `WorkloadPriorityClass`, and it is stated anyway so the predicate answers the question completely rather than only for this one caller.

#### Which issue(s) this PR fixes:

Fixes #13929

#### Special notes for your reviewer:

Split out of #13920, which is where the predicate started. That PR adds a second, Workload-keyed reconciler and is a lifecycle change with its own design questions; this is a guard on the existing sweep with an independent regression test, and the two do not need to be reviewed together. #13920 still carries this guard as well, so the two cannot both land as they stand: each defines `ownsPriority` in this package. Once this lands, #13920 drops the guard and keeps only the reconciler.

The ownership marker is the presence of `kueue.x-k8s.io/multikueue-origin`, not its value. That is the idiom already used wherever the question is whether an object is one MultiKueue created here: `jobframework/reconciler.go` guards the worker Pod label with `if _, exists := w.Labels[kueue.MultiKueueOriginLabel]; exists`, and the LeaderWorkerSet and StatefulSet paths spell it `_, isMultiKueueRemote := ...` down to the variable name. The value is what MultiKueue matches on where the question is *which* manager an object belongs to — the per-worker watch and the garbage collector both list by `MatchingLabels{kueue.MultiKueueOriginLabel: origin}`, and `ValidateRemoteObjectOwnership` compares it. This sweep asks the first question and not the second: it does not need to know which manager resolved the priority, only that one did. So an origin that somehow arrived empty is still not this cluster's to overwrite, and `TestOwnsPriority` pins that — swapping the presence check for a non-empty-value check fails that case and no other.

#14227 separately stops a Workload Kueue builds locally from inheriting this label off the Job or Pod it is built from. It is complementary rather than a prerequisite. The label already decides ownership on `main` — the watch, the garbage collector, `ValidateRemoteObjectOwnership` and the worker Pod label all read it — so reading it here follows that model rather than establishing a new trust relationship. To be exact about what the new reader adds: a Workload carrying an inherited origin is now also left alone by the sweep, so a later change to the class value stops reaching it. #14227 closes that at the source, and it is not a reason to hold a fix for a bug that needs no misconfiguration to hit at all. Neither PR rewrites Workloads that already carry the label.

The test is not just an assertion that nothing happened. It puts a local Workload and a MultiKueue-created one on the same class in the same reconcile, and asserts the local one is updated to the class value while the remote one keeps what it had. A reconciler that never ran would fail the first half, so the case cannot pass by the controller doing nothing.

There is an envtest alongside it now, because the unit case runs against a fake client and so proves the branch without touching the field index the sweep actually lists through, or the event that wakes it. It puts the same two Workloads on the class through the real controller and moves the class value. Both have to be reconciled first: a class event that arrives before they reach the cache is the ordering in #13866, and the case would pass without proving anything.

Mutation-checked, both of those: with the guard taken back out the unit case fails and no other does, and the envtest fails on the remote Workload within milliseconds of the class moving.

`go test ./pkg/...`, `make ci-lint`, and the integration case are green.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a worker-cluster WorkloadPriorityClass overwriting the priority of a MultiKueue remote Workload. WorkloadPriorityClass changes now update only locally owned Workloads that reference that class.
```

---

This PR was written in part with the assistance of generative AI.
I reviewed and tested every change myself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented priority updates for workloads managed by another cluster.
  * Ensured workloads without a WorkloadPriorityClass are not modified.
  * Continued updating priorities for locally managed workloads when their priority class changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




