### PR TITLE
DRA: aggregate extended resources by original name before mapping to quota key

### DIFF
--- a/keps/2941-DRA/README.md
+++ b/keps/2941-DRA/README.md
@@ -911,7 +911,12 @@ The two DRA paths resolve quota independently:
 
 #### Processing Flow
 
-1. Kueue detects extended resources in `resources.requests`
+1. Kueue detects extended resources in `resources.requests` and computes each
+   original resource name's Pod-level request (max across init containers, sum
+   across regular containers, then max of the two) before any DeviceClass lookup
+   or quota-key mapping. Two different resource names later mapped to the same
+   quota key are therefore aggregated independently first, so neither collapses
+   into the other's contribution.
 2. Looks up DeviceClasses by `extendedResourceName` by field indexer
 3. If no matching DeviceClass is found, the resource is not DRA-backed and Kueue
    processes it through the standard resource quota path (counted via `node.Status.Allocatable`)

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -93,44 +93,18 @@ func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceCla
 	return selected
 }
 
-// resolveContainerExtendedResources converts DRA-backed extended resources in a
-// container's requests into logical quota keys. For each extended resource, it looks
-// up DeviceClasses by spec.extendedResourceName, selects the one the scheduler would
-// allocate from, and uses that class's deviceClassMappings entry as the quota key;
-// otherwise the extendedResourceName itself is used. Returns the converted resources
-// and the set of original resource names that were replaced (for double-count prevention).
-func resolveContainerExtendedResources(
-	ctx context.Context,
-	cl client.Client,
-	mapper *ResourceMapper,
-	container corev1.Container,
-	containerPath *field.Path,
-) (corev1.ResourceList, sets.Set[corev1.ResourceName], field.ErrorList) {
-	log := ctrl.LoggerFrom(ctx)
+// extendedResourceRequests extracts a container's extended resource requests, keyed by
+// their original (unmapped) resource name, validating that each quantity is an integer.
+// The DeviceClass mapping is resolved later, once per original name for the whole
+// PodSet, rather than per container here: mapping before aggregating across containers
+// would let two different resource names that share a quota key collapse into each
+// other's contribution, since max(map(A), map(B)) != map(max(A, B)) once A and B differ.
+func extendedResourceRequests(container corev1.Container, containerPath *field.Path) (corev1.ResourceList, field.ErrorList) {
 	result := corev1.ResourceList{}
-	replaced := sets.New[corev1.ResourceName]()
 	var errs field.ErrorList
 
 	for resourceName, quantity := range container.Resources.Requests {
 		if quantity.IsZero() || !utilresource.IsExtendedResourceName(resourceName) {
-			continue
-		}
-
-		log.V(4).Info("Checking extended resource for DRA backing", "resource", resourceName, "quantity", quantity.String())
-
-		var dcList resourceapi.DeviceClassList
-		if err := cl.List(ctx, &dcList, client.MatchingFields{
-			"spec.extendedResourceName": string(resourceName),
-		}); err != nil {
-			errs = append(errs, field.InternalError(
-				containerPath.Child("resources", "requests", string(resourceName)),
-				fmt.Errorf("failed to list DeviceClasses for extended resource %q: %w", resourceName, err),
-			))
-			continue
-		}
-
-		if len(dcList.Items) == 0 {
-			log.V(4).Info("No DeviceClass found, not a DRA-backed extended resource", "resource", resourceName)
 			continue
 		}
 
@@ -144,55 +118,88 @@ func resolveContainerExtendedResources(
 			continue
 		}
 
-		// The class the scheduler will allocate from, not whichever List returned first.
-		selected := selectedDeviceClass(dcList.Items)
-
-		// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
-		// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
-		// Otherwise, use the extendedResourceName directly.
-		quotaKey := resourceName
-		if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
-			quotaKey = logicalName
-			if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(selected.Name))) > 0 {
-				errs = append(errs, field.Invalid(
-					containerPath,
-					resourceName,
-					fmt.Sprintf(
-						"extended resource %s resolves to DeviceClass %s with counters configured;"+
-							" use ResourceClaimTemplates with CEL selectors for counter-based quota",
-						resourceName, selected.Name,
-					),
-				))
-			} else if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(selected.Name))) > 0 {
-				errs = append(errs, field.Invalid(
-					containerPath,
-					resourceName,
-					fmt.Sprintf(
-						"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
-							" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
-						resourceName, selected.Name,
-					),
-				))
-			}
-		}
-
-		chargeQuantity := *resource.NewQuantity(qty, resource.DecimalSI)
-
-		log.V(4).Info("Resolved extended resource to DRA quota key",
-			"resource", resourceName, "quotaKey", quotaKey, "quantity", chargeQuantity.String(),
-			"deviceClass", selected.Name)
-
-		replaced.Insert(resourceName)
-		result = utilresource.MergeResourceListKeepSum(result, corev1.ResourceList{
-			quotaKey: chargeQuantity,
-		})
+		result[resourceName] = *resource.NewQuantity(qty, resource.DecimalSI)
 	}
