### PR TITLE
Take back only what the extended-resource charge replaces

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -911,16 +911,10 @@ The two DRA paths resolve quota independently:
 
 #### Processing Flow
 
-1. Kueue detects extended resources in the `resources.requests` of the PodSet spec
-   `AdjustResources` has already processed, and computes each original resource
-   name's Pod-level request the way a Pod's own requests are computed, before any
-   DeviceClass lookup or quota-key mapping. Regular and
-   restartable init containers together make the long-running total; each init
-   container is measured with the restartable ones already running beside it;
-   and the charge is the larger of that total and the largest of those init
-   measurements. Two different resource names later mapped to the same quota
-   key are therefore aggregated independently first, so neither collapses into
-   the other's contribution.
+1. Kueue detects extended resources in the PodSet spec and aggregates requests for
+   each original resource name using `resourcehelpers.PodRequests` before DeviceClass
+   lookup or quota-key mapping (overhead excluded; sidecars add to the app-container
+   total instead of being maxed as ordinary init containers).
 2. Looks up DeviceClasses by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
@@ -931,27 +925,20 @@ The two DRA paths resolve quota independently:
 5. If the mapping has counter sources configured, the workload is marked inadmissible.
    Extended resources do not carry profile-level information for counter-based charging.
    Otherwise charges device count.
-6. Subtracts what the containers asked for on that extended resource from what is
-   still retained under that name (tracked internally per PodSet) to avoid
-   double-counting. Pod overhead and resource transformation outputs carried under
-   the same name are not what the charge stands in for, so whatever of them is still
-   there once exclusions and transformations have run is left alone
+6. Subtracts only the translated container amount under the original extended resource
+   name from the Workload's effective requests (tracked internally per PodSet) to avoid
+   double-counting. Pod overhead and transformation outputs under that name remain.
 7. Admits the Workload against the resulting requests, which is the mapped logical
    name together with any contribution still standing under the original one
 
 The extended resource translation reads directly from the workload spec before
-`excludeResourcePrefixes` filtering is applied, so that what is charged is what the
-Pods will ask for. Where it is taken back from is a later view. The processing order:
-1. Extended resource translation runs first, reading the original spec. The container
-   contribution it aggregates under each translated name is the figure step 4 takes back
+`excludeResourcePrefixes` filtering is applied. The processing order:
+1. Extended resource translation runs first, reading the original spec
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
 3. Resource transformations run over what that filtering left, which is still the pod's
    own requests. The translated resource is not among them
 4. The container contribution is subtracted from what is still retained under the
    original name, so pod overhead and anything a transformation added under it survive.
-   A name an excluded prefix removed, or a `Replace` transformation consumed, has nothing
-   left to subtract from. A transformation may still generate a contribution under the
-   same name, and generated contributions are not touched by the subtraction
 5. Translated resource is added through `preprocessedDRAResources`
 
 Step 1 runs during DRA preprocessing, and what it produces is merged in at step 5, when

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -947,7 +947,8 @@ back from is a later view. The processing order:
 4. The container contribution is subtracted from what is still retained under that name,
    so pod overhead and anything a transformation added under it survive. A name an
    excluded prefix removed, or a `Replace` transformation consumed, has nothing left to
-   subtract from and nothing left to keep
+   subtract from. A transformation may still generate a contribution under the same
+   name, and generated contributions are not touched by the subtraction
 5. Translated resource is added through `preprocessedDRAResources`
 
 The container contribution is aggregated the way a Pod's own requests are, so a restartable
@@ -977,7 +978,8 @@ metadata:
 spec:
   extendedResourceName: example.com/gpu
 ---
-# Kueue config: deviceClassMappings only needed for ResourceClaimTemplate path
+# Kueue config: the ResourceClaimTemplate path needs deviceClassMappings, and
+# the extended-resource path reuses the same entry when one covers its DeviceClass
 apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 resources:
@@ -997,15 +999,22 @@ spec:
     flavors:
     - name: default
       resources:
-      - name: example.com/gpu    # for extended resource users
-        nominalQuota: 4
-      - name: gpu-claims          # for ResourceClaimTemplate users
+      - name: gpu-claims          # both paths charge here
+        nominalQuota: 8
+      - name: example.com/gpu    # residual only, see below
         nominalQuota: 4
 ```
 
-Both quota buckets draw from the same physical hardware. The admin controls how capacity is
-split between the two user populations. Since these are different resource names, the split
-is fixed at configuration time.
+`gpu-claims` is the device count both populations draw from. A container asking for
+`example.com/gpu` resolves its DeviceClass through the same `deviceClassMappings` entry,
+so it is charged to `gpu-claims` alongside the ResourceClaimTemplate users rather than to
+its own name. Giving the original name its own quota does not create a second device
+population, and splitting the eight devices between the two names would leave half of them
+unreachable.
+
+`example.com/gpu` is only needed where something other than the containers' request survives
+under that name, a chargeable pod overhead or a resource transformation output. Size it for
+that, not for devices.
 
 #### DeviceClass Resolution via Field Indexer
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -911,9 +911,10 @@ The two DRA paths resolve quota independently:
 
 #### Processing Flow
 
-1. Kueue detects extended resources in `resources.requests` and computes each
-   original resource name's Pod-level request the way a Pod's own requests are
-   computed, before any DeviceClass lookup or quota-key mapping. Regular and
+1. Kueue detects extended resources in the `resources.requests` of the PodSet spec
+   `AdjustResources` has already processed, and computes each original resource
+   name's Pod-level request the way a Pod's own requests are computed, before any
+   DeviceClass lookup or quota-key mapping. Regular and
    restartable init containers together make the long-running total; each init
    container is measured with the restartable ones already running beside it;
    and the charge is the larger of that total and the largest of those init
@@ -952,11 +953,13 @@ back from is a later view. The processing order:
    name, and generated contributions are not touched by the subtraction
 5. Translated resource is added through `preprocessedDRAResources`
 
-The container contribution is the figure step 1 computes, so the charge and the subtraction
-come from the same aggregation. For an extended resource name whose DeviceClass resolution
-holds for the length of preprocessing, the amount subtracted is the amount charged. Each
-name is aggregated under its own name before any mapping, so two names reaching one logical
-resource are charged and subtracted alike.
+These steps run during DRA preprocessing, before Kueue's accounting exclusions and resource
+transformations; what they produce is merged in later, when `TotalRequests` is built from the
+same spec. The container contribution is the figure step 1 computes, so the charge and the
+subtraction come from the same aggregation. For a name whose requests are valid and whose
+DeviceClass resolution holds for the length of preprocessing, the amount subtracted is the
+amount charged. Each name is aggregated under its own name before any mapping, so two names
+reaching one logical resource are charged and subtracted alike.
 
 This keeps the extended resource from being counted twice under its own name. It does not
 reach a resource transformation naming the same resource: a `Replace` consuming a DRA-backed
@@ -967,8 +970,9 @@ tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issues/14160).
 #### Same Hardware with Both Paths
 
 When the same hardware needs to serve both ResourceClaimTemplate users and extended resource
-users, admins configure separate flavors under the same ClusterQueue. Assuming a cluster
-with 1 node and 8 GPU devices available:
+users, both paths resolve to one logical device count, so admins give that name the quota
+and cover the original name beside it for whatever the charge does not replace. Assuming a
+cluster with 1 node and 8 GPU devices available:
 
 ```yaml
 # DeviceClass
@@ -996,7 +1000,7 @@ metadata:
   name: gpu-queue
 spec:
   resourceGroups:
-  - coveredResources: ["example.com/gpu", "gpu-claims"]
+  - coveredResources: ["gpu-claims", "example.com/gpu"]
     flavors:
     - name: default
       resources:

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -913,12 +913,13 @@ The two DRA paths resolve quota independently:
 
 1. Kueue detects extended resources in `resources.requests` and computes each
    original resource name's Pod-level request the way a Pod's own requests are
-   computed, before any DeviceClass lookup or quota-key mapping: regular and
-   restartable init containers contribute to the long-running total, and an
-   ordinary init container is measured together with the restartable ones
-   already started beside it. Two different resource names later mapped to the same
-   quota key are therefore aggregated independently first, so neither collapses
-   into the other's contribution.
+   computed, before any DeviceClass lookup or quota-key mapping. Regular and
+   restartable init containers together make the long-running total; each init
+   container is measured with the restartable ones already running beside it;
+   and the charge is the larger of that total and the largest of those init
+   measurements. Two different resource names later mapped to the same quota
+   key are therefore aggregated independently first, so neither collapses into
+   the other's contribution.
 2. Looks up DeviceClasses by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
@@ -951,11 +952,11 @@ back from is a later view. The processing order:
    name, and generated contributions are not touched by the subtraction
 5. Translated resource is added through `preprocessedDRAResources`
 
-The container contribution is aggregated the way a Pod's own requests are, so a restartable
-init container adds to it rather than being compared against it. For an extended resource
-name whose DeviceClass resolution holds for the length of preprocessing, the amount
-subtracted is the amount charged. Each name is aggregated under its own name before any
-mapping, so two names reaching one logical resource are charged and subtracted alike.
+The container contribution is the figure step 1 computes, so the charge and the subtraction
+come from the same aggregation. For an extended resource name whose DeviceClass resolution
+holds for the length of preprocessing, the amount subtracted is the amount charged. Each
+name is aggregated under its own name before any mapping, so two names reaching one logical
+resource are charged and subtracted alike.
 
 This keeps the extended resource from being counted twice under its own name. It does not
 reach a resource transformation naming the same resource: a `Replace` consuming a DRA-backed

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -948,9 +948,8 @@ name. Both are tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issu
 #### Same Hardware with Both Paths
 
 When the same hardware needs to serve both ResourceClaimTemplate users and extended resource
