### PR TITLE
Start the Workload branch even if the queue label patch fails

### DIFF
--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -101,10 +101,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return ctrl.Result{}, err
 	}
 
-	if err := r.syncQueueLabel(ctx, sts, podList.Items); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	// Finalizing pods and reconciling the Workload touch different objects, so
 	// one failing is no reason to abandon the other. A derived context would
 	// cancel it, and its own lookups would then fail as cancelled rather than
@@ -112,7 +108,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// carries shutdown and any deadline.
 	var eg errgroup.Group
 
+	// Both patch the same Pods, so they stay in order on one branch.
 	eg.Go(func() error {
+		if err := r.syncQueueLabel(ctx, sts, podList.Items); err != nil {
+			return err
+		}
 		return r.ungatePods(ctx, sts, podList.Items)
 	})
 

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -18,6 +18,7 @@ package statefulset
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -114,15 +115,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	var eg errgroup.Group
 
 	// Both patch the same Pods, so they stay in order on one branch.
+	// Wait reports the first error it is given and drops the other, so say
+	// which branch each one came from.
 	eg.Go(func() error {
 		if err := r.syncQueueLabel(ctx, sts, podList.Items); err != nil {
-			return err
+			return fmt.Errorf("syncing the Pod queue labels: %w", err)
 		}
-		return r.ungatePods(ctx, sts, podList.Items)
+		if err := r.ungatePods(ctx, sts, podList.Items); err != nil {
+			return fmt.Errorf("ungating the Pods: %w", err)
+		}
+		return nil
 	})
 
 	eg.Go(func() error {
-		return r.reconcileWorkload(ctx, workloadSts, wl)
+		if err := r.reconcileWorkload(ctx, workloadSts, wl); err != nil {
+			return fmt.Errorf("reconciling the Workload: %w", err)
+		}
+		return nil
 	})
 
 	return ctrl.Result{}, eg.Wait()

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -18,6 +18,7 @@ package statefulset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -112,34 +113,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// side changes the StatefulSet today, and a copy keeps it that way.
 	workloadSts := sts.DeepCopy()
 
-	var eg errgroup.Group
+	var (
+		eg      errgroup.Group
+		podErr  error
+		workErr error
+	)
 
-	// Both patch the same Pods, so they stay in order on one branch.
-	// Wait reports the first error it is given and drops the other, so say
-	// which branch each one came from.
 	eg.Go(func() error {
-		if err := r.syncQueueLabel(ctx, sts, podList.Items); err != nil {
-			return fmt.Errorf("syncing the Pod queue labels: %w", err)
-		}
-		if err := r.ungatePods(ctx, sts, podList.Items); err != nil {
-			return fmt.Errorf("ungating the Pods: %w", err)
-		}
-		return nil
+		podErr = r.reconcilePods(ctx, sts, podList.Items)
+		return podErr
 	})
 
 	eg.Go(func() error {
-		if err := r.reconcileWorkload(ctx, workloadSts, wl); err != nil {
-			return fmt.Errorf("reconciling the Workload: %w", err)
-		}
-		return nil
+		workErr = r.reconcileWorkload(ctx, workloadSts, wl)
+		return workErr
 	})
 
-	return ctrl.Result{}, eg.Wait()
+	// Wait keeps only the error it is handed first, and either branch can win
+	// that race, so hold both and report them together.
+	_ = eg.Wait()
+	if podErr != nil {
+		podErr = fmt.Errorf("reconciling the Pods: %w", podErr)
+	}
+	if workErr != nil {
+		workErr = fmt.Errorf("reconciling the Workload: %w", workErr)
+	}
+	return ctrl.Result{}, errors.Join(podErr, workErr)
 }
 
-func (r *Reconciler) ungatePods(ctx context.Context, sts *appsv1.StatefulSet, pods []corev1.Pod) error {
+// reconcilePods brings each Pod to its queue label and then ungates it. The two
+// writes go to the same Pod, so they are ordered per Pod rather than per phase:
+// a Pod whose label patch fails must not hold back the others.
+func (r *Reconciler) reconcilePods(ctx context.Context, sts *appsv1.StatefulSet, pods []corev1.Pod) error {
+	var queueName string
+	if sts != nil && ptr.Deref(sts.Spec.Replicas, 1) != 0 {
+		queueName = string(jobframework.QueueNameForObject(sts))
+	}
 	return parallelize.Until(ctx, len(pods), func(i int) error {
-		return r.ungatePod(ctx, sts, &pods[i])
+		pod := &pods[i]
+		if err := r.syncQueueLabel(ctx, pod, queueName); err != nil {
+			return fmt.Errorf("syncing the queue label on %s: %w", klog.KObj(pod), err)
+		}
+		if err := r.ungatePod(ctx, sts, pod); err != nil {
+			return fmt.Errorf("ungating %s: %w", klog.KObj(pod), err)
+		}
+		return nil
 	})
 }
 
@@ -158,28 +176,17 @@ func (r *Reconciler) ungatePod(ctx context.Context, sts *appsv1.StatefulSet, pod
 	}))
 }
 
