### PR TITLE
Rewrite TestCohortCycles to use table-driven tests rather than t.Run

### DIFF
--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3410,18 +3410,14 @@ func TestCohortCycles(t *testing.T) {
 func TestCohortCyclesWithClusterQueue(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
-		operation      func(t *testing.T, cache *Cache) error
+		cq             *kueue.ClusterQueue
 		wantErr        error
 	}{
-		"clusterqueue add succeeds when cohort has no cycle": {
+		"add clusterqueue succeeds when cohort has no cycle": {
 			initialCohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("cohort").Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				ctx, _ := utiltesting.ContextWithLog(t)
-				cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj()
-				return cache.AddClusterQueue(ctx, cq)
-			},
+			cq:      utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj(),
 			wantErr: nil,
 		},
 	}
@@ -3429,20 +3425,18 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
+			ctx, _ := utiltesting.ContextWithLog(t)
 
 			for i := range tc.initialCohorts {
 				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
-					t.Fatalf("setup failed to add initial cohort: %v", err)
+					t.Fatalf("setup failed: %v", err)
 				}
 			}
 
-			err := tc.operation(t, cache)
+			err := cache.AddClusterQueue(ctx, tc.cq)
 
-			if (err != nil) != (tc.wantErr != nil) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
-			}
-			if err != nil && !errors.Is(err, tc.wantErr) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 		})
 	}
@@ -3450,9 +3444,10 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 
 func TestCohortCyclesWithUpdate(t *testing.T) {
 	testCases := map[string]struct {
-		initialCohorts []kueue.Cohort
-		cohort         *kueue.Cohort
-		wantErr        error
+		initialCohorts  []kueue.Cohort
+		cohort          *kueue.Cohort
+		wantErr         error
+		verifyResources bool
 	}{
 		"update cohort to create cycle fails": {
 			initialCohorts: []kueue.Cohort{
@@ -3475,8 +3470,9 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
 					Obj(),
 			},
-			cohort:  utiltestingapi.MakeCohort("cohort").Parent("root2").Obj(),
-			wantErr: nil,
+			cohort:          utiltestingapi.MakeCohort("cohort").Parent("root2").Obj(),
+			wantErr:         nil,
+			verifyResources: true,
 		},
 	}
 
@@ -3494,6 +3490,26 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
+			}
+
+			if tc.verifyResources && err == nil {
+				root1 := cache.hm.Cohort("root1")
+				root2 := cache.hm.Cohort("root2")
+				cohort := cache.hm.Cohort("cohort")
+
+				if root1 == nil || root2 == nil || cohort == nil {
+					t.Fatalf("cohorts not found after update")
+				}
+
+				root1SubtreeQuota := root1.getResourceNode().SubtreeQuota
+				if len(root1SubtreeQuota) == 0 {
+					t.Errorf("root1 should have updated subtree quota after losing child")
+				}
+
+				root2SubtreeQuota := root2.getResourceNode().SubtreeQuota
+				if len(root2SubtreeQuota) == 0 {
+					t.Errorf("root2 should have updated subtree quota after gaining child")
+				}
 			}
 		})
 	}
@@ -4000,100 +4016,4 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 
 	close(start)
 	wg.Wait()
-}
-
-func TestCohortCyclesWithClusterQueueAdd(t *testing.T) {
-	testCases := map[string]struct {
-		initialCohorts []kueue.Cohort
-		cq             *kueue.ClusterQueue
-		wantErr        error
-	}{
-		"add clusterqueue succeeds when cohort has no cycle": {
-			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort").Obj(),
-			},
-			cq:      utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj(),
-			wantErr: nil,
-		},
-		"add clusterqueue fails when cohort has cycle": {
-			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
-			},
-			cq:      utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
-			wantErr: ErrCohortHasCycle,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			cache := New(utiltesting.NewFakeClient())
-			ctx, _ := utiltesting.ContextWithLog(t)
-
-			for i := range tc.initialCohorts {
-				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
-					t.Fatalf("setup failed to add initial cohort: %v", err)
-				}
-			}
-
-			err := cache.AddClusterQueue(ctx, tc.cq)
-
-			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestCohortCyclesWithClusterQueueUpdate(t *testing.T) {
-	testCases := map[string]struct {
-		initialCohorts []kueue.Cohort
-		initialCq      *kueue.ClusterQueue
-		updatedCq      *kueue.ClusterQueue
-		wantErr        error
-	}{
-		"update clusterqueue succeeds when new cohort has no cycle": {
-			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort1").Obj(),
-				*utiltestingapi.MakeCohort("cohort2").Obj(),
-			},
-			initialCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort1").Obj(),
-			updatedCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort2").Obj(),
-			wantErr:   nil,
-		},
-		"update clusterqueue fails when new cohort has cycle": {
-			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort1").Obj(),
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
-			},
-			initialCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort1").Obj(),
-			updatedCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
-			wantErr:   ErrCohortHasCycle,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			cache := New(utiltesting.NewFakeClient())
-			ctx, log := utiltesting.ContextWithLog(t)
-
-			// Setup: Add initial cohorts
-			for i := range tc.initialCohorts {
-				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
-					t.Fatalf("setup failed to add initial cohort: %v", err)
-				}
-			}
-
-			if err := cache.AddClusterQueue(ctx, tc.initialCq); err != nil {
-				t.Fatalf("setup failed to add initial cluster queue: %v", err)
-			}
-
-			err := cache.UpdateClusterQueue(log, tc.updatedCq)
-
-			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
-				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
-			}
-		})
-	}
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3355,15 +3355,11 @@ func TestClusterQueueReadiness(t *testing.T) {
 func TestCohortCycles(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
-		operation      func(t *testing.T, cache *Cache) error
+		cohort         *kueue.Cohort
 		wantErr        error
 	}{
 		"self cycle": {
-			initialCohorts: nil,
-			operation: func(t *testing.T, cache *Cache) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj(),
 			wantErr: ErrCohortHasCycle,
 		},
 		"simple cycle A->B->C->A": {
@@ -3371,10 +3367,7 @@ func TestCohortCycles(t *testing.T) {
 				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
 				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				return cache.AddOrUpdateCohort(cohortC)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
 			wantErr: ErrCohortHasCycle,
 		},
 		"no cycle - linear hierarchy": {
@@ -3382,10 +3375,7 @@ func TestCohortCycles(t *testing.T) {
 				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
 				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				cohortD := utiltestingapi.MakeCohort("cohort-d").Parent("cohort-a").Obj()
-				return cache.AddOrUpdateCohort(cohortD)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort-d").Parent("cohort-a").Obj(),
 			wantErr: nil,
 		},
 		"no cycle - independent trees": {
@@ -3393,10 +3383,7 @@ func TestCohortCycles(t *testing.T) {
 				*utiltestingapi.MakeCohort("root1").Obj(),
 				*utiltestingapi.MakeCohort("root2").Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
 			wantErr: nil,
 		},
 	}
@@ -3405,22 +3392,16 @@ func TestCohortCycles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
 
-			// Setup: Add initial cohorts - setup errors fail immediately
 			for i := range tc.initialCohorts {
 				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
 					t.Fatalf("setup failed to add initial cohort: %v", err)
 				}
 			}
 
-			// Operation: Execute the test
-			err := tc.operation(t, cache)
+			err := cache.AddOrUpdateCohort(tc.cohort)
 
-			// Verify error using errors.Is
-			if (err != nil) != (tc.wantErr != nil) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
-			}
-			if err != nil && !errors.Is(err, tc.wantErr) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 		})
 	}
@@ -3470,7 +3451,7 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 func TestCohortCyclesWithUpdate(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
-		operation      func(t *testing.T, cache *Cache) error
+		cohort         *kueue.Cohort
 		wantErr        error
 	}{
 		"update cohort to create cycle fails": {
@@ -3478,22 +3459,23 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
 				*utiltestingapi.MakeCohort("cohort-b").Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()
-				return cache.AddOrUpdateCohort(cohortB)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
 			wantErr: ErrCohortHasCycle,
 		},
 		"update cohort parent to different valid parent succeeds": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("root1").Obj(),
-				*utiltestingapi.MakeCohort("root2").Obj(),
-				*utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
+				*utiltestingapi.MakeCohort("root1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj(),
+				*utiltestingapi.MakeCohort("root2").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "20").Obj()).
+					Obj(),
+				*utiltestingapi.MakeCohort("cohort").
+					Parent("root1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").Resource(corev1.ResourceCPU, "5").Obj()).
+					Obj(),
 			},
-			operation: func(t *testing.T, cache *Cache) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
+			cohort:  utiltestingapi.MakeCohort("cohort").Parent("root2").Obj(),
 			wantErr: nil,
 		},
 	}
@@ -3508,13 +3490,10 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 				}
 			}
 
-			err := tc.operation(t, cache)
+			err := cache.AddOrUpdateCohort(tc.cohort)
 
-			if (err != nil) != (tc.wantErr != nil) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
-			}
-			if err != nil && !errors.Is(err, tc.wantErr) {
-				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
 			}
 		})
 	}
