### PR TITLE
Skip Kueue-side node health filtering under SchedulerLibraryIntegration

### DIFF
--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
@@ -50,20 +51,23 @@ func newNodesCache() *nodesCache {
 }
 
 func (t *nodesCache) sync(node *corev1.Node) {
-	schedulableAndReady := !node.Spec.Unschedulable &&
-		utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-
 	t.lock.Lock()
 	defer t.lock.Unlock()
+	if !features.Enabled(features.SchedulerLibraryIntegration) {
+		schedulableAndReady := !node.Spec.Unschedulable &&
+			utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
 
-	if !schedulableAndReady {
-		t.deleteWithoutLock(node.Name)
-		return
+		if !schedulableAndReady {
+			t.deleteWithoutLock(node.Name)
+			return
+		}
 	}
+
 	stripped := copyAndStripNode(node)
 	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
 		return
 	}
+
 	t.nodes[node.Name] = stripped
 	t.generation++
 }
@@ -114,7 +118,8 @@ func copyAndStripNode(node *corev1.Node) *corev1.Node {
 			Labels: node.Labels,
 		},
 		Spec: corev1.NodeSpec{
-			Taints: node.Spec.Taints,
+			Unschedulable: node.Spec.Unschedulable,
+			Taints:        node.Spec.Taints,
 		},
 		Status: corev1.NodeStatus{
 			Allocatable: node.Status.Allocatable,
@@ -134,6 +139,7 @@ func (t *nodesCache) getAllNodes() []*corev1.Node {
 // such as kubelet heartbeats.
 func strippedNodesEqual(a, b *corev1.Node) bool {
 	return maps.Equal(a.Labels, b.Labels) &&
+		a.Spec.Unschedulable == b.Spec.Unschedulable &&
 		equality.Semantic.DeepEqual(a.Spec.Taints, b.Spec.Taints) &&
 		equality.Semantic.DeepEqual(a.Status.Allocatable, b.Status.Allocatable)
 }

--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
@@ -42,33 +43,47 @@ type nodesCache struct {
 	// when a node is added or removed, or when its labels, taints, or allocatable
 	// resources change - not on every Node update event.
 	generation int64
+
+	// schedulableAndReadyNodes tracks node names that are both schedulable and ready
+	schedulableAndReadyNodes sets.Set[string]
 }
 
 func newNodesCache() *nodesCache {
 	return &nodesCache{
-		nodes: make(map[string]*corev1.Node),
+		nodes:                    make(map[string]*corev1.Node),
+		schedulableAndReadyNodes: sets.New[string](),
 	}
 }
 
 func (t *nodesCache) sync(node *corev1.Node) {
+	schedulableAndReady := !node.Spec.Unschedulable &&
+		utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	if !features.Enabled(features.SchedulerLibraryIntegration) {
-		schedulableAndReady := !node.Spec.Unschedulable &&
-			utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
 
-		if !schedulableAndReady {
-			t.deleteWithoutLock(node.Name)
-			return
-		}
-	}
-
-	stripped := copyAndStripNode(node)
-	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
+	if !features.Enabled(features.SchedulerLibraryIntegration) && !schedulableAndReady {
+		t.deleteWithoutLock(node.Name)
 		return
 	}
 
-	t.nodes[node.Name] = stripped
+	availabilityChanged := t.schedulableAndReadyNodes.Has(node.Name) != schedulableAndReady
+	if schedulableAndReady {
+		t.schedulableAndReadyNodes.Insert(node.Name)
+	} else {
+		t.schedulableAndReadyNodes.Delete(node.Name)
+	}
+
+	stripped := copyAndStripNode(node)
+	existing, found := t.nodes[node.Name]
+	nodeChanged := !found || !strippedNodesEqual(existing, stripped)
+
+	if !nodeChanged && !availabilityChanged {
+		return
+	}
+
+	if nodeChanged {
+		t.nodes[node.Name] = stripped
+	}
 	t.generation++
 }
 
@@ -81,6 +96,7 @@ func (t *nodesCache) delete(nodeName string) {
 func (t *nodesCache) deleteWithoutLock(nodeName string) {
 	if _, found := t.nodes[nodeName]; found {
 		delete(t.nodes, nodeName)
+		t.schedulableAndReadyNodes.Delete(nodeName)
 		t.generation++
 	}
 }
@@ -92,7 +108,14 @@ func (t *nodesCache) find(nodeLabels map[string]string, levels []string) ([]*cor
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	filteredNodes := make([]*corev1.Node, 0, len(t.nodes))
+	shouldExcludeUnschedulableAndNotReadyNodes :=
+		features.Enabled(features.SchedulerLibraryIntegration) &&
+			(len(levels) == 0 || !utiltas.IsLowestLevelHostname(levels))
+
 	for _, node := range t.nodes {
+		if shouldExcludeUnschedulableAndNotReadyNodes && !t.schedulableAndReadyNodes.Has(node.Name) {
+			continue
+		}
 		if utiltas.NodeMatchesFlavor(node.Labels, nodeLabels, levels) {
 			filteredNodes = append(filteredNodes, node)
 		}

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 )
 
@@ -269,5 +270,23 @@ func TestNodesCacheGeneration(t *testing.T) {
 				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
 			}
 		})
+	}
+}
+
+func TestNodesCacheWithSchedulerLibraryIntegration(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
+
+	nc := newNodesCache()
+	unreadyNode := node.MakeNode("unready-node").DeepCopy()
+	unschedNode := node.MakeNode("unsched-node").Unschedulable().Obj()
+
+	nc.sync(unreadyNode)
+	nc.sync(unschedNode)
+
+	if _, found := nc.nodes["unready-node"]; !found {
+		t.Errorf("expected unready-node to be cached when SchedulerLibraryIntegration is enabled")
+	}
+	if _, found := nc.nodes["unsched-node"]; !found {
+		t.Errorf("expected unsched-node to be cached when SchedulerLibraryIntegration is enabled")
 	}
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -280,43 +280,33 @@ func TestNodesCacheSync(t *testing.T) {
 	testCases := map[string]struct {
 		enableSchedulerLibraryIntegration bool
 		prime                             []corev1.Node
-		op                                func(nc *nodesCache)
+		node                              *corev1.Node
 		wantNodes                         []corev1.Node
 		wantSchedulableAndReady           []string
 	}{
 		"FG disabled: sync not ready removes node": {
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.DeepCopy())
-			},
+			node: nodeWrapper.DeepCopy(),
 		},
 		"FG disabled: sync ready adds node": {
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Obj())
-			},
+			node:                    nodeWrapper.Clone().Ready().Obj(),
 			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
 			wantSchedulableAndReady: []string{"test"},
 		},
 		"FG enabled: sync not ready keeps node in cache but not in schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.DeepCopy())