-func (r *Reconciler) syncQueueLabel(ctx context.Context, sts *appsv1.StatefulSet, pods []corev1.Pod) error {
-	if sts == nil || ptr.Deref(sts.Spec.Replicas, 1) == 0 {
+func (r *Reconciler) syncQueueLabel(ctx context.Context, pod *corev1.Pod, queueName string) error {
+	if queueName == "" || pod.Labels[controllerconstants.QueueLabel] == queueName {
 		return nil
 	}
-	queueName := string(jobframework.QueueNameForObject(sts))
-	if queueName == "" {
-		return nil
-	}
-
-	return parallelize.Until(ctx, len(pods), func(i int) error {
-		pod := &pods[i]
-		if pod.Labels[controllerconstants.QueueLabel] == queueName {
-			return nil
+	return client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
+		if pod.Labels == nil {
+			pod.Labels = make(map[string]string, 1)
 		}
-		return client.IgnoreNotFound(clientutil.Patch(ctx, r.client, pod, func() (bool, error) {
-			if pod.Labels == nil {
-				pod.Labels = make(map[string]string, 1)
-			}
-			pod.Labels[controllerconstants.QueueLabel] = queueName
-			return true, nil
-		}))
-	})
+		pod.Labels[controllerconstants.QueueLabel] = queueName
+		return true, nil
+	}))
 }
 
 // findWorkload returns the workload name and object for the given StatefulSet,

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler.go
@@ -106,6 +106,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// cancel it, and its own lookups would then fail as cancelled rather than
 	// for the reason they were about to find. The reconcile context still
 	// carries shutdown and any deadline.
+
+	// The branches share nothing they can write to. Nothing on the Workload
+	// side changes the StatefulSet today, and a copy keeps it that way.
+	workloadSts := sts.DeepCopy()
+
 	var eg errgroup.Group
 
 	// Both patch the same Pods, so they stay in order on one branch.
@@ -117,7 +122,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	})
 
 	eg.Go(func() error {
-		return r.reconcileWorkload(ctx, sts, wl)
+		return r.reconcileWorkload(ctx, workloadSts, wl)
 	})
 
 	return ctrl.Result{}, eg.Wait()

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -32,6 +32,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/component-base/featuregate"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1124,5 +1125,58 @@ func TestReconcileUpdatesTheWorkloadWhenTheQueueLabelPatchFails(t *testing.T) {
 	}
 	if got.Spec.QueueName != "lq" {
 		t.Errorf("Workload queue = %q, want lq: the queue label patch failed and the Workload branch never ran", got.Spec.QueueName)
+	}
+}
+
+// A Pod whose queue label cannot be patched used to take the whole slice with
+// it, since the sync ran over every Pod before any of them was ungated.
+func TestReconcilePodFailureLeavesTheOtherPodsAlone(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	group := GetWorkloadName("sts-uid", "sts")
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(2).Queue("lq").Obj()
+
+	conflicting := testingjobspod.MakePod("conflicting", "ns").GroupNameLabel(group).Queue("old-lq").Obj()
+	// This one already carries the queue, so the sync never touches it.
+	unrelated := testingjobspod.MakePod("unrelated", "ns").GroupNameLabel(group).Queue("lq").
+		KueueFinalizer().StatusPhase(corev1.PodSucceeded).Obj()
+
+	builder := utiltesting.NewClientBuilder().WithObjects(sts, conflicting, unrelated).WithStatusSubresource(sts)
+	indexer := utiltesting.AsIndexer(builder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+	}
+	wantErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "conflicting", nil)
+	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if obj.GetName() == "conflicting" {
+				return wantErr
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	}).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("NewReconciler() error: %v", err)
+	}
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}})
+	if !apierrors.IsConflict(err) {
+		t.Errorf("Reconcile() error = %v, want the Pod conflict", err)
+	}
+
+	var gotPod corev1.Pod
+	if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "unrelated"}, &gotPod); err != nil {
+		t.Fatalf("failed to get the unrelated Pod: %v", err)
+	}
+	if len(gotPod.Finalizers) != 0 {
+		t.Errorf("unrelated Pod finalizers = %v, want none: one Pod's failure held back another", gotPod.Finalizers)
+	}
+
+	var wls kueue.WorkloadList
+	if err := kClient.List(ctx, &wls, client.InNamespace("ns")); err != nil {
+		t.Fatalf("failed to list workloads: %v", err)
+	}
+	if len(wls.Items) != 1 {
+		t.Errorf("got %d Workloads, want the Workload branch to still finish", len(wls.Items))
 	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -1226,3 +1226,54 @@ func TestReconcileReportsBothBranchFailures(t *testing.T) {
 		t.Errorf("Reconcile() lost the Workload refusal: %v", err)
 	}
 }