-users, both paths resolve to one logical device count, so admins give that name the quota
-and cover the original name beside it for whatever the charge does not replace. Assuming a
-cluster with 1 node and 8 GPU devices available:
+users, both paths resolve to one logical device count, so that name carries the quota.
+Assuming a cluster with 1 node and 8 GPU devices available:
 
 ```yaml
 # DeviceClass

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -939,27 +939,27 @@ The two DRA paths resolve quota independently:
 7. Admits the Workload against the resulting requests, which is the mapped logical
    name together with any contribution still standing under the original one
 
-The container contribution is read from the workload spec as it stands, before any
-filtering, so that what is charged is what the Pods will ask for. Where it is taken
-back from is a later view. The processing order:
-1. The container contribution on each translated extended resource is read from the
-   original spec
+The extended resource translation reads directly from the workload spec before
+`excludeResourcePrefixes` filtering is applied, so that what is charged is what the
+Pods will ask for. Where it is taken back from is a later view. The processing order:
+1. Extended resource translation runs first, reading the original spec. The container
+   contribution it aggregates under each translated name is the figure step 4 takes back
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
-3. Resource transformations run
-4. The container contribution is subtracted from what is still retained under that name,
-   so pod overhead and anything a transformation added under it survive. A name an
-   excluded prefix removed, or a `Replace` transformation consumed, has nothing left to
-   subtract from. A transformation may still generate a contribution under the same
-   name, and generated contributions are not touched by the subtraction
+3. Resource transformations run over what that filtering left, which is still the pod's
+   own requests. The translated resource is not among them
+4. The container contribution is subtracted from what is still retained under the
+   original name, so pod overhead and anything a transformation added under it survive.
+   A name an excluded prefix removed, or a `Replace` transformation consumed, has nothing
+   left to subtract from. A transformation may still generate a contribution under the
+   same name, and generated contributions are not touched by the subtraction
 5. Translated resource is added through `preprocessedDRAResources`
 
-These steps run during DRA preprocessing, before Kueue's accounting exclusions and resource
-transformations; what they produce is merged in later, when `TotalRequests` is built from the
-same spec. The container contribution is the figure step 1 computes, so the charge and the
-subtraction come from the same aggregation. For a name whose requests are valid and whose
-DeviceClass resolution holds for the length of preprocessing, the amount subtracted is the
-amount charged. Each name is aggregated under its own name before any mapping, so two names
-reaching one logical resource are charged and subtracted alike.
+Step 1 runs during DRA preprocessing, and what it produces is merged in at step 5, when
+`TotalRequests` is built from the same spec. The charge and the subtraction therefore come
+from one aggregation: for a name whose requests are valid and whose DeviceClass resolution
+holds for the length of preprocessing, the amount subtracted is the amount charged. Each
+name is aggregated under its own name before any mapping, so two names reaching one logical
+resource are charged and subtracted alike.
 
 This keeps the extended resource from being counted twice under its own name. It does not
 reach a resource transformation naming the same resource: a `Replace` consuming a DRA-backed

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -924,11 +924,11 @@ The two DRA paths resolve quota independently:
 5. If the mapping has counter sources configured, the workload is marked inadmissible.
    Extended resources do not carry profile-level information for counter-based charging.
    Otherwise charges device count.
-6. Subtracts only the translated container amount under the original extended resource
-   name from the Workload's effective requests (tracked internally per PodSet) to avoid
-   double-counting. Pod overhead and transformation outputs under that name remain.
-7. Admits the Workload against the resulting requests, which is the mapped logical
-   name together with any contribution still standing under the original one
+6. Subtracts the original extended resource from the workload's effective resource
+   requests (tracked internally per PodSet) to avoid double-counting. Only the
+   translated container amount is subtracted; Pod overhead and transformation output
+   under the same name remain.
+7. Admits the Workload against the resulting requests
 
 The extended resource translation reads directly from the workload spec before
 `excludeResourcePrefixes` filtering is applied. The processing order:
@@ -939,11 +939,6 @@ The extended resource translation reads directly from the workload spec before
 4. Translated resource is added through `preprocessedDRAResources`
 
 This ensures no overlap or double-counting between the two mechanisms.
-
-This does not reach a resource transformation naming the same resource: a `Replace` consuming
-a DRA-backed input is still charged the device as well as whatever the transformation emits,
-and an output written to a `deviceClassMappings[].name` is added to the charge under that
-name. Both are tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issues/14160).
 
 #### Same Hardware with Both Paths
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -911,10 +911,9 @@ The two DRA paths resolve quota independently:
 
 #### Processing Flow
 
-1. Kueue detects extended resources in the PodSet spec and aggregates requests for
-   each original resource name using `resourcehelpers.PodRequests` before DeviceClass
-   lookup or quota-key mapping (overhead excluded; sidecars add to the app-container
-   total instead of being maxed as ordinary init containers).
+1. Kueue detects extended resources in the PodSet spec and aggregates each original
+   name using `resourcehelpers.PodRequests` (overhead excluded; sidecars add to the
+   app-container total, they are not maxed as ordinary inits).
 2. Looks up DeviceClasses by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
@@ -935,12 +934,11 @@ The extended resource translation reads directly from the workload spec before
 `excludeResourcePrefixes` filtering is applied. The processing order:
 1. Extended resource translation runs first, reading the original spec
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
-3. The container contribution is subtracted from what is still retained under the
-   original name, so pod overhead and anything a transformation added under it survive
+3. The translated container amount is removed from the workload's effective resource
+   requests, so it is not double-counted
 4. Translated resource is added through `preprocessedDRAResources`
 
-Each name is aggregated under its own name before any mapping, so two names reaching one
-logical resource are charged and subtracted alike.
+This ensures no overlap or double-counting between the two mechanisms.
 
 This does not reach a resource transformation naming the same resource: a `Replace` consuming
 a DRA-backed input is still charged the device as well as whatever the transformation emits,
@@ -980,26 +978,22 @@ metadata:
   name: gpu-queue
 spec:
   resourceGroups:
-  - coveredResources: ["gpu-claims", "example.com/gpu"]
+  - coveredResources: ["gpu-claims"]
     flavors:
     - name: default
       resources:
       - name: gpu-claims          # both paths charge here
         nominalQuota: 8
-      - name: example.com/gpu    # residual only, see below
-        nominalQuota: 4
 ```
 
 `gpu-claims` is the device count both populations draw from. A container asking for
 `example.com/gpu` resolves its DeviceClass through the same `deviceClassMappings` entry,
 so it is charged to `gpu-claims` alongside the ResourceClaimTemplate users rather than to
-its own name. Giving the original name its own quota does not create a second device
-population, and splitting the eight devices between the two names would leave half of them
-unreachable.
+its own name.
 
-`example.com/gpu` is only needed where something other than the containers' request survives
-under that name, a chargeable pod overhead or a resource transformation output. Size it for
-that, not for devices.
+The original name needs quota of its own only where something other than the containers'
+request survives under it, a chargeable pod overhead or a resource transformation output.
+Size that for the residue, not for devices.
 
 #### DeviceClass Resolution via Field Indexer
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -927,18 +927,33 @@ The two DRA paths resolve quota independently:
 5. If the mapping has counter sources configured, the workload is marked inadmissible.
    Extended resources do not carry profile-level information for counter-based charging.
    Otherwise charges device count.
-6. Removes original extended resource from the workload's effective resource requests
-   (tracked internally per PodSet) to avoid double-counting
+6. Subtracts what the containers asked for on that extended resource from the workload's
+   effective resource requests (tracked internally per PodSet) to avoid double-counting.
+   Pod overhead and resource transformation outputs carried under the same name are not
+   what the charge stands in for, so they are left intact
 7. Admits workload against the resolved quota key
 
 The extended resource translation reads directly from the workload spec before
 `excludeResourcePrefixes` filtering is applied. The processing order:
 1. Extended resource translation runs first, reading the original spec
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
-3. Original extended resource is removed from the workload's effective resource requests
-4. Translated resource is added through `preprocessedDRAResources`
+3. Resource transformations run
+4. What the containers asked for on each translated extended resource is subtracted from
+   the effective requests, so the pod overhead and anything a transformation added under
+   the same name are left alone
+5. Translated resource is added through `preprocessedDRAResources`
 
-This ensures no overlap or double-counting between the two mechanisms.
+The container contribution is aggregated the way a Pod's own requests are, so a restartable
+init container adds to it rather than being compared against it. For an extended resource
+name whose DeviceClass resolution holds for the length of preprocessing, the amount
+subtracted is the amount charged. Each name is aggregated under its own name before any
+mapping, so two names reaching one logical resource are charged and subtracted alike.
+
+This keeps the extended resource from being counted twice under its own name. It does not
+reach a resource transformation naming the same resource: a `Replace` consuming a DRA-backed
+input is still charged the device as well as whatever the transformation emits, and an output
+written to a `deviceClassMappings[].name` is added to the charge under that name. Both are
+tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issues/14160).
 
 #### Same Hardware with Both Paths
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -935,24 +935,17 @@ The extended resource translation reads directly from the workload spec before
 `excludeResourcePrefixes` filtering is applied. The processing order:
 1. Extended resource translation runs first, reading the original spec
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
-3. Resource transformations run over what that filtering left, which is still the pod's
-   own requests. The translated resource is not among them
-4. The container contribution is subtracted from what is still retained under the
-   original name, so pod overhead and anything a transformation added under it survive.
-5. Translated resource is added through `preprocessedDRAResources`
+3. The container contribution is subtracted from what is still retained under the
+   original name, so pod overhead and anything a transformation added under it survive
+4. Translated resource is added through `preprocessedDRAResources`
 
-Step 1 runs during DRA preprocessing, and what it produces is merged in at step 5, when
-`TotalRequests` is built from the same spec. The charge and the subtraction therefore come
-from one aggregation: for a name whose requests are valid and whose DeviceClass resolution
-holds for the length of preprocessing, the amount subtracted is the amount charged. Each
-name is aggregated under its own name before any mapping, so two names reaching one logical
-resource are charged and subtracted alike.
+Each name is aggregated under its own name before any mapping, so two names reaching one
+logical resource are charged and subtracted alike.
 
