### PR TITLE
fix: ungate elastic pods after the chain-root workload slice is deleted

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -52,6 +52,7 @@ import (
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
+	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
@@ -81,17 +82,22 @@ func SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration, roleTracke
 		roleTracker:       roleTracker,
 	}
 	podHandler := elasticPodHandler{
+		client:            r.client,
 		expectationsStore: r.expectationsStore,
 	}
-	// Reconcile by the stable slice-chain key rather than by an individual
-	// workload, so every slice in a chain (and every pod that names any slice in
-	// it) maps to a single reconcile request. Reconcile then resolves the active
-	// slice from that key.
+	// Reconcile by the chain's active slice, resolved from whichever slice fired
+	// the event. Every slice maps to the single currently-admitted slice, whose
+	// granted counts cap ungating; Reconcile then loads it directly (no lookup
+	// through a possibly-deleted origin).
 	sliceKeyHandler := handler.TypedEnqueueRequestsFromMapFunc(
-		func(_ context.Context, wl *kueue.Workload) []reconcile.Request {
+		func(ctx context.Context, wl *kueue.Workload) []reconcile.Request {
+			active, err := r.activeSlice(ctx, wl)
+			if err != nil || active == nil {
+				return nil
+			}
 			return []reconcile.Request{{NamespacedName: types.NamespacedName{
-				Namespace: wl.Namespace,
-				Name:      workloadslicing.SliceName(wl),
+				Namespace: active.Namespace,
+				Name:      active.Name,
 			}}}
 		},
 	)
@@ -116,44 +122,31 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile ElasticJobUngater")
 
-	if !r.expectationsStore.Satisfied(log, req.NamespacedName) {
-		return reconcile.Result{}, errPendingUngateOps
+	// req.Name is the chain's active (latest admitted, non-finished) slice: the
+	// enqueue handlers resolve it from whichever slice or pod triggered the event,
+	// so Reconcile always loads a live workload whose granted PodSet counts define
+	// how many pods may be ungated. If it is already gone (just finished/deleted),
+	// there is nothing to ungate.
+	active := &kueue.Workload{}
+	if err := r.client.Get(ctx, req.NamespacedName, active); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	// The handlers only enqueue active elastic slices, but an enqueue can race a
+	// slice finishing or being evicted; re-check before ungating against its (now
+	// stale) granted counts. Eviction is two writes — the condition is set before
+	// the reservation is released — so an evicted slice still reports a
+	// reservation while its capacity is on the way out; exclude it here, matching
+	// workloadslicing.FindLatestActiveWorkload.
+	if !shouldUngate(active) || workloadevict.IsEvicted(active) {
+		return reconcile.Result{}, nil
 	}
 
-	// req.Name is the stable slice-chain key shared by every slice and pod in the
-	// chain (see workloadslicing.SliceName); it is the name of the chain's root
-	// slice. Load it to find the owning job, then resolve the active (latest
-	// admitted, non-finished) slice from the job's slice chain: it is the only
-	// one whose granted PodSet counts define how many pods may be ungated, so the
-	// cap is always taken from the live slice regardless of which slice (or which
-	// pod's stamped WorkloadAnnotation) triggered the event.
-	//
-	// The root slice may be gone (e.g. a RayService rollout cascade-deletes the
-	// old RayCluster and its Workloads) while later slices and their still-gated
-	// pods keep pointing at its name. In that case recover the owning job from a
-	// chain pod instead of bailing, so those pods still get ungated.
-	var active *kueue.Workload
-	root := &kueue.Workload{}
-	switch err := r.client.Get(ctx, req.NamespacedName, root); {
-	case err == nil:
-		active, err = r.activeSlice(ctx, root)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	case apierrors.IsNotFound(err):
-		active, err = r.activeSliceForDeletedRoot(ctx, req.NamespacedName)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	default:
-		return reconcile.Result{}, err
-	}
-	if active == nil {
-		// Anomaly: the event was queued for an admitted, non-finished elastic slice
-		// (see shouldUngate), yet the chain has no active slice now — e.g. it just
-		// finished, or the root lost its controller owner between events.
-		log.V(2).Info("no active elastic slice resolved for the chain; skipping ungating", "workload", klog.KObj(root))
-		return reconcile.Result{}, nil
+	// Expectations are keyed by the stable chain key (the origin slice name shared
+	// by every slice and pod in the chain), not by the rolling active-slice name,
+	// so in-flight ungate expectations survive a scale rollover.
+	sliceKey := types.NamespacedName{Namespace: active.Namespace, Name: workloadslicing.SliceName(active)}
+	if !r.expectationsStore.Satisfied(log, sliceKey) {
+		return reconcile.Result{}, errPendingUngateOps
 	}
 
 	pods, err := r.podsToUngate(ctx, active)
@@ -169,7 +162,7 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	for i := range pods {
 		uids[i] = pods[i].UID
 	}
-	r.expectationsStore.ExpectUIDs(log, req.NamespacedName, uids)
+	r.expectationsStore.ExpectUIDs(log, sliceKey, uids)
 
 	err = parallelize.Until(ctx, len(pods), func(i int) error {
 		pod := pods[i]
@@ -182,12 +175,12 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 			return ungated, nil
 		})
 		if e != nil {
-			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+			r.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 			log.Error(e, "failed ungating elastic pod", "pod", klog.KObj(pod))
 			return e
 		}
 		if !ungated {
-			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+			r.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 		} else {
 			utilpod.RecordPodSchedulingGateRemovalSeconds(r.clock, kueue.ElasticJobSchedulingGate, active, false)
 		}
@@ -263,54 +256,20 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 	if owner == nil {
 		return nil, nil
 	}
-	return r.activeSliceForOwner(ctx, anyWl.Namespace, owner)
+	return latestActiveSliceForOwner(ctx, r.client, anyWl.Namespace, owner)
 }
 
-// activeSliceForDeletedRoot resolves the chain's active slice when the root slice
-// named by key has been deleted. The owning job is recovered from a still-present
-// pod of the chain (indexed by the same slice key), so ungating still proceeds for
-// pods left pointing at a now-deleted origin slice. The recovered owner UID is
-// matched against the active slice's controller owner so a stale pod pointing at a
-// recreated same-named job cannot ungate against the wrong job's granted count.
-// Returns nil if no chain pod, no job owner, or no matching active slice is found.
-func (r *elasticJobUngater) activeSliceForDeletedRoot(ctx context.Context, key types.NamespacedName) (*kueue.Workload, error) {
-	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList,
-		client.InNamespace(key.Namespace),
-		client.MatchingFields{indexer.WorkloadSliceNameKey: key.Name},
-	); err != nil {
-		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
-	}
-	for i := range podList.Items {
-		owner := metav1.GetControllerOf(&podList.Items[i])
-		if owner == nil {
-			continue
-		}
-		active, err := r.activeSliceForOwner(ctx, key.Namespace, owner)
-		if err != nil {
-			return nil, err
-		}
-		if active == nil {
-			continue
-		}
-		// The pod's owner-ref names a job by name+GVK, but a same-named job could
-		// have been recreated with a new UID. The active slice's controller owner
-		// carries the current job UID, so require it to match the pod's owner UID
-		// before trusting this slice's granted counts.
-		if activeOwner := metav1.GetControllerOf(active); activeOwner != nil && activeOwner.UID == owner.UID {
-			return active, nil
-		}
-	}
-	return nil, nil
+func (h *elasticPodHandler) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
+	return latestActiveSliceForOwner(ctx, h.client, namespace, owner)
 }
 
-// activeSliceForOwner resolves the latest active workload slice owned by the given
-// job (owner) in namespace. Shared by activeSlice and activeSliceForDeletedRoot.
-func (r *elasticJobUngater) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
+// latestActiveSliceForOwner resolves the latest active workload slice owned by the
+// given job (owner) in namespace, or nil if none qualifies.
+func latestActiveSliceForOwner(ctx context.Context, c client.Client, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
 	jobObject := &metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: owner.Name},
 	}