+
+// The queue has to land on a Pod before that Pod is let go, or it is scheduled
+// carrying a queue nothing will match it on.
+func TestReconcileQueueLabelFailureKeepsTheSamePodGated(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(1).Queue("lq").
+		CurrentRevision("1").UpdateRevision("2").Obj()
+	// Old revision during a rollout, so it is eligible to be ungated, and its
+	// queue is the one the sync has to correct first.
+	pod := testingjobspod.MakePod("pod1", "ns").
+		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
+		Queue("old-lq").
+		Label(appsv1.ControllerRevisionHashLabelKey, "1").
+		Gate(podconstants.SchedulingGateName).
+		Obj()
+
+	wantErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, nil)
+	builder := utiltesting.NewClientBuilder().WithObjects(sts, pod).WithStatusSubresource(sts)
+	indexer := utiltesting.AsIndexer(builder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+	}
+	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			// Only the queue write, so an ungate that ran first would go through.
+			if p, ok := obj.(*corev1.Pod); ok && p.Labels[controllerconstants.QueueLabel] == "lq" {
+				return wantErr
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	}).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("NewReconciler() error: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}}); !apierrors.IsConflict(err) {
+		t.Errorf("Reconcile() error = %v, want the queue conflict", err)
+	}
+
+	var got corev1.Pod
+	if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "pod1"}, &got); err != nil {
+		t.Fatalf("failed to get the Pod: %v", err)
+	}
+	if len(got.Spec.SchedulingGates) == 0 {
+		t.Error("the Pod was ungated even though its queue never landed")
+	}
+	if q := got.Labels[controllerconstants.QueueLabel]; q != "old-lq" {
+		t.Errorf("Pod queue = %q, want it left at old-lq", q)
+	}
+}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -1016,3 +1016,113 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 		t.Errorf("created Workload priority = %v, want the class value 100", created.Spec.Priority)
 	}
 }
+
+func TestReconcileStartsTheWorkloadBranchWhenTheQueueLabelPatchFails(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	// One revision, so finalization has nothing to patch and the queue label is
+	// the only Pod write the reconcile makes.
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+		UID("sts-uid").
+		Queue("lq").
+		WorkloadPriorityClass("wpc").
+		CurrentRevision("1").
+		UpdateRevision("1").
+		Obj()
+	// Without the queue label, so the sync has a patch to make and fail.
+	pod := testingjobspod.MakePod("pod1", "ns").
+		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
+		Label(appsv1.ControllerRevisionHashLabelKey, "1").
+		Gate(podconstants.SchedulingGateName).
+		KueueFinalizer().
+		Obj()
+	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
+
+	errPodConflict := apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
+	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			// Only the write that carries the queue label, so the failure the
+			// test names is the one it gets.
+			if pod, isPod := obj.(*corev1.Pod); isPod && pod.Labels[controllerconstants.QueueLabel] == "lq" {
+				return errPodConflict
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Indexing the pod group name: %v", err)
+	}
+	kClient := clientBuilder.WithObjects(sts, pod, wpc).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); !errors.Is(err, errPodConflict) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, errPodConflict)
+	}
+
+	created := &kueue.Workload{}
+	if err := kClient.Get(ctx, client.ObjectKey{Name: GetWorkloadName("sts-uid", "sts"), Namespace: "ns"}, created); err != nil {
+		t.Fatalf("Getting the Workload: the queue label patch failed and the Workload branch never ran: %v", err)
+	}
+	if created.Spec.QueueName != "lq" {
+		t.Errorf("created Workload queue = %q, want lq", created.Spec.QueueName)
+	}
+}
+
+func TestReconcileUpdatesTheWorkloadWhenTheQueueLabelPatchFails(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
+		UID("sts-uid").
+		Queue("lq").
+		CurrentRevision("1").
+		UpdateRevision("1").
+		Obj()
+	// Carrying the queue it was renamed away from, so the sync has the rename to
+	// make and fail.
+	pod := testingjobspod.MakePod("pod1", "ns").
+		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
+		Queue("old-lq").
+		Label(appsv1.ControllerRevisionHashLabelKey, "1").
+		Gate(podconstants.SchedulingGateName).
+		KueueFinalizer().
+		Obj()
+	wl := utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
+		Queue("old-lq").
+		OwnerReference(gvk, "sts", "sts-uid").
+		Obj()
+
+	errPodConflict := apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
+	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if pod, isPod := obj.(*corev1.Pod); isPod && pod.Labels[controllerconstants.QueueLabel] == "lq" {
+				return errPodConflict
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+	})
+	indexer := utiltesting.AsIndexer(clientBuilder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Indexing the pod group name: %v", err)
+	}
+	kClient := clientBuilder.WithObjects(sts, pod, wl).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("Creating the reconciler: %v", err)
+	}
+	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); !errors.Is(err, errPodConflict) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, errPodConflict)
+	}
+
+	got := &kueue.Workload{}
+	if err := kClient.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
+		t.Fatalf("Getting the Workload: %v", err)
+	}
+	if got.Spec.QueueName != "lq" {
+		t.Errorf("Workload queue = %q, want lq: the queue label patch failed and the Workload branch never ran", got.Spec.QueueName)
+	}
+}

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -1018,262 +1018,209 @@ func TestReconcileDoesNotCancelTheWorkloadBranch(t *testing.T) {
 	}
 }
 
