### PR TITLE
[release-0.19] Refuse a quota reservation with no admission, and let an existing one drain

### DIFF
--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -91,6 +91,11 @@ func (w *WorkloadWebhook) ValidateCreate(ctx context.Context, wl *kueue.Workload
 func (w *WorkloadWebhook) ValidateUpdate(ctx context.Context, oldWL, newWL *kueue.Workload) (admission.Warnings, error) {
 	log := ctrl.LoggerFrom(ctx).WithName("workload-webhook")
 	log.V(5).Info("Validating update")
+	if reservesQuotaWithoutAdmission(oldWL) && reservesQuotaWithoutAdmission(newWL) {
+		// An update that introduces this is refused and says so, so the one
+		// worth a trace is the one that was already like this and goes through.
+		log.V(3).Info("Workload already reserves quota with no admission recorded, letting the update through so it can converge")
+	}
 	return warningsForWorkload(newWL), ValidateWorkloadUpdate(newWL, oldWL).ToAggregate()
 }
 
@@ -139,7 +144,7 @@ func ValidateWorkload(obj, oldObj *kueue.Workload) field.ErrorList {
 
 	statusPath := field.NewPath("status")
 	if workload.HasQuotaReservation(obj) {
-		allErrs = append(allErrs, validateAdmission(obj, statusPath.Child("admission"))...)
+		allErrs = append(allErrs, validateAdmission(obj, oldObj, statusPath.Child("admission"))...)
 	}
 
 	allErrs = append(allErrs, metav1validation.ValidateConditions(obj.Status.Conditions, statusPath.Child("conditions"))...)
@@ -281,8 +286,24 @@ func validateTolerations(tolerations []corev1.Toleration, fldPath *field.Path) f
 	return allErrors
 }
 
-func validateAdmission(obj *kueue.Workload, path *field.Path) field.ErrorList {
+// reservesQuotaWithoutAdmission reports a Workload carrying the QuotaReserved
+// condition with no status.admission.
+func reservesQuotaWithoutAdmission(wl *kueue.Workload) bool {
+	return wl != nil && workload.HasQuotaReservation(wl) && wl.Status.Admission == nil
+}
+
+// validateAdmission is reached on the QuotaReserved condition rather than on the
+// field, so it has to answer for a Workload that carries one without the other.
+func validateAdmission(obj, oldObj *kueue.Workload, path *field.Path) field.ErrorList {
 	admission := obj.Status.Admission
+	if admission == nil {
+		// One that was already like this goes through, so it can converge and be
+		// removed, the way validateReclaimablePods lets a stale count through.
+		if reservesQuotaWithoutAdmission(oldObj) {
+			return nil
+		}
+		return field.ErrorList{field.Required(path, "must be set while the QuotaReserved condition is true")}
+	}
 	var allErrs field.ErrorList
 
 	names := sets.New[kueue.PodSetReference]()

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -48,6 +48,21 @@ const (
 	testWorkloadNamespace = "test-ns"
 )
 
+// quotaReservedWithoutAdmission builds a Workload with the QuotaReserved
+// condition and no status.admission.
+func quotaReservedWithoutAdmission(now time.Time) *kueue.Workload {
+	wl := utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+		PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).Obj()
+	wl.Status.Conditions = []metav1.Condition{{
+		Type:               kueue.WorkloadQuotaReserved,
+		Status:             metav1.ConditionTrue,
+		Reason:             "AdmittedByTest",
+		Message:            "admitted",
+		LastTransitionTime: metav1.NewTime(now),
+	}}
+	return wl
+}
+
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")
@@ -67,6 +82,12 @@ func TestValidateWorkload(t *testing.T) {
 				*utiltestingapi.MakePodSet("driver", 1).Obj(),
 				*utiltestingapi.MakePodSet("workers", 100).Obj(),
 			).Obj(),
+		},
+		"quota reserved without an admission is refused, not a panic": {
+			workload: quotaReservedWithoutAdmission(now),
+			wantErr: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "status.admission"},
+			}.ToAggregate(),
 		},
 		"should have a valid podSet name in status assignment": {
 			workload: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
@@ -724,6 +745,18 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 		wantErr       error
 		wantWarnings  admission.Warnings
 	}{
+		"an update may not put a workload in quota reserved with no admission": {
+			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+				PodSets(*utiltestingapi.MakePodSet("driver", 1).Obj()).Obj(),
+			after: quotaReservedWithoutAdmission(now),
+			wantErr: field.ErrorList{
+				&field.Error{Type: field.ErrorTypeRequired, Field: "status.admission"},
+			}.ToAggregate(),
+		},
+		"a workload already in that state stays updatable so it can be removed": {
+			before: quotaReservedWithoutAdmission(now),
+			after:  quotaReservedWithoutAdmission(now),
+		},
 		"reclaimable pod count can change up": {
 			before: utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
 				PodSets(
@@ -1413,6 +1446,16 @@ func TestValidateWorkloadUpdate(t *testing.T) {
 			wantWarnings: admission.Warnings{
 				"spec.podSets[0].topologyRequest.subGroupCount: negative value -1 is deprecated and will be rejected in a future release",
 			},
+		},
+		// Refusing this update would leave the object undeletable.
+		"a workload whose quota reservation lost its admission can still drop its finalizer": {
+			before: func() *kueue.Workload {
+				wl := quotaReservedWithoutAdmission(now)
+				wl.Finalizers = []string{kueue.ResourceInUseFinalizerName}
+				return wl
+			}(),
+			after:   quotaReservedWithoutAdmission(now),
+			wantErr: nil,
 		},
 	}
 	for name, tc := range testCases {

--- a/test/integration/singlecluster/webhook/core/workload_test.go
+++ b/test/integration/singlecluster/webhook/core/workload_test.go
@@ -592,6 +592,23 @@ var _ = ginkgo.Describe("Workload validating webhook", func() {
 			gomega.Expect(k8sClient.Delete(ctx, priorityClass)).To(gomega.Succeed())
 		})
 
+		ginkgo.It("Should refuse a status update reserving quota with no admission", func() {
+			wl := utiltestingapi.MakeWorkload(workloadName, ns.Name).Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+				wl.Status.Conditions = append(wl.Status.Conditions, metav1.Condition{
+					Type:               kueue.WorkloadQuotaReserved,
+					Status:             metav1.ConditionTrue,
+					Reason:             "Admitted",
+					Message:            "admitted",
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				})
+				g.Expect(k8sClient.Status().Update(ctx, wl)).Should(utiltesting.BeForbiddenError())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.DescribeTable("Validate Workload on update",
 			func(w func() *kueue.Workload, setQuotaReservation bool, updateWl func(newWL *kueue.Workload), matcher gomegatypes.GomegaMatcher) {
 				ginkgo.By("Creating a new Workload")


### PR DESCRIPTION
Manual cherry-pick of #14014, since the automated one hit conflicts on both webhook files.

/assign @mimowo

The two conflicts and how I took them:

`pkg/webhooks/workload_webhook.go`, `ValidateUpdate` returns `warningsForWorkload(newWL)` on this branch where main returns `nil`. Kept the branch's return and the `warningsForWorkload` helper untouched, and put the new V(3) log above it.

`pkg/webhooks/workload_webhook_test.go`, both sides append a case to the `TestValidateWorkloadUpdate` table. Kept both, the branch's `negative subGroupCount is accepted with a warning` and the new finalizer case.

Everything else applied as-is, so the diff matches the merged commit file for file: 3 files, +83/-2.

`go build ./...`, `go vet`, `golangci-lint run pkg/webhooks/...` and `go test ./pkg/webhooks/` are all clean here. The integration case came across untouched and CI will run it.

```release-note
The Workload validating webhook panicked when the `QuotaReserved` condition was set while `status.admission` was absent, so the API server refused the request with an internal error rather than one naming the field. It is now refused as a validation error. An update that leaves a Workload in the state it was already in is allowed through, so an object that entered etcd without passing through admission, from a restore or a migration, can still be updated and removed.
```

#### AI usage

This cherry-pick was prepared in part with the assistance of generative AI. I resolved both conflicts and ran the checks above myself.
