### PR TITLE
Backfill queue-name onto LeaderWorkerSet pods

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -526,8 +526,18 @@ func (r *Reconciler) reconcilePod(ctx context.Context, lws *leaderworkersetv1.Le
 }
 
 func (r *Reconciler) setDefault(lws *leaderworkersetv1.LeaderWorkerSet, pod *corev1.Pod) bool {
-	// Pod already has managed-by-kueue label, skipping.
+	queueName := jobframework.QueueNameForObject(lws)
+
 	if _, ok := pod.Labels[constants.ManagedByKueueLabelKey]; ok {
+		// TODO(#13968): Candidate for removal once LeaderWorkerSets admitted before #4932
+		// are gone, no earlier than 0.21. The webhook stamps the queue name on the pod
+		// templates, so it is only missing here on those, which #4932 did not migrate.
+		// Only gated pods qualify: the pod webhook rejects the change on others.
+		if queueName != "" && utilpod.HasGate(pod, podconstants.SchedulingGateName) &&
+			pod.Labels[controllerconstants.QueueLabel] != string(queueName) {
+			pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+			return true
+		}
 		return false
 	}
 
@@ -543,6 +553,14 @@ func (r *Reconciler) setDefault(lws *leaderworkersetv1.LeaderWorkerSet, pod *cor
 	}
 
 	pod.Labels[constants.ManagedByKueueLabelKey] = constants.ManagedByKueueLabelValue
+	// TODO(#13968): Candidate for removal together with the backfill above, no earlier
+	// than 0.21. Normally the webhook has already stamped the queue name on the pod
+	// template, so this only matters for a LeaderWorkerSet admitted before #4932;
+	// setting it here saves reconciling the pod a second time to backfill it.
+	// Only gated pods qualify: the pod webhook rejects the change on others.
+	if queueName != "" && utilpod.HasGate(pod, podconstants.SchedulingGateName) {
+		pod.Labels[controllerconstants.QueueLabel] = string(queueName)
+	}
 	podcontroller.SetPodGroupName(pod, wlName)
 	jobframework.SetPrebuiltWorkloadName(pod, wlName)
 	pod.Annotations[podconstants.GroupTotalCountAnnotation] = fmt.Sprint(ptr.Deref(lws.Spec.LeaderWorkerTemplate.Size, 1))

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -1119,6 +1119,239 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"should backfill queue-name on an already adopted pod": {
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testLWS).
+				Queue("queue").
+				Obj(),
+			statefulSets: []appsv1.StatefulSet{
+				*statefulset.MakeStatefulSet(testSTS, testNS).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Obj(),
+			},
+			// Migration case: the pod was already adopted but carries a stale queue name,
+			// because it came from a template the webhook never stamped.
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					ManagedByKueueLabel().
+					Queue("old-queue").
+					GroupNameLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkloadLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					KueueSchedulingGate().
+					KueueFinalizer().
+					Obj(),
+			},
+			wantLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+					UID(testLWS).
+					Queue("queue").
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					ManagedByKueueLabel().
+					Queue("queue").
+					GroupNameLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkloadLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					KueueSchedulingGate().
+					KueueFinalizer().
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+					JobUID(testLWS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(constants.JobOwnerNameAnnotation, testLWS).
+					Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
+					Queue("queue").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
+							Obj()).
+					Priority(0).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(testLWS, testLWS, "0"),
+					),
+				},
+			},
+		},
+		"should not backfill queue-name on an ungated pod": {
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testLWS).
+				Queue("queue").
+				Obj(),
+			statefulSets: []appsv1.StatefulSet{
+				*statefulset.MakeStatefulSet(testSTS, testNS).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Obj(),
+			},
+			// The pod is already ungated, so the pod webhook rejects a queue-name
+			// change as immutable. Leave it alone: it is running and does not need it.
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					ManagedByKueueLabel().
+					GroupNameLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkloadLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					KueueFinalizer().
+					Obj(),
+			},
+			wantLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+					UID(testLWS).
+					Queue("queue").
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					ManagedByKueueLabel().
+					GroupNameLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkloadLabel(GetWorkloadName(testLWS, testLWS, "0")).
+					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					KueueFinalizer().
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+					JobUID(testLWS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(constants.JobOwnerNameAnnotation, testLWS).
+					Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
+					Queue("queue").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
+							Obj()).
+					Priority(0).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(testLWS, testLWS, "0"),
+					),
+				},
+			},
+		},
+		"should set queue-name when adopting a pod without it": {
+			leaderWorkerSet: leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+				UID(testLWS).
+				Queue("queue").
+				Obj(),
+			statefulSets: []appsv1.StatefulSet{
+				*statefulset.MakeStatefulSet(testSTS, testNS).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Obj(),
+			},
+			// Migration case: unlike the test above, this pod comes from a template the
+			// webhook never stamped, so the reconciler sets the queue name while adopting
+			// it instead of leaving the pod unlabelled for a later reconcile to backfill.
+			pods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					KueueSchedulingGate().
+					Obj(),
+			},
+			wantLeaderWorkerSets: []leaderworkersetv1.LeaderWorkerSet{
+				*leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).
+					UID(testLWS).
+					Queue("queue").
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingjobspod.MakePod("pod1", testNS).
+					OwnerReference(testSTS, stsGVK).
+					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
+					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					ManagedByKueueLabel().
+					Queue("queue").
+					GroupNameAnnotation(GetWorkloadName(testLWS, testLWS, "0")).
+					GroupTotalCount("1").
+					PrebuiltWorkloadAnnotation(GetWorkloadName(testLWS, testLWS, "0")).
+					Annotation(podconstants.RoleHashAnnotation, string(kueue.DefaultPodSetName)).
+					KueueSchedulingGate().
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+					JobUID(testLWS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Annotation(constants.JobOwnerGVKAnnotation, gvk.String()).
+					Annotation(constants.JobOwnerNameAnnotation, testLWS).
+					Annotation(constants.ComponentWorkloadIndexAnnotation, "0").
+					Queue("queue").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							PodIndexLabel(new(leaderworkersetv1.WorkerIndexLabelKey)).
+							Obj()).
+					Priority(0).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: testLWS, Namespace: testNS},
+					EventType: corev1.EventTypeNormal,
+					Reason:    jobframework.ReasonCreatedWorkload,
+					Message: fmt.Sprintf(
+						"Created Workload: %s/%s",
+						testNS,
+						GetWorkloadName(testLWS, testLWS, "0"),
+					),
+				},
+			},
+		},
 		"should finalize pods if leaderworkerset is deleted": {
 			featureGates:    map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			leaderWorkerSet: nil,
@@ -1580,11 +1813,14 @@ func TestReconciler(t *testing.T) {
 					).
 					Obj(),
 			},
