### PR TITLE
Fix fair preemption after handling preemptor's CQ.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -574,6 +574,17 @@ const (
 	// validate an update if manageJobsWithoutQueueName is set or the new object carries a
 	// queue-name label.
 	ValidateRayAndSparkJobUpdates featuregate.Feature = "ValidateRayAndSparkJobUpdates"
+
+	// owner: @lightZebra
+	//
+	// pr: https://github.com/kubernetes-sigs/kueue/pull/14128
+	// Runs the first strategy again for fair preemption algorithm if DRS was decreased
+	// during processing. This allows to preempt more workloads if first run missed some
+	// candidates because of previously high DRS, preemptions are still fair.
+	//
+	// Note: This feature can be promoted to "beta" once https://github.com/kubernetes-sigs/kueue/issues/14543
+	// is fixed because it might boost chances for issue #14543 to appear.
+	FairSharingReevaluatePreemptionCandidates featuregate.Feature = "FairSharingReevaluatePreemptionCandidates"
 )
 
 func init() {
@@ -890,6 +901,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	ValidateRayAndSparkJobUpdates: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta}, // GA in 0.21
+	},
+
+	FairSharingReevaluatePreemptionCandidates: {
+		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -557,6 +557,19 @@ func (p *Preemptor) fairPreemptions(preemptionCtx *preemptionCtx, strategies []f
 	revertSimulation := preemptionCtx.preemptorCQ.SimulateUsageAddition(preemptionCtx.workloadUsage)
 
 	fits, targets, retryCandidates := runFirstFsStrategy(preemptionCtx, candidates, strategies[0])
+
+	if !fits && containsWorkloadFromPreemptorCQ(preemptionCtx, targets) {
+		// If "targets" contains workload from the same CQ as the preemptor, it means
+		// that DRS of the preemptor was decreased during the first run, and we can run
+		// the same strategy again with remaining candidates as they have chance to
+		// succeed now.
+		// No need to run the strategy a third time as first run already iterated
+		// though whole tree and removed all the preemptor's workloads.
+		var additionalTargets []*Target
+		fits, additionalTargets, retryCandidates = runFirstFsStrategy(preemptionCtx, retryCandidates, strategies[0])
+		targets = append(targets, additionalTargets...)
+	}
+
 	if !fits && len(strategies) > 1 {
 		if logV := preemptionCtx.log.V(6); logV.Enabled() {
 			logV.Info("First fair sharing strategy failed, trying second strategy",
@@ -586,6 +599,15 @@ func (p *Preemptor) fairPreemptions(preemptionCtx *preemptionCtx, strategies []f
 			"targets", logging.GetObjectReferences(targets))
 	}
 	return targets
+}
+
+func containsWorkloadFromPreemptorCQ(preemptionCtx *preemptionCtx, targets []*Target) bool {
+	for _, t := range targets {
+		if t.WorkloadInfo.ClusterQueue == preemptionCtx.preemptorCQ.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func flavorResourcesNeedPreemption(assignment flavorassigner.Assignment) sets.Set[resources.FlavorResource] {

--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -558,16 +558,18 @@ func (p *Preemptor) fairPreemptions(preemptionCtx *preemptionCtx, strategies []f
 
 	fits, targets, retryCandidates := runFirstFsStrategy(preemptionCtx, candidates, strategies[0])
 
-	if !fits && containsWorkloadFromPreemptorCQ(preemptionCtx, targets) {
-		// If "targets" contains workload from the same CQ as the preemptor, it means
-		// that DRS of the preemptor was decreased during the first run, and we can run
-		// the same strategy again with remaining candidates as they have chance to
-		// succeed now.
-		// No need to run the strategy a third time as first run already iterated
-		// though whole tree and removed all the preemptor's workloads.
-		var additionalTargets []*Target
-		fits, additionalTargets, retryCandidates = runFirstFsStrategy(preemptionCtx, retryCandidates, strategies[0])
-		targets = append(targets, additionalTargets...)
+	if features.Enabled(features.FairSharingReevaluatePreemptionCandidates) {
+		if !fits && containsWorkloadFromPreemptorCQ(preemptionCtx, targets) {
+			// If "targets" contains workload from the same CQ as the preemptor, it means
+			// that DRS of the preemptor was decreased during the first run, and we can run
+			// the same strategy again with remaining candidates as they have chance to
+			// succeed now.
+			// No need to run the strategy a third time as first run already iterated
+			// though whole tree and removed all the preemptor's workloads.
+			var additionalTargets []*Target
+			fits, additionalTargets, retryCandidates = runFirstFsStrategy(preemptionCtx, retryCandidates, strategies[0])
+			targets = append(targets, additionalTargets...)
+		}
 	}
 
 	if !fits && len(strategies) > 1 {

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -1159,6 +1159,7 @@ func TestFairPreemptions(t *testing.T) {
 						Resource(corev1.ResourceCPU, "0").Obj()).
 					Obj(),
 			},
+			strategies: []config.PreemptionStrategy{config.LessThanOrEqualToFinalShare},
 			admitted: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("left-a", "default", now).Obj(),
 				*utiltestingapi.MakeWorkload("a2", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("left-a", "default", now).Obj(),
@@ -1173,6 +1174,16 @@ func TestFairPreemptions(t *testing.T) {
 			},
 			incoming: utiltestingapi.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "10").Obj(),
 			targetCQ: "left-a",
+			// Detailed scenario:
+			// * Workloads from CQs "right-b" and "right-c" are processed first because of fairWeights.
+			// * Initially workloads from "right" cohort doesn't satisfy the strategy because
+			//   DRS of preemptor's is large (because of fairWright).
+			// * The fair preemption algorithm removes workloads from preemptor's CQ "left-a" without
+			//   considering the strategy (because they are from the same CQ), so preemptor's DRS decreases.
+			//   (preempted: a1, a2, a3)
+			// * Now, workloads from CQs "right-b" and "right-c" satisfy the fairness condition by the strategy.
+			// * Workloads from the "right-b" CQ are preempted because they had larger DRS than workloads from "right-c" CQ.
+			//   (preempted: b1, b2)
 			wantPreempted: sets.New(
 				targetKeyReason("/a1", kueue.InClusterQueueReason),
 				targetKeyReason("/a2", kueue.InClusterQueueReason),

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -1107,6 +1107,80 @@ func TestFairPreemptions(t *testing.T) {
 				targetKeyReason("/x1", kueue.InCohortFairSharingReason),
 			),
 		},
+		// The case when workloads from preemptor's CQ have lower priority, so all the other
+		// workloads are processed first, but none are considered fair by DPS.
+		// Later, once the preemptor's workloads are preempted, now workloads from
+		// other CQs are considered fair to be preempted by DPS.
+		"can admit after preempting workloads from the preemptor's CQ with lower processing priority": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("left-a").
+					Cohort("left").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyAny,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("right-b").
+					Cohort("right").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyAny,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("right-c").
+					Cohort("right").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyAny,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+			},
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("root").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "15").Obj()).
+					Obj(),
+				utiltestingapi.MakeCohort("left").
+					Parent("root").
+					FairWeight(resource.MustParse("20")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+				utiltestingapi.MakeCohort("right").
+					Parent("root").
+					FairWeight(resource.MustParse("10")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("a1", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("left-a", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("a2", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("left-a", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("a3", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("left-a", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b1", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b2", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b3", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b4", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b5", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("b6", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-b", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("c1", "").Request(corev1.ResourceCPU, "1").SimpleReserveQuota("right-c", "default", now).Obj(),
+			},
+			incoming: utiltestingapi.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "10").Obj(),
+			targetCQ: "left-a",
+			wantPreempted: sets.New(
+				targetKeyReason("/a1", kueue.InClusterQueueReason),
+				targetKeyReason("/a2", kueue.InClusterQueueReason),
+				targetKeyReason("/a3", kueue.InClusterQueueReason),
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/b2", kueue.InCohortFairSharingReason),
+			),
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -28,12 +28,14 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/component-base/featuregate"
 	clocktesting "k8s.io/utils/clock/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	utilslices "sigs.k8s.io/kueue/pkg/util/slices"
@@ -104,6 +106,7 @@ func TestFairPreemptions(t *testing.T) {
 		incoming         *kueue.Workload
 		targetCQ         kueue.ClusterQueueReference
 		wantPreempted    sets.Set[string]
+		featureGates     map[featuregate.Feature]bool
 	}{
 		"reclaim nominal from user using the most": {
 			clusterQueues: baseCQs,
@@ -1191,10 +1194,13 @@ func TestFairPreemptions(t *testing.T) {
 				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
 				targetKeyReason("/b2", kueue.InCohortFairSharingReason),
 			),
+			featureGates: map[featuregate.Feature]bool{features.FairSharingReevaluatePreemptionCandidates: true},
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			ctx, log := utiltesting.ContextWithLog(t)
 			// Set name as UID so that candidates sorting is predictable.
 			for i := range tc.admitted {

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -1108,9 +1108,9 @@ func TestFairPreemptions(t *testing.T) {
 			),
 		},
 		// The case when workloads from preemptor's CQ have lower priority, so all the other
-		// workloads are processed first, but none are considered fair by DPS.
+		// workloads are processed first, but none are considered fair by DRS.
 		// Later, once the preemptor's workloads are preempted, now workloads from
-		// other CQs are considered fair to be preempted by DPS.
+		// other CQs are considered fair to be preempted by DRS.
 		"can admit after preempting workloads from the preemptor's CQ with lower processing priority": {
 			clusterQueues: []*kueue.ClusterQueue{
 				utiltestingapi.MakeClusterQueue("left-a").

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -91,6 +91,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: FairSharingReevaluatePreemptionCandidates
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: FastQuotaReleaseInPodIntegration
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -91,6 +91,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.17"
+- name: FairSharingReevaluatePreemptionCandidates
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: FastQuotaReleaseInPodIntegration
   versionedSpecs:
   - default: false


### PR DESCRIPTION
Preempting workloads from the preemptor's CQ decreases its DRS, which can allow remaining candidates from other CQs to become eligible for fair preemption. Rerun the fair sharing strategy over retry candidates if the first pass did not fit and preempted workloads from the preemptor's CQ.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

The case was described in the issue #14122, most important part:
> There is a case when first strategy(runFirstFsStrategy) went though all the candidates and didn't find any good/fair candidates for the preemption and later it reached preemptor's CQ and removed all(or lower priority) workloads from there and exited. At this point preemptors DRS actually decreased and potentially some workloads from other CQs might be possible/fair to preempt now, but the algorithm is going to the second strategy which might not preempt the best candidates or might not find enough targets to fit incoming workload(but first strategy would find).

This PR improves the algorithm for the case described above. Now, the algorithm will be able to find fair preemption for the case when previously it would result in either no preemption or less optimal preemption targets.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14122

#### Special notes for your reviewer: 

None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
FairSharing: Fix a bug where Kueue could miss valid preemption targets after selecting workloads from the preemptor's own ClusterQueue and lowering its DRS. The fix is guarded by the Alpha `FairSharingReevaluatePreemptionCandidates` feature gate, which is disabled by default. Enabling the gate may increase exposure to the known fair-sharing preemption-loop issue tracked in #14543.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in feature gate for reevaluating fair-sharing preemption candidates.

* **Bug Fixes**
  * Improved fair-sharing preemption to identify additional eligible workloads when initial targets include workloads from the preemptor’s own cluster queue.
  * Enabled combining targets from the same cluster queue and other cohort queues when admitting higher-priority workloads.

* **Tests**
  * Added coverage for hierarchical and mixed in-cluster/cross-cohort preemption scenarios, including validation of reported preemption reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->