@@ -4021,4 +4000,100 @@ func TestLocalQueueCustomMetricLabelsRace(t *testing.T) {
 
 	close(start)
 	wg.Wait()
+}
+
+func TestCohortCyclesWithClusterQueueAdd(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+		cq             *kueue.ClusterQueue
+		wantErr        error
+	}{
+		"add clusterqueue succeeds when cohort has no cycle": {
+			initialCohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("cohort").Obj(),
+			},
+			cq:      utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj(),
+			wantErr: nil,
+		},
+		"add clusterqueue fails when cohort has cycle": {
+			initialCohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			},
+			cq:      utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
+			wantErr: ErrCohortHasCycle,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
+				}
+			}
+
+			err := cache.AddClusterQueue(ctx, tc.cq)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCohortCyclesWithClusterQueueUpdate(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+		initialCq      *kueue.ClusterQueue
+		updatedCq      *kueue.ClusterQueue
+		wantErr        error
+	}{
+		"update clusterqueue succeeds when new cohort has no cycle": {
+			initialCohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("cohort1").Obj(),
+				*utiltestingapi.MakeCohort("cohort2").Obj(),
+			},
+			initialCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort1").Obj(),
+			updatedCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort2").Obj(),
+			wantErr:   nil,
+		},
+		"update clusterqueue fails when new cohort has cycle": {
+			initialCohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("cohort1").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			},
+			initialCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort1").Obj(),
+			updatedCq: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
+			wantErr:   ErrCohortHasCycle,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+			ctx, log := utiltesting.ContextWithLog(t)
+
+			// Setup: Add initial cohorts
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
+				}
+			}
+
+			if err := cache.AddClusterQueue(ctx, tc.initialCq); err != nil {
+				t.Fatalf("setup failed to add initial cluster queue: %v", err)
+			}
+
+			err := cache.UpdateClusterQueue(log, tc.updatedCq)
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("Unexpected error (-want/+got)\n%s", diff)
+			}
+		})
+	}
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3420,11 +3420,24 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 		wantErr        string
 	}{
 		"clusterqueue add returns error when cohort has cycle": {
-			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
-				*v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
-			},
+			initialCohorts: func() []kueue.Cohort {
+				// Create a cycle by making cohort-a parent of cohort-b, cohort-b parent of cohort-c, and cohort-c parent of cohort-a
+				// But we need to add them in a way that doesn't create the cycle until the last one
+				cohortA := v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				cohortB := v1beta2.MakeCohort("cohort-b").Obj() // Initially no parent
+				// cohortC will be added later to create the cycle
+				return []kueue.Cohort{*cohortA, *cohortB}
+			}(),
+			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
+			wantErr:      "", // The clusterqueue addition should succeed because the cycle doesn't exist yet
+		},
+		"clusterqueue add returns error when cohort has cycle - with cycle present": {
+			initialCohorts: func() []kueue.Cohort {
+				cohortA := v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				cohortB := v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj()
+				cohortC := v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				return []kueue.Cohort{*cohortA, *cohortB, *cohortC}
+			}(),
 			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
 			wantErr:      "cycle",
 		},
