### PR TITLE
Automated cherry pick of #14197: RayJob validation failure test conflicts with controller update

### DIFF
--- a/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/rayjob/rayjob_controller_test.go
@@ -845,11 +845,11 @@ var _ = ginkgo.Describe("Job controller with preemption enabled", ginkgo.Ordered
 
 		ginkgo.By("marking the RayJob as validation failed", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
-				gomega.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
+				g.Expect(k8sClient.Get(ctx, lookupKey, createdJob)).
 					Should(gomega.Succeed())
 				createdJob.Status.JobDeploymentStatus =
 					rayv1.JobDeploymentStatusValidationFailed
-				gomega.Expect(k8sClient.Status().Update(ctx, createdJob)).
+				g.Expect(k8sClient.Status().Update(ctx, createdJob)).
 					Should(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})


### PR DESCRIPTION
Cherry pick of #14197 on release-0.18.

#14197: RayJob validation failure test conflicts with controller update

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind flake


```release-note
NONE
```