### PR TITLE
Add support workload custom labels for local_queue_pending_workloads

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -661,6 +661,14 @@ func (c *ClusterQueue) PendingInLocalQueue(lqRef utilqueue.LocalQueueReference) 
 	return c.workloads.PendingActiveInLocalQueue(lqRef), c.workloads.PendingInadmissibleInLocalQueue(lqRef)
 }
 
+// PendingBreakdownInLocalQueue returns LabelValsTrackers for active and inadmissible
+// pending workloads in the given LocalQueue, keyed by workload custom label values.
+func (c *ClusterQueue) PendingBreakdownInLocalQueue(lqRef utilqueue.LocalQueueReference) (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
+	c.rwm.RLock()
+	defer c.rwm.RUnlock()
+	return c.workloads.PendingBreakdownInLocalQueue(lqRef)
+}
+
 // Pop removes the head of the queue and returns it. It returns nil if the
 // queue is empty.
 func (c *ClusterQueue) Pop() *workload.Info {

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -359,7 +359,7 @@ func TestResyncClusterQueueGaugeMetrics(t *testing.T) {
 }
 
 func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
-	ctx, _ := utiltesting.ContextWithLog(t)
+	ctx, log := utiltesting.ContextWithLog(t)
 	defer metrics.InitMetricVectors(nil)
 
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
@@ -421,7 +421,7 @@ func TestResyncLocalQueueGaugeMetrics(t *testing.T) {
 	updatedLq := lq.DeepCopy()
 	updatedLq.Labels["team"] = "beta"
 	customLabels.LQStore(queue.Key(updatedLq), updatedLq.GetLabels(), updatedLq.GetAnnotations())
-	if err := manager.UpdateLocalQueue(logr.Discard(), updatedLq); err != nil {
+	if err := manager.UpdateLocalQueue(log, updatedLq); err != nil {
 		t.Fatalf("Failed to update local queue: %v", err)
 	}
 	clearLQMetrics(queue.Key(updatedLq))
@@ -2979,8 +2979,7 @@ func TestLQPendingWorkloads_WorkloadCustomLabels(t *testing.T) {
 	// labels when SourceKindWorkload is configured alongside LocalQueueMetrics.
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
-	ctx, _ := utiltesting.ContextWithLog(t)
-	log := logr.Discard()
+	ctx, log := utiltesting.ContextWithLog(t)
 	defer metrics.InitMetricVectors(nil)
 
 	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{
@@ -3055,8 +3054,7 @@ func TestLQPendingWorkloads_WorkloadCustomLabels(t *testing.T) {
 func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
-	ctx, _ := utiltesting.ContextWithLog(t)
-	log := logr.Discard()
+	ctx, log := utiltesting.ContextWithLog(t)
 	defer metrics.InitMetricVectors(nil)
 
 	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2973,3 +2973,162 @@ func TestUpdateLocalQueueWeightZeroReheapifies(t *testing.T) {
 		t.Errorf("zero weight did not disadvantage the LocalQueue (-want,+got):\n%s", diff)
 	}
 }
+
+func TestLQPendingWorkloads_WorkloadCustomLabels(t *testing.T) {
+	// Verify that local_queue_pending_workloads breaks down by workload custom
+	// labels when SourceKindWorkload is configured alongside LocalQueueMetrics.
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	log := logr.Discard()
+	defer metrics.InitMetricVectors(nil)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{
+		{Name: "tier", SourceKind: new(configapi.SourceKindWorkload)},
+	})
+	fakeClient := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
+	manager, _ := NewManagerForUnitTestsWithRequeuer(fakeClient, nil,
+		WithPreemptionExpectations(preemptexpectations.New()),
+		WithCustomLabels(customLabels),
+		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{Enabled: true, QueueSelector: labels.Everything()}),
+	)
+
+	cq := utiltestingapi.MakeClusterQueue("cq1").Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq1", defaultNamespace).ClusterQueue("cq1").Obj()
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("Failed adding cq1: %v", err)
+	}
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("Failed adding lq1: %v", err)
+	}
+
+	wlGold := utiltestingapi.MakeWorkload("wl-gold", defaultNamespace).Label("tier", "gold").Queue("lq1").Creation(time.Now()).Obj()
+	wlSilver := utiltestingapi.MakeWorkload("wl-silver", defaultNamespace).Label("tier", "silver").Queue("lq1").Creation(time.Now()).Obj()
+	if err := manager.AddOrUpdateWorkload(log, wlGold); err != nil {
+		t.Fatalf("Failed adding wl-gold: %v", err)
+	}
+	if err := manager.AddOrUpdateWorkload(log, wlSilver); err != nil {
+		t.Fatalf("Failed adding wl-silver: %v", err)
+	}
+
+	pendingVal := func(tier, status string) float64 {
+		t.Helper()
+		got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+			"name":        "lq1",
+			"namespace":   defaultNamespace,
+			"status":      status,
+			"custom_tier": tier,
+		})
+		if len(got) == 0 {
+			return 0
+		}
+		return got[0].Value
+	}
+
+	// Each workload has its own tier label, so each gets its own metric series.
+	if got := pendingVal("gold", metrics.PendingStatusActive); got != 1 {
+		t.Errorf("gold/active = %v, want 1", got)
+	}
+	if got := pendingVal("silver", metrics.PendingStatusActive); got != 1 {
+		t.Errorf("silver/active = %v, want 1", got)
+	}
+
+	// Updating a workload's label must move its count to the new label series.
+	wlGoldUpdated := wlGold.DeepCopy()
+	wlGoldUpdated.Labels["tier"] = "platinum"
+	if err := manager.AddOrUpdateWorkload(log, wlGoldUpdated); err != nil {
+		t.Fatalf("Failed updating wl-gold: %v", err)
+	}
+	if got := pendingVal("gold", metrics.PendingStatusActive); got != 0 {
+		t.Errorf("after label change: gold/active = %v, want 0", got)
+	}
+	if got := pendingVal("platinum", metrics.PendingStatusActive); got != 1 {
+		t.Errorf("after label change: platinum/active = %v, want 1", got)
+	}
+	if got := pendingVal("silver", metrics.PendingStatusActive); got != 1 {
+		t.Errorf("after label change: silver/active still = %v, want 1", got)
+	}
+}
+
+// TestLQPendingWorkloads_InadmissibleAndDelete verifies that workloads in the
+// inadmissible bucket are counted per workload-label value in
+// kueue_local_queue_pending_workloads, and that deleting a workload removes its
+// contribution from the metric.
+//
+// This complements TestLQPendingWorkloads_WorkloadCustomLabels which covers active
+// workloads and label changes.
+func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
+	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+	ctx, _ := utiltesting.ContextWithLog(t)
+	log := logr.Discard()
+	defer metrics.InitMetricVectors(nil)
+
+	customLabels := metrics.NewCustomLabels([]configapi.ControllerMetricsCustomLabel{
+		{Name: "tier", SourceKind: new(configapi.SourceKindWorkload)},
+	})
+	fakeClient := utiltesting.NewFakeClient(utiltesting.MakeNamespace(defaultNamespace))
+	manager, _ := NewManagerForUnitTestsWithRequeuer(fakeClient, nil,
+		WithPreemptionExpectations(preemptexpectations.New()),
+		WithCustomLabels(customLabels),
+		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{Enabled: true, QueueSelector: labels.Everything()}),
+	)
+
+	cq := utiltestingapi.MakeClusterQueue("cq2").Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq2", defaultNamespace).ClusterQueue("cq2").Obj()
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("AddClusterQueue: %v", err)
+	}
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("AddLocalQueue: %v", err)
+	}
+
+	// Bump popCycle so that RequeueWorkload sends workloads to inadmissible
+	// rather than back into the active heap (same technique as TestUpdateClusterQueue).
+	manager.getClusterQueue("cq2").popCycle++
+
+	wlGold := utiltestingapi.MakeWorkload("wl2-gold", defaultNamespace).Label("tier", "gold").Queue("lq2").Creation(time.Now()).Obj()
+	wlSilver := utiltestingapi.MakeWorkload("wl2-silver", defaultNamespace).Label("tier", "silver").Queue("lq2").Creation(time.Now()).Obj()
+	for _, wl := range []*kueue.Workload{wlGold, wlSilver} {
+		if err := fakeClient.Create(ctx, wl); err != nil {
+			t.Fatalf("Create %s: %v", wl.Name, err)
+		}
+		// RequeueWorkload with popCycle > queueInadmissibleCycle goes to inadmissible.
+		manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+	}
+
+	pendingVal := func(tier, status string) float64 {
+		t.Helper()
+		got := testingmetrics.CollectFilteredGaugeVec(metrics.LocalQueuePendingWorkloads, map[string]string{
+			"name":        "lq2",
+			"namespace":   defaultNamespace,
+			"status":      status,
+			"custom_tier": tier,
+		})
+		if len(got) == 0 {
+			return 0
+		}
+		return got[0].Value
+	}
+
+	// Both workloads land in inadmissible, each with their own tier series.
+	if got := pendingVal("gold", metrics.PendingStatusActive); got != 0 {
+		t.Errorf("initial gold/active = %v, want 0", got)
+	}
+	if got := pendingVal("gold", metrics.PendingStatusInadmissible); got != 1 {
+		t.Errorf("initial gold/inadmissible = %v, want 1", got)
+	}
+	if got := pendingVal("silver", metrics.PendingStatusInadmissible); got != 1 {
+		t.Errorf("initial silver/inadmissible = %v, want 1", got)
+	}
+
+	// Deleting silver must zero out its inadmissible series immediately.
+	manager.DeleteWorkload(log, workload.Key(wlSilver))
+	if got := pendingVal("silver", metrics.PendingStatusInadmissible); got != 0 {
+		t.Errorf("after delete silver: inadmissible = %v, want 0", got)
+	}
+	// Gold inadmissible is unaffected by deleting silver.
+	if got := pendingVal("gold", metrics.PendingStatusInadmissible); got != 1 {
+		t.Errorf("after delete silver: gold/inadmissible = %v, want 1", got)
+	}
+}

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -3050,13 +3050,8 @@ func TestLQPendingWorkloads_WorkloadCustomLabels(t *testing.T) {
 	}
 }
 
