### PR TITLE
WIP: Recompute conflicting assignments within a single scheduling cycle 

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -619,6 +619,13 @@ const (
 	// Note: This feature can be promoted to "beta" once https://github.com/kubernetes-sigs/kueue/issues/14543
 	// is fixed because it might boost chances for issue #14543 to appear.
 	FairSharingReevaluatePreemptionCandidates featuregate.Feature = "FairSharingReevaluatePreemptionCandidates"
+
+	// owner: @kshalot
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/13320
+	//
+	// Enable recomputing assignments if the assigned quota was exhausted
+	// by a workload earlier in the same scheduling cycle.
+	RecomputeAssignmentUponQuotaExhaustion featuregate.Feature = "RecomputeAssignmentUponQuotaExhaustion"
 )
 
 func init() {
@@ -957,6 +964,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	FairSharingReevaluatePreemptionCandidates: {
 		{Version: version.MustParse("0.20"), Default: false, PreRelease: featuregate.Alpha},
+	},
+
+	RecomputeAssignmentUponQuotaExhaustion: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -733,19 +733,21 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	usage := e.assignmentUsage(log)
 	fitsCheck := fits(snapshot, cq, &usage, preemptedWorkloads, e.preemptionTargets)
 
-	needsTASRecompute := fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)
-	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputeAssignmentUponPreemptionTargetsOverlap)
+	needsRecomputeAssignmentDueToUsageConflict :=
+		(fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)) ||
+			(fitsCheck == schdcache.FitsCheckNoQuota && features.Enabled(features.RecomputeAssignmentUponQuotaExhaustion))
+	needsRecomputeAssignmentDueToPreemptionTargetsOverlap := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputeAssignmentUponPreemptionTargetsOverlap)
 
 	var revertRemoval func()
 	switch {
-	case needsOverlapRecompute:
-		log.V(2).Info("Re-computing the assignment as preemption targets overlap")
+	case needsRecomputeAssignmentDueToPreemptionTargetsOverlap:
+		log.V(3).Info("Re-computing the assignment as preemption targets overlap")
 		// To get the projected cluster state after other preemptions complete,
 		// we simulate the removal of their victims.
 		victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
 		revertRemoval = snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
-	case needsTASRecompute:
-		log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
+	case needsRecomputeAssignmentDueToUsageConflict:
+		log.V(3).Info("Re-computing the assignment as the workload doesn't fit anymore after processing another workload", "fitsCheck", fitsCheck)
 	default:
 		// Short-circuit, nothing to recompute.
 		return usage, schdcache.FitsCheckOk == fitsCheck
@@ -756,7 +758,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	e.NominationMapping = e.readResourceToFlavorMapping()
 	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
 	e.recordAssignment(newAssignment, newTargets)
-	if needsOverlapRecompute {
+	if needsRecomputeAssignmentDueToPreemptionTargetsOverlap {
 		if revertRemoval != nil {
 			revertRemoval()
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -773,7 +773,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	e.NominationMapping = nil
 
 	// Determine the overlap recomputation result for metrics reporting.
-	if needsOverlapRecompute {
+	if needsRecomputeAssignmentDueToPreemptionTargetsOverlap {
 		var overlapRecomputeResult metrics.PreemptionTargetRecomputationResult
 		switch {
 		case e.assignment.RepresentativeMode() == flavorassigner.DeferredFit:

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -241,7 +241,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed, skipping flavor spot as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -386,7 +386,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 5 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -419,7 +419,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 				"eng-beta/light-usage": *utiltestingapi.MakeAdmission("fs-nom-b").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "5").Count(5).Obj()).Obj(),
 				"eng-alpha/nom-wl":     *utiltestingapi.MakeAdmission("fs-nom-a").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "45").Count(45).Obj()).Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"fs-nom-b": {"eng-beta/borrow-wl"},
 			},
 		},
@@ -546,7 +546,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 5 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -568,7 +568,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 				"eng-alpha/c0":   *utiltestingapi.MakeAdmission("cq-c").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj(),
 				"eng-alpha/wl-a": *utiltestingapi.MakeAdmission("cq-a").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "5").Count(1).Obj()).Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq-b": {"eng-alpha/wl-b"},
 			},
 		},