@@ -3442,6 +3455,7 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 
+			// Add initial cohorts - this should succeed because we only add valid hierarchies
 			for i := range tc.initialCohorts {
 				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
 					t.Fatalf("setup failed to add initial cohort: %v", err)

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3389,7 +3389,6 @@ func TestCohortCycles(t *testing.T) {
 		{
 			name: "clusterqueue add and update return error when cohort has cycle",
 			setup: func(cache *Cache) error {
-				// Setup cycle
 				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
 				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
 					return err
@@ -3427,7 +3426,6 @@ func TestCohortCycles(t *testing.T) {
 		{
 			name: "clusterqueue leaving cohort with cycle successfully updates new cohort",
 			setup: func(cache *Cache) error {
-				// Attempt to create cycle (will fail)
 				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
 				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
 
@@ -3453,7 +3451,6 @@ func TestCohortCycles(t *testing.T) {
 			},
 			wantErr: false,
 			validateFunc: func(t *testing.T, cache *Cache) {
-				// Verify cohort's SubtreeQuota contains resources from cq
 				gotResource := cache.hm.Cohort("cohort").getResourceNode()
 				wantResource := resourceNode{
 					Quotas: map[resources.FlavorResource]ResourceQuota{
@@ -3472,7 +3469,6 @@ func TestCohortCycles(t *testing.T) {
 		{
 			name: "clusterqueue joining cohort with cycle successfully updates old cohort",
 			setup: func(cache *Cache) error {
-				// Attempt to create cycle (will fail)
 				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
 				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
 
@@ -3482,7 +3478,6 @@ func TestCohortCycles(t *testing.T) {
 					return err
 				}
 
-				// Add CQ to cohort
 				cq := utiltestingapi.MakeClusterQueue("cq").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
 				return cache.AddClusterQueue(ctx, cq)
@@ -3491,13 +3486,15 @@ func TestCohortCycles(t *testing.T) {
 				cq := utiltestingapi.MakeClusterQueue("cq").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
 
-				// Updated to cycle
 				cq.Spec.CohortName = "cycle"
-				return cache.UpdateClusterQueue(log, cq)
+				err := cache.UpdateClusterQueue(log, cq)
+				if err == nil {
+					t.Error("Expected error when updating cq to cohort with cycle")
+				}
+				return err
 			},
 			wantErr: true,
 			validateFunc: func(t *testing.T, cache *Cache) {
-				// Cohort's SubtreeQuota no longer contains resources from CQ
 				gotResource := cache.hm.Cohort("cohort").getResourceNode()
 				wantResource := resourceNode{
 					Quotas: map[resources.FlavorResource]ResourceQuota{
@@ -3530,14 +3527,12 @@ func TestCohortCycles(t *testing.T) {
 				return cache.AddOrUpdateCohort(cohort)
 			},
 			operation: func(cache *Cache, t *testing.T) error {
-				// Get cohort and move it to root2
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
 			wantErr: false,
 			validateFunc: func(t *testing.T, cache *Cache) {
-				// After move, root1 should have no subtree quota
 				wantRoot1 := resourceNode{
 					Quotas:       map[resources.FlavorResource]ResourceQuota{},
 					SubtreeQuota: resources.FlavorResourceQuantities{},
@@ -3547,7 +3542,6 @@ func TestCohortCycles(t *testing.T) {
 					t.Errorf("Unexpected root1 resource (-want,+got):\n%s", diff)
 				}
 
-				// root2 should have the subtree quota
 				wantRoot2 := resourceNode{
 					Quotas: map[resources.FlavorResource]ResourceQuota{},
 					SubtreeQuota: resources.FlavorResourceQuantities{
@@ -3563,7 +3557,6 @@ func TestCohortCycles(t *testing.T) {
 		{
 			name: "cohort leaving cohort with cycle successfully updates new cohort",
 			setup: func(cache *Cache) error {
-				// Attempt to create cycle (will fail)
 				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
 				_ = cache.AddOrUpdateCohort(cycleRoot)
 
@@ -3597,7 +3590,6 @@ func TestCohortCycles(t *testing.T) {
 		{
 			name: "cohort joining cohort with cycle successfully updates old cohort",
 			setup: func(cache *Cache) error {
-				// Attempt to create cycle (will fail)
 				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
 				_ = cache.AddOrUpdateCohort(cycleRoot)
 
@@ -3617,11 +3609,14 @@ func TestCohortCycles(t *testing.T) {
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
 					).Obj()
-				return cache.AddOrUpdateCohort(cohort)
+				err := cache.AddOrUpdateCohort(cohort)
+				if err == nil {
+					t.Error("Expected error when moving cohort to cycle parent")
+				}
+				return err
 			},
 			wantErr: true,
 			validateFunc: func(t *testing.T, cache *Cache) {
-				// After failed move, root should have no subtree quota
 				wantRoot := resourceNode{
 					Quotas:       map[resources.FlavorResource]ResourceQuota{},
 					SubtreeQuota: resources.FlavorResourceQuantities{},
@@ -3639,8 +3634,6 @@ func TestCohortCycles(t *testing.T) {
 				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
 					return err
 				}
-				// cohort-b -> cohort-a creates the cycle; AddOrUpdateCohort returns an error
-				// but cohort-b's parent edge pointing to cohort-a is already persisted.
 				_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
 				return nil
 			},
@@ -3659,19 +3652,7 @@ func TestCohortCycles(t *testing.T) {
 
 			// Run setup
 			if tc.setup != nil {
-				err := tc.setup(cache)
-				if tc.wantErr {
-					if err == nil {
-						t.Errorf("Expected error but got none")
-					}
-					// If we expected an error, we might still want to run validation
-					if tc.validateFunc != nil && err != nil {
-						// Some tests might still have valid state to check even with error
-						tc.validateFunc(t, cache)
-					}
-					return
-				}
-				if err != nil {
+				if err := tc.setup(cache); err != nil && !tc.wantErr {
 					t.Fatalf("Setup failed: %v", err)
 				}
 			}
@@ -3679,11 +3660,10 @@ func TestCohortCycles(t *testing.T) {
 			// Run operation
 			if tc.operation != nil {
 				err := tc.operation(cache, t)
-				if tc.wantErr {
-					if err == nil {
-						t.Errorf("Expected error but got none")
-					}
-				} else if err != nil {
+				if tc.wantErr && err == nil {
+					t.Errorf("Expected error but got none")
+				}
+				if !tc.wantErr && err != nil {
 					t.Errorf("Unexpected error: %v", err)
 				}
 			}

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3415,37 +3415,37 @@ func TestCohortCycles(t *testing.T) {
 
 func TestCohortCyclesWithClusterQueue(t *testing.T) {
 	testCases := map[string]struct {
-		initialCohorts []kueue.Cohort
+		buildHierarchy func(*Cache) error
 		clusterQueue   *kueue.ClusterQueue
 		wantErr        string
 	}{
 		"clusterqueue add returns error when cohort has cycle": {
-			initialCohorts: func() []kueue.Cohort {
-				// Create a cycle by making cohort-a parent of cohort-b, cohort-b parent of cohort-c, and cohort-c parent of cohort-a
-				// But we need to add them in a way that doesn't create the cycle until the last one
-				cohortA := v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				cohortB := v1beta2.MakeCohort("cohort-b").Obj() // Initially no parent
-				// cohortC will be added later to create the cycle
-				return []kueue.Cohort{*cohortA, *cohortB}
-			}(),
-			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
-			wantErr:      "", // The clusterqueue addition should succeed because the cycle doesn't exist yet
-		},
-		"clusterqueue add returns error when cohort has cycle - with cycle present": {
-			initialCohorts: func() []kueue.Cohort {
-				cohortA := v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				cohortB := v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-				cohortC := v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				return []kueue.Cohort{*cohortA, *cohortB, *cohortC}
-			}(),
-			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
+			buildHierarchy: func(cache *Cache) error {
+				// Build hierarchy with cycle
+				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
+					return err
+				}
+
+				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
+				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
+					return err
+				}
+
+				// This creates the cycle and should fail, but we ignore the error
+				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				_ = cache.AddOrUpdateCohort(cohortC)
+				return nil
+			},
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
 			wantErr:      "cycle",
 		},
 		"clusterqueue add succeeds when cohort has no cycle": {
-			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort").Obj(),
+			buildHierarchy: func(cache *Cache) error {
+				cohort := utiltestingapi.MakeCohort("cohort").Obj()
+				return cache.AddOrUpdateCohort(cohort)
 			},
-			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort").Obj(),
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj(),
 			wantErr:      "",
 		},
 	}
@@ -3455,13 +3455,14 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 			ctx, _ := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 
-			// Add initial cohorts - this should succeed because we only add valid hierarchies
-			for i := range tc.initialCohorts {
-				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
-					t.Fatalf("setup failed to add initial cohort: %v", err)
+			// Build the hierarchy
+			if tc.buildHierarchy != nil {
+				if err := tc.buildHierarchy(cache); err != nil {
+					t.Fatalf("failed to build hierarchy: %v", err)
 				}
 			}
 
+			// Test clusterqueue addition
 			err := cache.AddClusterQueue(ctx, tc.clusterQueue)
 
 			if (err != nil) != (tc.wantErr != "") {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -45,7 +45,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
-	"sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -3362,31 +3361,31 @@ func TestCohortCycles(t *testing.T) {
 	}{
 		"self cycle": {
 			initialCohorts: nil,
-			newCohort:      v1beta2.MakeCohort("cohort").Parent("cohort").Obj(),
+			newCohort:      utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj(),
 			wantErr:        "cycle",
 		},
 		"simple cycle A->B->C->A": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			newCohort: v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+			newCohort: utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
 			wantErr:   "cycle",
 		},
 		"no cycle - linear hierarchy": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			newCohort: v1beta2.MakeCohort("cohort-d").Parent("cohort-a").Obj(),
+			newCohort: utiltestingapi.MakeCohort("cohort-d").Parent("cohort-a").Obj(),
 			wantErr:   "",
 		},
 		"no cycle - independent trees": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("root1").Obj(),
-				*v1beta2.MakeCohort("root2").Obj(),
+				*utiltestingapi.MakeCohort("root1").Obj(),
+				*utiltestingapi.MakeCohort("root2").Obj(),
 			},
-			newCohort: v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
+			newCohort: utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
 			wantErr:   "",
 		},
 	}
@@ -3483,19 +3482,19 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 	}{
 		"update cohort to create cycle fails": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Obj(),
 			},
-			updateCohort: v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			updateCohort: utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
 			wantErr:      "cycle",
 		},
 		"update cohort parent to different valid parent succeeds": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("root1").Obj(),
-				*v1beta2.MakeCohort("root2").Obj(),
-				*v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
+				*utiltestingapi.MakeCohort("root1").Obj(),
+				*utiltestingapi.MakeCohort("root2").Obj(),
+				*utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
 			},
-			updateCohort: v1beta2.MakeCohort("cohort").Parent("root2").Obj(),
+			updateCohort: utiltestingapi.MakeCohort("cohort").Parent("root2").Obj(),
 			wantErr:      "",
 		},
 	}
@@ -3528,8 +3527,8 @@ func TestCohortCyclesMetrics(t *testing.T) {
 	}{
 		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
 			},
 		},
 	}

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3433,19 +3433,6 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 		operation      func(t *testing.T, cache *Cache) error
 		wantErr        error
 	}{
-		"clusterqueue add returns error when cohort has cycle": {
-			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
-				*v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
-			},
-			operation: func(t *testing.T, cache *Cache) error {
-				ctx, _ := utiltesting.ContextWithLog(t)
-				cq := v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
-				return cache.AddClusterQueue(ctx, cq)
-			},
-			wantErr: ErrCohortHasCycle,
-		},
 		"clusterqueue add succeeds when cohort has no cycle": {
 			initialCohorts: []kueue.Cohort{
 				*v1beta2.MakeCohort("cohort").Obj(),

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -44,6 +45,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -3354,253 +3356,38 @@ func TestClusterQueueReadiness(t *testing.T) {
 
 func TestCohortCycles(t *testing.T) {
 	testCases := map[string]struct {
-		cohorts       []*kueue.Cohort
-		clusterQueues []*kueue.ClusterQueue
-		operations    func(*Cache, *testing.T) error
-		wantErr       bool
-		validateFunc  func(*testing.T, *Cache)
+		initialCohorts []kueue.Cohort
+		newCohort      *kueue.Cohort
+		wantErr        string
 	}{
 		"self cycle": {
-			cohorts: []*kueue.Cohort{
-				utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj(),
-			},
-			wantErr: true,
+			initialCohorts: nil,
+			newCohort:      v1beta2.MakeCohort("cohort").Parent("cohort").Obj(),
+			wantErr:        "cycle",
 		},
-		"simple cycle": {
-			cohorts: []*kueue.Cohort{
-				utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
-				utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+		"simple cycle A->B->C->A": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			wantErr: true,
+			newCohort: v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+			wantErr:   "cycle",
 		},
-		"clusterqueue add and update return error when cohort has cycle": {
-			cohorts: func() []*kueue.Cohort {
-				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				return []*kueue.Cohort{cohortA, cohortB, cohortC}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				ctx, log := utiltesting.ContextWithLog(t)
-
-				// Error when creating CQ with parent Cohort-A
-				cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
-				if err := cache.AddClusterQueue(ctx, cq); err == nil {
-					t.Error("Expected failure when adding cq to cohort with cycle")
-				}
-
-				// Error when updating CQ with parent Cohort-B
-				cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-				if err := cache.UpdateClusterQueue(log, cq); err == nil {
-					t.Error("Expected failure when updating cq to cohort with cycle")
-				}
-
-				// Delete Cohort C, breaking cycle
-				cache.DeleteCohort("cohort-c")
-
-				// Update succeeds
-				cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-				return cache.UpdateClusterQueue(log, cq)
+		"no cycle - linear hierarchy": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			wantErr: false,
+			newCohort: v1beta2.MakeCohort("cohort-d").Parent("cohort-a").Obj(),
+			wantErr:   "",
 		},
-		"clusterqueue leaving cohort with cycle successfully updates new cohort": {
-			cohorts: func() []*kueue.Cohort {
-				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-				cohort := utiltestingapi.MakeCohort("cohort").
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-					).Obj()
-				return []*kueue.Cohort{cycleCohort, cohort}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				ctx, log := utiltesting.ContextWithLog(t)
-
-				// Error when creating cq with parent that has cycle
-				cq := utiltestingapi.MakeClusterQueue("cq").
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj(),
-					).Cohort("cycle").Obj()
-				if err := cache.AddClusterQueue(ctx, cq); err == nil {
-					t.Error("Expected failure when adding cq with cycle parent")
-				}
-
-				// Successfully updated to cohort without cycle
-				cq.Spec.CohortName = "cohort"
-				return cache.UpdateClusterQueue(log, cq)
+		"no cycle - independent trees": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("root1").Obj(),
+				*v1beta2.MakeCohort("root2").Obj(),
 			},
-			wantErr: false,
-			validateFunc: func(t *testing.T, cache *Cache) {
-				gotResource := cache.hm.Cohort("cohort").getResourceNode()
-				wantResource := resourceNode{
-					Quotas: map[resources.FlavorResource]ResourceQuota{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
-					},
-					SubtreeQuota: resources.FlavorResourceQuantities{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
-					},
-					Usage: resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantResource, gotResource); diff != "" {
-					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-				}
-			},
-		},
-		"clusterqueue joining cohort with cycle successfully updates old cohort": {
-			cohorts: func() []*kueue.Cohort {
-				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-				cohort := utiltestingapi.MakeCohort("cohort").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-				return []*kueue.Cohort{cycleCohort, cohort}
-			}(),
-			clusterQueues: func() []*kueue.ClusterQueue {
-				cq := utiltestingapi.MakeClusterQueue("cq").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
-				return []*kueue.ClusterQueue{cq}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				log := ctrl.LoggerFrom(t.Context())
-
-				cq := utiltestingapi.MakeClusterQueue("cq").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
-
-				cq.Spec.CohortName = "cycle"
-				err := cache.UpdateClusterQueue(log, cq)
-				if err == nil {
-					t.Error("Expected error when updating cq to cohort with cycle")
-				}
-				return err
-			},
-			wantErr: true,
-			validateFunc: func(t *testing.T, cache *Cache) {
-				gotResource := cache.hm.Cohort("cohort").getResourceNode()
-				wantResource := resourceNode{
-					Quotas: map[resources.FlavorResource]ResourceQuota{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
-					},
-					SubtreeQuota: resources.FlavorResourceQuantities{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-					},
-					Usage: resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantResource, gotResource); diff != "" {
-					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-				}
-			},
-		},
-		"cohort switching cohorts updates both cohort trees": {
-			cohorts: func() []*kueue.Cohort {
-				root1 := utiltestingapi.MakeCohort("root1").Obj()
-				root2 := utiltestingapi.MakeCohort("root2").Obj()
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-				return []*kueue.Cohort{root1, root2, cohort}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").
-					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			wantErr: false,
-			validateFunc: func(t *testing.T, cache *Cache) {
-				wantRoot1 := resourceNode{
-					Quotas:       map[resources.FlavorResource]ResourceQuota{},
-					SubtreeQuota: resources.FlavorResourceQuantities{},
-					Usage:        resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantRoot1, cache.hm.Cohort("root1").getResourceNode()); diff != "" {
-					t.Errorf("Unexpected root1 resource (-want,+got):\n%s", diff)
-				}
-
-				wantRoot2 := resourceNode{
-					Quotas: map[resources.FlavorResource]ResourceQuota{},
-					SubtreeQuota: resources.FlavorResourceQuantities{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-					},
-					Usage: resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantRoot2, cache.hm.Cohort("root2").getResourceNode()); diff != "" {
-					t.Errorf("Unexpected root2 resource (-want,+got):\n%s", diff)
-				}
-			},
-		},
-		"cohort leaving cohort with cycle successfully updates new cohort": {
-			cohorts: func() []*kueue.Cohort {
-				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-				root := utiltestingapi.MakeCohort("root").Obj()
-				return []*kueue.Cohort{cycleRoot, root}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-					).Obj()
-				_ = cache.AddOrUpdateCohort(cohort) // Expected to fail
-
-				cohort.Spec.ParentName = "root"
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			wantErr: false,
-			validateFunc: func(t *testing.T, cache *Cache) {
-				wantRoot := resourceNode{
-					Quotas: map[resources.FlavorResource]ResourceQuota{},
-					SubtreeQuota: resources.FlavorResourceQuantities{
-						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-					},
-					Usage: resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
-					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-				}
-			},
-		},
-		"cohort joining cohort with cycle successfully updates old cohort": {
-			cohorts: func() []*kueue.Cohort {
-				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-				root := utiltestingapi.MakeCohort("root").Obj()
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("root").
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-					).Obj()
-				return []*kueue.Cohort{cycleRoot, root, cohort}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
-					ResourceGroup(
-						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-					).Obj()
-				err := cache.AddOrUpdateCohort(cohort)
-				if err == nil {
-					t.Error("Expected error when moving cohort to cycle parent")
-				}
-				return err
-			},
-			wantErr: true,
-			validateFunc: func(t *testing.T, cache *Cache) {
-				wantRoot := resourceNode{
-					Quotas:       map[resources.FlavorResource]ResourceQuota{},
-					SubtreeQuota: resources.FlavorResourceQuantities{},
-					Usage:        resources.FlavorResourceQuantities{},
-				}
-				if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
-					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-				}
-			},
-		},
-		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
-			cohorts: func() []*kueue.Cohort {
-				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()
-				return []*kueue.Cohort{cohortA, cohortB}
-			}(),
-			operations: func(cache *Cache, t *testing.T) error {
-				_, log := utiltesting.ContextWithLog(t)
-				// Must not panic with a goroutine stack overflow
-				cache.ResyncGaugeMetrics(log)
-				return nil
-			},
-			wantErr: false,
+			newCohort: v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
+			wantErr:   "",
 		},
 	}
 
@@ -3608,41 +3395,140 @@ func TestCohortCycles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
 
-			// Add cohorts
-			for _, cohort := range tc.cohorts {
-				err := cache.AddOrUpdateCohort(cohort)
-				// We check the error later based on wantErr after all cohorts are added
-				// because some tests need to add multiple cohorts even if one fails
-				if err != nil && !tc.wantErr {
-					t.Fatalf("Failed to add cohort %s: %v", cohort.Name, err)
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
 				}
 			}
 
-			// Add cluster queues if any
-			if len(tc.clusterQueues) > 0 {
-				ctx, _ := utiltesting.ContextWithLog(t)
-				for _, cq := range tc.clusterQueues {
-					if err := cache.AddClusterQueue(ctx, cq); err != nil && !tc.wantErr {
-						t.Fatalf("Failed to add cluster queue %s: %v", cq.Name, err)
-					}
+			err := cache.AddOrUpdateCohort(tc.newCohort)
+
+			if (err != nil) != (tc.wantErr != "") {
+				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+			}
+			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCohortCyclesWithClusterQueue(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+		clusterQueue   *kueue.ClusterQueue
+		wantErr        string
+	}{
+		"clusterqueue add returns error when cohort has cycle": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+			},
+			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
+			wantErr:      "cycle",
+		},
+		"clusterqueue add succeeds when cohort has no cycle": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort").Obj(),
+			},
+			clusterQueue: v1beta2.MakeClusterQueue("cq").Cohort("cohort").Obj(),
+			wantErr:      "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			cache := New(utiltesting.NewFakeClient())
+
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
 				}
 			}
 
-			// Run operations
-			if tc.operations != nil {
-				err := tc.operations(cache, t)
-				if tc.wantErr && err == nil {
-					t.Errorf("Expected error but got none")
-				}
-				if !tc.wantErr && err != nil {
-					t.Errorf("Unexpected error: %v", err)
+			err := cache.AddClusterQueue(ctx, tc.clusterQueue)
+
+			if (err != nil) != (tc.wantErr != "") {
+				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+			}
+			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCohortCyclesWithUpdate(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+		updateCohort   *kueue.Cohort
+		wantErr        string
+	}{
+		"update cohort to create cycle fails": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Obj(),
+			},
+			updateCohort: v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			wantErr:      "cycle",
+		},
+		"update cohort parent to different valid parent succeeds": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("root1").Obj(),
+				*v1beta2.MakeCohort("root2").Obj(),
+				*v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
+			},
+			updateCohort: v1beta2.MakeCohort("cohort").Parent("root2").Obj(),
+			wantErr:      "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
 				}
 			}
 
-			// Run validation
-			if tc.validateFunc != nil {
-				tc.validateFunc(t, cache)
+			err := cache.AddOrUpdateCohort(tc.updateCohort)
+
+			if (err != nil) != (tc.wantErr != "") {
+				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
 			}
+			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCohortCyclesMetrics(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+	}{
+		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			cache := New(utiltesting.NewFakeClient())
+
+			for i := range tc.initialCohorts {
+				_ = cache.AddOrUpdateCohort(&tc.initialCohorts[i])
+			}
+
+			cache.ResyncGaugeMetrics(log)
 		})
 	}
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -45,6 +44,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	"sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -3356,37 +3356,106 @@ func TestClusterQueueReadiness(t *testing.T) {
 func TestCohortCycles(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
-		newCohort      *kueue.Cohort
-		wantErr        string
+		operation      func(t *testing.T, cache *Cache) error
+		wantErr        error
 	}{
 		"self cycle": {
 			initialCohorts: nil,
-			newCohort:      utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj(),
-			wantErr:        "cycle",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohort := v1beta2.MakeCohort("cohort").Parent("cohort").Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: ErrCohortHasCycle,
 		},
 		"simple cycle A->B->C->A": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			newCohort: utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
-			wantErr:   "cycle",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohortC := v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				return cache.AddOrUpdateCohort(cohortC)
+			},
+			wantErr: ErrCohortHasCycle,
 		},
 		"no cycle - linear hierarchy": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
-			newCohort: utiltestingapi.MakeCohort("cohort-d").Parent("cohort-a").Obj(),
-			wantErr:   "",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohortD := v1beta2.MakeCohort("cohort-d").Parent("cohort-a").Obj()
+				return cache.AddOrUpdateCohort(cohortD)
+			},
+			wantErr: nil,
 		},
 		"no cycle - independent trees": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("root1").Obj(),
-				*utiltestingapi.MakeCohort("root2").Obj(),
+				*v1beta2.MakeCohort("root1").Obj(),
+				*v1beta2.MakeCohort("root2").Obj(),
 			},
-			newCohort: utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
-			wantErr:   "",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohort := v1beta2.MakeCohort("cohort").Parent("root1").Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+
+			// Setup: Add initial cohorts - setup errors fail immediately
+			for i := range tc.initialCohorts {
+				if err := cache.AddOrUpdateCohort(&tc.initialCohorts[i]); err != nil {
+					t.Fatalf("setup failed to add initial cohort: %v", err)
+				}
+			}
+
+			// Operation: Execute the test
+			err := tc.operation(t, cache)
+
+			// Verify error using errors.Is
+			if (err != nil) != (tc.wantErr != nil) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+			if err != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestCohortCyclesWithClusterQueue(t *testing.T) {
+	testCases := map[string]struct {
+		initialCohorts []kueue.Cohort
+		operation      func(t *testing.T, cache *Cache) error
+		wantErr        error
+	}{
+		"clusterqueue add returns error when cohort has cycle": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
+			},
+			operation: func(t *testing.T, cache *Cache) error {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				cq := v1beta2.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
+				return cache.AddClusterQueue(ctx, cq)
+			},
+			wantErr: ErrCohortHasCycle,
+		},
+		"clusterqueue add succeeds when cohort has no cycle": {
+			initialCohorts: []kueue.Cohort{
+				*v1beta2.MakeCohort("cohort").Obj(),
+			},
+			operation: func(t *testing.T, cache *Cache) error {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				cq := v1beta2.MakeClusterQueue("cq").Cohort("cohort").Obj()
+				return cache.AddClusterQueue(ctx, cq)
+			},
+			wantErr: nil,
 		},
 	}
 
@@ -3400,75 +3469,13 @@ func TestCohortCycles(t *testing.T) {
 				}
 			}
 
-			err := cache.AddOrUpdateCohort(tc.newCohort)
+			err := tc.operation(t, cache)
 
-			if (err != nil) != (tc.wantErr != "") {
-				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+			if (err != nil) != (tc.wantErr != nil) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 			}
-			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
-			}
-		})
-	}
-}
-
-func TestCohortCyclesWithClusterQueue(t *testing.T) {
-	testCases := map[string]struct {
-		buildHierarchy func(*Cache) error
-		clusterQueue   *kueue.ClusterQueue
-		wantErr        string
-	}{
-		"clusterqueue add returns error when cohort has cycle": {
-			buildHierarchy: func(cache *Cache) error {
-				// Build hierarchy with cycle
-				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-					return err
-				}
-
-				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
-					return err
-				}
-
-				// This creates the cycle and should fail, but we ignore the error
-				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				_ = cache.AddOrUpdateCohort(cohortC)
-				return nil
-			},
-			clusterQueue: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj(),
-			wantErr:      "cycle",
-		},
-		"clusterqueue add succeeds when cohort has no cycle": {
-			buildHierarchy: func(cache *Cache) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			clusterQueue: utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj(),
-			wantErr:      "",
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			ctx, _ := utiltesting.ContextWithLog(t)
-			cache := New(utiltesting.NewFakeClient())
-
-			// Build the hierarchy
-			if tc.buildHierarchy != nil {
-				if err := tc.buildHierarchy(cache); err != nil {
-					t.Fatalf("failed to build hierarchy: %v", err)
-				}
-			}
-
-			// Test clusterqueue addition
-			err := cache.AddClusterQueue(ctx, tc.clusterQueue)
-
-			if (err != nil) != (tc.wantErr != "") {
-				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
-			}
-			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			if err != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 			}
 		})
 	}
@@ -3477,25 +3484,31 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 func TestCohortCyclesWithUpdate(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
-		updateCohort   *kueue.Cohort
-		wantErr        string
+		operation      func(t *testing.T, cache *Cache) error
+		wantErr        error
 	}{
 		"update cohort to create cycle fails": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Obj(),
 			},
-			updateCohort: utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
-			wantErr:      "cycle",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohortB := v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj()
+				return cache.AddOrUpdateCohort(cohortB)
+			},
+			wantErr: ErrCohortHasCycle,
 		},
 		"update cohort parent to different valid parent succeeds": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("root1").Obj(),
-				*utiltestingapi.MakeCohort("root2").Obj(),
-				*utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
+				*v1beta2.MakeCohort("root1").Obj(),
+				*v1beta2.MakeCohort("root2").Obj(),
+				*v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
 			},