-// TestLQPendingWorkloads_InadmissibleAndDelete verifies that workloads in the
-// inadmissible bucket are counted per workload-label value in
-// kueue_local_queue_pending_workloads, and that deleting a workload removes its
-// contribution from the metric.
-//
-// This complements TestLQPendingWorkloads_WorkloadCustomLabels which covers active
-// workloads and label changes.
+// TestLQPendingWorkloads_InadmissibleAndDelete verifies that inadmissible workloads
+// are counted per workload-label value, and that deleting a workload removes its series.
 func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.CustomMetricLabels, true)
 	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
@@ -3093,7 +3088,6 @@ func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
 		if err := fakeClient.Create(ctx, wl); err != nil {
 			t.Fatalf("Create %s: %v", wl.Name, err)
 		}
-		// RequeueWorkload with popCycle > queueInadmissibleCycle goes to inadmissible.
 		manager.RequeueWorkload(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
 	}
 
@@ -3122,12 +3116,11 @@ func TestLQPendingWorkloads_InadmissibleAndDelete(t *testing.T) {
 		t.Errorf("initial silver/inadmissible = %v, want 1", got)
 	}
 
-	// Deleting silver must zero out its inadmissible series immediately.
+	// Deleting silver must zero out its series immediately.
 	manager.DeleteWorkload(log, workload.Key(wlSilver))
 	if got := pendingVal("silver", metrics.PendingStatusInadmissible); got != 0 {
 		t.Errorf("after delete silver: inadmissible = %v, want 0", got)
 	}