@@ -698,7 +698,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 5 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -720,7 +720,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 				"eng-alpha/c0":   *utiltestingapi.MakeAdmission("cq-c").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj(),
 				"eng-alpha/wl-a": *utiltestingapi.MakeAdmission("cq-a").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "5").Count(1).Obj()).Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq-b": {"eng-alpha/wl-b"},
 			},
 		},
@@ -881,7 +881,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -904,7 +904,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 				"eng-alpha/c-admitted":  *utiltestingapi.MakeAdmission("cq-c").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "20").Obj()).Obj(),
 				"eng-alpha/wl-a1":       *utiltestingapi.MakeAdmission("cq-a1").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "7").Count(1).Obj()).Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq-b": {"eng-alpha/wl-b"},
 			},
 		},
@@ -1063,7 +1063,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed, skipping flavor spot as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1086,7 +1086,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 				"eng-alpha/od-admitted":   *utiltestingapi.MakeAdmission("cq-b").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "8").Obj()).Obj(),
 				"eng-alpha/wl-a":          *utiltestingapi.MakeAdmission("cq-a").PodSets(utiltestingapi.MakePodSetAssignment("one").Assignment(corev1.ResourceCPU, "on-demand", "4").Count(1).Obj()).Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq-b": {"eng-alpha/wl-b"},
 			},
 		},
@@ -1284,7 +1284,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 61 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1310,7 +1310,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1347,7 +1347,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1387,7 +1387,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"e": {"eng-alpha/e1"},
 				"g": {"eng-alpha/g1"},
 				"f": {"eng-alpha/f1"},
@@ -1501,7 +1501,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 35 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1531,7 +1531,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"c": {"eng-alpha/c1"},
 			},
 		},
@@ -1627,8 +1627,8 @@ func TestScheduleForFairSharing(t *testing.T) {
 					Condition(metav1.Condition{
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
-						Reason:             "WaitingForQuota",
-						Message:            "Workload no longer fits after processing another workload",
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 4 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1689,7 +1689,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"b": {"eng-alpha/b1"},
 			},
 		},
@@ -1784,7 +1784,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 4 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1845,7 +1845,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"b": {"eng-alpha/b1"},
 			},
 		},
@@ -2083,7 +2083,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 10 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -2139,7 +2139,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"b": {"eng-alpha/b1"},
 			},
 		},
@@ -2201,7 +2201,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 10 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -2258,7 +2258,7 @@ func TestScheduleForFairSharing(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"b": {"eng-alpha/b1"},
 			},
 		},