+			// Normal case: the webhook stamped the queue name on the pod template, so the
+			// pod already carries it when the reconciler adopts it.
 			pods: []corev1.Pod{
 				*testingjobspod.MakePod("pod1", testNS).
 					OwnerReference(testSTS, stsGVK).
 					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
+					Queue("queue").
 					Annotation(podconstants.SuspendedByParentAnnotation, FrameworkName).
 					Annotation(podconstants.GroupServingAnnotationKey, podconstants.GroupServingAnnotationValue).
 					Obj(),
@@ -1622,6 +1858,7 @@ func TestReconciler(t *testing.T) {
 					Label(leaderworkersetv1.SetNameLabelKey, testLWS).
 					Label(leaderworkersetv1.GroupIndexLabelKey, "0").
 					ManagedByKueueLabel().
+					Queue("queue").
 					GroupNameLabel(GetWorkloadName(testLWS, testLWS, "0")).
 					GroupTotalCount("1").
 					PrebuiltWorkloadLabel(GetWorkloadName(testLWS, testLWS, "0")).


### PR DESCRIPTION
The LWS pod reconciler stopped writing the queue-name label onto pods when that write moved into the LWS webhook, which stamps the leader and worker pod templates instead. The webhook only runs on create/update, so a LeaderWorkerSet admitted before that change keeps templates without the label and there is no backfill.

Pods recreated from such a template start without a queue name. The pod integration then skips them ("queue-name label is not set, ignoring the job"), no workload annotation is written, the pod is missing from the WorkloadSliceNameKey index, and the topology ungater finds no candidates, so the scheduling gates are never removed. waitForPodsReady eventually evicts the workload, the pods are recreated from the same template, and the cycle repeats until requeueState.count reaches backoffLimitCount and the workload is deactivated.

Read the queue name from the LeaderWorkerSet and set it when adopting a pod, and reconcile it on pods that are already adopted. This mirrors what the StatefulSet pod reconciler already does, and keeps pods correct regardless of whether their templates were stamped.

#### What type of PR is this?

  /kind bug
  /area integrations

  #### What this PR does / why we need it:

  The LWS pod reconciler stopped writing the `queue-name` label onto pods when that write moved into the LWS webhook (#4932), which stamps the leader and worker pod templates instead. The webhook only runs on
  create/update, so a LeaderWorkerSet admitted before that change keeps templates without the label, and there is no backfill.

  Pods recreated from such a template start without a queue name. The pod integration then skips them (`"queue-name label is not set, ignoring the job"`), no workload annotation is written, the pod is missing from
  the `WorkloadSliceNameKey` index, and the topology ungater finds no candidates — so the scheduling gates are never removed. `waitForPodsReady` eventually evicts the workload, the pods are recreated from the same
  template, and the cycle repeats until `requeueState.count` reaches `backoffLimitCount` and the workload is deactivated. Throughout, the Workload reports `Admitted=True` with a valid TAS assignment, so quota looks
  healthy.

  `setDefault` now reads the queue name from the LeaderWorkerSet and sets it when adopting a pod, and reconciles it on pods that are already adopted. This mirrors what the StatefulSet pod reconciler already does,
  so pods are correct regardless of whether their templates were stamped.

  #### Which issue(s) this PR fixes:

  Fixes #13968

  #### Special notes for your reviewer:

  - Guarded by `queueName != ""`, so the webhook stays authoritative and `manageJobsWithoutQueueName` behaviour is unchanged. This is a repair path, not a revert of #4932.
  - Two new `TestReconciler` cases; both fail without the change.
  - One existing case (`should set default values even if queue-name changed and workload has quota reservation`) needed its `wantPods` updated: its LWS carries a queue name and its pod is newly adopted, so the pod
  now correctly gains the label.

  #### Does this PR introduce a user-facing change?
  N/A

  #### AI usage disclosure

  This change was developed with AI assistance (Claude). The diagnosis, code, and
  tests were authored with AI help and reviewed by me.

  ```release-note
LeaderWorkerSet: Fixed a bug where pods recreated from a LeaderWorkerSet whose pod templates were never stamped with the `kueue.x-k8s.io/queue-name` label stayed permanently scheduling-gated, eventually deactivating the Workload.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured eligible, Kueue-managed LeaderWorkerSet Pods receive the correct queue label when gated and a queue name is available.
  * Backfilled missing or outdated queue labels on adopted Pods while preserving ungated Pods without queue labels.
  * Newly managed Pods now receive queue labels during adoption when applicable.

* **Tests**
  * Added coverage for queue-label propagation on suspended, adopted, and ungated LeaderWorkerSet Pods.
  * Updated quota-reservation scenarios to reflect queue labels added by admission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->