-	// Gold inadmissible is unaffected by deleting silver.
 	if got := pendingVal("gold", metrics.PendingStatusInadmissible); got != 1 {
 		t.Errorf("after delete silver: gold/inadmissible = %v, want 1", got)
 	}

--- a/pkg/cache/queue/metrics.go
+++ b/pkg/cache/queue/metrics.go
@@ -128,8 +128,7 @@ func reportLQPendingWorkloads(m *Manager, lq *LocalQueue) {
 			inadmissible = metrics.MergedTracker(inadmissible, active)
 			active = metrics.NewLabelValsTracker()
 		}
-		// Wipe all existing series for this LQ before re-reporting so that stale
-		// workload label combinations (e.g. after a label change) are cleared.
+		// Clear all existing series before re-reporting to remove stale label combinations.
 		metrics.ClearLocalQueuePendingWorkloadsSeries(lqRef)
 		lqCustomLabels := m.customLabels.LQGet(lq.Key)
 		reportLQPendingWorkloadCounts(m, lqRef, lqCustomLabels, active, metrics.PendingStatusActive)

--- a/pkg/cache/queue/metrics.go
+++ b/pkg/cache/queue/metrics.go
@@ -113,19 +113,48 @@ func reportLQPendingWorkloads(m *Manager, lq *LocalQueue) {
 	if !m.lqMetrics.ShouldExposeLocalQueueMetrics(lq.labels) {
 		return
 	}
-	var active, inadmissible int
-	if cq := m.getClusterQueueLockless(lq.ClusterQueue); cq != nil {
-		active, inadmissible = cq.PendingInLocalQueue(lq.Key)
-	}
-	if m.statusChecker != nil && !m.statusChecker.ClusterQueueActive(lq.ClusterQueue) {
-		inadmissible += active
-		active = 0
-	}
 	namespace, lqName := queue.MustParseLocalQueueReference(lq.Key)
-	metrics.ReportLocalQueuePendingWorkloads(metrics.LocalQueueReference{
-		Name:      lqName,
-		Namespace: namespace,
-	}, active, inadmissible, m.customLabels.LQGet(lq.Key), m.roleTracker)
+	lqRef := metrics.LocalQueueReference{Name: lqName, Namespace: namespace}
+	cqActive := m.statusChecker == nil || m.statusChecker.ClusterQueueActive(lq.ClusterQueue)
+
+	if features.Enabled(features.CustomMetricLabels) && m.customLabels.KindConfigured(config.SourceKindWorkload) {
+		var active, inadmissible *metrics.LabelValsTracker
+		if cq := m.getClusterQueueLockless(lq.ClusterQueue); cq != nil {
+			active, inadmissible = cq.PendingBreakdownInLocalQueue(lq.Key)
+		} else {
+			active, inadmissible = metrics.NewLabelValsTracker(), metrics.NewLabelValsTracker()
+		}
+		if !cqActive {
+			inadmissible = metrics.MergedTracker(inadmissible, active)
+			active = metrics.NewLabelValsTracker()
+		}
+		// Wipe all existing series for this LQ before re-reporting so that stale
+		// workload label combinations (e.g. after a label change) are cleared.
+		metrics.ClearLocalQueuePendingWorkloadsSeries(lqRef)
+		lqCustomLabels := m.customLabels.LQGet(lq.Key)
+		reportLQPendingWorkloadCounts(m, lqRef, lqCustomLabels, active, metrics.PendingStatusActive)
+		reportLQPendingWorkloadCounts(m, lqRef, lqCustomLabels, inadmissible, metrics.PendingStatusInadmissible)
+	} else {
+		var active, inadmissible int
+		if cq := m.getClusterQueueLockless(lq.ClusterQueue); cq != nil {
+			active, inadmissible = cq.PendingInLocalQueue(lq.Key)
+		}
+		if !cqActive {
+			inadmissible += active
+			active = 0
+		}
+		metrics.ReportLocalQueuePendingWorkloads(lqRef, active, inadmissible, m.customLabels.LQGet(lq.Key), m.roleTracker)
+	}
+}
+
+func reportLQPendingWorkloadCounts(m *Manager, lqRef metrics.LocalQueueReference, lqCustomLabels []string, tracker *metrics.LabelValsTracker, status string) {
+	for wlLabelVals, count := range tracker.Iter() {
+		customLabels := m.customLabels.CombineLabelValues(map[config.SourceKind][]string{
+			config.SourceKindLocalQueue: lqCustomLabels,
+			config.SourceKindWorkload:   wlLabelVals.OrderedList(),
+		})
+		metrics.ReportLocalQueuePendingWorkloadsByWorkload(lqRef, status, count, customLabels, m.roleTracker)
+	}
 }
 
 func reportLQFinishedWorkloads(m *Manager, lq *LocalQueue) {

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -406,6 +406,31 @@ func (p *PendingWorkloads) PendingInadmissibleInLocalQueue(lqRef utilqueue.Local
 	return
 }
 
+// PendingBreakdownInLocalQueue returns LabelValsTrackers for active and inadmissible
+// pending workloads in the given LocalQueue, keyed by workload custom label values.
+func (p *PendingWorkloads) PendingBreakdownInLocalQueue(lqRef utilqueue.LocalQueueReference) (*metrics.LabelValsTracker, *metrics.LabelValsTracker) {
+	p.RLock()
+	defer p.RUnlock()
+
+	active := metrics.NewLabelValsTracker()
+	for _, wl := range p.active.List() {
+		if utilqueue.KeyFromWorkload(wl.Obj) == lqRef {
+			metrics.TrackWorkload(p.customLabels, active, wl.Obj)
+		}
+	}
+	if p.inflight != nil && utilqueue.KeyFromWorkload(p.inflight.Obj) == lqRef {
+		metrics.TrackWorkload(p.customLabels, active, p.inflight.Obj)
+	}
+
+	inadmissible := metrics.NewLabelValsTracker()
+	for _, wl := range p.inadmissible {
+		if utilqueue.KeyFromWorkload(wl.Obj) == lqRef {
+			metrics.TrackWorkload(p.customLabels, inadmissible, wl.Obj)
+		}
+	}
+	return active, inadmissible
+}
+
 // DumpActive produces a dump of the current active workloads of
 // this ClusterQueue. It returns false if the queue is empty,
 // otherwise returns true.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -490,7 +490,7 @@ Globally configured custom ClusterQueue labels are also appended to the base lab
 'status' can have the following values:
 - "active" means that the workloads are in the admission queue.
 - "inadmissible" means there was a failed admission attempt for these workloads and they won't be retried until cluster conditions, which could make this workload admissible, change`,
-		}, append([]string{"name", "namespace", "status", "replica_role"}, localQueueMetricsLabels...),
+		}, append([]string{"name", "namespace", "status", "replica_role"}, cl.LabelNames(configapi.SourceKindLocalQueue, configapi.SourceKindWorkload)...),
 	)
 	trackGaugeVec(LocalQueuePendingWorkloads, gaugeCleanupScopeLocalQueue)
 