-This keeps the extended resource from being counted twice under its own name. It does not
-reach a resource transformation naming the same resource: a `Replace` consuming a DRA-backed
-input is still charged the device as well as whatever the transformation emits, and an output
-written to a `deviceClassMappings[].name` is added to the charge under that name. Both are
-tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issues/14160).
+This does not reach a resource transformation naming the same resource: a `Replace` consuming
+a DRA-backed input is still charged the device as well as whatever the transformation emits,
+and an output written to a `deviceClassMappings[].name` is added to the charge under that
+name. Both are tracked in [#14160](https://github.com/kubernetes-sigs/kueue/issues/14160).
 
 #### Same Hardware with Both Paths
 

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -912,9 +912,11 @@ The two DRA paths resolve quota independently:
 #### Processing Flow
 
 1. Kueue detects extended resources in `resources.requests` and computes each
-   original resource name's Pod-level request (max across init containers, sum
-   across regular containers, then max of the two) before any DeviceClass lookup
-   or quota-key mapping. Two different resource names later mapped to the same
+   original resource name's Pod-level request the way a Pod's own requests are
+   computed, before any DeviceClass lookup or quota-key mapping: regular and
+   restartable init containers contribute to the long-running total, and an
+   ordinary init container is measured together with the restartable ones
+   already started beside it. Two different resource names later mapped to the same
    quota key are therefore aggregated independently first, so neither collapses
    into the other's contribution.
 2. Looks up DeviceClasses by `extendedResourceName` by field indexer
@@ -927,20 +929,25 @@ The two DRA paths resolve quota independently:
 5. If the mapping has counter sources configured, the workload is marked inadmissible.
    Extended resources do not carry profile-level information for counter-based charging.
    Otherwise charges device count.
-6. Subtracts what the containers asked for on that extended resource from the workload's
-   effective resource requests (tracked internally per PodSet) to avoid double-counting.
-   Pod overhead and resource transformation outputs carried under the same name are not
-   what the charge stands in for, so they are left intact
-7. Admits workload against the resolved quota key
+6. Subtracts what the containers asked for on that extended resource from what is
+   still retained under that name (tracked internally per PodSet) to avoid
+   double-counting. Pod overhead and resource transformation outputs carried under
+   the same name are not what the charge stands in for, so whatever of them is still
+   there once exclusions and transformations have run is left alone
+7. Admits the Workload against the resulting requests, which is the mapped logical
+   name together with any contribution still standing under the original one
 
-The extended resource translation reads directly from the workload spec before
-`excludeResourcePrefixes` filtering is applied. The processing order:
-1. Extended resource translation runs first, reading the original spec
+The container contribution is read from the workload spec as it stands, before any
+filtering, so that what is charged is what the Pods will ask for. Where it is taken
+back from is a later view. The processing order:
+1. The container contribution on each translated extended resource is read from the
+   original spec
 2. `excludeResourcePrefixes` filters the pod's `resources.requests`
 3. Resource transformations run
-4. What the containers asked for on each translated extended resource is subtracted from
-   the effective requests, so the pod overhead and anything a transformation added under
-   the same name are left alone
+4. The container contribution is subtracted from what is still retained under that name,
+   so pod overhead and anything a transformation added under it survive. A name an
+   excluded prefix removed, or a `Replace` transformation consumed, has nothing left to
+   subtract from and nothing left to keep
 5. Translated resource is added through `preprocessedDRAResources`
 
 The container contribution is aggregated the way a Pod's own requests are, so a restartable

--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -905,7 +905,7 @@ The two DRA paths resolve quota independently:
    name instead to unify quota with the ResourceClaimTemplate path. If the mapping has
    counter sources configured, the workload is marked inadmissible because extended resources
    do not carry the profile-level information needed for counter-based charging.
-2. **ResourceClaimTemplates** (`DynamicResourceAllocation` gate): uses `deviceClassMappings`
+2. **ResourceClaimTemplates** (`KueueDRAIntegration` gate): uses `deviceClassMappings`
    to map DeviceClass names to logical resource names. When the mapping has counter sources
    configured, charges counter units instead of device count.
 

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -199,13 +199,10 @@ type containerExtendedResourceRequests struct {
 }
 
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
-// into DRA logical quota resources. Per PodSet, the containers are totalled the way the
-// Pod's own requests are: regular and restartable init containers make the long-running
-// total, each init container is measured with the restartable ones already running beside
-// it, and the charge is the larger of the two. That total is taken under each original resource
-// name, before any two names sharing a quota key can collapse into each other's
-// contribution. The quota key for each original name is resolved once per PodSet, from
-// that name's own aggregated total.
+// into DRA logical quota resources. Per PodSet each original name is aggregated with
+// `resourcehelpers.PodRequests` (overhead excluded; sidecars add to the app-container
+// total, they are not maxed as ordinary inits), and its quota key is resolved from that
+// name's own total, so two names sharing a key cannot collapse into each other.
 func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper *ResourceMapper, wl *kueue.Workload) (
 	map[kueue.PodSetReference]corev1.ResourceList,
 	map[kueue.PodSetReference]sets.Set[corev1.ResourceName],

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -262,9 +262,9 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 		}
 		initCharged := charged(initEntries)
 		regularCharged := charged(regularEntries)