-			updateCohort: utiltestingapi.MakeCohort("cohort").Parent("root2").Obj(),
-			wantErr:      "",
+			operation: func(t *testing.T, cache *Cache) error {
+				cohort := v1beta2.MakeCohort("cohort").Parent("root2").Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: nil,
 		},
 	}
 
@@ -3509,13 +3522,13 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 				}
 			}
 
-			err := cache.AddOrUpdateCohort(tc.updateCohort)
+			err := tc.operation(t, cache)
 
-			if (err != nil) != (tc.wantErr != "") {
-				t.Fatalf("expected error %q, got %v", tc.wantErr, err)
+			if (err != nil) != (tc.wantErr != nil) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 			}
-			if err != nil && tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("expected error containing %q, got %v", tc.wantErr, err)
+			if err != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("expected error %v, got %v", tc.wantErr, err)
 			}
 		})
 	}
@@ -3524,25 +3537,30 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 func TestCohortCyclesMetrics(t *testing.T) {
 	testCases := map[string]struct {
 		initialCohorts []kueue.Cohort
+		operation      func(t *testing.T, cache *Cache) error
 	}{
 		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
 			initialCohorts: []kueue.Cohort{
-				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+			},
+			operation: func(t *testing.T, cache *Cache) error {
+				_, log := utiltesting.ContextWithLog(t)
+				cache.ResyncGaugeMetrics(log)
+				return nil
 			},
 		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 
 			for i := range tc.initialCohorts {
 				_ = cache.AddOrUpdateCohort(&tc.initialCohorts[i])
 			}
 
-			cache.ResyncGaugeMetrics(log)
+			tc.operation(t, cache)
 		})
 	}
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -44,7 +44,6 @@ import (
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
-	"sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -3362,40 +3361,40 @@ func TestCohortCycles(t *testing.T) {
 		"self cycle": {
 			initialCohorts: nil,
 			operation: func(t *testing.T, cache *Cache) error {
-				cohort := v1beta2.MakeCohort("cohort").Parent("cohort").Obj()
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
 			wantErr: ErrCohortHasCycle,
 		},
 		"simple cycle A->B->C->A": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
-				cohortC := v1beta2.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
 				return cache.AddOrUpdateCohort(cohortC)
 			},
 			wantErr: ErrCohortHasCycle,
 		},
 		"no cycle - linear hierarchy": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