--- a/pkg/scheduler/scheduler_recompute_assignment_test.go
+++ b/pkg/scheduler/scheduler_recompute_assignment_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestScheduleRecomputeAssignmentUponQuotaExhaustion(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+
+	resourceFlavors := []*kueue.ResourceFlavor{
+		utiltestingapi.MakeResourceFlavor("default").Obj(),
+	}
+
+	clusterQueues := []kueue.ClusterQueue{
+		*utiltestingapi.MakeClusterQueue("cq-1").
+			Cohort("cohort-1").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "100").Obj(),
+			).Obj(),
+		*utiltestingapi.MakeClusterQueue("cq-2").
+			Cohort("cohort-1").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "100").Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				WithinClusterQueue: kueue.PreemptionPolicyLowerPriority,
+			}).Obj(),
+	}
+
+	queues := []kueue.LocalQueue{
+		*utiltestingapi.MakeLocalQueue("lq-1", "eng-alpha").ClusterQueue("cq-1").Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-2", "eng-alpha").ClusterQueue("cq-2").Obj(),
+	}
+
+	cases := map[string]scheduleTestCase{
+		"feature gate enabled; quota stolen by preceding workload forces fallback to preemption": {
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputeAssignmentUponQuotaExhaustion: true,
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-1", "eng-alpha").
+					UID("wl-1").
+					JobUID("job-1-uid").
+					Queue("lq-1").
+					Priority(10).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-2", "eng-alpha").
+					UID("wl-2").
+					JobUID("job-2-uid").
+					Queue("lq-2").
+					Priority(5).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted", "eng-alpha").
+					UID("wl-admitted-uid").
+					JobUID("wl-admitted-job-uid").
+					Queue("lq-2").
+					Priority(1).
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-2").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-1", "eng-alpha").
+					UID("wl-1").
+					JobUID("job-1-uid").
+					Queue("lq-1").
+					Priority(10).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue cq-1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-2", "eng-alpha").
+					UID("wl-2").
+					JobUID("job-2-uid").
+					Queue("lq-2").
+					Priority(5).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 100 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted", "eng-alpha").
+					UID("wl-admitted-uid").
+					JobUID("wl-admitted-job-uid").
+					Queue("lq-2").
+					Priority(1).
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-2").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-2, JobUID: job-2-uid) due to prioritization in the ClusterQueue; preemptor path: /cohort-1/cq-2; preemptee path: /cohort-1/cq-2",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-2, JobUID: job-2-uid) due to prioritization in the ClusterQueue; preemptor path: /cohort-1/cq-2; preemptee path: /cohort-1/cq-2",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/wl-1":        *utiltestingapi.MakeAdmission("cq-1").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "100").Obj()).Obj(),
+				"eng-alpha/wl-admitted": *utiltestingapi.MakeAdmission("cq-2").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "100").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-2": {"eng-alpha/wl-2"},
+			},
+		},
+		"feature gate disabled; quota stolen by preceding workload causes workload to be skipped": {
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputeAssignmentUponQuotaExhaustion: false,
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-1", "eng-alpha").
+					UID("wl-1").
+					JobUID("job-1-uid").
+					Queue("lq-1").
+					Priority(10).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-2", "eng-alpha").
+					UID("wl-2").
+					JobUID("job-2-uid").
+					Queue("lq-2").
+					Priority(5).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted", "eng-alpha").
+					UID("wl-admitted-uid").
+					JobUID("wl-admitted-job-uid").
+					Queue("lq-2").
+					Priority(1).
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-2").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-1", "eng-alpha").
+					UID("wl-1").
+					JobUID("job-1-uid").
+					Queue("lq-1").
+					Priority(10).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionTrue,
+						Reason:             "QuotaReserved",
+						Message:            "Quota reserved in ClusterQueue cq-1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Admitted",
+						Message:            "The workload is admitted",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Admission(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-2", "eng-alpha").
+					UID("wl-2").
+					JobUID("job-2-uid").
+					Queue("lq-2").
+					Priority(5).
+					Request(corev1.ResourceCPU, "100").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "Workload no longer fits after processing another workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("100"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted", "eng-alpha").
+					UID("wl-admitted-uid").
+					JobUID("wl-admitted-job-uid").
+					Queue("lq-2").
+					Priority(1).
+					Request(corev1.ResourceCPU, "100").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-2").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "100").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/wl-1":        *utiltestingapi.MakeAdmission("cq-1").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "100").Obj()).Obj(),
+				"eng-alpha/wl-admitted": *utiltestingapi.MakeAdmission("cq-2").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "100").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-2": {"eng-alpha/wl-2"},
+			},
+		},
+	}
+
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:          queues,
+		clusterQueues:   clusterQueues,
+		resourceFlavors: resourceFlavors,
+		fakeClock:       fakeClock,
+	}, cases)
+}

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -128,7 +128,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			// the same candidate for preemption (wl-rest-admitted from cq-rest).
 			// Within the scheduling cycle, wl-tiny-pending is considered before wl-hero (due to
 			// Fair Sharing prioritization). So, wl-hero would normally be requeued due to
-			// overlapping preemption targets. But with RecomputePreemptionTargetsUponOverlap
+			// overlapping preemption targets. But with RecomputeAssignmentUponPreemptionTargetsOverlap
 			// featuregate, it refreshes its targets, finds wl-noisy-admitted from cq-noisy
 			// and preempts it in the same scheduling cycle.
 			enableFairSharing: true,
@@ -310,7 +310,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 				"cq-hero": {"new_targets": 1},
 			},
 		},
-		"with fair sharing: two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
+		"with fair sharing: two workloads reclaim nominal quota; RecomputeAssignmentUponPreemptionTargetsOverlap enabled": {
 			enableFairSharing: true,
 			cohorts:           defaultCohorts(),
 			workloads: []kueue.Workload{
@@ -472,7 +472,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 				"cq-hero": {"deferred_fit": 1},
 			},
 		},
-		"two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
+		"two workloads reclaim nominal quota; RecomputeAssignmentUponPreemptionTargetsOverlap enabled": {
 			enableFairSharing: false,
 			cohorts:           defaultCohorts(),
 			workloads: []kueue.Workload{
@@ -596,7 +596,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			},
 		},
 