@@ -1242,6 +1242,21 @@ func ReportLocalQueuePendingWorkloads(lq LocalQueueReference, active, inadmissib
 	inadmissibleLabels := append([]string{string(lq.Name), lq.Namespace, PendingStatusInadmissible, role}, customLabelValues...)
 	LocalQueuePendingWorkloads.WithLabelValues(activeLabels...).Set(float64(active))
 	LocalQueuePendingWorkloads.WithLabelValues(inadmissibleLabels...).Set(float64(inadmissible))
+}
+
+func ReportLocalQueuePendingWorkloadsByWorkload(lq LocalQueueReference, status string, count int, customLabelValues []string, tracker *roletracker.RoleTracker) {
+	labels := append([]string{string(lq.Name), lq.Namespace, status, roletracker.GetRole(tracker)}, customLabelValues...)
+	LocalQueuePendingWorkloads.WithLabelValues(labels...).Set(float64(count))
+}
+
+// ClearLocalQueuePendingWorkloadsSeries removes all LocalQueuePendingWorkloads
+// series for the given LocalQueue so stale workload label combinations are
+// cleaned up before a full re-report.
+func ClearLocalQueuePendingWorkloadsSeries(lq LocalQueueReference) {
+	LocalQueuePendingWorkloads.DeletePartialMatch(prometheus.Labels{
+		"name":      string(lq.Name),
+		"namespace": lq.Namespace,
+	})
 }
 
 func ReportEvictedWorkloads(cqName kueue.ClusterQueueReference, evictionReason, underlyingCause, priorityClass string, customLabelValues []string, tracker *roletracker.RoleTracker) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1249,9 +1249,7 @@ func ReportLocalQueuePendingWorkloadsByWorkload(lq LocalQueueReference, status s
 	LocalQueuePendingWorkloads.WithLabelValues(labels...).Set(float64(count))
 }
 