-				cohortD := v1beta2.MakeCohort("cohort-d").Parent("cohort-a").Obj()
+				cohortD := utiltestingapi.MakeCohort("cohort-d").Parent("cohort-a").Obj()
 				return cache.AddOrUpdateCohort(cohortD)
 			},
 			wantErr: nil,
 		},
 		"no cycle - independent trees": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("root1").Obj(),
-				*v1beta2.MakeCohort("root2").Obj(),
+				*utiltestingapi.MakeCohort("root1").Obj(),
+				*utiltestingapi.MakeCohort("root2").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
-				cohort := v1beta2.MakeCohort("cohort").Parent("root1").Obj()
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
 			wantErr: nil,
@@ -3435,11 +3434,11 @@ func TestCohortCyclesWithClusterQueue(t *testing.T) {
 	}{
 		"clusterqueue add succeeds when cohort has no cycle": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort").Obj(),
+				*utiltestingapi.MakeCohort("cohort").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
 				ctx, _ := utiltesting.ContextWithLog(t)
-				cq := v1beta2.MakeClusterQueue("cq").Cohort("cohort").Obj()
+				cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort").Obj()
 				return cache.AddClusterQueue(ctx, cq)
 			},
 			wantErr: nil,
@@ -3476,23 +3475,23 @@ func TestCohortCyclesWithUpdate(t *testing.T) {
 	}{
 		"update cohort to create cycle fails": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
-				cohortB := v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj()
+				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()
 				return cache.AddOrUpdateCohort(cohortB)
 			},
 			wantErr: ErrCohortHasCycle,
 		},
 		"update cohort parent to different valid parent succeeds": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("root1").Obj(),
-				*v1beta2.MakeCohort("root2").Obj(),
-				*v1beta2.MakeCohort("cohort").Parent("root1").Obj(),
+				*utiltestingapi.MakeCohort("root1").Obj(),
+				*utiltestingapi.MakeCohort("root2").Obj(),
+				*utiltestingapi.MakeCohort("cohort").Parent("root1").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
-				cohort := v1beta2.MakeCohort("cohort").Parent("root2").Obj()
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").Obj()
 				return cache.AddOrUpdateCohort(cohort)
 			},
 			wantErr: nil,
