### PR TITLE
fix(scheduler): dedup overlapping victims in fits()

### DIFF
--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -17,6 +17,9 @@ limitations under the License.
 package preemption
 
 import (
+	"maps"
+	"slices"
+
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -35,4 +38,16 @@ func (p PreemptedWorkloads) Insert(newTargets []*Target) {
 	for _, target := range newTargets {
 		p[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
 	}
+}
+
+// WorkloadsToRemove returns the union of workloads already preempted in this
+// scheduling cycle and the new preemption targets, deduplicated by workload key.
+// The receiver is not mutated.
+func (p PreemptedWorkloads) WorkloadsToRemove(newTargets []*Target) []*workload.Info {
+	merged := maps.Clone(p)
+	if merged == nil {
+		merged = make(PreemptedWorkloads, len(newTargets))
+	}
+	merged.Insert(newTargets)
+	return slices.Collect(maps.Values(merged))
 }

--- a/pkg/scheduler/preemption/preempted_workloads_test.go
+++ b/pkg/scheduler/preemption/preempted_workloads_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestWorkloadsToRemove(t *testing.T) {
+	original := workloadInfoForTest("ns", "victim-a")
+	replacement := workloadInfoForTest("ns", "victim-a")
+	additional := workloadInfoForTest("ns", "victim-b")
+	originalKey := workload.Key(original.Obj)
+	additionalKey := workload.Key(additional.Obj)
+
+	preempted := PreemptedWorkloads{originalKey: original}
+	got := preempted.WorkloadsToRemove([]*Target{
+		{WorkloadInfo: replacement},
+		{WorkloadInfo: additional},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("WorkloadsToRemove() returned %d workloads, want 2", len(got))
+	}
+	gotByKey := make(PreemptedWorkloads, len(got))
+	for _, info := range got {
+		gotByKey[workload.Key(info.Obj)] = info
+	}
+	if gotByKey[originalKey] != replacement {
+		t.Errorf("duplicate target was not deduplicated with the new target value")
+	}
+	if gotByKey[additionalKey] != additional {
+		t.Errorf("new target was not included")
+	}
+	if len(preempted) != 1 || preempted[originalKey] != original {
+		t.Errorf("WorkloadsToRemove() mutated receiver: %#v", preempted)
+	}
+}
+
+func TestWorkloadsToRemoveNilReceiver(t *testing.T) {
+	target := workloadInfoForTest("ns", "victim")
+	var preempted PreemptedWorkloads
+
+	got := preempted.WorkloadsToRemove([]*Target{{WorkloadInfo: target}})
+	if len(got) != 1 || workload.Key(got[0].Obj) != workload.Key(target.Obj) {
+		t.Fatalf("WorkloadsToRemove() = %#v, want the target workload", got)
+	}
+}
+
+func workloadInfoForTest(namespace, name string) *workload.Info {
+	return &workload.Info{Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}}
+}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -714,10 +714,16 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 
 func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads,
 	newTargets []*preemption.Target) schdcache.FitsCheck {
-	workloads := slices.Collect(maps.Values(preemptedWorkloads))
-	for _, target := range newTargets {
-		workloads = append(workloads, target.WorkloadInfo)
+	// Dedup by workload.Key so a victim present in both preemptedWorkloads and
+	// newTargets is only subtracted once (see kubernetes-sigs/kueue#14155).
+	toRemove := maps.Clone(preemptedWorkloads)
+	if toRemove == nil {
+		toRemove = make(preemption.PreemptedWorkloads, len(newTargets))
 	}
+	for _, target := range newTargets {
+		toRemove[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
+	}
+	workloads := slices.Collect(maps.Values(toRemove))
 	revertUsage := snapshot.SimulateWorkloadRemoval(workloads)
 	defer revertUsage()
 	return cq.Fits(*usage)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -714,16 +713,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 
 func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads,
 	newTargets []*preemption.Target) schdcache.FitsCheck {
-	// Dedup by workload.Key so a victim present in both preemptedWorkloads and
-	// newTargets is only subtracted once (see kubernetes-sigs/kueue#14155).
-	toRemove := maps.Clone(preemptedWorkloads)
-	if toRemove == nil {
-		toRemove = make(preemption.PreemptedWorkloads, len(newTargets))
-	}
-	for _, target := range newTargets {
-		toRemove[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
-	}
-	workloads := slices.Collect(maps.Values(toRemove))
+	workloads := preemptedWorkloads.WorkloadsToRemove(newTargets)
 	revertUsage := snapshot.SimulateWorkloadRemoval(workloads)
 	defer revertUsage()
 	return cq.Fits(*usage)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -9102,5 +9103,82 @@ func TestLastAssignmentOutdated(t *testing.T) {
 				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestFitsDedupsOverlappingVictims ensures fits() subtracts a victim only once when
+// it appears in both preemptedWorkloads and the entry's targets (kueue#14155).
+func TestFitsDedupsOverlappingVictims(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	now := time.Now()
+
+	cqObj := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+			Resource(corev1.ResourceCPU, "10").
+			Obj()).
+		Obj()
+	flavor := utiltestingapi.MakeResourceFlavor("default").Obj()
+
+	victimWL := utiltestingapi.MakeWorkload("victim", "ns").
+		Request(corev1.ResourceCPU, "6").
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "6").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+	otherWL := utiltestingapi.MakeWorkload("other", "ns").
+		Request(corev1.ResourceCPU, "2").
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "2").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+
+	cache := schdcache.New(utiltesting.NewFakeClient())
+	cache.AddOrUpdateResourceFlavor(log, flavor)
+	if err := cache.AddClusterQueue(ctx, cqObj); err != nil {
+		t.Fatalf("Failed to add ClusterQueue: %v", err)
+	}
+
+	snapshot, err := cache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Failed to build snapshot: %v", err)
+	}
+	cq := snapshot.ClusterQueue("cq")
+	if cq == nil {
+		t.Fatal("ClusterQueue snapshot missing")
+	}
+
+	victimInfo := workload.NewInfo(victimWL)
+	otherInfo := workload.NewInfo(otherWL)
+	snapshot.AddWorkload(victimInfo)
+	snapshot.AddWorkload(otherInfo)
+
+	// CQ usage is 8 CPU (victim 6 + other 2). Incoming needs 9.
+	// Freeing victim once leaves usage 2 → 8 free → 9 does not fit.
+	// Double-subtracting victim would leave usage -4 and wrongly report Ok.
+	incomingUsage := workload.Usage{
+		Quota: workload.ResourceUsage{
+			Assigned: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(9000),
+			},
+		},
+	}
+	preempted := preemption.PreemptedWorkloads{
+		workload.Key(victimWL): victimInfo,
+	}
+	targets := []*preemption.Target{{WorkloadInfo: victimInfo}}
+
+	got := fits(snapshot, cq, &incomingUsage, preempted, targets)
+	if got != schdcache.FitsCheckNoQuota {
+		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`fits()` concatenated `preemptedWorkloads` with the entry's `preemptionTargets` without deduplicating by `workload.Key`. When the same victim appeared in both lists, its usage was subtracted twice and the fit check became over-optimistic.

Dedup victims by `workload.Key` before simulating removal so the answer is correct regardless of which branch consumes it (including ahead of the `processEntry` overlap skip).

#### Which issue(s) this PR fixes:
Fixes #14155

#### Special notes for your reviewer:

Unit test `TestFitsDedupsOverlappingVictims` covers the overlap case from the issue: CQ nominal 10 CPU, usage 8 (victim 6 + other 2), incoming 9, victim in both lists → `FitsCheckNoQuota`.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

### Validation
- `go test ./pkg/scheduler/ -run 'TestFitsDedupsOverlappingVictims$' -count=1 -v` → PASS

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected scheduler quota calculations when a workload appears in multiple preemption records.
  - Prevented workloads from being removed more than once, avoiding inaccurate fit decisions.
  - Improved handling of repeated and newly identified preemption targets.

- **Reliability**
  - Preserved existing preemption state while calculating removal candidates.
  - Added coverage for overlapping workloads, additional targets, and empty preemption state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->