### PR TITLE
Automated cherry pick of #13415: RayJob: treat ValidationFailed before RayCluster as a terminal state
#14182: [Flake] Make RayJob validation fails test more durable

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -108,6 +108,13 @@ type JobWithSkip interface {
 	Skip(ctx context.Context) bool
 }
 
+// JobWithOnHold is an optional interface that should be implemented by generic jobs
+// when the job can request its Workload to be put on hold.
+type JobWithOnHold interface {
+	// IsOnHold returns whether the job should be put on hold.
+	IsOnHold() bool
+}
+
 // JobWithPriorityClass is an optional interface that should be implemented by generic jobs
 // when a custom priority class is needed.
 type JobWithPriorityClass interface {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -453,7 +453,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	if jobOnHold, ok := job.(JobWithOnHold); ok && jobOnHold.IsOnHold() {
 		if wl != nil && workload.HasQuotaReservation(wl) {
 			log.V(2).Info("Job is on hold, releasing quota reservation")
-			err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
+			err := workload.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
 				changed := workload.UnsetQuotaReservationWithCondition(
 					wl,
 					kueue.WorkloadOnHold,

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -449,7 +449,27 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	// 2. handle job is finished.
+	// 2. handle job is on hold.
+	if jobOnHold, ok := job.(JobWithOnHold); ok && jobOnHold.IsOnHold() {
+		if wl != nil && workload.HasQuotaReservation(wl) {
+			log.V(2).Info("Job is on hold, releasing quota reservation")
+			err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {
+				changed := workload.UnsetQuotaReservationWithCondition(
+					wl,
+					kueue.WorkloadOnHold,
+					"Job is on hold",
+					r.clock.Now(),
+				)
+				return changed, nil
+			})
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("putting workload on hold: %w", err)
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// 3. handle job is finished.
 	if message, success, finished := job.Finished(ctx); finished {
 		log.V(3).Info("The workload is already finished")
 		if wl != nil && !workload.IsFinished(wl) {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -218,8 +218,7 @@ func (j *RayJob) Finished(ctx context.Context) (message string, success, finishe
 	finished =
 		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
 			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
-			(j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed &&
-				j.Status.RayClusterName == "")
+			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed
 
 	return message, success, finished
 }

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -218,7 +218,8 @@ func (j *RayJob) Finished(ctx context.Context) (message string, success, finishe
 	finished =
 		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
 			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
-			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed
+			(j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed &&
+				j.Status.RayClusterName == "")
 
 	return message, success, finished
 }

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -215,32 +214,14 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 func (j *RayJob) Finished(ctx context.Context) (message string, success, finished bool) {
 	message = j.Status.Message
 	success = j.Status.JobStatus == rayv1.JobStatusSucceeded
-	finished = j.shouldFinish(ctrl.LoggerFrom(ctx))
+
+	finished =
+		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
+			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
+			(j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed &&
+				j.Status.RayClusterName == "")
 
 	return message, success, finished
-}
-
-func (j *RayJob) shouldFinish(log logr.Logger) bool {
-	switch j.Status.JobDeploymentStatus {
-	case rayv1.JobDeploymentStatusFailed:
-		log.V(2).Info("RayJob finished: deployment failed")
-		return true
-
-	case rayv1.JobDeploymentStatusComplete:
-		log.V(2).Info("RayJob finished: deployment completed")
-		return true
-
-	case rayv1.JobDeploymentStatusValidationFailed:
-		if j.Status.RayClusterName == "" {
-			log.V(2).Info("RayJob finished: validation failed before RayCluster creation")
-			return true
-		}
-
-		log.V(2).Info("RayJob not finished: validation failed after RayCluster creation",
-			"rayClusterName", j.Status.RayClusterName)
-	}
-
-	return false
 }
 
 func (j *RayJob) PodsReady(ctx context.Context, _ client.Client) bool {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -214,7 +214,12 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 func (j *RayJob) Finished(ctx context.Context) (message string, success, finished bool) {
 	message = j.Status.Message
 	success = j.Status.JobStatus == rayv1.JobStatusSucceeded
-	finished = j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed || j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete
+
+	finished =
+		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
+			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
+			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed
+
 	return message, success, finished
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -214,12 +214,7 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 func (j *RayJob) Finished(ctx context.Context) (message string, success, finished bool) {
 	message = j.Status.Message
 	success = j.Status.JobStatus == rayv1.JobStatusSucceeded
-
-	finished =
-		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
-			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
-			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed
-
+	finished = j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed || j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete
 	return message, success, finished
 }
 

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -214,14 +215,32 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 func (j *RayJob) Finished(ctx context.Context) (message string, success, finished bool) {
 	message = j.Status.Message
 	success = j.Status.JobStatus == rayv1.JobStatusSucceeded
-
-	finished =
-		j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusFailed ||
-			j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusComplete ||
-			(j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed &&
-				j.Status.RayClusterName == "")
+	finished = j.shouldFinish(ctrl.LoggerFrom(ctx))
 
 	return message, success, finished
+}
+
+func (j *RayJob) shouldFinish(log logr.Logger) bool {
+	switch j.Status.JobDeploymentStatus {
+	case rayv1.JobDeploymentStatusFailed:
+		log.V(2).Info("RayJob finished: deployment failed")
+		return true
+
+	case rayv1.JobDeploymentStatusComplete:
+		log.V(2).Info("RayJob finished: deployment completed")
+		return true
+
+	case rayv1.JobDeploymentStatusValidationFailed:
+		if j.Status.RayClusterName == "" {
+			log.V(2).Info("RayJob finished: validation failed before RayCluster creation")
+			return true
+		}
+
+		log.V(2).Info("RayJob not finished: validation failed after RayCluster creation",
+			"rayClusterName", j.Status.RayClusterName)
+	}
+
+	return false
 }
 
 func (j *RayJob) PodsReady(ctx context.Context, _ client.Client) bool {

--- a/pkg/controller/jobs/rayjob/rayjob_controller.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller.go
@@ -210,6 +210,9 @@ func (j *RayJob) RestorePodSetsInfo(podSetsInfo []podset.PodSetInfo) bool {
 
 	return changed
 }
+func (j *RayJob) IsOnHold() bool {
+	return j.Status.JobDeploymentStatus == rayv1.JobDeploymentStatusValidationFailed
+}
 
 func (j *RayJob) Finished(ctx context.Context) (message string, success, finished bool) {
 	message = j.Status.Message

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1017,13 +1017,24 @@ func Test_RayJobFinished(t *testing.T) {
 			expectedFinished: true,
 		},
 		{
-			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed",
+			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed, no RayClusterName",
 			status: rayv1.RayJobStatus{
 				JobStatus:           rayv1.JobStatusFailed,
 				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
+				RayClusterName:      "",
 			},
 			expectedSuccess:  false,
 			expectedFinished: true,
+		},
+		{
+			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed, RayClusterName set",
+			status: rayv1.RayJobStatus{
+				JobStatus:           rayv1.JobStatusFailed,
+				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
+				RayClusterName:      "rayjob-testname",
+			},
+			expectedSuccess:  false,
+			expectedFinished: false,
 		},
 		{
 			name: "jobStatus=Running, jobDeploymentStatus=Failed (when activeDeadlineSeconds is exceeded)",

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1017,6 +1017,15 @@ func Test_RayJobFinished(t *testing.T) {
 			expectedFinished: true,
 		},
 		{
+			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed",
+			status: rayv1.RayJobStatus{
+				JobStatus:           rayv1.JobStatusFailed,
+				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
+			},
+			expectedSuccess:  false,
+			expectedFinished: true,
+		},
+		{
 			name: "jobStatus=Running, jobDeploymentStatus=Failed (when activeDeadlineSeconds is exceeded)",
 			status: rayv1.RayJobStatus{
 				JobStatus:           rayv1.JobStatusRunning,

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1049,6 +1049,50 @@ func Test_RayJobFinished(t *testing.T) {
 	}
 }
 
+func Test_RayJobIsOnHold(t *testing.T) {
+	testcases := []struct {
+		name                string
+		jobDeploymentStatus rayv1.JobDeploymentStatus
+		expectedOnHold      bool
+	}{
+		{
+			name:                "jobDeploymentStatus=Running",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusRunning,
+			expectedOnHold:      false,
+		},
+		{
+			name:                "jobDeploymentStatus=Complete",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusComplete,
+			expectedOnHold:      false,
+		},
+		{
+			name:                "jobDeploymentStatus=Failed",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusFailed,
+			expectedOnHold:      false,
+		},
+		{
+			name:                "jobDeploymentStatus=ValidationFailed",
+			jobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
+			expectedOnHold:      true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			rayJob := testingrayutil.MakeJob("job", "ns").Obj()
+			rayJob.Status.JobDeploymentStatus = testcase.jobDeploymentStatus
+
+			onHold := ((*RayJob)(rayJob)).IsOnHold()
+
+			if onHold != testcase.expectedOnHold {
+				t.Logf("actual onHold: %v", onHold)
+				t.Logf("expected onHold: %v", testcase.expectedOnHold)
+				t.Error("unexpected result for 'onHold'")
+			}
+		})
+	}
+}
+
 func TestGetCustomAnnotations(t *testing.T) {
 	headSpec := rayv1.HeadGroupSpec{
 		Template: corev1.PodTemplateSpec{

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1017,15 +1017,6 @@ func Test_RayJobFinished(t *testing.T) {
 			expectedFinished: true,
 		},
 		{
-			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed",
-			status: rayv1.RayJobStatus{
-				JobStatus:           rayv1.JobStatusFailed,
-				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
-			},
-			expectedSuccess:  false,
-			expectedFinished: true,
-		},
-		{
 			name: "jobStatus=Running, jobDeploymentStatus=Failed (when activeDeadlineSeconds is exceeded)",
 			status: rayv1.RayJobStatus{
 				JobStatus:           rayv1.JobStatusRunning,

--- a/pkg/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/pkg/controller/jobs/rayjob/rayjob_controller_test.go
@@ -1017,24 +1017,13 @@ func Test_RayJobFinished(t *testing.T) {
 			expectedFinished: true,
 		},
 		{
-			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed, no RayClusterName",
+			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed",
 			status: rayv1.RayJobStatus{
 				JobStatus:           rayv1.JobStatusFailed,
 				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
-				RayClusterName:      "",
 			},
 			expectedSuccess:  false,
 			expectedFinished: true,
-		},
-		{
-			name: "jobStatus=Failed, jobDeploymentStatus=ValidationFailed, RayClusterName set",
-			status: rayv1.RayJobStatus{
-				JobStatus:           rayv1.JobStatusFailed,
-				JobDeploymentStatus: rayv1.JobDeploymentStatusValidationFailed,
-				RayClusterName:      "rayjob-testname",
-			},
-			expectedSuccess:  false,
-			expectedFinished: false,
 		},
 		{
 			name: "jobStatus=Running, jobDeploymentStatus=Failed (when activeDeadlineSeconds is exceeded)",

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -89,9 +89,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		}()
+		})
 
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
@@ -155,10 +155,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		}()
+		})
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -323,10 +323,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		}()
+		})
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -392,9 +392,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		}()
+		})
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
 			WithPriorityClassName(priorityClassName).

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -251,6 +251,64 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
+	ginkgo.It("Should handle ValidationFailed depending on RayClusterName", func() {
+		ginkgo.By("creating a RayJob")
+		job := testingrayjob.MakeJob(jobName, ns.Name).
+			Suspend(false).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		setInitStatus(jobName, ns.Name)
+
+		createdJob := &rayv1.RayJob{}
+		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+		}).Should(gomega.Succeed())
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{
+			Name:      workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}).Should(gomega.Succeed())
+
+		ginkgo.By("ValidationFailed with empty RayClusterName should finish the workload")
+
+		createdJob.Status.JobStatus = rayv1.JobStatusFailed
+		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
+		createdJob.Status.RayClusterName = ""
+		createdJob.Status.Message = "validation failed"
+
+		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+		}).Should(gomega.Succeed())
+
+		ginkgo.By("ValidationFailed with non-empty RayClusterName should not finish the workload")
+
+		createdWorkload.Status.Conditions = nil
+		gomega.Expect(k8sClient.Status().Update(ctx, createdWorkload)).Should(gomega.Succeed())
+
+		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
+		createdJob.Status.JobStatus = rayv1.JobStatusFailed
+		createdJob.Status.RayClusterName = "rayjob-test-cluster"
+
+		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
+
+		gomega.Consistently(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Status.Conditions).
+				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
 
 	ginkgo.It("A RayJob created in an unmanaged namespace is not suspended and a workload is not created", func() {
 		ginkgo.By("Creating an unsuspended job without a queue-name in unmanaged-ns")

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -257,9 +257,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		}()
+		})
 
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
@@ -457,10 +457,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		defer func() {
+		ginkgo.DeferCleanup(func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		}()
+		})
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -484,27 +484,47 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 				},
 			},
 		).Obj()