-	return workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+	return workloadslicing.FindLatestActiveWorkload(ctx, c, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
 }
 
 // Workload predicates
@@ -342,6 +301,7 @@ func (r *elasticJobUngater) Generic(event.TypedGenericEvent[*kueue.Workload]) bo
 var _ handler.EventHandler = (*elasticPodHandler)(nil)
 
 type elasticPodHandler struct {
+	client            client.Client
 	expectationsStore *expectations.Store
 }
 
@@ -365,24 +325,52 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 	if !isPod {
 		return
 	}
-	// Enqueue by the stable slice-chain key, not the pod's stamped
-	// WorkloadAnnotation. A pod minted after a scale-up still carries the previous
-	// (now Finished) slice's name, but the chain key is shared by every slice, so
-	// Reconcile can always resolve the active slice from it.
+	// Expectations are keyed by the stable chain key (the origin slice name the
+	// pod carries), so observations survive scale rollovers.
 	sliceName := podSliceName(pod)
 	if sliceName == "" {
 		return
 	}
-	key := types.NamespacedName{
-		Name:      sliceName,
-		Namespace: pod.Namespace,
-	}
+	sliceKey := types.NamespacedName{Name: sliceName, Namespace: pod.Namespace}
 	// Mark expectation as observed when the gate has been removed or the pod is deleted.
 	if !utilpod.HasGate(pod, kueue.ElasticJobSchedulingGate) || deleted {
-		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", key.String())
-		h.expectationsStore.ObservedUID(log, key, pod.UID)
+		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
+		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	q.AddAfter(reconcile.Request{NamespacedName: key}, constants.UpdatesBatchPeriod)
+	// Enqueue the chain's active slice so Reconcile loads a live workload directly
+	// (a deleted origin slice no longer strands the pod). Resolve the owning job
+	// from the named slice if it still exists, otherwise from the pod's own
+	// controller owner-ref — the latter is what keeps ungating working after the
+	// origin slice the pod points at has been garbage-collected.
+	owner := h.ownerForPod(ctx, pod, sliceKey)
+	if owner == nil {
+		return
+	}
+	active, err := h.activeSliceForOwner(ctx, pod.Namespace, owner)
+	if err != nil || active == nil {
+		return
+	}
+	q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: active.Namespace,
+		Name:      active.Name,
+	}}, constants.UpdatesBatchPeriod)
+}
+
+// ownerForPod finds the job owning the pod's slice chain: prefer the controller
+// owner of the named slice when it still exists (pods are not always owned by the
+// job directly), and fall back to the pod's own controller owner-ref when that
+// slice has been deleted.
+func (h *elasticPodHandler) ownerForPod(ctx context.Context, pod *corev1.Pod, sliceKey types.NamespacedName) *metav1.OwnerReference {
+	slice := &kueue.Workload{}
+	switch err := h.client.Get(ctx, sliceKey, slice); {
+	case err == nil:
+		if owner := metav1.GetControllerOf(slice); owner != nil {
+			return owner
+		}
+	case !apierrors.IsNotFound(err):
+		return nil
+	}
+	return metav1.GetControllerOf(pod)
 }
 
 // podSliceName returns the slice-chain key for a pod: the WorkloadSliceName

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -269,8 +269,10 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 // activeSliceForDeletedRoot resolves the chain's active slice when the root slice
 // named by key has been deleted. The owning job is recovered from a still-present
 // pod of the chain (indexed by the same slice key), so ungating still proceeds for
