### PR TITLE
[release-0.19] MultiKueue: forward RayService serveConfigV2 in-place updates to the worker (#14036)

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -1062,6 +1063,57 @@ func (c *configHandler) queueWorkloadsForConfig(ctx context.Context, configName 
 	return errors.Join(errs...)
 }
 
+// localJobHandler enqueues the workload(s) owned by a manager-side job when the
+// job's spec changes.
+//
+// Normally a job spec edit makes the job controller update the workload, which in
+// turn reconciles this admission-check controller. But a spec change that does not
+// alter the workload's PodSets (e.g. a RayService serveConfigV2 edit) leaves the
+// workload untouched, so that path never fires and this controller would only
+// reconcile on the next periodic requeue. This handler bridges that gap by watching
+// the job directly, so such a change promptly re-runs SyncJob.
+type localJobHandler struct {
+	client            client.Client
+	gvk               schema.GroupVersionKind
+	eventsBatchPeriod time.Duration
+}
+
+var _ handler.EventHandler = (*localJobHandler)(nil)
+
+func (h *localJobHandler) Create(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) Update(ctx context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// React to spec changes only; a status-only update (e.g. status synced back
+	// from the worker) neither needs nor should re-trigger a sync.
+	//
+	// TODO: generation bumps only on spec changes, so metadata-only edits (labels,
+	// annotations) are filtered out here. Revisit if a future adapter needs to forward
+	// such metadata to the worker.
+	if e.ObjectOld.GetGeneration() == e.ObjectNew.GetGeneration() {
+		return
+	}
+	h.queue(ctx, e.ObjectNew, q)
+}
+
+func (h *localJobHandler) Delete(context.Context, event.DeleteEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) Generic(context.Context, event.GenericEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (h *localJobHandler) queue(ctx context.Context, obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	wls := &kueue.WorkloadList{}
+	if err := h.client.List(ctx, wls, client.InNamespace(obj.GetNamespace()),
+		client.MatchingFields{indexer.OwnerReferenceIndexKey(h.gvk): obj.GetName()}); err != nil {
+		ctrl.LoggerFrom(ctx).V(2).Error(err, "Listing workloads for manager job", "job", klog.KObj(obj))
+		return
+	}
+	for i := range wls.Items {
+		q.AddAfter(reconcile.Request{NamespacedName: client.ObjectKeyFromObject(&wls.Items[i])}, h.eventsBatchPeriod)
+	}
+}
+
 func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 	syncHndl := handler.Funcs{
 		GenericFunc: func(_ context.Context, e event.GenericEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
@@ -1072,16 +1124,60 @@ func (w *wlReconciler) setupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		Named("multikueue_workload").
 		For(&kueue.Workload{}).
 		WatchesRawSource(source.Channel(w.clusters.wlUpdateCh, syncHndl)).
-		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod}).
+		Watches(&kueue.MultiKueueConfig{}, &configHandler{client: w.client, eventsBatchPeriod: w.eventsBatchPeriod})
+
+	c, err := builder.
 		WithEventFilter(w).
 		WithOptions(controller.Options{
 			LogConstructor: roletracker.NewLogConstructor(w.roleTracker, "multikueue-workload"),
 		}).
-		Complete(w)
+		Build(w)
+	if err != nil {
+		return err
+	}
+
+	// Watch the local (manager) job objects of adapters that forward spec changes
+	// after admission. Such an edit (e.g. RayService serveConfigV2) does not alter the
+	// workload CR, so it does not reconcile this controller through the usual path;
+	// watching the job directly lets it promptly trigger a sync instead of waiting for
+	// the next periodic requeue.
+	//
+	// The watch is added on the built controller (not the builder) and only once the
+	// job's CRD is served (jobframework.WaitForAPI). A job CRD may be installed after
+	// Kueue starts (e.g. KubeRay), so adding it to the builder would make this
+	// controller's cache sync fail and crash-loop the manager; deferring degrades
+	// gracefully and picks the watch up when the CRD appears.
+	if features.Enabled(features.MultiKueueRemoteSpecSync) {
+		for _, adapter := range w.adapters {
+			lw, ok := adapter.(jobframework.MultiKueueLocalJobWatcher)
+			if !ok {
+				continue
+			}
+			emptyJob := lw.NewEmptyLocalJob()
+			if emptyJob == nil {
+				continue
+			}
+			gvk := adapter.GVK()
+			h := &localJobHandler{client: w.client, gvk: gvk, eventsBatchPeriod: w.eventsBatchPeriod}
+			if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				log := ctrl.LoggerFrom(ctx).WithName("multikueue-workload")
+				jobframework.WaitForAPI(ctx, mgr, log, gvk, func() {
+					if err := c.Watch(source.Kind(mgr.GetCache(), emptyJob, h)); err != nil {
+						log.Error(err, "Unable to watch local job for MultiKueue spec sync", "gvk", gvk)
+					}
+				})
+				return nil
+			})); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func findPodSetAssignment(assignments []kueue.PodSetAssignment, name kueue.PodSetReference) *kueue.PodSetAssignment {

--- a/pkg/controller/jobframework/multikueue.go
+++ b/pkg/controller/jobframework/multikueue.go
@@ -66,6 +66,18 @@ type MultiKueueWatcher interface {
 	WorkloadKeysFor(runtime.Object) ([]types.NamespacedName, error)
 }
 
+// MultiKueueLocalJobWatcher is an optional interface for MultiKueue adapters that
+// forward manager-side spec changes to the worker after admission (see the Ray
+// adapter's RemoteSpecSyncer). Watching the local (manager) job lets a spec change
+// promptly trigger a workload reconcile (and thus SyncJob) instead of waiting for
+// the next periodic requeue. Adapters that don't forward spec changes simply do not
+// implement it.
+type MultiKueueLocalJobWatcher interface {
+	// NewEmptyLocalJob returns an empty job object of the adapter's type to watch,
+	// or nil when this adapter does not currently need a local watch.
+	NewEmptyLocalJob() client.Object
+}
+
 // MultiKueueMultiWorkloadAdapter is an optional interface for MultiKueue adapters
 // whose jobs create multiple workloads (e.g., LeaderWorkerSet creates one workload per replica).
 type MultiKueueMultiWorkloadAdapter interface {

--- a/pkg/controller/jobframework/setup.go
+++ b/pkg/controller/jobframework/setup.go
@@ -94,7 +94,7 @@ func (m *integrationManager) setupControllers(ctx context.Context, mgr ctrl.Mana
 					return fmt.Errorf("%s: unable to create webhook: %w", fwkNamePrefix, err)
 				}
 				logger.Info("No matching API in the server for job framework, deferring setting up controller")
-				go waitForAPI(ctx, mgr, log, gvk, func() {
+				go WaitForAPI(ctx, mgr, log, gvk, func() {
 					log.Info("API now available, starting controller", "gvk", gvk)
 					if err := m.setupControllerAndWebhook(ctx, mgr, name, fwkNamePrefix, cb, options, opts...); err != nil {
 						log.Error(err, "Failed to setup controller for job framework")
@@ -147,7 +147,12 @@ func (m *integrationManager) setupControllerAndWebhook(ctx context.Context, mgr 
 	return nil
 }
 
-func waitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
+// WaitForAPI runs action once the CRD for gvk is served by the API server: it invokes
+// action immediately if the CRD is already installed, otherwise it polls (with backoff)
+// until the CRD appears, then invokes action. It returns early if ctx is cancelled. This
+// lets callers set up watches on optional CRDs without hard-depending on the CRD being
+// present at manager start.
+func WaitForAPI(ctx context.Context, mgr ctrl.Manager, log logr.Logger, gvk schema.GroupVersionKind, action func()) {
 	rateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[string](baseBackoffWaitForIntegration, maxBackoffWaitForIntegration)
 	item := gvk.String()
 	for {

--- a/pkg/controller/jobs/ray/ray_multikueue_adapter.go
+++ b/pkg/controller/jobs/ray/ray_multikueue_adapter.go
@@ -55,6 +55,22 @@ type adapter[PtrT objAsPtr[T], T any] struct {
 	// on the worker cluster. It is left unset for job types that do not support
 	// this (see ElasticReplicaSync).
 	elastic *ElasticReplicaSync[PtrT, T]
+	// remoteSpecSync is optional. When set, the adapter forwards manager-side spec
+	// changes onto the remote copy on the worker cluster after admission (see
+	// RemoteSpecSyncer).
+	remoteSpecSync RemoteSpecSyncer[PtrT]
+}
+
+// RemoteSpecSyncer lets a job type forward selected spec changes from the manager
+// copy to its worker copy after the job is admitted, via an in-place patch of the
+// remote. Each job type decides which fields to forward and when a sync is needed.
+type RemoteSpecSyncer[PtrT any] interface {
+	// NeedsSync reports whether a manager-side change must be forwarded to the
+	// worker copy. It must be side-effect free.
+	NeedsSync(remote, local PtrT) bool
+	// Apply copies the safe fields from local onto remote. It is invoked only when
+	// NeedsSync returned true, and must be idempotent.
+	Apply(remote, local PtrT)
 }
 
 // ElasticReplicaSync carries the type-specific hooks that let the MultiKueue
@@ -96,9 +112,18 @@ func WithElasticReplicaSync[PtrT objAsPtr[T], T any](e *ElasticReplicaSync[PtrT,
 	}
 }
 
+// WithRemoteSpecSync enables forwarding manager-side spec changes to the worker copy
+// for job types that support it (see RemoteSpecSyncer).
+func WithRemoteSpecSync[PtrT objAsPtr[T], T any](s RemoteSpecSyncer[PtrT]) Option[PtrT, T] {
+	return func(a *adapter[PtrT, T]) {
+		a.remoteSpecSync = s
+	}
+}
+
 type fullInterface interface {
 	jobframework.MultiKueueAdapter
 	jobframework.MultiKueueWatcher
+	jobframework.MultiKueueLocalJobWatcher
 }
 
 // NewMKAdapter creates a generic MultiKueue adapter for Ray job types.
@@ -177,6 +202,9 @@ func (a *adapter[PtrT, T]) SyncJob(
 		if a.needElasticSync(ctx, workloadName, localJob, remoteJob) {
 			return false, a.syncElastic(ctx, remoteClient, workloadName, localJob, remoteJob)
 		}
+		if a.remoteSpecSync != nil && features.Enabled(features.MultiKueueRemoteSpecSync) && a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
+			return false, a.syncRemoteSpec(ctx, remoteClient, localJob, remoteJob)
+		}
 		return false, nil
 	}
 
@@ -239,6 +267,22 @@ func (a *adapter[PtrT, T]) syncElastic(ctx context.Context, remoteClient client.
 	return nil
 }
 
+// syncRemoteSpec patches the remote object's spec fields to match the local
+// (manager) object via the configured RemoteSpecSyncer. It should only be called
+// when the syncer's NeedsSync returns true.
+func (a *adapter[PtrT, T]) syncRemoteSpec(ctx context.Context, remoteClient client.Client, localJob, remoteJob PtrT) error {
+	if err := clientutil.Patch(ctx, remoteClient, remoteJob, func() (bool, error) {
+		if !a.remoteSpecSync.NeedsSync(remoteJob, localJob) {
+			return false, nil
+		}
+		a.remoteSpecSync.Apply(remoteJob, localJob)
+		return true, nil
+	}); err != nil {
+		return fmt.Errorf("failed to sync remote %s spec: %w", a.gvk.Kind, err)
+	}
+	return nil
+}
+
 func totalReplicas(counts map[kueue.PodSetReference]int32) int32 {
 	var total int32
 	for _, c := range counts {
@@ -256,6 +300,17 @@ func (a *adapter[PtrT, T]) DeleteRemoteObject(ctx context.Context, _ client.Clie
 
 func (a *adapter[PtrT, T]) GetEmptyList() client.ObjectList {
 	return a.emptyList()
+}
+
+// NewEmptyLocalJob lets the MultiKueue controller watch the manager job so a spec
+// change promptly triggers a sync. It is wired only for types that forward spec
+// changes after admission (remoteSpecSync); create-once types return nil and are
+// not watched.
+func (a *adapter[PtrT, T]) NewEmptyLocalJob() client.Object {
+	if a.remoteSpecSync == nil {
+		return nil
+	}
+	return PtrT(new(T))
 }
 
 func (a *adapter[PtrT, T]) WorkloadKeysFor(o runtime.Object) ([]types.NamespacedName, error) {

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -54,13 +54,15 @@ const (
 
 func init() {
 	utilruntime.Must(jobframework.RegisterIntegration(FrameworkName, jobframework.IntegrationCallbacks{
-		SetupIndexes:      SetupIndexes,
-		NewJob:            newJob,
-		NewReconciler:     NewReconciler,
-		SetupWebhook:      SetupRayServiceWebhook,
-		JobType:           &rayv1.RayService{},
-		AddToScheme:       rayv1.AddToScheme,
-		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy),
+		SetupIndexes:  SetupIndexes,
+		NewJob:        newJob,
+		NewReconciler: NewReconciler,
+		SetupWebhook:  SetupRayServiceWebhook,
+		JobType:       &rayv1.RayService{},
+		AddToScheme:   rayv1.AddToScheme,
+		MultiKueueAdapter: ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+			ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](remoteSpecSyncer{}),
+		),
 	}))
 }
 

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter.go
@@ -27,6 +27,22 @@ import (
 
 var _ jobframework.MultiKueueAdapter = ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
 
+// remoteSpecSyncer is RayService's RemoteSpecSyncer for MultiKueue.
+type remoteSpecSyncer struct{}
+
+var _ ray.RemoteSpecSyncer[*rayv1.RayService] = remoteSpecSyncer{}
+
+// NeedsSync reports whether the manager's serveConfigV2 differs from the worker's.
+// serveConfigV2 is the Ray Serve application config; forwarding it performs an
+// in-place Serve update on the worker cluster's RayService.
+func (remoteSpecSyncer) NeedsSync(remote, local *rayv1.RayService) bool {
+	return remote.Spec.ServeConfigV2 != local.Spec.ServeConfigV2
+}
+
+func (remoteSpecSyncer) Apply(remote, local *rayv1.RayService) {
+	remote.Spec.ServeConfigV2 = local.Spec.ServeConfigV2
+}
+
 func copyJobStatus(dst, src *rayv1.RayService) {
 	dst.Status = src.Status
 }

--- a/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_multikueue_adapter_test.go
@@ -82,6 +82,34 @@ func TestMultiKueueAdapter(t *testing.T) {
 					Obj(),
 			},
 		},
+		"sync forwards a serveConfigV2 change to the existing remote rayservice": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			managersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
+			},
+			workerRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					WithServeConfigV2("old-config").
+					Obj(),
+			},
+			operation: func(ctx context.Context, adapter jobframework.MultiKueueAdapter, managerClient, workerClient client.Client) error {
+				_, err := adapter.SyncJob(ctx, managerClient, workerClient, types.NamespacedName{Name: "rayservice1", Namespace: TestNamespace}, "wl1", "origin1")
+				return err
+			},
+
+			wantManagersRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().WithServeConfigV2("new-config").Obj(),
+			},
+			wantWorkerRayServices: []rayv1.RayService{
+				*rayServiceBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, "origin1").
+					WithServeConfigV2("new-config").
+					Obj(),
+			},
+		},
 		"sync status from remote rayservice": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			managersRayServices: []rayv1.RayService{
@@ -264,7 +292,8 @@ func TestMultiKueueAdapter(t *testing.T) {
 
 			ctx, _ := utiltesting.ContextWithLog(t)
 
-			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy)
+			adapter := ray.NewMKAdapter(copyJobSpec, copyJobStatus, getEmptyList, gvk, getManagedBy, setManagedBy,
+				ray.WithRemoteSpecSync[*rayv1.RayService, rayv1.RayService](remoteSpecSyncer{}))
 
 			gotErr := tc.operation(ctx, adapter, managerClient, workerClient)
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -585,6 +585,13 @@ const (
 	// begun, and suspend defaulting only ever adds suspend, so no path exists to
 	// unsuspend an object or bypass quota via create-then-delete.
 	SkipAncestorCheckForDeletedWorkloads featuregate.Feature = "SkipAncestorCheckForDeletedWorkloads"
+
+	// owner: @kevin85421
+	//
+	// Enables MultiKueue to forward manager-side spec changes (currently a RayService
+	// serveConfigV2 edit) onto the worker copy after admission, and to watch the manager
+	// job so such a change is forwarded promptly instead of on the next periodic requeue.
+	MultiKueueRemoteSpecSync featuregate.Feature = "MultiKueueRemoteSpecSync"
 )
 
 func init() {
@@ -894,6 +901,10 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	SkipAncestorCheckForDeletedWorkloads: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+
+	MultiKueueRemoteSpecSync: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 }

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -285,6 +285,12 @@
     lockToDefault: true
     preRelease: GA
     version: "0.18"
+- name: MultiKueueRemoteSpecSync
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: MultiKueueWaitForWorkloadAdmitted
   versionedSpecs:
   - default: true

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -285,6 +285,12 @@
     lockToDefault: true
     preRelease: GA
     version: "0.18"
+- name: MultiKueueRemoteSpecSync
+  versionedSpecs:
+  - default: true
+    lockToDefault: false
+    preRelease: Beta
+    version: "0.19"
 - name: MultiKueueWaitForWorkloadAdmitted
   versionedSpecs:
   - default: true

--- a/test/e2e/multikueue/extended/e2e_test.go
+++ b/test/e2e/multikueue/extended/e2e_test.go
@@ -986,6 +986,51 @@ app = HelloWorld.bind()`,
 						g.Expect(apimeta.IsStatusConditionTrue(createdRayService.Status.Conditions, string(rayv1.RayServiceReady))).To(gomega.BeTrue())
 					}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 				})
+
+				// An in-place serveConfigV2 edit is quota-neutral, so MultiKueue forwards it
+				// to the worker copy without re-admission. num_replicas 1 -> 2 is a clear,
+				// observable change within serveConfigV2.
+				updatedServeConfigV2 := `applications:
+  - name: hello_app
+    import_path: hello_serve:app
+    route_prefix: /
+    deployments:
+      - name: HelloWorld
+        num_replicas: 2
+        max_replicas_per_node: 1
+        ray_actor_options:
+          num_cpus: 0.2`
+
+				gomega.Expect(updatedServeConfigV2).NotTo(gomega.Equal(serveConfigV2), "the updated serveConfigV2 must differ from the initial config so the forward assertion is meaningful")
+
+				workerClient := kubernetesClients[admittedWorker].client
+				var workerRayServiceUID types.UID
+				ginkgo.By("Recording the existing worker copy and its initial serveConfigV2", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						workerRayService := &rayv1.RayService{}
+						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
+						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(serveConfigV2))
+						workerRayServiceUID = workerRayService.UID
+					}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Updating serveConfigV2 on the manager", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						createdRayService := &rayv1.RayService{}
+						g.Expect(k8sManagerClient.Get(ctx, client.ObjectKeyFromObject(rayService), createdRayService)).To(gomega.Succeed())
+						createdRayService.Spec.ServeConfigV2 = updatedServeConfigV2
+						g.Expect(k8sManagerClient.Update(ctx, createdRayService)).To(gomega.Succeed())
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				})
+
+				ginkgo.By("Checking the change is promptly forwarded to the same worker copy (in-place, no re-admission)", func() {
+					gomega.Eventually(func(g gomega.Gomega) {
+						workerRayService := &rayv1.RayService{}
+						g.Expect(workerClient.Get(ctx, client.ObjectKeyFromObject(rayService), workerRayService)).To(gomega.Succeed())
+						g.Expect(workerRayService.Spec.ServeConfigV2).To(gomega.Equal(updatedServeConfigV2))
+						g.Expect(workerRayService.UID).To(gomega.Equal(workerRayServiceUID))
+					}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
+				})
 			})
 		})
 	})

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -58,6 +58,7 @@ import (
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/admissioncheck"
@@ -72,6 +73,7 @@ import (
 	testingpytorchjob "sigs.k8s.io/kueue/pkg/util/testingjobs/pytorchjob"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
+	testingrayservice "sigs.k8s.io/kueue/pkg/util/testingjobs/rayservice"
 	testingtfjob "sigs.k8s.io/kueue/pkg/util/testingjobs/tfjob"
 	testingtrainjob "sigs.k8s.io/kueue/pkg/util/testingjobs/trainjob"
 	testingxgboostjob "sigs.k8s.io/kueue/pkg/util/testingjobs/xgboostjob"
@@ -83,7 +85,7 @@ import (
 )
 
 var defaultEnabledIntegrations = sets.New(
-	"batch/job", "kubeflow.org/mpijob", "ray.io/rayjob", "ray.io/raycluster",
+	"batch/job", "kubeflow.org/mpijob", "ray.io/rayjob", "ray.io/raycluster", "ray.io/rayservice",
 	"jobset.x-k8s.io/jobset", "kubeflow.org/paddlejob",
 	"kubeflow.org/pytorchjob", "kubeflow.org/tfjob", "kubeflow.org/xgboostjob", "kubeflow.org/jaxjob",
 	"pod", "workload.codeflare.dev/appwrapper", "trainer.kubeflow.org/trainjob")
@@ -1789,6 +1791,45 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(createdRayCluster.Status.DesiredWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.ReadyWorkerReplicas).To(gomega.Equal(int32(1)))
 				g.Expect(createdRayCluster.Status.AvailableWorkerReplicas).To(gomega.Equal(int32(1)))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
+	ginkgo.It("Should forward a serveConfigV2 update to the RayService on the worker if admitted", func() {
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
+			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
+		)
+		rayService := testingrayservice.MakeService("rayservice1", managerNs.Name).
+			Queue(managerLq.Name).
+			WithServeConfigV2("serve-config-v1").
+			Obj()
+		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, rayService)
+		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
+		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
+
+		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+
+		ginkgo.By("checking the remote RayService is created with the initial serveConfigV2", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.ServeConfigV2).To(gomega.Equal("serve-config-v1"))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("updating serveConfigV2 on the manager, the change is forwarded to the remote RayService", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				createdRayService.Spec.ServeConfigV2 = "serve-config-v2"
+				g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, &createdRayService)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdRayService := rayv1.RayService{}
+				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, client.ObjectKeyFromObject(rayService), &createdRayService)).To(gomega.Succeed())
+				g.Expect(createdRayService.Spec.ServeConfigV2).To(gomega.Equal("serve-config-v2"))
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})

--- a/test/integration/multikueue/suite_test.go
+++ b/test/integration/multikueue/suite_test.go
@@ -53,6 +53,7 @@ import (
 	workloadpod "sigs.k8s.io/kueue/pkg/controller/jobs/pod"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	workloadrayjob "sigs.k8s.io/kueue/pkg/controller/jobs/rayjob"
+	workloadrayservice "sigs.k8s.io/kueue/pkg/controller/jobs/rayservice"
 	workloadtrainjob "sigs.k8s.io/kueue/pkg/controller/jobs/trainjob"
 	"sigs.k8s.io/kueue/pkg/controller/workloaddispatcher"
 	"sigs.k8s.io/kueue/pkg/dra"
@@ -388,6 +389,23 @@ func managerSetup(ctx context.Context, mgr manager.Manager) {
 		jobframework.WithCache(cCache),
 		jobframework.WithQueues(queues),
 	)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = workloadrayservice.SetupIndexes(ctx, mgr.GetFieldIndexer())
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	rayServiceReconciler, err := workloadrayservice.NewReconciler(
+		ctx,
+		mgr.GetClient(),
+		mgr.GetFieldIndexer(),
+		mgr.GetEventRecorder(constants.JobControllerName),
+		jobframework.WithCache(cCache),
+		jobframework.WithQueues(queues))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	err = rayServiceReconciler.SetupWithManager(mgr)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	err = workloadrayservice.SetupRayServiceWebhook(mgr, jobframework.WithCache(cCache), jobframework.WithQueues(queues))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = workloadaw.SetupIndexes(ctx, mgr.GetFieldIndexer())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

Manual cherry-pick of #14036 to `release-0.19`.

The original change lets MultiKueue forward an in-place `serveConfigV2` (Ray Serve application config) edit on a manager `RayService` to its worker copy after admission, and watches the manager job so the change is forwarded promptly instead of on the next periodic requeue. It is gated behind the `MultiKueueRemoteSpecSync` feature gate (Beta, enabled by default) so it can ship as a safely toggleable bugfix.

**Conflict-resolution notes** (`release-0.19` diverges from `main`):

- The Ray adapter (`ray_multikueue_adapter.go`) applied cleanly — `release-0.19` already has the elastic-replica-sync feature, so unlike the `release-0.18` backport nothing had to be dropped there.
- RayService integration registration keeps `release-0.19`'s `init()` + `RegisterIntegration` form, with `WithRemoteSpecSync` added.
- `release-0.19` does not yet have the main-only `admissionCheckHandler` (added after 0.19 branched, unrelated to this PR), so it was not introduced; `wlReconciler.setupWithManager` keeps 0.19's existing sources plus the new deferred `localJobHandler` watch.
- The MultiKueue integration test suite wiring was adapted to `release-0.19` (no `integrationManager`/`WithIntegrationManager`), enabling the RayService integration the `release-0.19` way.
- The `MultiKueueRemoteSpecSync` feature gate is added as Beta, enabled by default, at version `0.19`.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

- Cherry-pick of #14036 (cherry picked from commit a81fbeea13129747c755a35e5e1f11094d498d86).
- Local verification on `release-0.19`: `go build ./...`, unit tests (`pkg/features`, `pkg/controller/jobs/ray`, `pkg/controller/jobs/rayservice`, `pkg/controller/admissionchecks/multikueue`), and `go vet` all pass. Integration/e2e run in CI.
- AI tools were used to help prepare this cherry-pick, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Forwarded in-place `serveConfigV2` (Ray Serve application config) updates on a `RayService` from the manager to the worker cluster, so editing the Serve config on the manager now takes effect on the worker promptly. Changes to `rayClusterConfig`/`upgradeStrategy` (zero-downtime upgrade) are not yet propagated.
```