+		lookupKey := types.NamespacedName{
+			Name:      jobName,
+			Namespace: ns.Name,
+		}
+		ginkgo.By("admitting the workload")
 		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+
+		ginkgo.By("waiting for the RayJob to be unsuspended")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("verifying the admission event is recorded")
 		gomega.Eventually(func(g gomega.Gomega) {
-			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
+			ok, _ := utiltesting.CheckEventRecordedFor(
+				ctx,
+				k8sClient,
+				"Started",
+				corev1.EventTypeNormal,
+				fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name),
+				lookupKey,
+			)
 			g.Expect(ok).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("verifying the node selectors are injected")
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
+
+		ginkgo.By("waiting for the workload to become quota reserved")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		ginkgo.By("checking the workload is not finished when validation fails after a RayCluster is created")
 
+		ginkgo.By("checking the workload is not finished when validation fails after a RayCluster is created")
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.JobStatus = rayv1.JobStatusFailed
 		createdJob.Status.RayClusterName = "rayjob-test-cluster"

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -251,62 +251,277 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
-	ginkgo.It("Should handle ValidationFailed depending on RayClusterName", func() {
-		ginkgo.By("creating a RayJob")
+
+	ginkgo.It("Should finish the workload when a RayJob fails validation before creating a RayCluster", func() {
+		ginkgo.By("checking the job gets suspended when created unsuspended")
+		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
+			PriorityValue(priorityValue).Obj()
+		util.MustCreate(ctx, k8sClient, priorityClass)
+		defer func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
+		}()
+
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
+			WithPriorityClassName(priorityClassName).
 			Obj()
 		util.MustCreate(ctx, k8sClient, job)
+		createdJob := &rayv1.RayJob{}
 
 		setInitStatus(jobName, ns.Name)
-
-		createdJob := &rayv1.RayJob{}
-		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
-
 		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-		}).Should(gomega.Succeed())
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
+		ginkgo.By("checking the workload is created without queue assigned")
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{
-			Name:      workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID),
-			Namespace: ns.Name,
-		}
-
+		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID), Namespace: ns.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
+		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
 