-// pods left pointing at a now-deleted origin slice. Returns nil if no chain pod or
-// job owner can be found.
+// pods left pointing at a now-deleted origin slice. The recovered owner UID is
+// matched against the active slice's controller owner so a stale pod pointing at a
+// recreated same-named job cannot ungate against the wrong job's granted count.
+// Returns nil if no chain pod, no job owner, or no matching active slice is found.
 func (r *elasticJobUngater) activeSliceForDeletedRoot(ctx context.Context, key types.NamespacedName) (*kueue.Workload, error) {
 	var podList corev1.PodList
 	if err := r.client.List(ctx, &podList,
@@ -280,8 +282,23 @@ func (r *elasticJobUngater) activeSliceForDeletedRoot(ctx context.Context, key t
 		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
 	}
 	for i := range podList.Items {
-		if owner := metav1.GetControllerOf(&podList.Items[i]); owner != nil {
-			return r.activeSliceForOwner(ctx, key.Namespace, owner)
+		owner := metav1.GetControllerOf(&podList.Items[i])
+		if owner == nil {
+			continue
+		}
+		active, err := r.activeSliceForOwner(ctx, key.Namespace, owner)
+		if err != nil {
+			return nil, err
+		}
+		if active == nil {
+			continue
+		}
+		// The pod's owner-ref names a job by name+GVK, but a same-named job could
+		// have been recreated with a new UID. The active slice's controller owner
+		// carries the current job UID, so require it to match the pod's owner UID
+		// before trusting this slice's granted counts.
+		if activeOwner := metav1.GetControllerOf(active); activeOwner != nil && activeOwner.UID == owner.UID {
+			return active, nil
 		}
 	}
 	return nil, nil

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -126,12 +127,25 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	// one whose granted PodSet counts define how many pods may be ungated, so the
 	// cap is always taken from the live slice regardless of which slice (or which
 	// pod's stamped WorkloadAnnotation) triggered the event.
+	//
+	// The root slice may be gone (e.g. a RayService rollout cascade-deletes the
+	// old RayCluster and its Workloads) while later slices and their still-gated
+	// pods keep pointing at its name. In that case recover the owning job from a
+	// chain pod instead of bailing, so those pods still get ungated.
+	var active *kueue.Workload
 	root := &kueue.Workload{}
-	if err := r.client.Get(ctx, req.NamespacedName, root); err != nil {
-		return reconcile.Result{}, client.IgnoreNotFound(err)
-	}
-	active, err := r.activeSlice(ctx, root)
-	if err != nil {
+	switch err := r.client.Get(ctx, req.NamespacedName, root); {
+	case err == nil:
+		active, err = r.activeSlice(ctx, root)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	case apierrors.IsNotFound(err):
+		active, err = r.activeSliceForDeletedRoot(ctx, req.NamespacedName)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	default:
 		return reconcile.Result{}, err
 	}
 	if active == nil {
@@ -249,8 +263,35 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 	if owner == nil {
 		return nil, nil
 	}
+	return r.activeSliceForOwner(ctx, anyWl.Namespace, owner)
+}
+
+// activeSliceForDeletedRoot resolves the chain's active slice when the root slice
+// named by key has been deleted. The owning job is recovered from a still-present
+// pod of the chain (indexed by the same slice key), so ungating still proceeds for
+// pods left pointing at a now-deleted origin slice. Returns nil if no chain pod or
+// job owner can be found.
+func (r *elasticJobUngater) activeSliceForDeletedRoot(ctx context.Context, key types.NamespacedName) (*kueue.Workload, error) {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList,
+		client.InNamespace(key.Namespace),
+		client.MatchingFields{indexer.WorkloadSliceNameKey: key.Name},
+	); err != nil {
+		return nil, fmt.Errorf("listing pods for workload slice: %w", err)
+	}
+	for i := range podList.Items {
+		if owner := metav1.GetControllerOf(&podList.Items[i]); owner != nil {
+			return r.activeSliceForOwner(ctx, key.Namespace, owner)
+		}
+	}
+	return nil, nil
+}
+
+// activeSliceForOwner resolves the latest active workload slice owned by the given
+// job (owner) in namespace. Shared by activeSlice and activeSliceForDeletedRoot.
+func (r *elasticJobUngater) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
 	jobObject := &metav1.PartialObjectMetadata{
-		ObjectMeta: metav1.ObjectMeta{Namespace: anyWl.Namespace, Name: owner.Name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: owner.Name},
 	}
 	return workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
 }

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -686,7 +686,7 @@ func TestReconcile(t *testing.T) {
 					Finalizers(kueue.ResourceInUseFinalizerName).
 					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					ControllerReference(rayClusterGVK, "ray", "ray").
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					ReserveQuotaAt(
 						utiltestingapi.MakeAdmission("cq").
@@ -723,6 +723,46 @@ func TestReconcile(t *testing.T) {
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
 					OwnerReference("ray", rayClusterGVK).
+					Obj(),
+			},
+		},
+		"does not ungate when the chain pod owner UID no longer matches the active slice": {
+			// Guard against a stale pod pointing at a same-named job that was
+			// recreated with a new UID: the active slice belongs to the new job, so
+			// its granted count must not be used to ungate the stale pod. The pod
+			// keeps its gate.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "new-ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "2").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				// Owner UID "ray" (stale) != active slice owner UID "new-ray-uid".
+				*testingpod.MakePod("stale-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("stale-pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 			},
 		},

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -674,6 +674,58 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"ungates pods when the chain-root slice has been deleted": {
+			// A RayService rollout can cascade-delete the old RayCluster and its
+			// root Workload while later scale-up slices and their still-gated pods
+			// keep pointing at the (now gone) root name. The reconcile key is the
+			// root name, which no longer resolves; the ungater must recover the
+			// owning job from a chain pod and still ungate up to the active slice's
+			// granted count instead of silently giving up.
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "2").
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				// NOTE: the root slice "wl" is intentionally absent (deleted).
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod-from-parent", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+				*testingpod.MakePod("pod-from-scale-up", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod-from-parent", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Obj(),
+				*testingpod.MakePod("pod-from-scale-up", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					OwnerReference("ray", rayClusterGVK).
+					Obj(),
+			},
+		},
 		"preserve topology gate when ungating elastic gate": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -674,98 +674,6 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
-		"ungates pods when the chain-root slice has been deleted": {
-			// A RayService rollout can cascade-delete the old RayCluster and its
-			// root Workload while later scale-up slices and their still-gated pods
-			// keep pointing at the (now gone) root name. The reconcile key is the
-			// root name, which no longer resolves; the ungater must recover the
-			// owning job from a chain pod and still ungate up to the active slice's
-			// granted count instead of silently giving up.
-			workloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					ControllerReference(rayClusterGVK, "ray", "ray").
-					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuotaAt(
-						utiltestingapi.MakeAdmission("cq").
-							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Assignment(corev1.ResourceCPU, "flavor", "2").
-								Obj()).
-							Obj(), now,
-					).
-					AdmittedAt(true, now).
-					Obj(),
-				// NOTE: the root slice "wl" is intentionally absent (deleted).
-			},
-			pods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-parent", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-				*testingpod.MakePod("pod-from-scale-up", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-			},
-			wantPods: []corev1.Pod{
-				*testingpod.MakePod("pod-from-parent", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Obj(),
-				*testingpod.MakePod("pod-from-scale-up", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Obj(),
-			},
-		},
-		"does not ungate when the chain pod owner UID no longer matches the active slice": {
-			// Guard against a stale pod pointing at a same-named job that was
-			// recreated with a new UID: the active slice belongs to the new job, so
-			// its granted count must not be used to ungate the stale pod. The pod
-			// keeps its gate.
-			workloads: []kueue.Workload{
-				*utiltestingapi.MakeWorkload("wl-slice-1", "ns").
-					Finalizers(kueue.ResourceInUseFinalizerName).
-					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					ControllerReference(rayClusterGVK, "ray", "new-ray-uid").
-					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
-					ReserveQuotaAt(
-						utiltestingapi.MakeAdmission("cq").
-							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
-								Assignment(corev1.ResourceCPU, "flavor", "2").
-								Obj()).
-							Obj(), now,
-					).
-					AdmittedAt(true, now).
-					Obj(),
-			},
-			pods: []corev1.Pod{
-				// Owner UID "ray" (stale) != active slice owner UID "new-ray-uid".
-				*testingpod.MakePod("stale-pod", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-			},
-			wantPods: []corev1.Pod{
-				*testingpod.MakePod("stale-pod", "ns").
-					Annotation(kueue.WorkloadAnnotation, "wl").
-					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
-					OwnerReference("ray", rayClusterGVK).
-					Gate(kueue.ElasticJobSchedulingGate).
-					Obj(),
-			},
-		},
 		"preserve topology gate when ungating elastic gate": {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl", "ns").
@@ -1032,17 +940,24 @@ func TestReconcile(t *testing.T) {
 				return
 			}
 
-			// The ungater reconciles by the stable slice-chain key, not by an
-			// individual workload name, so derive the request key from the chain.
-			key := types.NamespacedName{
-				Namespace: tc.workloads[0].Namespace,
-				Name:      workloadslicing.SliceName(&tc.workloads[0]),
+			// The ungater now reconciles by the chain's ACTIVE slice: the enqueue
+			// handlers resolve it via activeSlice, so mirror that here to pick the
+			// request key. Expectations stay keyed by the stable chain key (the
+			// active slice's origin name).
+			active, err := ungater.activeSlice(ctx, &tc.workloads[0])
+			if err != nil {
+				t.Fatalf("resolving active slice: %v", err)
 			}
+			if active == nil {
+				active = &tc.workloads[0]
+			}
+			key := types.NamespacedName{Namespace: active.Namespace, Name: active.Name}
+			sliceKey := types.NamespacedName{Namespace: active.Namespace, Name: workloadslicing.SliceName(active)}
 			if len(tc.expectUIDs) > 0 {
-				ungater.expectationsStore.ExpectUIDs(log, key, tc.expectUIDs)
+				ungater.expectationsStore.ExpectUIDs(log, sliceKey, tc.expectUIDs)
 			}
 
-			_, err := ungater.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			_, err = ungater.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			if diff := gocmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
 			}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4636,6 +4636,94 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Regression for the stranded-pod bug (kueue#14129): after a scale-up the
+		// origin (root) slice can be garbage-collected while a still-gated pod
+		// keeps pointing at the gone origin name (e.g. a RayService rollout
+		// deletes the old RayCluster and its Workloads). The ungater must recover
+		// the owning job from the pod and ungate against the surviving active
+		// slice, rather than bailing on the missing origin. Demonstrated here on a
+		// plain Job to show it is not Ray-specific.
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+		testJob := testingjob.MakeJob("deleted-origin", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(2).
+			Obj()
+
+		ginkgo.By("creating and admitting the job's origin workload slice")
+		util.MustCreate(ctx, k8sClient, testJob)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up parallelism to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old workloads")
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			g.Expect(err).To(gomega.Succeed())
+			// Strip the finalizer so the pending delete completes.
+			wl.Finalizers = nil
+			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
+			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the Job")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(pkgconstants.PodSetLabel, string(activeSlice.Spec.PodSets[0].Name)).
+			OwnerReference(testJob.Name, jobGVK).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences[0].UID = testJob.UID
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should not wedge the reconciler when scaling down below the accumulated succeeded count", framework.SlowSpec, func() {
 		// Regression for kueue#12670: with job-completions-equal-parallelism,
 		// the workload's reclaimablePods count mirrors the Job's

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4689,20 +4689,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old workloads")
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
-		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			wl := &kueue.Workload{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			g.Expect(err).To(gomega.Succeed())
-			// Strip the finalizer so the pending delete completes.
-			wl.Finalizers = nil
-			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
-			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
 
 		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the Job")
 		gatedPod := testingpod.MakePod("worker-0", ns.Name).
@@ -4751,20 +4738,7 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		originSliceName := originSlice.Name
 
 		ginkgo.By("deleting the only slice so the chain has no eligible active slice")
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
-		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			wl := &kueue.Workload{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			g.Expect(err).To(gomega.Succeed())
-			// Strip the finalizer so the pending delete completes.
-			wl.Finalizers = nil
-			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
-			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
 
 		ginkgo.By("creating a gated pod that points at the deleted origin, owned by the Job")
 		gatedPod := testingpod.MakePod("worker-0", ns.Name).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4724,6 +4724,68 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should keep chain pods gated when the origin slice is deleted and no active slice survives", framework.SlowSpec, func() {
+		// Negative companion to the deleted-origin recovery test: when the origin
+		// slice is gone AND no admitted, non-finished slice remains, there is no
+		// granted count to ungate against, so the pod must stay gated rather than
+		// be let through against stale capacity.
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+		testJob := testingjob.MakeJob("deleted-origin-no-active", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(1).
+			Obj()
+
+		ginkgo.By("creating and admitting the job's only workload slice")
+		util.MustCreate(ctx, k8sClient, testJob)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("deleting the only slice so the chain has no eligible active slice")
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			g.Expect(err).To(gomega.Succeed())
+			// Strip the finalizer so the pending delete completes.
+			wl.Finalizers = nil
+			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
+			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("creating a gated pod that points at the deleted origin, owned by the Job")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(pkgconstants.PodSetLabel, string(kueue.DefaultPodSetName)).
+			OwnerReference(testJob.Name, jobGVK).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences[0].UID = testJob.UID
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the pod keeps its elastic scheduling gate, since no active slice grants capacity")
+		gomega.Consistently(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).Should(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should not wedge the reconciler when scaling down below the accumulated succeeded count", framework.SlowSpec, func() {
 		// Regression for kueue#12670: with job-completions-equal-parallelism,
 		// the workload's reclaimablePods count mirrors the Job's

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -25,7 +25,6 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +33,6 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -1002,20 +1000,7 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("deleting the origin slice to emulate a RayService rollout GC of the old RayCluster's workloads")
-		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
-		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			wl := &kueue.Workload{}
-			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
-			if apierrors.IsNotFound(err) {
-				return
-			}
-			g.Expect(err).To(gomega.Succeed())
-			if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
-				g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
-			}
-			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
 
 		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the RayCluster")
 		gatedPod := testingpod.MakePod("worker-0", ns.Name).

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -1001,23 +1001,6 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("creating a still-gated pod that points at the origin slice, owned by the RayCluster")
-		gatedPod := testingpod.MakePod("worker-0", ns.Name).
-			Annotation(kueue.WorkloadAnnotation, originSliceName).
-			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
-			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
-			Gate(kueue.ElasticJobSchedulingGate).
-			Obj()
-		gatedPod.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion:         rayv1.SchemeGroupVersion.String(),
-			Kind:               "RayCluster",
-			Name:               testRayCluster.Name,
-			UID:                testRayCluster.UID,
-			Controller:         new(true),
-			BlockOwnerDeletion: new(true),
-		}}
-		util.MustCreate(ctx, k8sClient, gatedPod)
-
 		ginkgo.By("deleting the origin slice to emulate a RayService rollout GC of the old RayCluster's workloads")
 		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
 		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
@@ -1033,6 +1016,23 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 			}
 			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the RayCluster")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               testRayCluster.Name,
+			UID:                testRayCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
 
 		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
 		gomega.Eventually(func(g gomega.Gomega) {

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -25,6 +25,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	corev1 "k8s.io/api/core/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,16 +34,19 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -116,7 +120,7 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Label("job:ray", "area:j
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
 		var jobQueueName kueue.LocalQueueName = "test-queue"
-		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
+		createdJob.Labels = map[string]string{controllerconstants.QueueLabel: string(jobQueueName)}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
@@ -269,9 +273,9 @@ var _ = ginkgo.Describe("Job controller RayCluster for workloads when only jobs 
 		ginkgo.By("checking the workload is created when queue name is set")
 		jobQueueName := "test-queue"
 		if createdJob.Labels == nil {
-			createdJob.Labels = map[string]string{constants.QueueLabel: jobQueueName}
+			createdJob.Labels = map[string]string{controllerconstants.QueueLabel: jobQueueName}
 		} else {
-			createdJob.Labels[constants.QueueLabel] = jobQueueName
+			createdJob.Labels[controllerconstants.QueueLabel] = jobQueueName
 		}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -341,7 +345,7 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			ginkgo.By("Create a job")
 			job := testingraycluster.MakeCluster(jobName, ns.Name).Obj()
 			jobQueueName := "test-queue"
-			job.Labels = map[string]string{constants.QueueLabel: jobQueueName}
+			job.Labels = map[string]string{controllerconstants.QueueLabel: jobQueueName}
 			util.MustCreate(ctx, k8sClient, job)
 			lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
 			createdJob := &rayv1.RayCluster{}
@@ -922,7 +926,8 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		ginkgo.By("raycluster-b's workload remains pending with unreserved quota")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testRayClusterA.Namespace), client.MatchingLabels{constants.JobUIDLabel: string(testRayClusterB.UID)})).Should(gomega.Succeed())
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testRayClusterA.Namespace), client.MatchingLabels{controllerconstants.JobUIDLabel: string(testRayClusterB.UID)})).
+				Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			testRayClusterBWorkload = &workloads.Items[0]
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, testRayClusterBWorkload)
@@ -942,6 +947,99 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayClusterB), testRayClusterB)).Should(gomega.Succeed())
 			g.Expect(ptr.Deref(testRayClusterB.Spec.Suspend, false)).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Reproduces the stranded-pod bug: after a scale-up the origin (root) slice