-func TestReconcileStartsTheWorkloadBranchWhenTheQueueLabelPatchFails(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	// One revision, so finalization has nothing to patch and the queue label is
-	// the only Pod write the reconcile makes.
-	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
-		UID("sts-uid").
-		Queue("lq").
-		WorkloadPriorityClass("wpc").
-		CurrentRevision("1").
-		UpdateRevision("1").
-		Obj()
-	// Without the queue label, so the sync has a patch to make and fail.
-	pod := testingjobspod.MakePod("pod1", "ns").
-		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
-		Label(appsv1.ControllerRevisionHashLabelKey, "1").
-		Gate(podconstants.SchedulingGateName).
-		KueueFinalizer().
-		Obj()
-	wpc := utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()
-
-	errPodConflict := apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
-	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+// refusingQueueLabelPatch refuses the write that carries the new queue name, so
+// a case can watch what the first of a Pod's two writes costs the second.
+func refusingQueueLabelPatch(queueName string, err error) interceptor.Funcs {
+	return interceptor.Funcs{
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			// Only the write that carries the queue label, so the failure the
-			// test names is the one it gets.
-			if pod, isPod := obj.(*corev1.Pod); isPod && pod.Labels[controllerconstants.QueueLabel] == "lq" {
-				return errPodConflict
+			if pod, isPod := obj.(*corev1.Pod); isPod && pod.Labels[controllerconstants.QueueLabel] == queueName {
+				return err
 			}
 			return c.Patch(ctx, obj, patch, opts...)
 		},
-	})
-	indexer := utiltesting.AsIndexer(clientBuilder)
-	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
-		t.Fatalf("Indexing the pod group name: %v", err)
-	}
-	kClient := clientBuilder.WithObjects(sts, pod, wpc).Build()
-
-	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
-	if err != nil {
-		t.Fatalf("Creating the reconciler: %v", err)
-	}
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); !errors.Is(err, errPodConflict) {
-		t.Fatalf("Reconcile() error = %v, want %v", err, errPodConflict)
-	}
-
-	created := &kueue.Workload{}
-	if err := kClient.Get(ctx, client.ObjectKey{Name: GetWorkloadName("sts-uid", "sts"), Namespace: "ns"}, created); err != nil {
-		t.Fatalf("Getting the Workload: the queue label patch failed and the Workload branch never ran: %v", err)
-	}
-	if created.Spec.QueueName != "lq" {
-		t.Errorf("created Workload queue = %q, want lq", created.Spec.QueueName)
 	}
 }
 
-func TestReconcileUpdatesTheWorkloadWhenTheQueueLabelPatchFails(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-
-	sts := statefulsettesting.MakeStatefulSet("sts", "ns").
-		UID("sts-uid").
-		Queue("lq").
-		CurrentRevision("1").
-		UpdateRevision("1").
-		Obj()
-	// Carrying the queue it was renamed away from, so the sync has the rename to
-	// make and fail.
-	pod := testingjobspod.MakePod("pod1", "ns").
-		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
-		Queue("old-lq").
-		Label(appsv1.ControllerRevisionHashLabelKey, "1").
-		Gate(podconstants.SchedulingGateName).
-		KueueFinalizer().
-		Obj()
-	wl := utiltestingapi.MakeWorkload(GetWorkloadName("sts-uid", "sts"), "ns").
-		Queue("old-lq").
-		OwnerReference(gvk, "sts", "sts-uid").
-		Obj()
-
-	errPodConflict := apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
-	clientBuilder := utiltesting.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+// refusingPatchOf refuses every write to one Pod by name and lets the rest through.
+func refusingPatchOf(podName string, err error) interceptor.Funcs {
+	return interceptor.Funcs{
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if pod, isPod := obj.(*corev1.Pod); isPod && pod.Labels[controllerconstants.QueueLabel] == "lq" {
-				return errPodConflict
+			if obj.GetName() == podName {
+				return err
 			}
 			return c.Patch(ctx, obj, patch, opts...)
 		},
-	})
-	indexer := utiltesting.AsIndexer(clientBuilder)
-	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
-		t.Fatalf("Indexing the pod group name: %v", err)
-	}
-	kClient := clientBuilder.WithObjects(sts, pod, wl).Build()
-
-	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
-	if err != nil {
-		t.Fatalf("Creating the reconciler: %v", err)
-	}
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(sts)}); !errors.Is(err, errPodConflict) {
-		t.Fatalf("Reconcile() error = %v, want %v", err, errPodConflict)
-	}
-
-	got := &kueue.Workload{}
-	if err := kClient.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
-		t.Fatalf("Getting the Workload: %v", err)
-	}
-	if got.Spec.QueueName != "lq" {
-		t.Errorf("Workload queue = %q, want lq: the queue label patch failed and the Workload branch never ran", got.Spec.QueueName)
 	}
 }
 
