### PR TITLE
feat: validate WorkloadPriorityClass exists on job create

### DIFF
--- a/pkg/controller/jobframework/base_webhook.go
+++ b/pkg/controller/jobframework/base_webhook.go
@@ -91,6 +91,7 @@ func (w *BaseWebhook[T]) ValidateCreate(ctx context.Context, obj T) (admission.W
 	log := ctrl.LoggerFrom(ctx)
 	log.V(5).Info("Validating create")
 	allErrs := ValidateJobOnCreate(job)
+	allErrs = append(allErrs, validateCreateForWorkloadPriorityClassName(ctx, w.Client, job)...)
 	if jobWithValidation, ok := job.(JobWithCustomValidation); ok {
 		validationErrs, err := jobWithValidation.ValidateOnCreate(ctx)
 		if err != nil {

--- a/pkg/controller/jobframework/base_webhook_test.go
+++ b/pkg/controller/jobframework/base_webhook_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jobframework_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -30,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -239,8 +242,10 @@ func TestValidateOnCreate(t *testing.T) {
 		customValidationFailure field.ErrorList
 		customValidationError   error
 
-		wantError   error
-		wantWarning admission.Warnings // Note: ValidateCreate always returns nil for admission.Warning.
+		objects           []client.Object
+		clientInterceptor interceptor.Funcs
+		wantError         error
+		wantWarning       admission.Warnings // Note: ValidateCreate always returns nil for admission.Warning.
 	}{
 		{
 			name: "valid request",
@@ -269,6 +274,51 @@ func TestValidateOnCreate(t *testing.T) {
 			// different error types. This simplifies the assertion logic.
 			wantError: field.InternalError(nil, errors.New("test-custom-validation-error")),
 		},
+		{
+			name: "invalid workloadpriorityclass",
+			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+				Label(constants.QueueLabel, "queue").
+				Label(constants.WorkloadPriorityClassLabel, "nonexist").Obj(),
+			wantError: field.ErrorList{
+				field.Invalid(
+					field.NewPath("metadata.labels[kueue.x-k8s.io/priority-class]"),
+					"nonexist",
+					`no WorkloadPriorityClass with name "nonexist" was found`,
+				),
+			}.ToAggregate(),
+		},
+		{
+			name: "valid workloadpriorityclass",
+			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+				Label(constants.QueueLabel, "queue").
+				Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+			objects: []client.Object{
+				utiltestingapi.MakeWorkloadPriorityClass("test-wpc").PriorityValue(100).Obj(),
+			},
+		},
+		{
+			// Transient apiserver errors (timeouts, connection resets) must
+			// surface as InternalError so admission returns 500 and the
+			// client retries, rather than a permanent Invalid rejection.
+			name: "workloadpriorityclass get returns internal error",
+			job: utiljob.MakeJob("job", metav1.NamespaceDefault).
+				Label(constants.QueueLabel, "queue").
+				Label(constants.WorkloadPriorityClassLabel, "test-wpc").Obj(),
+			clientInterceptor: interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*kueue.WorkloadPriorityClass); ok {
+						return errors.New("boom")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantError: field.ErrorList{
+				field.InternalError(
+					field.NewPath("metadata.labels[kueue.x-k8s.io/priority-class]"),
+					errors.New("boom"),
+				),
+			}.ToAggregate(),
+		},
 	}
 
 	for _, tc := range testcases {
@@ -291,6 +341,10 @@ func TestValidateOnCreate(t *testing.T) {
 			job.MockJobWithCustomValidation.EXPECT().ValidateOnCreate(gomock.Any()).Return(tc.customValidationFailure, tc.customValidationError).AnyTimes()
 
 			w := &jobframework.BaseWebhook[*mockJob]{
+				Client: interceptor.NewClient(
+					utiltesting.NewClientBuilder().WithObjects(tc.objects...).Build(),
+					tc.clientInterceptor,
+				),
 				FromObject: func(object *mockJob) jobframework.GenericJob {
 					return object
 				},

--- a/pkg/controller/jobframework/validation.go
+++ b/pkg/controller/jobframework/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package jobframework
 
 import (
+	"context"
 	"fmt"
 	"maps"
 	"slices"
@@ -30,14 +31,17 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	jobset "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
@@ -283,6 +287,23 @@ func validateImmutablePodGroupPodSpecPath(newShape, oldShape map[string]any, fie
 	}
 
 	return allErrs
+}
+
+func validateCreateForWorkloadPriorityClassName(ctx context.Context, c client.Client, job GenericJob) field.ErrorList {
+	name := WorkloadPriorityClassName(job.Object())
+	if name == "" {
+		return nil
+	}
+
+	wpc := &kueue.WorkloadPriorityClass{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, wpc); err != nil {
+		if apierrors.IsNotFound(err) {
+			msg := fmt.Sprintf("no WorkloadPriorityClass with name %q was found", name)
+			return field.ErrorList{field.Invalid(workloadPriorityClassNamePath, name, msg)}
+		}
+		return field.ErrorList{field.InternalError(workloadPriorityClassNamePath, err)}
+	}
+	return nil
 }
 
 func IsWorkloadPriorityClassNameEmpty(obj client.Object) bool {


### PR DESCRIPTION
Reject Job creation when the kueue.x-k8s.io/priority-class label references a WorkloadPriorityClass that does not exist, surfacing the error at admission time instead of leaving the workload silently suspended.


#### What type of PR is this?

/kind feature

Please also consider setting the area:
/area webhook

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- When a non-existent WorkloadPriorityClass or PriorityClass is specified for a job, the creation of the job will be denied
```

related 
- https://github.com/kubernetes-sigs/kueue/pull/6688
- https://github.com/kubernetes-sigs/kueue/pull/13645



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workload priority class references are now validated when creating workloads.
  - Clear validation errors are shown when the referenced priority class is missing.
  - Temporary lookup failures are reported appropriately instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->