-			},
-			wantNodes: []corev1.Node{*nodeWrapper.DeepCopy()},
+			node:                              nodeWrapper.DeepCopy(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.DeepCopy()},
 		},
 		"FG enabled: sync unschedulable keeps node in cache but not in schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Unschedulable().Obj())
-			},
-			wantNodes: []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
+			node:                              nodeWrapper.Clone().Ready().Unschedulable().Obj(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
 		},
 		"FG enabled: sync ready adds node to cache and schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Obj())
-			},
-			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
-			wantSchedulableAndReady: []string{"test"},
+			node:                              nodeWrapper.Clone().Ready().Obj(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady:           []string{"test"},
 		},
 	}
 	for name, tc := range testCases {
@@ -326,17 +316,18 @@ func TestNodesCacheSync(t *testing.T) {
 			for i := range tc.prime {
 				nc.sync(&tc.prime[i])
 			}
-			tc.op(nc)
+			nc.sync(tc.node)
 
-			wantNodesMap := make(map[string]*corev1.Node, len(tc.wantNodes))
+			wantNodeNameNodes := make(map[string]*corev1.Node, len(tc.wantNodes))
 			for i := range tc.wantNodes {
-				wantNodesMap[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
+				wantNodeNameNodes[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
 			}
-			if diff := cmp.Diff(wantNodesMap, nc.nodes); diff != "" {
+			if diff := cmp.Diff(wantNodeNameNodes, nc.nodes, cmpopts.SortMaps(func(a, b string) bool {
+				return a < b
+			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
 			}
-			wantSet := sets.New(tc.wantSchedulableAndReady...)
-			if diff := cmp.Diff(wantSet, nc.schedulableAndReadyNodes); diff != "" {
+			if diff := cmp.Diff(sets.New(tc.wantSchedulableAndReady...), nc.schedulableAndReadyNodes); diff != "" {
 				t.Errorf("Unexpected schedulableAndReadyNodes (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
@@ -273,20 +274,71 @@ func TestNodesCacheGeneration(t *testing.T) {
 	}
 }
 
-func TestNodesCacheWithSchedulerLibraryIntegration(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
+func TestNodesCacheSync(t *testing.T) {
+	nodeWrapper := node.MakeNode("test")
 
-	nc := newNodesCache()
-	unreadyNode := node.MakeNode("unready-node").DeepCopy()
-	unschedNode := node.MakeNode("unsched-node").Unschedulable().Obj()
-
-	nc.sync(unreadyNode)
-	nc.sync(unschedNode)
-
-	if _, found := nc.nodes["unready-node"]; !found {
-		t.Errorf("expected unready-node to be cached when SchedulerLibraryIntegration is enabled")
+	testCases := map[string]struct {
+		enableSchedulerLibraryIntegration bool
+		prime                             []corev1.Node
+		op                                func(nc *nodesCache)
+		wantNodes                         []corev1.Node
+		wantSchedulableAndReady           []string
+	}{
+		"FG disabled: sync not ready removes node": {
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.DeepCopy())
+			},
+		},
+		"FG disabled: sync ready adds node": {
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Obj())
+			},
+			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady: []string{"test"},
+		},
+		"FG enabled: sync not ready keeps node in cache but not in schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.DeepCopy())
+			},
+			wantNodes: []corev1.Node{*nodeWrapper.DeepCopy()},
+		},
+		"FG enabled: sync unschedulable keeps node in cache but not in schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Unschedulable().Obj())
+			},
+			wantNodes: []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
+		},
+		"FG enabled: sync ready adds node to cache and schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Obj())
+			},
+			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady: []string{"test"},
+		},
 	}
-	if _, found := nc.nodes["unsched-node"]; !found {
-		t.Errorf("expected unsched-node to be cached when SchedulerLibraryIntegration is enabled")
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, tc.enableSchedulerLibraryIntegration)
+			nc := newNodesCache()
+			for i := range tc.prime {
+				nc.sync(&tc.prime[i])
+			}
+			tc.op(nc)
+
+			wantNodesMap := make(map[string]*corev1.Node, len(tc.wantNodes))
+			for i := range tc.wantNodes {
+				wantNodesMap[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
+			}
+			if diff := cmp.Diff(wantNodesMap, nc.nodes); diff != "" {
+				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
+			}
+			wantSet := sets.New(tc.wantSchedulableAndReady...)
+			if diff := cmp.Diff(wantSet, nc.schedulableAndReadyNodes); diff != "" {
+				t.Errorf("Unexpected schedulableAndReadyNodes (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeunschedulable"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,6 +59,7 @@ func newWASSchedulerConfig() *schedulerconfig.KubeSchedulerConfiguration {
 					},
 					Filter: schedulerconfig.PluginSet{
 						Enabled: []schedulerconfig.Plugin{
+							{Name: nodeunschedulable.Name},
 							{Name: tainttoleration.Name},
 							{Name: nodeaffinity.Name},
 							{Name: nodeports.Name},

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -203,3 +203,46 @@ func TestNodePortsFeasibility(t *testing.T) {
 		})
 	}
 }
+
+func TestNodeUnschedulableFeasibility(t *testing.T) {
+	ctx := t.Context()
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{corev1.LabelHostname: "node1"}},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
+		Spec:       corev1.NodeSpec{Unschedulable: false},
+	}
+	nodes := []*corev1.Node{node1, node2}
+
+	sim, err := NewWASSimulatorForTest(ctx)
+	if err != nil {
+		t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+	}
+
+	candidates := func(yield func(simulator.Candidate) bool) {
+		for _, n := range nodes {
+			if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+				return
+			}
+		}
+	}
+
+	checker, err := sim.NewFeasibilityChecker(ctx, nodes)
+	if err != nil {
+		t.Fatalf("NewFeasibilityChecker failed: %v", err)
+	}
+
+	results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+		PodTemplate: &corev1.PodTemplateSpec{},
+	}, &simulator.NodeExclusionStats{})
+	if err != nil {
+		t.Fatalf("FindFeasibleNodes failed: %v", err)
+	}
+
+	if len(results) != 1 || results[0].GetNode().Name != "node2" {
+		t.Errorf("expected only node2 to be feasible, got %v", results)
+	}
+}

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -21,6 +21,7 @@ package was
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,34 +216,59 @@ func TestNodeUnschedulableFeasibility(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
 		Spec:       corev1.NodeSpec{Unschedulable: false},
 	}