-// A Pod whose queue label cannot be patched used to take the whole slice with
-// it, since the sync ran over every Pod before any of them was ungated.
-func TestReconcilePodFailureLeavesTheOtherPodsAlone(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-	group := GetWorkloadName("sts-uid", "sts")
-	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(2).Queue("lq").Obj()
-
-	conflicting := testingjobspod.MakePod("conflicting", "ns").GroupNameLabel(group).Queue("old-lq").Obj()
-	// This one already carries the queue, so the sync never touches it.
-	unrelated := testingjobspod.MakePod("unrelated", "ns").GroupNameLabel(group).Queue("lq").
-		KueueFinalizer().StatusPhase(corev1.PodSucceeded).Obj()
-
-	builder := utiltesting.NewClientBuilder().WithObjects(sts, conflicting, unrelated).WithStatusSubresource(sts)
-	indexer := utiltesting.AsIndexer(builder)
-	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
-		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
-	}
-	wantErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "conflicting", nil)
-	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
+// refusingBothBranches fails one write on each side of the errgroup.
+func refusingBothBranches(podErr, workloadErr error) interceptor.Funcs {
+	return interceptor.Funcs{
 		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if obj.GetName() == "conflicting" {
-				return wantErr
-			}
-			return c.Patch(ctx, obj, patch, opts...)
-		},
-	}).Build()
-
-	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
-	if err != nil {
-		t.Fatalf("NewReconciler() error: %v", err)
-	}
-	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}})
-	if !apierrors.IsConflict(err) {
-		t.Errorf("Reconcile() error = %v, want the Pod conflict", err)
-	}
-
-	var gotPod corev1.Pod
-	if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "unrelated"}, &gotPod); err != nil {
-		t.Fatalf("failed to get the unrelated Pod: %v", err)
-	}
-	if len(gotPod.Finalizers) != 0 {
-		t.Errorf("unrelated Pod finalizers = %v, want none: one Pod's failure held back another", gotPod.Finalizers)
-	}
-
-	var wls kueue.WorkloadList
-	if err := kClient.List(ctx, &wls, client.InNamespace("ns")); err != nil {
-		t.Fatalf("failed to list workloads: %v", err)
-	}
-	if len(wls.Items) != 1 {
-		t.Errorf("got %d Workloads, want the Workload branch to still finish", len(wls.Items))
-	}
-}
-
-// Wait hands back whichever error arrives first, so a failure on one branch
-// used to hide the other on every retry.
-func TestReconcileReportsBothBranchFailures(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-	group := GetWorkloadName("sts-uid", "sts")
-	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(1).Queue("lq").Obj()
-	pod := testingjobspod.MakePod("pod", "ns").GroupNameLabel(group).Queue("old-lq").Obj()
-
-	// Held by value: apierrors.IsForbidden and friends run errors.As against the
-	// APIStatus interface, which stops at whichever error the join holds first.
-	wantPodErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "pod", nil)
-	wantWorkloadErr := apierrors.NewForbidden(schema.GroupResource{Resource: "workloads"}, "wl", errors.New("denied by a webhook"))
-
-	builder := utiltesting.NewClientBuilder().WithObjects(sts, pod).WithStatusSubresource(sts)
-	indexer := utiltesting.AsIndexer(builder)
-	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
-		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
-	}
-	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
-		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			if _, ok := obj.(*corev1.Pod); ok {
-				return wantPodErr
+			if _, isPod := obj.(*corev1.Pod); isPod {
+				return podErr
 			}
 			return c.Patch(ctx, obj, patch, opts...)
 		},
 		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
-			if _, ok := obj.(*kueue.Workload); ok {
-				return wantWorkloadErr
+			if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+				return workloadErr
 			}
 			return c.Create(ctx, obj, opts...)
 		},
-	}).Build()
-
-	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
-	if err != nil {
-		t.Fatalf("NewReconciler() error: %v", err)
-	}
-	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}})
-	if !errors.Is(err, wantPodErr) {
-		t.Errorf("Reconcile() lost the Pod conflict: %v", err)
-	}
-	if !errors.Is(err, wantWorkloadErr) {
-		t.Errorf("Reconcile() lost the Workload refusal: %v", err)
 	}
 }
 
-// The queue has to land on a Pod before that Pod is let go, or it is scheduled
-// carrying a queue nothing will match it on.
-func TestReconcileQueueLabelFailureKeepsTheSamePodGated(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
-	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(1).Queue("lq").
-		CurrentRevision("1").UpdateRevision("2").Obj()
-	// Old revision during a rollout, so it is eligible to be ungated, and its
-	// queue is the one the sync has to correct first.
-	pod := testingjobspod.MakePod("pod1", "ns").
-		GroupNameLabel(GetWorkloadName("sts-uid", "sts")).
-		Queue("old-lq").
-		Label(appsv1.ControllerRevisionHashLabelKey, "1").
-		Gate(podconstants.SchedulingGateName).
-		Obj()
+// A nil field is not asserted.
+type wantPodState struct {
+	gated *bool
+	queue *string
+}
 
-	wantErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, pod.Name, nil)
-	builder := utiltesting.NewClientBuilder().WithObjects(sts, pod).WithStatusSubresource(sts)
-	indexer := utiltesting.AsIndexer(builder)
-	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
-		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
-	}
-	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
-		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-			// Only the queue write, so an ungate that ran first would go through.
-			if p, ok := obj.(*corev1.Pod); ok && p.Labels[controllerconstants.QueueLabel] == "lq" {
-				return wantErr
-			}
-			return c.Patch(ctx, obj, patch, opts...)
+// The queue label and the ungate are two writes to one Pod, and the Workload is
+// a third object on its own branch. A failure has to stop at whichever of the
+// three it belongs to.
+func TestReconcileWhenAWriteFails(t *testing.T) {
+	group := GetWorkloadName("sts-uid", "sts")
+	errQueue := apierrors.NewConflict(corev1.Resource("pods"), "pod1", errors.New("conflict"))
+	errConflicting := apierrors.NewConflict(corev1.Resource("pods"), "conflicting", errors.New("conflict"))
+	errWorkload := apierrors.NewForbidden(schema.GroupResource{Resource: "workloads"}, "wl", errors.New("denied by a webhook"))
+
+	cases := map[string]struct {
+		statefulSet       *appsv1.StatefulSet
+		pods              []corev1.Pod
+		workloads         []kueue.Workload
+		interceptors      interceptor.Funcs
+		wantErrs          []error
+		wantPods          map[string]wantPodState
+		wantWorkloadQueue kueue.LocalQueueName
+		wantWorkloadCount int
+	}{
+		"the Workload is created even though the queue label never lands": {
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").Queue("lq").CurrentRevision("1").UpdateRevision("1").Obj(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").GroupNameLabel(group).
+					Label(appsv1.ControllerRevisionHashLabelKey, "1").
+					Gate(podconstants.SchedulingGateName).KueueFinalizer().Obj(),
+			},
+			interceptors:      refusingQueueLabelPatch("lq", errQueue),
+			wantErrs:          []error{errQueue},
+			wantWorkloadQueue: "lq",
 		},
