### PR TITLE
[release-0.18] Charge the DeviceClass the scheduler will allocate from

### DIFF
--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -65,12 +65,38 @@ func NeedsDRAReconcile(wl *kueue.Workload, erCache *ExtendedResourceCache) bool 
 	return false
 }
 
+// selectedDeviceClass returns the DeviceClass Kubernetes uses when more than one
+// declares the same extendedResourceName. Quoting the field's documentation:
+//
+//	It should be unique among all the device classes in a cluster. If two device
+//	classes have the same name, then the class created later is picked to satisfy
+//	a pod's extended resource requests. If two classes are created at the same
+//	time, then the name of the class lexicographically sorted first is picked.
+//
+// Ties are the common case, since a creation timestamp carries seconds. items
+// is non-empty and already filtered to one extendedResourceName.
+func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceClass {
+	selected := &items[0]
+	for i := range items[1:] {
+		candidate := &items[i+1]
+		switch candidate.CreationTimestamp.Compare(selected.CreationTimestamp.Time) {
+		case 1:
+			selected = candidate
+		case 0:
+			if candidate.Name < selected.Name {
+				selected = candidate
+			}
+		}
+	}
+	return selected
+}
+
 // resolveContainerExtendedResources converts DRA-backed extended resources in a
 // container's requests into logical quota keys. For each extended resource, it looks
-// up DeviceClasses by spec.extendedResourceName. If a DeviceClass is found in
-// deviceClassMappings, the mapped name is used as quota key; otherwise the
-// extendedResourceName itself is used. Returns the converted resources and the set
-// of original resource names that were replaced (for double-count prevention).
+// up DeviceClasses by spec.extendedResourceName, selects the one the scheduler would
+// allocate from, and uses that class's deviceClassMappings entry as the quota key;
+// otherwise the extendedResourceName itself is used. Returns the converted resources
+// and the set of original resource names that were replaced (for double-count prevention).
 func resolveContainerExtendedResources(
 	ctx context.Context,
 	cl client.Client,
@@ -116,26 +142,25 @@ func resolveContainerExtendedResources(
 			continue
 		}
 
+		// The class the scheduler will allocate from, not whichever List returned first.
+		selected := selectedDeviceClass(dcList.Items)
+
 		// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
 		// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
 		// Otherwise, use the extendedResourceName directly.
 		quotaKey := resourceName
-		for _, dc := range dcList.Items {
-			if logicalName, found := mapper.Lookup(corev1.ResourceName(dc.Name)); found {
-				quotaKey = logicalName
-				if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && mapper.getCounterConfig(corev1.ResourceName(dc.Name)) != nil {
-					errs = append(errs, field.Invalid(
-						containerPath,
-						resourceName,
-						fmt.Sprintf(
-							"extended resource %s resolves to DeviceClass %s with counters configured;"+
-								" use ResourceClaimTemplates with CEL selectors for counter-based quota",
-							resourceName, dc.Name,
-						),
-					))
-					continue
-				}
-				break
+		if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
+			quotaKey = logicalName
+			if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && mapper.getCounterConfig(corev1.ResourceName(selected.Name)) != nil {
+				errs = append(errs, field.Invalid(
+					containerPath,
+					resourceName,
+					fmt.Sprintf(
+						"extended resource %s resolves to DeviceClass %s with counters configured;"+
+							" use ResourceClaimTemplates with CEL selectors for counter-based quota",
+						resourceName, selected.Name,
+					),
+				))
 			}
 		}
 
@@ -143,7 +168,7 @@ func resolveContainerExtendedResources(
 
 		log.V(4).Info("Resolved extended resource to DRA quota key",
 			"resource", resourceName, "quotaKey", quotaKey, "quantity", chargeQuantity.String(),
-			"deviceClass", dcList.Items[0].Name)
+			"deviceClass", selected.Name)
 
 		replaced.Insert(resourceName)
 		result = utilresource.MergeResourceListKeepSum(result, corev1.ResourceList{

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -111,6 +111,53 @@ func TestIsExtendedResourceName(t *testing.T) {
 	}
 }
 
+func TestSelectedDeviceClass(t *testing.T) {
+	at := func(sec int64) metav1.Time { return metav1.Unix(sec, 0) }
+	class := func(name string, created metav1.Time) resourceapi.DeviceClass {
+		return resourceapi.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: name, CreationTimestamp: created}}
+	}
+	cases := map[string]struct {
+		items []resourceapi.DeviceClass
+		want  string
+	}{
+		"one class is the one": {
+			items: []resourceapi.DeviceClass{class("a", at(100))},
+			want:  "a",
+		},
+		"the class created later wins": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("b", at(200))},
+			want:  "b",
+		},
+		"and wins from either end of the list": {
+			items: []resourceapi.DeviceClass{class("b", at(200)), class("a", at(100))},
+			want:  "b",
+		},
+		"created together, the lexicographically first name wins": {
+			items: []resourceapi.DeviceClass{class("b", at(100)), class("a", at(100))},
+			want:  "a",
+		},
+		"and that tie does not depend on the list order either": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("b", at(100))},
+			want:  "a",
+		},
+		"a later class beats an earlier one with a smaller name": {
+			items: []resourceapi.DeviceClass{class("a", at(100)), class("z", at(200))},
+			want:  "z",
+		},
+		"the tie-break applies among the latest only": {
+			items: []resourceapi.DeviceClass{class("a", at(300)), class("z", at(100)), class("b", at(300))},
+			want:  "a",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := selectedDeviceClass(tc.items); got.Name != tc.want {
+				t.Errorf("selectedDeviceClass() = %q, want %q", got.Name, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolveExtendedResourceQuota(t *testing.T) {
 	gpuDeviceClass := &resourceapi.DeviceClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -135,6 +182,28 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			Name: "plain.nvidia.com",
 		},
 		Spec: resourceapi.DeviceClassSpec{},
+	}
+
+	// Two classes on one extendedResourceName. The names sort against the
+	// timestamps, so only the creation order can explain the class picked.
+	alphaDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "alpha.example.com",
+			CreationTimestamp: metav1.Unix(100, 0),
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("example.com/gpu"),
+		},
+	}
+
+	omegaDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "omega.example.com",
+			CreationTimestamp: metav1.Unix(200, 0),
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("example.com/gpu"),
+		},
 	}
 
 	tests := []struct {
@@ -533,6 +602,90 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 					field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "containers").Index(0),
 					"", "",
 				),
