### PR TITLE
fix: report DeviceClass name in NotFound error, not full sentence

### DIFF
--- a/pkg/controller/core/workload_controller_dra_test.go
+++ b/pkg/controller/core/workload_controller_dra_test.go
@@ -292,7 +292,7 @@ func TestReconcileDRA(t *testing.T) {
 						Type:    kueue.WorkloadQuotaReserved,
 						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadQuotaReservedReasonMisconfigured,
-						Message: "spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName: Not found: \"DeviceClass unmapped.example.com is not mapped in DRA configuration for podset main\"",
+						Message: "spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName.deviceClassName: Not found: \"unmapped.example.com\"",
 					}).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadAdmitted,
@@ -304,7 +304,7 @@ func TestReconcileDRA(t *testing.T) {
 						Type:    kueue.WorkloadRequeued,
 						Status:  metav1.ConditionFalse,
 						Reason:  kueue.WorkloadInadmissible,
-						Message: "spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName: Not found: \"DeviceClass unmapped.example.com is not mapped in DRA configuration for podset main\"",
+						Message: "spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName.deviceClassName: Not found: \"unmapped.example.com\"",
 					}).
 					Obj()
 				wl.Spec.PodSets[0].Template.Spec.ResourceClaims = []corev1.PodResourceClaim{{

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -216,8 +216,8 @@ func GetResourceRequestsForResourceClaimTemplates(
 				logical, found := mapper.Lookup(dc)
 				if !found {
 					allErrs = append(allErrs, field.NotFound(
-						field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j).Child("resourceClaimTemplateName"),
-						fmt.Sprintf("DeviceClass %s is not mapped in DRA configuration for podset %s", dc, ps.Name),
+						field.NewPath("spec", "podSets").Index(i).Child("template", "spec", "resourceClaims").Index(j).Child("resourceClaimTemplateName").Child("deviceClassName"),
+						dc,
 					))
 					return nil, allErrs
 				}

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -104,7 +104,7 @@ func Test_GetResourceRequests(t *testing.T) {
 			name:   "Unmapped DeviceClass returns error",
 			lookup: noLookup,
 			wantErr: field.ErrorList{
-				field.NotFound(field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("resourceClaimTemplateName"), ""),
+				field.NotFound(field.NewPath("spec", "podSets").Index(0).Child("template", "spec", "resourceClaims").Index(0).Child("resourceClaimTemplateName").Child("deviceClassName"), "test-deviceclass-1"),
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
1. If this is your first time, please read our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
   and developer guide:
   https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR:
   https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Optionally add one or more of the following kinds if applicable:
/kind cleanup
/kind documentation
/kind feature
/kind kep
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

This PR fixes the error reported when a DeviceClass used by a DRA ResourceClaimTemplate is not mapped in the Kueue DRA configuration.

Previously, Kueue constructed a `field.NotFound` error with the entire human-readable explanation in the `value`/`BadValue` field. This caused the resulting Workload condition to report a message such as:

```text
spec.podSets[0].template.spec.resourceClaims[0].resourceClaimTemplateName: Not found: "DeviceClass gpu.example.com is not mapped in DRA configuration for podset main"
```

The actual missing value is the DeviceClass name (`gpu.example.com`), while the explanation should be kept separate.

This PR makes the minimal change necessary to correct the error payload while preserving the existing validation path and overall DRA behavior:

- Keeps using `field.NotFound`, since the validation category is already correct.
- Changes the error field path to `deviceClassName`, so the error points to the field that is actually invalid.
- Sets `BadValue` to the missing DeviceClass name instead of the full explanatory sentence.
- Removes the long human-readable explanation from the missing-value slot.
- Updates the affected unit and controller tests to validate the corrected error shape and message.
- Does not change the broader DRA admission, scheduling, or validation flow.
- Does not modify documentation in this PR; documentation updates can be handled separately if maintainers want the wording mirrored there.

### Files changed

**`pkg/dra/claims.go`**

Updated the unmapped DeviceClass error construction:

- The field path now ends in `deviceClassName`.
- The `BadValue` contains the actual missing DeviceClass name.
- The explanatory sentence is no longer used as the missing value.

This is the core bug fix.

**`pkg/dra/claims_test.go`**

Updated the unit test for the helper that creates the error:

- Expects the corrected `deviceClassName` field path.
- Expects the actual missing DeviceClass value.

**`pkg/controller/core/workload_controller_dra_test.go`**

Updated the controller test so the Workload conditions reflect the corrected error message exposed to users.

### Why this approach

The issue is about the shape and contents of the validation error rather than the underlying DRA admission logic.

The fix therefore:

- Keeps the existing validation branch.
- Preserves the same failure outcome.
- Reports the DeviceClass name as the value that was actually not found.
- Points the error at `deviceClassName`.
- Keeps the change intentionally small and isolated.
- Avoids unrelated DRA behavior changes.

This follows the expected Kubernetes-style `field.Error` structure, where the missing value is represented as the value that could not be found and the explanation is kept separate.

#### Which issue(s) this PR fixes:

Fixes #14206

<!--
Automatically closes linked issue when PR is merged.

Usage:
Fixes #<issue number>
or
Fixes (paste link of issue)

If PR is about failing-tests or flakes, please post the related issues/tests in a comment and do not use `Fixes`.
-->

#### Special notes for your reviewer:

This is intentionally a minimal fix for the unmapped DeviceClass error reporting.

The existing validation logic and failure behavior are preserved. The change is limited to making the `field.NotFound` payload accurately represent the missing DeviceClass and updating the tests that assert the old error string.

The issue specifically called out that the missing value should be the DeviceClass name, while the explanation should not be stored as the value. The field path was also updated from `resourceClaimTemplateName` to `deviceClassName` so it identifies the field that is actually invalid.

No unrelated tests or DRA code paths were changed.

### Testing

The narrowest useful tests covering this change were run:

```shell
go test ./pkg/dra -run 'Test_GetResourceRequests/Unmapped DeviceClass returns error'
go test ./pkg/controller/core -run 'TestReconcileDRA/reconcile DRA ResourceClaimTemplate with unmapped device class'
```

Both tests passed:

```text
pkg/dra: ok
pkg/controller/core: ok
```

#### Does this PR introduce a user-facing change?

Yes. The user-facing validation error for an unmapped DeviceClass is now more accurate and reports the actual DeviceClass name as the missing value.

Release note:

```release-note
Fix unmapped DeviceClass validation errors to report the actual DeviceClass name as the missing value.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation errors for unmapped device classes.
  - Errors now identify the specific `deviceClassName` field and include the missing device class name.
  - Removed a misleading podset-specific error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->