-		ginkgo.By("ValidationFailed with empty RayClusterName should finish the workload")
+		ginkgo.By("checking the workload is created with workload priority class", func() {
+			util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, priorityClassName, priorityValue, wlLookupKey)
+		})
 
-		createdJob.Status.JobStatus = rayv1.JobStatusFailed
+		ginkgo.By("checking the workload is updated with queue name when the job does")
+		var jobQueueName kueue.LocalQueueName = "test-queue"
+		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
+		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(jobQueueName))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking a second non-matching workload is deleted")
+		secondWl := &kueue.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadrayjob.GetWorkloadNameForRayJob("second-workload", "test-uid"),
+				Namespace: createdWorkload.Namespace,
+			},
+			Spec: *createdWorkload.Spec.DeepCopy(),
+		}
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
+		secondWl.Spec.PodSets[0].Count++
+
+		util.MustCreate(ctx, k8sClient, secondWl)
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
+			g.Expect(k8sClient.Get(ctx, key, wl)).Should(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		// check the original wl is still there
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the job is unsuspended when workload is assigned")
+		onDemandFlavor := utiltestingapi.MakeResourceFlavor("on-demand").NodeLabel(instanceKey, "on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
+		util.MustCreate(ctx, k8sClient, spotFlavor)
+		defer func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		}()
+		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
+			).Obj()
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
+			kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[0].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "on-demand",
+				},
+			}, kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[1].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "spot",
+				},
+			}, kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[2].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "on-demand",
+				},
+			},
+		).Obj()
+		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
+			g.Expect(ok).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the workload is finished when validation fails before a RayCluster is created")
+
+		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
+		createdJob.Status.JobStatus = rayv1.JobStatusFailed
 		createdJob.Status.RayClusterName = ""
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
 