-		"flavor stickiness with RecomputePreemptionTargetsUponOverlap": {
+		"flavor stickiness with RecomputeAssignmentUponPreemptionTargetsOverlap": {
 			// Admitted state:
 			// - wl-admitted-default (cq-1): uses 10 CPU on default flavor (borrowing 5)
 			// - wl-admitted-on-demand (cq-1): uses 10 CPU on on-demand flavor (borrowing 5)

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -1187,6 +1187,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 				features.RecomputeAssignmentUponPreemptionTargetsOverlap: false,
 				features.TopologyAwareScheduling:                         false,
 				features.TASRecomputeAssignmentWithinSchedulingCycle:     false,
+				features.RecomputeAssignmentUponQuotaExhaustion:          false,
 			},
 			enableFairSharing: true,
 			cohorts: []kueue.Cohort{

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -9231,7 +9231,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor tas-default, 2 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -9249,7 +9249,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 					}).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"tas-cq-b": {"default/b1"},
 			},
 			wantNewAssignments: map[workload.Reference]kueue.Admission{
@@ -9265,7 +9265,7 @@ func TestScheduleForTASCohorts(t *testing.T) {
 			},
 			wantEvents: []utiltesting.EventRecord{
 				utiltesting.MakeEventRecord("default", "b1", kueue.WorkloadQuotaReservedReasonWaitingForQuota, corev1.EventTypeWarning).
-					Message("Workload no longer fits after processing another workload").Obj(),
+					Message("couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor tas-default, 2 more needed").Obj(),
 				utiltesting.MakeEventRecord("default", "a1", "QuotaReserved", corev1.EventTypeNormal).
 					Message("Quota reserved in ClusterQueue tas-cq-a, wait time since queued was 9223372037s; Flavors considered: one: tas-default(Fit;borrow=1)").Obj(),
 				utiltesting.MakeEventRecord("default", "a1", "Admitted", corev1.EventTypeNormal).

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -718,7 +718,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 5 more needed, untolerated taint {key val NoSchedule <nil>} in flavor spot-tainted",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 5 more needed, skipping flavor spot-tainted as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1378,7 +1378,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 1 more needed, skipping flavor spot as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -1540,7 +1540,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 50 more needed, insufficient unused quota for cpu in flavor spot, 1 more needed",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor spot, 1 more needed, skipping flavor on-demand as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -2518,7 +2518,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 41 more needed, insufficient unused quota for cpu in flavor spot, 50 more needed",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor on-demand, 41 more needed, skipping flavor spot as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -3229,7 +3229,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for r1 in flavor default, 2 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -3254,7 +3254,7 @@ func TestSchedule(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq2": {"sales/wl2"},
 			},
 		},
@@ -4299,7 +4299,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 3 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -4319,7 +4319,9 @@ func TestSchedule(t *testing.T) {
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"other-alpha": {"eng-alpha/preemptor"},
-				"other-beta":  {"eng-beta/pretending-preemptor"},
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"other-beta": {"eng-beta/pretending-preemptor"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-alpha/a1": *utiltestingapi.MakeAdmission("other-alpha").
@@ -4332,10 +4334,6 @@ func TestSchedule(t *testing.T) {
 						Assignment(corev1.ResourceCPU, "default", "2").
 						Obj()).
 					Obj(),
-			},
-			wantSkippedPreemptions: map[string]int{
-				"other-alpha": 0,
-				"other-beta":  1,
 			},
 		},
 		"not enough resources": {
@@ -5002,7 +5000,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for gpu in flavor on-demand, 5 more needed",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for gpu in flavor on-demand, 10 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -5295,7 +5293,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for gpu in flavor on-demand, 1 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -5313,11 +5311,9 @@ func TestSchedule(t *testing.T) {
 					}).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
-				"ClusterQueueB": {"eng-beta/b1-pending"},
-			},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
+				"ClusterQueueB": {"eng-beta/b1-pending"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-alpha/a1-admitted": *utiltestingapi.MakeAdmission("ClusterQueueA").
@@ -5406,7 +5402,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for gpu in flavor on-demand, 1 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -5424,11 +5420,9 @@ func TestSchedule(t *testing.T) {
 					}).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
-				"ClusterQueueB": {"eng-beta/b1-pending"},
-			},
 			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"ClusterQueueA": {"eng-alpha/a2-pending"},
