### PR TITLE
fix: require TAS for TASRecomputeAssignmentWithinSchedulingCycle

### DIFF
--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1839,14 +1839,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"cannot set TAS profile with TAS disabled": {
 			featureGateMap: map[string]bool{
-				string(features.TASProfileMixed):                  true,
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TASProfileMixed):                             true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1890,16 +1891,17 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"ElasticJobsViaWorkloadSlicesWithTAS requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
-				string(features.ElasticJobsViaWorkloadSlices):        true,
-				string(features.TopologyAwareScheduling):             false,
-				string(features.TASHandleOverlappingFlavors):         false,
-				string(features.TASProfileMixed):                     false,
-				string(features.TASFailedNodeReplacement):            false,
-				string(features.TASFailedNodeReplacementFailFast):    false,
-				string(features.TASReplaceNodeOnPodTermination):      false,
-				string(features.TASReplaceNodeOnNodeTaints):          false,
-				string(features.TASMultiLayerTopology):               false,
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS):         true,
+				string(features.ElasticJobsViaWorkloadSlices):                true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1919,16 +1921,17 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"multiple FG validation errors at once": {
 			featureGateMap: map[string]bool{
-				string(features.TASProfileMixed):                     true,
-				string(features.TopologyAwareScheduling):             false,
-				string(features.TASHandleOverlappingFlavors):         true,
-				string(features.ElasticJobsViaWorkloadSlicesWithTAS): true,
-				string(features.ElasticJobsViaWorkloadSlices):        false,
-				string(features.TASFailedNodeReplacement):            false,
-				string(features.TASFailedNodeReplacementFailFast):    false,
-				string(features.TASReplaceNodeOnPodTermination):      false,
-				string(features.TASReplaceNodeOnNodeTaints):          false,
-				string(features.TASMultiLayerTopology):               false,
+				string(features.TASProfileMixed):                             true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASHandleOverlappingFlavors):                 true,
+				string(features.ElasticJobsViaWorkloadSlicesWithTAS):         true,
+				string(features.ElasticJobsViaWorkloadSlices):                false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1939,14 +1942,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASHandleOverlappingFlavors requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      true,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 true,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1962,16 +1966,37 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 				string(features.TASHandleOverlappingFlavors): true,
 			},
 		},
+		"TASRecomputeAssignmentWithinSchedulingCycle requires TopologyAwareScheduling": {
+			featureGateMap: map[string]bool{
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "featureGates",
+					Detail: "TASRecomputeAssignmentWithinSchedulingCycle is enabled, but depends on features that are disabled: [TopologyAwareScheduling]",
+				},
+			},
+		},
 		"TASFailedNodeReplacement requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         true,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    true,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -1983,15 +2008,16 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASBalancedPlacement requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASBalancedPlacement):             true,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASBalancedPlacement):                        true,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2003,14 +2029,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASReplaceNodeOnNodeTaints requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       true,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  true,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2022,14 +2049,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASMultiLayerTopology requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            true,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       true,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2041,15 +2069,16 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASRespectNodeAffinityPreferred requires TopologyAwareScheduling": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASRespectNodeAffinityPreferred):  true,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASRespectNodeAffinityPreferred):             true,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2092,14 +2121,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASFailedNodeReplacementFailFast requires both TopologyAwareScheduling and TASFailedNodeReplacement": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): true,
