### PR TITLE
MultiKueue: drop the redundant second watcher.Add in fswatch set()

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -124,10 +124,6 @@ func (w *KubeConfigFSWatcher) set(cluster, kcPath string) error {
 	defer w.lock.Unlock()
 
 	dir := path.Dir(kcPath)
-	// fsnotify watches the parent directory, so a directory only needs to be
-	// added the first time one of its files is tracked. Do this before mutating
-	// the bookkeeping maps below so that a failed Add (e.g. the directory does
-	// not exist) leaves the watcher state unchanged.
 	if _, found := w.parentDirToFiles[dir]; !found {
 		if err := w.watcher.Add(dir); err != nil {
 			return err

--- a/pkg/controller/admissionchecks/multikueue/fswatch.go
+++ b/pkg/controller/admissionchecks/multikueue/fswatch.go
@@ -124,9 +124,12 @@ func (w *KubeConfigFSWatcher) set(cluster, kcPath string) error {
 	defer w.lock.Unlock()
 
 	dir := path.Dir(kcPath)
+	// fsnotify watches the parent directory, so a directory only needs to be
+	// added the first time one of its files is tracked. Do this before mutating
+	// the bookkeeping maps below so that a failed Add (e.g. the directory does
+	// not exist) leaves the watcher state unchanged.
 	if _, found := w.parentDirToFiles[dir]; !found {
-		err := w.watcher.Add(dir)
-		if err != nil {
+		if err := w.watcher.Add(dir); err != nil {
 			return err
 		}
 	}
@@ -141,7 +144,6 @@ func (w *KubeConfigFSWatcher) set(cluster, kcPath string) error {
 		w.parentDirToFiles[dir].Insert(kcPath)
 	} else {
 		w.parentDirToFiles[dir] = set.New(kcPath)
-		return w.watcher.Add(dir)
 	}
 	return nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

`KubeConfigFSWatcher.set()` added a newly-tracked file's parent directory to the fsnotify watcher **twice** for a new directory:

- up front, when the directory was not yet in `parentDirToFiles`; and
- again in the `else` branch that creates the `parentDirToFiles` entry (`return w.watcher.Add(dir)`).

Nothing populates `parentDirToFiles` between the two checks, so for a new directory both blocks ran and `watcher.Add(dir)` was called twice. fsnotify treats a second `Add` on an already-watched path as a no-op, so the behavior was correct but the second call was dead weight.

This PR keeps the up-front `Add` and drops the one in the `else` branch, leaving a single `Add` per newly-watched directory.

Note the up-front `Add` is **load-bearing** and must stay: it runs before the bookkeeping maps (`clusterToFile` / `fileToClusters` / `parentDirToFiles`) are mutated, so a failed `Add` (e.g. the directory does not exist yet) returns early and leaves the watcher state untouched. Moving the `Add` into the `else` branch instead would mutate those maps before the failing `Add`, stranding the cluster: a later `AddOrUpdate` with the same path would short-circuit on the already-recorded mapping and never actually add the directory to the watcher.

#### Which issue(s) this PR fixes:

<!-- no linked issue; found by code inspection -->

#### Special notes for your reviewer:

- No behavior change on any path; the removed call was a no-op on the happy path and unreachable on the error path.
- Covered by the existing `TestFSWatchAddRm` (which exercises the missing-directory error case at `d1` and the subsequent successful add). No new test is added because the removed call is behavior-neutral, and asserting the `Add` call count would require abstracting `*fsnotify.Watcher` behind an interface — out of scope for this cleanup.
- AI assistance disclosure: this change was prepared with the help of Claude Code (analysis, patch, and description). A human reviewed and verified the reasoning and ran the tests locally.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-watching behavior when monitoring nested directories.
  * Prevented redundant directory monitoring operations, improving reliability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->