-// ClearLocalQueuePendingWorkloadsSeries removes all LocalQueuePendingWorkloads
-// series for the given LocalQueue so stale workload label combinations are
-// cleaned up before a full re-report.
+// ClearLocalQueuePendingWorkloadsSeries removes all pending workload series for lq.
 func ClearLocalQueuePendingWorkloadsSeries(lq LocalQueueReference) {
 	LocalQueuePendingWorkloads.DeletePartialMatch(prometheus.Labels{
 		"name":      string(lq.Name),

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -1234,7 +1234,7 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			cq = utiltestingapi.MakeClusterQueue("cq-lq-pending").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
-						Resource(corev1.ResourceCPU, "5").
+						Resource(corev1.ResourceCPU, "0").
 						Obj(),
 				).Label("team", "ml-team").Obj()
 			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
@@ -1244,12 +1244,15 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 				ClusterQueue(cq.Name).Obj()
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
+			// wl1: kind1 with tracked annotation — exercises the positive annotation path.
 			wl1 := utiltestingapi.MakeWorkload("wl1-pending", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
+			// wl2: kind2 with no annotation — exercises the untracked annotation path.
 			wl2 := utiltestingapi.MakeWorkload("wl2-pending", ns.Name).
 				Label("workload-kind", "kind2").
 				Queue(kueue.LocalQueueName(lq.Name)).
@@ -1257,15 +1260,15 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			util.MustCreate(ctx, k8sClient, wl2)
 
 			ginkgo.By("verifying LQ pending workloads metric includes custom WL and LQ label values")
-			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind1", "")
-			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind2", "")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 1, "lq-val", "kind1", "anno1")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 1, "lq-val", "kind2", config.UntrackedCustomLabelValue)
 		})
 
 		ginkgo.It("LQ pending workloads metric should update when workload label changes", func() {
 			cq = utiltestingapi.MakeClusterQueue("cq-lq-pending-update").
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
-						Resource(corev1.ResourceCPU, "5").
+						Resource(corev1.ResourceCPU, "0").
 						Obj(),
 				).Label("team", "ml-team").Obj()
 			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
@@ -1275,14 +1278,16 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 				ClusterQueue(cq.Name).Obj()
 			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
 
+			// wl1: kind1 with tracked annotation anno1.
 			wl1 := utiltestingapi.MakeWorkload("wl1-pending-update", ns.Name).
 				Label("workload-kind", "kind1").
+				Annotation("workload-anno", "anno1").
 				Queue(kueue.LocalQueueName(lq.Name)).
 				Request(corev1.ResourceCPU, "1").Obj()
 			util.MustCreate(ctx, k8sClient, wl1)
 
-			ginkgo.By("verifying initial LQ pending metric for kind1")
-			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind1", "")
+			ginkgo.By("verifying initial LQ pending metric for kind1/anno1")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 1, "lq-val", "kind1", "anno1")
 
 			ginkgo.By("updating workload label from kind1 to kind2")
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1292,9 +1297,9 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 				g.Expect(k8sClient.Update(ctx, &fetchedWl)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("verifying LQ pending metric moves from kind1 to kind2")
-			util.ExpectLQPendingWorkloadsMetric(lq, 0, 0, "lq-val", "kind1", "")
-			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind2", "")
+			ginkgo.By("verifying LQ pending metric moves from kind1/anno1 to kind2/anno1")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 0, "lq-val", "kind1", "anno1")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 1, "lq-val", "kind2", "anno1")
 		})
 	})
 