-				string(features.TASReplaceNodeOnPodTermination):   false,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            true,
+				string(features.TASReplaceNodeOnPodTermination):              false,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
@@ -2110,14 +2140,15 @@ func TestLoadAndValidateFeatureGates(t *testing.T) {
 		},
 		"TASReplaceNodeOnPodTermination requires both TopologyAwareScheduling and TASFailedNodeReplacement": {
 			featureGateMap: map[string]bool{
-				string(features.TopologyAwareScheduling):          false,
-				string(features.TASProfileMixed):                  false,
-				string(features.TASHandleOverlappingFlavors):      false,
-				string(features.TASFailedNodeReplacement):         false,
-				string(features.TASFailedNodeReplacementFailFast): false,
-				string(features.TASReplaceNodeOnPodTermination):   true,
-				string(features.TASReplaceNodeOnNodeTaints):       false,
-				string(features.TASMultiLayerTopology):            false,
+				string(features.TopologyAwareScheduling):                     false,
+				string(features.TASProfileMixed):                             false,
+				string(features.TASHandleOverlappingFlavors):                 false,
+				string(features.TASFailedNodeReplacement):                    false,
+				string(features.TASFailedNodeReplacementFailFast):            false,
+				string(features.TASReplaceNodeOnPodTermination):              true,
+				string(features.TASReplaceNodeOnNodeTaints):                  false,
+				string(features.TASMultiLayerTopology):                       false,
+				string(features.TASRecomputeAssignmentWithinSchedulingCycle): false,
 			},
 			wantErr: field.ErrorList{
 				&field.Error{

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -426,6 +426,7 @@ const (
 	// kep: https://github.com/kubernetes-sigs/kueue/tree/main/keps/2724-topology-aware-scheduling
 	//
 	// Enable re-computing the assignment within the same scheduling cycle when a TAS workload doesn't fit.
+	// Requires TopologyAwareScheduling to be enabled.
 	TASRecomputeAssignmentWithinSchedulingCycle featuregate.Feature = "TASRecomputeAssignmentWithinSchedulingCycle"
 
 	// owner: @j-skiba
@@ -554,22 +555,23 @@ func init() {
 }
 
 var defaultFeatureGateDependencies = map[featuregate.Feature][]featuregate.Feature{
-	TASFailedNodeReplacement:                 {TopologyAwareScheduling},
-	TASFailedNodeReplacementFailFast:         {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASReplaceNodeOnPodTermination:           {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASReplaceNodeDueToNotReadyOverFixedTime: {TopologyAwareScheduling, TASFailedNodeReplacement},
-	TASBalancedPlacement:                     {TopologyAwareScheduling},
-	TASReplaceNodeOnNodeTaints:               {TopologyAwareScheduling},
-	TASMultiLayerTopology:                    {TopologyAwareScheduling},
-	TASRespectNodeAffinityPreferred:          {TopologyAwareScheduling},
-	UnadmittedWorkloadsExplicitStatus:        {UnadmittedWorkloadsObservability},
-	TASHandleOverlappingFlavors:              {TopologyAwareScheduling},
-	TASProfileMixed:                          {TopologyAwareScheduling},
-	ElasticJobsViaWorkloadSlicesWithTAS:      {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
-	KueueDRAIntegrationExtendedResource:      {KueueDRAIntegration},
-	KueueDRAIntegrationPartitionableDevices:  {KueueDRAIntegration},
-	KueueDRAIntegrationConsumableCapacity:    {KueueDRAIntegration},
-	FlavorFungibilityPreserveScanProgress:    {FlavorFungibility},
+	TASFailedNodeReplacement:                    {TopologyAwareScheduling},
+	TASFailedNodeReplacementFailFast:            {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASReplaceNodeOnPodTermination:              {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASReplaceNodeDueToNotReadyOverFixedTime:    {TopologyAwareScheduling, TASFailedNodeReplacement},
+	TASBalancedPlacement:                        {TopologyAwareScheduling},
+	TASReplaceNodeOnNodeTaints:                  {TopologyAwareScheduling},
+	TASMultiLayerTopology:                       {TopologyAwareScheduling},
+	TASRespectNodeAffinityPreferred:             {TopologyAwareScheduling},
+	UnadmittedWorkloadsExplicitStatus:           {UnadmittedWorkloadsObservability},
+	TASHandleOverlappingFlavors:                 {TopologyAwareScheduling},
+	TASProfileMixed:                             {TopologyAwareScheduling},
+	TASRecomputeAssignmentWithinSchedulingCycle: {TopologyAwareScheduling},
+	ElasticJobsViaWorkloadSlicesWithTAS:         {ElasticJobsViaWorkloadSlices, TopologyAwareScheduling},
+	KueueDRAIntegrationExtendedResource:         {KueueDRAIntegration},
+	KueueDRAIntegrationPartitionableDevices:     {KueueDRAIntegration},
+	KueueDRAIntegrationConsumableCapacity:       {KueueDRAIntegration},
+	FlavorFungibilityPreserveScanProgress:       {FlavorFungibility},
 }
 
 // defaultVersionedFeatureGates consists of all known Kueue-specific feature keys.

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -780,7 +780,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{
 				features.RecomputeAssignmentUponPreemptionTargetsOverlap: true,
 				features.TopologyAwareScheduling:                         false,
-				features.TASRecomputeAssignmentWithinSchedulingCycle:     true,
+				features.TASRecomputeAssignmentWithinSchedulingCycle:     false,
 			},
 			// Admitted state:
 			// - wl-admitted-default (cq-1): uses 10 CPU on default flavor (borrowing 5)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kueue/issues/14234

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
TAS: Fix a bug where TASRecomputeAssignmentWithinSchedulingCycle can be enabled even if TopologyAwareScheduling is disabled.

ACTION REQUIRED: If you disable TopologyAwareScheduling, also set TASRecomputeAssignmentWithinSchedulingCycle=false before upgrading.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for topology-aware scheduling feature gates.
  * Added dependency checks ensuring assignment recomputation, balanced placement, preferred node affinity, failed-node replacement, and pod-termination replacement are enabled only with the required topology-aware scheduling feature.
  * Improved reporting for combined and invalid feature-gate configurations.
  * Corrected scheduling behavior when topology-aware scheduling is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->