-	}).Build()
+		"an existing Workload is updated even though the queue label never lands": {
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").Queue("lq").CurrentRevision("1").UpdateRevision("1").Obj(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").GroupNameLabel(group).Queue("old-lq").
+					Label(appsv1.ControllerRevisionHashLabelKey, "1").
+					Gate(podconstants.SchedulingGateName).KueueFinalizer().Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(group, "ns").Queue("old-lq").
+					OwnerReference(gvk, "sts", "sts-uid").Obj(),
+			},
+			interceptors:      refusingQueueLabelPatch("lq", errQueue),
+			wantErrs:          []error{errQueue},
+			wantWorkloadQueue: "lq",
+		},
+		"one Pod's failure leaves the other Pods alone": {
+			// Mid-rollout, so a Pod on the current revision is one the reconcile ungates.
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").Replicas(2).Queue("lq").CurrentRevision("1").UpdateRevision("2").Obj(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("conflicting", "ns").GroupNameLabel(group).Queue("old-lq").Obj(),
+				// Already carrying the queue, so the ungate is its only write left.
+				*testingjobspod.MakePod("unrelated", "ns").GroupNameLabel(group).Queue("lq").
+					Label(appsv1.ControllerRevisionHashLabelKey, "1").
+					Gate(podconstants.SchedulingGateName).Obj(),
+			},
+			interceptors:      refusingPatchOf("conflicting", errConflicting),
+			wantErrs:          []error{errConflicting},
+			wantPods:          map[string]wantPodState{"unrelated": {gated: new(false)}},
+			wantWorkloadCount: 1,
+		},
+		"neither branch hides the other's failure": {
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").Replicas(1).Queue("lq").Obj(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod", "ns").GroupNameLabel(group).Queue("old-lq").Obj(),
+			},
+			interceptors: refusingBothBranches(errQueue, errWorkload),
+			wantErrs:     []error{errQueue, errWorkload},
+		},
+		"a Pod whose queue never lands stays gated": {
+			statefulSet: statefulsettesting.MakeStatefulSet("sts", "ns").
+				UID("sts-uid").Replicas(1).Queue("lq").CurrentRevision("1").UpdateRevision("2").Obj(),
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", "ns").GroupNameLabel(group).Queue("old-lq").
+					Label(appsv1.ControllerRevisionHashLabelKey, "1").
+					Gate(podconstants.SchedulingGateName).Obj(),
+			},
+			interceptors: refusingQueueLabelPatch("lq", errQueue),
+			wantErrs:     []error{errQueue},
+			wantPods: map[string]wantPodState{
+				"pod1": {gated: new(true), queue: new("old-lq")},
+			},
+		},
+	}
 
-	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
-	if err != nil {
-		t.Fatalf("NewReconciler() error: %v", err)
-	}
-	if _, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}}); !apierrors.IsConflict(err) {
-		t.Errorf("Reconcile() error = %v, want the queue conflict", err)
-	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			objs := []client.Object{tc.statefulSet, utiltestingapi.MakeWorkloadPriorityClass("wpc").PriorityValue(100).Obj()}
+			for i := range tc.pods {
+				objs = append(objs, &tc.pods[i])
+			}
+			for i := range tc.workloads {
+				objs = append(objs, &tc.workloads[i])
+			}
+			builder := utiltesting.NewClientBuilder().
+				WithObjects(objs...).
+				WithStatusSubresource(tc.statefulSet).
+				WithInterceptorFuncs(tc.interceptors)
+			indexer := utiltesting.AsIndexer(builder)
+			if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+				t.Fatalf("Indexing the pod group name: %v", err)
+			}
+			kClient := builder.Build()
 