+		// can be garbage-collected (e.g. a RayService rollout deletes the old
+		// RayCluster and its Workloads), while a still-gated pod keeps pointing at
+		// the gone origin name. The ungater must recover the owning job from the
+		// pod and ungate against the surviving active slice, rather than bailing on
+		// the missing origin.
+		testRayCluster := testingraycluster.MakeCluster("foo", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			WithEnableAutoscaling(new(true)).
+			ScaleFirstWorkerGroup(1).
+			Obj()
+
+		ginkgo.By("creating and admitting the raycluster's origin workload slice")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayCluster), testRayCluster)).Should(gomega.Succeed())
+			testRayCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, testRayCluster)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("creating a still-gated pod that points at the origin slice, owned by the RayCluster")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               testRayCluster.Name,
+			UID:                testRayCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("deleting the origin slice to emulate a RayService rollout GC of the old RayCluster's workloads")
+		gomega.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, originSlice)).To(gomega.Succeed())
+		gomega.Expect(k8sClient.Delete(ctx, originSlice)).To(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			g.Expect(err).To(gomega.Succeed())
+			if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
+				g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
+			}
+			g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Namespace: ns.Name, Name: originSliceName}, wl))).To(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1460,6 +1460,29 @@ func FindNonFinishedWorkloads(workloads []kueue.Workload) []kueue.Workload {
 	return active
 }
 
+// DeleteWorkloadSliceAndAwaitDeletion deletes the named workload slice and waits
+// until it is gone, stripping the resource-in-use finalizer if it blocks removal.
+// Used by elastic-job tests to emulate a rollout garbage-collecting an origin
+// (root) slice while later slices and their pods still point at its name.
+func DeleteWorkloadSliceAndAwaitDeletion(ctx context.Context, k8sClient client.Client, key types.NamespacedName) {
+	ginkgo.GinkgoHelper()
+	slice := &kueue.Workload{}
+	gomega.Expect(k8sClient.Get(ctx, key, slice)).To(gomega.Succeed())
+	gomega.Expect(k8sClient.Delete(ctx, slice)).To(gomega.Succeed())
+	gomega.Eventually(func(g gomega.Gomega) {
+		wl := &kueue.Workload{}
+		err := k8sClient.Get(ctx, key, wl)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		g.Expect(err).To(gomega.Succeed())
+		if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
+			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
+		}
+		g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, wl))).To(gomega.BeTrue())
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 // ExpectWorkloadSliceAdmittedBeforeOldFinished watches workload events and asserts
 // that the old workload slice is not marked Finished before the new slice is Admitted.
 // The watcher must be started before the scale-up that triggers the replacement.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area was