-	return result, replaced, errs
+	return result, errs
+}
+
+// resolveQuotaKey looks up the DeviceClasses backing resourceName by
+// spec.extendedResourceName, selects the one the scheduler would allocate from, and
+// returns that class's deviceClassMappings entry as the quota key; otherwise
+// resourceName itself is used. Returns "" if resourceName is not DRA-backed (no
+// matching DeviceClass).
+func resolveQuotaKey(
+	ctx context.Context,
+	cl client.Client,
+	mapper *ResourceMapper,
+	resourceName corev1.ResourceName,
+	path *field.Path,
+) (corev1.ResourceName, field.ErrorList) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(4).Info("Checking extended resource for DRA backing", "resource", resourceName)
+
+	var dcList resourceapi.DeviceClassList
+	if err := cl.List(ctx, &dcList, client.MatchingFields{
+		"spec.extendedResourceName": string(resourceName),
+	}); err != nil {
+		return "", field.ErrorList{field.InternalError(
+			path.Child("resources", "requests", string(resourceName)),
+			fmt.Errorf("failed to list DeviceClasses for extended resource %q: %w", resourceName, err),
+		)}
+	}
+
+	if len(dcList.Items) == 0 {
+		log.V(4).Info("No DeviceClass found, not a DRA-backed extended resource", "resource", resourceName)
+		return "", nil
+	}
+
+	// The class the scheduler will allocate from, not whichever List returned first.
+	selected := selectedDeviceClass(dcList.Items)
+
+	// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
+	// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
+	// Otherwise, use the extendedResourceName directly.
+	quotaKey := resourceName
+	var errs field.ErrorList
+	if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
+		quotaKey = logicalName
+		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(selected.Name))) > 0 {
+			errs = append(errs, field.Invalid(
+				path,
+				resourceName,
+				fmt.Sprintf(
+					"extended resource %s resolves to DeviceClass %s with counters configured;"+
+						" use ResourceClaimTemplates with CEL selectors for counter-based quota",
+					resourceName, selected.Name,
+				),
+			))
+		} else if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(selected.Name))) > 0 {
+			errs = append(errs, field.Invalid(
+				path,
+				resourceName,
+				fmt.Sprintf(
+					"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
+						" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
+					resourceName, selected.Name,
+				),
+			))
+		}
+	}
+	if len(errs) > 0 {
+		return "", errs
+	}
+
+	log.V(4).Info("Resolved extended resource to DRA quota key",
+		"resource", resourceName, "quotaKey", quotaKey, "deviceClass", selected.Name)
+	return quotaKey, nil
 }
 
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
 // into DRA logical quota resources. Per PodSet, init containers are aggregated with