-	var got corev1.Pod
-	if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "pod1"}, &got); err != nil {
-		t.Fatalf("failed to get the Pod: %v", err)
-	}
-	if len(got.Spec.SchedulingGates) == 0 {
-		t.Error("the Pod was ungated even though its queue never landed")
-	}
-	if q := got.Labels[controllerconstants.QueueLabel]; q != "old-lq" {
-		t.Errorf("Pod queue = %q, want it left at old-lq", q)
+			reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+			if err != nil {
+				t.Fatalf("Creating the reconciler: %v", err)
+			}
+			_, gotErr := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tc.statefulSet)})
+			for _, want := range tc.wantErrs {
+				if !errors.Is(gotErr, want) {
+					t.Errorf("Reconcile() error = %v, want it to carry %v", gotErr, want)
+				}
+			}
+
+			for podName, want := range tc.wantPods {
+				got := &corev1.Pod{}
+				if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: podName}, got); err != nil {
+					t.Fatalf("Getting Pod %s: %v", podName, err)
+				}
+				if want.gated != nil {
+					if gated := len(got.Spec.SchedulingGates) > 0; gated != *want.gated {
+						t.Errorf("%s gated = %v, want %v", podName, gated, *want.gated)
+					}
+				}
+				if want.queue != nil {
+					if q := got.Labels[controllerconstants.QueueLabel]; q != *want.queue {
+						t.Errorf("%s queue = %q, want %q", podName, q, *want.queue)
+					}
+				}
+			}
+
+			if tc.wantWorkloadQueue != "" {
+				got := &kueue.Workload{}
+				if err := kClient.Get(ctx, types.NamespacedName{Namespace: "ns", Name: group}, got); err != nil {
+					t.Fatalf("Getting the Workload: %v", err)
+				}
+				if got.Spec.QueueName != tc.wantWorkloadQueue {
+					t.Errorf("Workload queue = %q, want %q", got.Spec.QueueName, tc.wantWorkloadQueue)
+				}
+			}
+			if tc.wantWorkloadCount > 0 {
+				var wls kueue.WorkloadList
+				if err := kClient.List(ctx, &wls, client.InNamespace("ns")); err != nil {
+					t.Fatalf("Listing the Workloads: %v", err)
+				}
+				if len(wls.Items) != tc.wantWorkloadCount {
+					t.Errorf("got %d Workloads, want %d", len(wls.Items), tc.wantWorkloadCount)
+				}
+			}
+		})
 	}
 }

--- a/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
+++ b/pkg/controller/jobs/statefulset/statefulset_reconciler_test.go
@@ -1180,3 +1180,49 @@ func TestReconcilePodFailureLeavesTheOtherPodsAlone(t *testing.T) {
 		t.Errorf("got %d Workloads, want the Workload branch to still finish", len(wls.Items))
 	}
 }