-		// Totalled as the Pod's own requests are, so a sidecar adds to the regular
-		// containers instead of being maxed against them. The overhead belongs to the
-		// Pod, not to what its containers asked for.
+		// Totalled as the Pod's own requests are: a sidecar joins the regular containers
+		// in the long-running total, and that total is maxed against each init container
+		// measured beside the sidecars already running. The overhead belongs to the Pod.
 		podRequests := resourcehelpers.PodRequests(
 			&corev1.Pod{Spec: corev1.PodSpec{InitContainers: initCharged, Containers: regularCharged}},
 			resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -200,8 +200,9 @@ type containerExtendedResourceRequests struct {
 
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
 // into DRA logical quota resources. Per PodSet, the containers are totalled the way the
-// Pod's own requests are, so a restartable init container adds to the regular containers
-// rather than being maxed against them. That total is taken under each original resource
+// Pod's own requests are: regular and restartable init containers make the long-running
+// total, each init container is measured with the restartable ones already running beside
+// it, and the charge is the larger of the two. That total is taken under each original resource
 // name, before any two names sharing a quota key can collapse into each other's
 // contribution. The quota key for each original name is resolved once per PodSet, from
 // that name's own aggregated total.

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	resourcehelpers "k8s.io/component-helpers/resource"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -192,14 +193,18 @@ func resolveQuotaKey(
 type containerExtendedResourceRequests struct {
 	path      *field.Path
 	resources corev1.ResourceList
+	// Carried so the total can be taken the way the Pod's own is: a restartable
+	// init container runs alongside the rest and adds to them.
+	restartPolicy *corev1.ContainerRestartPolicy
 }
 
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
-// into DRA logical quota resources. Per PodSet, init containers are aggregated with
-// max (sequential) and regular containers with sum (concurrent), then combined with
-// max — per original resource name, before any two names sharing a quota key can
-// collapse into each other's contribution. The quota key for each original name is
-// resolved once per PodSet, from that name's own aggregated total.
+// into DRA logical quota resources. Per PodSet, the containers are totalled the way the
+// Pod's own requests are, so a restartable init container adds to the regular containers
+// rather than being maxed against them. That total is taken under each original resource
+// name, before any two names sharing a quota key can collapse into each other's
+// contribution. The quota key for each original name is resolved once per PodSet, from
+// that name's own aggregated total.
 func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper *ResourceMapper, wl *kueue.Workload) (
 	map[kueue.PodSetReference]corev1.ResourceList,
 	map[kueue.PodSetReference]sets.Set[corev1.ResourceName],
@@ -226,8 +231,9 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 					continue
 				}
 				entries = append(entries, containerExtendedResourceRequests{
-					path:      podSetPath.Child(pathSegment).Index(j),
-					resources: res,
+					path:          podSetPath.Child(pathSegment).Index(j),
+					resources:     res,
+					restartPolicy: container.RestartPolicy,
 				})
 			}
 			return entries
@@ -239,24 +245,29 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 		// The field path of the first container an original resource name is seen in,
 		// for error reporting once that name is resolved below.
 		firstPath := map[corev1.ResourceName]*field.Path{}
-		var maxInitResources, sumRegularResources corev1.ResourceList
-		for _, e := range initEntries {
-			for name := range e.resources {
-				if _, ok := firstPath[name]; !ok {
-					firstPath[name] = e.path
+		charged := func(entries []containerExtendedResourceRequests) []corev1.Container {
+			out := make([]corev1.Container, 0, len(entries))
+			for _, e := range entries {
+				for name := range e.resources {
+					if _, ok := firstPath[name]; !ok {
+						firstPath[name] = e.path
+					}
 				}
+				out = append(out, corev1.Container{
+					RestartPolicy: e.restartPolicy,
+					Resources:     corev1.ResourceRequirements{Requests: e.resources},
+				})
 			}
-			maxInitResources = utilresource.MergeResourceListKeepMax(maxInitResources, e.resources)
+			return out
 		}
-		for _, e := range regularEntries {
-			for name := range e.resources {
-				if _, ok := firstPath[name]; !ok {
-					firstPath[name] = e.path
-				}
-			}
-			sumRegularResources = utilresource.MergeResourceListKeepSum(sumRegularResources, e.resources)
-		}
-		podRequests := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
+		initCharged := charged(initEntries)
+		regularCharged := charged(regularEntries)
+		// Totalled as the Pod's own requests are, so a sidecar adds to the regular
+		// containers instead of being maxed against them. The overhead belongs to the
+		// Pod, not to what its containers asked for.
+		podRequests := resourcehelpers.PodRequests(
+			&corev1.Pod{Spec: corev1.PodSpec{InitContainers: initCharged, Containers: regularCharged}},
+			resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})
 
 		aggregated := corev1.ResourceList{}
 		replaced := sets.New[corev1.ResourceName]()

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -263,9 +263,7 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 		}
 		initCharged := charged(initEntries)
 		regularCharged := charged(regularEntries)
-		// Totalled as the Pod's own requests are: a sidecar joins the regular containers
-		// in the long-running total, and that total is maxed against each init container
-		// measured beside the sidecars already running. The overhead belongs to the Pod.
+		// PodRequests adds a sidecar to the regular containers rather than maxing it against them.
 		podRequests := resourcehelpers.PodRequests(
 			&corev1.Pod{Spec: corev1.PodSpec{InitContainers: initCharged, Containers: regularCharged}},
 			resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -489,7 +489,7 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
-			name: "init containers use max, regular containers use sum",
+			name: "ordinary init containers use max, regular containers use sum",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
 				Spec: kueue.WorkloadSpec{
@@ -547,6 +547,115 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			want: map[kueue.PodSetReference]corev1.ResourceList{
 				"main": {
 					"example.com/gpu": resource.MustParse("5"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
+			// The scheduler keeps a sidecar's devices for as long as the regular
+			// containers hold theirs, so the two are held at once.
+			name: "a restartable init container adds to the total rather than being maxed against it",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:          "sidecar",
+										Image:         "pause",
+										RestartPolicy: new(corev1.ContainerRestartPolicyAlways),
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("2"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
+			// The init container runs with the sidecar declared before it already up,
+			// so 5 and 2 together beat the 1 and 2 that follow.
+			name: "an ordinary init container is measured with the sidecar already running",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:          "sidecar",
+										Image:         "pause",
+										RestartPolicy: new(corev1.ContainerRestartPolicyAlways),
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("2"),
+											},
+										},
+									},
+									{
+										Name:  "init1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("5"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("7"),
 				},
 			},
 			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -604,6 +604,57 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			// A non-positive request is dropped before any aggregation runs, so the
+			// sidecar contributes nothing rather than being subtracted from the
+			// regular container it now shares the long-running total with.
+			name: "a negative restartable init container does not reduce the regular container's charge",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:          "sidecar",
+										Image:         "pause",
+										RestartPolicy: new(corev1.ContainerRestartPolicyAlways),
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("-3"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("8"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("8"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
 			// The init container runs with the sidecar declared before it already up,
 			// so 5 and 2 together beat the 1 and 2 that follow.
 			name: "an ordinary init container is measured with the sidecar already running",

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -663,6 +663,66 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			// The same two init containers the other way round. Nothing is running
+			// beside the ordinary one this time, so its own 5 stands against the 2
+			// and 1 that outlive it.
+			name: "an ordinary init container declared before the sidecar does not run with it",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:  "init1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("5"),
+											},
+										},
+									},
+									{
+										Name:          "sidecar",
+										Image:         "pause",
+										RestartPolicy: new(corev1.ContainerRestartPolicyAlways),
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("2"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("1"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"example.com/gpu": resource.MustParse("5"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
 			// vendor.example/a and vendor.example/b both map to the "gpu-claims" quota
 			// key, but each is charged against the OTHER container kind (init vs.
 			// regular), so the max/sum aggregation only ever sees one contribution

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -165,7 +165,10 @@ func WithPreserveTotalRequests() InfoOption {
 	}
 }
 
-// WithPreprocessedDRAResources provides DRA resources to add and extended resources to remove.
+// WithPreprocessedDRAResources provides the DRA logical resources to add and the names
+// of the extended resources whose container contribution the charge replaces. How much
+// each contributed is derived from the PodSet spec where it is subtracted, and is all
+// that may be taken back.
 func WithPreprocessedDRAResources(
 	draResources map[kueue.PodSetReference]corev1.ResourceList,
 	replacedExtendedResources map[kueue.PodSetReference]sets.Set[corev1.ResourceName],
@@ -571,7 +574,7 @@ func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.R
 	return reqs.ToResourceList(formatter)
 }
 
-func applyResourceTransformations(input corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) corev1.ResourceList {
+func applyResourceTransformations(input corev1.ResourceList, transforms map[corev1.ResourceName]*config.ResourceTransformation) (retained, generated corev1.ResourceList) {
 	match := false
 	for resourceName := range input {
 		if _, ok := transforms[resourceName]; ok {
@@ -580,7 +583,7 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 		}
 	}
 	if !match {
-		return input
+		return input, nil
 	}
 	// What the transformations produce is kept apart from what the PodSet asked
 	// for until the end. A negative output factor is how an allowance is
@@ -588,8 +591,8 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 	// generates cannot go on to reduce a request that was never part of that
 	// arithmetic: an ordinary request under the same name, or the DRA charge
 	// merged in after this returns.
-	retained := make(corev1.ResourceList)
-	generated := make(corev1.ResourceList)
+	retained = make(corev1.ResourceList)
+	generated = make(corev1.ResourceList)
 	for inputName, inputQuantity := range input {
 		mapping, ok := transforms[inputName]
 		if !ok {
@@ -622,7 +625,7 @@ func applyResourceTransformations(input corev1.ResourceList, transforms map[core
 			generated[name] = resource.Quantity{}
 		}
 	}
-	return utilresource.MergeResourceListKeepSum(retained, generated)
+	return retained, generated
 }
 
 func multiplyResourceQuantities(value, mul resource.Quantity) resource.Quantity {
@@ -694,24 +697,40 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Count: count,
 		}
 		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
-		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
-		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
+		retained, generated := applyResourceTransformations(
+			dropExcludedResources(specRequests, info.excludedResourcePrefixes),
+			info.resourceTransformations,
+		)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
-			// First, remove extended resources that were converted to DRA logical resources
+			// The charge stands in for what the containers asked for, so take back
+			// that much and no more. The overhead and any transformation output
+			// carried under the same name are not part of it.
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {
+				// Read without the overhead rather than subtracting it back off, so
+				// this cannot disagree with whichever view specRequests is taken as.
+				containerRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec},
+					resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})
 				for extRes := range replacedRes {
-					delete(effectiveRequests, extRes)
+					// Gone already when an excluded prefix dropped it or a Replace
+					// transformation consumed it.
+					q, ok := retained[extRes]
+					if !ok {
+						continue
+					}
+					q.Sub(containerRequests[extRes])
+					if q.CmpInt64(0) <= 0 {
+						delete(retained, extRes)
+						continue
+					}
+					retained[extRes] = q
 				}
 			}
 			// Then, add the DRA logical resources
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {
-				for resName, quantity := range draRes {
-					q := effectiveRequests[resName]
-					q.Add(quantity)
-					effectiveRequests[resName] = q
-				}
+				generated = utilresource.MergeResourceListKeepSum(generated, draRes)
 			}
 		}
+		effectiveRequests := utilresource.MergeResourceListKeepSum(retained, generated)
 		setRes.Requests = resources.NewRequestsFromResourceList(effectiveRequests)
 		setRes.Requests.FloorToZero()
 		setRes.Requests.Mul(int64(count))

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -165,10 +165,7 @@ func WithPreserveTotalRequests() InfoOption {
 	}
 }
 
-// WithPreprocessedDRAResources provides the DRA logical resources to add and the names
-// of the extended resources whose container contribution the charge replaces. How much
-// each contributed is derived from the PodSet spec where it is subtracted, and is all
-// that may be taken back.
+// WithPreprocessedDRAResources provides DRA resources to add and extended resources whose container contribution the charge replaces.
 func WithPreprocessedDRAResources(
 	draResources map[kueue.PodSetReference]corev1.ResourceList,
 	replacedExtendedResources map[kueue.PodSetReference]sets.Set[corev1.ResourceName],

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -684,11 +684,11 @@ func PodSetNameToTopologyRequest(wl *kueue.Workload) map[kueue.PodSetReference]*
 	})
 }
 
-// subtractReplacedRequests takes out of retained what the containers asked for on
+// subtractReplacedRequestsFrom takes out of retained what the containers asked for on
 // each name a DRA charge stands in for. The charge replaces that much and no more,
 // so a pod overhead or a transformation output carried under the same name is left
 // where it is.
-func subtractReplacedRequests(retained corev1.ResourceList, spec *corev1.PodSpec, replaced sets.Set[corev1.ResourceName]) {
+func subtractReplacedRequestsFrom(retained corev1.ResourceList, spec *corev1.PodSpec, replaced sets.Set[corev1.ResourceName]) {
 	// Read without the overhead rather than subtracting it back off, so this cannot
 	// disagree with whichever view the retained requests were taken as.
 	containerRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec},
@@ -728,7 +728,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 		)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {
-				subtractReplacedRequests(retained, &ps.Template.Spec, replacedRes)
+				subtractReplacedRequestsFrom(retained, &ps.Template.Spec, replacedRes)
 			}
 			// Then, add the DRA logical resources
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -684,6 +684,31 @@ func PodSetNameToTopologyRequest(wl *kueue.Workload) map[kueue.PodSetReference]*
 	})
 }
 
