### PR TITLE
TAS: apply overlapping-flavor usage only to domains the flavor holds

### DIFF
--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -18,9 +18,11 @@ package scheduler
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -33,8 +35,10 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/resourcegroups"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
@@ -52,12 +56,21 @@ var snapCmpOpts = cmp.Options{
 func TestSnapshot(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	testCases := map[string]struct {
-		cqs          []*kueue.ClusterQueue
-		cohorts      []*kueue.Cohort
-		rfs          []*kueue.ResourceFlavor
-		topologies   []*kueue.Topology
-		wls          []*kueue.Workload
-		wantSnapshot Snapshot
+		cqs        []*kueue.ClusterQueue
+		cohorts    []*kueue.Cohort
+		rfs        []*kueue.ResourceFlavor
+		topologies []*kueue.Topology
+		wls        []*kueue.Workload
+		// nodes are synced into the TAS cache before the snapshot.
+		nodes []*corev1.Node
+		// tasFlavorUsage records raw TAS usage on a flavor before the snapshot.
+		tasFlavorUsage map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests
+		// relabeledFlavors are reapplied after tasFlavorUsage, moving a flavor off
+		// the nodes its usage was recorded on.
+		relabeledFlavors []*kueue.ResourceFlavor
+		wantSnapshot     Snapshot
+		// wantTASUsage asserts per-flavor domain usage (and that none was skipped).
+		wantTASUsage map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests
 	}{
 		"empty": {},
 		"independent clusterQueues": {
@@ -853,10 +866,139 @@ func TestSnapshot(t *testing.T) {
 				},
 			},
 		},
+		// The next three cases exercise how Cache.Snapshot feeds
+		// TASHandleOverlappingFlavors usage into each flavor's snapshot (#10659).
+		"overlapping flavors selecting disjoint nodes take only their own usage": {
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-zone-a").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-zone-b").TopologyName("topology").NodeLabel("zone", "b").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-zone-a").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-zone-b").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+				node.MakeNode("x2").Label(corev1.LabelHostname, "x2").Label("zone", "b").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-zone-a": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-zone-b": {{
+					Values:            []string{"x2"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-zone-a": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+				"tas-zone-b": {"x2": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+			},
+		},
+		"overlapping flavors differing only in taints share the usage of their node (#10659)": {
+			// Both flavors select x1; counting per-flavor would double-count it.
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-shared").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-dedicated").TopologyName("topology").NodeLabel("zone", "a").
+					Taint(corev1.Taint{Key: "dedicated", Value: "special", Effect: corev1.TaintEffectNoSchedule}).Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-shared").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-dedicated").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-shared": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-dedicated": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-shared":    {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+				"tas-dedicated": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+			},
+		},
+		"overlapping flavor that moved to other nodes still counts on the node holding its usage": {
+			// tas-moved is relabelled to zone=b after its usage was recorded on
+			// x1; tas-stay still selects x1 and must still count that usage.
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-stay").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-moved").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-stay").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-moved").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-stay": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-moved": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			relabeledFlavors: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-moved").TopologyName("topology").NodeLabel("zone", "b").Obj(),
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-stay": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+				// tas-moved has no leaf now, so it accounts nothing.
+				"tas-moved": {},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if tc.wantTASUsage != nil {
+				// These cases exercise the gated overlapping-flavor usage
+				// aggregation, which depends on TAS being enabled.
+				features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+				features.SetFeatureGateDuringTest(t, features.TASHandleOverlappingFlavors, true)
+			}
 			ctx, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 			for _, cq := range tc.cqs {
@@ -878,13 +1020,77 @@ func TestSnapshot(t *testing.T) {
 			for _, wl := range tc.wls {
 				cache.AddOrUpdateWorkload(log, wl)
 			}
-			snapshot, err := cache.Snapshot(ctx)
+			for _, n := range tc.nodes {
+				cache.TASCache().SyncNode(n)
+			}
+			for flavor, usage := range tc.tasFlavorUsage {
+				flavorCache := cache.TASCache().Get(flavor)
+				if flavorCache == nil {
+					t.Fatalf("TAS flavor cache for %q was not created", flavor)
+				}
+				flavorCache.addUsage(log, workload.Reference("default/"+string(flavor)), usage)
+			}
+			// Reapplying a flavor after its usage was recorded moves it onto
+			// other nodes while the usage stays on the node it left.
+			for _, rf := range tc.relabeledFlavors {
+				cache.AddOrUpdateResourceFlavor(log, rf)
+			}
+
+			// A domain of a node a flavor does not select carries no usage it can
+			// account, so Cache.Snapshot must skip it without logging a line per
+			// such domain.
+			var skippedDomains []utiltas.TopologyDomainID
+			snapshotCtx := ctx
+			if tc.wantTASUsage != nil {
+				capturingLog := funcr.NewJSON(func(obj string) {
+					entry := make(map[string]any)
+					if err := json.Unmarshal([]byte(obj), &entry); err != nil {
+						t.Errorf("Failed to parse log entry %q: %v", obj, err)
+						return
+					}
+					if entry["msg"] == "skip accounting for TAS usage in domain" {
+						skippedDomains = append(skippedDomains, utiltas.TopologyDomainID(fmt.Sprint(entry["domain"])))
+					}
+				}, funcr.Options{Verbosity: 3})
+				snapshotCtx = logr.NewContext(ctx, capturingLog)
+			}
+			snapshot, err := cache.Snapshot(snapshotCtx)
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
+
+			if tc.wantTASUsage != nil {
+				if len(skippedDomains) > 0 {
+					t.Errorf("Snapshot reported skipped TAS usage for domains %v, want none", skippedDomains)
+				}
+				cqName := kueue.ClusterQueueReference(tc.cqs[0].Name)
+				cqSnapshot := snapshot.ClusterQueue(cqName)
+				if cqSnapshot == nil {
+					t.Fatalf("ClusterQueue %q is missing from the snapshot", cqName)
+				}
+				gotTASUsage := make(map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests, len(tc.wantTASUsage))
+				for flavor := range tc.wantTASUsage {
+					flavorSnapshot := cqSnapshot.TASFlavors[flavor]
+					if flavorSnapshot == nil {
+						t.Fatalf("flavor %q is missing from the ClusterQueue snapshot", flavor)
+					}
+					// A leaf's usage is nil until first updated; skip those.
+					domainUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+					for domainID, leaf := range flavorSnapshot.leaves {
+						if leafCapacity := flavorSnapshot.leafCapacityOf(leaf); leafCapacity.tasUsage != nil {
+							domainUsage[domainID] = leafCapacity.tasUsage
+						}
+					}
+					gotTASUsage[flavor] = domainUsage
+				}
+				usageCmpOpts := cmp.Options{cmpopts.EquateEmpty(), cmp.Comparer(resources.Equal)}
+				if diff := cmp.Diff(tc.wantTASUsage, gotTASUsage, usageCmpOpts...); diff != "" {
+					t.Errorf("unexpected TAS usage in the flavor snapshots (-want,+got):\n%s", diff)
+				}
+			} else if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected Snapshot (-want,+got):\n%s", diff)
 			}
+
 			for _, cq := range snapshot.ClusterQueues() {
 				for i := range cq.ResourceGroups {
 					rg := &cq.ResourceGroups[i]

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -212,9 +212,7 @@ func (c *TASFlavorCache) snapshot(
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
 		tasDomainUsages = aggregatedDomainUsages
 	}
-	for domainID, usage := range tasDomainUsages {
-		snapshot.addTASUsage(domainID, usage)
-	}
+	snapshot.addTASUsageForHeldDomains(tasDomainUsages)
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := tree.nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -283,6 +283,31 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 	return leafCapacity.cachedRemainingCapacity.Get()
 }
 
+// hasDomain reports whether the domain has a leaf in the snapshot, i.e. whether
+// it holds a node the flavor selects.
+func (s *TASFlavorSnapshot) hasDomain(domainID utiltas.TopologyDomainID) bool {
+	return s.leaves[domainID] != nil
+}
+
+// addTASUsageForHeldDomains adds usage only for domains this snapshot has a leaf
+// for. With TASHandleOverlappingFlavors, usages can cover far more domains than
+// the flavor selects, so it walks whichever side is smaller.
+func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.TopologyDomainID]resources.Requests) {
+	if len(s.leaves) < len(usages) {
+		for domainID := range s.leaves {
+			if usage, found := usages[domainID]; found {
+				s.addTASUsage(domainID, usage)
+			}
+		}
+		return
+	}
+	for domainID, usage := range usages {
+		if s.hasDomain(domainID) {
+			s.addTASUsage(domainID, usage)
+		}
+	}
+}
+
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the