-// max (sequential) and regular containers with sum (concurrent), then combined with max.
+// max (sequential) and regular containers with sum (concurrent), then combined with
+// max — per original resource name, before any two names sharing a quota key can
+// collapse into each other's contribution. The quota key for each original name is
+// resolved once per PodSet, from that name's own aggregated total.
 func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper *ResourceMapper, wl *kueue.Workload) (
 	map[kueue.PodSetReference]corev1.ResourceList,
 	map[kueue.PodSetReference]sets.Set[corev1.ResourceName],
@@ -209,26 +216,47 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 
 	for i := range wl.Spec.PodSets {
 		ps := &wl.Spec.PodSets[i]
-		replaced := sets.New[corev1.ResourceName]()
 		podSetPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec")
 
-		// Closure captures outer `replaced` set to accumulate across init and regular containers.
-		resolveContainers := func(containers []corev1.Container, pathSegment string, merge func(a, b corev1.ResourceList) corev1.ResourceList) corev1.ResourceList {
+		// The field path of the first container an original resource name is seen in,
+		// for error reporting once that name is resolved below.
+		firstPath := map[corev1.ResourceName]*field.Path{}
+
+		extract := func(containers []corev1.Container, pathSegment string, merge func(a, b corev1.ResourceList) corev1.ResourceList) corev1.ResourceList {
 			var result corev1.ResourceList
 			for j, container := range containers {
 				containerPath := podSetPath.Child(pathSegment).Index(j)
-				res, containerReplaced, errs := resolveContainerExtendedResources(ctx, cl, mapper, container, containerPath)
+				res, errs := extendedResourceRequests(container, containerPath)
 				allErrs = append(allErrs, errs...)
-				replaced = replaced.Union(containerReplaced)
+				for name := range res {
+					if _, ok := firstPath[name]; !ok {
+						firstPath[name] = containerPath
+					}
+				}
 				result = merge(result, res)
 			}
 			return result
 		}
 
-		maxInitResources := resolveContainers(ps.Template.Spec.InitContainers, "initContainers", utilresource.MergeResourceListKeepMax)
-		sumRegularResources := resolveContainers(ps.Template.Spec.Containers, "containers", utilresource.MergeResourceListKeepSum)
+		maxInitResources := extract(ps.Template.Spec.InitContainers, "initContainers", utilresource.MergeResourceListKeepMax)
+		sumRegularResources := extract(ps.Template.Spec.Containers, "containers", utilresource.MergeResourceListKeepSum)
+		podRequests := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
 
-		aggregated := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
+		aggregated := corev1.ResourceList{}
+		replaced := sets.New[corev1.ResourceName]()
+		for resourceName, quantity := range podRequests {
+			quotaKey, errs := resolveQuotaKey(ctx, cl, mapper, resourceName, firstPath[resourceName])
+			if len(errs) > 0 {
+				allErrs = append(allErrs, errs...)
+				continue
+			}
+			if quotaKey == "" {
+				continue
+			}
+			replaced.Insert(resourceName)
+			aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{quotaKey: quantity})
+		}
+
 		if len(aggregated) > 0 {
 			log.V(4).Info("Resolved extended resources for PodSet", "podSet", ps.Name, "resources", aggregated)
 			perPodSet[ps.Name] = aggregated

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -300,7 +300,7 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 				allErrs = append(allErrs, field.Invalid(
 					firstPath[resourceName].Child("resources", "requests", string(resourceName)),
 					quantity.String(),
-					"total extended resource quantity must be an integer",
+					"total extended resource quantity overflows int64",
 				))
 				continue
 			}

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -93,34 +93,23 @@ func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceCla
 	return selected
 }
 
-// extendedResourceRequests extracts a container's extended resource requests, keyed by
-// their original (unmapped) resource name, validating that each quantity is an integer.
-// The DeviceClass mapping is resolved later, once per original name for the whole
-// PodSet, rather than per container here: mapping before aggregating across containers
-// would let two different resource names that share a quota key collapse into each
-// other's contribution, since max(map(A), map(B)) != map(max(A, B)) once A and B differ.
-func extendedResourceRequests(container corev1.Container, containerPath *field.Path) (corev1.ResourceList, field.ErrorList) {
+// extendedResourceRequests extracts a container's non-zero extended resource requests,
+// keyed by their original (unmapped) resource name. Quantities are not validated here:
+// the integer-only rule only applies to resources that turn out to be DRA-backed, which
+// isn't known until a DeviceClass is resolved for the name later in
+// ResolveExtendedResourceQuota. Validating here would reject fractional requests for
+// extended resources that aren't DRA-backed at all, which the standard (non-DRA) quota
+// path accepts.
+func extendedResourceRequests(container corev1.Container) corev1.ResourceList {
 	result := corev1.ResourceList{}
-	var errs field.ErrorList
 
 	for resourceName, quantity := range container.Resources.Requests {
 		if quantity.IsZero() || !utilresource.IsExtendedResourceName(resourceName) {
 			continue
 		}
-
-		qty, ok := quantity.AsInt64()
-		if !ok {
-			errs = append(errs, field.Invalid(
-				containerPath.Child("resources", "requests", string(resourceName)),
-				quantity.String(),
-				"extended resource quantity must be an integer",
-			))
-			continue
-		}
-
-		result[resourceName] = *resource.NewQuantity(qty, resource.DecimalSI)
+		result[resourceName] = quantity
 	}
-	return result, errs
+	return result
 }
 
 // resolveQuotaKey looks up the DeviceClasses backing resourceName by
@@ -194,6 +183,14 @@ func resolveQuotaKey(
 	return quotaKey, nil
 }
 
+// containerExtendedResourceRequests pairs a container's non-zero extended resource
+// requests, keyed by original (unmapped) resource name, with the field path used to
+// report errors against that container.
+type containerExtendedResourceRequests struct {
+	path      *field.Path
+	resources corev1.ResourceList
+}
+
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
 // into DRA logical quota resources. Per PodSet, init containers are aggregated with
 // max (sequential) and regular containers with sum (concurrent), then combined with
@@ -218,28 +215,44 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 		ps := &wl.Spec.PodSets[i]
 		podSetPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec")
 
+		collect := func(containers []corev1.Container, pathSegment string) []containerExtendedResourceRequests {
+			var entries []containerExtendedResourceRequests
+			for j, container := range containers {
+				res := extendedResourceRequests(container)
+				if len(res) == 0 {
+					continue
+				}
+				entries = append(entries, containerExtendedResourceRequests{
+					path:      podSetPath.Child(pathSegment).Index(j),
+					resources: res,
+				})
+			}
+			return entries
+		}
+
+		initEntries := collect(ps.Template.Spec.InitContainers, "initContainers")
+		regularEntries := collect(ps.Template.Spec.Containers, "containers")
+
 		// The field path of the first container an original resource name is seen in,
 		// for error reporting once that name is resolved below.
 		firstPath := map[corev1.ResourceName]*field.Path{}
-
-		extract := func(containers []corev1.Container, pathSegment string, merge func(a, b corev1.ResourceList) corev1.ResourceList) corev1.ResourceList {
-			var result corev1.ResourceList
-			for j, container := range containers {
-				containerPath := podSetPath.Child(pathSegment).Index(j)
-				res, errs := extendedResourceRequests(container, containerPath)
-				allErrs = append(allErrs, errs...)
-				for name := range res {
-					if _, ok := firstPath[name]; !ok {
-						firstPath[name] = containerPath
-					}
+		var maxInitResources, sumRegularResources corev1.ResourceList
+		for _, e := range initEntries {
+			for name := range e.resources {
+				if _, ok := firstPath[name]; !ok {
+					firstPath[name] = e.path
 				}
-				result = merge(result, res)
 			}
-			return result
+			maxInitResources = utilresource.MergeResourceListKeepMax(maxInitResources, e.resources)
 		}
-
-		maxInitResources := extract(ps.Template.Spec.InitContainers, "initContainers", utilresource.MergeResourceListKeepMax)
-		sumRegularResources := extract(ps.Template.Spec.Containers, "containers", utilresource.MergeResourceListKeepSum)
+		for _, e := range regularEntries {
+			for name := range e.resources {
+				if _, ok := firstPath[name]; !ok {
+					firstPath[name] = e.path
+				}
+			}
+			sumRegularResources = utilresource.MergeResourceListKeepSum(sumRegularResources, e.resources)
+		}
 		podRequests := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
 
 		aggregated := corev1.ResourceList{}
@@ -253,8 +266,37 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 			if quotaKey == "" {
 				continue
 			}
+
+			// resourceName is confirmed DRA-backed: now hold it to the
+			// integer-only rule, checked per container rather than on the
+			// aggregate above, so two invalid fractional requests (e.g. two
+			// 500m requests summing to a valid 1) can't hide each other.
+			var intErrs field.ErrorList
+			for _, entries := range [][]containerExtendedResourceRequests{initEntries, regularEntries} {
+				for _, e := range entries {
+					qty, ok := e.resources[resourceName]
+					if !ok {
+						continue
+					}
+					if _, ok := qty.AsInt64(); !ok {
+						intErrs = append(intErrs, field.Invalid(
+							e.path.Child("resources", "requests", string(resourceName)),
+							qty.String(),
+							"extended resource quantity must be an integer",
+						))
+					}
+				}
+			}
+			if len(intErrs) > 0 {
+				allErrs = append(allErrs, intErrs...)
+				continue
+			}
+
+			// Safe: every container quantity contributing to this aggregate
+			// just passed the integer check above.
+			intQty, _ := quantity.AsInt64()
 			replaced.Insert(resourceName)
-			aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{quotaKey: quantity})
+			aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{quotaKey: *resource.NewQuantity(intQty, resource.DecimalSI)})
 		}
 
 		if len(aggregated) > 0 {

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -292,9 +292,18 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 				continue
 			}
 
-			// Safe: every container quantity contributing to this aggregate
-			// just passed the integer check above.
-			intQty, _ := quantity.AsInt64()
+			// Each container's quantity passed the integer check above, but their
+			// sum can still overflow int64 (e.g. two containers requesting 9e18
+			// each), so the aggregate needs its own check rather than assuming ok.
+			intQty, ok := quantity.AsInt64()
+			if !ok {
+				allErrs = append(allErrs, field.Invalid(
+					firstPath[resourceName].Child("resources", "requests", string(resourceName)),
+					quantity.String(),
+					"total extended resource quantity must be an integer",
+				))
+				continue
+			}
 			replaced.Insert(resourceName)
 			aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{quotaKey: *resource.NewQuantity(intQty, resource.DecimalSI)})
 		}

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -335,6 +335,33 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			want:          nil,
 		},
 		{
+			name: "workload with fractional quantity for extended resource not backed by DRA (no matching DeviceClass)",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"other.vendor.io/resource": resource.MustParse("1500m"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want:          nil,
+		},
+		{
 			name: "workload with no extended resources",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -623,6 +623,55 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			// Each container's quantity fits int64 on its own, but their sum
+			// overflows it. Charging the aggregate without re-checking would
+			// silently charge nothing instead of rejecting the request.
+			name: "workload with per-container integer quantities that overflow int64 when summed",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("9e18"),
+											},
+										},
+									},
+									{
+										Name:  "c2",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("9e18"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			wantErr: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "podSets").Index(0).
+						Child("template", "spec", "containers").Index(0).
+						Child("resources", "requests", "example.com/gpu"),
+					"",
+					"",
+				),
+			},
+		},
+		{
 			name: "extended resource uses deviceClassMappings logical name when DeviceClass is mapped",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -206,6 +206,26 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 		},
 	}
 