+		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
+	})
+
+	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {
+
+		ginkgo.By("checking the job gets suspended when created unsuspended")
+		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
+			PriorityValue(priorityValue).Obj()
+		util.MustCreate(ctx, k8sClient, priorityClass)
+		defer func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
+		}()
+
+		job := testingrayjob.MakeJob(jobName, ns.Name).
+			Suspend(false).
+			WithPriorityClassName(priorityClassName).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+		createdJob := &rayv1.RayJob{}
+
+		setInitStatus(jobName, ns.Name)
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the workload is created without queue assigned")
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID), Namespace: ns.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).
-				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
+		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
 
-		ginkgo.By("ValidationFailed with non-empty RayClusterName should not finish the workload")
+		ginkgo.By("checking the workload is created with workload priority class", func() {
+			util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, priorityClassName, priorityValue, wlLookupKey)
+		})
 
-		createdWorkload.Status.Conditions = nil
-		gomega.Expect(k8sClient.Status().Update(ctx, createdWorkload)).Should(gomega.Succeed())
+		ginkgo.By("checking the workload is updated with queue name when the job does")
+		var jobQueueName kueue.LocalQueueName = "test-queue"
+		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
+		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(jobQueueName))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking a second non-matching workload is deleted")
+		secondWl := &kueue.Workload{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      workloadrayjob.GetWorkloadNameForRayJob("second-workload", "test-uid"),
+				Namespace: createdWorkload.Namespace,
+			},
+			Spec: *createdWorkload.Spec.DeepCopy(),
+		}
+		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
+		secondWl.Spec.PodSets[0].Count++
+
+		util.MustCreate(ctx, k8sClient, secondWl)
+		gomega.Eventually(func(g gomega.Gomega) {
+			wl := &kueue.Workload{}
+			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
+			g.Expect(k8sClient.Get(ctx, key, wl)).Should(utiltesting.BeNotFoundError())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		// check the original wl is still there
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the job is unsuspended when workload is assigned")
+		onDemandFlavor := utiltestingapi.MakeResourceFlavor("on-demand").NodeLabel(instanceKey, "on-demand").Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
+		util.MustCreate(ctx, k8sClient, spotFlavor)
+		defer func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		}()
+		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
+				*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
+			).Obj()
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
+			kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[0].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "on-demand",
+				},
+			}, kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[1].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "spot",
+				},
+			}, kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[2].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: "on-demand",
+				},
+			},
+		).Obj()
+		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Eventually(func(g gomega.Gomega) {
+			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
+			g.Expect(ok).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
+		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.By("checking the workload is not finished when validation fails after a RayCluster is created")
 
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.JobStatus = rayv1.JobStatusFailed
 		createdJob.Status.RayClusterName = "rayjob-test-cluster"
+		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
 
 		gomega.Consistently(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+
 			g.Expect(createdWorkload.Status.Conditions).
 				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+
+			g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -383,6 +383,12 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+		}).Should(gomega.Succeed())
+
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -371,7 +371,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("checking the workload is finished when validation fails before a RayCluster is created")
-
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
@@ -380,19 +379,15 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
-
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}).Should(gomega.Succeed())
-
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {
-
 		ginkgo.By("checking the job gets suspended when created unsuspended")
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
@@ -400,7 +395,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
 		}()