+			},
+		},
+		{
+			name: "the mapping of the later DeviceClass decides the quota key",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{alphaDeviceClass, omegaDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "alpha-claims",
+					DeviceClassNames: []corev1.ResourceName{"alpha.example.com"},
+				},
+				{
+					Name:             "omega-claims",
+					DeviceClassNames: []corev1.ResourceName{"omega.example.com"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"omega-claims": resource.MustParse("1"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
+			name: "an unmapped later DeviceClass leaves the extended resource name as the quota key",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{alphaDeviceClass, omegaDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "alpha-claims",
+					DeviceClassNames: []corev1.ResourceName{"alpha.example.com"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("1"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #14044 on release-0.18, requested by @sohankunkerkar.

The branch has the same defect: `resolveContainerExtendedResources` charges the first listed DeviceClass that happens to carry a `deviceClassMappings` entry, rather than the one Kubernetes will allocate from, so the charge can land in a resource group the allocation had nothing to do with.

Not a clean pick, so the differences are worth naming. `selectedDeviceClass` and its table come over unchanged. The call site does not, because this branch predates two things on main: `getCounterConfigs` is still singular here as `getCounterConfig` returning a pointer, and there is no consumable-capacity branch, since `KueueDRAIntegrationConsumableCapacity` arrives in 0.19. The resolution keeps this branch's shape and only changes which class is asked about.

Verified on the branch rather than assumed: `go vet` and `go test ./pkg/dra/...` pass, all seven `TestSelectedDeviceClass` cases and both composed cases in `TestResolveExtendedResourceQuota` run, and reverting the selection to `&dcList.Items[0]` turns the composed cases red here as it does on main.

#### Does this PR introduce a user-facing change?

```release-note
Fixed Kueue charging a DRA-backed extended resource against a DeviceClass the scheduler may not allocate from. When several DeviceClasses declare the same `extendedResourceName`, Kueue now selects the one Kubernetes selects, the class created later and the lexicographically first name among classes created together, and reads the `deviceClassMappings` entry of that class. Previously the first listed class with a mapping decided the quota key, which could debit a different ClusterQueue resource group than the allocation used.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I resolved the conflict and ran the checks above myself.