+	// Two distinct extendedResourceNames, both mapped by the same deviceClassMappings
+	// entry to the logical key "gpu-claims".
+	classADeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "class-a",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("vendor.example/a"),
+		},
+	}
+
+	classBDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "class-b",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("vendor.example/b"),
+		},
+	}
+
 	tests := []struct {
 		name           string
 		workload       *kueue.Workload
@@ -477,6 +497,67 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
 				"main": sets.New[corev1.ResourceName]("example.com/gpu"),
+			},
+		},
+		{
+			// vendor.example/a and vendor.example/b both map to the "gpu-claims" quota
+			// key, but each is charged against the OTHER container kind (init vs.
+			// regular), so the max/sum aggregation only ever sees one contribution
+			// per key if the mapping happens before aggregation across containers.
+			// The correct charge is the sum of each name's own Pod aggregation:
+			// max(A's init contribution, A's regular contribution) is 5 for A alone,
+			// and likewise 5 for B alone, so the quota key must be charged 10, not
+			// max(5, 5) = 5.
+			name: "two extended resource names sharing a quota key are not collapsed by cross-container aggregation",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:  "init",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"vendor.example/a": resource.MustParse("5"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"vendor.example/b": resource.MustParse("5"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{classADeviceClass, classBDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "gpu-claims",
+					DeviceClassNames: []corev1.ResourceName{"class-a", "class-b"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"gpu-claims": resource.MustParse("10"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("vendor.example/a", "vendor.example/b"),
 			},
 		},
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dra

#### What this PR does / why we need it:

`ResolveExtendedResourceQuota` charges DRA-backed extended resources against a
logical `deviceClassMappings` quota key. It used to map each container's
requests to that quota key first, and only aggregate across containers
(max across init containers, sum across regular containers, then max of the
two) afterwards. That aggregation is not linear, so once two different
extended resource names are mapped to the same quota key, mapping before
aggregating collapses their independent contributions: `max(map(A), map(B))`
is not `map(max(A, B))`.

For example, with `class-a` (`vendor.example/a`) and `class-b`
(`vendor.example/b`) both mapped to quota key `gpu-claims`, an init container
requesting `vendor.example/a: 5` and a regular container requesting
`vendor.example/b: 5` charged `gpu-claims: 5` (the max of the two
already-mapped values) instead of `gpu-claims: 10` (the sum of each name's
own Pod-level aggregation), undercharging quota for that PodSet.

This PR reorders the computation so the per-container max/sum/max
aggregation runs on each original (unmapped) extended resource name first,
and each name's quota key is resolved once per PodSet from its own
aggregated total, then summed into the final per-key charge:
`charge[key] = sum(PodAggregation(R) for every R mapped to key)`. As a side
effect, a DeviceClass's mapping is now resolved once per original resource
name per PodSet instead of once per container occurrence, closing the
window where a DeviceClass created or deleted between two per-container
reads could leave a name inconsistently resolved.

The integer-quantity check on extended resource requests is now applied only
once a resource is confirmed to be DRA-backed (a matching DeviceClass is
found), instead of unconditionally on every domain-qualified resource name
before that's known. Previously, reordering the aggregation ahead of the
DeviceClass lookup meant a fractional quantity on a resource with no matching
DeviceClass at all (e.g. `other.example/d: 1500m`, which the standard,
non-DRA quota path accepts) would abort resolution for the whole PodSet. The
check still runs per container rather than on the aggregate, so two invalid
fractional requests can't sum to a valid whole and hide each other.

#### Which issue(s) this PR fixes:

Fixes #14156

#### Special notes for your reviewer:

This predates and is independent of PR #14154 (which rewrites the
container-aggregation mechanics in the same function but keeps the mapping
order, so it does not fix this collapse). No behavioral change for the
common case where at most one original extended resource name maps to a
given quota key within a PodSet — all pre-existing test cases in
`pkg/dra/extended_resources_test.go` still pass unmodified.

Validation performed: `go build ./...`; `go test ./pkg/dra/...
./pkg/controller/core/... ./pkg/workload/...` (all pass); `golangci-lint run
./pkg/dra/...` (0 issues); `gofmt -l` and `go vet ./pkg/dra/...` (clean). A
new test case reproduces the issue's exact scenario (two extended resource
names sharing a quota key, split across an init and a regular container) and
was manually confirmed to fail against the pre-fix code (asserting `5`) and
pass against the post-fix code (asserting `10`) via `git stash` of only the
non-test file. No live cluster / e2e run was performed; this is a pure
function over the workload spec and DeviceClass objects, fully exercised by
the existing fake-client unit test harness in this package.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed quota undercount when two extended resource names sharing a deviceClassMappings key were requested by different containers in the same PodSet.
```

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed extended-resource quota calculations when multiple resource names map to the same quota.
  * Ensured requests from initialization and regular containers are combined accurately.
  * Ignored fractional requests for resources that are not quota-backed.
  * Improved validation and resource replacement tracking for pod-level resource requests.
  * Added validation for per-container quantities that exceed supported integer limits.
  * Ensured quota resolution and capacity validation remain consistent across containers and resource names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