+// subtractReplacedRequests takes out of retained what the containers asked for on
+// each name a DRA charge stands in for. The charge replaces that much and no more,
+// so a pod overhead or a transformation output carried under the same name is left
+// where it is.
+func subtractReplacedRequests(retained corev1.ResourceList, spec *corev1.PodSpec, replaced sets.Set[corev1.ResourceName]) {
+	// Read without the overhead rather than subtracting it back off, so this cannot
+	// disagree with whichever view the retained requests were taken as.
+	containerRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec},
+		resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})
+	for extRes := range replaced {
+		// Gone already when an excluded prefix dropped it or a Replace
+		// transformation consumed it.
+		q, ok := retained[extRes]
+		if !ok {
+			continue
+		}
+		q.Sub(containerRequests[extRes])
+		if q.CmpInt64(0) <= 0 {
+			delete(retained, extRes)
+			continue
+		}
+		retained[extRes] = q
+	}
+}
+
 func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetResources {
 	if len(wl.Spec.PodSets) == 0 {
 		return nil
@@ -702,28 +727,8 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			info.resourceTransformations,
 		)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {
-			// The charge stands in for what the containers asked for, so take back
-			// that much and no more. The overhead and any transformation output
-			// carried under the same name are not part of it.
 			if replacedRes, exists := info.replacedExtendedResources[ps.Name]; exists {
-				// Read without the overhead rather than subtracting it back off, so
-				// this cannot disagree with whichever view specRequests is taken as.
-				containerRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec},
-					resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})
-				for extRes := range replacedRes {
-					// Gone already when an excluded prefix dropped it or a Replace
-					// transformation consumed it.
-					q, ok := retained[extRes]
-					if !ok {
-						continue
-					}
-					q.Sub(containerRequests[extRes])
-					if q.CmpInt64(0) <= 0 {
-						delete(retained, extRes)
-						continue
-					}
-					retained[extRes] = q
-				}
+				subtractReplacedRequests(retained, &ps.Template.Spec, replacedRes)
 			}
 			// Then, add the DRA logical resources
 			if draRes, exists := info.preprocessedDRAResources[ps.Name]; exists {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -686,13 +686,9 @@ func PodSetNameToTopologyRequest(wl *kueue.Workload) map[kueue.PodSetReference]*
 // so a pod overhead or a transformation output carried under the same name is left
 // where it is.
 func subtractReplacedRequestsFrom(retained corev1.ResourceList, spec *corev1.PodSpec, replaced sets.Set[corev1.ResourceName]) {
-	// Read without the overhead rather than subtracting it back off, so this cannot
-	// disagree with whichever view the retained requests were taken as.
 	containerRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: *spec},
 		resourcehelpers.PodResourcesOptions{ExcludeOverhead: true})
 	for extRes := range replaced {
-		// Gone already when an excluded prefix dropped it or a Replace
-		// transformation consumed it.
 		q, ok := retained[extRes]
 		if !ok {
 			continue

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1140,10 +1140,8 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// The case above without a deviceClassMappings entry, so the quota key falls
-		// back to the original name. That is the setup the extended-resource guide
-		// describes, and the two contributions have nowhere to go but the one key, so
-		// the total under it is no longer a count of devices.
+		// Without a deviceClassMappings entry, the DRA charge for the container
+		// request and the Pod overhead both use the original resource name.
 		"withNoMappingTheChargeAndTheOverheadShareOneKey": {
 			workload: *utiltestingapi.MakeWorkload("dra", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).
@@ -1166,8 +1164,8 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// A transformation output landing on the replaced name is not the container
-		// request either, so only the container's share is taken back.
+		// The DRA replacement subtracts only the container request; a transformation
+		// output under the same name remains.
 		"transformOutputOnAReplacedKeySurvives": {
 			workload: *utiltestingapi.MakeWorkload("dra", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1090,6 +1090,34 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// The case above without a deviceClassMappings entry, so the quota key falls
+		// back to the original name. That is the setup the extended-resource guide
+		// describes, and the two contributions have nowhere to go but the one key, so
+		// the total under it is no longer a count of devices.
+		"withNoMappingTheChargeAndTheOverheadShareOneKey": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("dra", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("1"),
+				}
+				return *wl
+			}(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{WithPreprocessedDRAResources(
+				map[kueue.PodSetReference]corev1.ResourceList{"a": {"example.com/gpu": resource.MustParse("1")}},
+				map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+			)},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// A transformation output landing on the replaced name is not the container
 		// request either, so only the container's share is taken back.
 		"transformOutputOnAReplacedKeySurvives": {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -972,6 +972,155 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// What a transformation generated under the replaced name is not the request
+		// the DRA charge stands in for. Charging both is not new: an output on any
+		// other name is already charged beside the device, and this shape only stops
+		// losing the output along with the request. Issue 14160 has the question of
+		// whether the device belongs on that bill at all.
+		"replaceOutputOnItsOwnInputSurvivesTheDRASubtraction": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:    "example.com/gpu",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("5")},
+				}}),
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+				),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 5,
+						"gpu":             1,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The excluded prefix removed the request the charge replaces, so an output
+		// that recreates the name later belongs to the transformation, not to it.
+		"outputRecreatingAnExcludedNameSurvivesTheDRASubtraction": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("vendor.example/gpu", "2").
+					Request("quota.example/credit", "1").Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{
+				WithExcludedResourcePrefixes([]string{"vendor.example/"}),
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:    "quota.example/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"vendor.example/gpu": resource.MustParse("1")},
+				}}),
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("2")}},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("vendor.example/gpu")},
+				),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"vendor.example/gpu": 1,
+						"gpu":                2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// With the integration off nothing is taken back and nothing is added, so the
+		// PodSet keeps the extended resource it asked for and no logical name appears.
+		"withTheDRAGateOffTheExtendedResourceIsLeftAlone": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("dra", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("1"),
+				}
+				return *wl
+			}(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
+			infoOptions: []InfoOption{WithPreprocessedDRAResources(
+				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
+				map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+			)},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 2,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// The DRA charge replaces what the containers asked for, so an overhead on
+		// the same name is not part of it and has to survive the replacement.
+		"overheadOnAReplacedKeySurvives": {
+			workload: func() kueue.Workload {
+				wl := utiltestingapi.MakeWorkload("dra", "").
+					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					"example.com/gpu": resource.MustParse("1"),
+				}
+				return *wl
+			}(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{WithPreprocessedDRAResources(
+				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
+				map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+			)},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 1,
+						"gpu":             1,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// A transformation output landing on the replaced name is not the container
+		// request either, so only the container's share is taken back.
+		"transformOutputOnAReplacedKeySurvives": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/credit", "1").
+					Request("example.com/gpu", "1").Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{
+				WithResourceTransformations([]config.ResourceTransformation{{
+					Input:    "example.com/credit",
+					Strategy: new(config.Replace),
+					Outputs:  corev1.ResourceList{"example.com/gpu": resource.MustParse("1")},
+				}}),
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+				),
+			},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 1,
+						"gpu":             1,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// A transformation product past the range must not arrive negative and
 		// be floored away.
 		"transformProductPastTheRangeIsNotFlooredAway": {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1040,14 +1040,12 @@ func TestNewInfo(t *testing.T) {
 		// With the integration off nothing is taken back and nothing is added, so the
 		// PodSet keeps the extended resource it asked for and no logical name appears.
 		"withTheDRAGateOffTheExtendedResourceIsLeftAlone": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("dra", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					"example.com/gpu": resource.MustParse("1"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("1")}).
+					Obj()).
+				Obj(),
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: false},
 			infoOptions: []InfoOption{WithPreprocessedDRAResources(
 				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
@@ -1066,14 +1064,12 @@ func TestNewInfo(t *testing.T) {
 		// The DRA charge replaces what the containers asked for, so an overhead on
 		// the same name is not part of it and has to survive the replacement.
 		"overheadOnAReplacedKeySurvives": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("dra", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					"example.com/gpu": resource.MustParse("1"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("1")}).
+					Obj()).
+				Obj(),
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
 			infoOptions: []InfoOption{WithPreprocessedDRAResources(
 				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("1")}},
@@ -1090,19 +1086,71 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
+		// The resolver drops the sidecar's negative before charging, so it charges 8
+		// where the accounting view of the same spec reads 5. Both leave nothing under
+		// the replaced name: what the containers asked for is taken back in full.
+		"aNegativeSidecarLeavesNothingUnderTheReplacedName": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "8").
+					InitContainers(*utiltesting.MakeContainer().Name("sidecar").AsSidecar().
+						WithResourceReq("example.com/gpu", "-3").Obj()).
+					Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{WithPreprocessedDRAResources(
+				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("8")}},
+				map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+			)},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"gpu": 8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
+		// An overhead beside the sidecar is not what the containers asked for, so it
+		// survives. Taking back the charge's 8 rather than the containers' 5 would put
+		// the remainder below zero and delete the overhead along with it.
+		"anOverheadSurvivesBesideANegativeSidecar": {
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "8").
+					InitContainers(*utiltesting.MakeContainer().Name("sidecar").AsSidecar().
+						WithResourceReq("example.com/gpu", "-3").Obj()).
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("1")}).
+					Obj()).
+				Obj(),
+			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
+			infoOptions: []InfoOption{WithPreprocessedDRAResources(
+				map[kueue.PodSetReference]corev1.ResourceList{"a": {"gpu": resource.MustParse("8")}},
+				map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{"a": sets.New[corev1.ResourceName]("example.com/gpu")},
+			)},
+			wantInfo: Info{
+				TotalRequests: []PodSetResources{{
+					Name: "a",
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+						"example.com/gpu": 1,
+						"gpu":             8,
+					}),
+					Count: 1,
+				}},
+			},
+		},
 		// The case above without a deviceClassMappings entry, so the quota key falls
 		// back to the original name. That is the setup the extended-resource guide
 		// describes, and the two contributions have nowhere to go but the one key, so
 		// the total under it is no longer a count of devices.
 		"withNoMappingTheChargeAndTheOverheadShareOneKey": {
-			workload: func() kueue.Workload {
-				wl := utiltestingapi.MakeWorkload("dra", "").
-					PodSets(*utiltestingapi.MakePodSet("a", 1).Request("example.com/gpu", "1").Obj()).Obj()
-				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
-					"example.com/gpu": resource.MustParse("1"),
-				}
-				return *wl
-			}(),
+			workload: *utiltestingapi.MakeWorkload("dra", "").
+				PodSets(*utiltestingapi.MakePodSet("a", 1).
+					Request("example.com/gpu", "1").
+					PodOverHead(corev1.ResourceList{"example.com/gpu": resource.MustParse("1")}).
+					Obj()).
+				Obj(),
 			featureGates: map[featuregate.Feature]bool{features.KueueDRAIntegration: true},
 			infoOptions: []InfoOption{WithPreprocessedDRAResources(
 				map[kueue.PodSetReference]corev1.ResourceList{"a": {"example.com/gpu": resource.MustParse("1")}},

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -972,11 +972,8 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// What a transformation generated under the replaced name is not the request
-		// the DRA charge stands in for. Charging both is not new: an output on any
-		// other name is already charged beside the device, and this shape only stops
-		// losing the output along with the request. Issue 14160 has the question of
-		// whether the device belongs on that bill at all.
+		// A Replace consumes its input, so an output under that same name is not the
+		// container request and the DRA subtraction leaves it whole.
 		"replaceOutputOnItsOwnInputSurvivesTheDRASubtraction": {
 			workload: *utiltestingapi.MakeWorkload("dra", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).
@@ -1112,9 +1109,6 @@ func TestNewInfo(t *testing.T) {
 				}},
 			},
 		},
