### PR TITLE
Fix LocalQueue status after ClusterQueue deletion

### DIFF
--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -1038,16 +1038,23 @@ type LocalQueueUsageStats struct {
 }
 
 func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, error) {
+	usage, _, err := c.LocalQueueUsageAndClusterQueueExists(qObj)
+	return usage, err
+}
+
+// LocalQueueUsageAndClusterQueueExists returns the LocalQueue usage and whether
+// its referenced ClusterQueue exists in the cache from the same cache snapshot.
+func (c *Cache) LocalQueueUsageAndClusterQueueExists(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, bool, error) {
 	c.RLock()
 	defer c.RUnlock()
 
 	cqImpl := c.hm.ClusterQueue(qObj.Spec.ClusterQueue)
 	if cqImpl == nil {
-		return &LocalQueueUsageStats{}, nil
+		return &LocalQueueUsageStats{}, false, nil
 	}
 	qImpl, ok := cqImpl.localQueues[queueKey(qObj)]
 	if !ok {
-		return nil, errQNotFound
+		return nil, true, errQNotFound
 	}
 
 	return &LocalQueueUsageStats{
@@ -1055,7 +1062,7 @@ func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, 
 		ReservingWorkloads: qImpl.reservingWorkloads,
 		AdmittedResources:  c.filterLocalQueueUsage(qImpl.admittedUsage, cqImpl.ResourceGroups),
 		AdmittedWorkloads:  qImpl.admittedWorkloads,
-	}, nil
+	}, true, nil
 }
 
 func handleTASFlavor(rf *kueue.ResourceFlavor) bool {

--- a/pkg/cache/scheduler/cache.go
+++ b/pkg/cache/scheduler/cache.go
@@ -1037,14 +1037,10 @@ type LocalQueueUsageStats struct {
 	AdmittedWorkloads  int
 }
 
-func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, error) {
-	usage, _, err := c.LocalQueueUsageAndClusterQueueExists(qObj)
-	return usage, err
-}
-
-// LocalQueueUsageAndClusterQueueExists returns the LocalQueue usage and whether
-// its referenced ClusterQueue exists in the cache from the same cache snapshot.
-func (c *Cache) LocalQueueUsageAndClusterQueueExists(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, bool, error) {
+// LocalQueueUsage returns the LocalQueue usage and whether its referenced
+// ClusterQueue exists, both read from the same cache snapshot so callers can
+// rely on the two being consistent.
+func (c *Cache) LocalQueueUsage(qObj *kueue.LocalQueue) (*LocalQueueUsageStats, bool, error) {
 	c.RLock()
 	defer c.RUnlock()
 

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -2137,9 +2137,19 @@ func TestLocalQueueUsage(t *testing.T) {
 					t.Fatalf("Workload %s was not added", workload.Key(&w))
 				}
 			}
-			gotUsage, err := cache.LocalQueueUsage(&localQueue)
+			gotUsage, clusterQueueExists, err := cache.LocalQueueUsageAndClusterQueueExists(&localQueue)
 			if err != nil {
 				t.Fatalf("Couldn't get usage for the queue: %v", err)
+			}
+			if wantClusterQueueExists := tc.cq != nil; clusterQueueExists != wantClusterQueueExists {
+				t.Errorf("ClusterQueue exists = %t, want %t", clusterQueueExists, wantClusterQueueExists)
+			}
+			legacyUsage, err := cache.LocalQueueUsage(&localQueue)
+			if err != nil {
+				t.Fatalf("Couldn't get usage through the legacy API: %v", err)
+			}
+			if diff := cmp.Diff(gotUsage, legacyUsage); diff != "" {
+				t.Errorf("LocalQueueUsage changed (-atomic/+legacy):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantUsage, gotUsage.ReservedResources); diff != "" {
 				t.Errorf("Unexpected used resources for the queue (-want,+got):\n%s", diff)

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -2137,19 +2137,12 @@ func TestLocalQueueUsage(t *testing.T) {
 					t.Fatalf("Workload %s was not added", workload.Key(&w))
 				}
 			}
-			gotUsage, clusterQueueExists, err := cache.LocalQueueUsageAndClusterQueueExists(&localQueue)
+			gotUsage, clusterQueueExists, err := cache.LocalQueueUsage(&localQueue)
 			if err != nil {
 				t.Fatalf("Couldn't get usage for the queue: %v", err)
 			}
 			if wantClusterQueueExists := tc.cq != nil; clusterQueueExists != wantClusterQueueExists {
 				t.Errorf("ClusterQueue exists = %t, want %t", clusterQueueExists, wantClusterQueueExists)
-			}
-			legacyUsage, err := cache.LocalQueueUsage(&localQueue)
-			if err != nil {
-				t.Fatalf("Couldn't get usage through the legacy API: %v", err)
-			}
-			if diff := cmp.Diff(gotUsage, legacyUsage); diff != "" {
-				t.Errorf("LocalQueueUsage changed (-atomic/+legacy):\n%s", diff)
 			}
 			if diff := cmp.Diff(tc.wantUsage, gotUsage.ReservedResources); diff != "" {
 				t.Errorf("Unexpected used resources for the queue (-want,+got):\n%s", diff)

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -1945,10 +1945,11 @@ func TestLocalQueueUsage(t *testing.T) {
 	localQueue := *utiltestingapi.MakeLocalQueue("test", "ns1").
 		ClusterQueue("foo").Obj()
 	cases := map[string]struct {
-		cq             *kueue.ClusterQueue
-		wls            []kueue.Workload
-		wantUsage      []kueue.LocalQueueFlavorUsage
-		inAdmissibleWl sets.Set[string]
+		cq                     *kueue.ClusterQueue
+		wls                    []kueue.Workload
+		wantUsage              []kueue.LocalQueueFlavorUsage
+		wantClusterQueueExists bool
+		inAdmissibleWl         sets.Set[string]
 	}{
 		"clusterQueue is missing": {
 			wls: []kueue.Workload{
@@ -1959,7 +1960,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			inAdmissibleWl: sets.New("one"),
 		},
 		"workloads is nothing": {
-			cq: &cq,
+			cq:                     &cq,
+			wantClusterQueueExists: true,
 			wantUsage: []kueue.LocalQueueFlavorUsage{
 				{
 					Name: "default",
@@ -1999,7 +2001,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			},
 		},
 		"all workloads are admitted": {
-			cq: &cq,
+			cq:                     &cq,
+			wantClusterQueueExists: true,
 			wls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("one", "ns1").
 					Queue("test").
@@ -2063,7 +2066,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			},
 		},
 		"some workloads are inadmissible": {
-			cq: &cq,
+			cq:                     &cq,
+			wantClusterQueueExists: true,
 			wls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("one", "ns1").
 					Queue("test").
@@ -2141,8 +2145,8 @@ func TestLocalQueueUsage(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Couldn't get usage for the queue: %v", err)
 			}
-			if wantClusterQueueExists := tc.cq != nil; clusterQueueExists != wantClusterQueueExists {
-				t.Errorf("ClusterQueue exists = %t, want %t", clusterQueueExists, wantClusterQueueExists)
+			if clusterQueueExists != tc.wantClusterQueueExists {
+				t.Errorf("ClusterQueue exists = %t, want %t", clusterQueueExists, tc.wantClusterQueueExists)
 			}
 			if diff := cmp.Diff(tc.wantUsage, gotUsage.ReservedResources); diff != "" {
 				t.Errorf("Unexpected used resources for the queue (-want,+got):\n%s", diff)

--- a/pkg/controller/core/core.go
+++ b/pkg/controller/core/core.go
@@ -79,7 +79,7 @@ func SetupControllers(mgr ctrl.Manager, qManager *qcache.Manager, cc *schdcache.
 	}
 
 	fairSharingEnabled := fairsharing.Enabled(cfg.FairSharing)
-	watchers := []ClusterQueueUpdateWatcher{rfRec, acRec}
+	watchers := []ClusterQueueUpdateWatcher{rfRec, acRec, qRec}
 	cohortRec := NewCohortReconciler(mgr.GetClient(), cc, qManager,
 		CohortReconcilerWithFairSharing(fairSharingEnabled),
 		CohortReconcilerWithRoleTracker(opts.RoleTracker),

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -63,9 +64,12 @@ const (
 )
 
 const (
-	StoppedReason                = "Stopped"
-	clusterQueueIsInactiveReason = "ClusterQueueIsInactive"
+	StoppedReason                  = "Stopped"
+	clusterQueueIsInactiveReason   = "ClusterQueueIsInactive"
+	clusterQueueDoesNotExistReason = "ClusterQueueDoesNotExist"
 )
+
+var errClusterQueueStillInCache = errors.New("clusterQueue still exists in scheduler cache")
 
 type LocalQueueReconcilerOptions struct {
 	admissionFSConfig *config.AdmissionFairSharing
@@ -119,6 +123,7 @@ type LocalQueueReconciler struct {
 	queues            *qcache.Manager
 	cache             *schdcache.Cache
 	wlUpdateCh        chan event.GenericEvent
+	cqUpdateCh        chan event.GenericEvent
 	admissionFSConfig *config.AdmissionFairSharing
 	clock             clock.Clock
 	roleTracker       *roletracker.RoleTracker
@@ -145,6 +150,7 @@ func NewLocalQueueReconciler(
 		cache:             cache,
 		client:            client,
 		wlUpdateCh:        make(chan event.GenericEvent, updateChBuffer),
+		cqUpdateCh:        make(chan event.GenericEvent, updateChBuffer),
 		admissionFSConfig: options.admissionFSConfig,
 		clock:             options.clock,
 		roleTracker:       options.roleTracker,
@@ -167,6 +173,12 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 	}
 	if newWl != nil {
 		r.wlUpdateCh <- event.GenericEvent{Object: newWl}
+	}
+}
+
+func (r *LocalQueueReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.ClusterQueue) {
+	if oldCQ != nil && newCQ == nil {
+		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
 	}
 }
 
@@ -199,7 +211,10 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var cq kueue.ClusterQueue
 	if err := r.client.Get(ctx, client.ObjectKey{Name: string(queueObj.Spec.ClusterQueue)}, &cq); err != nil {
 		if apierrors.IsNotFound(err) {
-			err = r.updateStatusIfChanged(ctx, &queueObj, &schdcache.LocalQueueUsageStats{}, metav1.ConditionFalse, "ClusterQueueDoesNotExist", clusterQueueIsInactiveMsg)
+			err = r.updateStatusIfChanged(ctx, &queueObj, true, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
+			if errors.Is(err, errClusterQueueStillInCache) {
+				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
+			}
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -599,7 +614,12 @@ func (h *qCQHandler) Delete(ctx context.Context, e event.DeleteEvent, wq workque
 	h.addLocalQueueToWorkQueue(ctx, cq, wq)
 }
 
-func (h *qCQHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (h *qCQHandler) Generic(ctx context.Context, e event.GenericEvent, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	cq, ok := e.Object.(*kueue.ClusterQueue)
+	if !ok {
+		return
+	}
+	h.addLocalQueueToWorkQueue(ctx, cq, wq)
 }
 
 func (h *qCQHandler) addLocalQueueToWorkQueue(ctx context.Context, cq *kueue.ClusterQueue, wq workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -636,6 +656,7 @@ func (r *LocalQueueReconciler) SetupWithManager(mgr ctrl.Manager, cfg *config.Co
 			LogConstructor:          roletracker.NewLogConstructor(r.roleTracker, "localqueue-reconciler"),
 		}).
 		WatchesRawSource(source.Channel(r.wlUpdateCh, &qWorkloadHandler{})).
+		WatchesRawSource(source.Channel(r.cqUpdateCh, &queueCQHandler)).
 		Watches(&kueue.ClusterQueue{}, &queueCQHandler).
 		Complete(WithLeadingManager(mgr, r, &kueue.LocalQueue{}, cfg))
 }
@@ -646,13 +667,13 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
-	return r.updateStatusIfChanged(ctx, queue, nil, conditionStatus, reason, msg)
+	return r.updateStatusIfChanged(ctx, queue, false, conditionStatus, reason, msg)
 }
 
 func (r *LocalQueueReconciler) updateStatusIfChanged(
 	ctx context.Context,
 	queue *kueue.LocalQueue,
-	usage *schdcache.LocalQueueUsageStats,
+	waitForClusterQueueCacheDeletion bool,
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
@@ -669,13 +690,13 @@ func (r *LocalQueueReconciler) updateStatusIfChanged(
 			return err
 		}
 	}
-	stats := usage
-	if stats == nil {
-		stats, err = r.cache.LocalQueueUsage(queue)
-		if err != nil {
-			log.Error(err, failedUpdateLqStatusMsg)
-			return err
-		}
+	stats, clusterQueueExists, err := r.cache.LocalQueueUsageAndClusterQueueExists(queue)
+	if waitForClusterQueueCacheDeletion && clusterQueueExists {
+		return errClusterQueueStillInCache
+	}
+	if err != nil {
+		log.Error(err, failedUpdateLqStatusMsg)
+		return err
 	}
 	queue.Status.PendingWorkloads = pendingWls
 	queue.Status.ReservingWorkloads = int32(stats.ReservingWorkloads)

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -178,9 +178,14 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 // ClusterQueue watch, while Delete must run again after ClusterQueueReconciler
 // removes the scheduler cache entry so LocalQueue status can publish
 // ClusterQueueDoesNotExist with zero usage from the cache.
+// The send is non-blocking so a full channel cannot stall ClusterQueue delete
+// handling or later watchers; RequeueAfter in Reconcile covers dropped notifies.
 func (r *LocalQueueReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.ClusterQueue) {
 	if oldCQ != nil && newCQ == nil {
-		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
+		select {
+		case r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}:
+		default:
+		}
 	}
 }
 
@@ -220,17 +225,13 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// publishing ClusterQueueDoesNotExist so status never mixes that
 			// reason with stale usage. NotifyClusterQueueUpdate requeues
 			// LocalQueues after cleanup; RequeueAfter is a backup if this
-			// reconcile raced ahead of the notify.
-			stats, cqInCache, cacheErr := r.cache.LocalQueueUsage(&queueObj)
-			// Presence is checked before the error because a LocalQueue
-			// missing from a still-cached ClusterQueue is the same
-			// disagreement, not a failure to report.
+			// reconcile raced ahead of the notify, or if the notify was dropped.
+			// LocalQueueUsage returns existence and usage from one snapshot;
+			// when the ClusterQueue is absent it returns empty stats and a nil
+			// error.
+			stats, cqInCache, _ := r.cache.LocalQueueUsage(&queueObj)
 			if cqInCache {
 				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
-			}
-			if cacheErr != nil {
-				log.Error(cacheErr, failedUpdateLqStatusMsg)
-				return ctrl.Result{}, cacheErr
 			}
 			err = r.applyLocalQueueStatus(ctx, &queueObj, stats, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
 		}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -176,16 +176,11 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 // NotifyClusterQueueUpdate enqueues LocalQueues after ClusterQueue cache cleanup.
 // Only delete events are forwarded: Create/Update are already covered by the
 // ClusterQueue watch. On Delete, ClusterQueueReconciler removes the scheduler
-// cache entry and then notifies so LocalQueue reconcile can publish
+// cache entry and then notifies, so LocalQueue reconcile can publish
 // ClusterQueueDoesNotExist with zero usage from the cache.
-// The send is non-blocking so a full channel cannot stall ClusterQueue delete
-// handling or later watchers; RequeueAfter in Reconcile covers dropped notifies.
 func (r *LocalQueueReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.ClusterQueue) {
 	if oldCQ != nil && newCQ == nil {
-		select {
-		case r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}:
-		default:
-		}
+		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
 	}
 }
 
@@ -218,20 +213,20 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var cq kueue.ClusterQueue
 	if err := r.client.Get(ctx, client.ObjectKey{Name: string(queueObj.Spec.ClusterQueue)}, &cq); err != nil {
 		if apierrors.IsNotFound(err) {
-			// Active comes from this API Get; usage comes from the scheduler
-			// cache. ClusterQueueReconciler deletes the cache entry
-			// asynchronously, so reconcile can observe NotFound while the
-			// cache still holds non-zero usage. Wait for cleanup before
-			// publishing ClusterQueueDoesNotExist so status never mixes that
-			// reason with stale usage. NotifyClusterQueueUpdate requeues
-			// LocalQueues after cleanup; RequeueAfter is a backup if this
-			// reconcile raced ahead of the notify, or if the notify was dropped.
-			// LocalQueueUsage returns existence and usage from one snapshot;
-			// when the ClusterQueue is absent it returns empty stats and a nil
-			// error.
-			stats, cqInCache, _ := r.cache.LocalQueueUsage(&queueObj)
+			// Active comes from this API Get, usage from the scheduler cache.
+			// ClusterQueueReconciler deletes the cache entry asynchronously, so
+			// reconcile can observe NotFound while the cache still holds
+			// non-zero usage. Wait for that cleanup instead of publishing a
+			// status that mixes ClusterQueueDoesNotExist with stale usage.
+			// NotifyClusterQueueUpdate enqueues the LocalQueues once cleanup is
+			// done; RequeueAfter backs it up if this reconcile raced ahead of
+			// the notify.
+			stats, cqInCache, usageErr := r.cache.LocalQueueUsage(&queueObj)
 			if cqInCache {
 				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
+			}
+			if usageErr != nil {
+				return ctrl.Result{}, usageErr
 			}
 			err = r.applyLocalQueueStatus(ctx, &queueObj, stats, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
 		}

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -18,7 +18,6 @@ package core
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -68,8 +67,6 @@ const (
 	clusterQueueIsInactiveReason   = "ClusterQueueIsInactive"
 	clusterQueueDoesNotExistReason = "ClusterQueueDoesNotExist"
 )
-
-var errClusterQueueStillInCache = errors.New("clusterQueue still exists in scheduler cache")
 
 type LocalQueueReconcilerOptions struct {
 	admissionFSConfig *config.AdmissionFairSharing
@@ -176,6 +173,11 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 	}
 }
 
+// NotifyClusterQueueUpdate enqueues LocalQueues after ClusterQueue cache cleanup.
+// Only delete events are forwarded: Create/Update are already covered by the
+// ClusterQueue watch, while Delete must run again after ClusterQueueReconciler
+// removes the scheduler cache entry so LocalQueue status can publish
+// ClusterQueueDoesNotExist with zero usage from the cache.
 func (r *LocalQueueReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.ClusterQueue) {
 	if oldCQ != nil && newCQ == nil {
 		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
@@ -211,10 +213,23 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	var cq kueue.ClusterQueue
 	if err := r.client.Get(ctx, client.ObjectKey{Name: string(queueObj.Spec.ClusterQueue)}, &cq); err != nil {
 		if apierrors.IsNotFound(err) {
-			err = r.updateStatusIfChanged(ctx, &queueObj, true, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
-			if errors.Is(err, errClusterQueueStillInCache) {
+			// Active comes from this API Get; usage comes from the scheduler
+			// cache. ClusterQueueReconciler deletes the cache entry
+			// asynchronously, so reconcile can observe NotFound while the
+			// cache still holds non-zero usage. Wait for cleanup before
+			// publishing ClusterQueueDoesNotExist so status never mixes that
+			// reason with stale usage. NotifyClusterQueueUpdate requeues
+			// LocalQueues after cleanup; RequeueAfter is a backup if this
+			// reconcile raced ahead of the notify.
+			stats, cqInCache, cacheErr := r.cache.LocalQueueUsageAndClusterQueueExists(&queueObj)
+			if cacheErr != nil {
+				log.Error(cacheErr, failedUpdateLqStatusMsg)
+				return ctrl.Result{}, cacheErr
+			}
+			if cqInCache {
 				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
 			}
+			err = r.applyLocalQueueStatus(ctx, &queueObj, stats, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
@@ -667,13 +682,32 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
-	return r.updateStatusIfChanged(ctx, queue, false, conditionStatus, reason, msg)
+	return r.updateStatusIfChanged(ctx, queue, conditionStatus, reason, msg)
 }
 
 func (r *LocalQueueReconciler) updateStatusIfChanged(
 	ctx context.Context,
 	queue *kueue.LocalQueue,
-	waitForClusterQueueCacheDeletion bool,
+	conditionStatus metav1.ConditionStatus,
+	reason, msg string,
+) error {
+	log := r.logger()
+	stats, _, err := r.cache.LocalQueueUsageAndClusterQueueExists(queue)
+	if err != nil {
+		log.Error(err, failedUpdateLqStatusMsg)
+		return err
+	}
+	return r.applyLocalQueueStatus(ctx, queue, stats, conditionStatus, reason, msg)
+}
+
+// applyLocalQueueStatus writes LocalQueue status from caller-provided usage
+// stats. Callers must obtain stats from the scheduler cache (via
+// LocalQueueUsageAndClusterQueueExists) so usage always has one derivation
+// path and can stay atomic with a ClusterQueue existence check.
+func (r *LocalQueueReconciler) applyLocalQueueStatus(
+	ctx context.Context,
+	queue *kueue.LocalQueue,
+	stats *schdcache.LocalQueueUsageStats,
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
@@ -689,14 +723,6 @@ func (r *LocalQueueReconciler) updateStatusIfChanged(
 			log.Error(err, failedUpdateLqStatusMsg)
 			return err
 		}
-	}
-	stats, clusterQueueExists, err := r.cache.LocalQueueUsageAndClusterQueueExists(queue)
-	if waitForClusterQueueCacheDeletion && clusterQueueExists {
-		return errClusterQueueStillInCache
-	}
-	if err != nil {
-		log.Error(err, failedUpdateLqStatusMsg)
-		return err
 	}
 	queue.Status.PendingWorkloads = pendingWls
 	queue.Status.ReservingWorkloads = int32(stats.ReservingWorkloads)

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -221,13 +221,16 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// reason with stale usage. NotifyClusterQueueUpdate requeues
 			// LocalQueues after cleanup; RequeueAfter is a backup if this
 			// reconcile raced ahead of the notify.
-			stats, cqInCache, cacheErr := r.cache.LocalQueueUsageAndClusterQueueExists(&queueObj)
+			stats, cqInCache, cacheErr := r.cache.LocalQueueUsage(&queueObj)
+			// Presence is checked before the error because a LocalQueue
+			// missing from a still-cached ClusterQueue is the same
+			// disagreement, not a failure to report.
+			if cqInCache {
+				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
+			}
 			if cacheErr != nil {
 				log.Error(cacheErr, failedUpdateLqStatusMsg)
 				return ctrl.Result{}, cacheErr
-			}
-			if cqInCache {
-				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
 			}
 			err = r.applyLocalQueueStatus(ctx, &queueObj, stats, metav1.ConditionFalse, clusterQueueDoesNotExistReason, clusterQueueIsInactiveMsg)
 		}
@@ -682,17 +685,8 @@ func (r *LocalQueueReconciler) UpdateStatusIfChanged(
 	conditionStatus metav1.ConditionStatus,
 	reason, msg string,
 ) error {
-	return r.updateStatusIfChanged(ctx, queue, conditionStatus, reason, msg)
-}
-
-func (r *LocalQueueReconciler) updateStatusIfChanged(
-	ctx context.Context,
-	queue *kueue.LocalQueue,
-	conditionStatus metav1.ConditionStatus,
-	reason, msg string,
-) error {
 	log := r.logger()
-	stats, _, err := r.cache.LocalQueueUsageAndClusterQueueExists(queue)
+	stats, _, err := r.cache.LocalQueueUsage(queue)
 	if err != nil {
 		log.Error(err, failedUpdateLqStatusMsg)
 		return err
@@ -701,9 +695,9 @@ func (r *LocalQueueReconciler) updateStatusIfChanged(
 }
 
 // applyLocalQueueStatus writes LocalQueue status from caller-provided usage
-// stats. Callers must obtain stats from the scheduler cache (via
-// LocalQueueUsageAndClusterQueueExists) so usage always has one derivation
-// path and can stay atomic with a ClusterQueue existence check.
+// stats. Callers must obtain stats from Cache.LocalQueueUsage so usage always
+// has one derivation path, and so the not-found branch can publish the same
+// snapshot it used to decide the ClusterQueue is gone.
 func (r *LocalQueueReconciler) applyLocalQueueStatus(
 	ctx context.Context,
 	queue *kueue.LocalQueue,

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -175,8 +175,8 @@ func (r *LocalQueueReconciler) NotifyWorkloadUpdate(oldWl, newWl *kueue.Workload
 
 // NotifyClusterQueueUpdate enqueues LocalQueues after ClusterQueue cache cleanup.
 // Only delete events are forwarded: Create/Update are already covered by the
-// ClusterQueue watch, while Delete must run again after ClusterQueueReconciler
-// removes the scheduler cache entry so LocalQueue status can publish
+// ClusterQueue watch. On Delete, ClusterQueueReconciler removes the scheduler
+// cache entry and then notifies so LocalQueue reconcile can publish
 // ClusterQueueDoesNotExist with zero usage from the cache.
 // The send is non-blocking so a full channel cannot stall ClusterQueue delete
 // handling or later watchers; RequeueAfter in Reconcile covers dropped notifies.

--- a/pkg/controller/core/localqueue_controller.go
+++ b/pkg/controller/core/localqueue_controller.go
@@ -220,9 +220,13 @@ func (r *LocalQueueReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			// status that mixes ClusterQueueDoesNotExist with stale usage.
 			// NotifyClusterQueueUpdate enqueues the LocalQueues once cleanup is
 			// done; RequeueAfter backs it up if this reconcile raced ahead of
-			// the notify.
+			// the notify. errQNotFound is part of the same disagreement rather
+			// than a reconcile failure, since it only occurs while the
+			// ClusterQueue is still cached.
 			stats, cqInCache, usageErr := r.cache.LocalQueueUsage(&queueObj)
 			if cqInCache {
+				log.V(2).Info("ClusterQueue is deleted but still in the scheduler cache, waiting for cleanup before updating status",
+					"clusterQueue", queueObj.Spec.ClusterQueue, "cacheReadError", usageErr)
 				return ctrl.Result{RequeueAfter: constants.UpdatesBatchPeriod}, nil
 			}
 			if usageErr != nil {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -30,6 +30,7 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -37,6 +38,7 @@ import (
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	queueafs "sigs.k8s.io/kueue/pkg/cache/queue/afs"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	kueuemetrics "sigs.k8s.io/kueue/pkg/metrics"
 	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
@@ -55,18 +57,38 @@ const pendingWlKey queueafs.WorkloadReference = "ns/pending-wl"
 func TestLocalQueueReconcile(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	clock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
+	makeLocalQueueWithUsage := func() *kueue.LocalQueue {
+		queue := utiltestingapi.MakeLocalQueue("test-queue", "default").
+			ClusterQueue("test-cluster-queue").
+			Generation(1).
+			Active(metav1.ConditionTrue).
+			ReservingWorkloads(1).
+			AdmittedWorkloads(1).
+			Obj()
+		usage := []kueue.LocalQueueFlavorUsage{{
+			Name: "rf",
+			Resources: []kueue.LocalQueueResourceUsage{{
+				Name:  corev1.ResourceCPU,
+				Total: resource.MustParse("4"),
+			}},
+		}}
+		queue.Status.FlavorsReservation = usage
+		queue.Status.FlavorsUsage = usage
+		return queue
+	}
 	cases := map[string]struct {
-		clusterQueue             *kueue.ClusterQueue
-		deleteClusterQueue       bool
-		localQueue               *kueue.LocalQueue
-		wantLocalQueue           *kueue.LocalQueue
-		wantError                error
-		afsConfig                *config.AdmissionFairSharing
-		runningWls               []kueue.Workload
-		wantRequeueAfter         *time.Duration
-		initialConsumedResources queueafs.UsageLedgerEntry
-		pendingEntryPenalty      corev1.ResourceList
-		wantConsumedResources    *queueafs.UsageLedgerEntry
+		clusterQueue                 *kueue.ClusterQueue
+		deleteClusterQueue           bool
+		deleteClusterQueueFromCaches bool
+		localQueue                   *kueue.LocalQueue
+		wantLocalQueue               *kueue.LocalQueue
+		wantError                    error
+		wantResult                   *reconcile.Result
+		afsConfig                    *config.AdmissionFairSharing
+		runningWls                   []kueue.Workload
+		initialConsumedResources     queueafs.UsageLedgerEntry
+		pendingEntryPenalty          corev1.ResourceList
+		wantConsumedResources        *queueafs.UsageLedgerEntry
 	}{
 		"local queue with Hold StopPolicy": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
@@ -144,10 +166,29 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			deleteClusterQueue: true,
-			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
-				ClusterQueue("test-cluster-queue").
-				Generation(1).
+			localQueue:         makeLocalQueueWithUsage(),
+			runningWls: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("test-queue").
+					Request(corev1.ResourceCPU, "4").
+					SimpleReserveQuota("test-cluster-queue", "rf", now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantLocalQueue: makeLocalQueueWithUsage(),
+			wantResult: &reconcile.Result{
+				RequeueAfter: constants.UpdatesBatchPeriod,
+			},
+			wantError: nil,
+		},
+		"cluster queue deleted after its scheduler cache entry is removed": {
+			clusterQueue: utiltestingapi.MakeClusterQueue("test-cluster-queue").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("rf").Resource(corev1.ResourceCPU, "10").Obj()).
+				Active(metav1.ConditionTrue).
 				Obj(),
+			deleteClusterQueue:           true,
+			deleteClusterQueueFromCaches: true,
+			localQueue:                   makeLocalQueueWithUsage(),
 			runningWls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "default").
 					Queue("test-queue").
@@ -162,12 +203,13 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Condition(
 					kueue.LocalQueueActive,
 					metav1.ConditionFalse,
-					"ClusterQueueDoesNotExist",
+					clusterQueueDoesNotExistReason,
 					clusterQueueIsInactiveMsg,
 					1,
 				).
 				Obj(),
-			wantError: nil,
+			wantError:  nil,
+			wantResult: &reconcile.Result{},
 		},
 		"local queue decaying usage decays if there is no running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -262,7 +304,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 			// The full interval pins that the tick ran; the sampling-interval
 			// guard short-circuit would return interval minus the (negative)
 			// sinceLastUpdate instead.
-			wantRequeueAfter: new(5 * time.Minute),
+			wantResult: &reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the previous state and running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -593,7 +635,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantRequeueAfter: new(time.Minute),
+			wantResult: &reconcile.Result{RequeueAfter: time.Minute},
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
@@ -893,7 +935,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				}).
 				Obj(),
 			// 5s interval - 1s elapsed = 4s remaining
-			wantRequeueAfter: new(4 * time.Second),
+			wantResult: &reconcile.Result{RequeueAfter: 4 * time.Second},
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 60 * time.Second},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Second},
@@ -932,6 +974,10 @@ func TestLocalQueueReconcile(t *testing.T) {
 					t.Fatalf("Unexpected error: %v", err)
 				}
 			}
+			if tc.deleteClusterQueueFromCaches {
+				cqCache.DeleteClusterQueue(tc.clusterQueue)
+				qManager.DeleteClusterQueue(log, tc.clusterQueue)
+			}
 			if tc.initialConsumedResources.Resources != nil {
 				lqKey := utilqueue.Key(tc.localQueue)
 				qManager.AfsUsageLedger.Update(lqKey, func(queueafs.UsageLedgerEntry, bool) queueafs.UsageLedgerEntry {
@@ -954,9 +1000,9 @@ func TestLocalQueueReconcile(t *testing.T) {
 				ctx,
 				reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tc.localQueue)},
 			)
-			if tc.wantRequeueAfter != nil {
-				if diff := cmp.Diff(*tc.wantRequeueAfter, result.RequeueAfter); diff != "" {
-					t.Errorf("unexpected reconcile requeue after (-want/+got):\n%s", diff)
+			if tc.wantResult != nil {
+				if diff := cmp.Diff(*tc.wantResult, result); diff != "" {
+					t.Errorf("unexpected reconcile result (-want/+got):\n%s", diff)
 				}
 			}
 
@@ -1007,6 +1053,80 @@ func TestLocalQueueReconcile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
+	clusterQueue := utiltestingapi.MakeClusterQueue("cq").Obj()
+	cases := map[string]struct {
+		oldClusterQueue *kueue.ClusterQueue
+		newClusterQueue *kueue.ClusterQueue
+		wantEvent       bool
+	}{
+		"create does not notify": {
+			newClusterQueue: clusterQueue,
+		},
+		"update does not notify": {
+			oldClusterQueue: clusterQueue,
+			newClusterQueue: clusterQueue.DeepCopy(),
+		},
+		"delete notifies with the deleted ClusterQueue": {
+			oldClusterQueue: clusterQueue,
+			wantEvent:       true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			reconciler := NewLocalQueueReconciler(nil, nil, nil)
+			reconciler.NotifyClusterQueueUpdate(tc.oldClusterQueue, tc.newClusterQueue)
+
+			select {
+			case gotEvent := <-reconciler.cqUpdateCh:
+				if !tc.wantEvent {
+					t.Fatal("unexpected ClusterQueue update event")
+				}
+				gotClusterQueue, ok := gotEvent.Object.(*kueue.ClusterQueue)
+				if !ok {
+					t.Fatalf("event object type = %T, want *kueue.ClusterQueue", gotEvent.Object)
+				}
+				if diff := cmp.Diff(tc.oldClusterQueue, gotClusterQueue); diff != "" {
+					t.Errorf("event ClusterQueue mismatch (-want/+got):\n%s", diff)
+				}
+			default:
+				if tc.wantEvent {
+					t.Fatal("expected ClusterQueue update event")
+				}
+			}
+		})
+	}
+}
+
+func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {
+	clusterQueue := utiltestingapi.MakeClusterQueue("cq").Obj()
+	matchingQueues := []*kueue.LocalQueue{
+		utiltestingapi.MakeLocalQueue("lq-a", "ns-a").ClusterQueue(clusterQueue.Name).Obj(),
+		utiltestingapi.MakeLocalQueue("lq-b", "ns-b").ClusterQueue(clusterQueue.Name).Obj(),
+	}
+	unrelatedQueue := utiltestingapi.MakeLocalQueue("other", "ns-a").ClusterQueue("other-cq").Obj()
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(matchingQueues[0], matchingQueues[1], unrelatedQueue).
+		Build()
+	handler := qCQHandler{client: cl}
+	queue := &utiltesting.MockTypedRateLimitingInterface{}
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	handler.Generic(ctx, event.GenericEvent{Object: clusterQueue}, queue)
+
+	wantRequests := []reconcile.Request{
+		{NamespacedName: client.ObjectKeyFromObject(matchingQueues[0])},
+		{NamespacedName: client.ObjectKeyFromObject(matchingQueues[1])},
+	}
+	sortRequests := cmpopts.SortSlices(func(a, b reconcile.Request) bool {
+		return a.NamespacedName.String() < b.NamespacedName.String()
+	})
+	if diff := cmp.Diff(wantRequests, queue.Items, sortRequests); diff != "" {
+		t.Errorf("enqueued requests mismatch (-want/+got):\n%s", diff)
 	}
 }
 

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -83,7 +83,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 		localQueue                   *kueue.LocalQueue
 		wantLocalQueue               *kueue.LocalQueue
 		wantError                    error
-		wantResult                   *reconcile.Result
+		wantResult                   reconcile.Result
 		afsConfig                    *config.AdmissionFairSharing
 		runningWls                   []kueue.Workload
 		initialConsumedResources     queueafs.UsageLedgerEntry
@@ -176,7 +176,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 					Obj(),
 			},
 			wantLocalQueue: makeLocalQueueWithUsage(),
-			wantResult: &reconcile.Result{
+			wantResult: reconcile.Result{
 				RequeueAfter: constants.UpdatesBatchPeriod,
 			},
 			wantError: nil,
@@ -209,7 +209,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				).
 				Obj(),
 			wantError:  nil,
-			wantResult: &reconcile.Result{},
+			wantResult: reconcile.Result{},
 		},
 		"local queue decaying usage decays if there is no running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -248,6 +248,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"clamps a future LastUpdate stamped by a concurrent settlement": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -304,7 +305,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 			// The full interval pins that the tick ran; the sampling-interval
 			// guard short-circuit would return interval minus the (negative)
 			// sinceLastUpdate instead.
-			wantResult: &reconcile.Result{RequeueAfter: 5 * time.Minute},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the previous state and running workloads": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -353,6 +354,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the usage from different flavors and resources": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -415,6 +417,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the previous state and running workloads half time twice larger than sampling": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -463,6 +466,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the previous state and running workloads with long half time": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -501,6 +505,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 24 * time.Hour},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage sums the previous state and running GPU workloads half time twice larger than sampling": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -549,6 +554,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 10 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage resets to 0 when half life is 0": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -593,6 +599,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 0 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue decaying usage is not reconciled if not enough time has passed": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
@@ -635,7 +642,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 						},
 					}).
 				Obj(),
-			wantResult: &reconcile.Result{RequeueAfter: time.Minute},
+			wantResult: reconcile.Result{RequeueAfter: time.Minute},
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
@@ -670,6 +677,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue with uninitialized cache and no prior status seeds empty usage": {
 			// The admitted workload must not be counted at full weight here:
@@ -715,6 +723,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue with uninitialized cache seeds from persisted status usage": {
 			// Restart recovery: the persisted status EMA (8 CPU) is restored
@@ -769,6 +778,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue seed merges persisted status into a settlement-created entry": {
 			// Restart recovery when settlement wins the race: the entry (2 CPU,
@@ -839,6 +849,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"local queue seed does not re-merge persisted status into an accounted entry": {
 			// Same shape as above but the entry is already StatusAccounted: the
@@ -907,6 +918,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Minute},
 			},
+			wantResult: reconcile.Result{RequeueAfter: 5 * time.Minute},
 		},
 		"AFS reconcile skips when cache is recent but status lacks AdmissionFairSharingStatus": {
 			clusterQueue: utiltestingapi.MakeClusterQueue("cq-afs-skip").
@@ -935,7 +947,7 @@ func TestLocalQueueReconcile(t *testing.T) {
 				}).
 				Obj(),
 			// 5s interval - 1s elapsed = 4s remaining
-			wantResult: &reconcile.Result{RequeueAfter: 4 * time.Second},
+			wantResult: reconcile.Result{RequeueAfter: 4 * time.Second},
 			afsConfig: &config.AdmissionFairSharing{
 				UsageHalfLifeTime:     metav1.Duration{Duration: 60 * time.Second},
 				UsageSamplingInterval: metav1.Duration{Duration: 5 * time.Second},
@@ -1000,10 +1012,8 @@ func TestLocalQueueReconcile(t *testing.T) {
 				ctx,
 				reconcile.Request{NamespacedName: client.ObjectKeyFromObject(tc.localQueue)},
 			)
-			if tc.wantResult != nil {
-				if diff := cmp.Diff(*tc.wantResult, result); diff != "" {
-					t.Errorf("unexpected reconcile result (-want/+got):\n%s", diff)
-				}
+			if diff := cmp.Diff(tc.wantResult, result); diff != "" {
+				t.Errorf("unexpected reconcile result (-want/+got):\n%s", diff)
 			}
 
 			if diff := cmp.Diff(tc.wantError, gotError); diff != "" {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -1110,26 +1110,6 @@ func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
 			}
 		})
 	}
-
-	t.Run("delete drops notify when channel is full", func(t *testing.T) {
-		reconciler := NewLocalQueueReconciler(nil, nil, nil)
-		for range cap(reconciler.cqUpdateCh) {
-			reconciler.cqUpdateCh <- event.GenericEvent{Object: clusterQueue}
-		}
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			reconciler.NotifyClusterQueueUpdate(clusterQueue, nil)
-		}()
-		select {
-		case <-done:
-		case <-time.After(time.Second):
-			t.Fatal("NotifyClusterQueueUpdate blocked on full channel")
-		}
-		if got, want := len(reconciler.cqUpdateCh), cap(reconciler.cqUpdateCh); got != want {
-			t.Fatalf("channel length = %d, want %d", got, want)
-		}
-	})
 }
 
 func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -1123,7 +1123,7 @@ func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {
 		{NamespacedName: client.ObjectKeyFromObject(matchingQueues[1])},
 	}
 	sortRequests := cmpopts.SortSlices(func(a, b reconcile.Request) bool {
-		return a.NamespacedName.String() < b.NamespacedName.String()
+		return a.String() < b.String()
 	})
 	if diff := cmp.Diff(wantRequests, queue.Items, sortRequests); diff != "" {
 		t.Errorf("enqueued requests mismatch (-want/+got):\n%s", diff)

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -1100,6 +1100,26 @@ func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("delete drops notify when channel is full", func(t *testing.T) {
+		reconciler := NewLocalQueueReconciler(nil, nil, nil)
+		for range cap(reconciler.cqUpdateCh) {
+			reconciler.cqUpdateCh <- event.GenericEvent{Object: clusterQueue}
+		}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			reconciler.NotifyClusterQueueUpdate(clusterQueue, nil)
+		}()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("NotifyClusterQueueUpdate blocked on full channel")
+		}
+		if got, want := len(reconciler.cqUpdateCh), cap(reconciler.cqUpdateCh); got != want {
+			t.Fatalf("channel length = %d, want %d", got, want)
+		}
+	})
 }
 
 func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {

--- a/pkg/controller/core/localqueue_controller_test.go
+++ b/pkg/controller/core/localqueue_controller_test.go
@@ -57,24 +57,12 @@ const pendingWlKey queueafs.WorkloadReference = "ns/pending-wl"
 func TestLocalQueueReconcile(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	clock := testingclock.NewFakeClock(time.Now().Truncate(time.Second))
-	makeLocalQueueWithUsage := func() *kueue.LocalQueue {
-		queue := utiltestingapi.MakeLocalQueue("test-queue", "default").
-			ClusterQueue("test-cluster-queue").
-			Generation(1).
-			Active(metav1.ConditionTrue).
-			ReservingWorkloads(1).
-			AdmittedWorkloads(1).
-			Obj()
-		usage := []kueue.LocalQueueFlavorUsage{{
-			Name: "rf",
-			Resources: []kueue.LocalQueueResourceUsage{{
-				Name:  corev1.ResourceCPU,
-				Total: resource.MustParse("4"),
-			}},
-		}}
-		queue.Status.FlavorsReservation = usage
-		queue.Status.FlavorsUsage = usage
-		return queue
+	flavorUsage := kueue.LocalQueueFlavorUsage{
+		Name: "rf",
+		Resources: []kueue.LocalQueueResourceUsage{{
+			Name:  corev1.ResourceCPU,
+			Total: resource.MustParse("4"),
+		}},
 	}
 	cases := map[string]struct {
 		clusterQueue                 *kueue.ClusterQueue
@@ -166,7 +154,15 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Active(metav1.ConditionTrue).
 				Obj(),
 			deleteClusterQueue: true,
-			localQueue:         makeLocalQueueWithUsage(),
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FlavorsReservation(*flavorUsage.DeepCopy()).
+				FlavorsUsage(*flavorUsage.DeepCopy()).
+				Obj(),
 			runningWls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "default").
 					Queue("test-queue").
@@ -175,7 +171,15 @@ func TestLocalQueueReconcile(t *testing.T) {
 					AdmittedAt(true, now).
 					Obj(),
 			},
-			wantLocalQueue: makeLocalQueueWithUsage(),
+			wantLocalQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FlavorsReservation(*flavorUsage.DeepCopy()).
+				FlavorsUsage(*flavorUsage.DeepCopy()).
+				Obj(),
 			wantResult: reconcile.Result{
 				RequeueAfter: constants.UpdatesBatchPeriod,
 			},
@@ -188,7 +192,15 @@ func TestLocalQueueReconcile(t *testing.T) {
 				Obj(),
 			deleteClusterQueue:           true,
 			deleteClusterQueueFromCaches: true,
-			localQueue:                   makeLocalQueueWithUsage(),
+			localQueue: utiltestingapi.MakeLocalQueue("test-queue", "default").
+				ClusterQueue("test-cluster-queue").
+				Generation(1).
+				Active(metav1.ConditionTrue).
+				ReservingWorkloads(1).
+				AdmittedWorkloads(1).
+				FlavorsReservation(*flavorUsage.DeepCopy()).
+				FlavorsUsage(*flavorUsage.DeepCopy()).
+				Obj(),
 			runningWls: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "default").
 					Queue("test-queue").
@@ -584,7 +596,9 @@ func TestLocalQueueReconcile(t *testing.T) {
 				AdmittedWorkloads(1).
 				FairSharingStatus(
 					&kueue.LocalQueueFairSharingStatus{
-						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{},
+						AdmissionFairSharingStatus: &kueue.LocalQueueAdmissionFairSharingStatus{
+							ConsumedResources: corev1.ResourceList{},
+						},
 					}).
 				Obj(),
 			runningWls: []kueue.Workload{
@@ -1029,7 +1043,6 @@ func TestLocalQueueReconcile(t *testing.T) {
 			}
 
 			cmpOpts := cmp.Options{
-				cmpopts.EquateEmpty(),
 				util.IgnoreConditionTimestamps,
 				util.IgnoreObjectMetaResourceVersion,
 				cmpopts.IgnoreFields(kueue.LocalQueueAdmissionFairSharingStatus{}, "LastUpdate"),
@@ -1071,7 +1084,7 @@ func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
 	cases := map[string]struct {
 		oldClusterQueue *kueue.ClusterQueue
 		newClusterQueue *kueue.ClusterQueue
-		wantEvent       bool
+		wantEvent       *kueue.ClusterQueue
 	}{
 		"create does not notify": {
 			newClusterQueue: clusterQueue,
@@ -1082,7 +1095,7 @@ func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
 		},
 		"delete notifies with the deleted ClusterQueue": {
 			oldClusterQueue: clusterQueue,
-			wantEvent:       true,
+			wantEvent:       utiltestingapi.MakeClusterQueue("cq").Obj(),
 		},
 	}
 
@@ -1093,23 +1106,27 @@ func TestLocalQueueNotifyClusterQueueUpdate(t *testing.T) {
 
 			select {
 			case gotEvent := <-reconciler.cqUpdateCh:
-				if !tc.wantEvent {
+				if tc.wantEvent == nil {
 					t.Fatal("unexpected ClusterQueue update event")
 				}
 				gotClusterQueue, ok := gotEvent.Object.(*kueue.ClusterQueue)
 				if !ok {
 					t.Fatalf("event object type = %T, want *kueue.ClusterQueue", gotEvent.Object)
 				}
-				if diff := cmp.Diff(tc.oldClusterQueue, gotClusterQueue); diff != "" {
+				if diff := cmp.Diff(tc.wantEvent, gotClusterQueue); diff != "" {
 					t.Errorf("event ClusterQueue mismatch (-want/+got):\n%s", diff)
 				}
 			default:
-				if tc.wantEvent {
+				if tc.wantEvent != nil {
 					t.Fatal("expected ClusterQueue update event")
 				}
 			}
 		})
 	}
+}
+
+func reconcileRequestLess(a, b reconcile.Request) bool {
+	return a.String() < b.String()
 }
 
 func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {
@@ -1129,12 +1146,10 @@ func TestLocalQueueClusterQueueHandlerGeneric(t *testing.T) {
 	handler.Generic(ctx, event.GenericEvent{Object: clusterQueue}, queue)
 
 	wantRequests := []reconcile.Request{
-		{NamespacedName: client.ObjectKeyFromObject(matchingQueues[0])},
-		{NamespacedName: client.ObjectKeyFromObject(matchingQueues[1])},
+		{NamespacedName: client.ObjectKey{Namespace: "ns-a", Name: "lq-a"}},
+		{NamespacedName: client.ObjectKey{Namespace: "ns-b", Name: "lq-b"}},
 	}
-	sortRequests := cmpopts.SortSlices(func(a, b reconcile.Request) bool {
-		return a.String() < b.String()
-	})
+	sortRequests := cmpopts.SortSlices(reconcileRequestLess)
 	if diff := cmp.Diff(wantRequests, queue.Items, sortRequests); diff != "" {
 		t.Errorf("enqueued requests mismatch (-want/+got):\n%s", diff)
 	}

--- a/pkg/util/testing/v1beta2/wrappers.go
+++ b/pkg/util/testing/v1beta2/wrappers.go
@@ -867,6 +867,18 @@ func (q *LocalQueueWrapper) AdmittedWorkloads(n int32) *LocalQueueWrapper {
 	return q
 }
 
+// FlavorsReservation sets the reserved resources per flavor.
+func (q *LocalQueueWrapper) FlavorsReservation(usage ...kueue.LocalQueueFlavorUsage) *LocalQueueWrapper {
+	q.Status.FlavorsReservation = usage
+	return q
+}
+
+// FlavorsUsage sets the admitted resources per flavor.
+func (q *LocalQueueWrapper) FlavorsUsage(usage ...kueue.LocalQueueFlavorUsage) *LocalQueueWrapper {
+	q.Status.FlavorsUsage = usage
+	return q
+}
+
 // Condition sets a condition on the LocalQueue.
 func (q *LocalQueueWrapper) Condition(conditionType string, status metav1.ConditionStatus, reason, message string, generation int64) *LocalQueueWrapper {
 	apimeta.SetStatusCondition(&q.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When a ClusterQueue is forcefully deleted, the LocalQueue controller can observe the API deletion before scheduler cache cleanup and publish `ClusterQueueDoesNotExist` while retaining non-zero usage. This PR waits for scheduler cache cleanup before publishing the missing-ClusterQueue status, adds a post-cleanup notification to reconcile affected LocalQueues promptly, and reads ClusterQueue presence and LocalQueue usage from one scheduler-cache snapshot before publishing that status.

#### Which issue(s) this PR fixes:

Fixes #13873

#### Special notes for your reviewer:

cc @mimowo

You raised the original concern in #13708, and the issue flags one decision worth your sign-off: option 3 changes *when* the `Active` condition becomes visible. Between the ClusterQueue API deletion and scheduler cache cleanup, the LocalQueue keeps reporting `Active=True`/`Ready` rather than flipping to `Active=False` immediately as it does today. The window is bounded by one `UpdatesBatchPeriod` requeue, and in practice the cache entry is already gone by then because `ClusterQueueReconciler.Delete` cleans it synchronously before notifying. The issue treats this as the accepted cost of never publishing a contradictory status — please confirm you agree with that trade before this merges.

On acceptance criterion 1: `applyLocalQueueStatus` still takes a `stats` parameter rather than dropping it. It is now mandatory instead of a nil-able override, and both callers source it from `Cache.LocalQueueUsage`, so usage has a single derivation path. The parameter stays because the not-found branch must use ClusterQueue presence and usage from the same cache snapshot. Separate reads could straddle cache cleanup and recreate the contradictory status.

`NotifyClusterQueueUpdate` uses a blocking send, matching `resourceflavor_controller.go`, `admissioncheck_controller.go`, and `cohort_controller.go`. Correctness does not depend on the notification: the `RequeueAfter` in the not-found branch converges on its own, and the notify only removes a requeue round-trip.

The existing force-deletion integration regression is unchanged. Deterministic unit tests cover both stale-cache and cleaned-cache ordering, plus the post-cleanup notification and its handler. The `wantRequeueAfter` → `wantResult` conversion across the existing table cases is intentional: every case now asserts the full `reconcile.Result`, so an unexpected requeue can no longer slip past a skipped assertion.

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated.

Validation:
- `go test ./pkg/controller/core ./pkg/cache/scheduler -run '^(TestLocalQueueReconcile|TestLocalQueueNotifyClusterQueueUpdate|TestLocalQueueClusterQueueHandlerGeneric|TestLocalQueueUsage)$' -count=1`
- `go test -race ./pkg/controller/core ./pkg/cache/scheduler -count=1`
- `go test -race ./test/integration/singlecluster/controller/core -run '^TestAPIs$' -ginkgo.focus='Should update status when ClusterQueue are forcefully deleted' -count=1`
- `golangci-lint run ./pkg/controller/core/...`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
LocalQueue: Fixed status showing non-zero usage alongside ClusterQueueDoesNotExist during ClusterQueue teardown.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LocalQueue status accuracy when its associated ClusterQueue is deleted or unavailable.
  * Prevented stale usage information while cache updates are completing.
  * LocalQueues now refresh automatically after related ClusterQueue changes.
  * Added clearer status reporting when the associated ClusterQueue does not exist.
  * Improved preservation and initialization of fair-sharing usage data during reconciliation.
  * Improved handling of delayed cache updates and incomplete ClusterQueue information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->