+				"ClusterQueueB": {"eng-beta/b1-pending"},
 			},
 			wantAssignments: map[workload.Reference]kueue.Admission{
 				"eng-alpha/a1-admitted": *utiltestingapi.MakeAdmission("ClusterQueueA").
@@ -5502,7 +5496,7 @@ func TestSchedule(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload no longer fits after processing another workload",
+						Message:            "couldn't assign flavors to pod set one: insufficient unused quota for cpu in flavor default, 4 more needed",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -5558,7 +5552,7 @@ func TestSchedule(t *testing.T) {
 						Obj()).
 					Obj(),
 			},
-			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"best-effort": {"eng-alpha/best-effort"},
 			},
 		},
@@ -7718,7 +7712,7 @@ func TestLastSchedulingContext(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "couldn't assign flavors to pod set main: insufficient quota for cpu in flavor spot, previously considered podsets requests (0) + current podset request (20) > maximum capacity (10), insufficient unused quota for cpu in flavor on-demand, 20 more needed",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor on-demand, 20 more needed, skipping flavor spot as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -335,6 +335,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: RecomputeAssignmentUponQuotaExhaustion
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -329,6 +329,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.20"
+- name: RecomputeAssignmentUponQuotaExhaustion
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/test/e2e/singlecluster/baseline/metrics_test.go
+++ b/test/e2e/singlecluster/baseline/metrics_test.go
@@ -557,7 +557,6 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Label("area:singlecluster", "feature:m
 			})
 
 			metrics := [][]string{
-				{"kueue_admission_cycle_preemption_skips"},
 				{"kueue_evicted_workloads_total"},
 				{"kueue_evicted_workloads_once_total"},
 				{"kueue_preempted_workloads_total"},

--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -3351,7 +3351,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 
 			ginkgo.By("no new best-effort workloads admitted as foundation workload is trying to schedule")
 			util.ExpectReservingActiveWorkloadsMetric(cq2, 1)
-			util.ExpectPendingWorkloadsMetric(cq2, 1, 0)
+			util.ExpectPendingWorkloadsMetric(cq2, 0, 1)
 
 			ginkgo.By("second foundation workload reclaims capacity from a best-effort workload")
 			util.FinishEvictionOfWorkloadsInCQ(ctx, k8sClient, cq2, 1)
@@ -3398,7 +3398,7 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 			createWorkloadWithPriority("best-effort-queue", "1", 0)
 			util.ExpectReservingActiveWorkloadsMetric(cq2, 0)
-			util.ExpectPendingWorkloadsMetric(cq2, 2, 0)
+			util.ExpectPendingWorkloadsMetric(cq2, 0, 2)
 
 			ginkgo.By("finish first foundation workload")
 			util.FinishRunningWorkloadsInCQ(ctx, k8sClient, cq1, 1)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
When the quota of a workload is "stolen" by a workload processed earlier in the cycle, the scheduler will skip this workload and continue the search starting from the next flavor (in the subsequent cycles). This might be sub-optimal in cases where a valid assignment still exists in the current flavor, via preemption.

The current behavior is either:
* The workload will get assigned a less favorable flavor.
* If an assignment is not available in the less favorable flavor, the workload will eventually "loop around" and try the skipped flavor again. This is why this issue is transient in some cases and heals on its own.

 We can use the existing "recompute" behavior to cover this scenario to immediately find the new assignment via preemptions, preventing a sub-optimal assignment when a more preferable one exists.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:
Part 2 of https://github.com/kubernetes-sigs/kueue/pull/13863.

See the [document](https://docs.google.com/document/d/1PSB7HkUuP-7CjJFazbq3bH6jRxNZw9ZYV3jLB1Iz_cw/edit?resourcekey=0-wDLih8iorKJJMMZIasaX6g&tab=t.0) describing how this and the related fixes affect the scheduler.

#### Does this PR introduce a user-facing change?
```release-note
Scheduling: Kueue now recomputes an assignment calculated during nomination if the workload's quota was taken by workloads processed earlier in the same scheduling cycle.
This fixes the issue where a workload will transiently skip a more favorable flavor and try the next one, while a valid assignment is still possible in the more favorable one via preemption.

The behavior is controlled by the Beta `RecomputeAssignmentUponQuotaExhaustion` feature gate.
```