-
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
 			WithPriorityClassName(priorityClassName).
@@ -517,16 +511,12 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
-
 		gomega.Consistently(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-
 			g.Expect(createdWorkload.Status.Conditions).
 				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-
 			g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -371,6 +371,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
 		ginkgo.By("checking the workload is finished when validation fails before a RayCluster is created")
+
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
@@ -379,15 +380,19 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
+
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
+
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}).Should(gomega.Succeed())
+
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {
+
 		ginkgo.By("checking the job gets suspended when created unsuspended")
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
@@ -395,6 +400,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
 		}()
+
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
 			WithPriorityClassName(priorityClassName).
@@ -511,12 +517,16 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
+
 		gomega.Consistently(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
+
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+
 			g.Expect(createdWorkload.Status.Conditions).
 				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+
 			g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -89,9 +89,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		})
+		}()
 
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
@@ -155,10 +155,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		})
+		}()
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -323,10 +323,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		})
+		}()
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -392,9 +392,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		})
+		}()
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
 			WithPriorityClassName(priorityClassName).

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -383,12 +383,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 
 		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).
-				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}).Should(gomega.Succeed())
-
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -843,16 +843,16 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("marking the RayJob as validation failed")
-
-		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
-			Should(gomega.Succeed())
-
-		createdJob.Status.JobDeploymentStatus =
-			rayv1.JobDeploymentStatusValidationFailed
-
-		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).
-			Should(gomega.Succeed())
+		ginkgo.By("marking the RayJob as validation failed", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
+					Should(gomega.Succeed())
+				createdJob.Status.JobDeploymentStatus =
+					rayv1.JobDeploymentStatusValidationFailed
+				gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).
+					Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
 
 		ginkgo.By("checking the workload is put on hold")
 

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -251,277 +251,62 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
-
-	ginkgo.It("Should finish the workload when a RayJob fails validation before creating a RayCluster", func() {
-		ginkgo.By("checking the job gets suspended when created unsuspended")
-		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
-			PriorityValue(priorityValue).Obj()
-		util.MustCreate(ctx, k8sClient, priorityClass)
-		defer func() {
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		}()
-
+	ginkgo.It("Should handle ValidationFailed depending on RayClusterName", func() {
+		ginkgo.By("creating a RayJob")
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
-			WithPriorityClassName(priorityClassName).
 			Obj()
 		util.MustCreate(ctx, k8sClient, job)
-		createdJob := &rayv1.RayJob{}
 
 		setInitStatus(jobName, ns.Name)
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
-			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-		ginkgo.By("checking the workload is created without queue assigned")
-		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID), Namespace: ns.Name}
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
-		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
-
-		ginkgo.By("checking the workload is created with workload priority class", func() {
-			util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, priorityClassName, priorityValue, wlLookupKey)
-		})
-
-		ginkgo.By("checking the workload is updated with queue name when the job does")
-		var jobQueueName kueue.LocalQueueName = "test-queue"
-		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
-		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(jobQueueName))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking a second non-matching workload is deleted")
-		secondWl := &kueue.Workload{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      workloadrayjob.GetWorkloadNameForRayJob("second-workload", "test-uid"),
-				Namespace: createdWorkload.Namespace,
-			},
-			Spec: *createdWorkload.Spec.DeepCopy(),
-		}
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count++
-
-		util.MustCreate(ctx, k8sClient, secondWl)
-		gomega.Eventually(func(g gomega.Gomega) {
-			wl := &kueue.Workload{}
-			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
-			g.Expect(k8sClient.Get(ctx, key, wl)).Should(utiltesting.BeNotFoundError())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		// check the original wl is still there
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking the job is unsuspended when workload is assigned")
-		onDemandFlavor := utiltestingapi.MakeResourceFlavor("on-demand").NodeLabel(instanceKey, "on-demand").Obj()
-		util.MustCreate(ctx, k8sClient, onDemandFlavor)
-		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
-		util.MustCreate(ctx, k8sClient, spotFlavor)
-		defer func() {
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		}()
-		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
-				*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
-			).Obj()
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
-			kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[0].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "on-demand",
-				},
-			}, kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[1].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "spot",
-				},
-			}, kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[2].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "on-demand",
-				},
-			},
-		).Obj()
-		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
-		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+		createdJob := &rayv1.RayJob{}
 		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