--- a/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
+++ b/pkg/cache/scheduler/tas_overlapping_flavor_bench_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+
+	"sigs.k8s.io/kueue/pkg/features"
+	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+// countingSink is a logr.LogSink that counts only the "skip accounting for TAS
+// usage in domain" lines emitted at or below enabledV, so a benchmark can
+// measure skip-log volume without a logging backend. Other V(3) records (e.g.
+// "Constructing TAS snapshot") are ignored.
+type countingSink struct {
+	enabledV int
+	lines    int64
+}
+
+func (s *countingSink) Init(logr.RuntimeInfo)  {}
+func (s *countingSink) Enabled(level int) bool { return level <= s.enabledV }
+func (s *countingSink) Info(_ int, msg string, _ ...any) {
+	if msg == "skip accounting for TAS usage in domain" {
+		s.lines++
+	}
+}
+func (s *countingSink) Error(error, string, ...any)    {}
+func (s *countingSink) WithValues(...any) logr.LogSink { return s }
+func (s *countingSink) WithName(string) logr.LogSink   { return s }
+
+// BenchmarkTASFlavorSnapshotOverlappingUsage models N disjoint flavors sharing a
+// hostname topology: each flavor's snapshot receives the merged usage of all N,
+// so held*(flavors-1) domains are foreign to it. logLines/op is the V(3) skip
+// lines produced; v2 disables them, v3 enables them.
+func BenchmarkTASFlavorSnapshotOverlappingUsage(b *testing.B) {
+	features.SetFeatureGateDuringTest(b, features.TASHandleOverlappingFlavors, true)
+	levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+	usage := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+
+	for _, tc := range []struct{ held, flavors int }{
+		{held: 100, flavors: 10},
+		{held: 250, flavors: 10},
+	} {
+		for _, v := range []int{2, 3} {
+			b.Run(fmt.Sprintf("held=%d/flavors=%d/v%d", tc.held, tc.flavors, v), func(b *testing.B) {
+				nodes := buildBenchNodes(benchTopology{nodes: tc.held, nodesPerRack: 16, racksPerBlock: 16})
+				tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+				for i := range nodes {
+					tasCache.SyncNode(&nodes[i])
+				}
+				flavorCache := tasCache.NewTASFlavorCache(
+					topologyInformation{Levels: levels},
+					flavorInformation{TopologyName: "default"},
+				)
+
+				// Held domains come from the flavor's own leaves; the rest are foreign.
+				held, err := flavorCache.snapshot(b.Context(), logr.Discard(), nil)
+				if err != nil {
+					b.Fatalf("initial TASFlavorSnapshot creation failed: %v", err)
+				}
+				merged := make(map[utiltas.TopologyDomainID]resources.Requests, tc.held*tc.flavors)
+				for domainID := range held.leaves {
+					merged[domainID] = usage
+				}
+				for i := range tc.held * (tc.flavors - 1) {
+					merged[utiltas.TopologyDomainID(fmt.Sprintf("other-flavor-node-%d", i))] = usage
+				}
+
+				sink := &countingSink{enabledV: v}
+				log := logr.New(sink)
+				b.ReportAllocs()
+				iters := 0
+				for b.Loop() {
+					if _, err := flavorCache.snapshot(b.Context(), log, merged); err != nil {
+						b.Fatalf("TASFlavorSnapshot creation failed: %v", err)
+					}
+					iters++
+				}
+				b.ReportMetric(float64(sink.lines)/float64(iters), "logLines/op")
+			})
+		}
+	}
+}


