### PR TITLE
Enable TAS feasibility checking for non-hostname topologies

### DIFF
--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -68,6 +68,7 @@
   - [Support for Elastic Workloads](#support-for-elastic-workloads)
   - [Balanced placement](#balanced-placement)
     - [Example](#example-3)
+  - [Support for topologies without a hostname level](#support-for-topologies-without-a-hostname-level)
   - [Support for Preferred Node Affinity](#support-for-preferred-node-affinity)
     - [Future Vision](#future-vision)
   - [Support for ProvisioningRequests](#support-for-provisioningrequests)
@@ -1887,6 +1888,41 @@ For a 3-level topology (block, rack, hostname), in the TopologyRequest, the user
 | [[15],[15]] [[15, 15]] | 25 | 1 | [[0],[0]] [[13, 12]] | prefer block where the request fits in a single rack
 | [[15], [15], [15, 15]] | 25|5 |  [[0], [0], [15, 10]] | `podset-slice-required-topology = hostname`
 
+### Support for topologies without a hostname level
+
+Kueue evaluates capacity and feasibility at the lowest level a Topology declares. When
+that level is not `kubernetes.io/hostname` a domain covers several nodes, so the checks
+answer a question about the domain rather than about any node inside it. A rack of
+CPU-only nodes passes for a Workload requesting devices, and a Workload fitting a rack's
+total capacity is admitted even when no single node can hold one of its Pods. Its Pods
+then stay Pending, since kube-scheduler places them per node.
+
+Behind the `TASNodeFeasibilityForAllLevels` feature gate Kueue appends
+`kubernetes.io/hostname` to such a Topology's levels internally. Every leaf is then
+exactly one node, so node capacity, taints, node selectors and node affinity are
+evaluated per node on every Topology.
+
+The appended level is internal. Leaves are keyed by node name rather than by the
+hostname label, which is neither unique nor immutable, and the level is stripped on
+serialization, so a `TopologyAssignment` still names only the levels the Topology
+declares. Every check which reads the serialized levels, such as failed node
+replacement and the hostname-prefix encoding, is therefore unaffected.
+
+Usage stays recorded against the level the `TopologyAssignment` names, because the node
+inside a domain that holds a Pod is chosen by kube-scheduler after ungating and is never
+reported back. Leaves are evaluated against node capacity alone, and the domain's own
+remaining capacity bounds the count rolled up from its leaves. Usage accounting stays as
+accurate as it is today, while feasibility becomes exact.
+
+Declaring `kubernetes.io/hostname` explicitly still decides several things:
+- the assignment names nodes, so ungated Pods are pinned to them instead of being left
+  for kube-scheduler to place anywhere within the domain
+- `podset-required-topology: kubernetes.io/hostname` is only a valid request on a
+  Topology which declares the level
+- failed node replacement and cross-flavor usage aggregation both need assignments at
+  node granularity
+- usage is attributed exactly, with no domain-level approximation
+
 ### Support for Preferred Node Affinity
 
 In 0.18 we introduce the pilot support for domain affinity based on `preferredDuringSchedulingIgnoredDuringExecution`, behind the 
@@ -1894,7 +1930,9 @@ In 0.18 we introduce the pilot support for domain affinity based on `preferredDu
 When the feature gate is enabled, we compute the "domain affinity scores" at all levels by
 aggregating (summing) the scores from child topology domains.
 Then, the "domain affinity scores" takes precedence over standard placement ordering of domains (based on BestFit or LeastFreeCapacity policies).
-This feature only works when the lowest topology level specified in the Topology CRD is `kubernetes.io/hostname`.
+This feature works when the lowest topology level specified in the Topology CRD is
+`kubernetes.io/hostname`, and on other Topologies when the `TASNodeFeasibilityForAllLevels`
+feature gate is enabled (see [Support for topologies without a hostname level](#support-for-topologies-without-a-hostname-level)).
 
 #### Future Vision
 
@@ -2053,11 +2091,8 @@ The new validations which are for MVP, but likely will be relaxed in the future:
 - re-evaluate the need to support for "preferred/required" preferences at the
   Workload level (see [Story 3](#story-3))
 - re-evaluate the need for the `kueue.x-k8s.io/tas`
-- re-evaluate handling of topologies without `kubernetes.io/hostname` in the lowest
-  level, the main issues are: (a) no check for fragmentation, and (b) no support
-  for node taints. Some options to consider include virtual level as proposed in
-  the [issue](https://github.com/kubernetes-sigs/kueue/issues/3658#issuecomment-2505583333)
-  or explicit level added by webhook.
+- attribute a domain's usage to the node holding each Pod on topologies without
+  `kubernetes.io/hostname` in the lowest level, which needs Pod location tracking
 - re-evaluate the need for admin-facing configuration of the second phase
   requeuing for ProvisioningRequests based on user feedback
 - change how the information about the failed nodes is stored at a Workload from Annotation into a field in workload.Status

--- a/keps/2724-topology-aware-scheduling/README.md
+++ b/keps/2724-topology-aware-scheduling/README.md
@@ -1890,12 +1890,13 @@ For a 3-level topology (block, rack, hostname), in the TopologyRequest, the user
 
 ### Support for topologies without a hostname level
 
-Kueue evaluates capacity and feasibility at the lowest level a Topology declares. When
-that level is not `kubernetes.io/hostname` a domain covers several nodes, so the checks
-answer a question about the domain rather than about any node inside it. A rack of
-CPU-only nodes passes for a Workload requesting devices, and a Workload fitting a rack's
-total capacity is admitted even when no single node can hold one of its Pods. Its Pods
-then stay Pending, since kube-scheduler places them per node.
+Before 0.20, Kueue evaluated capacity and feasibility at the lowest level a Topology
+declares. When that level is not `kubernetes.io/hostname` a domain covers several
+nodes, so the checks answered a question about the domain rather than about any node
+inside it. A rack of CPU-only nodes passed for a Workload requesting devices, and a
+Workload fitting a rack's total capacity was admitted even when no single node could
+hold one of its Pods. Its Pods then stayed Pending, since kube-scheduler places them
+per node.
 
 Behind the `TASNodeFeasibilityForAllLevels` feature gate Kueue appends
 `kubernetes.io/hostname` to such a Topology's levels internally. Every leaf is then

--- a/keps/2724-topology-aware-scheduling/kep.yaml
+++ b/keps/2724-topology-aware-scheduling/kep.yaml
@@ -53,6 +53,7 @@ feature-gates:
   - name: TASRecomputeAssignmentWithinSchedulingCycle
   - name: TASAssignmentsEncodingByHostnamePrefix
   - name: SkipReassignmentForPodOwnedWorkloads
+  - name: TASNodeFeasibilityForAllLevels
 disable-supported: true
 
 # The following PRR answers are required at beta release

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -224,7 +224,11 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		// flavors is immutable in snapshot.
 		tasFlavorCache := c.TASFlavors[tasFlavor]
 		flvOpts := options
-		if features.Enabled(features.TASHandleOverlappingFlavors) && tasFlavorCache.isLowestLevelNode {
+		// The aggregation is limited to flavors with a user-declared hostname
+		// level, as only node names identify the same capacity across
+		// flavors. Aggregating at node granularity for virtual hostname
+		// topologies is left to a follow-up.
+		if features.Enabled(features.TASHandleOverlappingFlavors) && !tasFlavorCache.virtualHostname {
 			flvOpts = append(slices.Clone(options), WithAggregatedDomainUsages(aggregatedDomainUsages))
 		}
 		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(ctx, flavorTASRequests, flvOpts...)

--- a/pkg/cache/scheduler/clusterqueue_snapshot.go
+++ b/pkg/cache/scheduler/clusterqueue_snapshot.go
@@ -228,7 +228,7 @@ func (c *ClusterQueueSnapshot) FindTopologyAssignmentsForWorkload(
 		// level, as only node names identify the same capacity across
 		// flavors. Aggregating at node granularity for virtual hostname
 		// topologies is left to a follow-up.
-		if features.Enabled(features.TASHandleOverlappingFlavors) && !tasFlavorCache.virtualHostname {
+		if features.Enabled(features.TASHandleOverlappingFlavors) && tasFlavorCache.declaresHostnameLevel() {
 			flvOpts = append(slices.Clone(options), WithAggregatedDomainUsages(aggregatedDomainUsages))
 		}
 		flvResult := tasFlavorCache.FindTopologyAssignmentsForFlavor(ctx, flavorTASRequests, flvOpts...)

--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -375,9 +375,15 @@ func (s *TASFlavorSnapshot) pruneDomainNodeBelowThreshold(d *domain, threshold i
 }
 
 func (s *TASFlavorSnapshot) pruneDomainsBelowThreshold(domains []*domain, threshold int32, sliceSize int32, sliceLevelIdx int, level int, leaderRequired bool) {
-	for _, d := range domains {
-		for _, c := range d.children {
-			s.pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
+	// An injected hostname level sits below the level slices are counted at, so
+	// its leaves carry no sliceCount and pruning would clear every one of them.
+	// The check is scoped to that case so topologies declaring hostname keep
+	// pruning exactly as before.
+	if !s.virtualHostname || level != s.usageLevelIdx() {
+		for _, d := range domains {
+			for _, c := range d.children {
+				s.pruneDomainNodeBelowThreshold(c, threshold, leaderRequired)
+			}
 		}
 	}
 	for _, d := range domains {

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -344,7 +344,7 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 			for _, d := range got {
 				gotStates[string(d.id)] = *s.domainStateOf(d)
 			}
-			if diff := cmp.Diff(tc.want, gotStates, cmp.AllowUnexported(domainState{})); diff != "" {
+			if diff := cmp.Diff(tc.want, gotStates, cmp.AllowUnexported(domainState{}, domainCapacityBound{})); diff != "" {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -140,6 +140,35 @@ func TestFindTopologyAssignments(t *testing.T) {
 			Ready().
 			Obj(),
 	}
+	// A rack whose two nodes differ only by an untolerated taint.
+	taintedRackNodes := []corev1.Node{
+		*testingnode.MakeNode("n-ok").
+			Label(tasBlockLabel, "b1").
+			Label(tasRackLabel, "r1").
+			Label(corev1.LabelHostname, "n-ok").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("1"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Obj(),
+		*testingnode.MakeNode("n-tainted").
+			Label(tasBlockLabel, "b1").
+			Label(tasRackLabel, "r1").
+			Label(corev1.LabelHostname, "n-tainted").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("1"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			}).
+			Ready().
+			Taints(corev1.Taint{
+				Key:    "example.com/gpu",
+				Value:  "present",
+				Effect: corev1.TaintEffectNoSchedule,
+			}).
+			Obj(),
+	}
+
 	//nolint:dupword // suppress duplicate r1 word
 	//       b1           b2
 	//       |             |
@@ -1437,10 +1466,94 @@ func TestFindTopologyAssignments(t *testing.T) {
 				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 6; excluded: resource "cpu": 6`,
 			}},
 		},
+		"hostname required on a topology which does not declare it; per-node feasibility": {
+			// The injected level is internal. It must not turn
+			// podset-required-topology: kubernetes.io/hostname into a valid
+			// request on a Topology which never declared the level.
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: true},
+			nodes:        defaultNodes,
+			levels:       defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(corev1.LabelHostname),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count:      1,
+				wantReason: "no requested topology level: kubernetes.io/hostname",
+			}},
+		},
+		"rack required; untolerated taint inside the rack; feature gate off": {
+			// The rack is the leaf, so its nodes' taints are never consulted and
+			// both Pods are admitted. One of them cannot then be scheduled.
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: false},
+			nodes:        taintedRackNodes,
+			levels:       defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(tasRackLabel),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 2,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultTwoLevels,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  2,
+							Values: []string{"b1", "r1"},
+						},
+					},
+				},
+			}},
+		},
+		"rack required; untolerated taint inside the rack; per-node feasibility": {
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: true},
+			nodes:        taintedRackNodes,
+			levels:       defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(tasRackLabel),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count:      2,
+				wantReason: `topology "default" allows to fit only 1 out of 2 pod(s). Total nodes: 2; excluded: taint "example.com/gpu=present:NoSchedule": 1`,
+			}},
+		},
+		"rack required; Pod fits in the rack's aggregated capacity but on no single node; feature gate off": {
+			// Without per-node feasibility the rack's 3 CPU aggregate admits the
+			// Pod, which is the behaviour every release so far has shipped.
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: false},
+			nodes:        defaultNodes,
+			levels:       defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(tasRackLabel),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 2500,
+				},
+				count: 1,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultTwoLevels,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  1,
+							Values: []string{"b1", "r2"},
+						},
+					},
+				},
+			}},
+		},
 		"rack required; Pod fits in the rack's aggregated capacity but on no single node; BestFit": {
 			// Rack b1/r2 aggregates 3 CPU, but the largest node has 2 CPU.
-			nodes:  defaultNodes,
-			levels: defaultTwoLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: true},
+			nodes:        defaultNodes,
+			levels:       defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Required: new(tasRackLabel),
@@ -1455,8 +1568,9 @@ func TestFindTopologyAssignments(t *testing.T) {
 		"unconstrained; all nodes needed; non-hostname lowest level; BestFit": {
 			// The assignment must be published at the user-specified levels
 			// with per-rack counts summed over the underlying nodes.
-			nodes:  defaultNodes,
-			levels: defaultTwoLevels,
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: true},
+			nodes:        defaultNodes,
+			levels:       defaultTwoLevels,
 			podSets: []PodSetTestCase{{
 				topologyRequest: &kueue.PodSetTopologyRequest{
 					Unconstrained: new(true),
@@ -1488,15 +1602,19 @@ func TestFindTopologyAssignments(t *testing.T) {
 				},
 			}},
 		},
-		"rack required; usage on a multi-node rack is distributed across its nodes; BestFit": {
-			// The 1.5 CPU rack-level usage leaves 0.5 CPU per node in b1/r2 and
-			// on x4, so no rack fits two 0.75-CPU Pods, only 1 on x3 or x2.
-			nodes:  defaultNodes,
-			levels: defaultTwoLevels,
+		"rack required; usage recorded on a rack bounds the rack, not its nodes; BestFit": {
+			// Which node inside b1/r2 holds the 1 CPU is unknown, so the usage
+			// bounds the rack: 3 CPU total less 1 CPU used fits both Pods. The
+			// nodes themselves stay at 1 CPU each, so each can hold one Pod.
+			// b2/r2 is bounded the other way: x4 has 2 CPU allocatable, but
+			// only 0.5 CPU of the rack is left, so it takes no Pod at all.
+			featureGates: map[featuregate.Feature]bool{features.TASNodeFeasibilityForAllLevels: true},
+			nodes:        defaultNodes,
+			levels:       defaultTwoLevels,
 			priorOwnUsage: []workload.TopologyDomainRequests{
 				{
 					Values:            []string{"b1", "r2"},
-					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1500}),
+					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1000}),
 					Count:             1,
 				},
 				{
@@ -1510,10 +1628,18 @@ func TestFindTopologyAssignments(t *testing.T) {
 					Required: new(tasRackLabel),
 				},
 				requests: map[corev1.ResourceName]int64{
-					corev1.ResourceCPU: 750,
+					corev1.ResourceCPU: 1000,
 				},
-				count:      2,
-				wantReason: `topology "default" allows to fit only 1 out of 2 pod(s). Total nodes: 6; excluded: resource "cpu": 4`,
+				count: 2,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultTwoLevels,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  2,
+							Values: []string{"b1", "r2"},
+						},
+					},
+				},
 			}},
 		},
 		"block required; too many Pods to fit requested; BestFit": {

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -1434,7 +1434,86 @@ func TestFindTopologyAssignments(t *testing.T) {
 					corev1.ResourceCPU: 4000,
 				},
 				count:      1,
-				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 4; excluded: resource "cpu": 4`,
+				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 6; excluded: resource "cpu": 6`,
+			}},
+		},
+		"rack required; Pod fits in the rack's aggregated capacity but on no single node; BestFit": {
+			// Rack b1/r2 aggregates 3 CPU, but the largest node has 2 CPU.
+			nodes:  defaultNodes,
+			levels: defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(tasRackLabel),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 2500,
+				},
+				count:      1,
+				wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 6; excluded: resource "cpu": 6`,
+			}},
+		},
+		"unconstrained; all nodes needed; non-hostname lowest level; BestFit": {
+			// The assignment must be published at the user-specified levels
+			// with per-rack counts summed over the underlying nodes.
+			nodes:  defaultNodes,
+			levels: defaultTwoLevels,
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Unconstrained: new(true),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 1000,
+				},
+				count: 7,
+				wantAssignment: &tas.TopologyAssignment{
+					Levels: defaultTwoLevels,
+					Domains: []tas.TopologyDomainAssignment{
+						{
+							Count:  1,
+							Values: []string{"b1", "r1"},
+						},
+						{
+							Count:  3,
+							Values: []string{"b1", "r2"},
+						},
+						{
+							Count:  1,
+							Values: []string{"b2", "r1"},
+						},
+						{
+							Count:  2,
+							Values: []string{"b2", "r2"},
+						},
+					},
+				},
+			}},
+		},
+		"rack required; usage on a multi-node rack is distributed across its nodes; BestFit": {
+			// The 1.5 CPU rack-level usage leaves 0.5 CPU per node in b1/r2 and
+			// on x4, so no rack fits two 0.75-CPU Pods, only 1 on x3 or x2.
+			nodes:  defaultNodes,
+			levels: defaultTwoLevels,
+			priorOwnUsage: []workload.TopologyDomainRequests{
+				{
+					Values:            []string{"b1", "r2"},
+					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1500}),
+					Count:             1,
+				},
+				{
+					Values:            []string{"b2", "r2"},
+					SinglePodRequests: resources.NewRequestsFromMap(resources.MapRequests{corev1.ResourceCPU: 1500}),
+					Count:             1,
+				},
+			},
+			podSets: []PodSetTestCase{{
+				topologyRequest: &kueue.PodSetTopologyRequest{
+					Required: new(tasRackLabel),
+				},
+				requests: map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 750,
+				},
+				count:      2,
+				wantReason: `topology "default" allows to fit only 1 out of 2 pod(s). Total nodes: 6; excluded: resource "cpu": 4`,
 			}},
 		},
 		"block required; too many Pods to fit requested; BestFit": {

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -107,7 +107,7 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 		placementLeader = nil
 	}
 
-	deltaAssignments, reason := s.findTopologyAssignment(ctx, deltaRequest, placementLeader, assumedUsage, opts.simulateEmpty, "", opts.workload)
+	deltaAssignments, deltaLeafAssignments, reason := s.findTopologyAssignment(ctx, deltaRequest, placementLeader, assumedUsage, opts.simulateEmpty, "", opts.workload)
 	if reason != "" {
 		result[workers.PodSet.Name] = tasPodSetAssignmentResult{FailureReason: reason}
 		return elasticPlacementResult{applied: true, assignments: result}
@@ -122,12 +122,12 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 			result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: leaderPrevAssignment}
 		} else {
 			result[leader.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: deltaAssignments[leader.PodSet.Name]}
-			addAssumedUsage(assumedUsage, deltaAssignments[leader.PodSet.Name], leader)
+			addAssumedUsageForCycle(assumedUsage, deltaAssignments[leader.PodSet.Name], deltaLeafAssignments[leader.PodSet.Name], leader)
 		}
 	}
 
 	// Add only delta to avoid double-counting previous pods.
-	addAssumedUsage(assumedUsage, deltaAssignment, &workers)
+	addAssumedUsageForCycle(assumedUsage, deltaAssignment, deltaLeafAssignments[workers.PodSet.Name], &workers)
 	return elasticPlacementResult{applied: true, assignments: result}
 }
 

--- a/pkg/cache/scheduler/tas_elastic_workloads.go
+++ b/pkg/cache/scheduler/tas_elastic_workloads.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
@@ -38,7 +37,7 @@ func (s *TASFlavorSnapshot) handleElasticWorkload(
 	ctx context.Context,
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	if workers.PreviousAssignment == nil {
@@ -83,7 +82,7 @@ func (s *TASFlavorSnapshot) handleScaleUp(
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
 	previousCount int32,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 	opts *findTopologyAssignmentsOption,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
@@ -136,7 +135,7 @@ func (s *TASFlavorSnapshot) handleScaleDown(
 	workers TASPodSetRequests,
 	leader *TASPodSetRequests,
 	prevAssignment *utiltas.TopologyAssignment,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 ) elasticPlacementResult {
 	truncatedAssignment := utiltas.TruncateAssignment(prevAssignment, workers.Count)
 	return s.finalizeElasticAssignment(workers, truncatedAssignment, leader, assumedUsage)
@@ -149,7 +148,7 @@ func (s *TASFlavorSnapshot) finalizeElasticAssignment(
 	workers TASPodSetRequests,
 	workersAssignment *utiltas.TopologyAssignment,
 	leader *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 ) elasticPlacementResult {
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
 	result[workers.PodSet.Name] = tasPodSetAssignmentResult{TopologyAssignment: workersAssignment}

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -205,26 +205,11 @@ func (c *TASFlavorCache) snapshot(
 	log.V(3).Info("Constructing TAS snapshot", infoKV...)
 
 	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, tree, c.flavor.Tolerations, simulatorSnapshot, withResourceFormatter(c.resourceFormatter))
-
-	if utiltas.IsLowestLevelHostname(c.topology.Levels) {
-		// Domains are single leaves, so the aggregate equals the sum of
-		// the per-Workload shares. Cross-flavor aggregates only exist for
-		// hostname-lowest flavors.
-		tasDomainUsages := c.usage
-		if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
-			tasDomainUsages = aggregatedDomainUsages
-		}
-		snapshot.addTASUsageForHeldDomains(tasDomainUsages)
-	} else {
-		// Usage domains span multiple leaves. Charge usage per Workload so
-		// that removing one Workload cancels exactly its share; ceil shares
-		// are not additive (see uniformShare).
-		for _, topologyRequests := range c.wlUsage {
-			for _, tr := range topologyRequests {
-				snapshot.updateTASUsage(utiltas.DomainID(tr.Values), tr.TotalRequests(), add, tr.Count)
-			}
-		}
+	tasDomainUsages := c.usage
+	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
+		tasDomainUsages = aggregatedDomainUsages
 	}
+	snapshot.addTASUsageForHeldDomains(tasDomainUsages)
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := tree.nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -205,11 +205,26 @@ func (c *TASFlavorCache) snapshot(
 	log.V(3).Info("Constructing TAS snapshot", infoKV...)
 
 	snapshot := newTASFlavorSnapshot(log, c.flavor.TopologyName, tree, c.flavor.Tolerations, simulatorSnapshot, withResourceFormatter(c.resourceFormatter))
-	tasDomainUsages := c.usage
-	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
-		tasDomainUsages = aggregatedDomainUsages
+
+	if utiltas.IsLowestLevelHostname(c.topology.Levels) {
+		// Domains are single leaves, so the aggregate equals the sum of
+		// the per-Workload shares. Cross-flavor aggregates only exist for
+		// hostname-lowest flavors.
+		tasDomainUsages := c.usage
+		if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
+			tasDomainUsages = aggregatedDomainUsages
+		}
+		snapshot.addTASUsageForHeldDomains(tasDomainUsages)
+	} else {
+		// Usage domains span multiple leaves. Charge usage per Workload so
+		// that removing one Workload cancels exactly its share; ceil shares
+		// are not additive (see uniformShare).
+		for _, topologyRequests := range c.wlUsage {
+			for _, tr := range topologyRequests {
+				snapshot.updateTASUsage(utiltas.DomainID(tr.Values), tr.TotalRequests(), add, tr.Count)
+			}
+		}
 	}
-	snapshot.addTASUsageForHeldDomains(tasDomainUsages)
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := tree.nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -284,7 +284,8 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 }
 
 // hasDomain reports whether the domain has a leaf in the snapshot, i.e. whether
-// it holds a node the flavor selects.
+// it holds a node the flavor selects. Only meaningful for hostname-lowest
+// topologies, where usage domains are the leaves.
 func (s *TASFlavorSnapshot) hasDomain(domainID utiltas.TopologyDomainID) bool {
 	return s.leaves[domainID] != nil
 }
@@ -308,36 +309,85 @@ func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.Topolog
 	}
 }
 
+// leavesForUsageDomain resolves the leaves to charge for usage recorded under
+// the given domain ID, which references the user-lowest level when the
+// hostname level is virtual.
+func (s *TASFlavorSnapshot) leavesForUsageDomain(domainID utiltas.TopologyDomainID) []*leafDomain {
+	if !s.virtualHostname {
+		// Usage domains are the leaves themselves.
+		if leaf := s.leaves[domainID]; leaf != nil {
+			return []*leafDomain{leaf}
+		}
+		return nil
+	}
+	// Usage domains reference the user-lowest level; never consult the leaf
+	// map, where a node name can collide with a domain ID.
+	domain, found := s.domainsPerLevel[len(s.levelKeys)-2][domainID]
+	if !found {
+		return nil
+	}
+	leaves := make([]*leafDomain, 0, len(domain.children))
+	for _, child := range domain.children {
+		if leaf := s.leaves[child.id]; leaf != nil {
+			leaves = append(leaves, leaf)
+		}
+	}
+	return leaves
+}
+
+// uniformShare splits usage evenly across n leaves, rounding up per
+// resource. Per-leaf remaining capacity is underestimated: one used device
+// can zero out every leaf in the domain. Ceil is not additive, so add and
+// remove must use the same per-Workload operands to cancel.
+func uniformShare(usage resources.Requests, n int) resources.Requests {
+	if n <= 1 {
+		return usage
+	}
+	share := usage.Clone()
+	share.ForEach(func(name corev1.ResourceName, val int64) {
+		share.Set(name, (val+int64(n)-1)/int64(n))
+	})
+	return share
+}
+
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	if s.leaves[domainID] == nil {
+	leaves := s.leavesForUsageDomain(domainID)
+	if len(leaves) == 0 {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
 		// function was not called).
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
-	if leafCapacity.tasUsage == nil {
-		leafCapacity.tasUsage = resources.NewRequests()
+	share := uniformShare(usage, len(leaves))
+	for _, leaf := range leaves {
+		leafCapacity := s.leafCapacityOf(leaf)
+		if leafCapacity.tasUsage == nil {
+			leafCapacity.tasUsage = resources.NewRequests()
+		}
+		leafCapacity.tasUsage.Add(share)
+		leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 	}
-	leafCapacity.tasUsage.Add(usage)
-	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	if s.leaves[domainID] == nil {
+	leaves := s.leavesForUsageDomain(domainID)
+	if len(leaves) == 0 {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
 		// function was not called).
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
-	if leafCapacity.tasUsage == nil {
-		leafCapacity.tasUsage = resources.NewRequests()
+	share := uniformShare(usage, len(leaves))
+	for _, leaf := range leaves {
+		leafCapacity := s.leafCapacityOf(leaf)
+		if leafCapacity.tasUsage == nil {
+			leafCapacity.tasUsage = resources.NewRequests()
+		}
+		leafCapacity.tasUsage.Sub(share)
+		leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 	}
-	leafCapacity.tasUsage.Sub(usage)
-	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 type domainCapacityDetails struct {
@@ -434,12 +484,19 @@ func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for _, domainUsage := range flavorUsage {
 		domainID := utiltas.DomainID(domainUsage.Values)
-		leaf, found := s.leaves[domainID]
-		if !found {
+		leaves := s.leavesForUsageDomain(domainID)
+		if len(leaves) == 0 {
 			return false
 		}
-		remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
-		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
+		var fitCount int32
+		for _, leaf := range leaves {
+			remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
+			fitCount += domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get())
+			if fitCount >= domainUsage.Count {
+				break
+			}
+		}
+		if fitCount < domainUsage.Count {
 			return false
 		}
 	}
@@ -682,7 +739,11 @@ func findLeaderAndWorkers(trs FlavorTASRequests) (*TASPodSetRequests, TASPodSetR
 
 // findReplacementAssignment finds the topology assignment for the replacement node
 // it return new corrected topologyAssignment, a replacement topologyAssignment used to patched the old, faulty one, and
-// reason if finding fails
+// reason if finding fails.
+// It is only reachable for workloads with hostname-level assignments, as
+// UnhealthyNodes is populated behind an IsLowestLevelHostname gate; the
+// assignment values here and in its helpers are therefore node-scoped even
+// when the topology has a virtual hostname level.
 func (s *TASFlavorSnapshot) findReplacementAssignment(
 	ctx context.Context,
 	tr *TASPodSetRequests,
@@ -729,6 +790,30 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	}
 	newAssignment := s.mergeTopologyAssignments(replacementAssignment[tr.PodSet.Name], existingAssignment)
 	return newAssignment, replacementAssignment[tr.PodSet.Name], ""
+}
+
+// remapAssumedUsageToLeaves converts assumed usage keyed by serialized domain
+// IDs to the per-leaf granularity consumed by fillLeafCounts.
+func (s *TASFlavorSnapshot) remapAssumedUsageToLeaves(assumedUsage map[utiltas.TopologyDomainID]resources.Requests) map[utiltas.TopologyDomainID]resources.Requests {
+	if !s.virtualHostname || len(assumedUsage) == 0 {
+		return assumedUsage
+	}
+	remapped := make(map[utiltas.TopologyDomainID]resources.Requests, len(assumedUsage))
+	for domainID, usage := range assumedUsage {
+		leaves := s.leavesForUsageDomain(domainID)
+		if len(leaves) == 0 {
+			s.log.V(2).Info("skip assumed usage for domain absent from the snapshot", "domain", domainID, "usage", usage)
+			continue
+		}
+		share := uniformShare(usage, len(leaves))
+		for _, leaf := range leaves {
+			if remapped[leaf.id] == nil {
+				remapped[leaf.id] = resources.NewRequests()
+			}
+			remapped[leaf.id].Add(share)
+		}
+	}
+	return remapped
 }
 
 func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
@@ -788,7 +873,7 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 				}
 			}
 		}
-		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize, s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.lowestLevel()))
+		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize, s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.userLowestLevel()))
 	}
 
 	if !isRequired(tr.PodSet.TopologyRequest) {
@@ -812,12 +897,30 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 	return domain.id
 }
 
+// domainForAssignmentValues resolves the domain referenced by a serialized
+// topologyAssignment entry. With a virtual hostname level the serialized
+// values end one level above the leaves, so the lookup cannot use s.leaves.
+func (s *TASFlavorSnapshot) domainForAssignmentValues(levels, values []string) *domain {
+	if len(levels) == 0 || len(values) == 0 {
+		return nil
+	}
+	startIdx := slices.Index(s.levelKeys, levels[0])
+	if startIdx == -1 {
+		return nil
+	}
+	levelIdx := startIdx + len(values) - 1
+	if levelIdx >= len(s.domainsPerLevel) {
+		return nil
+	}
+	return s.domainsPerLevel[levelIdx][utiltas.DomainID(values)]
+}
+
 // IsTopologyAssignmentStale indicates whether the topologyAssignment have Nodes
 // that don't exists in the snapshot. It may be cause e.g. by Node deletion, or change
 // in Node's NodeReady condition
 func (s *TASFlavorSnapshot) IsTopologyAssignmentStale(ta *utiltas.TopologyAssignment) (bool, string) {
 	for _, domain := range ta.Domains {
-		if _, found := s.leaves[utiltas.DomainID(domain.Values)]; !found {
+		if s.domainForAssignmentValues(ta.Levels, domain.Values) == nil {
 			return true, domain.Values[0]
 		}
 	}
@@ -890,7 +993,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
 	requirements := &topologyAssignmentPodRequirements{
-		assumedUsage:              assumedUsage,
+		assumedUsage:              s.remapAssumedUsageToLeaves(assumedUsage),
 		requiredReplacementDomain: requiredReplacementDomain,
 		simulateEmpty:             simulateEmpty,
 	}
@@ -937,7 +1040,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	}
 	state.requestedLevelIdx = requestedLevelIdx
 
-	sliceTopologyKey := s.sliceLevelKeyWithDefault(workersTasPodSetRequests.PodSet.TopologyRequest, s.lowestLevel())
+	sliceTopologyKey := s.sliceLevelKeyWithDefault(workersTasPodSetRequests.PodSet.TopologyRequest, s.userLowestLevel())
 	sliceLevelIdx, found := s.resolveLevelIdx(sliceTopologyKey)
 	if !found {
 		return nil, fmt.Sprintf("no requested topology level for slices: %s", sliceTopologyKey)
@@ -960,20 +1063,16 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 
 	requirements.podRequirements.Tolerations = append(info.Tolerations, s.tolerations...)
 
-	if s.isLowestLevelNode {
-		sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
-		if err != nil {
-			return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
+	sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
+	if err != nil {
+		return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
+	}
+	requirements.podRequirements.Selector = sel
+	if features.Enabled(features.TASCacheNodeMatchResults) && wl != nil && wl.UID != "" {
+		requirements.matchKey = &podSetMatchKey{
+			WorkloadUID: wl.UID,
+			PodSetName:  string(workersTasPodSetRequests.PodSet.Name),
 		}
-		requirements.podRequirements.Selector = sel
-		if features.Enabled(features.TASCacheNodeMatchResults) && wl != nil && wl.UID != "" {
-			requirements.matchKey = &podSetMatchKey{
-				WorkloadUID: wl.UID,
-				PodSetName:  string(workersTasPodSetRequests.PodSet.Name),
-			}
-		}
-	} else {
-		requirements.podRequirements.Selector = labels.Everything()
 	}
 
 	if info.Affinity != nil && info.Affinity.NodeAffinity != nil {
@@ -999,7 +1098,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	requirements.podRequirements.PodTemplate = workersTasPodSetRequests.PodSet.Template.DeepCopy()
 
 	// phase 1 - determine the number of pods and slices which can fit in each topology domain
-	err := s.fillInCounts(ctx, requirements, state)
+	err = s.fillInCounts(ctx, requirements, state)
 	if err != nil {
 		return nil, fmt.Sprintf("unable to calculate domain capacities for PodSet %s, error: %s", info.Name, err.Error())
 	}
@@ -1173,7 +1272,7 @@ func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
 		return false
 	}
 
-	sliceKey := s.sliceLevelKeyWithDefault(r, s.lowestLevel())
+	sliceKey := s.sliceLevelKeyWithDefault(r, s.userLowestLevel())
 
 	_, mainTopologyFound := s.resolveLevelIdx(*mainKey)
 	_, sliceTopologyFound := s.resolveLevelIdx(sliceKey)
@@ -1202,6 +1301,11 @@ func (s *TASFlavorSnapshot) sliceLevelKeyWithDefault(tr *kueue.PodSetTopologyReq
 }
 
 func (s *TASFlavorSnapshot) resolveLevelIdx(levelKey string) (int, bool) {
+	// The injected virtual hostname level is internal only; it must not be
+	// addressable by user requests on topologies which don't declare it.
+	if s.virtualHostname && levelKey == corev1.LabelHostname {
+		return -1, false
+	}
 	levelIdx := slices.Index(s.levelKeys, levelKey)
 	if levelIdx == -1 {
 		return levelIdx, false
@@ -1214,7 +1318,7 @@ func (s *TASFlavorSnapshot) levelKeyWithImpliedFallback(tasRequests *TASPodSetRe
 		return key
 	}
 	if tasRequests.Implied {
-		return new(s.lowestLevel())
+		return new(s.userLowestLevel())
 	}
 	return nil
 }
@@ -1231,7 +1335,7 @@ func (s *TASFlavorSnapshot) levelKey(topologyRequest *kueue.PodSetTopologyReques
 	case isSliceTopologyOnlyRequest(topologyRequest):
 		return new(s.highestLevel())
 	case ptr.Deref(topologyRequest.Unconstrained, false):
-		return new(s.lowestLevel())
+		return new(s.userLowestLevel())
 	default:
 		return nil
 	}
@@ -1679,19 +1783,19 @@ func (s *TASFlavorSnapshot) logLeafDomainsIfVerbose() {
 		"leafDomains", slices.Sorted(maps.Keys(s.leaves)))
 }
 
-// buildTopologyAssignmentForLevels build TopologyAssignment for levels starting from levelIdx
-func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, levelIdx int) *utiltas.TopologyAssignment {
+// buildTopologyAssignmentForLevels build TopologyAssignment for levels within [levelIdx, endIdx)
+func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, levelIdx, endIdx int) *utiltas.TopologyAssignment {
 	assignment := &utiltas.TopologyAssignment{
 		Domains: make([]utiltas.TopologyDomainAssignment, 0),
 	}
-	assignment.Levels = s.levelKeys[levelIdx:]
+	assignment.Levels = s.levelKeys[levelIdx:endIdx]
 	for _, domain := range domains {
 		if s.domainStateOf(domain).podCount == 0 {
 			// It may happen when PodSet count is 0 or when using LeastFreeCapacity algorithm.
 			continue
 		}
 		assignment.Domains = append(assignment.Domains, utiltas.TopologyDomainAssignment{
-			Values: domain.levelValues[levelIdx:],
+			Values: domain.levelValues[levelIdx:endIdx],
 			Count:  s.domainStateOf(domain).podCount,
 		})
 	}
@@ -1701,12 +1805,42 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
 	slices.SortFunc(domains, s.compareDomainLevelValues)
-	levelIdx := 0
-	// assign only hostname values if topology defines it
-	if s.isLowestLevelNode {
-		levelIdx = len(s.levelKeys) - 1
+	levelIdx := len(s.levelKeys) - 1
+	endIdx := len(s.levelKeys)
+	if s.virtualHostname {
+		// Publish the assignment at the user-specified levels; the injected
+		// hostname level is internal only.
+		domains = s.rollUpToParents(domains)
+		levelIdx = 0
+		endIdx = len(s.levelKeys) - 1
+		slices.SortFunc(domains, s.compareDomainLevelValues)
 	}
-	return s.buildTopologyAssignmentForLevels(domains, levelIdx)
+	return s.buildTopologyAssignmentForLevels(domains, levelIdx, endIdx)
+}
+
+// rollUpToParents groups the selected leaves by parent, summing their assigned
+// counts into the parent. Summing is required because the parent's podCount
+// holds the phase-1 capacity count when the fit level is the leaf level itself.
+func (s *TASFlavorSnapshot) rollUpToParents(leaves []*domain) []*domain {
+	seen := make(map[utiltas.TopologyDomainID]bool)
+	var parents []*domain
+	for _, leaf := range leaves {
+		parent := leaf.parent
+		if parent == nil {
+			continue
+		}
+		parentState := s.domainStateOf(parent)
+		if !seen[parent.id] {
+			seen[parent.id] = true
+			parents = append(parents, parent)
+			parentState.podCount = 0
+			parentState.leaderCount = 0
+		}
+		leafState := s.domainStateOf(leaf)
+		parentState.podCount += leafState.podCount
+		parentState.leaderCount += leafState.leaderCount
+	}
+	return parents
 }
 
 func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
@@ -1718,7 +1852,7 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 }
 
 func (s *TASFlavorSnapshot) compareDomainLevelValues(a, b *domain) int {
-	if s.isLowestLevelNode && a.parent == b.parent {
+	if a.parent == b.parent {
 		return strings.Compare(a.levelValues[len(a.levelValues)-1], b.levelValues[len(b.levelValues)-1])
 	}
 	return compareDomainLevelValues(a, b)
@@ -1816,23 +1950,14 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
-		if s.isLowestLevelNode {
-			feasibleLeaves, err := s.simulatorSnapshot.FindFeasibleNodes(ctx, simulator.AsCandidates(s.candidates()), &requirements.podRequirements, &state.stats.NodeExclusionStats)
-
-			if err != nil {
-				return err
-			}
-
-			for _, ml := range feasibleLeaves {
-				leaf := s.leaves[ml.GetID()]
-				s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
-				s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
-			}
-		} else {
-			state.stats.TotalNodes += len(s.leaves)
-			for candidate := range s.candidates() {
-				s.fillLeafCounts(candidate.leaf, requirements, state, cachingRemainingResourcesEnabled)
-			}
+		feasibleLeaves, err := s.simulatorSnapshot.FindFeasibleNodes(ctx, simulator.AsCandidates(s.candidates()), &requirements.podRequirements, &state.stats.NodeExclusionStats)
+		if err != nil {
+			return err
+		}
+		for _, ml := range feasibleLeaves {
+			leaf := s.leaves[ml.GetID()]
+			s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
+			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	}
 
@@ -1843,16 +1968,6 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 }
 
 func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements *topologyAssignmentPodRequirements) ([]simulator.MatchedCandidate, *tasExclusionStats, error) {
-	if !s.isLowestLevelNode {
-		stats := newTASExclusionStats()
-		stats.TotalNodes += len(s.leaves)
-		result := make([]simulator.MatchedCandidate, 0, len(s.leaves))
-		for candidate := range s.candidates() {
-			result = append(result, candidate)
-		}
-		return result, stats, nil
-	}
-
 	if requirements.matchKey != nil {
 		cached, found := s.matchingLeavesCache[*requirements.matchKey]
 		if found {
@@ -2070,13 +2185,17 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 
 // mergeTopologyAssignments merges two topology assignments keeping the lexicographical order of levelValues.
 func (s *TASFlavorSnapshot) mergeTopologyAssignments(a, b *utiltas.TopologyAssignment) *utiltas.TopologyAssignment {
-	nodeLevel := len(s.levelKeys) - 1
+	levels := a.Levels
 	sortedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(a.Domains)+len(b.Domains))
 	sortedDomains = append(sortedDomains, a.Domains...)
 	sortedDomains = append(sortedDomains, b.Domains...)
 	slices.SortFunc(sortedDomains, func(a, b utiltas.TopologyDomainAssignment) int {
-		aDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(a.Values)]
-		bDomain := s.domainsPerLevel[nodeLevel][utiltas.DomainID(b.Values)]
+		aDomain := s.domainForAssignmentValues(levels, a.Values)
+		bDomain := s.domainForAssignmentValues(levels, b.Values)
+		if aDomain == nil || bDomain == nil {
+			// Defensive: staleness is verified before merging.
+			return cmp.Compare(utiltas.DomainID(a.Values), utiltas.DomainID(b.Values))
+		}
 		return cmp.Compare(utiltas.DomainID(aDomain.levelValues), utiltas.DomainID(bDomain.levelValues))
 	})
 	mergedDomains := make([]utiltas.TopologyDomainAssignment, 0, len(sortedDomains))

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -33,6 +33,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -81,6 +82,12 @@ type domainState struct {
 	// affinityScore is the sum of weights of all preferred affinity terms that match the node.
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
+
+	// podCap bounds podCount by what the domain's own remaining capacity
+	// allows. The leaves do not see usage recorded against the domain, so
+	// without this bound the roll-up would overcount. Set by
+	// recordUsageDomainCaps, and read only at the level it writes.
+	podCap int32
 }
 
 // leafCapacity is the per-snapshot mutable capacity data of a leaf domain,
@@ -155,6 +162,19 @@ type TASFlavorSnapshot struct {
 	// of a Workload to avoid recalculating selectors/taints during preemption simulations or
 	// multiple worker PodSet placements within the same scheduling cycle snapshot.
 	matchingLeavesCache map[podSetMatchKey]*matchingLeavesCacheEntry
+
+	// domainTASUsage holds the TAS usage of the domains which span several
+	// leaves, i.e. only when the hostname level is virtual. A
+	// TopologyAssignment on such a topology names the domain, not the node:
+	// kube-scheduler picks the node inside the domain after ungating and never
+	// reports it back, so the usage cannot be charged to a leaf.
+	domainTASUsage map[utiltas.TopologyDomainID]resources.Requests
+
+	// domainFreeCapacities caches the summed free capacity of each usage
+	// domain's leaves. It is filled on first read and never invalidated, which
+	// holds because addNonTASUsage is the only writer of leaf free capacity and
+	// snapshot() calls it before the snapshot is used.
+	domainFreeCapacities map[utiltas.TopologyDomainID]resources.Requests
 
 	// simulatorSnapshot stores enough data to run a WAS scheduling simulation.
 	simulatorSnapshot simulator.SimulatorSnapshot
@@ -239,15 +259,17 @@ func newTASFlavorSnapshot(
 	}
 
 	snapshot := &TASFlavorSnapshot{
-		log:               log,
-		topologyName:      topologyName,
-		topologyTree:      tree,
-		domainStates:      make([]domainState, tree.domainCount),
-		leafCapacities:    make([]leafCapacity, len(tree.leaves)),
-		leafCandidates:    make([]leafCandidate, len(tree.leaves)),
-		tolerations:       slices.Clone(tolerations),
-		simulatorSnapshot: simulatorSnapshot,
-		resourceFormatter: options.resourceFormatter,
+		log:                  log,
+		topologyName:         topologyName,
+		topologyTree:         tree,
+		domainStates:         make([]domainState, tree.domainCount),
+		domainTASUsage:       make(map[utiltas.TopologyDomainID]resources.Requests),
+		domainFreeCapacities: make(map[utiltas.TopologyDomainID]resources.Requests),
+		leafCapacities:       make([]leafCapacity, len(tree.leaves)),
+		leafCandidates:       make([]leafCandidate, len(tree.leaves)),
+		tolerations:          slices.Clone(tolerations),
+		simulatorSnapshot:    simulatorSnapshot,
+		resourceFormatter:    options.resourceFormatter,
 	}
 	for _, leaf := range tree.leaves {
 		snapshot.leafCapacities[leaf.leafIdx].freeCapacity = leaf.capacity.Clone()
@@ -283,19 +305,41 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 	return leafCapacity.cachedRemainingCapacity.Get()
 }
 
-// hasDomain reports whether the domain has a leaf in the snapshot, i.e. whether
-// it holds a node the flavor selects. Only meaningful for hostname-lowest
-// topologies, where usage domains are the leaves.
+// hasDomain reports whether the snapshot holds the domain the usage is
+// recorded against, i.e. whether it holds nodes the flavor selects.
 func (s *TASFlavorSnapshot) hasDomain(domainID utiltas.TopologyDomainID) bool {
-	return s.leaves[domainID] != nil
+	return s.usageDomain(domainID) != nil
 }
 
-// addTASUsageForHeldDomains adds usage only for domains this snapshot has a leaf
-// for. With TASHandleOverlappingFlavors, usages can cover far more domains than
-// the flavor selects, so it walks whichever side is smaller.
+// usageLevelIdx is the level TAS usage is recorded against, which is the level
+// the TopologyAssignment names: the user-lowest one.
+func (s *TASFlavorSnapshot) usageLevelIdx() int {
+	if s.virtualHostname {
+		return len(s.levelKeys) - 2
+	}
+	return len(s.levelKeys) - 1
+}
+
+// usageDomains returns the domains usage is recorded against, keyed the same
+// way as the TopologyAssignment values.
+func (s *TASFlavorSnapshot) usageDomains() domainByID {
+	return s.domainsPerLevel[s.usageLevelIdx()]
+}
+
+// usageDomain returns the domain that usage keyed by domainID belongs to: the
+// leaf itself when the topology declares the hostname level, otherwise the
+// user-lowest domain, which spans several leaves. It never consults the leaf
+// map, where a node name can collide with a domain ID.
+func (s *TASFlavorSnapshot) usageDomain(domainID utiltas.TopologyDomainID) *domain {
+	return s.usageDomains()[domainID]
+}
+
+// addTASUsageForHeldDomains adds usage only for the usage domains this snapshot
+// holds. With TASHandleOverlappingFlavors, usages can cover far more domains
+// than the flavor selects, so it walks whichever side is smaller.
 func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.TopologyDomainID]resources.Requests) {
-	if len(s.leaves) < len(usages) {
-		for domainID := range s.leaves {
+	if len(s.usageDomains()) < len(usages) {
+		for domainID := range s.usageDomains() {
 			if usage, found := usages[domainID]; found {
 				s.addTASUsage(domainID, usage)
 			}
@@ -309,85 +353,88 @@ func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.Topolog
 	}
 }
 
-// leavesForUsageDomain resolves the leaves to charge for usage recorded under
-// the given domain ID, which references the user-lowest level when the
-// hostname level is virtual.
-func (s *TASFlavorSnapshot) leavesForUsageDomain(domainID utiltas.TopologyDomainID) []*leafDomain {
-	if !s.virtualHostname {
-		// Usage domains are the leaves themselves.
-		if leaf := s.leaves[domainID]; leaf != nil {
-			return []*leafDomain{leaf}
+// leavesOf yields the leaves dom holds: dom itself when the topology declares
+// the hostname level and dom is therefore a leaf, otherwise its children.
+func (s *TASFlavorSnapshot) leavesOf(dom *domain) iter.Seq[*leafDomain] {
+	return func(yield func(*leafDomain) bool) {
+		if len(dom.children) == 0 {
+			if leaf := s.leaves[dom.id]; leaf != nil {
+				yield(leaf)
+			}
+			return
 		}
-		return nil
-	}
-	// Usage domains reference the user-lowest level; never consult the leaf
-	// map, where a node name can collide with a domain ID.
-	domain, found := s.domainsPerLevel[len(s.levelKeys)-2][domainID]
-	if !found {
-		return nil
-	}
-	leaves := make([]*leafDomain, 0, len(domain.children))
-	for _, child := range domain.children {
-		if leaf := s.leaves[child.id]; leaf != nil {
-			leaves = append(leaves, leaf)
+		for _, child := range dom.children {
+			if leaf := s.leaves[child.id]; leaf != nil && !yield(leaf) {
+				return
+			}
 		}
 	}
-	return leaves
 }
 
-// uniformShare splits usage evenly across n leaves, rounding up per
-// resource. Per-leaf remaining capacity is underestimated: one used device
-// can zero out every leaf in the domain. Ceil is not additive, so add and
-// remove must use the same per-Workload operands to cancel.
-func uniformShare(usage resources.Requests, n int) resources.Requests {
-	if n <= 1 {
-		return usage
+// domainFreeCapacityOf returns the summed free capacity of the domain's leaves.
+func (s *TASFlavorSnapshot) domainFreeCapacityOf(dom *domain) resources.Requests {
+	if free, found := s.domainFreeCapacities[dom.id]; found {
+		return free
 	}
-	share := usage.Clone()
-	share.ForEach(func(name corev1.ResourceName, val int64) {
-		share.Set(name, (val+int64(n)-1)/int64(n))
-	})
-	return share
+	free := resources.NewRequests()
+	for leaf := range s.leavesOf(dom) {
+		free.Add(s.leafCapacityOf(leaf).freeCapacity)
+	}
+	s.domainFreeCapacities[dom.id] = free
+	return free
+}
+
+// domainRemainingCapacity is remainingCapacityForLeaf at the level usage is
+// recorded against, which the leaves never see. See domainTASUsage for why.
+func (s *TASFlavorSnapshot) domainRemainingCapacity(dom *domain, assumedUsage resources.Requests, simulateEmpty bool) resources.LazyRequests {
+	remaining := resources.NewLazyRequests(s.domainFreeCapacityOf(dom))
+	if !simulateEmpty {
+		remaining.Sub(s.domainTASUsage[dom.id])
+		remaining.Sub(assumedUsage)
+	}
+	return remaining
 }
 
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	leaves := s.leavesForUsageDomain(domainID)
-	if len(leaves) == 0 {
+	s.applyTASUsage(domainID, usage, add)
+}
+
+func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
+	s.applyTASUsage(domainID, usage, subtract)
+}
+
+// applyTASUsage records usage against the domain the TopologyAssignment names,
+// as resolved by usageDomain.
+func (s *TASFlavorSnapshot) applyTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp) {
+	dom := s.usageDomain(domainID)
+	if dom == nil {
 		// this can happen if there is an admitted workload for which the
 		// backing node was deleted or is no longer Ready (so the addCapacity
 		// function was not called).
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	share := uniformShare(usage, len(leaves))
-	for _, leaf := range leaves {
-		leafCapacity := s.leafCapacityOf(leaf)
-		if leafCapacity.tasUsage == nil {
-			leafCapacity.tasUsage = resources.NewRequests()
-		}
-		leafCapacity.tasUsage.Add(share)
-		leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
-	}
-}
-
-func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
-	leaves := s.leavesForUsageDomain(domainID)
-	if len(leaves) == 0 {
-		// this can happen if there is an admitted workload for which the
-		// backing node was deleted or is no longer Ready (so the addCapacity
-		// function was not called).
-		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
+	if s.virtualHostname {
+		s.domainTASUsage[dom.id] = updateUsage(s.domainTASUsage[dom.id], usage, op)
 		return
 	}
-	share := uniformShare(usage, len(leaves))
-	for _, leaf := range leaves {
-		leafCapacity := s.leafCapacityOf(leaf)
-		if leafCapacity.tasUsage == nil {
-			leafCapacity.tasUsage = resources.NewRequests()
-		}
-		leafCapacity.tasUsage.Sub(share)
-		leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity := s.leafCapacityOf(s.leaves[dom.id])
+	leafCapacity.tasUsage = updateUsage(leafCapacity.tasUsage, usage, op)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
+}
+
+// updateUsage applies op to tracked and returns it, allocating on first use.
+// The result must be stored back, as tracked may have been nil.
+func updateUsage(tracked, usage resources.Requests, op usageOp) resources.Requests {
+	if tracked == nil {
+		tracked = resources.NewRequests()
 	}
+	if op == add {
+		tracked.Add(usage)
+	} else {
+		tracked.Sub(usage)
+	}
+	return tracked
 }
 
 type domainCapacityDetails struct {
@@ -416,6 +463,16 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 		details[domainID] = domainCapacityDetails{
 			FreeCapacity: s.resourceDetails(leafCapacity.freeCapacity),
 			TasUsage:     s.resourceDetails(leafCapacity.tasUsage),
+		}
+	}
+	// A virtual topology records usage on the domains, not the leaves, so
+	// without this the dump reads as if nothing is used.
+	if s.virtualHostname {
+		for domainID, dom := range s.usageDomains() {
+			details[domainID] = domainCapacityDetails{
+				FreeCapacity: s.resourceDetails(s.domainFreeCapacityOf(dom)),
+				TasUsage:     s.resourceDetails(s.domainTASUsage[domainID]),
+			}
 		}
 	}
 
@@ -483,18 +540,21 @@ type FlavorTASRequests []TASPodSetRequests
 func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
 	for _, domainUsage := range flavorUsage {
-		domainID := utiltas.DomainID(domainUsage.Values)
-		leaves := s.leavesForUsageDomain(domainID)
-		if len(leaves) == 0 {
+		dom := s.usageDomain(utiltas.DomainID(domainUsage.Values))
+		if dom == nil {
 			return false
 		}
 		var fitCount int32
-		for _, leaf := range leaves {
+		for leaf := range s.leavesOf(dom) {
 			remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
 			fitCount += domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get())
 			if fitCount >= domainUsage.Count {
 				break
 			}
+		}
+		if s.virtualHostname {
+			remaining := s.domainRemainingCapacity(dom, nil, false)
+			fitCount = min(fitCount, domainUsage.SinglePodRequests.CountIn(remaining.Get()))
 		}
 		if fitCount < domainUsage.Count {
 			return false
@@ -704,7 +764,7 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(ctx context.Context
 			}
 
 			// Normal path: no previous assignment or stale assignment
-			assignments, reason := s.findTopologyAssignment(ctx, workers, leader, assumedUsage, opts.simulateEmpty, "", opts.workload)
+			assignments, leafAssignments, reason := s.findTopologyAssignment(ctx, workers, leader, assumedUsage, opts.simulateEmpty, "", opts.workload)
 			for _, tr := range trs {
 				podSetName := tr.PodSet.Name
 				result[podSetName] = tasPodSetAssignmentResult{TopologyAssignment: assignments[podSetName], FailureReason: reason}
@@ -714,7 +774,7 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(ctx context.Context
 				return result
 			}
 			for _, tr := range trs {
-				addAssumedUsage(assumedUsage, assignments[tr.PodSet.Name], &tr)
+				addAssumedUsageForCycle(assumedUsage, assignments[tr.PodSet.Name], leafAssignments[tr.PodSet.Name], &tr)
 			}
 		}
 	}
@@ -781,7 +841,7 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 		trCopy.PodSet.TopologyRequest.PodSetSliceRequiredTopology = effectiveSliceTopology
 		trCopy.PodSet.TopologyRequest.PodSetSliceSize = new(effectiveSliceSize)
 	}
-	replacementAssignment, reason := s.findTopologyAssignment(ctx, trCopy, nil, assumedUsage, false, requiredReplacementDomain, wl)
+	replacementAssignment, _, reason := s.findTopologyAssignment(ctx, trCopy, nil, assumedUsage, false, requiredReplacementDomain, wl)
 	if reason != "" {
 		return nil, nil, reason
 	}
@@ -792,28 +852,15 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	return newAssignment, replacementAssignment[tr.PodSet.Name], ""
 }
 
-// remapAssumedUsageToLeaves converts assumed usage keyed by serialized domain
-// IDs to the per-leaf granularity consumed by fillLeafCounts.
-func (s *TASFlavorSnapshot) remapAssumedUsageToLeaves(assumedUsage map[utiltas.TopologyDomainID]resources.Requests) map[utiltas.TopologyDomainID]resources.Requests {
-	if !s.virtualHostname || len(assumedUsage) == 0 {
-		return assumedUsage
+// addAssumedUsageForCycle records the usage of an assignment made in this cycle.
+// When the leaf-level assignment is known it is keyed by leaf, so a later PodSet
+// sees the exact nodes taken rather than a bound spread over the whole domain.
+func addAssumedUsageForCycle(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, published, leaves *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
+	if leaves != nil {
+		addAssumedUsage(assumedUsage, leaves, tr)
+		return
 	}
-	remapped := make(map[utiltas.TopologyDomainID]resources.Requests, len(assumedUsage))
-	for domainID, usage := range assumedUsage {
-		leaves := s.leavesForUsageDomain(domainID)
-		if len(leaves) == 0 {
-			s.log.V(2).Info("skip assumed usage for domain absent from the snapshot", "domain", domainID, "usage", usage)
-			continue
-		}
-		share := uniformShare(usage, len(leaves))
-		for _, leaf := range leaves {
-			if remapped[leaf.id] == nil {
-				remapped[leaf.id] = resources.NewRequests()
-			}
-			remapped[leaf.id].Add(share)
-		}
-	}
-	return remapped
+	addAssumedUsage(assumedUsage, published, tr)
 }
 
 func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
@@ -873,7 +920,7 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 				}
 			}
 		}
-		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize, s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.userLowestLevel()))
+		return s.findIncompleteSliceDomain(tr, ta, tr.Count, sliceSize, s.sliceLevelKeyWithDefault(tr.PodSet.TopologyRequest, s.explicitLowestLevel()))
 	}
 
 	if !isRequired(tr.PodSet.TopologyRequest) {
@@ -991,9 +1038,9 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	workersTasPodSetRequests TASPodSetRequests,
 	leaderTasPodSetRequests *TASPodSetRequests,
 	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
-	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (map[kueue.PodSetReference]*utiltas.TopologyAssignment, string) {
+	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (assignments, leafAssignments map[kueue.PodSetReference]*utiltas.TopologyAssignment, reason string) {
 	requirements := &topologyAssignmentPodRequirements{
-		assumedUsage:              s.remapAssumedUsageToLeaves(assumedUsage),
+		assumedUsage:              assumedUsage,
 		requiredReplacementDomain: requiredReplacementDomain,
 		simulateEmpty:             simulateEmpty,
 	}
@@ -1016,14 +1063,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	info := podset.FromPodSet(workersTasPodSetRequests.PodSet)
 	for _, podSetUpdate := range workersTasPodSetRequests.PodSetUpdates {
 		if err := info.Merge(podset.FromUpdate(podSetUpdate)); err != nil {
-			return nil, fmt.Sprintf("invalid podSetUpdate for PodSet %s, error: %s", workersTasPodSetRequests.PodSet.Name, err.Error())
+			return nil, nil, fmt.Sprintf("invalid podSetUpdate for PodSet %s, error: %s", workersTasPodSetRequests.PodSet.Name, err.Error())
 		}
 	}
 
 	// If slice topology is not requested then we can assume that slice is a single pod
 	sliceSize, reason := getSliceSizeWithSinglePodAsDefault(workersTasPodSetRequests.PodSet.TopologyRequest)
 	if len(reason) > 0 {
-		return nil, reason
+		return nil, nil, reason
 	}
 	state.sliceSize = sliceSize
 
@@ -1032,28 +1079,28 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 
 	topologyKey := s.levelKeyWithImpliedFallback(&workersTasPodSetRequests)
 	if topologyKey == nil {
-		return nil, "topology level not specified"
+		return nil, nil, "topology level not specified"
 	}
 	requestedLevelIdx, found := s.resolveLevelIdx(*topologyKey)
 	if !found {
-		return nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
+		return nil, nil, fmt.Sprintf("no requested topology level: %s", *topologyKey)
 	}
 	state.requestedLevelIdx = requestedLevelIdx
 
-	sliceTopologyKey := s.sliceLevelKeyWithDefault(workersTasPodSetRequests.PodSet.TopologyRequest, s.userLowestLevel())
+	sliceTopologyKey := s.sliceLevelKeyWithDefault(workersTasPodSetRequests.PodSet.TopologyRequest, s.explicitLowestLevel())
 	sliceLevelIdx, found := s.resolveLevelIdx(sliceTopologyKey)
 	if !found {
-		return nil, fmt.Sprintf("no requested topology level for slices: %s", sliceTopologyKey)
+		return nil, nil, fmt.Sprintf("no requested topology level for slices: %s", sliceTopologyKey)
 	}
 	state.sliceLevelIdx = sliceLevelIdx
 
 	if state.requestedLevelIdx > state.sliceLevelIdx {
-		return nil, fmt.Sprintf("podset slice topology %s is above the podset topology %s", sliceTopologyKey, *topologyKey)
+		return nil, nil, fmt.Sprintf("podset slice topology %s is above the podset topology %s", sliceTopologyKey, *topologyKey)
 	}
 
 	sliceSizeAtLevel, reason := s.buildSliceSizeAtLevel(workersTasPodSetRequests, state.sliceSize, state.sliceLevelIdx)
 	if len(reason) > 0 {
-		return nil, reason
+		return nil, nil, reason
 	}
 	state.sliceSizeAtLevel = sliceSizeAtLevel
 
@@ -1063,23 +1110,27 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 
 	requirements.podRequirements.Tolerations = append(info.Tolerations, s.tolerations...)
 
-	sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
-	if err != nil {
-		return nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
-	}
-	requirements.podRequirements.Selector = sel
-	if features.Enabled(features.TASCacheNodeMatchResults) && wl != nil && wl.UID != "" {
-		requirements.matchKey = &podSetMatchKey{
-			WorkloadUID: wl.UID,
-			PodSetName:  string(workersTasPodSetRequests.PodSet.Name),
+	if s.leafIsNode() {
+		sel, err := labels.ValidatedSelectorFromSet(info.NodeSelector)
+		if err != nil {
+			return nil, nil, fmt.Sprintf("invalid node selectors: %s, reason: %s", info.NodeSelector, err)
 		}
+		requirements.podRequirements.Selector = sel
+		if features.Enabled(features.TASCacheNodeMatchResults) && wl != nil && wl.UID != "" {
+			requirements.matchKey = &podSetMatchKey{
+				WorkloadUID: wl.UID,
+				PodSetName:  string(workersTasPodSetRequests.PodSet.Name),
+			}
+		}
+	} else {
+		requirements.podRequirements.Selector = labels.Everything()
 	}
 
 	if info.Affinity != nil && info.Affinity.NodeAffinity != nil {
 		if requiredAffinity := info.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution; requiredAffinity != nil {
 			affinitySelector, err := nodeaffinity.NewNodeSelector(requiredAffinity)
 			if err != nil {
-				return nil, fmt.Sprintf("invalid affinity node selectors: %s, reason: %s", requiredAffinity, err)
+				return nil, nil, fmt.Sprintf("invalid affinity node selectors: %s, reason: %s", requiredAffinity, err)
 			}
 			requirements.podRequirements.AffinitySelector = affinitySelector
 		}
@@ -1088,7 +1139,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			if len(preferredAffinity) > 0 {
 				prefTerms, err := nodeaffinity.NewPreferredSchedulingTerms(preferredAffinity)
 				if err != nil {
-					return nil, fmt.Sprintf("invalid preferred node affinity terms: %v, reason: %s", preferredAffinity, err)
+					return nil, nil, fmt.Sprintf("invalid preferred node affinity terms: %v, reason: %s", preferredAffinity, err)
 				}
 				requirements.podRequirements.PreferredSchedulingTerms = prefTerms
 			}
@@ -1098,9 +1149,9 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	requirements.podRequirements.PodTemplate = workersTasPodSetRequests.PodSet.Template.DeepCopy()
 
 	// phase 1 - determine the number of pods and slices which can fit in each topology domain
-	err = s.fillInCounts(ctx, requirements, state)
+	err := s.fillInCounts(ctx, requirements, state)
 	if err != nil {
-		return nil, fmt.Sprintf("unable to calculate domain capacities for PodSet %s, error: %s", info.Name, err.Error())
+		return nil, nil, fmt.Sprintf("unable to calculate domain capacities for PodSet %s, error: %s", info.Name, err.Error())
 	}
 
 	// phase 2a: determine the level at which the assignment is done along with
@@ -1124,7 +1175,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	if !useBalancedPlacement {
 		fitLevelIdx, currFitDomain, reason = s.findLevelWithFitDomains(state.requestedLevelIdx, state)
 		if len(reason) > 0 {
-			return nil, reason
+			return nil, nil, reason
 		}
 	}
 	// phase 2b: traverse the tree down level-by-level optimizing the number of
@@ -1177,7 +1228,8 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		currFitDomain = newCurrFitDomain
 	}
 
-	assignments := make(map[kueue.PodSetReference]*utiltas.TopologyAssignment)
+	assignments = make(map[kueue.PodSetReference]*utiltas.TopologyAssignment)
+	leafAssignments = make(map[kueue.PodSetReference]*utiltas.TopologyAssignment)
 
 	if leaderTasPodSetRequests != nil {
 		var leaderFitDomains []*domain
@@ -1196,13 +1248,13 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			}
 		}
 
-		assignments[leaderTasPodSetRequests.PodSet.Name] = s.buildAssignment(leaderFitDomains)
+		assignments[leaderTasPodSetRequests.PodSet.Name], leafAssignments[leaderTasPodSetRequests.PodSet.Name] = s.buildAssignment(leaderFitDomains)
 		currFitDomain = workerFitDomains
 	}
 
-	assignments[workersTasPodSetRequests.PodSet.Name] = s.buildAssignment(currFitDomain)
+	assignments[workersTasPodSetRequests.PodSet.Name], leafAssignments[workersTasPodSetRequests.PodSet.Name] = s.buildAssignment(currFitDomain)
 
-	return assignments, ""
+	return assignments, leafAssignments, ""
 }
 
 // buildSliceSizeAtLevel builds a map from topology level index to the slice
@@ -1272,7 +1324,7 @@ func (s *TASFlavorSnapshot) HasLevel(r *kueue.PodSetTopologyRequest) bool {
 		return false
 	}
 
-	sliceKey := s.sliceLevelKeyWithDefault(r, s.userLowestLevel())
+	sliceKey := s.sliceLevelKeyWithDefault(r, s.explicitLowestLevel())
 
 	_, mainTopologyFound := s.resolveLevelIdx(*mainKey)
 	_, sliceTopologyFound := s.resolveLevelIdx(sliceKey)
@@ -1318,7 +1370,7 @@ func (s *TASFlavorSnapshot) levelKeyWithImpliedFallback(tasRequests *TASPodSetRe
 		return key
 	}
 	if tasRequests.Implied {
-		return new(s.userLowestLevel())
+		return new(s.explicitLowestLevel())
 	}
 	return nil
 }
@@ -1335,7 +1387,7 @@ func (s *TASFlavorSnapshot) levelKey(topologyRequest *kueue.PodSetTopologyReques
 	case isSliceTopologyOnlyRequest(topologyRequest):
 		return new(s.highestLevel())
 	case ptr.Deref(topologyRequest.Unconstrained, false):
-		return new(s.userLowestLevel())
+		return new(s.explicitLowestLevel())
 	default:
 		return nil
 	}
@@ -1802,27 +1854,33 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 	return assignment
 }
 
-func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) *utiltas.TopologyAssignment {
+// buildAssignment returns the assignment published on the Workload, and for a
+// virtual hostname level the leaf-level assignment it was rolled up from. The
+// leaves are known only inside the cycle that picked them, and let a later
+// PodSet see the exact nodes taken instead of a domain-wide bound.
+func (s *TASFlavorSnapshot) buildAssignment(domains []*domain) (published, leaves *utiltas.TopologyAssignment) {
 	// lex sort domains by their levelValues instead of IDs, as leaves' IDs can only contain the hostname
 	slices.SortFunc(domains, s.compareDomainLevelValues)
-	levelIdx := len(s.levelKeys) - 1
-	endIdx := len(s.levelKeys)
-	if s.virtualHostname {
-		// Publish the assignment at the user-specified levels; the injected
-		// hostname level is internal only.
+	levelIdx, endIdx := 0, len(s.levelKeys)
+	switch {
+	case s.virtualHostname:
+		leaves = s.buildTopologyAssignmentForLevels(domains, len(s.levelKeys)-1, len(s.levelKeys))
+		// Publish at the declared levels; the injected level is internal only.
 		domains = s.rollUpToParents(domains)
-		levelIdx = 0
 		endIdx = len(s.levelKeys) - 1
 		slices.SortFunc(domains, s.compareDomainLevelValues)
+	case s.declaresHostnameLevel():
+		// assign only hostname values if topology defines it
+		levelIdx = len(s.levelKeys) - 1
 	}
-	return s.buildTopologyAssignmentForLevels(domains, levelIdx, endIdx)
+	return s.buildTopologyAssignmentForLevels(domains, levelIdx, endIdx), leaves
 }
 
 // rollUpToParents groups the selected leaves by parent, summing their assigned
 // counts into the parent. Summing is required because the parent's podCount
 // holds the phase-1 capacity count when the fit level is the leaf level itself.
 func (s *TASFlavorSnapshot) rollUpToParents(leaves []*domain) []*domain {
-	seen := make(map[utiltas.TopologyDomainID]bool)
+	parentIDs := sets.New[utiltas.TopologyDomainID]()
 	var parents []*domain
 	for _, leaf := range leaves {
 		parent := leaf.parent
@@ -1830,8 +1888,8 @@ func (s *TASFlavorSnapshot) rollUpToParents(leaves []*domain) []*domain {
 			continue
 		}
 		parentState := s.domainStateOf(parent)
-		if !seen[parent.id] {
-			seen[parent.id] = true
+		if !parentIDs.Has(parent.id) {
+			parentIDs.Insert(parent.id)
 			parents = append(parents, parent)
 			parentState.podCount = 0
 			parentState.leaderCount = 0
@@ -1852,7 +1910,7 @@ func (s *TASFlavorSnapshot) lowerLevelDomains(domains []*domain) []*domain {
 }
 
 func (s *TASFlavorSnapshot) compareDomainLevelValues(a, b *domain) int {
-	if a.parent == b.parent {
+	if s.leafIsNode() && a.parent == b.parent {
 		return strings.Compare(a.levelValues[len(a.levelValues)-1], b.levelValues[len(b.levelValues)-1])
 	}
 	return compareDomainLevelValues(a, b)
@@ -1938,7 +1996,8 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 	s.domainStates = s.domainStates[:s.domainCount]
 	clear(s.domainStates)
 	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
-	if features.Enabled(features.TASCacheNodeMatchResults) {
+	switch {
+	case features.Enabled(features.TASCacheNodeMatchResults):
 		matchingLeaves, stats, err := s.getMatchingLeaves(ctx, requirements)
 		if err != nil {
 			return err
@@ -1949,7 +2008,7 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 			s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
-	} else {
+	case s.leafIsNode():
 		feasibleLeaves, err := s.simulatorSnapshot.FindFeasibleNodes(ctx, simulator.AsCandidates(s.candidates()), &requirements.podRequirements, &state.stats.NodeExclusionStats)
 		if err != nil {
 			return err
@@ -1959,15 +2018,44 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 			s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
+	default:
+		// A leaf spans several nodes, so it has none to check for feasibility.
+		state.stats.TotalNodes += len(s.leaves)
+		for candidate := range s.candidates() {
+			s.fillLeafCounts(candidate.leaf, requirements, state, cachingRemainingResourcesEnabled)
+		}
 	}
 
+	if s.virtualHostname {
+		s.recordUsageDomainCaps(requirements)
+	}
 	for _, root := range s.roots {
 		s.fillInCountsHelper(root, state.sliceSize, state.sliceLevelIdx, 0, state.sliceSizeAtLevel, state.leaderCount > 0)
 	}
 	return nil
 }
 
+// recordUsageDomainCaps stores, for each usage domain, how many Pods its own
+// remaining capacity allows. fillInCountsHelper applies the bound when it rolls
+// the leaves up; the leaves are evaluated against node capacity alone, so
+// without it the roll-up would ignore the domain's usage entirely.
+func (s *TASFlavorSnapshot) recordUsageDomainCaps(requirements *topologyAssignmentPodRequirements) {
+	for domainID, dom := range s.usageDomains() {
+		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage[domainID], requirements.simulateEmpty)
+		s.domainStateOf(dom).podCap = requirements.requests.CountIn(remaining.Get())
+	}
+}
+
 func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements *topologyAssignmentPodRequirements) ([]simulator.MatchedCandidate, *tasExclusionStats, error) {
+	if !s.leafIsNode() {
+		stats := newTASExclusionStats()
+		stats.TotalNodes += len(s.leaves)
+		result := make([]simulator.MatchedCandidate, 0, len(s.leaves))
+		for candidate := range s.candidates() {
+			result = append(result, candidate)
+		}
+		return result, stats, nil
+	}
 	if requirements.matchKey != nil {
 		cached, found := s.matchingLeavesCache[*requirements.matchKey]
 		if found {
@@ -2020,9 +2108,10 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	}
 	remainingCapacity := s.remainingCapacityForLeaf(leaf, requirements.simulateEmpty, cachingRemainingResourcesEnabled)
 
-	if leafAssumedUsage, found := requirements.assumedUsage[leaf.id]; found {
-		remainingCapacity.Sub(leafAssumedUsage)
-	}
+	// In-cycle assignments are keyed by leaf, so this picks up the exact nodes
+	// an earlier PodSet took. Domain-keyed entries, which come from assignments
+	// recovered from the Workload, are applied in recordUsageDomainCaps.
+	remainingCapacity.Sub(requirements.assumedUsage[leaf.id])
 	var limitingRes corev1.ResourceName
 	leafDomainState := s.domainStateOf(&leaf.domain)
 	leafDomainState.podCount, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
@@ -2089,6 +2178,10 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		}
 		leaderCount = max(childDomainState.leaderCount, leaderCount)
 		affinityScore += childDomainState.affinityScore
+	}
+	if s.virtualHostname && level == s.usageLevelIdx() && domainState.podCap < childrenCapacity {
+		childrenCapacity = domainState.podCap
+		sliceCapacity = min(sliceCapacity, childrenCapacity/sliceSize)
 	}
 	domainState.podCount = childrenCapacity
 	sliceCountWithLeader := int32(0)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -83,13 +83,21 @@ type domainState struct {
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
 
-	// podCap, leaderCap and podCapWithLeader mirror podCount, leaderCount and
-	// podCountWithLeader for the domain's own remaining capacity, which the
-	// leaves do not see. Without them the roll-up would overcount. Set by
-	// recordUsageDomainCaps, and read only at the level it writes.
-	podCap           int32
-	leaderCap        int32
-	podCapWithLeader int32
+	// capacityBound is set by recordUsageDomainCaps, and read only at the level
+	// it writes.
+	capacityBound domainCapacityBound
+}
+
+// domainCapacityBound bounds the counts rolled up from a domain's leaves by what
+// the domain's own remaining capacity allows, field for field against podCount,
+// leaderCount and podCountWithLeader. A leaf only sees its own node, so it
+// reports room the domain may already owe; domainTASUsage explains why.
+// Attributing that usage to the node holding each Pod would remove the need for
+// this bound.
+type domainCapacityBound struct {
+	podCount           int32
+	leaderCount        int32
+	podCountWithLeader int32
 }
 
 // leafCapacity is the per-snapshot mutable capacity data of a leaf domain,
@@ -402,8 +410,11 @@ func (s *TASFlavorSnapshot) domainRemainingCapacity(dom *domain, assumedUsage re
 	remaining := resources.NewLazyRequests(s.domainFreeCapacityOf(dom))
 	if !simulateEmpty {
 		remaining.Sub(s.domainTASUsage[dom.id])
-		remaining.Sub(assumedUsage)
 	}
+	// Placements made earlier in this cycle are always subtracted: they belong to
+	// the Workload being assigned, so preemption cannot reclaim them. fillLeafCounts
+	// subtracts the leaf-keyed side the same way.
+	remaining.Sub(assumedUsage)
 	return remaining
 }
 
@@ -892,11 +903,6 @@ func newAssumedUsage(perDomain map[utiltas.TopologyDomainID]resources.Requests) 
 	return &assumedUsage{perDomain: perDomain}
 }
 
-// recordDomainUsage adds usage keyed by the domain a TopologyAssignment names.
-func (u *assumedUsage) recordDomainUsage(usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
-	addUsagePerDomain(u.perDomain, usagePerDomain)
-}
-
 // recordLeafUsage adds usage keyed by leaf, allocating on first use.
 func (u *assumedUsage) recordLeafUsage(usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	if u.perLeaf == nil {
@@ -919,7 +925,7 @@ func addAssumedUsageForCycle(assumedUsage *assumedUsage, published, leaves *util
 }
 
 func addAssumedUsage(assumedUsage *assumedUsage, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
-	assumedUsage.recordDomainUsage(utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
+	addUsagePerDomain(assumedUsage.perDomain, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
 }
 
 func addUsagePerDomain(tracked map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
@@ -2097,14 +2103,14 @@ func (s *TASFlavorSnapshot) recordUsageDomainCaps(requirements *topologyAssignme
 	for domainID, dom := range s.usageDomains() {
 		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage.perDomain[domainID], requirements.simulateEmpty)
 		domainState := s.domainStateOf(dom)
-		domainState.podCap = requirements.requests.CountIn(remaining.Get())
+		domainState.capacityBound.podCount = requirements.requests.CountIn(remaining.Get())
 
-		domainState.leaderCap = 0
+		domainState.capacityBound.leaderCount = 0
 		if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remaining.Get()) > 0 {
-			domainState.leaderCap = 1
+			domainState.capacityBound.leaderCount = 1
 			remaining.Sub(requirements.leaderRequests)
 		}
-		domainState.podCapWithLeader = requirements.requests.CountIn(remaining.Get())
+		domainState.capacityBound.podCountWithLeader = requirements.requests.CountIn(remaining.Get())
 	}
 }
 
@@ -2252,11 +2258,11 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	domainState.leaderCount = leaderCount
 	domainState.affinityScore = affinityScore
 	if s.virtualHostname && level == s.usageLevelIdx() {
-		domainState.podCount = min(domainState.podCount, domainState.podCap)
-		domainState.leaderCount = min(domainState.leaderCount, domainState.leaderCap)
+		domainState.podCount = min(domainState.podCount, domainState.capacityBound.podCount)
+		domainState.leaderCount = min(domainState.leaderCount, domainState.capacityBound.leaderCount)
 		// The leader's cost is measured against a leaf, so it can exceed the
 		// bounded pod count and drive the difference below zero.
-		domainState.podCountWithLeader = min(max(0, domainState.podCountWithLeader), domainState.podCapWithLeader)
+		domainState.podCountWithLeader = min(max(0, domainState.podCountWithLeader), domainState.capacityBound.podCountWithLeader)
 		sliceCapacity = min(sliceCapacity, domainState.podCount/sliceSize)
 		sliceCountWithLeader = min(max(0, sliceCountWithLeader), domainState.podCountWithLeader/sliceSize)
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -83,11 +83,13 @@ type domainState struct {
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
 
-	// podCap bounds podCount by what the domain's own remaining capacity
-	// allows. The leaves do not see usage recorded against the domain, so
-	// without this bound the roll-up would overcount. Set by
+	// podCap, leaderCap and podCapWithLeader mirror podCount, leaderCount and
+	// podCountWithLeader for the domain's own remaining capacity, which the
+	// leaves do not see. Without them the roll-up would overcount. Set by
 	// recordUsageDomainCaps, and read only at the level it writes.
-	podCap int32
+	podCap           int32
+	leaderCap        int32
+	podCapWithLeader int32
 }
 
 // leafCapacity is the per-snapshot mutable capacity data of a leaf domain,
@@ -353,6 +355,16 @@ func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.Topolog
 	}
 }
 
+// assumedUsageForLeaf returns the usage this cycle already placed on the leaf.
+// Without a virtual hostname level the leaf is the domain a TopologyAssignment
+// names, so the domain-keyed side holds it.
+func (s *TASFlavorSnapshot) assumedUsageForLeaf(usage *assumedUsage, leaf *leafDomain) resources.Requests {
+	if s.virtualHostname {
+		return usage.perLeaf[leaf.id]
+	}
+	return usage.perDomain[leaf.id]
+}
+
 // leavesOf yields the leaves dom holds: dom itself when the topology declares
 // the hostname level and dom is therefore a leaf, otherwise its children.
 func (s *TASFlavorSnapshot) leavesOf(dom *domain) iter.Seq[*leafDomain] {
@@ -579,7 +591,7 @@ type topologyAssignmentPodRequirements struct {
 	podRequirements           simulator.PodRequirements
 	requests                  resources.Requests
 	leaderRequests            resources.Requests
-	assumedUsage              map[utiltas.TopologyDomainID]resources.Requests
+	assumedUsage              *assumedUsage
 	requiredReplacementDomain utiltas.TopologyDomainID
 	simulateEmpty             bool
 	matchKey                  *podSetMatchKey
@@ -700,10 +712,11 @@ func (s *TASFlavorSnapshot) FindTopologyAssignmentsForFlavor(ctx context.Context
 	}
 
 	result := make(map[kueue.PodSetReference]tasPodSetAssignmentResult)
-	assumedUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
-	if features.Enabled(features.TASHandleOverlappingFlavors) && opts.aggregatedDomainUsages != nil {
-		assumedUsage = opts.aggregatedDomainUsages
+	var sharedDomainUsages map[utiltas.TopologyDomainID]resources.Requests
+	if features.Enabled(features.TASHandleOverlappingFlavors) {
+		sharedDomainUsages = opts.aggregatedDomainUsages
 	}
+	assumedUsage := newAssumedUsage(sharedDomainUsages)
 
 	groupedTASRequests := make(map[string]FlavorTASRequests)
 	groupsOrder := make([]string, 0)
@@ -809,7 +822,7 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	tr *TASPodSetRequests,
 	existingAssignment *utiltas.TopologyAssignment,
 	wl *kueue.Workload,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 ) (*utiltas.TopologyAssignment, *utiltas.TopologyAssignment, string) {
 	tr.Count = deleteDomain(existingAssignment, wl.Status.UnhealthyNodes[0].Name)
 	if isStale, staleDomain := s.IsTopologyAssignmentStale(existingAssignment); isStale {
@@ -852,27 +865,69 @@ func (s *TASFlavorSnapshot) findReplacementAssignment(
 	return newAssignment, replacementAssignment[tr.PodSet.Name], ""
 }
 
-// addAssumedUsageForCycle records the usage of an assignment made in this cycle.
-// When the leaf-level assignment is known it is keyed by leaf, so a later PodSet
-// sees the exact nodes taken rather than a bound spread over the whole domain.
-func addAssumedUsageForCycle(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, published, leaves *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
+// assumedUsage holds the usage of the placements made earlier in this
+// scheduling cycle. Domain IDs are not unique across levels, so the entries
+// keyed by leaf are kept apart from those keyed by the domain a
+// TopologyAssignment names; a node named after a domain would otherwise share
+// its entry.
+type assumedUsage struct {
+	// perDomain is keyed the way TopologyAssignment values are. With
+	// TASHandleOverlappingFlavors it is shared with the sibling flavors, see
+	// WithAggregatedDomainUsages.
+	perDomain map[utiltas.TopologyDomainID]resources.Requests
+
+	// perLeaf is keyed by leaf, and is filled only when the hostname level is
+	// virtual. The leaf a Pod lands on is then known within the cycle, but is
+	// not part of the published assignment. Reads of a nil map are valid, so it
+	// stays nil on the topologies that never write it.
+	perLeaf map[utiltas.TopologyDomainID]resources.Requests
+}
+
+// newAssumedUsage returns an assumedUsage recording domain-level usage into
+// perDomain, which is shared with the sibling flavors when one is passed.
+func newAssumedUsage(perDomain map[utiltas.TopologyDomainID]resources.Requests) *assumedUsage {
+	if perDomain == nil {
+		perDomain = make(map[utiltas.TopologyDomainID]resources.Requests)
+	}
+	return &assumedUsage{perDomain: perDomain}
+}
+
+// recordDomainUsage adds usage keyed by the domain a TopologyAssignment names.
+func (u *assumedUsage) recordDomainUsage(usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+	addUsagePerDomain(u.perDomain, usagePerDomain)
+}
+
+// recordLeafUsage adds usage keyed by leaf, allocating on first use.
+func (u *assumedUsage) recordLeafUsage(usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+	if u.perLeaf == nil {
+		u.perLeaf = make(map[utiltas.TopologyDomainID]resources.Requests, len(usagePerDomain))
+	}
+	addUsagePerDomain(u.perLeaf, usagePerDomain)
+}
+
+// addAssumedUsageForCycle records the usage of an assignment made in this cycle
+// on both sides. A later PodSet needs the leaf-keyed entry to see the exact
+// nodes taken, and the domain-keyed entry to see that the domain itself shrank:
+// neither bound implies the other, because a leaf does not carry the usage
+// recorded on its domain, and a domain does not know which of its nodes are
+// taken.
+func addAssumedUsageForCycle(assumedUsage *assumedUsage, published, leaves *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
 	if leaves != nil {
-		addAssumedUsage(assumedUsage, leaves, tr)
-		return
+		assumedUsage.recordLeafUsage(utiltas.ComputeUsagePerDomain(leaves, tr.SinglePodRequests))
 	}
 	addAssumedUsage(assumedUsage, published, tr)
 }
 
-func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
-	addUsagePerDomain(assumedUsage, utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
+func addAssumedUsage(assumedUsage *assumedUsage, ta *utiltas.TopologyAssignment, tr *TASPodSetRequests) {
+	assumedUsage.recordDomainUsage(utiltas.ComputeUsagePerDomain(ta, tr.SinglePodRequests))
 }
 
-func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
+func addUsagePerDomain(tracked map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	for domainID, usage := range usagePerDomain {
-		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.NewRequests()
+		if tracked[domainID] == nil {
+			tracked[domainID] = resources.NewRequests()
 		}
-		assumedUsage[domainID].Add(usage)
+		tracked[domainID].Add(usage)
 	}
 }
 
@@ -1037,7 +1092,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	ctx context.Context,
 	workersTasPodSetRequests TASPodSetRequests,
 	leaderTasPodSetRequests *TASPodSetRequests,
-	assumedUsage map[utiltas.TopologyDomainID]resources.Requests,
+	assumedUsage *assumedUsage,
 	simulateEmpty bool, requiredReplacementDomain utiltas.TopologyDomainID, wl *kueue.Workload) (assignments, leafAssignments map[kueue.PodSetReference]*utiltas.TopologyAssignment, reason string) {
 	requirements := &topologyAssignmentPodRequirements{
 		assumedUsage:              assumedUsage,
@@ -2035,14 +2090,21 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 	return nil
 }
 
-// recordUsageDomainCaps stores, for each usage domain, how many Pods its own
-// remaining capacity allows. fillInCountsHelper applies the bound when it rolls
-// the leaves up; the leaves are evaluated against node capacity alone, so
-// without it the roll-up would ignore the domain's usage entirely.
+// recordUsageDomainCaps evaluates every usage domain against its own remaining
+// capacity, the way fillLeafCounts evaluates a leaf against its node.
+// fillInCountsHelper applies the bounds when it rolls the leaves up.
 func (s *TASFlavorSnapshot) recordUsageDomainCaps(requirements *topologyAssignmentPodRequirements) {
 	for domainID, dom := range s.usageDomains() {
-		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage[domainID], requirements.simulateEmpty)
-		s.domainStateOf(dom).podCap = requirements.requests.CountIn(remaining.Get())
+		remaining := s.domainRemainingCapacity(dom, requirements.assumedUsage.perDomain[domainID], requirements.simulateEmpty)
+		domainState := s.domainStateOf(dom)
+		domainState.podCap = requirements.requests.CountIn(remaining.Get())
+
+		domainState.leaderCap = 0
+		if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remaining.Get()) > 0 {
+			domainState.leaderCap = 1
+			remaining.Sub(requirements.leaderRequests)
+		}
+		domainState.podCapWithLeader = requirements.requests.CountIn(remaining.Get())
 	}
 }
 
@@ -2111,7 +2173,7 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	// In-cycle assignments are keyed by leaf, so this picks up the exact nodes
 	// an earlier PodSet took. Domain-keyed entries, which come from assignments
 	// recovered from the Workload, are applied in recordUsageDomainCaps.
-	remainingCapacity.Sub(requirements.assumedUsage[leaf.id])
+	remainingCapacity.Sub(s.assumedUsageForLeaf(requirements.assumedUsage, leaf))
 	var limitingRes corev1.ResourceName
 	leafDomainState := s.domainStateOf(&leaf.domain)
 	leafDomainState.podCount, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
@@ -2179,10 +2241,6 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 		leaderCount = max(childDomainState.leaderCount, leaderCount)
 		affinityScore += childDomainState.affinityScore
 	}
-	if s.virtualHostname && level == s.usageLevelIdx() && domainState.podCap < childrenCapacity {
-		childrenCapacity = domainState.podCap
-		sliceCapacity = min(sliceCapacity, childrenCapacity/sliceSize)
-	}
 	domainState.podCount = childrenCapacity
 	sliceCountWithLeader := int32(0)
 	if hasWithLeaderCapacityContributor {
@@ -2193,6 +2251,15 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	}
 	domainState.leaderCount = leaderCount
 	domainState.affinityScore = affinityScore
+	if s.virtualHostname && level == s.usageLevelIdx() {
+		domainState.podCount = min(domainState.podCount, domainState.podCap)
+		domainState.leaderCount = min(domainState.leaderCount, domainState.leaderCap)
+		// The leader's cost is measured against a leaf, so it can exceed the
+		// bounded pod count and drive the difference below zero.
+		domainState.podCountWithLeader = min(max(0, domainState.podCountWithLeader), domainState.podCapWithLeader)
+		sliceCapacity = min(sliceCapacity, domainState.podCount/sliceSize)
+		sliceCountWithLeader = min(max(0, sliceCountWithLeader), domainState.podCountWithLeader/sliceSize)
+	}
 	if level == sliceLevelIdx {
 		// initialize the sliceCount for the requested slice level.
 		sliceCapacity = domainState.podCount / sliceSize

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -179,30 +179,43 @@ func runBenchmarkTASFlavorSnapshot(b *testing.B, topo benchTopology, flavors int
 	})
 }
 
+// assignmentBenchCase describes one BenchmarkTASFlavorAssignment run. levels
+// selects whether the topology declares the hostname level or gets a virtual
+// one, which decides where usage is accounted and how the counts roll up.
+type assignmentBenchCase struct {
+	name       string
+	topology   benchTopology
+	levels     []string
+	withLeader bool
+}
+
 func BenchmarkTASFlavorAssignment(b *testing.B) {
 	features.SetFeatureGateDuringTest(b, features.TASBalancedPlacement, true)
+	features.SetFeatureGateDuringTest(b, features.TASNodeFeasibilityForAllLevels, true)
 
-	benchmarks := []struct {
-		name       string
-		topology   benchTopology
-		withLeader bool
-	}{
-		{name: "nodes=100/workersOnly", topology: benchTopology{nodes: 100, nodesPerRack: 16, racksPerBlock: 16}},
-		{name: "nodes=500/workersOnly", topology: benchTopology{nodes: 500, nodesPerRack: 16, racksPerBlock: 16}},
-		{name: "nodes=2500/workersOnly", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}},
-		{name: "nodes=2500/withLeader", topology: benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}, withLeader: true},
-	}
-	for _, benchmark := range benchmarks {
-		runBenchmarkTASFlavorAssignment(b, benchmark.topology, benchmark.name, benchmark.withLeader)
+	topo := benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}
+	hostnameLowest := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+	rackLowest := []string{benchBlockLabel, benchRackLabel}
+
+	for _, benchmark := range []assignmentBenchCase{
+		{name: "nodes=100/workersOnly", topology: benchTopology{nodes: 100, nodesPerRack: 16, racksPerBlock: 16}, levels: hostnameLowest},
+		{name: "nodes=500/workersOnly", topology: benchTopology{nodes: 500, nodesPerRack: 16, racksPerBlock: 16}, levels: hostnameLowest},
+		{name: "nodes=2500/workersOnly", topology: topo, levels: hostnameLowest},
+		{name: "nodes=2500/withLeader", topology: topo, levels: hostnameLowest, withLeader: true},
+		{name: "nodes=2500/workersOnly/rackLowest", topology: topo, levels: rackLowest},
+		{name: "nodes=2500/withLeader/rackLowest", topology: topo, levels: rackLowest, withLeader: true},
+	} {
+		runBenchmarkTASFlavorAssignment(b, benchmark)
 	}
 }
 
-func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name string, withLeader bool) {
-	b.Run(name, func(b *testing.B) {
+func runBenchmarkTASFlavorAssignment(b *testing.B, tc assignmentBenchCase) {
+	b.Run(tc.name, func(b *testing.B) {
 		b.ReportAllocs()
 		_, log := utiltesting.ContextWithLog(b)
+		topo := tc.topology
 		nodes := buildBenchNodes(topo)
-		levels := []string{benchBlockLabel, benchRackLabel, benchHostLabel}
+		levels := tc.levels
 
 		tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
 		for i := range nodes {
@@ -217,7 +230,7 @@ func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name stri
 			b.Fatalf("TASFlavorSnapshot creation failed: %v", err)
 		}
 
-		requests := balancedPlacementBenchRequests(topo, withLeader)
+		requests := balancedPlacementBenchRequests(topo, tc.withLeader)
 		result := snapshot.FindTopologyAssignmentsForFlavor(b.Context(), requests)
 		if failure := result.Failure(); failure != nil {
 			b.Fatalf("balanced placement preflight failed: %s", failure.Reason)
@@ -265,10 +278,12 @@ func balancedPlacementBenchRequests(topo benchTopology, withLeader bool) FlavorT
 	return requests
 }
 
-// Measures snapshot construction with admitted-Workload usage recorded,
-// which the modes above leave empty. Rack-lowest topologies charge usage
-// per Workload; hostname-lowest topologies add the per-domain aggregate.
+// Measures snapshot construction with admitted-Workload usage recorded, which
+// the modes above leave empty. The level schemes vary how many nodes a usage
+// domain spans: one for hostname-lowest, a rack, and a whole block.
 func BenchmarkTASFlavorSnapshotWithWorkloadUsage(b *testing.B) {
+	// A no-op for the hostname-lowest scheme, which declares the level anyway.
+	features.SetFeatureGateDuringTest(b, features.TASNodeFeasibilityForAllLevels, true)
 	topo := benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}
 	levelSchemes := []struct {
 		name   string
@@ -276,13 +291,14 @@ func BenchmarkTASFlavorSnapshotWithWorkloadUsage(b *testing.B) {
 	}{
 		{name: "hostname-lowest", levels: []string{benchBlockLabel, benchRackLabel, benchHostLabel}},
 		{name: "rack-lowest", levels: []string{benchBlockLabel, benchRackLabel}},
+		{name: "block-lowest", levels: []string{benchBlockLabel}},
 	}
 	for _, scheme := range levelSchemes {
 		for _, admittedWorkloads := range []int{1000, 5000} {
 			name := fmt.Sprintf("levels=%s/workloads=%d", scheme.name, admittedWorkloads)
 			b.Run(name, func(b *testing.B) {
 				b.ReportAllocs()
-				log := logr.Discard()
+				_, log := utiltesting.ContextWithLog(b)
 				nodes := buildBenchNodes(topo)
 				tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
 				for i := range nodes {
@@ -300,6 +316,7 @@ func BenchmarkTASFlavorSnapshotWithWorkloadUsage(b *testing.B) {
 					if len(scheme.levels) == 3 {
 						values = append(values, fmt.Sprintf("node-%d", n))
 					}
+					values = values[:len(scheme.levels)]
 					fc.addUsage(log, workload.Reference(fmt.Sprintf("wl-%d", i)), []workload.TopologyDomainRequests{{
 						Values:            values,
 						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -31,6 +31,7 @@ import (
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	testingnode "sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 const (
@@ -262,4 +263,58 @@ func balancedPlacementBenchRequests(topo benchTopology, withLeader bool) FlavorT
 		})
 	}
 	return requests
+}
+
+// Measures snapshot construction with admitted-Workload usage recorded,
+// which the modes above leave empty. Rack-lowest topologies charge usage
+// per Workload; hostname-lowest topologies add the per-domain aggregate.
+func BenchmarkTASFlavorSnapshotWithWorkloadUsage(b *testing.B) {
+	topo := benchTopology{nodes: 2500, nodesPerRack: 16, racksPerBlock: 16}
+	levelSchemes := []struct {
+		name   string
+		levels []string
+	}{
+		{name: "hostname-lowest", levels: []string{benchBlockLabel, benchRackLabel, benchHostLabel}},
+		{name: "rack-lowest", levels: []string{benchBlockLabel, benchRackLabel}},
+	}
+	for _, scheme := range levelSchemes {
+		for _, admittedWorkloads := range []int{1000, 5000} {
+			name := fmt.Sprintf("levels=%s/workloads=%d", scheme.name, admittedWorkloads)
+			b.Run(name, func(b *testing.B) {
+				b.ReportAllocs()
+				log := logr.Discard()
+				nodes := buildBenchNodes(topo)
+				tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+				for i := range nodes {
+					tasCache.SyncNode(&nodes[i])
+				}
+				fc := tasCache.NewTASFlavorCache(
+					topologyInformation{Levels: scheme.levels},
+					flavorInformation{TopologyName: "default"},
+				)
+				for i := range admittedWorkloads {
+					n := i % topo.nodes
+					rack := n / topo.nodesPerRack
+					block := rack / topo.racksPerBlock
+					values := []string{fmt.Sprintf("block-%d", block), fmt.Sprintf("rack-%d", rack)}
+					if len(scheme.levels) == 3 {
+						values = append(values, fmt.Sprintf("node-%d", n))
+					}
+					fc.addUsage(log, workload.Reference(fmt.Sprintf("wl-%d", i)), []workload.TopologyDomainRequests{{
+						Values:            values,
+						SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+						Count:             1,
+					}})
+				}
+				if _, err := fc.snapshot(b.Context(), log, newDefaultSimulatorSnapshot(), nil); err != nil {
+					b.Fatalf("initial TASFlavorSnapshot creation failed: %v", err)
+				}
+				for b.Loop() {
+					if _, err := fc.snapshot(b.Context(), log, newDefaultSimulatorSnapshot(), nil); err != nil {
+						b.Fatalf("TASFlavorSnapshot creation failed: %v", err)
+					}
+				}
+			})
+		}
+	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -188,12 +188,14 @@ func TestIsTopologyAssignmentStale(t *testing.T) {
 		"existing hostname leaf is not stale": {
 			tree: hostnameLowest,
 			assignment: &tas.TopologyAssignment{
+				Levels:  []string{corev1.LabelHostname},
 				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n1"}}},
 			},
 		},
 		"missing hostname leaf is stale": {
 			tree: hostnameLowest,
 			assignment: &tas.TopologyAssignment{
+				Levels:  []string{corev1.LabelHostname},
 				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n2"}}},
 			},
 			wantStale:       true,
@@ -202,6 +204,7 @@ func TestIsTopologyAssignmentStale(t *testing.T) {
 		"deleted node is stale even when its hostname matches an existing root domain ID": {
 			tree: hostnameLowest,
 			assignment: &tas.TopologyAssignment{
+				Levels:  []string{corev1.LabelHostname},
 				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1"}}},
 			},
 			wantStale:       true,
@@ -210,12 +213,14 @@ func TestIsTopologyAssignmentStale(t *testing.T) {
 		"existing non-hostname leaf is not stale": {
 			tree: rackLowest,
 			assignment: &tas.TopologyAssignment{
+				Levels:  []string{blockLabel, rackLabel},
 				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r1"}}},
 			},
 		},
 		"missing non-hostname leaf is stale": {
 			tree: rackLowest,
 			assignment: &tas.TopologyAssignment{
+				Levels:  []string{blockLabel, rackLabel},
 				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r2"}}},
 			},
 			wantStale:       true,
@@ -1504,7 +1509,54 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 	}
 }
 
-// newObservedLogger returns a logger that discards output and an observer of its entries.
+func TestFitsNonHostnameLowestLevel(t *testing.T) {
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU: resource.MustParse("8"),
+		}).
+		Ready()
+
+	cases := map[string]struct {
+		count int32
+		want  bool
+	}{
+		"pods fit across the rack's nodes": {
+			count: 2,
+			want:  true,
+		},
+		// The rack aggregates 16 CPU, but each node fits only one 5-CPU pod.
+		"pods fit in the rack's aggregate but not per node": {
+			count: 3,
+			want:  false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, log := utiltesting.ContextWithLog(t)
+			nodes := []*corev1.Node{rackNode.Clone().Name("n1").Obj(), rackNode.Clone().Name("n2").Obj()}
+			tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+			flavorUsage := workload.TASFlavorUsage{{
+				Values: []string{"b1", "r1"},
+				SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+					corev1.ResourceCPU: 5000,
+				}),
+				Count: tc.count,
+			}}
+			if got := snapshot.Fits(flavorUsage); got != tc.want {
+				t.Errorf("Fits() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs) {
 	logsObserver, observedLogs := observer.New(level)
 	logger := crzap.New(

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"testing"
 
@@ -151,6 +152,60 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+// Usage recorded against a domain the snapshot does not hold is skipped rather
+// than panicking. This happens when the backing node was deleted or stopped
+// being Ready between the Workload being admitted and the snapshot being taken.
+func TestApplyTASUsageSkipsDomainTheSnapshotDoesNotHold(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const rackLabel = "cloud.provider.com/topology-rack"
+	_, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("n1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).
+		Ready().
+		Obj()
+	tree := newTopologyTree([]string{rackLabel}, []*corev1.Node{rackNode}, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	snapshot.updateTASUsage(tas.DomainID([]string{"gone"}), oneCPU, add, 1)
+
+	if got := len(snapshot.domainTASUsage); got != 0 {
+		t.Errorf("usage recorded for %d domains, want none", got)
+	}
+}
+
+// A virtual topology keeps usage on the domains rather than the leaves, so the
+// dump must report those domains or it reads as if nothing is used.
+func TestFreeCapacityPerDomainReportsUsageDomains(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const rackLabel = "cloud.provider.com/topology-rack"
+	_, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}).
+		Ready()
+	tree := newTopologyTree([]string{rackLabel}, []*corev1.Node{
+		rackNode.Clone().Name("n1").Obj(),
+		rackNode.Clone().Name("n2").Obj(),
+	}, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot(),
+		withResourceFormatter(resources.NewResourceFormatter()))
+	snapshot.updateTASUsage(tas.DomainID([]string{"r1"}),
+		resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}), add, 1)
+
+	got, err := snapshot.SerializeFreeCapacityPerDomain()
+	if err != nil {
+		t.Fatalf("SerializeFreeCapacityPerDomain() error = %v", err)
+	}
+	want := `"r1":{"freeCapacity":{"cpu":"4"},"tasUsage":{"cpu":"1","pods":"1"}}`
+	if !strings.Contains(got, want) {
+		t.Errorf("SerializeFreeCapacityPerDomain() = %s, want it to contain %s", got, want)
 	}
 }
 
@@ -1112,19 +1167,19 @@ func TestCompareDomainLevelValues(t *testing.T) {
 		b      *domain
 		want   int
 	}{
-		"isLowestLevelNode with same-parent sibling domains: ascending by hostname": {
+		"leafIsNode with same-parent sibling domains: ascending by hostname": {
 			levels: hostnameLevels,
 			a:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
 			b:      &domain{id: "node-b", parent: parent1, levelValues: []string{"b1", "r1", "node-b"}},
 			want:   -1,
 		},
-		"isLowestLevelNode with same-parent sibling domains: descending by hostname": {
+		"leafIsNode with same-parent sibling domains: descending by hostname": {
 			levels: hostnameLevels,
 			a:      &domain{id: "node-b", parent: parent1, levelValues: []string{"b1", "r1", "node-b"}},
 			b:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
 			want:   1,
 		},
-		"isLowestLevelNode with same-parent sibling domains: equal hostname": {
+		"leafIsNode with same-parent sibling domains: equal hostname": {
 			levels: hostnameLevels,
 			a:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
 			b:      &domain{id: "node-a", parent: parent1, levelValues: []string{"b1", "r1", "node-a"}},
@@ -1510,6 +1565,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 }
 
 func TestFitsNonHostnameLowestLevel(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
 	const blockLabel = "cloud.provider.com/topology-block"
 	const rackLabel = "cloud.provider.com/topology-rack"
 
@@ -1557,10 +1613,103 @@ func TestFitsNonHostnameLowestLevel(t *testing.T) {
 	}
 }
 
-// Usage domain IDs reference the user-lowest level while the hostname level
-// is virtual; a node whose name equals a domain ID must not capture the
+// Usage recorded against a domain that spans several nodes bounds the domain,
+// not its nodes: which node inside the domain holds a Pod is decided by
+// kube-scheduler after ungating and is never reported back. Charging a share
+// of it to every node instead makes the nodes look full and rejects Workloads
+// the domain has room for.
+func TestFindAssignmentsWithDomainRecordedUsage(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	rack := rackLabel
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+
+	// A rack of two nodes, one CPU each.
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).
+		Ready()
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("n1").Label(corev1.LabelHostname, "n1").Obj(),
+		rackNode.Clone().Name("n2").Label(corev1.LabelHostname, "n2").Obj(),
+	}
+
+	podSet := func(name kueue.PodSetReference) TASPodSetRequests {
+		return TASPodSetRequests{
+			PodSet: &kueue.PodSet{
+				Name:            name,
+				TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: &rack},
+			},
+			SinglePodRequests: oneCPU,
+			Count:             1,
+		}
+	}
+
+	// A PodSet pinned to one node by its nodeSelector.
+	podSetOn := func(name kueue.PodSetReference, nodeName string) TASPodSetRequests {
+		tr := podSet(name)
+		tr.PodSet.Template.Spec.NodeSelector = map[string]string{corev1.LabelHostname: nodeName}
+		return tr
+	}
+
+	cases := map[string]struct {
+		priorRackUsage int32
+		requests       FlavorTASRequests
+		wantFit        bool
+	}{
+		// Both PodSets can only run on n1, which holds one of them. The rack
+		// has room for both, so only per-node in-cycle usage rejects this.
+		"two PodSets pinned to the same node do not both fit on it": {
+			requests: FlavorTASRequests{podSetOn("ps-a", "n1"), podSetOn("ps-b", "n1")},
+			wantFit:  false,
+		},
+		"two PodSets pinned to different nodes fit": {
+			requests: FlavorTASRequests{podSetOn("ps-a", "n1"), podSetOn("ps-b", "n2")},
+			wantFit:  true,
+		},
+		"two PodSets of one Pod each land on a node of their own": {
+			requests: FlavorTASRequests{podSet("ps-a"), podSet("ps-b")},
+			wantFit:  true,
+		},
+		"a Pod fits next to a Workload already admitted on the rack": {
+			priorRackUsage: 1,
+			requests:       FlavorTASRequests{podSet("ps-b")},
+			wantFit:        true,
+		},
+		"no Pod fits once the rack's capacity is fully used": {
+			priorRackUsage: 2,
+			requests:       FlavorTASRequests{podSet("ps-b")},
+			wantFit:        false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+			if tc.priorRackUsage > 0 {
+				snapshot.updateTASUsage(tas.DomainID([]string{"b1", "r1"}),
+					oneCPU.ScaledUp(int64(tc.priorRackUsage)), add, tc.priorRackUsage)
+			}
+			gotFit := snapshot.FindTopologyAssignmentsForFlavor(ctx, tc.requests).Failure() == nil
+			if gotFit != tc.wantFit {
+				t.Errorf("FindTopologyAssignmentsForFlavor() fit = %t, want %t", gotFit, tc.wantFit)
+			}
+		})
+	}
+}
+
+// Usage domain IDs name the explicit-lowest level while the hostname level is
+// virtual, so a node whose name equals a domain ID must not capture that
 // domain's usage.
-func TestLeavesForUsageDomainIgnoresNameCollision(t *testing.T) {
+func TestUsageDomainIgnoresNodeNameCollision(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
 	const rackLabel = "cloud.provider.com/topology-rack"
 	_, log := utiltesting.ContextWithLog(t)
 
@@ -1574,13 +1723,13 @@ func TestLeavesForUsageDomainIgnoresNameCollision(t *testing.T) {
 
 	tree := newTopologyTree([]string{rackLabel}, []*corev1.Node{nodeA, nodeB, nodeNamedR1}, 0)
 	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
-	leaves := snapshot.leavesForUsageDomain("r1")
+	leaves := slices.Collect(snapshot.leavesOf(snapshot.usageDomain("r1")))
 	if len(leaves) != 2 {
-		t.Fatalf("leavesForUsageDomain(\"r1\") = %d leaves, want rack r1's 2 leaves", len(leaves))
+		t.Fatalf("usageDomain(\"r1\") holds %d leaves, want rack r1's 2 leaves", len(leaves))
 	}
 	for _, leaf := range leaves {
 		if leaf.node.Name == "r1" {
-			t.Error("leavesForUsageDomain(\"r1\") returned the node named \"r1\" instead of the rack's leaves")
+			t.Error("usageDomain(\"r1\") resolved to the node named \"r1\" instead of the rack")
 		}
 	}
 
@@ -1588,18 +1737,16 @@ func TestLeavesForUsageDomainIgnoresNameCollision(t *testing.T) {
 	// the leaves themselves and the leaf lookup must keep working.
 	declaredTree := newTopologyTree([]string{rackLabel, corev1.LabelHostname}, []*corev1.Node{nodeA, nodeB}, 0)
 	declaredSnapshot := newTASFlavorSnapshot(log, "tas-topology", declaredTree, nil, newDefaultSimulatorSnapshot())
-	declaredLeaves := declaredSnapshot.leavesForUsageDomain("node-a")
+	declaredLeaves := slices.Collect(declaredSnapshot.leavesOf(declaredSnapshot.usageDomain("node-a")))
 	if len(declaredLeaves) != 1 || declaredLeaves[0].node.Name != "node-a" {
-		t.Errorf("leavesForUsageDomain(\"node-a\") = %d leaves, want the node-a leaf", len(declaredLeaves))
+		t.Errorf("usageDomain(\"node-a\") holds %d leaves, want the node-a leaf", len(declaredLeaves))
 	}
 }
 
-// Removing one Workload's usage must not erase the usage of Workloads that
-// remain admitted. This holds only when the snapshot records usage per
-// Workload: rounded-up per-leaf shares are not additive, so an
-// aggregate-initialized snapshot loses the survivor's usage on removal and
-// Fits overreports free capacity.
+// Simulated removal of one Workload's usage must not erase the usage of the
+// Workloads that remain admitted, or preemption would free capacity twice.
 func TestFitsAfterPerWorkloadRemoval(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
 	const blockLabel = "cloud.provider.com/topology-block"
 	const rackLabel = "cloud.provider.com/topology-rack"
 	dev := corev1.ResourceName("example.com/device")

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1557,6 +1557,110 @@ func TestFitsNonHostnameLowestLevel(t *testing.T) {
 	}
 }
 
+// Usage domain IDs reference the user-lowest level while the hostname level
+// is virtual; a node whose name equals a domain ID must not capture the
+// domain's usage.
+func TestLeavesForUsageDomainIgnoresNameCollision(t *testing.T) {
+	const rackLabel = "cloud.provider.com/topology-rack"
+	_, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}).
+		Ready()
+	nodeA := rackNode.Clone().Name("node-a").Label(corev1.LabelHostname, "node-a").Label(rackLabel, "r1").Obj()
+	nodeB := rackNode.Clone().Name("node-b").Label(corev1.LabelHostname, "node-b").Label(rackLabel, "r1").Obj()
+	// A third node is named like rack r1 itself, but lives in rack r2.
+	nodeNamedR1 := rackNode.Clone().Name("r1").Label(corev1.LabelHostname, "r1").Label(rackLabel, "r2").Obj()
+
+	tree := newTopologyTree([]string{rackLabel}, []*corev1.Node{nodeA, nodeB, nodeNamedR1}, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+	leaves := snapshot.leavesForUsageDomain("r1")
+	if len(leaves) != 2 {
+		t.Fatalf("leavesForUsageDomain(\"r1\") = %d leaves, want rack r1's 2 leaves", len(leaves))
+	}
+	for _, leaf := range leaves {
+		if leaf.node.Name == "r1" {
+			t.Error("leavesForUsageDomain(\"r1\") returned the node named \"r1\" instead of the rack's leaves")
+		}
+	}
+
+	// Control: with hostname declared as the lowest level, usage domains are
+	// the leaves themselves and the leaf lookup must keep working.
+	declaredTree := newTopologyTree([]string{rackLabel, corev1.LabelHostname}, []*corev1.Node{nodeA, nodeB}, 0)
+	declaredSnapshot := newTASFlavorSnapshot(log, "tas-topology", declaredTree, nil, newDefaultSimulatorSnapshot())
+	declaredLeaves := declaredSnapshot.leavesForUsageDomain("node-a")
+	if len(declaredLeaves) != 1 || declaredLeaves[0].node.Name != "node-a" {
+		t.Errorf("leavesForUsageDomain(\"node-a\") = %d leaves, want the node-a leaf", len(declaredLeaves))
+	}
+}
+
+// Removing one Workload's usage must not erase the usage of Workloads that
+// remain admitted. This holds only when the snapshot records usage per
+// Workload: rounded-up per-leaf shares are not additive, so an
+// aggregate-initialized snapshot loses the survivor's usage on removal and
+// Fits overreports free capacity.
+func TestFitsAfterPerWorkloadRemoval(t *testing.T) {
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	dev := corev1.ResourceName("example.com/device")
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	tasCache := NewTASCache(nil, newDefaultSimulator(), resources.NewResourceFormatter())
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{dev: resource.MustParse("1")}).
+		Ready()
+	for _, name := range []string{"n1", "n2"} {
+		tasCache.SyncNode(rackNode.Clone().Name(name).Label(corev1.LabelHostname, name).Obj())
+	}
+	fc := tasCache.NewTASFlavorCache(
+		topologyInformation{Levels: []string{blockLabel, rackLabel}},
+		flavorInformation{TopologyName: "default"},
+	)
+	singleDevice := []workload.TopologyDomainRequests{{
+		Values: []string{"b1", "r1"},
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			dev: 1,
+		}),
+		Count: 1,
+	}}
+	bothDevices := workload.TASFlavorUsage{{
+		Values: []string{"b1", "r1"},
+		SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			dev: 1,
+		}),
+		Count: 2,
+	}}
+
+	// Control: with no usage recorded, both devices are free.
+	empty, err := fc.snapshot(ctx, log, newDefaultSimulatorSnapshot(), nil)
+	if err != nil {
+		t.Fatalf("snapshot() error = %v", err)
+	}
+	if got := empty.Fits(bothDevices); !got {
+		t.Errorf("Fits() with no usage = %t, want true", got)
+	}
+
+	fc.addUsage(log, "wl1", singleDevice)
+	fc.addUsage(log, "wl2", singleDevice)
+	snapshot, err := fc.snapshot(ctx, log, newDefaultSimulatorSnapshot(), nil)
+	if err != nil {
+		t.Fatalf("snapshot() error = %v", err)
+	}
+	if got := snapshot.Fits(bothDevices); got {
+		t.Errorf("Fits() with both devices used = %t, want false", got)
+	}
+
+	// Preemption simulation removes one Workload; the other still holds a device.
+	for _, tr := range singleDevice {
+		snapshot.updateTASUsage(tas.DomainID(tr.Values), tr.TotalRequests(), subtract, tr.Count)
+	}
+	if got := snapshot.Fits(bothDevices); got {
+		t.Errorf("Fits() after removing one Workload = %t, want false", got)
+	}
+}
+
 func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs) {
 	logsObserver, observedLogs := observer.New(level)
 	logger := crzap.New(

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1767,6 +1767,175 @@ func TestAssumedUsageRecordsIntoTheSharedDomainMap(t *testing.T) {
 	}
 }
 
+// Preemption simulation treats usage it could reclaim as absent, but the
+// placements made earlier in this cycle belong to the Workload being assigned,
+// so no preemption can free them and they stay subtracted.
+func TestSimulateEmptyKeepsInCycleUsage(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	rack := rackLabel
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).Ready()
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("n1").Obj(),
+		rackNode.Clone().Name("n2").Obj(),
+	}
+
+	tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	// An elastic Workload already placed both of the rack's CPUs in this cycle.
+	assumedUsage := newAssumedUsage(map[tas.TopologyDomainID]resources.Requests{
+		tas.DomainID([]string{"b1", "r1"}): resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU:  2000,
+			corev1.ResourcePods: 2,
+		}),
+	})
+	tasRequests := TASPodSetRequests{
+		PodSet: &kueue.PodSet{
+			Name:            "ps",
+			TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: &rack},
+		},
+		SinglePodRequests: oneCPU,
+		Count:             1,
+	}
+
+	_, _, reason := snapshot.findTopologyAssignment(ctx, tasRequests, nil, assumedUsage, true, "", nil)
+	if reason == "" {
+		t.Error("findTopologyAssignment() reported a fit while simulating an empty flavor, want none: the rack's two CPUs went to Pods of this same Workload")
+	}
+}
+
+// Preferred node affinity is scored only where node feasibility is evaluated, so
+// on a Topology whose lowest level is not the hostname it was never scored at
+// all. The injected level makes every leaf a node, so the scores are computed
+// and roll up to the domain the assignment names.
+func TestPreferredNodeAffinityIsRespectedWithInjectedHostnameLevel(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, true)
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	const perfLabel = "example.com/perf"
+	rack := rackLabel
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).Ready()
+	// Both racks hold two nodes of one CPU, so only the preference separates them.
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("n1").Label(rackLabel, "r1").Obj(),
+		rackNode.Clone().Name("n2").Label(rackLabel, "r1").Obj(),
+		rackNode.Clone().Name("n3").Label(rackLabel, "r2").Label(perfLabel, "fast").Obj(),
+		rackNode.Clone().Name("n4").Label(rackLabel, "r2").Label(perfLabel, "fast").Obj(),
+	}
+
+	tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	podSet := &kueue.PodSet{
+		Name:            "ps",
+		TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: &rack},
+	}
+	podSet.Template.Spec.Affinity = &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{
+				Weight: 100,
+				Preference: corev1.NodeSelectorTerm{
+					MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key:      perfLabel,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{"fast"},
+					}},
+				},
+			}},
+		},
+	}
+	tasRequests := TASPodSetRequests{
+		PodSet: podSet,
+		SinglePodRequests: resources.NewRequestsFromMap(
+			map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+		Count: 2,
+	}
+
+	assignments, _, reason := snapshot.findTopologyAssignment(ctx, tasRequests, nil, newAssumedUsage(nil), false, "", nil)
+	if reason != "" {
+		t.Fatalf("findTopologyAssignment() = %q, want the Pods to fit in the preferred rack", reason)
+	}
+	perRack := map[string]int32{}
+	for _, domain := range assignments["ps"].Domains {
+		perRack[domain.Values[len(domain.Values)-1]] += domain.Count
+	}
+	if perRack["r2"] != 2 {
+		t.Errorf("findTopologyAssignment() placed r1=%d r2=%d, want both Pods on rack r2, whose nodes match the preference",
+			perRack["r1"], perRack["r2"])
+	}
+}
+
+// The injected hostname level sits below the level slices are counted at, so its
+// leaves carry no slice count. Balanced placement must not read that as a domain
+// worth pruning, or it clears every leaf and silently stops balancing.
+func TestBalancedPlacementWithInjectedHostnameLevel(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	features.SetFeatureGateDuringTest(t, features.TASBalancedPlacement, true)
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	rack := rackLabel
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("2"),
+			corev1.ResourcePods: resource.MustParse("20"),
+		}).Ready()
+	// Two racks of two nodes, four CPUs each.
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("n1").Label(rackLabel, "r1").Obj(),
+		rackNode.Clone().Name("n2").Label(rackLabel, "r1").Obj(),
+		rackNode.Clone().Name("n3").Label(rackLabel, "r2").Obj(),
+		rackNode.Clone().Name("n4").Label(rackLabel, "r2").Obj(),
+	}
+
+	tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	tasRequests := TASPodSetRequests{
+		PodSet: &kueue.PodSet{
+			Name:            "ps",
+			TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: &rack},
+		},
+		SinglePodRequests: oneCPU,
+		Count:             6,
+	}
+
+	assignments, _, reason := snapshot.findTopologyAssignment(ctx, tasRequests, nil, newAssumedUsage(nil), false, "", nil)
+	if reason != "" {
+		t.Fatalf("findTopologyAssignment() = %q, want the six Pods to fit across both racks", reason)
+	}
+	perRack := map[string]int32{}
+	for _, domain := range assignments["ps"].Domains {
+		perRack[domain.Values[len(domain.Values)-1]] += domain.Count
+	}
+	// Eight CPUs over two equal racks, so a balanced placement is three each.
+	if perRack["r1"] != 3 || perRack["r2"] != 3 {
+		t.Errorf("findTopologyAssignment() placed r1=%d r2=%d, want 3 and 3", perRack["r1"], perRack["r2"])
+	}
+}
+
 // A TopologyAssignment recovered from a Workload is keyed by the domain it
 // names, so it must not be charged to a leaf which is a node of the same name.
 // Only a Topology of a single level can collide: below that, domain IDs join

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1385,8 +1385,9 @@ func TestAddAssumedUsage(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			addAssumedUsage(tc.assumedUsage, tc.assignment, tc.tasRequests)
-			if diff := cmp.Diff(tc.want, tc.assumedUsage, cmp.Comparer(resources.Equal)); diff != "" {
+			assumedUsage := newAssumedUsage(tc.assumedUsage)
+			addAssumedUsage(assumedUsage, tc.assignment, tc.tasRequests)
+			if diff := cmp.Diff(tc.want, assumedUsage.perDomain, cmp.Comparer(resources.Equal)); diff != "" {
 				t.Errorf("addAssumedUsage() mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -1740,6 +1741,221 @@ func TestUsageDomainIgnoresNodeNameCollision(t *testing.T) {
 	declaredLeaves := slices.Collect(declaredSnapshot.leavesOf(declaredSnapshot.usageDomain("node-a")))
 	if len(declaredLeaves) != 1 || declaredLeaves[0].node.Name != "node-a" {
 		t.Errorf("usageDomain(\"node-a\") holds %d leaves, want the node-a leaf", len(declaredLeaves))
+	}
+}
+
+// The domain-keyed side has to stay the map the sibling flavors were given, or
+// they stop seeing each other's placements. The leaf-keyed side must not, since
+// node names do not identify the same capacity across flavors.
+func TestAssumedUsageRecordsIntoTheSharedDomainMap(t *testing.T) {
+	shared := map[tas.TopologyDomainID]resources.Requests{}
+	assumedUsage := newAssumedUsage(shared)
+
+	assumedUsage.perDomain["r1"] = resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	assumedUsage.recordLeafUsage(map[tas.TopologyDomainID]resources.Requests{
+		"n1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000}),
+	})
+
+	want := map[tas.TopologyDomainID]resources.Requests{
+		"r1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+	}
+	if diff := cmp.Diff(want, shared, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("shared cross-flavor usage mismatch (-want +got):\n%s", diff)
+	}
+	if newAssumedUsage(nil).perDomain == nil {
+		t.Error("newAssumedUsage(nil) left perDomain nil, recording domain usage would panic")
+	}
+}
+
+// A TopologyAssignment recovered from a Workload is keyed by the domain it
+// names, so it must not be charged to a leaf which is a node of the same name.
+// Only a Topology of a single level can collide: below that, domain IDs join
+// their level values with a separator no node name can hold.
+func TestAssumedDomainUsageIsNotChargedToNodeOfTheSameName(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const rackLabel = "cloud.provider.com/topology-rack"
+	rack := rackLabel
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).Ready()
+	// The node named "r1" is in rack r2, so rack r1's usage is not its own.
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("r1").Label(rackLabel, "r2").Obj(),
+		rackNode.Clone().Name("n1").Label(rackLabel, "r1").Obj(),
+	}
+
+	tree := newTopologyTree([]string{rackLabel}, nodes, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	// What an elastic Workload's previous assignment on rack r1 records.
+	assumedUsage := newAssumedUsage(map[tas.TopologyDomainID]resources.Requests{
+		"r1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+			corev1.ResourceCPU:  1000,
+			corev1.ResourcePods: 1,
+		}),
+	})
+	tasRequests := TASPodSetRequests{
+		PodSet: &kueue.PodSet{
+			Name:            "ps",
+			TopologyRequest: &kueue.PodSetTopologyRequest{Preferred: &rack},
+		},
+		SinglePodRequests: oneCPU,
+		Count:             1,
+	}
+
+	if _, _, reason := snapshot.findTopologyAssignment(ctx, tasRequests, nil, assumedUsage, false, "", nil); reason != "" {
+		t.Errorf("findTopologyAssignment() = %q, want the Pod to fit on the node named r1, which is in rack r2", reason)
+	}
+}
+
+// Two PodSets placed in one cycle both draw on the same usage domain. Recording
+// the placement against the leaf alone leaves the domain's own bound blind to
+// it, and recording it against the domain alone loses which node went, so both
+// have to be kept: neither implies the other.
+func TestTwoPodSetsShareTheDomainBudget(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+	block := blockLabel
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	rackNode := node.MakeNode("").
+		Label(blockLabel, "b1").
+		Label(rackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{
+			corev1.ResourceCPU:  resource.MustParse("1"),
+			corev1.ResourcePods: resource.MustParse("10"),
+		}).Ready()
+	nodes := []*corev1.Node{
+		rackNode.Clone().Name("n1").Obj(),
+		rackNode.Clone().Name("n2").Obj(),
+	}
+
+	tree := newTopologyTree([]string{blockLabel, rackLabel}, nodes, 0)
+	snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	// An admitted Workload holds one of the rack's two CPUs, and no node carries
+	// that usage.
+	snapshot.updateTASUsage(tas.DomainID([]string{"b1", "r1"}), oneCPU, add, 1)
+
+	podSet := func(name string) TASPodSetRequests {
+		groupName := name
+		return TASPodSetRequests{
+			PodSet: &kueue.PodSet{
+				Name: kueue.PodSetReference(name),
+				TopologyRequest: &kueue.PodSetTopologyRequest{
+					Required:        &block,
+					PodSetGroupName: &groupName,
+				},
+			},
+			SinglePodRequests: oneCPU,
+			Count:             1,
+			PodSetGroupName:   &groupName,
+		}
+	}
+
+	// Two PodSets of one Pod each need two CPUs, one more than the rack keeps.
+	result := snapshot.FindTopologyAssignmentsForFlavor(ctx, FlavorTASRequests{podSet("ps-a"), podSet("ps-b")})
+	if result.Failure() == nil {
+		var total int32
+		for _, podSetResult := range result {
+			for _, domain := range podSetResult.TopologyAssignment.Domains {
+				total += domain.Count
+			}
+		}
+		t.Errorf("FindTopologyAssignmentsForFlavor() admitted %d Pods, want no admission as rack r1 keeps one CPU", total)
+	}
+}
+
+// A usage domain has to be judged against its own remaining capacity for the
+// workers, for the leader, and for the two together. Its nodes carry none of
+// the usage recorded on it, so they always look emptier than the domain is.
+func TestLeaderIsNotPlacedInUsedUpDomain(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	const rackLabel = "cloud.provider.com/topology-rack"
+	unconstrained := true
+	oneCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000})
+	twoCPU := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000})
+
+	cases := map[string]struct {
+		rackUsage      int32
+		leaderRequests resources.Requests
+		workerCount    int32
+	}{
+		// The rack is spent, so neither PodSet may land in it even though its
+		// node reports five free CPUs.
+		"a spent rack takes no Pod of either PodSet": {
+			rackUsage:      5,
+			leaderRequests: oneCPU,
+			workerCount:    1,
+		},
+		// The rack keeps one CPU: room for a worker, not for the leader.
+		"a rack that fits a worker but not the leader takes no leader": {
+			rackUsage:      4,
+			leaderRequests: twoCPU,
+			workerCount:    1,
+		},
+		// The rack fits the leader, but then has nothing left beside it.
+		"a rack that fits only the leader takes no worker beside it": {
+			rackUsage:      3,
+			leaderRequests: twoCPU,
+			workerCount:    2,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			rackNode := node.MakeNode("").
+				StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:  resource.MustParse("5"),
+					corev1.ResourcePods: resource.MustParse("10"),
+				}).Ready()
+			nodes := []*corev1.Node{
+				rackNode.Clone().Name("n1").Label(rackLabel, "r1").Obj(),
+				rackNode.Clone().Name("n2").Label(rackLabel, "r2").Obj(),
+			}
+			tree := newTopologyTree([]string{rackLabel}, nodes, 0)
+			snapshot := newTASFlavorSnapshot(log, "tas-topology", tree, nil, newDefaultSimulatorSnapshot())
+			snapshot.updateTASUsage("r1", oneCPU.ScaledUp(int64(tc.rackUsage)), add, tc.rackUsage)
+
+			podSet := func(name kueue.PodSetReference, singlePodRequests resources.Requests, count int32) TASPodSetRequests {
+				return TASPodSetRequests{
+					PodSet: &kueue.PodSet{
+						Name:            name,
+						TopologyRequest: &kueue.PodSetTopologyRequest{Unconstrained: &unconstrained},
+					},
+					SinglePodRequests: singlePodRequests,
+					Count:             count,
+				}
+			}
+			workers := podSet("workers", oneCPU, tc.workerCount)
+			leader := podSet("leader", tc.leaderRequests, 1)
+
+			assignments, _, reason := snapshot.findTopologyAssignment(ctx, workers, &leader, newAssumedUsage(nil), false, "", nil)
+			if reason != "" {
+				t.Fatalf("findTopologyAssignment() = %q, want the Pods to fit in rack r2", reason)
+			}
+			// Rack r1 keeps 5 CPUs minus what the admitted Workload took.
+			wantFree := 5 - tc.rackUsage
+			var gotCPU int32
+			for _, tr := range []TASPodSetRequests{workers, leader} {
+				for _, domain := range assignments[tr.PodSet.Name].Domains {
+					if domain.Values[0] == "r1" {
+						gotCPU += domain.Count * int32(tr.SinglePodRequests.ResourceValue(corev1.ResourceCPU)/1000)
+					}
+				}
+			}
+			if gotCPU > wantFree {
+				t.Errorf("findTopologyAssignment() gave rack r1 %d CPU(s), want at most %d", gotCPU, wantFree)
+			}
+		})
 	}
 }
 

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -21,6 +21,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
@@ -96,10 +97,11 @@ type topologyTree struct {
 	// domainsPerLevel stores the static tree information
 	domainsPerLevel []domainByID
 
-	// virtualHostname is true when kubernetes.io/hostname was not part of
-	// the user-specified topology levels and was injected as the lowest
-	// level so that every leaf represents exactly one node. The injected
-	// level is excluded from topologyAssignment serialization.
+	// virtualHostname is true when kubernetes.io/hostname was appended to the
+	// levels because the Topology did not declare it, which happens only with
+	// the TASNodeFeasibilityForAllLevels feature gate enabled. Every leaf is
+	// then exactly one node, and the appended level is excluded from
+	// topologyAssignment serialization.
 	virtualHostname bool
 
 	// nodes lists the nodes matching the flavor which the tree was built
@@ -114,7 +116,11 @@ type topologyTree struct {
 // newTopologyTree builds the static topology structure from the given node
 // set, read at the given nodesCache generation.
 func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *topologyTree {
-	virtual := len(levels) == 0 || levels[len(levels)-1] != corev1.LabelHostname
+	// Injecting the hostname level makes every leaf exactly one node, so
+	// capacity and feasibility are evaluated per node instead of per declared
+	// domain. Without the gate the lowest declared level stays the leaf.
+	virtual := features.Enabled(features.TASNodeFeasibilityForAllLevels) &&
+		(len(levels) == 0 || levels[len(levels)-1] != corev1.LabelHostname)
 	if virtual {
 		levels = append(slices.Clone(levels), corev1.LabelHostname)
 	}
@@ -142,32 +148,52 @@ func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *t
 }
 
 func (t *topologyTree) addNode(node *corev1.Node) utiltas.TopologyDomainID {
-	// The injected hostname level is internal, so key it by node name, which
-	// is unique; declared hostname levels keep the label, the user's contract.
-	hostname := node.Name
-	if !t.virtualHostname {
-		if label := node.Labels[corev1.LabelHostname]; label != "" {
-			hostname = label
-		}
+	levelValues := utiltas.LevelValues(t.levelKeys, node.Labels)
+	var domainID utiltas.TopologyDomainID
+	switch {
+	case t.virtualHostname:
+		// The injected level is internal, so key it by node name, which is
+		// unique. Hostname labels are neither unique nor immutable, and two
+		// nodes sharing one must not merge into a leaf with pooled capacity.
+		levelValues[len(levelValues)-1] = node.Name
+		domainID = utiltas.TopologyDomainID(node.Name)
+	case t.leafIsNode():
+		// A declared hostname level keeps the label, the user's contract.
+		domainID = utiltas.TopologyDomainID(node.Labels[corev1.LabelHostname])
+	default:
+		domainID = utiltas.DomainID(levelValues)
 	}
-	domainID := utiltas.TopologyDomainID(hostname)
 	if _, leafFound := t.leaves[domainID]; !leafFound {
-		levelValues := utiltas.LevelValues(t.levelKeys, node.Labels)
-		levelValues[len(levelValues)-1] = hostname
-		t.leaves[domainID] = &leafDomain{
+		leaf := &leafDomain{
 			domain:  domain{id: domainID, levelValues: levelValues},
 			leafIdx: len(t.leaves),
-			node:    node,
 		}
+		if t.leafIsNode() {
+			leaf.node = node
+		}
+		t.leaves[domainID] = leaf
 	}
 	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
 	t.addCapacity(domainID, capacity)
 	return domainID
 }
 
-// userLowestLevel returns the lowest level specified in the Topology CR,
-// excluding the injected virtual hostname level.
-func (t *topologyTree) userLowestLevel() string {
+// leafIsNode reports whether every leaf of the tree is exactly one node. That
+// holds when the Topology declares kubernetes.io/hostname as its lowest level,
+// and when the level was injected.
+func (t *topologyTree) leafIsNode() bool {
+	return len(t.levelKeys) > 0 && t.levelKeys[len(t.levelKeys)-1] == corev1.LabelHostname
+}
+
+// declaresHostnameLevel reports whether the Topology itself names the hostname
+// level, as opposed to one having been injected.
+func (t *topologyTree) declaresHostnameLevel() bool {
+	return t.leafIsNode() && !t.virtualHostname
+}
+
+// explicitLowestLevel returns the lowest level the Topology CR declares,
+// excluding the hostname level when that was injected.
+func (t *topologyTree) explicitLowestLevel() string {
 	if t.virtualHostname {
 		return t.levelKeys[len(t.levelKeys)-2]
 	}

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -96,8 +96,11 @@ type topologyTree struct {
 	// domainsPerLevel stores the static tree information
 	domainsPerLevel []domainByID
 
-	// isLowestLevelNode indicates if kubernetes.io/hostname is the lowest topology level
-	isLowestLevelNode bool
+	// virtualHostname is true when kubernetes.io/hostname was not part of
+	// the user-specified topology levels and was injected as the lowest
+	// level so that every leaf represents exactly one node. The injected
+	// level is excluded from topologyAssignment serialization.
+	virtualHostname bool
 
 	// nodes lists the nodes matching the flavor which the tree was built
 	// from.
@@ -111,20 +114,25 @@ type topologyTree struct {
 // newTopologyTree builds the static topology structure from the given node
 // set, read at the given nodesCache generation.
 func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *topologyTree {
+	virtual := len(levels) == 0 || levels[len(levels)-1] != corev1.LabelHostname
+	if virtual {
+		levels = append(slices.Clone(levels), corev1.LabelHostname)
+	}
+
 	domainsPerLevel := make([]domainByID, len(levels))
 	for level := range levels {
 		domainsPerLevel[level] = make(domainByID)
 	}
 
 	tree := &topologyTree{
-		generation:        generation,
-		levelKeys:         slices.Clone(levels),
-		leaves:            make(leafDomainByID),
-		roots:             make(domainByID),
-		domainsPerLevel:   domainsPerLevel,
-		isLowestLevelNode: len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
-		nodes:             slices.Clip(slices.Clone(nodes)),
-		nodeToDomain:      make(map[string]utiltas.TopologyDomainID, len(nodes)),
+		generation:      generation,
+		levelKeys:       slices.Clone(levels),
+		leaves:          make(leafDomainByID),
+		roots:           make(domainByID),
+		domainsPerLevel: domainsPerLevel,
+		virtualHostname: virtual,
+		nodes:           slices.Clip(slices.Clone(nodes)),
+		nodeToDomain:    make(map[string]utiltas.TopologyDomainID, len(nodes)),
 	}
 	for _, node := range nodes {
 		tree.nodeToDomain[node.Name] = tree.addNode(node)
@@ -134,42 +142,35 @@ func newTopologyTree(levels []string, nodes []*corev1.Node, generation int64) *t
 }
 
 func (t *topologyTree) addNode(node *corev1.Node) utiltas.TopologyDomainID {
-	var levelValues []string
-	var domainID utiltas.TopologyDomainID
-	var leafFound bool
-
-	if t.isLowestLevelNode {
-		// When the lowest level is kubernetes.io/hostname, directly extract hostname.
-		hostname := node.Labels[corev1.LabelHostname]
-		domainID = utiltas.TopologyDomainID(hostname)
-		_, leafFound = t.leaves[domainID]
-		// Only compute levelValues when we actually need to create a new leafDomain.
-		if !leafFound {
-			levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
+	// The injected hostname level is internal, so key it by node name, which
+	// is unique; declared hostname levels keep the label, the user's contract.
+	hostname := node.Name
+	if !t.virtualHostname {
+		if label := node.Labels[corev1.LabelHostname]; label != "" {
+			hostname = label
 		}
-	} else {
-		// Compute full level values and domain ID.
-		levelValues = utiltas.LevelValues(t.levelKeys, node.Labels)
-		domainID = utiltas.DomainID(levelValues)
-		_, leafFound = t.leaves[domainID]
 	}
-	if !leafFound {
-		leafDomain := leafDomain{
+	domainID := utiltas.TopologyDomainID(hostname)
+	if _, leafFound := t.leaves[domainID]; !leafFound {
+		levelValues := utiltas.LevelValues(t.levelKeys, node.Labels)
+		levelValues[len(levelValues)-1] = hostname
+		t.leaves[domainID] = &leafDomain{
 			domain:  domain{id: domainID, levelValues: levelValues},
 			leafIdx: len(t.leaves),
+			node:    node,
 		}
-
-		if t.isLowestLevelNode {
-			leafDomain.node = node
-		}
-		t.leaves[domainID] = &leafDomain
 	}
 	capacity := resources.NewRequestsFromResourceList(node.Status.Allocatable)
 	t.addCapacity(domainID, capacity)
 	return domainID
 }
 
-func (t *topologyTree) lowestLevel() string {
+// userLowestLevel returns the lowest level specified in the Topology CR,
+// excluding the injected virtual hostname level.
+func (t *topologyTree) userLowestLevel() string {
+	if t.virtualHostname {
+		return t.levelKeys[len(t.levelKeys)-2]
+	}
 	return t.levelKeys[len(t.levelKeys)-1]
 }
 

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -603,13 +603,64 @@ func TestNewTopologyTree(t *testing.T) {
 				{Level: 1, ID: "b1,r1"}: {
 					LevelValues: []string{"b1", "r1"},
 					Parent:      domainKey{Level: 0, ID: "b1"},
-					Leaf:        true,
-					CPUCapacity: 8000,
+					Children:    []domainKey{{Level: 2, ID: "n1"}, {Level: 2, ID: "n2"}},
 				},
 				{Level: 1, ID: "b1,r2"}: {
 					LevelValues: []string{"b1", "r2"},
 					Parent:      domainKey{Level: 0, ID: "b1"},
+					Children:    []domainKey{{Level: 2, ID: "n3"}},
+				},
+				{Level: 2, ID: "n1"}: {
+					LevelValues: []string{"b1", "r1", "n1"},
+					Parent:      domainKey{Level: 1, ID: "b1,r1"},
 					Leaf:        true,
+					NodeName:    "n1",
+					CPUCapacity: 4000,
+				},
+				{Level: 2, ID: "n2"}: {
+					LevelValues: []string{"b1", "r1", "n2"},
+					Parent:      domainKey{Level: 1, ID: "b1,r1"},
+					Leaf:        true,
+					NodeName:    "n2",
+					CPUCapacity: 4000,
+				},
+				{Level: 2, ID: "n3"}: {
+					LevelValues: []string{"b1", "r2", "n3"},
+					Parent:      domainKey{Level: 1, ID: "b1,r2"},
+					Leaf:        true,
+					NodeName:    "n3",
+					CPUCapacity: 4000,
+				},
+			},
+		},
+		"node without hostname label on a non-hostname topology falls back to node name": {
+			levels: []string{treeTestBlockLabel, treeTestRackLabel},
+			nodes: []*corev1.Node{
+				testingnode.MakeNode("n1").
+					Label(treeTestBlockLabel, "b1").
+					Label(treeTestRackLabel, "r1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("4"),
+					}).
+					Ready().
+					Obj(),
+			},
+			want: map[domainKey]topologyTreeDomainDump{
+				{Level: 0, ID: "b1"}: {
+					LevelValues: []string{"b1"},
+					Children:    []domainKey{{Level: 1, ID: "b1,r1"}},
+					Root:        true,
+				},
+				{Level: 1, ID: "b1,r1"}: {
+					LevelValues: []string{"b1", "r1"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Children:    []domainKey{{Level: 2, ID: "n1"}},
+				},
+				{Level: 2, ID: "n1"}: {
+					LevelValues: []string{"b1", "r1", "n1"},
+					Parent:      domainKey{Level: 1, ID: "b1,r1"},
+					Leaf:        true,
+					NodeName:    "n1",
 					CPUCapacity: 4000,
 				},
 			},

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -45,15 +46,12 @@ const (
 // are neither unique nor immutable, and two nodes sharing one label must
 // not merge into a single leaf with pooled capacity.
 func TestTreeVirtualLevelKeyedByNodeName(t *testing.T) {
-	makeLabeledNode := func(name, hostnameLabel string) *corev1.Node {
-		return testingnode.MakeNode(name).
-			Label(treeTestBlockLabel, "b1").
-			Label(treeTestRackLabel, "r1").
-			Label(corev1.LabelHostname, hostnameLabel).
-			StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}).
-			Ready().
-			Obj()
-	}
+	features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, true)
+	labeledNode := testingnode.MakeNode("").
+		Label(treeTestBlockLabel, "b1").
+		Label(treeTestRackLabel, "r1").
+		StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}).
+		Ready()
 	testCases := map[string]struct {
 		hostnameLabels []string
 	}{
@@ -69,20 +67,20 @@ func TestTreeVirtualLevelKeyedByNodeName(t *testing.T) {
 			tree := newTopologyTree(
 				[]string{treeTestBlockLabel, treeTestRackLabel},
 				[]*corev1.Node{
-					makeLabeledNode("node-a", tc.hostnameLabels[0]),
-					makeLabeledNode("node-b", tc.hostnameLabels[1]),
+					labeledNode.Clone().Name("node-a").Label(corev1.LabelHostname, tc.hostnameLabels[0]).Obj(),
+					labeledNode.Clone().Name("node-b").Label(corev1.LabelHostname, tc.hostnameLabels[1]).Obj(),
 				},
 				0,
 			)
 			if len(tree.leaves) != 2 {
 				t.Fatalf("expected one leaf per node, got %d leaves for 2 nodes", len(tree.leaves))
 			}
-			seen := map[string]bool{}
+			nodeNames := sets.New[string]()
 			for _, leaf := range tree.leaves {
-				seen[leaf.node.Name] = true
+				nodeNames.Insert(leaf.node.Name)
 			}
-			if !seen["node-a"] || !seen["node-b"] {
-				t.Errorf("expected leaves backed by node-a and node-b, got %v", seen)
+			if !nodeNames.HasAll("node-a", "node-b") {
+				t.Errorf("leaves must be backed by node-a and node-b, got %v", sets.List(nodeNames))
 			}
 		})
 	}
@@ -584,9 +582,10 @@ func validateTopologyTreeStateIndexes(t *testing.T, tree *topologyTree) {
 
 func TestNewTopologyTree(t *testing.T) {
 	tests := map[string]struct {
-		levels []string
-		nodes  []*corev1.Node
-		want   map[domainKey]topologyTreeDomainDump
+		nodeFeasibility bool
+		levels          []string
+		nodes           []*corev1.Node
+		want            map[domainKey]topologyTreeDomainDump
 	}{
 		"lowest level is hostname": {
 			levels: []string{treeTestBlockLabel, treeTestRackLabel, corev1.LabelHostname},
@@ -634,8 +633,38 @@ func TestNewTopologyTree(t *testing.T) {
 				},
 			},
 		},
-		"lowest level is not hostname": {
+		"lowest level is not hostname; feature gate off": {
+			// Without the gate the lowest declared level stays the leaf, so a
+			// rack aggregates its nodes' capacity and carries no node of its own.
 			levels: []string{treeTestBlockLabel, treeTestRackLabel},
+			nodes: []*corev1.Node{
+				makeTreeTestNode("n1", "b1", "r1"),
+				makeTreeTestNode("n2", "b1", "r1"),
+				makeTreeTestNode("n3", "b1", "r2"),
+			},
+			want: map[domainKey]topologyTreeDomainDump{
+				{Level: 0, ID: "b1"}: {
+					LevelValues: []string{"b1"},
+					Children:    []domainKey{{Level: 1, ID: "b1,r1"}, {Level: 1, ID: "b1,r2"}},
+					Root:        true,
+				},
+				{Level: 1, ID: "b1,r1"}: {
+					LevelValues: []string{"b1", "r1"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Leaf:        true,
+					CPUCapacity: 8000,
+				},
+				{Level: 1, ID: "b1,r2"}: {
+					LevelValues: []string{"b1", "r2"},
+					Parent:      domainKey{Level: 0, ID: "b1"},
+					Leaf:        true,
+					CPUCapacity: 4000,
+				},
+			},
+		},
+		"lowest level is not hostname": {
+			nodeFeasibility: true,
+			levels:          []string{treeTestBlockLabel, treeTestRackLabel},
 			nodes: []*corev1.Node{
 				makeTreeTestNode("n1", "b1", "r1"),
 				makeTreeTestNode("n2", "b1", "r1"),
@@ -681,7 +710,8 @@ func TestNewTopologyTree(t *testing.T) {
 			},
 		},
 		"node without hostname label on a non-hostname topology falls back to node name": {
-			levels: []string{treeTestBlockLabel, treeTestRackLabel},
+			nodeFeasibility: true,
+			levels:          []string{treeTestBlockLabel, treeTestRackLabel},
 			nodes: []*corev1.Node{
 				testingnode.MakeNode("n1").
 					Label(treeTestBlockLabel, "b1").
@@ -736,6 +766,7 @@ func TestNewTopologyTree(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.TASNodeFeasibilityForAllLevels, tc.nodeFeasibility)
 			tree := newTopologyTree(tc.levels, tc.nodes, 0)
 			validateTopologyTreeStateIndexes(t, tree)
 			if diff := cmp.Diff(tc.want, dumpTopologyTree(tree)); diff != "" {

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -41,6 +41,53 @@ const (
 	treeTestRackLabel  = "cloud.provider.com/topology-rack"
 )
 
+// The virtual hostname level must identify nodes by name: hostname labels
+// are neither unique nor immutable, and two nodes sharing one label must
+// not merge into a single leaf with pooled capacity.
+func TestTreeVirtualLevelKeyedByNodeName(t *testing.T) {
+	makeLabeledNode := func(name, hostnameLabel string) *corev1.Node {
+		return testingnode.MakeNode(name).
+			Label(treeTestBlockLabel, "b1").
+			Label(treeTestRackLabel, "r1").
+			Label(corev1.LabelHostname, hostnameLabel).
+			StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("4")}).
+			Ready().
+			Obj()
+	}
+	testCases := map[string]struct {
+		hostnameLabels []string
+	}{
+		"distinct hostname labels": {
+			hostnameLabels: []string{"node-a", "node-b"},
+		},
+		"duplicate hostname labels": {
+			hostnameLabels: []string{"dup", "dup"},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tree := newTopologyTree(
+				[]string{treeTestBlockLabel, treeTestRackLabel},
+				[]*corev1.Node{
+					makeLabeledNode("node-a", tc.hostnameLabels[0]),
+					makeLabeledNode("node-b", tc.hostnameLabels[1]),
+				},
+				0,
+			)
+			if len(tree.leaves) != 2 {
+				t.Fatalf("expected one leaf per node, got %d leaves for 2 nodes", len(tree.leaves))
+			}
+			seen := map[string]bool{}
+			for _, leaf := range tree.leaves {
+				seen[leaf.node.Name] = true
+			}
+			if !seen["node-a"] || !seen["node-b"] {
+				t.Errorf("expected leaves backed by node-a and node-b, got %v", seen)
+			}
+		})
+	}
+}
+
 func makeTreeTestNode(name, block, rack string) *corev1.Node {
 	return testingnode.MakeNode(name).
 		Label(treeTestBlockLabel, block).

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2140,6 +2140,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TASProfileMixed):                             true,
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
 				string(features.TASFailedNodeReplacementFailFast):            false,
@@ -2194,6 +2195,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.ElasticJobsViaWorkloadSlicesWithTAS):         true,
 				string(features.ElasticJobsViaWorkloadSlices):                true,
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2224,6 +2226,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TASProfileMixed):                             true,
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASHandleOverlappingFlavors):                 true,
 				string(features.ElasticJobsViaWorkloadSlicesWithTAS):         true,
 				string(features.ElasticJobsViaWorkloadSlices):                false,
@@ -2245,6 +2248,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASHandleOverlappingFlavors requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 true,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2263,6 +2267,27 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				},
 			},
 		},
+		"TASNodeFeasibilityForAllLevels requires TopologyAwareScheduling": {
+			featureGateMap: map[string]bool{
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              true,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASNodeFeasibilityForAllLevels is enabled, but depends on features that are disabled: [TopologyAwareScheduling]",
+				},
+			},
+		},
 		"TASHandleOverlappingFlavors valid when all dependencies enabled": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):     true,
@@ -2273,6 +2298,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TASRecomputeAssignmentWithinSchedulingCycle): true,
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2293,6 +2319,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASFailedNodeReplacement requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    true,
@@ -2314,6 +2341,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASBalancedPlacement requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2336,6 +2364,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASReplaceNodeOnNodeTaints requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2357,6 +2386,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASMultiLayerTopology requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2378,6 +2408,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASRespectNodeAffinityPreferred requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2452,6 +2483,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASFailedNodeReplacementFailFast requires both TopologyAwareScheduling and TASFailedNodeReplacement": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2472,6 +2504,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		"TASReplaceNodeOnPodTermination requires both TopologyAwareScheduling and TASFailedNodeReplacement": {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2271,6 +2271,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TopologyAwareScheduling):                     false,
 				string(features.TASNodeFeasibilityForAllLevels):              true,
+				string(features.TASGroupedPodSetSlicing):                     false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,
@@ -2432,6 +2433,7 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 			featureGateMap: map[string]bool{
 				string(features.TASGroupedPodSetSlicing):                     true,
 				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASNodeFeasibilityForAllLevels):              false,
 				string(features.TASProfileMixed):                             false,
 				string(features.TASHandleOverlappingFlavors):                 false,
 				string(features.TASFailedNodeReplacement):                    false,

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -442,6 +442,16 @@ const (
 	// Enable accurately topology aware scheduling when multiple flavors cover the same Node.
 	TASHandleOverlappingFlavors featuregate.Feature = "TASHandleOverlappingFlavors"
 
+	// owner: @sohankunkerkar
+	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/10548
+	// Enable per-node capacity and feasibility checks on Topologies which do not
+	// declare kubernetes.io/hostname as their lowest level. Without it such a
+	// Topology is evaluated per declared domain, so a Workload fitting a domain's
+	// total capacity is admitted even when no single node can hold a Pod, and a
+	// rack of CPU-only nodes passes for a Workload requesting devices.
+	TASNodeFeasibilityForAllLevels featuregate.Feature = "TASNodeFeasibilityForAllLevels"
+
 	// owner: @j-skiba
 	// kep: https://github.com/kubernetes-sigs/kueue/issues/10852
 	//
@@ -654,6 +664,7 @@ var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Featu
 	TASGroupedPodSetSlicing:                         {TopologyAwareScheduling},
 	UnadmittedWorkloadsExplicitStatus:               {UnadmittedWorkloadsObservability},
 	TASHandleOverlappingFlavors:                     {TopologyAwareScheduling},
+	TASNodeFeasibilityForAllLevels:                  {TopologyAwareScheduling},
 	TASProfileMixed:                                 {TopologyAwareScheduling},
 	TASRecomputeAssignmentWithinSchedulingCycle:     {TopologyAwareScheduling},
 	ElasticJobsViaWorkloadSlicesWithTAS:             {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
@@ -892,6 +903,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 	TASHandleOverlappingFlavors: {
 		{Version: version.MustParse("0.18"), Default: true, PreRelease: featuregate.Beta},
+	},
+	TASNodeFeasibilityForAllLevels: {
+		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
 	},
 	UnadmittedWorkloadsObservability: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -487,6 +487,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASNodeFeasibilityForAllLevels
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -487,6 +487,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.19"
+- name: TASNodeFeasibilityForAllLevels
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.20"
 - name: TASProfileMixed
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4103,9 +4103,7 @@ var _ = ginkgo.Describe("Job controller with TAS and ElasticJobsViaWorkloadSlice
 				Ready().
 				Obj(),
 		}
-		for i := range nodes {
-			util.MustCreate(ctx, k8sClient, &nodes[i])
-		}
+		util.CreateNodesWithStatus(ctx, k8sClient, nodes)
 
 		topology = utiltestingapi.MakeTopology("default").Levels(tasBlockLabel).Obj()
 		util.MustCreate(ctx, k8sClient, topology)

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -2111,6 +2111,7 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			var nodes []corev1.Node
 
 			ginkgo.BeforeEach(func() {
+				features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.TASNodeFeasibilityForAllLevels, true)
 				// Rack r1 has a large tainted node and a small untainted one;
 				// rack r2 has two small untainted nodes.
 				nodes = []corev1.Node{

--- a/test/integration/singlecluster/tas/tas_test.go
+++ b/test/integration/singlecluster/tas/tas_test.go
@@ -2107,6 +2107,154 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Ordered, func() {
 			})
 		})
 
+		ginkgo.When("Non-hostname topology evaluates feasibility and capacity per node", func() {
+			var nodes []corev1.Node
+
+			ginkgo.BeforeEach(func() {
+				// Rack r1 has a large tainted node and a small untainted one;
+				// rack r2 has two small untainted nodes.
+				nodes = []corev1.Node{
+					*testingnode.MakeNode("vh-r1-n1").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						Taints(corev1.Taint{Key: "gpu", Value: "true", Effect: corev1.TaintEffectNoSchedule}).
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("vh-r1-n2").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r1").
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("vh-r2-n1").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r2").
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Ready().
+						Obj(),
+					*testingnode.MakeNode("vh-r2-n2").
+						Label("node-group", "tas").
+						Label(utiltesting.DefaultBlockTopologyLevel, "b1").
+						Label(utiltesting.DefaultRackTopologyLevel, "r2").
+						StatusAllocatable(corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourcePods:   resource.MustParse("10"),
+						}).
+						Ready().
+						Obj(),
+				}
+				util.CreateNodesWithStatus(ctx, k8sClient, nodes)
+
+				topology = utiltestingapi.MakeDefaultTwoLevelTopology("default")
+				util.MustCreate(ctx, k8sClient, topology)
+
+				tasFlavor = utiltestingapi.MakeResourceFlavor("tas-flavor").
+					NodeLabel("node-group", "tas").
+					TopologyName("default").Obj()
+				util.MustCreate(ctx, k8sClient, tasFlavor)
+
+				clusterQueue = utiltestingapi.MakeClusterQueue("cluster-queue").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas(tasFlavor.Name).Resource(corev1.ResourceCPU, "10").Obj()).
+					Obj()
+				util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, clusterQueue)
+
+				localQueue = utiltestingapi.MakeLocalQueue("local-queue", ns.Name).ClusterQueue(clusterQueue.Name).Obj()
+				util.CreateLocalQueuesAndWaitForActive(ctx, k8sClient, localQueue)
+			})
+
+			ginkgo.AfterEach(func() {
+				gomega.Expect(util.DeleteWorkloadsInNamespace(ctx, k8sClient, ns)).Should(gomega.Succeed())
+				gomega.Expect(util.DeleteObject(ctx, k8sClient, localQueue)).Should(gomega.Succeed())
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, tasFlavor, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, topology, true)
+				for _, node := range nodes {
+					util.ExpectObjectToBeDeleted(ctx, k8sClient, &node, true)
+				}
+			})
+
+			ginkgo.It("should not admit a workload which fits a rack's aggregate but no feasible node", func() {
+				// The only node with 2 CPU is tainted; every other node has 1 CPU.
+				wl := utiltestingapi.MakeWorkload("wl-no-single-node", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).
+					Request(corev1.ResourceCPU, "2").Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				util.ExpectWorkloadsToBePending(ctx, k8sClient, wl)
+				util.ExpectPendingWorkloadsMetric(clusterQueue, 0, 1)
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+				}, util.ShortConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+
+			ginkgo.It("should admit a workload on the feasible node of a partially tainted rack", func() {
+				wl := utiltestingapi.MakeWorkload("wl-feasible-node", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).
+					Request(corev1.ResourceCPU, "1").Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				ginkgo.By("verifying the assignment stays at the topology's levels", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						var updated kueue.Workload
+						g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+						g.Expect(updated.Status.Admission).NotTo(gomega.BeNil())
+						g.Expect(updated.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+						assignment := utiltas.InternalFrom(updated.Status.Admission.PodSetAssignments[0].TopologyAssignment)
+						g.Expect(assignment.Levels).To(gomega.Equal([]string{utiltesting.DefaultBlockTopologyLevel, utiltesting.DefaultRackTopologyLevel}))
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+			})
+
+			ginkgo.It("should admit pods across a rack's nodes when no single node fits all of them", func() {
+				// Two 1-CPU pods only fit together in rack r2, one per node.
+				wl := utiltestingapi.MakeWorkload("wl-spread-in-rack", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					PodSets(*utiltestingapi.MakePodSet("main", 2).
+						RequiredTopologyRequest(utiltesting.DefaultRackTopologyLevel).
+						Obj()).
+					Request(corev1.ResourceCPU, "1").Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
+				expected := utiltas.V1Beta2From(&utiltas.TopologyAssignment{
+					Levels:  []string{utiltesting.DefaultBlockTopologyLevel, utiltesting.DefaultRackTopologyLevel},
+					Domains: []utiltas.TopologyDomainAssignment{{Count: 2, Values: []string{"b1", "r2"}}},
+				})
+				gomega.Eventually(func(g gomega.Gomega) {
+					var updated kueue.Workload
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &updated)).To(gomega.Succeed())
+					g.Expect(updated.Status.Admission).NotTo(gomega.BeNil())
+					g.Expect(updated.Status.Admission.PodSetAssignments).To(gomega.HaveLen(1))
+					g.Expect(updated.Status.Admission.PodSetAssignments[0].TopologyAssignment).To(gomega.BeComparableTo(expected))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.When("Nodes are created before test with the hostname being the lowest level", func() {
 			var (
 				nodes            []corev1.Node


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/area tas
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

TAS skipped node feasibility checks for topologies that don't declare `kubernetes.io/hostname` and counted capacity against each domain's aggregate, so node taints, selectors and affinity were silently ignored, and a Workload could be admitted into a rack it fits in aggregate but on no single node.

As suggested by @mimowo, this appends `kubernetes.io/hostname` to such a topology's levels internally, so every leaf is one node and feasibility is evaluated per node. The appended level is stripped when serializing the `topologyAssignment`, so assignments still name only the declared levels, and every check that reads those levels is unaffected.

Usage stays recorded against the level the assignment names, since the node holding a pod inside a domain is chosen by kube-scheduler after ungating and is never reported back. The domain's own remaining capacity bounds the count rolled up from its nodes. Behind the `TASNodeFeasibilityForAllLevels` gate. With it off the tree is exactly what's on main.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes-sigs/kueue/issues/13534

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Added the `TASNodeFeasibilityForAllLevels` feature gate, Beta and enabled by default. Topologies that do not declare `kubernetes.io/hostname` as their lowest level now check capacity and node feasibility per node instead of per aggregated domain, so node taints, node selectors and node affinity exclude individual nodes inside a domain. Workloads that fit a domain's total capacity but no single node are no longer admitted. Requires `TopologyAwareScheduling`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added optional per-node feasibility checks for topology-aware scheduling, including topologies without a hostname level.
- Improved capacity tracking across racks and other multi-node topology domains.
- Workloads now avoid nodes with insufficient capacity or untolerated taints when the feature is enabled.
- Enhanced placement across multiple nodes when no single node can satisfy the workload.

## Documentation
- Documented configuration, capacity accounting, and affinity behavior for non-hostname topologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->