--- a/test/integration/singlecluster/controller/core/custom_labels_test.go
+++ b/test/integration/singlecluster/controller/core/custom_labels_test.go
@@ -1227,6 +1227,75 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 			util.ExpectLQAdmittedActiveWorkloadsGaugeMetric(lq, 0, "lq-val", "kind1", "anno1")
 			util.ExpectLQAdmittedWorkloadsTotalMetric(lq, "", 1, "lq-val", "kind1", "anno1")
 		})
+
+		// Custom label order for LQ pending metrics: lq_label, wl_kind, wl_anno
+		// (SourceKind strings sorted alphabetically: LocalQueue < Workload).
+		ginkgo.It("LQ pending workloads metric should track workloads by custom WL and LQ labels", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-lq-pending").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Label("team", "ml-team").Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-pending", ns.Name).
+				Label("lq-label", "lq-val").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			wl1 := utiltestingapi.MakeWorkload("wl1-pending", ns.Name).
+				Label("workload-kind", "kind1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+
+			wl2 := utiltestingapi.MakeWorkload("wl2-pending", ns.Name).
+				Label("workload-kind", "kind2").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl2)
+
+			ginkgo.By("verifying LQ pending workloads metric includes custom WL and LQ label values")
+			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind1", "")
+			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind2", "")
+		})
+
+		ginkgo.It("LQ pending workloads metric should update when workload label changes", func() {
+			cq = utiltestingapi.MakeClusterQueue("cq-lq-pending-update").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(defaultFlavor.Name).
+						Resource(corev1.ResourceCPU, "5").
+						Obj(),
+				).Label("team", "ml-team").Obj()
+			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
+
+			lq := utiltestingapi.MakeLocalQueue("lq-pending-update", ns.Name).
+				Label("lq-label", "lq-val").
+				ClusterQueue(cq.Name).Obj()
+			util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, lq)
+
+			wl1 := utiltestingapi.MakeWorkload("wl1-pending-update", ns.Name).
+				Label("workload-kind", "kind1").
+				Queue(kueue.LocalQueueName(lq.Name)).
+				Request(corev1.ResourceCPU, "1").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+
+			ginkgo.By("verifying initial LQ pending metric for kind1")
+			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind1", "")
+
+			ginkgo.By("updating workload label from kind1 to kind2")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var fetchedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), &fetchedWl)).To(gomega.Succeed())
+				fetchedWl.Labels["workload-kind"] = "kind2"
+				g.Expect(k8sClient.Update(ctx, &fetchedWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying LQ pending metric moves from kind1 to kind2")
+			util.ExpectLQPendingWorkloadsMetric(lq, 0, 0, "lq-val", "kind1", "")
+			util.ExpectLQPendingWorkloadsMetric(lq, 1, 0, "lq-val", "kind2", "")
+		})
 	})
 
 	ginkgo.When("PendingWorkloads metric when CustomMetricLabels is enabled with workload custom labels", func() {
@@ -1236,6 +1305,8 @@ var _ = ginkgo.Describe("CustomMetricLabels", ginkgo.Label("controller:clusterqu
 
 		ginkgo.BeforeEach(func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.CustomMetricLabels, true)
+			// LocalQueueMetrics must be enabled for reportLQPendingWorkloads to be called.
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.LocalQueueMetrics, true)
 			controllersCfg := &config.Configuration{}
 			controllersCfg.Metrics.CustomLabels = []config.ControllerMetricsCustomLabel{
 				utiltestingapi.MakeCustomLabel("team_cq").SourceLabelKey("team").SourceKind(config.SourceKindClusterQueue).Obj(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Adds workload custom label support to the kueue_local_queue_pending_workloads metric. When CustomMetricLabels is enabled and a SourceKindWorkload label is configured, the metric emits one series per unique workload label combination per LocalQueue

Part of #12629 


<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind feature

#### What this PR does / why we need it:

Adds workload custom label support to the kueue_local_queue_pending_workloads metric. When CustomMetricLabels is enabled and a SourceKindWorkload label is configured, the metric emits one series per unique workload label combination per LocalQueue. The same breakdown that kueue_pending_workloads (ClusterQueue level) already supports.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13588 

#### Special notes for your reviewer:

AI assistance was used in developing this PR

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
`kueue_local_queue_pending_workloads` now emits one series per workload label combination when `CustomMetricLabels` is enabled with a `SourceKindWorkload` custom label
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - LocalQueue pending-workload metrics now include custom labels from workloads.
  - Metrics separately report active and inadmissible pending workloads.
  - Custom labels are reported consistently alongside LocalQueue labels.
  - Metric series are automatically cleared when workloads are removed or labels change.

- **Bug Fixes**
  - Pending workloads associated with inactive queues are classified correctly as inadmissible.
  - Updated workload labels are reflected immediately in reported metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->