### PR DESCRIPTION
Fixes #14169

## What this does

With `TASHandleOverlappingFlavors`, `Cache.Snapshot` merges the TAS usage of every hostname-level ResourceFlavor into one map keyed by node name and feeds it to each of those flavors' snapshots. A flavor has a leaf only for the nodes it selects, so `addTASUsage` discarded every other domain after logging `skip accounting for TAS usage in domain` at V(3), up to (N-1)*M times per scheduling cycle for N flavors over M nodes. Scheduling is single-goroutine, so those writes land in cycle latency rather than CPU, and the variadic key-value pairs are built even when the sink drops the line.

`TASFlavorCache.snapshot` now applies the intersection of the merged usage and the flavor's leaves, walking whichever side is shorter, so `addTASUsage` is never called for a domain it would reject. The usage reaching a snapshot is unchanged, because a domain with no leaf could never take any. `addTASUsage` keeps its report for `ClusterQueueSnapshot`'s per-cycle updates, where a domain with no leaf still means the backing node was deleted or went NotReady.

## Tests

`TestSnapshotOverlappingFlavorUsage`, three cases on one hostname topology, each asserting the per-flavor leaf usage and that no `skip accounting for TAS usage in domain` line is emitted:

- flavors selecting disjoint nodes take only their own usage;
- flavors differing only in taints share their node's usage (#10659);
- a flavor relabelled onto other nodes while a workload of its own keeps running, so the flavor still selecting that node keeps counting the usage. This case fails under the label-narrowing approach.