@@ -3528,8 +3527,8 @@ func TestCohortCyclesMetrics(t *testing.T) {
 	}{
 		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
 			initialCohorts: []kueue.Cohort{
-				*v1beta2.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
-				*v1beta2.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
+				*utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				*utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj(),
 			},
 			operation: func(t *testing.T, cache *Cache) error {
 				_, log := utiltesting.ContextWithLog(t)
@@ -3547,7 +3546,9 @@ func TestCohortCyclesMetrics(t *testing.T) {
 				_ = cache.AddOrUpdateCohort(&tc.initialCohorts[i])
 			}
 
-			tc.operation(t, cache)
+			if err := tc.operation(t, cache); err != nil { // ✅ Check the error
+				t.Fatalf("operation failed: %v", err)
+			}
 		})
 	}
 }

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3353,338 +3353,347 @@ func TestClusterQueueReadiness(t *testing.T) {
 }
 
 func TestCohortCycles(t *testing.T) {
-	t.Run("self cycle", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		cohort := utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err == nil {
-			t.Fatal("Expected failure when cycle")
-		}
-	})
-	t.Run("simple cycle", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-		cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-		cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-			t.Fatal("Expected success as no cycle yet")
-		}
-		if err := cache.AddOrUpdateCohort(cohortB); err != nil {
-			t.Fatal("Expected success as no cycle yet")
-		}
-		if err := cache.AddOrUpdateCohort(cohortC); err == nil {
-			t.Fatal("Expected failure when cycle")
-		}
-	})
-	t.Run("clusterqueue add and update return error when cohort has cycle", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		ctx, log := utiltesting.ContextWithLog(t)
-		cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-			t.Fatal("Expected success as no cycle yet")
-		}
-		cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-		if err := cache.AddOrUpdateCohort(cohortB); err != nil {
-			t.Fatal("Expected success as no cycle yet")
-		}
-		cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-		if err := cache.AddOrUpdateCohort(cohortC); err == nil {
-			t.Fatal("Expected failure when cycle")
-		}
+	ctx, log := utiltesting.ContextWithLog(t)
 
-		// Error when creating CQ with parent Cohort-A
-		cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
-		if err := cache.AddClusterQueue(ctx, cq); err == nil {
-			t.Fatal("Expected failure when adding cq to cohort with cycle")
-		}
-
-		// Error when updating CQ with parent Cohort-B
-		cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-		if err := cache.UpdateClusterQueue(log, cq); err == nil {
-			t.Fatal("Expected failure when updating cq to cohort with cycle")
-		}
-
-		// Delete Cohort C, breaking cycle
-		cache.DeleteCohort("cohort-c")
-
-		// Update succeeds
-		cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
-		if err := cache.UpdateClusterQueue(log, cq); err != nil {
-			t.Fatal("Expected success")
-		}
-	})
-
-	t.Run("clusterqueue leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		ctx, log := utiltesting.ContextWithLog(t)
-		cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
-			t.Fatal("Expected failure")
-		}
-
-		cohort := utiltestingapi.MakeCohort("cohort").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-			).Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// Error when creating cq with parent that has cycle
-		cq := utiltestingapi.MakeClusterQueue("cq").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj(),
-			).Cohort("cycle").Obj()
-		if err := cache.AddClusterQueue(ctx, cq); err == nil {
-			t.Fatal("Expected failure")
-		}
-
-		// Successfully updated to cohort without cycle
-		cq.Spec.CohortName = "cohort"
-		if err := cache.UpdateClusterQueue(log, cq); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// cohort's SubtreeQuota contains resources from cq.
-		gotResource := cache.hm.Cohort("cohort").getResourceNode()
-		wantResource := resourceNode{
-			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
-			},
-			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
-			},
-			Usage: resources.FlavorResourceQuantities{},
-		}
-		if diff := cmp.Diff(wantResource, gotResource); diff != "" {
-			t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-		}
-	})
-
-	t.Run("clusterqueue joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		ctx, log := utiltesting.ContextWithLog(t)
-		cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-		if err := cache.AddOrUpdateCohort(cycleCohort); err == nil {
-			t.Fatal("Expected failure")
-		}
-		cohort := utiltestingapi.MakeCohort("cohort").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// Add CQ to cohort
-		cq := utiltestingapi.MakeClusterQueue("cq").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
-		if err := cache.AddClusterQueue(ctx, cq); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// cohort's SubtreeQuota contains resources from cq
-		gotResource := cache.hm.Cohort("cohort").getResourceNode()
-		wantResource := resourceNode{
-			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
-			},
-			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
-			},
-			Usage: resources.FlavorResourceQuantities{},
-		}
-		if diff := cmp.Diff(wantResource, gotResource); diff != "" {
-			t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-		}
-
-		// Updated to cycle
-		cq.Spec.CohortName = "cycle"
-		if err := cache.UpdateClusterQueue(log, cq); err == nil {
-			t.Fatal("Expected failure")
-		}
-
-		// Cohort's SubtreeQuota no longer contains resources from CQ.
-		gotResource = cache.hm.Cohort("cohort").getResourceNode()
-		wantResource = resourceNode{
-			Quotas: map[resources.FlavorResource]ResourceQuota{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
-			},
-			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-			},
-			Usage: resources.FlavorResourceQuantities{},
-		}
-		if diff := cmp.Diff(wantResource, gotResource); diff != "" {
-			t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-		}
-	})
-
-	t.Run("cohort switching cohorts updates both cohort trees", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		root1 := utiltestingapi.MakeCohort("root1").Obj()
-		root2 := utiltestingapi.MakeCohort("root2").Obj()
-		if err := cache.AddOrUpdateCohort(root1); err != nil {
-			t.Fatal("Expected success")
-		}
-		if err := cache.AddOrUpdateCohort(root2); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// before move
+	testCases := []struct {
+		name         string
+		setup        func(*Cache) error
+		operation    func(*Cache, *testing.T) error
+		wantErr      bool
+		validateFunc func(*testing.T, *Cache)
+	}{
 		{
-			wantRoot1 := resourceNode{
-				Quotas: map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-				},
-				Usage: resources.FlavorResourceQuantities{},
-			}
-			wantRoot2 := resourceNode{
-				Quotas:       map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{},
-				Usage:        resources.FlavorResourceQuantities{},
-			}
-			if diff := cmp.Diff(wantRoot1, cache.hm.Cohort("root1").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(wantRoot2, cache.hm.Cohort("root2").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-		}
-		cohort.Spec.ParentName = "root2"
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-		// after move
-		{
-			wantRoot1 := resourceNode{
-				Quotas:       map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{},
-				Usage:        resources.FlavorResourceQuantities{},
-			}
-			wantRoot2 := resourceNode{
-				Quotas: map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-				},
-				Usage: resources.FlavorResourceQuantities{},
-			}
-			if diff := cmp.Diff(wantRoot1, cache.hm.Cohort("root1").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-			if diff := cmp.Diff(wantRoot2, cache.hm.Cohort("root2").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-		}
-	})
-
-	t.Run("cohort leaving cohort with cycle successfully updates new cohort", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-		if err := cache.AddOrUpdateCohort(cycleRoot); err == nil {
-			t.Fatal("Expected failure")
-		}
-		root := utiltestingapi.MakeCohort("root").Obj()
-		if err := cache.AddOrUpdateCohort(root); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-			).Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err == nil {
-			t.Fatal("Expected failure")
-		}
-
-		cohort.Spec.ParentName = "root"
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-		wantRoot := resourceNode{
-			Quotas: map[resources.FlavorResource]ResourceQuota{},
-			SubtreeQuota: resources.FlavorResourceQuantities{
-				{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+			name: "self cycle",
+			setup: func(cache *Cache) error {
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj()
+				return cache.AddOrUpdateCohort(cohort)
 			},
-			Usage: resources.FlavorResourceQuantities{},
-		}
-		if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
-			t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-		}
-	})
-
-	t.Run("cohort joining cohort with cycle successfully updates old cohort", func(t *testing.T) {
-		cache := New(utiltesting.NewFakeClient())
-		cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-		if err := cache.AddOrUpdateCohort(cycleRoot); err == nil {
-			t.Fatal("Expected failure")
-		}
-		root := utiltestingapi.MakeCohort("root").Obj()
-		if err := cache.AddOrUpdateCohort(root); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		cohort := utiltestingapi.MakeCohort("cohort").Parent("root").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
-			).Obj()
-		if err := cache.AddOrUpdateCohort(cohort); err != nil {
-			t.Fatal("Expected success")
-		}
-
-		// before move
+			wantErr: true,
+		},
 		{
-			wantRoot := resourceNode{
-				Quotas: map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{
-					{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
-				},
-				Usage: resources.FlavorResourceQuantities{},
-			}
-			if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-		}
-
-		cohort.Spec.ParentName = "cycle-root"
-		if err := cache.AddOrUpdateCohort(cohort); err == nil {
-			t.Fatal("Expected failure")
-		}
-
-		// after move
+			name: "simple cycle",
+			setup: func(cache *Cache) error {
+				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
+					return err
+				}
+				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
+				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
+					return err
+				}
+				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				return cache.AddOrUpdateCohort(cohortC)
+			},
+			wantErr: true,
+		},
 		{
-			wantRoot := resourceNode{
-				Quotas:       map[resources.FlavorResource]ResourceQuota{},
-				SubtreeQuota: resources.FlavorResourceQuantities{},
-				Usage:        resources.FlavorResourceQuantities{},
-			}
-			if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
-				t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
-			}
-		}
-	})
+			name: "clusterqueue add and update return error when cohort has cycle",
+			setup: func(cache *Cache) error {
+				// Setup cycle
+				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
+					return err
+				}
+				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
+				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
+					return err
+				}
+				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
+				_ = cache.AddOrUpdateCohort(cohortC) // This will fail, but leaves cycle in cache
+				return nil
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				// Error when creating CQ with parent Cohort-A
+				cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
+				if err := cache.AddClusterQueue(ctx, cq); err == nil {
+					t.Error("Expected failure when adding cq to cohort with cycle")
+				}
 