-		// An overhead beside the sidecar is not what the containers asked for, so it
-		// survives. Taking back the charge's 8 rather than the containers' 5 would put
-		// the remainder below zero and delete the overhead along with it.
 		"anOverheadSurvivesBesideANegativeSidecar": {
 			workload: *utiltestingapi.MakeWorkload("dra", "").
 				PodSets(*utiltestingapi.MakePodSet("a", 1).

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -68,7 +68,8 @@ quota key, and drops the auto-created claim from accounting. This prevents
 quota from being charged for both the `resources.requests` entry **and** the
 auto-created claim, which would double count the same device. No
 `deviceClassMappings` configuration is needed; the mapping is discovered
-from the `DeviceClass` automatically.
+from the `DeviceClass` automatically. A `deviceClassMappings` entry covering
+that `DeviceClass` moves the charge to the mapping's logical name.
 
 This behavior is controlled by the `KueueDRAIntegrationExtendedResource`
 feature gate, which is enabled by default since v0.19.

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -82,23 +82,13 @@ The extended resource path additionally requires the Kubernetes
 
 ## Path separation
 
-The two submission paths are distinct, but they can share a quota key.
+The two paths are independent:
 - **ResourceClaimTemplate path**: uses `deviceClassMappings` configuration.
-- **Extended resource path**: auto-discovers the mapping by indexing `DeviceClass`
-  objects, metering under the `DeviceClass`'s `extendedResourceName`. When that
-  `DeviceClass` also appears in `deviceClassMappings`, the containers' request is
-  metered under the mapping's logical name instead, so ResourceClaimTemplate and
-  extended-resource workloads can draw on the same quota pool.
+- **Extended resource path**: uses auto-discovery from `DeviceClass` objects.
 
-Only the containers' request is translated to the logical name. A chargeable Pod
-overhead or a resource-transformation output left under the original
-`extendedResourceName` stays there, so a `ClusterQueue` that meters both must
-cover the logical name and the original one.
-
-Requesting the same capacity through both a ResourceClaimTemplate and an extended
-resource in one workload charges both additively; Kueue does not deduplicate them
-into a single device allocation, even when both charges land on the same logical
-quota key.
+Do not configure the same `DeviceClass` in both paths for the same workload.
+If overlap occurs, Kueue merges the resources using the `deviceClassMappings`
+logical name as the quota key, which may result in incorrect quota accounting.
 
 ## Quota accounting
 

--- a/site/content/en/docs/concepts/dynamic_resource_allocation.md
+++ b/site/content/en/docs/concepts/dynamic_resource_allocation.md
@@ -81,13 +81,23 @@ The extended resource path additionally requires the Kubernetes
 
 ## Path separation
 
-The two paths are independent:
+The two submission paths are distinct, but they can share a quota key.
 - **ResourceClaimTemplate path**: uses `deviceClassMappings` configuration.
-- **Extended resource path**: uses auto-discovery from `DeviceClass` objects.
+- **Extended resource path**: auto-discovers the mapping by indexing `DeviceClass`
+  objects, metering under the `DeviceClass`'s `extendedResourceName`. When that
+  `DeviceClass` also appears in `deviceClassMappings`, the containers' request is
+  metered under the mapping's logical name instead, so ResourceClaimTemplate and
+  extended-resource workloads can draw on the same quota pool.
 
-Do not configure the same `DeviceClass` in both paths for the same workload.
-If overlap occurs, Kueue merges the resources using the `deviceClassMappings`
-logical name as the quota key, which may result in incorrect quota accounting.
+Only the containers' request is translated to the logical name. A chargeable Pod
+overhead or a resource-transformation output left under the original
+`extendedResourceName` stays there, so a `ClusterQueue` that meters both must
+cover the logical name and the original one.
+
+Requesting the same capacity through both a ResourceClaimTemplate and an extended
+resource in one workload charges both additively; Kueue does not deduplicate them
+into a single device allocation, even when both charges land on the same logical
+quota key.
 
 ## Quota accounting
 

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -166,6 +166,35 @@ The `coveredResources` must include the extended resource name that matches
 kubectl apply -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-queues.yaml
 ```
 
+### What is charged where when the name is remapped
+
+If a `deviceClassMappings` entry gives the DeviceClass a different logical name,
+only the request the Pod's containers make is translated to that name. Anything
+else under the original `extendedResourceName` stays there: a chargeable Pod
+overhead, or a `ResourceTransformation` output written to the same name.
+
+Pod overhead reaches this without anyone writing it by hand. A RuntimeClass
+`overhead.podFixed` entry is copied onto the PodSet, and it is an ordinary
+`ResourceList`, so it can name an extended resource.
+
+To meter both contributions, the ClusterQueue has to cover the logical name and
+the original one. Covering only the logical name behaves differently depending
+on `quotaCheckStrategy` in the Kueue Configuration:
+
+- `BlockUndeclared`, the default: the Workload is not admitted, and reports the
+  original name as unavailable in the ClusterQueue.
+- `IgnoreUndeclared`: the undeclared contribution is skipped deliberately, so
+  the Workload is admitted and that contribution is left out of the usage
+  recorded in `status.admission`.
+
+The charge left under the original name is Kueue accounting alone. It does not
+make the kube-scheduler ask for another device, since the claim it builds comes
+from the containers' requests.
+
+Where the logical name and the original name are the same, the two
+contributions share one quota key, and the total under it is no longer a count
+of devices.
+
 ### Late DeviceClass creation
 
 Kueue watches `DeviceClass` objects for create, update, and delete events.

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -197,15 +197,18 @@ on `quotaCheckStrategy` in the Kueue Configuration:
   the Workload is admitted and that contribution is left out of the usage
   recorded in `status.admission`.
 
-The charge left under the original name does not make the kube-scheduler ask for
-another device, since the claim it builds comes from the containers' requests.
-It is still a quota resource, though, and it is assigned a ResourceFlavor like
-any other. Kueue applies the node labels and tolerations of every flavor in the
-assignment to the Pods, so give the two names the same flavor by keeping them in
-one resource group. A flavor reached only through the original name adds its
-labels and tolerations to Workloads that were placed by the logical one alone
-until now, and where both flavors set the same label key, which value survives
-is not defined.
+On a node where the kube-scheduler hands the resource to DRA, the charge left
+under the original name does not make it ask for another device: the claim it
+builds comes from the containers' requests. A node advertising the same name
+through a device plugin is scheduled on the whole Pod request instead, overhead
+included, so a cluster serving one name both ways has to leave room for the
+residual there too. It is a quota resource either way, and it is assigned a
+ResourceFlavor like any other. Kueue applies the node labels and tolerations of
+every flavor in the assignment to the Pods, so give the two names the same
+flavor by keeping them in one resource group. A flavor reached only through the
+original name adds its labels and tolerations to Workloads that were placed by
+the logical one alone until now, and where both flavors set the same label key,
+which value survives is not defined.
 
 Where the logical name and the original name are the same, the two
 contributions share one quota key, and the total under it is no longer a count

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -169,9 +169,14 @@ kubectl apply -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-queues.yaml
 ### What is charged where when the name is remapped
 
 If a `deviceClassMappings` entry gives the DeviceClass a different logical name,
-only the request the Pod's containers make is translated to that name. Anything
-else under the original `extendedResourceName` stays there: a chargeable Pod
-overhead, or a `ResourceTransformation` output written to the same name.
+only the request the Pod's containers make is translated to that name. What the
+translation takes back is that contribution and no more, so anything still under
+the original `extendedResourceName` by the time it runs stays there: a chargeable
+Pod overhead, or a `ResourceTransformation` output written to the same name.
+
+`excludeResourcePrefixes` and the transformations run before it, so a name one of
+them removed or a `Replace` consumed has nothing left under it either way. What
+changed is that the translation no longer takes the name itself.
 
 Pod overhead reaches this without anyone writing it by hand. A RuntimeClass
 `overhead.podFixed` entry is copied onto the PodSet, and it is an ordinary

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -192,9 +192,15 @@ on `quotaCheckStrategy` in the Kueue Configuration:
   the Workload is admitted and that contribution is left out of the usage
   recorded in `status.admission`.
 
-The charge left under the original name is Kueue accounting alone. It does not
-make the kube-scheduler ask for another device, since the claim it builds comes
-from the containers' requests.
+The charge left under the original name does not make the kube-scheduler ask for
+another device, since the claim it builds comes from the containers' requests.
+It is still a quota resource, though, and it is assigned a ResourceFlavor like
+any other. Kueue applies the node labels and tolerations of every flavor in the
+assignment to the Pods, so give the two names the same flavor by keeping them in
+one resource group. A flavor reached only through the original name adds its
+labels and tolerations to Workloads that were placed by the logical one alone
+until now, and where both flavors set the same label key, which value survives
+is not defined.
 
 Where the logical name and the original name are the same, the two
 contributions share one quota key, and the total under it is no longer a count

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -175,7 +175,9 @@ the original `extendedResourceName` by the time it runs stays there: a chargeabl
 Pod overhead, or a `ResourceTransformation` output written to the same name.
 
 `excludeResourcePrefixes` and the transformations run before it, so a name one of
-them removed or a `Replace` consumed has nothing left under it either way. What
+them removed or a `Replace` consumed has no retained value left to take from. A
+transformation can still generate a new contribution under that name, and that output is
+left alone. What
 changed is that the translation no longer takes the name itself.
 
 Pod overhead reaches this without anyone writing it by hand. A RuntimeClass

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -158,7 +158,10 @@ auto-discovers the mapping by indexing `DeviceClass` objects.
 ### 2. Add the extended resource to your ClusterQueue
 
 The `coveredResources` must include the extended resource name that matches
-`spec.extendedResourceName` on the `DeviceClass`:
+`spec.extendedResourceName` on the `DeviceClass`. Where a `deviceClassMappings`
+entry remaps that name, cover the mapped name instead, and the original one only
+for whatever is left standing under it. See
+[What is charged where when the name is remapped](#what-is-charged-where-when-the-name-is-remapped).
 
 {{< include "examples/dra/sample-dra-queues.yaml" "yaml" >}}
 

--- a/site/content/en/docs/tasks/manage/setup_dra.md
+++ b/site/content/en/docs/tasks/manage/setup_dra.md
@@ -159,60 +159,15 @@ auto-discovers the mapping by indexing `DeviceClass` objects.
 
 The `coveredResources` must include the extended resource name that matches
 `spec.extendedResourceName` on the `DeviceClass`. Where a `deviceClassMappings`
-entry remaps that name, cover the mapped name instead, and the original one only
-for whatever is left standing under it. See
-[What is charged where when the name is remapped](#what-is-charged-where-when-the-name-is-remapped).
+entry remaps that name, only the containers' request moves to the mapped name, so
+cover that one alongside the original, which still carries a chargeable Pod
+overhead or a resource-transformation output written to it.
 
 {{< include "examples/dra/sample-dra-queues.yaml" "yaml" >}}
 
 ```shell
 kubectl apply -f https://kueue.sigs.k8s.io/examples/dra/sample-dra-queues.yaml
 ```
-
-### What is charged where when the name is remapped
-
-If a `deviceClassMappings` entry gives the DeviceClass a different logical name,
-only the request the Pod's containers make is translated to that name. What the
-translation takes back is that contribution and no more, so anything still under
-the original `extendedResourceName` by the time it runs stays there: a chargeable
-Pod overhead, or a `ResourceTransformation` output written to the same name.
-
-`excludeResourcePrefixes` and the transformations run before it, so a name one of
-them removed or a `Replace` consumed has no retained value left to take from. A
-transformation can still generate a new contribution under that name, and that output is
-left alone. What
-changed is that the translation no longer takes the name itself.
-
-Pod overhead reaches this without anyone writing it by hand. A RuntimeClass
-`overhead.podFixed` entry is copied onto the PodSet, and it is an ordinary
-`ResourceList`, so it can name an extended resource.
-
-To meter both contributions, the ClusterQueue has to cover the logical name and
-the original one. Covering only the logical name behaves differently depending
-on `quotaCheckStrategy` in the Kueue Configuration:
-
-- `BlockUndeclared`, the default: the Workload is not admitted, and reports the
-  original name as unavailable in the ClusterQueue.
-- `IgnoreUndeclared`: the undeclared contribution is skipped deliberately, so
-  the Workload is admitted and that contribution is left out of the usage
-  recorded in `status.admission`.
-
-On a node where the kube-scheduler hands the resource to DRA, the charge left
-under the original name does not make it ask for another device: the claim it
-builds comes from the containers' requests. A node advertising the same name
-through a device plugin is scheduled on the whole Pod request instead, overhead
-included, so a cluster serving one name both ways has to leave room for the
-residual there too. It is a quota resource either way, and it is assigned a
-ResourceFlavor like any other. Kueue applies the node labels and tolerations of
-every flavor in the assignment to the Pods, so give the two names the same
-flavor by keeping them in one resource group. A flavor reached only through the
-original name adds its labels and tolerations to Workloads that were placed by
-the logical one alone until now, and where both flavors set the same label key,
-which value survives is not defined.
-
-Where the logical name and the original name are the same, the two
-contributions share one quota key, and the total under it is no longer a count
-of devices.
 
 ### Late DeviceClass creation
 

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -982,13 +982,27 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			ginkgo.By("Only the containers' request moves to the logical name, so the overhead is left with nowhere to go")
-			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+			// Named rather than left to any pending reason: six of the seven that
+			// helper accepts are ones a Workload passes through on its way to being
+			// admitted, so one of those would satisfy a weaker assertion while the
+			// overhead went missing.
+			ginkgo.By("Waiting on the original name, rather than refused as misconfigured DRA")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				cond := apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadQuotaReserved)
+				g.Expect(cond).NotTo(gomega.BeNil())
+				g.Expect(cond.Status).To(gomega.Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(gomega.Equal(kueue.WorkloadQuotaReservedReasonNoMatchingFlavor))
+				g.Expect(cond.Message).To(gomega.ContainSubstring(extendedResourceName))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("Waiting on quota it has not been given, rather than refused as misconfigured DRA")
+			ginkgo.By("And staying there, rather than reaching quota once the overhead is dropped")
 			gomega.Consistently(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+				g.Expect(updatedWl.Status.Admission).To(gomega.BeNil())
 				g.Expect(apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadRequeued)).To(gomega.BeNil())
 			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 		})

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -982,11 +982,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			// Named rather than left to any pending reason: six of the seven that
-			// helper accepts are ones a Workload passes through on its way to being
-			// admitted, so one of those would satisfy a weaker assertion while the
-			// overhead went missing.
-			ginkgo.By("Waiting on the original name, rather than refused as misconfigured DRA")
+			ginkgo.By("Verifying the Pod overhead charge uses the original extended resource name")
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
@@ -997,7 +993,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 				g.Expect(cond.Message).To(gomega.ContainSubstring(extendedResourceName))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("And staying there, rather than reaching quota once the overhead is dropped")
+			ginkgo.By("Verifying the Pod overhead charge under the original extended resource name continues to prevent quota reservation")
 			gomega.Consistently(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
@@ -1085,7 +1081,7 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}
 			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
 
-			ginkgo.By("Both names are covered, so each contribution is charged where it belongs")
+			ginkgo.By("Verifying the DRA charge uses the logical name and Pod overhead uses the original name")
 			gomega.Eventually(func(g gomega.Gomega) {
 				var updatedWl kueue.Workload
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -970,6 +970,120 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 				g.Expect(assignment.ResourceUsage).To(gomega.HaveKey(corev1.ResourceName(logicalName)))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
+
+		ginkgo.It("Should leave pod overhead under the original extended resource name", func() {
+			ginkgo.By("Creating a workload whose overhead names the DRA-backed resource")
+			wl := utiltestingapi.MakeWorkload("overhead-wl", ns.Name).
+				Queue("unified-lq").
+				Request(corev1.ResourceName(extendedResourceName), "1").
+				Obj()
+			wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+			}
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Only the containers' request moves to the logical name, so the overhead is left with nowhere to go")
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+
+			ginkgo.By("Waiting on quota it has not been given, rather than refused as misconfigured DRA")
+			gomega.Consistently(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(apimeta.FindStatusCondition(updatedWl.Status.Conditions, kueue.WorkloadRequeued)).To(gomega.BeNil())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.When("Extended Resources where the ClusterQueue covers both names", func() {
+		var (
+			ns             *corev1.Namespace
+			resourceFlavor *kueue.ResourceFlavor
+			clusterQueue   *kueue.ClusterQueue
+			localQueue     *kueue.LocalQueue
+			deviceClass    *resourcev1.DeviceClass
+		)
+
+		const (
+			extendedResourceName = "example.com/gpu"
+			logicalName          = "gpu-claims"
+		)
+
+		ginkgo.BeforeAll(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegration, true)
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.KueueDRAIntegrationExtendedResource, true)
+
+			deviceClass = utiltesting.MakeDeviceClass("gpu-both.example.com").
+				ExtendedResourceName(extendedResourceName).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+
+			fwk.StopManager(ctx)
+			fwk.StartManager(ctx, cfg, managerSetup(func(c *config.Configuration) {
+				c.Resources.DeviceClassMappings = append(c.Resources.DeviceClassMappings, config.DeviceClassMapping{
+					Name:             logicalName,
+					DeviceClassNames: []corev1.ResourceName{"gpu-both.example.com"},
+				})
+			}))
+		})
+
+		ginkgo.AfterAll(func() {
+			fwk.StopManager(ctx)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			fwk.StartManager(ctx, cfg, managerSetup(nil))
+		})
+
+		ginkgo.BeforeEach(func() {
+			ns = utiltesting.MakeNamespaceWithGenerateName("dra-both-")
+			gomega.Expect(k8sClient.Create(ctx, ns)).To(gomega.Succeed())
+
+			resourceFlavor = utiltestingapi.MakeResourceFlavor("").GeneratedName("rf-both-").Obj()
+			gomega.Expect(k8sClient.Create(ctx, resourceFlavor)).To(gomega.Succeed())
+
+			clusterQueue = utiltestingapi.MakeClusterQueue("").GeneratedName("both-cq-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(resourceFlavor.Name).
+						Resource(logicalName, "8").
+						Resource(corev1.ResourceName(extendedResourceName), "8").
+						Obj(),
+				).Obj()
+			gomega.Expect(k8sClient.Create(ctx, clusterQueue)).To(gomega.Succeed())
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, clusterQueue)
+
+			localQueue = utiltestingapi.MakeLocalQueue("both-lq", ns.Name).
+				ClusterQueue(clusterQueue.Name).Obj()
+			gomega.Expect(k8sClient.Create(ctx, localQueue)).To(gomega.Succeed())
+		})
+
+		ginkgo.AfterEach(func() {
+			gomega.Expect(util.DeleteNamespace(ctx, k8sClient, ns)).To(gomega.Succeed())
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, resourceFlavor, true)
+		})
+
+		ginkgo.It("Should charge the containers to the logical name and the overhead to the original one", func() {
+			ginkgo.By("Creating a workload whose overhead names the DRA-backed resource")
+			wl := utiltestingapi.MakeWorkload("both-wl", ns.Name).
+				Queue("both-lq").
+				Request(corev1.ResourceName(extendedResourceName), "1").
+				Obj()
+			wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+				corev1.ResourceName(extendedResourceName): resource.MustParse("1"),
+			}
+			gomega.Expect(k8sClient.Create(ctx, wl)).To(gomega.Succeed())
+
+			ginkgo.By("Both names are covered, so each contribution is charged where it belongs")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				g.Expect(updatedWl.Status.Admission).NotTo(gomega.BeNil())
+				g.Expect(updatedWl.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+
+				usage := updatedWl.Status.Admission.PodSetAssignments[0].ResourceUsage
+				g.Expect(usage).To(gomega.HaveKeyWithValue(corev1.ResourceName(logicalName), resource.MustParse("1")))
+				g.Expect(usage).To(gomega.HaveKeyWithValue(corev1.ResourceName(extendedResourceName), resource.MustParse("1")))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 	})
 
 	ginkgo.When("KueueDRAIntegrationExtendedResource feature gate disabled", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dra

#### What this PR does / why we need it:

A DRA-backed extended resource was taken out of a PodSet's requests by deleting its name, so pod overhead and a transformation output carried under that same name went with it, and the rebuilt device charge stood in for all of them. The accounting now subtracts the containers' own request rather than removing the entry, read from the PodSet spec with the overhead left out rather than added and then taken back off.

That also fixes the second half of the issue. The resolver took the maximum over every init container and then the maximum of that against the sum of the regular ones, so a restartable init container was maxed against the total instead of added to it. It now aggregates the way a Pod's own requests are aggregated, which is also how the subtracted amount is derived, so the two sides stay comparable.

Three shapes from the issue are now cases, and each fails without the change:

- a container and pod overhead on one name, where the overhead used to disappear with the key
- a container and a transformation output on one name, same
- a restartable init container beside a regular one, which used to be charged once instead of twice, with an ordinary init container measured beside a running sidecar as a second resolver case

#### Which issue(s) this PR fixes:

Fixes #14004

#### Special notes for your reviewer:

The subtracted amount is derived where it is used, from the same PodSet spec the accounting already reads, rather than being resolved during preprocessing and carried alongside the charge. `ResolveExtendedResourceQuota` keeps its signature and still reports a set of names. One source of truth for the amount means there is no second value that can disagree with the spec for a given original resource name, so there is no mismatch to detect, floor, or report there. #14200 has since made each original name aggregate under its own name before any mapping, so the two sides agree there and #14156 is closed; this is rebased on top of it and keeps that ordering, along with its per-container integer check and its field paths.

#14047 is the one that has to land with a shared view rather than beside one, and I have measured what happens if it does not. It normalizes a negative container request to zero before the accounting view is built, while the amount taken back here is read from the PodSpec as it stands. Merged as they are, a PodSet asking `example.com/gpu: -3` on a DRA-backed name is charged `example.com/gpu: 3`: the retained side is zero, the subtraction reads `-3`, and `0 - (-3)` is a positive charge invented out of a request nobody made. With a pod overhead of `5` beside it the same arithmetic gives `8` where the overhead alone is `5`. The sidecar shape this PR corrects reaches a residual by a different route, and I measured it by merging the two branches locally: a restartable init container asking `-3` beside a regular container asking `8` leaves the retained side at `8` while the subtraction reads the raw `5`, so `3` is left standing under the original name with the logical name charged `8`. Reading them from one view is what removes both, which is why the fix cannot be a clamp on the subtracted amount alone. The cases added here pin the arithmetic as it stands, so that residual arrives as a failing test on the #14047 rebase rather than as a number nobody notices.

Clamping the subtracted amount at zero fixes both of those and breaks this PR on its own, which is the part worth being careful about: without #14047 the retained side still carries the `-3`, so `2 - 0` leaves `2` where the overhead is `5`. The two sides have to be read from the same chargeable per-container view, and neither PR can do that alone. Whichever lands second owns it. That was three readers until #14367 normalized the resolver, which is what closed #14216 and what this branch now sits on. Two are left, the retained side and the subtraction, and both still read the PodSpec as it stands.

#14367 had to land first, and it has: it merged on 19 August and this branch is rebased on top of it. What the table measures is why that order mattered. It drops a non-positive extended-resource request at the resolver, before the aggregation. Without it, correcting the sidecar lifecycle here starts letting a negative request cancel a positive one, because the old code hid that behind a max:

```
                                      main   this PR alone   14367 + this PR
restartable init -1, regular 1          1          0                1
restartable init -3, regular 8          8          5                8
```

The 0 and the 5 are undercharges this PR introduces on its own, reachable on a Workload created before `WorkloadValidateResourcesAreNonNegative` or with it turned off. The aggregation here is right for valid input; what is missing is the normalization at the source, which is #14367's one line rather than mine. The branch is rebased on it now, and the combination neither PR covers on its own — a negative restartable init beside a positive regular container — is a case at the resolver and two more through the accounting. Each was checked by breaking what it stands on: reverting the one-line filter takes the resolver case to 5, the row above, and deleting the replaced key outright instead of subtracting the container contribution takes the overhead beside the sidecar with it.

#14048 changes the same `applyResourceTransformations` signature and the same call site, to read `multiplyBy` from the requests before exclusion. Whichever lands first, the other needs both the unfiltered multiplier source and the retained/generated split, and the DRA merge has to stay after the generated totals are floored.

Transformation output is kept apart from the PodSet's own request while the subtraction happens, so an output landing on a replaced name survives it. That covers an output that recreates a name `excludeResourcePrefixes` had already removed, and a `Replace` whose output goes back onto its own input. Both were consumed before.

The second one is the only place this changes what a transformation costs, so it is worth being precise about. A `Replace` consuming a DRA-backed request is charged the device as well as whatever the transformation emits, and that is true on main too: measured on a PodSet requesting `example.com/gpu: 3`, an output of `example.com/credit: 1` gives `credit=3` and `gpu=3` both before and after this change, and an output written to the logical name gives `gpu=6` both before and after. Neither is touched here. What changes is only the case where the output lands back on the replaced name, which main dropped along with the request and this keeps, so it stops being the one shape that behaves differently from the other two. Whether the device should be charged at all once a `Replace` has consumed the request is #14160, and this PR does not answer it.

The KEP-2941 processing flow described the old behaviour, `Removes original extended resource`, and did not mention transformations, so it is updated alongside the change that makes it wrong.

PannagaRao and sohankunkerkar settled the policy on that thread: document the split rather than remap the residual onto the logical name or refuse the configuration. The DRA setup guide now says what is charged where, since that is the page someone configuring a ClusterQueue reads rather than the KEP, and two integration cases pin it.

One thing I offered on that thread was too absolute. I said a case pinning a logical-only ClusterQueue as inadmissible, which holds under the default `BlockUndeclared` strategy and not under `IgnoreUndeclared`. Measured through flavor assignment, with the container charge on the logical name and a residual under the raw one:

```
logical-only CQ, BlockUndeclared    NoFit   resource example.com/gpu unavailable in ClusterQueue
logical-only CQ, IgnoreUndeclared   Fit     the undeclared contribution is skipped
both names, BlockUndeclared         Fit     each contribution charged where it belongs
```

Both are in the guide. The integration case takes the default, and also pins that no `Requeued` condition is written, since a ClusterQueue missing a resource is an ordinary quota wait rather than a DRA misconfiguration, and treating it as one would reach the recovery problem in #13969.

There is a third shape, and it is the one the guide asks for rather than an edge: a `DeviceClass` with no `deviceClassMappings` entry, where the quota key falls back to the original name. Both contributions then land on that one key, so a ClusterQueue cannot meter them apart and the total under it stops being a count of devices. Every case here resolved a different logical name, so nothing was covering it; a container asking for 1 beside an overhead of 1 is now a case at 2 on the one key. Refusing that shape instead would refuse the documented default, and it needs no ClusterQueue change, only room for what was being dropped.

Verified rather than assumed. Reverting the subtraction to the old `delete` turns both accounting cases red. Reverting the aggregation to the old max-based one, and separately dropping `RestartPolicy` from the reconstructed containers, each turn both resolver cases red, the sidecar case at 1 instead of 2 and the ordinary-init case at 5 instead of 7. Beyond the cases, I swept 1008 configurations across container shapes, restartable and plain init containers, pod overhead, both transformation strategies and three excluded prefixes, and compared each against current main. 228 differ, and every one is a case where the old code dropped pod overhead or a transformation output carried under the replaced name. `gofmt`, `go vet`, `go build ./...`, and `pkg/dra`, `pkg/workload`, `pkg/cache` and `pkg/controller/core` under `-race` are clean. The two new integration cases run against envtest, and the whole suite runs with them: `Ran 58 of 58 Specs`, all passing, which is what the new block's manager restart needed checking against rather than running the two on their own. Reverting the subtraction to the old whole-key `delete` turns both of them red, the second one because the overhead it leaves behind is what the logical-only queue has no room for: on the old behaviour that Workload is admitted.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed a bug where a chargeable Pod overhead or a resource-transformation output that shared a name with a DRA-backed extended resource was taken back along with the DRA charge and dropped from quota accounting. Only the containers' own request is subtracted now, so any such contribution left under the original `extendedResourceName` after `excludeResourcePrefixes` and transformations is preserved. Also fixed a restartable init (sidecar) container being maxed against the total instead of added to it, so its devices are counted alongside the regular containers'.

ACTION REQUIRED: When a `deviceClassMappings` entry maps a DeviceClass to a different logical name, ClusterQueues must cover that logical name. A container-only request is fully translated and needs quota only on the logical name; cover the original `extendedResourceName` as well only if a Workload leaves chargeable Pod overhead or a resource-transformation output under it (normally in the same resource group). With such a residual uncovered, `BlockUndeclared` makes the Workload wait with the original name reported unavailable, while `IgnoreUndeclared` skips the residual and leaves it out of recorded usage. Where no mapping renames the DeviceClass, or the mapped name is the `extendedResourceName` itself, the device charge and the residual land on that one key, so its corrected usage can rise: a container asking for 1 with 1 of chargeable overhead now records 2 where it recorded 1. No second key is needed there, but the nominal quota has to cover the pair rather than a count of devices. The change applies as Workloads are evaluated, not to existing reservations at once.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I reviewed and tested every change myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource accounting for workloads using dynamically resolved extended resources.
  * Preserved remaining resource requests when transformed or replaced resources are processed.
  * Improved handling of overhead and transformed resources that share resource names.
  * Corrected request aggregation for restartable init containers so their resource usage is accounted for consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