Reverting the production change fails the log assertion in two of the three cases. `gofmt`, `go vet` and `go test ./pkg/...` are clean. Integration and e2e were not run locally.

## Benchmark

`BenchmarkTASFlavorSnapshotOverlappingUsage`: N disjoint flavors on one hostname topology, so each flavor's snapshot is handed `held*(N-1)` foreign domains. logLines/op counts the `skip accounting for TAS usage in domain` records emitted at V(3). `before` is `origin/main`, `after` is this branch. 1000 iterations.

| case | logLines/op before → after | allocs/op before → after |
|---|---|---|
| held=100, flavors=10 | 900 → 0 | 2208 → 408 |
| held=250, flavors=10 | 2250 → 0 | 5508 → 1008 |

The skip lines drop from `held*(N-1)` to zero, and the wasted foreign-domain accounting goes with them: ~5x fewer allocations, at both V=2 and V=3, so the work is saved regardless of verbosity. Wall-clock is ~3-4x lower in the microbench but machine-noisy, so the allocation and line counts are the reliable signal.

## Disclosure

This change, including its description, was written with AI assistance and reviewed before submission.

```release-note
TAS: Fixed a bug where cross-flavor TAS usage was matched against topology domains a ResourceFlavor does not hold, adding redundant per-node work and V(3) log lines to every scheduling cycle.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved topology-aware scheduling snapshots when flavors overlap.
* Prevented usage from unrelated topology domains from affecting snapshot calculations.
* Correctly handles disjoint flavors, shared nodes with different taints, and flavors relabeled after usage is recorded.
* Ensured topology domains without selected snapshot leaves are excluded from usage aggregation.
* Improved accuracy and consistency of resource usage reporting across overlapping topology configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->