-	t.Run("ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts", func(t *testing.T) {
-		// AddOrUpdateCohort returns an error when a cycle is formed, but the cycle edge
-		// is already stored in the hierarchy manager before the error is returned.
-		// ResyncGaugeMetrics must not call getRootUnsafe() on cohorts that are part of
-		// a cycle, as that would cause infinite recursion and a stack overflow panic.
-		_, log := utiltesting.ContextWithLog(t)
-		cache := New(utiltesting.NewFakeClient())
-		cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-		if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-			t.Fatal("Expected success as no cycle yet")
-		}
-		// cohort-b -> cohort-a creates the cycle; AddOrUpdateCohort returns an error
-		// but cohort-b's parent edge pointing to cohort-a is already persisted.
-		_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
-		// Must not panic with a goroutine stack overflow.
-		cache.ResyncGaugeMetrics(log)
-	})
+				// Error when updating CQ with parent Cohort-B
+				cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
+				if err := cache.UpdateClusterQueue(log, cq); err == nil {
+					t.Error("Expected failure when updating cq to cohort with cycle")
+				}
+
+				// Delete Cohort C, breaking cycle
+				cache.DeleteCohort("cohort-c")
+
+				// Update succeeds
+				cq = utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-b").Obj()
+				return cache.UpdateClusterQueue(log, cq)
+			},
+			wantErr: false,
+		},
+		{
+			name: "clusterqueue leaving cohort with cycle successfully updates new cohort",
+			setup: func(cache *Cache) error {
+				// Attempt to create cycle (will fail)
+				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
+				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
+
+				cohort := utiltestingapi.MakeCohort("cohort").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+					).Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				// Error when creating cq with parent that has cycle
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj(),
+					).Cohort("cycle").Obj()
+				if err := cache.AddClusterQueue(ctx, cq); err == nil {
+					t.Error("Expected failure when adding cq with cycle parent")
+				}
+
+				// Successfully updated to cohort without cycle
+				cq.Spec.CohortName = "cohort"
+				return cache.UpdateClusterQueue(log, cq)
+			},
+			wantErr: false,
+			validateFunc: func(t *testing.T, cache *Cache) {
+				// Verify cohort's SubtreeQuota contains resources from cq
+				gotResource := cache.hm.Cohort("cohort").getResourceNode()
+				wantResource := resourceNode{
+					Quotas: map[resources.FlavorResource]ResourceQuota{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
+					},
+					SubtreeQuota: resources.FlavorResourceQuantities{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
+					},
+					Usage: resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantResource, gotResource); diff != "" {
+					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "clusterqueue joining cohort with cycle successfully updates old cohort",
+			setup: func(cache *Cache) error {
+				// Attempt to create cycle (will fail)
+				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
+				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
+
+				cohort := utiltestingapi.MakeCohort("cohort").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
+				if err := cache.AddOrUpdateCohort(cohort); err != nil {
+					return err
+				}
+
+				// Add CQ to cohort
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
+				return cache.AddClusterQueue(ctx, cq)
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				cq := utiltestingapi.MakeClusterQueue("cq").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
+
+				// Updated to cycle
+				cq.Spec.CohortName = "cycle"
+				return cache.UpdateClusterQueue(log, cq)
+			},
+			wantErr: true,
+			validateFunc: func(t *testing.T, cache *Cache) {
+				// Cohort's SubtreeQuota no longer contains resources from CQ
+				gotResource := cache.hm.Cohort("cohort").getResourceNode()
+				wantResource := resourceNode{
+					Quotas: map[resources.FlavorResource]ResourceQuota{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: {Nominal: resources.NewAmount(10_000)},
+					},
+					SubtreeQuota: resources.FlavorResourceQuantities{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+					},
+					Usage: resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantResource, gotResource); diff != "" {
+					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "cohort switching cohorts updates both cohort trees",
+			setup: func(cache *Cache) error {
+				root1 := utiltestingapi.MakeCohort("root1").Obj()
+				if err := cache.AddOrUpdateCohort(root1); err != nil {
+					return err
+				}
+				root2 := utiltestingapi.MakeCohort("root2").Obj()
+				if err := cache.AddOrUpdateCohort(root2); err != nil {
+					return err
+				}
+
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				// Get cohort and move it to root2
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: false,
+			validateFunc: func(t *testing.T, cache *Cache) {
+				// After move, root1 should have no subtree quota
+				wantRoot1 := resourceNode{
+					Quotas:       map[resources.FlavorResource]ResourceQuota{},
+					SubtreeQuota: resources.FlavorResourceQuantities{},
+					Usage:        resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantRoot1, cache.hm.Cohort("root1").getResourceNode()); diff != "" {
+					t.Errorf("Unexpected root1 resource (-want,+got):\n%s", diff)
+				}
+
+				// root2 should have the subtree quota
+				wantRoot2 := resourceNode{
+					Quotas: map[resources.FlavorResource]ResourceQuota{},
+					SubtreeQuota: resources.FlavorResourceQuantities{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+					},
+					Usage: resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantRoot2, cache.hm.Cohort("root2").getResourceNode()); diff != "" {
+					t.Errorf("Unexpected root2 resource (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "cohort leaving cohort with cycle successfully updates new cohort",
+			setup: func(cache *Cache) error {
+				// Attempt to create cycle (will fail)
+				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
+				_ = cache.AddOrUpdateCohort(cycleRoot)
+
+				root := utiltestingapi.MakeCohort("root").Obj()
+				return cache.AddOrUpdateCohort(root)
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+					).Obj()
+				_ = cache.AddOrUpdateCohort(cohort) // Expected to fail
+
+				cohort.Spec.ParentName = "root"
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: false,
+			validateFunc: func(t *testing.T, cache *Cache) {
+				wantRoot := resourceNode{
+					Quotas: map[resources.FlavorResource]ResourceQuota{},
+					SubtreeQuota: resources.FlavorResourceQuantities{
+						{Flavor: "arm", Resource: corev1.ResourceCPU}: resources.NewAmount(10_000),
+					},
+					Usage: resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
+					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "cohort joining cohort with cycle successfully updates old cohort",
+			setup: func(cache *Cache) error {
+				// Attempt to create cycle (will fail)
+				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
+				_ = cache.AddOrUpdateCohort(cycleRoot)
+
+				root := utiltestingapi.MakeCohort("root").Obj()
+				if err := cache.AddOrUpdateCohort(root); err != nil {
+					return err
+				}
+
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+					).Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
+					).Obj()
+				return cache.AddOrUpdateCohort(cohort)
+			},
+			wantErr: true,
+			validateFunc: func(t *testing.T, cache *Cache) {
+				// After failed move, root should have no subtree quota
+				wantRoot := resourceNode{
+					Quotas:       map[resources.FlavorResource]ResourceQuota{},
+					SubtreeQuota: resources.FlavorResourceQuantities{},
+					Usage:        resources.FlavorResourceQuantities{},
+				}
+				if diff := cmp.Diff(wantRoot, cache.hm.Cohort("root").getResourceNode()); diff != "" {
+					t.Errorf("Unexpected resource (-want,+got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts",
+			setup: func(cache *Cache) error {
+				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
+				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
+					return err
+				}
+				// cohort-b -> cohort-a creates the cycle; AddOrUpdateCohort returns an error
+				// but cohort-b's parent edge pointing to cohort-a is already persisted.
+				_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
+				return nil
+			},
+			operation: func(cache *Cache, t *testing.T) error {
+				// Must not panic with a goroutine stack overflow
+				cache.ResyncGaugeMetrics(log)
+				return nil
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := New(utiltesting.NewFakeClient())
+
+			// Run setup
+			if tc.setup != nil {
+				err := tc.setup(cache)
+				if tc.wantErr {
+					if err == nil {
+						t.Errorf("Expected error but got none")
+					}
+					// If we expected an error, we might still want to run validation
+					if tc.validateFunc != nil && err != nil {
+						// Some tests might still have valid state to check even with error
+						tc.validateFunc(t, cache)
+					}
+					return
+				}
+				if err != nil {
+					t.Fatalf("Setup failed: %v", err)
+				}
+			}
+
+			// Run operation
+			if tc.operation != nil {
+				err := tc.operation(cache, t)
+				if tc.wantErr {
+					if err == nil {
+						t.Errorf("Expected error but got none")
+					}
+				} else if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			// Run validation
+			if tc.validateFunc != nil {
+				tc.validateFunc(t, cache)
+			}
+		})
+	}
 }
 
 func TestDeleteCohortUpdatesAncestorSubtreeQuota(t *testing.T) {

--- a/pkg/cache/scheduler/cache_test.go
+++ b/pkg/cache/scheduler/cache_test.go
@@ -3353,55 +3353,37 @@ func TestClusterQueueReadiness(t *testing.T) {
 }
 
 func TestCohortCycles(t *testing.T) {
-	ctx, log := utiltesting.ContextWithLog(t)
-
-	testCases := []struct {
-		name         string
-		setup        func(*Cache) error
-		operation    func(*Cache, *testing.T) error
-		wantErr      bool
-		validateFunc func(*testing.T, *Cache)
+	testCases := map[string]struct {
+		cohorts       []*kueue.Cohort
+		clusterQueues []*kueue.ClusterQueue
+		operations    func(*Cache, *testing.T) error
+		wantErr       bool
+		validateFunc  func(*testing.T, *Cache)
 	}{
-		{
-			name: "self cycle",
-			setup: func(cache *Cache) error {
-				cohort := utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj()
-				return cache.AddOrUpdateCohort(cohort)
+		"self cycle": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort").Parent("cohort").Obj(),
 			},
 			wantErr: true,
 		},
-		{
-			name: "simple cycle",
-			setup: func(cache *Cache) error {
-				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-					return err
-				}
-				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
-					return err
-				}
-				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				return cache.AddOrUpdateCohort(cohortC)
+		"simple cycle": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj(),
+				utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj(),
+				utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj(),
 			},
 			wantErr: true,
 		},
-		{
-			name: "clusterqueue add and update return error when cohort has cycle",
-			setup: func(cache *Cache) error {
+		"clusterqueue add and update return error when cohort has cycle": {
+			cohorts: func() []*kueue.Cohort {
 				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-					return err
-				}
 				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-c").Obj()
-				if err := cache.AddOrUpdateCohort(cohortB); err != nil {
-					return err
-				}
 				cohortC := utiltestingapi.MakeCohort("cohort-c").Parent("cohort-a").Obj()
-				_ = cache.AddOrUpdateCohort(cohortC) // This will fail, but leaves cycle in cache
-				return nil
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.Cohort{cohortA, cohortB, cohortC}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
+				ctx, log := utiltesting.ContextWithLog(t)
+
 				// Error when creating CQ with parent Cohort-A
 				cq := utiltestingapi.MakeClusterQueue("cq").Cohort("cohort-a").Obj()
 				if err := cache.AddClusterQueue(ctx, cq); err == nil {
@@ -3423,19 +3405,18 @@ func TestCohortCycles(t *testing.T) {
 			},
 			wantErr: false,
 		},
-		{
-			name: "clusterqueue leaving cohort with cycle successfully updates new cohort",
-			setup: func(cache *Cache) error {
+		"clusterqueue leaving cohort with cycle successfully updates new cohort": {
+			cohorts: func() []*kueue.Cohort {
 				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
-
 				cohort := utiltestingapi.MakeCohort("cohort").
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
 					).Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.Cohort{cycleCohort, cohort}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
+				ctx, log := utiltesting.ContextWithLog(t)
+
 				// Error when creating cq with parent that has cycle
 				cq := utiltestingapi.MakeClusterQueue("cq").
 					ResourceGroup(
@@ -3466,23 +3447,21 @@ func TestCohortCycles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "clusterqueue joining cohort with cycle successfully updates old cohort",
-			setup: func(cache *Cache) error {
+		"clusterqueue joining cohort with cycle successfully updates old cohort": {
+			cohorts: func() []*kueue.Cohort {
 				cycleCohort := utiltestingapi.MakeCohort("cycle").Parent("cycle").Obj()
-				_ = cache.AddOrUpdateCohort(cycleCohort) // Expected to fail
-
 				cohort := utiltestingapi.MakeCohort("cohort").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-				if err := cache.AddOrUpdateCohort(cohort); err != nil {
-					return err
-				}
-
+				return []*kueue.Cohort{cycleCohort, cohort}
+			}(),
+			clusterQueues: func() []*kueue.ClusterQueue {
 				cq := utiltestingapi.MakeClusterQueue("cq").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
-				return cache.AddClusterQueue(ctx, cq)
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.ClusterQueue{cq}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
+				log := ctrl.LoggerFrom(t.Context())
+
 				cq := utiltestingapi.MakeClusterQueue("cq").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "5").Obj()).Cohort("cohort").Obj()
 
@@ -3510,23 +3489,15 @@ func TestCohortCycles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "cohort switching cohorts updates both cohort trees",
-			setup: func(cache *Cache) error {
+		"cohort switching cohorts updates both cohort trees": {
+			cohorts: func() []*kueue.Cohort {
 				root1 := utiltestingapi.MakeCohort("root1").Obj()
-				if err := cache.AddOrUpdateCohort(root1); err != nil {
-					return err
-				}
 				root2 := utiltestingapi.MakeCohort("root2").Obj()
-				if err := cache.AddOrUpdateCohort(root2); err != nil {
-					return err
-				}
-
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("root1").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.Cohort{root1, root2, cohort}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("root2").
 					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj()).Obj()
 				return cache.AddOrUpdateCohort(cohort)
@@ -3554,16 +3525,13 @@ func TestCohortCycles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "cohort leaving cohort with cycle successfully updates new cohort",
-			setup: func(cache *Cache) error {
+		"cohort leaving cohort with cycle successfully updates new cohort": {
+			cohorts: func() []*kueue.Cohort {
 				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-				_ = cache.AddOrUpdateCohort(cycleRoot)
-
 				root := utiltestingapi.MakeCohort("root").Obj()
-				return cache.AddOrUpdateCohort(root)
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.Cohort{cycleRoot, root}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
@@ -3587,24 +3555,17 @@ func TestCohortCycles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "cohort joining cohort with cycle successfully updates old cohort",
-			setup: func(cache *Cache) error {
+		"cohort joining cohort with cycle successfully updates old cohort": {
+			cohorts: func() []*kueue.Cohort {
 				cycleRoot := utiltestingapi.MakeCohort("cycle-root").Parent("cycle-root").Obj()
-				_ = cache.AddOrUpdateCohort(cycleRoot)
-
 				root := utiltestingapi.MakeCohort("root").Obj()
-				if err := cache.AddOrUpdateCohort(root); err != nil {
-					return err
-				}
-
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("root").
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
 					).Obj()
-				return cache.AddOrUpdateCohort(cohort)
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				return []*kueue.Cohort{cycleRoot, root, cohort}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
 				cohort := utiltestingapi.MakeCohort("cohort").Parent("cycle-root").
 					ResourceGroup(
 						*utiltestingapi.MakeFlavorQuotas("arm").Resource(corev1.ResourceCPU, "10").Obj(),
@@ -3627,17 +3588,14 @@ func TestCohortCycles(t *testing.T) {
 				}
 			},
 		},
-		{
-			name: "ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts",
-			setup: func(cache *Cache) error {
+		"ResyncGaugeMetrics does not infinitely recurse with cyclic cohorts": {
+			cohorts: func() []*kueue.Cohort {
 				cohortA := utiltestingapi.MakeCohort("cohort-a").Parent("cohort-b").Obj()
-				if err := cache.AddOrUpdateCohort(cohortA); err != nil {
-					return err
-				}
-				_ = cache.AddOrUpdateCohort(utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj())
-				return nil
-			},
-			operation: func(cache *Cache, t *testing.T) error {
+				cohortB := utiltestingapi.MakeCohort("cohort-b").Parent("cohort-a").Obj()
+				return []*kueue.Cohort{cohortA, cohortB}
+			}(),
+			operations: func(cache *Cache, t *testing.T) error {
+				_, log := utiltesting.ContextWithLog(t)
 				// Must not panic with a goroutine stack overflow
 				cache.ResyncGaugeMetrics(log)
 				return nil
@@ -3646,20 +3604,33 @@ func TestCohortCycles(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			cache := New(utiltesting.NewFakeClient())
 
-			// Run setup
-			if tc.setup != nil {
-				if err := tc.setup(cache); err != nil && !tc.wantErr {
-					t.Fatalf("Setup failed: %v", err)
+			// Add cohorts
+			for _, cohort := range tc.cohorts {
+				err := cache.AddOrUpdateCohort(cohort)
+				// We check the error later based on wantErr after all cohorts are added
+				// because some tests need to add multiple cohorts even if one fails
+				if err != nil && !tc.wantErr {
+					t.Fatalf("Failed to add cohort %s: %v", cohort.Name, err)
 				}
 			}
 
-			// Run operation
-			if tc.operation != nil {
-				err := tc.operation(cache, t)
+			// Add cluster queues if any
+			if len(tc.clusterQueues) > 0 {
+				ctx, _ := utiltesting.ContextWithLog(t)
+				for _, cq := range tc.clusterQueues {
+					if err := cache.AddClusterQueue(ctx, cq); err != nil && !tc.wantErr {
+						t.Fatalf("Failed to add cluster queue %s: %v", cq.Name, err)
+					}
+				}
+			}
+
+			// Run operations
+			if tc.operations != nil {
+				err := tc.operations(cache, t)
 				if tc.wantErr && err == nil {
 					t.Errorf("Expected error but got none")
 				}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #14114

#### Special notes for your reviewer:
I have added comments too for easy understanding of code.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded regression coverage for cyclic cohort configurations, including self-cycles, multi-node cycles, and valid hierarchies.
  * Added coverage for cyclic parent relationships during ClusterQueue additions and cohort updates.
  * Verified that metrics remain synchronized when cohorts contain cycles.
  * Consolidated related scenarios into table-driven test cases for clearer, more maintainable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->