### PR TITLE
[release-0.19] Fix TAS domain ID collision between leaf and root domains (#14010)

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -151,9 +151,6 @@ type TASFlavorSnapshot struct {
 	// roots maps domainID to domains that are at the highest level of topology structure
 	roots domainByID
 
-	// domains maps domainID to every domain available in the topology structure
-	domains domainByID
-
 	// domainsPerLevel stores the static tree information
 	domainsPerLevel []domainByID
 
@@ -224,7 +221,6 @@ func newTASFlavorSnapshot(
 		levelKeys:          slices.Clone(levels),
 		leaves:             make(leafDomainByID),
 		tolerations:        slices.Clone(tolerations),
-		domains:            make(domainByID),
 		roots:              make(domainByID),
 		domainsPerLevel:    domainsPerLevel,
 		isLowestLevelNode:  len(levels) > 0 && levels[len(levels)-1] == corev1.LabelHostname,
@@ -283,7 +279,6 @@ func (s *TASFlavorSnapshot) highestLevel() string {
 func (s *TASFlavorSnapshot) initialize() {
 	for _, leafDomain := range s.leaves {
 		domain := &leafDomain.domain
-		s.domains[domain.id] = domain
 		s.domainsPerLevel[len(domain.levelValues)-1][domain.id] = domain
 		s.initializeHelper(domain)
 	}
@@ -297,13 +292,12 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 	}
 	parentValues := dom.levelValues[:len(dom.levelValues)-1]
 	parentID := utiltas.DomainID(parentValues)
-	parent, parentFound := s.domains[parentID]
+	parent, parentFound := s.domainsPerLevel[len(parentValues)-1][parentID]
 	if !parentFound {
 		// create parent
 		parent = &domain{id: parentID, levelValues: parentValues}
 
 		s.domainsPerLevel[len(parentValues)-1][parentID] = parent
-		s.domains[parentID] = parent
 		s.initializeHelper(parent)
 	}
 	// connect parent and child
@@ -851,7 +845,7 @@ func (s *TASFlavorSnapshot) requiredReplacementDomain(tr *TASPodSetRequests, ta 
 // in Node's NodeReady condition
 func (s *TASFlavorSnapshot) IsTopologyAssignmentStale(ta *utiltas.TopologyAssignment) (bool, string) {
 	for _, domain := range ta.Domains {
-		if _, found := s.domains[utiltas.DomainID(domain.Values)]; !found {
+		if _, found := s.leaves[utiltas.DomainID(domain.Values)]; !found {
 			return true, domain.Values[0]
 		}
 	}
@@ -1788,15 +1782,17 @@ func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool)
 // fillInCounts computes per-domain pod, slice, and leader capacities from the
 // pod requirements, then rolls those capacities up the topology tree.
 func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState) error {
-	for _, domain := range s.domains {
-		// cleanup the state in case some remaining values are present from computing
-		// assignments for previous PodSets.
-		domain.state = 0
-		domain.stateWithLeader = 0
-		domain.sliceState = 0
-		domain.sliceStateWithLeader = 0
-		domain.leaderState = 0
-		domain.affinityScore = 0
+	for _, domainsAtLevel := range s.domainsPerLevel {
+		for _, domain := range domainsAtLevel {
+			// cleanup the state in case some remaining values are present from computing
+			// assignments for previous PodSets.
+			domain.state = 0
+			domain.stateWithLeader = 0
+			domain.sliceState = 0
+			domain.sliceStateWithLeader = 0
+			domain.leaderState = 0
+			domain.affinityScore = 0
+		}
 	}
 	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
 	if features.Enabled(features.TASCacheNodeMatchResults) {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1095,3 +1095,129 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 		})
 	}
 }
+
+func newTestSnapshot(t *testing.T, levels []string, nodes ...*corev1.Node) *TASFlavorSnapshot {
+	t.Helper()
+	_, log := utiltesting.ContextWithLog(t)
+	s := newTASFlavorSnapshot(log, "dummy", levels, nil, &defaultChecker{})
+	for _, n := range nodes {
+		s.addNode(n)
+	}
+	s.initialize()
+	return s
+}
+
+func TestInitializeDomainIDCollision(t *testing.T) {
+	const blockLabel = "cloud.provider.com/topology-block"
+
+	s := newTestSnapshot(t, []string{blockLabel, corev1.LabelHostname},
+		node.MakeNode("b1").
+			Label(blockLabel, "b1").
+			Label(corev1.LabelHostname, "b1").
+			Obj(),
+	)
+
+	leaf, found := s.leaves["b1"]
+	if !found {
+		t.Fatalf("leaf domain %q not found", "b1")
+	}
+	if leaf.parent == nil {
+		t.Fatalf("leaf domain %q has no parent", leaf.id)
+	}
+	if leaf.parent == &leaf.domain {
+		t.Errorf("leaf domain %q is its own parent", leaf.id)
+	}
+	if diff := cmp.Diff([]string{"b1"}, leaf.parent.levelValues); diff != "" {
+		t.Errorf("unexpected parent level values (-want,+got): %s", diff)
+	}
+	if got := len(s.domainsPerLevel[0]); got != 1 {
+		t.Errorf("len(domainsPerLevel[0]) = %d, want 1", got)
+	}
+	if got := len(s.domainsPerLevel[1]); got != 1 {
+		t.Errorf("len(domainsPerLevel[1]) = %d, want 1", got)
+	}
+	if got := len(s.roots); got != 1 {
+		t.Fatalf("len(roots) = %d, want 1", got)
+	}
+	if _, isRoot := s.roots[leaf.parent.id]; !isRoot {
+		t.Errorf("parent of leaf %q is not registered as a root", leaf.id)
+	}
+}
+
+func TestIsTopologyAssignmentStale(t *testing.T) {
+	const blockLabel = "cloud.provider.com/topology-block"
+	const rackLabel = "cloud.provider.com/topology-rack"
+
+	hostnameLowest := func(t *testing.T) *TASFlavorSnapshot {
+		return newTestSnapshot(t, []string{blockLabel, corev1.LabelHostname},
+			node.MakeNode("n1").
+				Label(blockLabel, "b1").
+				Label(corev1.LabelHostname, "n1").
+				Obj(),
+		)
+	}
+	rackLowest := func(t *testing.T) *TASFlavorSnapshot {
+		return newTestSnapshot(t, []string{blockLabel, rackLabel},
+			node.MakeNode("n1").
+				Label(blockLabel, "b1").
+				Label(rackLabel, "r1").
+				Obj(),
+		)
+	}
+
+	cases := map[string]struct {
+		snapshot        func(t *testing.T) *TASFlavorSnapshot
+		assignment      *tas.TopologyAssignment
+		wantStale       bool
+		wantStaleDomain string
+	}{
+		"existing hostname leaf is not stale": {
+			snapshot: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n1"}}},
+			},
+		},
+		"missing hostname leaf is stale": {
+			snapshot: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"n2"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "n2",
+		},
+		"deleted node is stale even when its hostname matches an existing root domain ID": {
+			snapshot: hostnameLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "b1",
+		},
+		"existing non-hostname leaf is not stale": {
+			snapshot: rackLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r1"}}},
+			},
+		},
+		"missing non-hostname leaf is stale": {
+			snapshot: rackLowest,
+			assignment: &tas.TopologyAssignment{
+				Domains: []tas.TopologyDomainAssignment{{Values: []string{"b1", "r2"}}},
+			},
+			wantStale:       true,
+			wantStaleDomain: "b1",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			gotStale, gotStaleDomain := tc.snapshot(t).IsTopologyAssignmentStale(tc.assignment)
+			if gotStale != tc.wantStale {
+				t.Errorf("IsTopologyAssignmentStale() stale = %t, want %t", gotStale, tc.wantStale)
+			}
+			if gotStaleDomain != tc.wantStaleDomain {
+				t.Errorf("IsTopologyAssignmentStale() stale domain = %q, want %q", gotStaleDomain, tc.wantStaleDomain)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Manual cherry-pick of #14010 to `release-0.19`

#### Which issue(s) this PR fixes:

Original issue: https://github.com/kubernetes-sigs/kueue/issues/14009

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where a node whose hostname matched the value of the topology's top level was silently excluded from placement. The node stayed Ready with free capacity but never received pods, because its domain was recorded as its own parent and never registered as a topology root.
```