-	nodes := []*corev1.Node{node1, node2}
 
-	sim, err := NewWASSimulatorForTest(ctx)
-	if err != nil {
-		t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+	tests := map[string]struct {
+		nodes        []*corev1.Node
+		candidatePod corev1.PodTemplateSpec
+		wantFeasible map[string]bool
+	}{
+		"unschedulable node is excluded": {
+			nodes:        []*corev1.Node{node1, node2},
+			candidatePod: corev1.PodTemplateSpec{},
+			wantFeasible: map[string]bool{"node2": true},
+		},
+		"all schedulable nodes are feasible": {
+			nodes:        []*corev1.Node{node2},
+			candidatePod: corev1.PodTemplateSpec{},
+			wantFeasible: map[string]bool{"node2": true},
+		},
 	}
 
-	candidates := func(yield func(simulator.Candidate) bool) {
-		for _, n := range nodes {
-			if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
-				return
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim, err := NewWASSimulatorForTest(ctx)
+			if err != nil {
+				t.Fatalf("NewWASSimulatorForTest failed: %v", err)
 			}
-		}
-	}
 
-	checker, err := sim.NewFeasibilityChecker(ctx, nodes)
-	if err != nil {
-		t.Fatalf("NewFeasibilityChecker failed: %v", err)
-	}
+			candidates := func(yield func(simulator.Candidate) bool) {
+				for _, n := range tc.nodes {
+					if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+						return
+					}
+				}
+			}
 
