### PR TITLE
Fix flake in concurrent admission flavor removal test

### DIFF
--- a/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
+++ b/test/integration/singlecluster/controller/concurrentadmission/concurrent_admission_test.go
@@ -735,13 +735,20 @@ var _ = ginkgo.Describe("Concurrent Admission", func() {
 			flavorSpot = utiltestingapi.MakeResourceFlavor("spot").Obj()
 			util.MustCreate(ctx, k8sClient, flavorSpot)
 
-			// Both flavors have real quota so the parent admits on the preferred
-			// (first) flavor, reservation.
+			// Only reservation has quota, so only its variant can admit.
+			// Giving spot quota, or a cohort it can borrow spot quota from, makes the
+			// spot variant schedulable again: either variant can then be the ClusterQueue
+			// head first, since the tie on priority and creation timestamp is broken by
+			// UID, and admitting on spot would need a flavor migration that this spec
+			// never completes.
+			//
+			// The removal step later releases quota on spot, which the final re-admission
+			// assertion needs.
 			cq = utiltestingapi.MakeClusterQueue("cq-evict").
 				ConcurrentAdmissionPolicy(kueue.ConcurrentAdmissionTryPreferredFlavors).
 				ResourceGroup(
 					*utiltestingapi.MakeFlavorQuotas(flavorReservation.Name).Resource(corev1.ResourceCPU, "5").Obj(),
-					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "5").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "0").Obj(),
 				).Obj()
 			util.CreateClusterQueuesAndWaitForActive(ctx, k8sClient, cq)
 
@@ -776,18 +783,13 @@ var _ = ginkgo.Describe("Concurrent Admission", func() {
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Removing the reservation flavor (the one the parent is admitted on)", func() {
+			ginkgo.By("Removing the admitted reservation flavor and releasing quota on spot", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					var updatedCq kueue.ClusterQueue
 					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: cq.Name}, &updatedCq)).To(gomega.Succeed())
-					flavors := updatedCq.Spec.ResourceGroups[0].Flavors
-					kept := flavors[:0]
-					for _, f := range flavors {
-						if f.Name != kueue.ResourceFlavorReference(flavorReservation.Name) {
-							kept = append(kept, f)
-						}
+					updatedCq.Spec.ResourceGroups[0].Flavors = []kueue.FlavorQuotas{
+						*utiltestingapi.MakeFlavorQuotas(flavorSpot.Name).Resource(corev1.ResourceCPU, "5").Obj(),
 					}
-					updatedCq.Spec.ResourceGroups[0].Flavors = kept
 					g.Expect(k8sClient.Update(ctx, &updatedCq)).To(gomega.Succeed())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind flake
/area testing

#### What this PR does / why we need it:

The `re-admits the parent on a remaining flavor` spec in the `concurrentadmission` integration suite asserts first that the parent workload is admitted on the `reservation` flavor. Rarely it is admitted on `spot` instead.

`cq-evict` gives quota to both `reservation` and `spot`, so both variants are schedulable. The `reservation` variant is created first and usually admits before `spot` is queued, but when both are queued in the same scheduling cycle, priority and the second-granular `creationTimestamp` tie and `baseCompareFunc` breaks the tie on UID. How often they batch into one cycle depends on load, which is why this fails rarely.

When `spot` wins, converging on `reservation` needs a flavor migration: `syncVariantEvictionStatus` evicts the parent and waits for it to lose its quota reservation, which in production the job reconciler does after `stopJob`. envtest has no job controller, so nothing clears it until the spec calls `util.FinishEvictionForWorkloads` later. The first assertion times out, and no timeout would be long enough.

This PR gives `spot` zero quota so only the `reservation` variant can admit, and releases that quota in the same ClusterQueue update that removes the `reservation` flavor. The two have to ride in one update: `clusterQueueFlavorsChanged` compares flavor names only, so a quota-only write would not enqueue the parent. Migration stays covered by `cq-migrate`.

Verified by running the `concurrentadmission` suite with this change. Note it also passes without the change, since reproducing the flake needs both variants queued in the same cycle.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13858

#### Special notes for your reviewer:

Flake reported in #13858. Failing run: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_kueue/13780/pull-kueue-test-integration-shard-1-main/2084914242527432704

The failure details in that issue are accurate (`concurrent_admission_test.go:776`, expected `reservation`, observed `spot`), but the title describes the re-admission after flavor removal, whereas the assertion that timed out is the spec's first one. The optimistic-lock conflicts it points at are real, but they all come from other specs in the same run, which passed. The failing spec logs none, so they are not part of this failure.

The removal step now states the resulting resource group with the `utiltestingapi` builder, since the old `kept := flavors[:0]` filter read as though it might index the pre-filter slice once a quota line was added.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage for concurrent admission eviction scenarios.
  * Added validation for transitions between reservation and spot flavors, including quota changes when a flavor is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->