+
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
-			g.Expect(ok).Should(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
+		}).Should(gomega.Succeed())
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{
+			Name:      workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}).Should(gomega.Succeed())
 
-		ginkgo.By("checking the workload is finished when validation fails before a RayCluster is created")
+		ginkgo.By("ValidationFailed with empty RayClusterName should finish the workload")
 
-		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-
-		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.JobStatus = rayv1.JobStatusFailed
+		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.RayClusterName = ""
 		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
 
-		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-
-	})
-
-	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {
-
-		ginkgo.By("checking the job gets suspended when created unsuspended")
-		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
-			PriorityValue(priorityValue).Obj()
-		util.MustCreate(ctx, k8sClient, priorityClass)
-		defer func() {
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		}()
-
-		job := testingrayjob.MakeJob(jobName, ns.Name).
-			Suspend(false).
-			WithPriorityClassName(priorityClassName).
-			Obj()
-		util.MustCreate(ctx, k8sClient, job)
-		createdJob := &rayv1.RayJob{}
-
-		setInitStatus(jobName, ns.Name)
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: ns.Name}, createdJob)).Should(gomega.Succeed())
-			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking the workload is created without queue assigned")
-		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID), Namespace: ns.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(kueue.LocalQueueName("")), "The Workload shouldn't have .spec.queueName set")
-		gomega.Expect(metav1.IsControlledBy(createdWorkload, createdJob)).To(gomega.BeTrue(), "The Workload should be owned by the Job")
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+		}).Should(gomega.Succeed())
 
-		ginkgo.By("checking the workload is created with workload priority class", func() {
-			util.ExpectWorkloadsWithPodPriority(ctx, k8sClient, priorityClassName, priorityValue, wlLookupKey)
-		})
+		ginkgo.By("ValidationFailed with non-empty RayClusterName should not finish the workload")
 