-	results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
-		PodTemplate: &corev1.PodTemplateSpec{},
-	}, &simulator.NodeExclusionStats{})
-	if err != nil {
-		t.Fatalf("FindFeasibleNodes failed: %v", err)
-	}
+			snapshot, err := sim.Snapshot(ctx, tc.nodes)
+			if err != nil {
+				t.Fatalf("Snapshot failed: %v", err)
+			}
 
-	if len(results) != 1 || results[0].GetNode().Name != "node2" {
-		t.Errorf("expected only node2 to be feasible, got %v", results)
+			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+				PodTemplate: &tc.candidatePod,
+			}, &simulator.NodeExclusionStats{})
+			if err != nil {
+				t.Fatalf("FindFeasibleNodes failed: %v", err)
+			}
+
+			gotNames := make(map[string]bool)
+			for _, r := range results {
+				gotNames[r.GetNode().Name] = true
+			}
+
+			if diff := cmp.Diff(tc.wantFeasible, gotNames); diff != "" {
+				t.Errorf("Unexpected feasible nodes (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -41,6 +41,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/was"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -3408,6 +3409,159 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 		},
+		"SchedulerLibraryIntegration enabled: generic TAS workload admitted on healthy node": {
+			nodes:           defaultSingleNode,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
+		"SchedulerLibraryIntegration enabled: non-hostname lowest-level TAS excludes unschedulable node": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(tasRackLabel, "r1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(tasRackLabel, "r2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Unschedulable().
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{
+				*utiltestingapi.MakeTopology("tas-rack-only").
+					Levels(tasRackLabel).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("tas-rack-flavor").
+					NodeLabel("tas-node", "true").
+					TopologyName("tas-rack-only").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-rack-flavor").
+						Resource(corev1.ResourceCPU, "50").Obj()).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-rack", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(tasRackLabel).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl-rack": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-rack-flavor", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{tasRackLabel}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"r1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-rack", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-rack", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
+		"SchedulerLibraryIntegration enabled: hostname lowest-level TAS filters unschedulable node via WAS": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Unschedulable().
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hostname", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl-hostname": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-hostname", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-hostname", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
 	}
 	scenarios := []map[featuregate.Feature]bool{
 		{
@@ -3486,7 +3640,15 @@ func TestScheduleForTAS(t *testing.T) {
 					_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 					cl := clientBuilder.Build()
 					recorder := &utiltesting.EventRecorder{}
-					cqCache := schdcache.New(cl, schdcache.WithResourceTransformations(tc.resourceTransformations))
+					cacheOptions := []schdcache.Option{schdcache.WithResourceTransformations(tc.resourceTransformations)}
+					if features.Enabled(features.SchedulerLibraryIntegration) {
+						sim, err := was.NewWASSimulatorForTest(ctx)
+						if err != nil {
+							t.Fatalf("Failed to initialize WAS scheduling simulator: %v", err)
+						}
+						cacheOptions = append(cacheOptions, schdcache.WithSchedulingSimulator(sim))
+					}
+					cqCache := schdcache.New(cl, cacheOptions...)
 					fakeClock := testingclock.NewFakeClock(now)
 					qManager := qcache.NewManagerForUnitTests(cl, cqCache,
 						qcache.WithClock(fakeClock), qcache.WithResourceTransformations(tc.resourceTransformations))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/area tas
/area was

#### What this PR does / why we need it:

Delegates node health and unschedulable checks to the WAS scheduling library when `SchedulerLibraryIntegration` is enabled.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #14176 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
WorkloadAwareScheduler: Delegated TAS node readiness and `spec.unschedulable` checks to the `scheduler-library` instead of applying them when building the TAS node cache. Controlled by the `SchedulerLibraryIntegration` feature gate, which is Alpha and disabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduler cache handling for nodes that are unready or marked unschedulable.
  - Prevented unschedulable nodes from being selected during scheduling while continuing to consider eligible nodes.
  - Preserved appropriate hostname-level placement behavior when filtering unavailable nodes.

- **Tests**
  - Added coverage for node retention and filtering across scheduler integration scenarios.
  - Added integration coverage for generic admission and rack- and hostname-level placement involving unschedulable nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->