### PR TITLE
docs: the quota key itself drifts when the selected DeviceClass changes

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -378,9 +378,11 @@ is documented here:
      Users deploying DRA with Kueue should enable `waitForPodsReady`.
    - **Quota drift**: the scheduler allocates from a different DeviceClass than Kueue charged
      quota against, but the pod runs successfully. `waitForPodsReady` does not catch this.
-     Since the extended resources path uses `extendedResourceName` directly as the quota key,
-     quota accounting remains correct at the resource name level, though not at the physical
-     DeviceClass level.
+     Since the extended resources path resolves the quota key from the selected DeviceClass,
+     the mapped logical name when that class is in `deviceClassMappings` and the
+     `extendedResourceName` otherwise, a class switch drifts the quota key itself whenever the
+     two classes map to different logical resources, and not only the physical device behind a
+     stable key.
    To mitigate:
    - Kueue uses a controller-runtime field indexer on `DeviceClass` by `spec.extendedResourceName`
      to resolve DeviceClasses deterministically.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/area dra

#### What this PR does / why we need it:

Follow-up to #14158, which merged while @sohankunkerkar was pointing at a third passage. His catch did not make it into that PR, so it lands here.

The Quota drift bullet in Risks and Mitigations concluded that "quota accounting remains correct at the resource name level". That conclusion rested on the quota key being the `extendedResourceName` no matter which DeviceClass was selected, which stopped being true when #14044 started reading the key from the selected class. Two classes declaring the same `extendedResourceName` under different `deviceClassMappings` entries now move the key itself when the selection switches, so the drift is not confined to the physical device behind a stable key.

That makes it a risk the section was understating rather than only describing in old words. The mitigations below it still hold, and the KEP-5004 one reads as the direct answer to it.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:

Text only, five lines, no behaviour change. The wording is @sohankunkerkar's from https://github.com/kubernetes-sigs/kueue/pull/14158#discussion_r3755061791, widened slightly to keep the physical-device distinction his version dropped.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### AI usage

This PR was written in part with the assistance of generative AI. I checked the claim against the implementation myself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Risks and Mitigations guidance for extended-resource quota drift.
  - Clarified that quota keys depend on the selected DeviceClass and may change when switching between DeviceClasses with different mappings.
  - Documented the fallback to `extendedResourceName` when no logical mapping is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->