-		ginkgo.By("checking the workload is updated with queue name when the job does")
-		var jobQueueName kueue.LocalQueueName = "test-queue"
-		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
-		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Spec.QueueName).Should(gomega.Equal(jobQueueName))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking a second non-matching workload is deleted")
-		secondWl := &kueue.Workload{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      workloadrayjob.GetWorkloadNameForRayJob("second-workload", "test-uid"),
-				Namespace: createdWorkload.Namespace,
-			},
-			Spec: *createdWorkload.Spec.DeepCopy(),
-		}
-		gomega.Expect(ctrl.SetControllerReference(createdJob, secondWl, k8sClient.Scheme())).Should(gomega.Succeed())
-		secondWl.Spec.PodSets[0].Count++
-
-		util.MustCreate(ctx, k8sClient, secondWl)
-		gomega.Eventually(func(g gomega.Gomega) {
-			wl := &kueue.Workload{}
-			key := types.NamespacedName{Name: secondWl.Name, Namespace: secondWl.Namespace}
-			g.Expect(k8sClient.Get(ctx, key, wl)).Should(utiltesting.BeNotFoundError())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		// check the original wl is still there
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("checking the job is unsuspended when workload is assigned")
-		onDemandFlavor := utiltestingapi.MakeResourceFlavor("on-demand").NodeLabel(instanceKey, "on-demand").Obj()
-		util.MustCreate(ctx, k8sClient, onDemandFlavor)
-		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
-		util.MustCreate(ctx, k8sClient, spotFlavor)
-		defer func() {
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
-			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		}()
-		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
-			ResourceGroup(
-				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
-				*utiltestingapi.MakeFlavorQuotas("spot").Resource(corev1.ResourceCPU, "5").Obj(),
-			).Obj()
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(
-			kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[0].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "on-demand",
-				},
-			}, kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[1].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "spot",
-				},
-			}, kueue.PodSetAssignment{
-				Name: createdWorkload.Spec.PodSets[2].Name,
-				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
-					corev1.ResourceCPU: "on-demand",
-				},
-			},
-		).Obj()
-		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
-		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Eventually(func(g gomega.Gomega) {
-			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
-			g.Expect(ok).Should(gomega.BeTrue())
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
-		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-		ginkgo.By("checking the workload is not finished when validation fails after a RayCluster is created")
+		createdWorkload.Status.Conditions = nil
+		gomega.Expect(k8sClient.Status().Update(ctx, createdWorkload)).Should(gomega.Succeed())
 
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.JobStatus = rayv1.JobStatusFailed
 		createdJob.Status.RayClusterName = "rayjob-test-cluster"
-		createdJob.Status.Message = "validation failed"
 
 		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
 
 		gomega.Consistently(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-
-			g.Expect(createdWorkload.Status.Conditions).
-				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
-
 			g.Expect(createdWorkload.Status.Conditions).
 				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-
-			g.Expect(createdWorkload.Status.Admission).ShouldNot(gomega.BeNil())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
 

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -738,4 +738,138 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
 		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
 	})
+
+	ginkgo.It("Should put the workload on hold when RayJob validation fails", func() {
+		ginkgo.By("creating the resource flavor")
+
+		onDemandFlavor := utiltestingapi.MakeResourceFlavor("rayjob-on-demand").
+			NodeLabel(instanceKey, "rayjob-on-demand").
+			Obj()
+		util.MustCreate(ctx, k8sClient, onDemandFlavor)
+		ginkgo.By("creating the ClusterQueue")
+
+		clusterQueue := utiltestingapi.MakeClusterQueue("rayjob-cluster-queue").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("rayjob-on-demand").
+					Resource(corev1.ResourceCPU, "5").
+					Obj(),
+			).
+			Obj()
+		util.MustCreate(ctx, k8sClient, clusterQueue)
+
+		ginkgo.By("creating the LocalQueue")
+
+		localQueue := utiltestingapi.MakeLocalQueue("rayjob-queue", ns.Name).
+			ClusterQueue(clusterQueue.Name).
+			Obj()
+		util.MustCreate(ctx, k8sClient, localQueue)
+		defer func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, localQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, clusterQueue, true)
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
+		}()
+
+		ginkgo.By("creating a RayJob")
+		job := testingrayjob.MakeJob(jobName, ns.Name).
+			Label(constants.QueueLabel, localQueue.Name).
+			Suspend(false).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		setInitStatus(jobName, ns.Name)
+
+		lookupKey := types.NamespacedName{
+			Name:      jobName,
+			Namespace: ns.Name,
+		}
+
+		createdJob := &rayv1.RayJob{}
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
+				Should(gomega.Succeed())
+			g.Expect(createdJob.Spec.Suspend).
+				Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the workload is created")
+
+		createdWorkload := &kueue.Workload{}
+		wlLookupKey := types.NamespacedName{
+			Name:      workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID),
+			Namespace: ns.Name,
+		}
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).
+				Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("admitting the workload")
+
+		admission := utiltestingapi.MakeAdmission(
+			kueue.ClusterQueueReference(clusterQueue.Name),
+		).PodSets(
+			kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[0].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				},
+			},
+			kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[1].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				},
+			},
+			kueue.PodSetAssignment{
+				Name: createdWorkload.Spec.PodSets[2].Name,
+				Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+					corev1.ResourceCPU: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+				},
+			},
+		).Obj()
+
+		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
+		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
+
+		ginkgo.By("checking the workload has a quota reservation")
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).
+				Should(gomega.Succeed())
+
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("marking the RayJob as validation failed")
+
+		gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
+			Should(gomega.Succeed())
+
+		createdJob.Status.JobDeploymentStatus =
+			rayv1.JobDeploymentStatusValidationFailed
+
+		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).
+			Should(gomega.Succeed())
+
+		ginkgo.By("checking the workload is put on hold")
+
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).
+				Should(gomega.Succeed())
+
+			g.Expect(createdWorkload.Status.Conditions).
+				Should(utiltesting.HaveConditionStatusFalseAndReason(
+					kueue.WorkloadQuotaReserved,
+					kueue.WorkloadOnHold,
+				))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("checking the workload is not finished")
+
+		gomega.Expect(createdWorkload.Status.Conditions).
+			ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+	})
 })

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -384,7 +384,7 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
 			g.Expect(createdWorkload.Status.Conditions).
 				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		}).Should(gomega.Succeed())
 	})
 
 	ginkgo.It("Should not finish the workload when a RayJob fails validation after creating a RayCluster", func() {

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -257,9 +257,9 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		priorityClass := utiltesting.MakePriorityClass(priorityClassName).
 			PriorityValue(priorityValue).Obj()
 		util.MustCreate(ctx, k8sClient, priorityClass)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, priorityClass, true)
-		})
+		}()
 
 		job := testingrayjob.MakeJob(jobName, ns.Name).
 			Suspend(false).
@@ -457,10 +457,10 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 		util.MustCreate(ctx, k8sClient, onDemandFlavor)
 		spotFlavor := utiltestingapi.MakeResourceFlavor("spot").NodeLabel(instanceKey, "spot").Obj()
 		util.MustCreate(ctx, k8sClient, spotFlavor)