#### What this PR does / why we need it:

`ElasticJobUngater.Reconcile` keys off the chain-root slice name (shared by every slice and pod), loads that `Workload`, and bails on `NotFound` before resolving the active slice.

When the root slice is deleted (e.g. a `RayService` rollout cascade-deletes the old `RayCluster` and its `Workload`s), later scale-up slices and their still-gated pods keep pointing at the gone root name. The reconcile key no longer resolves, so pods stay `SchedulingGated` on `kueue.x-k8s.io/elastic-job` forever (`RayCluster` `desired` > `available` indefinitely).

Fix: on `NotFound`, recover the owning job from a chain pod (same slice index) and resolve the active slice as usual. Happy path unchanged.

#### Which issue(s) this PR fixes:

Fixes #14129

#### Special notes for your reviewer:

`activeSlice` factored into a shared `activeSliceForOwner`, reused by the new `activeSliceForDeletedRoot`. Unit test fails without the fix, passes with it.

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed elastic jobs (e.g. autoscaling RayClusters via `ElasticJobsViaWorkloadSlices`) leaving scaled-up pods stuck `SchedulingGated` after the origin workload slice was deleted.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pods remain correctly ungated after their original workload slice is deleted during scaling.
  * The system now identifies the surviving active workload and continues processing eligible pods.
  * Pods with stale or invalid ownership remain gated to prevent unintended access.

* **Tests**
  * Added coverage for workload-slice replacement, deleted origin slices, and recovery through active workloads.
  * Added integration scenarios for elastic scaling and pod ungating across Job and RayCluster workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->