+
+// Wait hands back whichever error arrives first, so a failure on one branch
+// used to hide the other on every retry.
+func TestReconcileReportsBothBranchFailures(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	group := GetWorkloadName("sts-uid", "sts")
+	sts := statefulsettesting.MakeStatefulSet("sts", "ns").UID("sts-uid").Replicas(1).Queue("lq").Obj()
+	pod := testingjobspod.MakePod("pod", "ns").GroupNameLabel(group).Queue("old-lq").Obj()
+
+	// Held by value: apierrors.IsForbidden and friends run errors.As against the
+	// APIStatus interface, which stops at whichever error the join holds first.
+	wantPodErr := apierrors.NewConflict(schema.GroupResource{Resource: "pods"}, "pod", nil)
+	wantWorkloadErr := apierrors.NewForbidden(schema.GroupResource{Resource: "workloads"}, "wl", errors.New("denied by a webhook"))
+
+	builder := utiltesting.NewClientBuilder().WithObjects(sts, pod).WithStatusSubresource(sts)
+	indexer := utiltesting.AsIndexer(builder)
+	if err := indexer.IndexField(ctx, &corev1.Pod{}, podcontroller.PodGroupNameCacheKey, podcontroller.IndexPodGroupName); err != nil {
+		t.Fatalf("Could not add index for %s field name", podcontroller.PodGroupNameCacheKey)
+	}
+	kClient := builder.WithInterceptorFuncs(interceptor.Funcs{
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			if _, ok := obj.(*corev1.Pod); ok {
+				return wantPodErr
+			}
+			return c.Patch(ctx, obj, patch, opts...)
+		},
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*kueue.Workload); ok {
+				return wantWorkloadErr
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	}).Build()
+
+	reconciler, err := NewReconciler(ctx, kClient, indexer, &utiltesting.EventRecorder{})
+	if err != nil {
+		t.Fatalf("NewReconciler() error: %v", err)
+	}
+	_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "sts"}})
+	if !errors.Is(err, wantPodErr) {
+		t.Errorf("Reconcile() lost the Pod conflict: %v", err)
+	}
+	if !errors.Is(err, wantWorkloadErr) {
+		t.Errorf("Reconcile() lost the Workload refusal: %v", err)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The StatefulSet reconcile synchronizes the queue label on the Pods before it starts anything else, and returns if that fails:

```go
if err := r.syncQueueLabel(ctx, sts, podList.Items); err != nil {
	return ctrl.Result{}, err
}

var eg errgroup.Group
eg.Go(func() error { return r.finalizePods(ctx, sts, podList.Items) })
eg.Go(func() error { return r.reconcileWorkload(ctx, sts) })
```

So a Pod patch that cannot be applied, a conflict being the ordinary one, keeps `reconcileWorkload` from starting at all. The Workload it would create or update is a different object and had no part in that failure. Returning the error does requeue the request, so this is not a wait for an unrelated event, but every retry fails in the same place before the Workload is reached, so the Workload stays behind for as long as the patch keeps failing.

The sync moves into the branch that already patches those Pods, and follows each Pod rather than the whole set: a Pod's label is written, then that same Pod is finalized. Both writes touch one object, so keeping them in order on one goroutine avoids two concurrent patches to it, while a Pod whose label cannot be written no longer holds up the Pods beside it, and the Workload branch waits on none of them.

#### Which issue(s) this PR fixes:

Fixes #14013

#### Special notes for your reviewer:

Stacked on #13921, which changes the same statement from `errgroup.WithContext` to a plain `errgroup.Group`. Five commits belong to this PR: the first moves the queue label sync onto the Pod branch, the second hands the Workload branch its own copy of the StatefulSet so a later write there cannot race the reads on the Pod side, the third says which branch an error came from, the fourth orders the two Pod writes per Pod rather than per phase, and the fifth pins that neither branch's error hides the other. I will mark it ready once #13921 merges.

The two are separate defects on the same lines. #13921 stops a failing branch from cancelling its sibling; this one stops a failure before the group from keeping a branch out of it.

The regression test puts a Pod with no queue label under the StatefulSet, so the sync has a patch to make, and fails that patch through an interceptor. It then asserts the Workload exists. Mutation-checked: with the call moved back out of the branch the case fails with `the queue label patch failed and the Workload branch never ran`.

Four things I checked before proposing this, since they are the questions I would ask.

What this does not cover. `findWorkloadName` and the Pod list still run before the branches, so a failure in either still keeps `reconcileWorkload` from starting, for the same reason the queue-label sync used to. `reconcileWorkload` looks the name up again itself and never reads the list, so moving both inside the Pod branch would finish the job. I left that out to keep this to the reported failure, and I am happy to send it separately.

One thing worth knowing before a rebase. The Workload branch now takes its own snapshot, so #13675's `syncReplicas`, which writes `sts.Spec.Replicas` from inside `reconcileWorkload`, has somewhere to write that the Pod side is not reading.

The branches stay independent. `reconcileWorkload` takes only the StatefulSet: it reads the queue name from `QueueNameForObject(sts)` and Gets the Workload by name, and never looks at `podList` or at the labels the sync writes. It also only reads the StatefulSet, so nothing is written on one side while the other reads it. Both branch errors are now held and joined rather than left to `Wait`, which keeps whichever one reaches it first. One thing to know about the joined error: `IsConflict` and `IsForbidden` run `errors.As` against the `APIStatus` interface, and `As` stops at the first error in the join that satisfies it, so only one of them can be true at a time. `errors.Is` against a specific error still finds either, which is what the new test asserts.

The Pods are the shared mutable state. The sync and the ungating are paired on each Pod, so the label lands before that Pod is ungated without the whole slice waiting on the slowest or the most broken one. `TestReconcilePodFailureLeavesTheOtherPodsAlone` pins it: a conflicting label patch on one Pod still leaves a terminated Pod finalized and the Workload created, and restoring the whole-slice barrier fails it. `go test -race -count=5 ./pkg/controller/jobs/statefulset/...` is clean.

LeaderWorkerSet does not have the same defect, which is why this only touches StatefulSet even though #13921 touched both. Its three branches act on disjoint sets of Workloads, nothing patches Pods before the group, and its queue name is applied inside `updateWorkload` on the Workload spec rather than on Pods.

The error the reconcile returns can now come from either branch, where a queue label failure used to be the returned error by construction. That is why both are held and joined rather than left to `Wait`, which keeps only whichever arrived first. Within the Pod branch the aggregation is coarser: `parallelize.Until` attempts every Pod but its error channel holds one, so a second Pod's failure is retried without being named in the log.

The coverage is at unit level on purpose. What this fixes is triggered by a Pod patch failing, a conflict being the ordinary cause, and forcing one in envtest would mean racing the reconcile against another writer. The interceptor makes that deterministic. Happy to add an integration case if you would rather see it there.

`go test ./pkg/...`, `go test -race -count=5` on the changed package, and `make ci-lint` are green.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a StatefulSet whose Pod queue-label patch fails, for example on a conflict, leaving its Workload uncreated or unupdated for as long as the patch keeps failing, because the label synchronization ran before the Workload reconcile rather than beside it.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved StatefulSet reconciliation so workload updates and individual Pod processing can continue independently.
  * Ensured one Pod’s queue-label synchronization failure does not block unrelated Pods or workload creation and updates.
  * Preserved queue assignment when synchronization fails, keeping affected Pods safely gated.
  * Improved error reporting when multiple reconciliation operations encounter issues simultaneously.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->