-		ginkgo.DeferCleanup(func() {
+		defer func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, spotFlavor, true)
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
-		})
+		}()
 		clusterQueue := utiltestingapi.MakeClusterQueue("cluster-queue").
 			ResourceGroup(
 				*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "5").Obj(),
@@ -484,47 +484,27 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 				},
 			},
 		).Obj()
-		lookupKey := types.NamespacedName{
-			Name:      jobName,
-			Namespace: ns.Name,
-		}
-		ginkgo.By("admitting the workload")
 		util.SetQuotaReservation(ctx, k8sClient, wlLookupKey, admission)
 		util.SyncAdmittedConditionForWorkloads(ctx, k8sClient, createdWorkload)
-
-		ginkgo.By("waiting for the RayJob to be unsuspended")
+		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
 			g.Expect(createdJob.Spec.Suspend).Should(gomega.BeFalse())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("verifying the admission event is recorded")
 		gomega.Eventually(func(g gomega.Gomega) {
-			ok, _ := utiltesting.CheckEventRecordedFor(
-				ctx,
-				k8sClient,
-				"Started",
-				corev1.EventTypeNormal,
-				fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name),
-				lookupKey,
-			)
+			ok, _ := utiltesting.CheckEventRecordedFor(ctx, k8sClient, "Started", corev1.EventTypeNormal, fmt.Sprintf("Admitted by clusterQueue %v", clusterQueue.Name), lookupKey)
 			g.Expect(ok).Should(gomega.BeTrue())
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-		ginkgo.By("verifying the node selectors are injected")
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.HeadGroupSpec.Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(onDemandFlavor.Name))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector).Should(gomega.HaveLen(1))
 		gomega.Expect(createdJob.Spec.RayClusterSpec.WorkerGroupSpecs[0].Template.Spec.NodeSelector[instanceKey]).Should(gomega.Equal(spotFlavor.Name))
-
-		ginkgo.By("waiting for the workload to become quota reserved")
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).
-				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
+			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadQuotaReserved))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
 		ginkgo.By("checking the workload is not finished when validation fails after a RayCluster is created")
+
 		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
 		createdJob.Status.JobStatus = rayv1.JobStatusFailed
 		createdJob.Status.RayClusterName = "rayjob-test-cluster"

--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -251,64 +251,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:ray", "area:jobs"), 
 			g.Expect(createdWorkload.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
-	ginkgo.It("Should handle ValidationFailed depending on RayClusterName", func() {
-		ginkgo.By("creating a RayJob")
-		job := testingrayjob.MakeJob(jobName, ns.Name).
-			Suspend(false).
-			Obj()
-		util.MustCreate(ctx, k8sClient, job)
-
-		setInitStatus(jobName, ns.Name)
-
-		createdJob := &rayv1.RayJob{}
-		lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).Should(gomega.Succeed())
-		}).Should(gomega.Succeed())
-
-		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{
-			Name:      workloadrayjob.GetWorkloadNameForRayJob(job.Name, job.UID),
-			Namespace: ns.Name,
-		}
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-		}).Should(gomega.Succeed())
-
-		ginkgo.By("ValidationFailed with empty RayClusterName should finish the workload")
-
-		createdJob.Status.JobStatus = rayv1.JobStatusFailed
-		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
-		createdJob.Status.RayClusterName = ""
-		createdJob.Status.Message = "validation failed"
-
-		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
-
-		gomega.Eventually(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).
-				Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}).Should(gomega.Succeed())
-
-		ginkgo.By("ValidationFailed with non-empty RayClusterName should not finish the workload")
-
-		createdWorkload.Status.Conditions = nil
-		gomega.Expect(k8sClient.Status().Update(ctx, createdWorkload)).Should(gomega.Succeed())
-
-		createdJob.Status.JobDeploymentStatus = rayv1.JobDeploymentStatusValidationFailed
-		createdJob.Status.JobStatus = rayv1.JobStatusFailed
-		createdJob.Status.RayClusterName = "rayjob-test-cluster"
-
-		gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).Should(gomega.Succeed())
-
-		gomega.Consistently(func(g gomega.Gomega) {
-			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
-			g.Expect(createdWorkload.Status.Conditions).
-				ShouldNot(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
-		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
-	})
 
 	ginkgo.It("A RayJob created in an unmanaged namespace is not suspended and a workload is not created", func() {
 		ginkgo.By("Creating an unsuspended job without a queue-name in unmanaged-ns")


### PR DESCRIPTION
Cherry pick of #13415 #14182 on release-0.18.

#13415: RayJob: treat ValidationFailed before RayCluster as a terminal state
#14182: [Flake] Make RayJob validation fails test more durable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug
/kind flake


```release-note
RayJob: Fixed a bug where Workloads created for KubeRay RayJobs that ended in `ValidationFailed` could remain admitted and continue holding quota indefinitely.
```