### PR TITLE
docs: say which DeviceClass the extended-resource quota key comes from

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -910,11 +910,13 @@ The two DRA paths resolve quota independently:
 #### Processing Flow
 
 1. Kueue detects extended resources in `resources.requests`
-2. Looks up DeviceClass by `extendedResourceName` by field indexer
+2. Looks up DeviceClasses by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)
-4. If a matching DeviceClass is found, resolves the quota key. If the DeviceClass is also
-   in `deviceClassMappings`, uses the mapped logical name. Otherwise uses `extendedResourceName`.
+4. If one or more DeviceClasses match, picks the one the scheduler would use: the latest
+   creation time wins, and the name breaks ties when they were created in the same second.
+   Uses that class's `deviceClassMappings` entry as the quota key, or falls back to
+   `extendedResourceName` when the selected class is not mapped.
 5. If the mapping has counter sources configured, the workload is marked inadmissible.
    Extended resources do not carry profile-level information for counter-based charging.
    Otherwise charges device count.
@@ -984,8 +986,9 @@ dependencies on non-staging k8s repos.
 
 Even when multiple DeviceClasses share the same `extendedResourceName` (which K8s
 [permits with deterministic tiebreaking](https://github.com/kubernetes/kubernetes/blob/v1.35.0/staging/src/k8s.io/api/resource/v1/types.go#L1816-L1820)),
-Kueue still treats the resource as DRA-backed. The quota key is the `extendedResourceName`
-itself, not the DeviceClass name, so multiple matching DeviceClasses do not affect quota accounting.
+Kueue still treats the resource as DRA-backed, and the selected class determines the charge.
+Kueue picks the class the scheduler would use and reads the quota key from it, so the charge
+follows the allocation rather than whichever class the lookup happened to return first.
 
 #### DeviceClass Lifecycle Scenarios
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area dra

#### What this PR does / why we need it:

The KEP-2941 extended-resource processing flow reads as though one DeviceClass matches an `extendedResourceName`. Several can, and #14044 changed which one the charge follows: the class Kubernetes will allocate from, meaning the one created later and the lexicographically first name among classes created together, rather than whichever the List happened to return first with a `deviceClassMappings` entry.

That behaviour shipped without the document catching up, so steps 2 and 4 now say it.

The DeviceClass Resolution section went further and said multiple matching DeviceClasses do not affect quota accounting, which is the opposite of what the selection fixed, so that paragraph is corrected too. Text only, no behaviour change.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Split out rather than folded into #14154, which touches steps 3 and 6 of the same list for a different reason, so each change stays about one thing. They are on separate lines, so whichever lands second should rebase cleanly.

`make toc-update` leaves the table of contents alone, since no headings moved.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I checked the wording against the implementation myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when multiple device classes use the same extended resource.
  * Resource quota resolution now consistently follows Kubernetes class selection rules.
  * Ensures the newest matching class is selected, with deterministic tie-breaking.
  * Supports quota resolution through the selected class’s mapped resource name or the extended resource name.

* **Documentation**
  * Clarified how device class selection affects resource quota charges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
