### PR TITLE
MultiKueue: extract shared integration test fixture and adopt it in jobs_test.go

### DIFF
--- a/test/integration/multikueue/helpers_test.go
+++ b/test/integration/multikueue/helpers_test.go
@@ -235,3 +235,122 @@ func checkingTheWorkloadCreation(wlLookupKey types.NamespacedName, matcher gomeg
 		}, util.Timeout, util.Interval).Should(matcher)
 	})
 }
+
+// multiKueueFixture holds the manager/worker resources that every MultiKueue
+// integration spec needs: namespaces, kubeconfig secrets, MultiKueueClusters,
+// the MultiKueueConfig, the MultiKueue AdmissionCheck, and the ClusterQueue,
+// LocalQueue and ResourceFlavor on the manager and both workers.
+//
+// Per-framework test files create it in BeforeEach via setupMultiKueueFixture
+// and release it in AfterEach via teardown, so the common setup lives in one
+// place instead of being duplicated in every file.
+type multiKueueFixture struct {
+	managerNs *corev1.Namespace
+	worker1Ns *corev1.Namespace
+	worker2Ns *corev1.Namespace
+
+	managerMultiKueueSecret1 *corev1.Secret
+	managerMultiKueueSecret2 *corev1.Secret
+	workerCluster1           *kueue.MultiKueueCluster
+	workerCluster2           *kueue.MultiKueueCluster
+	managerMultiKueueConfig  *kueue.MultiKueueConfig
+	multiKueueAC             *kueue.AdmissionCheck
+	managerCq                *kueue.ClusterQueue
+	managerLq                *kueue.LocalQueue
+	managerFlavor            *kueue.ResourceFlavor
+
+	worker1Cq     *kueue.ClusterQueue
+	worker1Lq     *kueue.LocalQueue
+	worker1Flavor *kueue.ResourceFlavor
+
+	worker2Cq     *kueue.ClusterQueue
+	worker2Lq     *kueue.LocalQueue
+	worker2Flavor *kueue.ResourceFlavor
+}
+
+func setupMultiKueueFixture() *multiKueueFixture {
+	ginkgo.GinkgoHelper()
+	f := &multiKueueFixture{}
+
+	f.managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
+	f.worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, f.managerNs.Name)
+	f.worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, f.managerNs.Name)
+
+	w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	w2Kubeconfig, err := worker2TestCluster.kubeConfigBytes()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	f.managerMultiKueueSecret1 = utiltesting.MakeSecret("multikueue1", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w1Kubeconfig).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueSecret1)
+
+	f.managerMultiKueueSecret2 = utiltesting.MakeSecret("multikueue2", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w2Kubeconfig).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueSecret2)
+
+	f.workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, f.managerMultiKueueSecret1.Name).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster1)
+
+	f.workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2").KubeConfig(kueue.SecretLocationType, f.managerMultiKueueSecret2.Name).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2)
+
+	f.managerMultiKueueConfig = utiltestingapi.MakeMultiKueueConfig("multikueueconfig").Clusters(f.workerCluster1.Name, f.workerCluster2.Name).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueConfig)
+
+	f.multiKueueAC = utiltestingapi.MakeAdmissionCheck("ac1").
+		ControllerName(kueue.MultiKueueControllerName).
+		Parameters(kueue.SchemeGroupVersion.Group, "MultiKueueConfig", f.managerMultiKueueConfig.Name).
+		Obj()
+	util.CreateAdmissionChecksAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, f.multiKueueAC)
+
+	f.managerFlavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
+	util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, f.managerFlavor)
+
+	f.managerCq = utiltestingapi.MakeClusterQueue("q1").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
+		AdmissionChecks(kueue.AdmissionCheckReference(f.multiKueueAC.Name)).
+		Obj()
+	util.CreateClusterQueuesAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, f.managerCq)
+
+	f.managerLq = utiltestingapi.MakeLocalQueue(f.managerCq.Name, f.managerNs.Name).ClusterQueue(f.managerCq.Name).Obj()
+	util.CreateLocalQueuesAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, f.managerLq)
+
+	f.worker1Flavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
+	util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Flavor)
+	f.worker1Cq = utiltestingapi.MakeClusterQueue("q1").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
+		Obj()
+	util.CreateClusterQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Cq)
+	f.worker1Lq = utiltestingapi.MakeLocalQueue(f.worker1Cq.Name, f.worker1Ns.Name).ClusterQueue(f.worker1Cq.Name).Obj()
+	util.CreateLocalQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Lq)
+
+	f.worker2Flavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
+	util.MustCreate(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Flavor)
+	f.worker2Cq = utiltestingapi.MakeClusterQueue("q1").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
+		Obj()
+	util.CreateClusterQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Cq)
+	f.worker2Lq = utiltestingapi.MakeLocalQueue(f.worker2Cq.Name, f.worker2Ns.Name).ClusterQueue(f.worker2Cq.Name).Obj()
+	util.CreateLocalQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Lq)
+
+	return f
+}
+
+func (f *multiKueueFixture) teardown() {
+	ginkgo.GinkgoHelper()
+	gomega.Expect(util.DeleteNamespace(managerTestCluster.ctx, managerTestCluster.client, f.managerNs)).To(gomega.Succeed())
+	gomega.Expect(util.DeleteNamespace(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Ns)).To(gomega.Succeed())
+	gomega.Expect(util.DeleteNamespace(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Ns)).To(gomega.Succeed())
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerCq, true)
+	util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Cq, true)
+	util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Cq, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerFlavor, true)
+	util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, f.worker1Flavor, true)
+	util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, f.worker2Flavor, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.multiKueueAC, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueConfig, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster1, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueSecret1, true)
+	util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerMultiKueueSecret2, true)
+}

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -81,29 +81,7 @@ import (
 )
 
 var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:multikueue"), ginkgo.Ordered, ginkgo.ContinueOnFailure, func() {
-	var (
-		managerNs *corev1.Namespace
-		worker1Ns *corev1.Namespace
-		worker2Ns *corev1.Namespace
-
-		managerMultiKueueSecret1 *corev1.Secret
-		managerMultiKueueSecret2 *corev1.Secret
-		workerCluster1           *kueue.MultiKueueCluster
-		workerCluster2           *kueue.MultiKueueCluster
-		managerMultiKueueConfig  *kueue.MultiKueueConfig
-		multiKueueAC             *kueue.AdmissionCheck
-		managerCq                *kueue.ClusterQueue
-		managerLq                *kueue.LocalQueue
-		managerFlavor            *kueue.ResourceFlavor
-
-		worker1Cq     *kueue.ClusterQueue
-		worker1Lq     *kueue.LocalQueue
-		worker1Flavor *kueue.ResourceFlavor
-
-		worker2Cq     *kueue.ClusterQueue
-		worker2Lq     *kueue.LocalQueue
-		worker2Flavor *kueue.ResourceFlavor
-	)
+	var f *multiKueueFixture
 
 	ginkgo.BeforeAll(func() {
 		managerTestCluster.fwk.StartManager(managerTestCluster.ctx, managerTestCluster.cfg, func(ctx context.Context, mgr manager.Manager) {
@@ -116,98 +94,25 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.BeforeEach(func() {
-		managerNs = util.CreateNamespaceFromPrefixWithLog(managerTestCluster.ctx, managerTestCluster.client, "multikueue-")
-		worker1Ns = util.CreateNamespaceWithLog(worker1TestCluster.ctx, worker1TestCluster.client, managerNs.Name)
-		worker2Ns = util.CreateNamespaceWithLog(worker2TestCluster.ctx, worker2TestCluster.client, managerNs.Name)
-
-		w1Kubeconfig, err := worker1TestCluster.kubeConfigBytes()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		w2Kubeconfig, err := worker2TestCluster.kubeConfigBytes()
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-
-		managerMultiKueueSecret1 = utiltesting.MakeSecret("multikueue1", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w1Kubeconfig).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret1)
-
-		managerMultiKueueSecret2 = utiltesting.MakeSecret("multikueue2", managersConfigNamespace.Name).Data(kueue.MultiKueueConfigSecretKey, w2Kubeconfig).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret2)
-
-		workerCluster1 = utiltestingapi.MakeMultiKueueCluster("worker1").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret1.Name).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, workerCluster1)
-
-		workerCluster2 = utiltestingapi.MakeMultiKueueCluster("worker2").KubeConfig(kueue.SecretLocationType, managerMultiKueueSecret2.Name).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, workerCluster2)
-
-		managerMultiKueueConfig = utiltestingapi.MakeMultiKueueConfig("multikueueconfig").Clusters(workerCluster1.Name, workerCluster2.Name).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueConfig)
-
-		multiKueueAC = utiltestingapi.MakeAdmissionCheck("ac1").
-			ControllerName(kueue.MultiKueueControllerName).
-			Parameters(kueue.SchemeGroupVersion.Group, "MultiKueueConfig", managerMultiKueueConfig.Name).
-			Obj()
-		util.CreateAdmissionChecksAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC)
-
-		managerFlavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
-		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, managerFlavor)
-
-		managerCq = utiltestingapi.MakeClusterQueue("q1").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
-			AdmissionChecks(kueue.AdmissionCheckReference(multiKueueAC.Name)).
-			Obj()
-		util.CreateClusterQueuesAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, managerCq)
-
-		managerLq = utiltestingapi.MakeLocalQueue(managerCq.Name, managerNs.Name).ClusterQueue(managerCq.Name).Obj()
-		util.CreateLocalQueuesAndWaitForActive(managerTestCluster.ctx, managerTestCluster.client, managerLq)
-
-		worker1Flavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
-		util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, worker1Flavor)
-		worker1Cq = utiltestingapi.MakeClusterQueue("q1").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
-			Obj()
-		util.CreateClusterQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq)
-		worker1Lq = utiltestingapi.MakeLocalQueue(worker1Cq.Name, worker1Ns.Name).ClusterQueue(worker1Cq.Name).Obj()
-		util.CreateLocalQueuesAndWaitForActive(worker1TestCluster.ctx, worker1TestCluster.client, worker1Lq)
-
-		worker2Flavor = utiltestingapi.MakeResourceFlavor(string(multikueueTestFlavor)).Obj()
-		util.MustCreate(worker2TestCluster.ctx, worker2TestCluster.client, worker2Flavor)
-		worker2Cq = utiltestingapi.MakeClusterQueue("q1").
-			ResourceGroup(*utiltestingapi.MakeFlavorQuotas(string(multikueueTestFlavor)).Resource(corev1.ResourceCPU, "5").Obj()).
-			Obj()
-		util.CreateClusterQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq)
-		worker2Lq = utiltestingapi.MakeLocalQueue(worker2Cq.Name, worker2Ns.Name).ClusterQueue(worker2Cq.Name).Obj()
-		util.CreateLocalQueuesAndWaitForActive(worker2TestCluster.ctx, worker2TestCluster.client, worker2Lq)
+		f = setupMultiKueueFixture()
 	})
 
 	ginkgo.AfterEach(func() {
-		gomega.Expect(util.DeleteNamespace(managerTestCluster.ctx, managerTestCluster.client, managerNs)).To(gomega.Succeed())
-		gomega.Expect(util.DeleteNamespace(worker1TestCluster.ctx, worker1TestCluster.client, worker1Ns)).To(gomega.Succeed())
-		gomega.Expect(util.DeleteNamespace(worker2TestCluster.ctx, worker2TestCluster.client, worker2Ns)).To(gomega.Succeed())
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerCq, true)
-		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1Cq, true)
-		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2Cq, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerFlavor, true)
-		util.ExpectObjectToBeDeleted(worker1TestCluster.ctx, worker1TestCluster.client, worker1Flavor, true)
-		util.ExpectObjectToBeDeleted(worker2TestCluster.ctx, worker2TestCluster.client, worker2Flavor, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, multiKueueAC, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueConfig, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret1, true)
-		util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerMultiKueueSecret2, true)
+		f.teardown()
 	})
 
 	ginkgo.It("Should run a job on worker if admitted", func() {
-		admittedMetricBefore := util.GetMultiKueueWorkloadsAdmittedTotal(managerCq, "worker1")
-		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+		admittedMetricBefore := util.GetMultiKueueWorkloadsAdmittedTotal(f.managerCq, "worker1")
+		job := testingjob.MakeJob("job", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
 
 		ginkgo.By("setting workload reservation in the management cluster", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -225,14 +130,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
@@ -246,7 +151,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(managerCq, "worker1", admittedMetricBefore+1)
+			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(f.managerCq, "worker1", admittedMetricBefore+1)
 		})
 
 		ginkgo.By("finishing the worker job", func() {
@@ -296,13 +201,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should retry a Job whose remote workload finishes OutOfSync instead of finishing the manager workload", func() {
-		job := testingjob.MakeJob("job-oos", managerNs.Name).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+		job := testingjob.MakeJob("job-oos", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		gomega.Expect(managerTestCluster.client.Create(managerTestCluster.ctx, job)).Should(gomega.Succeed())
 
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 			Obj()
 
@@ -315,7 +220,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name, kueue.CheckStateReady, `The workload was admitted on "worker1"`,
+				f.multiKueueAC.Name, kueue.CheckStateReady, `The workload was admitted on "worker1"`,
 			)
 		})
 
@@ -351,17 +256,17 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a job on worker if admitted (ManagedBy)", func() {
-		job := testingjob.MakeJob("job", managerNs.Name).
+		job := testingjob.MakeJob("job", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
 
 		ginkgo.By("setting workload reservation in the management cluster", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -379,14 +284,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
@@ -476,8 +381,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a jobSet on worker if admitted", func() {
-		jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
-			Queue(managerLq.Name).
+		jobSet := testingjobset.MakeJobSet("job-set", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
 			ReplicatedJobs(
 				testingjobset.ReplicatedJobRequirements{
@@ -494,14 +399,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, jobSet)
-		wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: f.managerNs.Name}
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("replicated-job-1").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("replicated-job-2").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the jobset in the worker, updates the manager's jobset status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -536,9 +441,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a TFJob on worker if admitted", framework.RedundantSpec, func() {
-		tfJob := testingtfjob.MakeTFJob("tfjob1", managerNs.Name).
+		tfJob := testingtfjob.MakeTFJob("tfjob1", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			TFReplicaSpecs(
 				testingtfjob.TFReplicaSpecRequirement{
 					ReplicaType:   kftraining.TFJobReplicaTypeChief,
@@ -561,14 +466,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, tfJob)
-		wlLookupKey := types.NamespacedName{Name: workloadtfjob.GetWorkloadNameForTFJob(tfJob.Name, tfJob.UID), Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		wlLookupKey := types.NamespacedName{Name: workloadtfjob.GetWorkloadNameForTFJob(tfJob.Name, tfJob.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("chief").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("ps").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the TFJob in the worker, updates the manager's TFJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -626,9 +531,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a PaddleJob on worker if admitted", framework.RedundantSpec, func() {
-		paddleJob := testingpaddlejob.MakePaddleJob("paddlejob1", managerNs.Name).
+		paddleJob := testingpaddlejob.MakePaddleJob("paddlejob1", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			PaddleReplicaSpecs(
 				testingpaddlejob.PaddleReplicaSpecRequirement{
 					ReplicaType:   kftraining.PaddleJobReplicaTypeMaster,
@@ -646,13 +551,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, paddleJob)
 
-		wlLookupKey := types.NamespacedName{Name: workloadpaddlejob.GetWorkloadNameForPaddleJob(paddleJob.Name, paddleJob.UID), Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		wlLookupKey := types.NamespacedName{Name: workloadpaddlejob.GetWorkloadNameForPaddleJob(paddleJob.Name, paddleJob.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("master").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the PaddleJob in the worker, updates the manager's PaddleJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -702,9 +607,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a PyTorchJob on worker if admitted", func() {
-		pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob1", managerNs.Name).
+		pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob1", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			PyTorchReplicaSpecs(
 				testingpytorchjob.PyTorchReplicaSpecRequirement{
 					ReplicaType:   kftraining.PyTorchJobReplicaTypeMaster,
@@ -722,13 +627,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, pyTorchJob)
 
-		wlLookupKey := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		wlLookupKey := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("master").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the PyTorchJob in the worker, updates the manager's PyTorchJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -780,12 +685,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should not run a PyTorchJob on worker if set to be managed by wrong external controller", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("master").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob-not-managed", managerNs.Name).
-			Queue(managerLq.Name).
+		pyTorchJob := testingpytorchjob.MakePyTorchJob("pytorchjob-not-managed", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy("example.com/other-controller-not-training-operator").
 			PyTorchReplicaSpecs(
 				testingpytorchjob.PyTorchReplicaSpecRequirement{
@@ -806,15 +711,15 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, pyTorchJob)
 		})
 
-		wlLookupKeyNoManagedBy := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: managerNs.Name}
+		wlLookupKeyNoManagedBy := types.NamespacedName{Name: workloadpytorchjob.GetWorkloadNameForPyTorchJob(pyTorchJob.Name, pyTorchJob.UID), Namespace: f.managerNs.Name}
 		setQuotaReservationInCluster(wlLookupKeyNoManagedBy, admission)
 		checkingTheWorkloadCreation(wlLookupKeyNoManagedBy, gomega.Not(gomega.Succeed()))
 	})
 
 	ginkgo.It("Should run a XGBoostJob on worker if admitted", framework.RedundantSpec, func() {
-		xgBoostJob := testingxgboostjob.MakeXGBoostJob("xgboostjob1", managerNs.Name).
+		xgBoostJob := testingxgboostjob.MakeXGBoostJob("xgboostjob1", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			XGBReplicaSpecs(
 				testingxgboostjob.XGBReplicaSpecRequirement{
 					ReplicaType:   kftraining.XGBoostJobReplicaTypeMaster,
@@ -832,13 +737,13 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, xgBoostJob)
 
-		wlLookupKey := types.NamespacedName{Name: workloadxgboostjob.GetWorkloadNameForXGBoostJob(xgBoostJob.Name, xgBoostJob.UID), Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		wlLookupKey := types.NamespacedName{Name: workloadxgboostjob.GetWorkloadNameForXGBoostJob(xgBoostJob.Name, xgBoostJob.UID), Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("master").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the XGBoostJob in the worker, updates the manager's XGBoostJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -890,22 +795,22 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run an appwrapper on worker if admitted", func() {
-		aw := testingaw.MakeAppWrapper("aw", managerNs.Name).
+		aw := testingaw.MakeAppWrapper("aw", f.managerNs.Name).
 			Component(testingaw.Component{
-				Template: testingjob.MakeJob("job-1", managerNs.Name).SetTypeMeta().Parallelism(1).Obj(),
+				Template: testingjob.MakeJob("job-1", f.managerNs.Name).SetTypeMeta().Parallelism(1).Obj(),
 			}).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
 			Obj()
 
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, aw)
-		wlLookupKey := types.NamespacedName{Name: workloadappwrapper.GetWorkloadNameForAppWrapper(aw.Name, aw.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadappwrapper.GetWorkloadNameForAppWrapper(aw.Name, aw.UID), Namespace: f.managerNs.Name}
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("aw-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the appwrapper in the worker, updates the manager's appwrappers status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -935,12 +840,12 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should not run a MPIJob on worker if set to be managed by external controller", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("launcher").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		mpijobNoManagedBy := testingmpijob.MakeMPIJob("mpijob2", managerNs.Name).
-			Queue(managerLq.Name).
+		mpijobNoManagedBy := testingmpijob.MakeMPIJob("mpijob2", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy("example.com/other-controller-not-mpi-operator").
 			MPIJobReplicaSpecs(
 				testingmpijob.MPIJobReplicaSpecRequirement{
@@ -959,18 +864,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, mpijobNoManagedBy)
 		})
 
-		wlLookupKeyNoManagedBy := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijobNoManagedBy.Name, mpijobNoManagedBy.UID), Namespace: managerNs.Name}
+		wlLookupKeyNoManagedBy := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijobNoManagedBy.Name, mpijobNoManagedBy.UID), Namespace: f.managerNs.Name}
 		setQuotaReservationInCluster(wlLookupKeyNoManagedBy, admission)
 		checkingTheWorkloadCreation(wlLookupKeyNoManagedBy, gomega.Not(gomega.Succeed()))
 	})
 
 	ginkgo.It("Should run a MPIJob on worker if admitted", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("launcher").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("worker").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		mpijob := testingmpijob.MakeMPIJob("mpijob1", managerNs.Name).
-			Queue(managerLq.Name).
+		mpijob := testingmpijob.MakeMPIJob("mpijob1", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
 			MPIJobReplicaSpecs(
 				testingmpijob.MPIJobReplicaSpecRequirement{
@@ -986,8 +891,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, mpijob)
-		wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijob.Name, mpijob.UID), Namespace: managerNs.Name}
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		wlLookupKey := types.NamespacedName{Name: workloadmpijob.GetWorkloadNameForMPIJob(mpijob.Name, mpijob.UID), Namespace: f.managerNs.Name}
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the MPIJob in the worker, updates the manager's MPIJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1039,8 +944,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should create a pod on worker if admitted", func() {
-		pod := testingpod.MakePod("pod1", managerNs.Name).
-			Queue(managerLq.Name).
+		pod := testingpod.MakePod("pod1", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedByKueueLabel().
 			KueueSchedulingGate().
 			Obj()
@@ -1048,10 +953,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, pod)
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadpod.GetWorkloadNameForPod(pod.Name, pod.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadpod.GetWorkloadNameForPod(pod.Name, pod.UID), Namespace: f.managerNs.Name}
 
 		ginkgo.By("setting workload reservation in the management cluster", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -1069,7 +974,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
@@ -1080,7 +985,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
@@ -1147,8 +1052,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 	ginkgo.It("Should create a pod group on worker if admitted", func() {
 		groupName := "test-group"
-		podgroup := testingpod.MakePod(groupName, managerNs.Name).
-			Queue(managerLq.Name).
+		podgroup := testingpod.MakePod(groupName, f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedByKueueLabel().
 			KueueFinalizer().
 			KueueSchedulingGate().
@@ -1160,8 +1065,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		// any pod should give the same workload Key
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: groupName, Namespace: managerNs.Name}
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+		wlLookupKey := types.NamespacedName{Name: groupName, Namespace: f.managerNs.Name}
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 			PodSets(
 				utiltestingapi.MakePodSetAssignment("bf90803c").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Count(3).Obj(),
 			).Obj()
@@ -1193,7 +1098,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
@@ -1271,19 +1176,19 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, testAc2)
 
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(managerCq), managerCq)).To(gomega.Succeed())
-				managerCq.Spec.AdmissionChecksStrategy.AdmissionChecks = append(
-					managerCq.Spec.AdmissionChecksStrategy.AdmissionChecks,
+				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, client.ObjectKeyFromObject(f.managerCq), f.managerCq)).To(gomega.Succeed())
+				f.managerCq.Spec.AdmissionChecksStrategy.AdmissionChecks = append(
+					f.managerCq.Spec.AdmissionChecksStrategy.AdmissionChecks,
 					kueue.AdmissionCheckStrategyRule{Name: kueue.AdmissionCheckReference(testAc.Name)},
 					kueue.AdmissionCheckStrategyRule{Name: kueue.AdmissionCheckReference(testAc2.Name)},
 				)
-				g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, managerCq)).To(gomega.Succeed())
+				g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, f.managerCq)).To(gomega.Succeed())
 			}, util.VeryLongTimeout, util.Interval).Should(gomega.Succeed())
 		})
 
 		groupName := "test-group"
-		podgroup := testingpod.MakePod(groupName, managerNs.Name).
-			Queue(managerLq.Name).
+		podgroup := testingpod.MakePod(groupName, f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedByKueueLabel().
 			KueueFinalizer().
 			KueueSchedulingGate().
@@ -1294,14 +1199,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		}
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: groupName, Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: groupName, Namespace: f.managerNs.Name}
 
 		ginkgo.By("checking workload in manager is set up correctly", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				g.Expect(admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))).
+				g.Expect(admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))).
 					To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:  kueue.AdmissionCheckReference(multiKueueAC.Name),
+						Name:  kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 						State: kueue.CheckStatePending,
 					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))
 				g.Expect(admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(testAc.Name))).
@@ -1317,7 +1222,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 			PodSets(
 				utiltestingapi.MakePodSetAssignment("bf90803c").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Count(3).Obj(),
 			).Obj()
@@ -1385,7 +1290,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))
 				g.Expect(acs).NotTo(gomega.BeNil())
 				g.Expect(acs.State).To(gomega.Equal(kueue.CheckStateReady))
 				g.Expect(acs.Message).To(gomega.Equal(`The workload was admitted on "worker1"`))
@@ -1448,18 +1353,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should remove the worker's workload and job after reconnect when the managers job and workload are deleted", func() {
-		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+		job := testingjob.MakeJob("job", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 		jobLookupKey := client.ObjectKeyFromObject(job)
 		createdJob := &batchv1.Job{}
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
 
 		ginkgo.By("setting workload reservation in the management cluster", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -1476,10 +1381,10 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
+		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("setting workload reservation in worker1, the job is created in worker1", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
@@ -1489,7 +1394,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, managersConfigNamespace.Name)
+		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster1, managersConfigNamespace.Name)
 
 		ginkgo.By("removing the managers job and workload", func() {
 			gomega.Expect(managerTestCluster.client.Delete(managerTestCluster.ctx, job)).Should(gomega.Succeed())
@@ -1536,16 +1441,16 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("should clean up the remote workload on a reconnected worker after the job finishes", framework.SlowSpec, func() {
-		job := testingjob.MakeJob("job", managerNs.Name).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+		job := testingjob.MakeJob("job", f.managerNs.Name).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 		jobLookupKey := client.ObjectKeyFromObject(job)
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 			Obj()
 
@@ -1564,7 +1469,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster1, managersConfigNamespace.Name)
+		restoreConnectionToWorker1 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster1, managersConfigNamespace.Name)
 
 		ginkgo.By("setting workload reservation in worker2, the workload is admitted and job is created in worker2", func() {
 			util.SetQuotaReservation(worker2TestCluster.ctx, worker2TestCluster.client, wlLookupKey, admission)
@@ -1624,8 +1529,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should requeue the workload with a delay when the connection to the admitting worker is lost", framework.SlowSpec, func() {
-		jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
-			Queue(managerLq.Name).
+		jobSet := testingjobset.MakeJobSet("job-set", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
 			ReplicatedJobs(
 				testingjobset.ReplicatedJobRequirements{
@@ -1643,24 +1548,24 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, jobSet)
 
-		wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: f.managerNs.Name}
 
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("replicated-job-1").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("replicated-job-2").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
-		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
+		restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("waiting for the local workload admission check state to be set to pending and quotaReservatio removed", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
 				createdWorkload := &kueue.Workload{}
 				g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+				acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))
 				g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-					Name:       kueue.AdmissionCheckReference(multiKueueAC.Name),
+					Name:       kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 					State:      kueue.CheckStatePending,
 					RetryCount: new(int32(1)),
 				}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))
@@ -1677,20 +1582,20 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should not evict admitted workloads when the connection to the admitting worker is briefly lost", framework.SlowSpec, func() {
-		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
+		keys := admitJobsAndAgeAdmissionCheck(f.managerNs.Name, f.managerLq.Name, f.managerCq.Name, f.multiKueueAC.Name, 3)
 
-		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, managersConfigNamespace.Name)
 		restoreConnection()
 
 		ginkgo.By("no admitted workload is evicted after the brief connection loss", func() {
-			expectNoEviction(keys, multiKueueAC.Name, testingWorkerLostTimeout*2)
+			expectNoEviction(keys, f.multiKueueAC.Name, testingWorkerLostTimeout*2)
 		})
 	})
 
 	ginkgo.It("Should not immediately evict but eventually retry admitted workloads after a manager restart while the admitting worker is unreachable", framework.SlowSpec, func() {
-		keys := admitJobsAndAgeAdmissionCheck(managerNs.Name, managerLq.Name, managerCq.Name, multiKueueAC.Name, 3)
+		keys := admitJobsAndAgeAdmissionCheck(f.managerNs.Name, f.managerLq.Name, f.managerCq.Name, f.multiKueueAC.Name, 3)
 
-		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
+		restoreConnection := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, managersConfigNamespace.Name)
 
 		ginkgo.By("restarting the manager while worker2 is unreachable", func() {
 			managerTestCluster.fwk.StopManager(managerTestCluster.ctx)
@@ -1700,30 +1605,30 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("the restarted manager re-anchors the grace and does not immediately evict", func() {
-			expectNoEviction(keys, multiKueueAC.Name, testingWorkerLostTimeout*2/3)
+			expectNoEviction(keys, f.multiKueueAC.Name, testingWorkerLostTimeout*2/3)
 		})
 
 		ginkgo.By("the re-anchored grace is finite, so the workloads are eventually retried", func() {
-			expectEventuallyRetried(keys, multiKueueAC.Name, testingWorkerLostTimeout*4)
+			expectEventuallyRetried(keys, f.multiKueueAC.Name, testingWorkerLostTimeout*4)
 		})
 
 		restoreConnection()
 	})
 
 	ginkgo.It("Should run a RayJob on worker if admitted", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		rayjob := testingrayjob.MakeJob("rayjob1", managerNs.Name).
+		rayjob := testingrayjob.MakeJob("rayjob1", f.managerNs.Name).
 			WithSubmissionMode(rayv1.InteractiveMode).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, rayjob)
-		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(rayjob.Name, rayjob.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadrayjob.GetWorkloadNameForRayJob(rayjob.Name, rayjob.UID), Namespace: f.managerNs.Name}
 		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the RayJob in the worker, updates the manager's RayJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1754,18 +1659,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a RayCluster on worker if admitted", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
-			Queue(managerLq.Name).
+		raycluster := testingraycluster.MakeCluster("raycluster1", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, raycluster)
-		wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadraycluster.GetWorkloadNameForRayCluster(raycluster.Name, raycluster.UID), Namespace: f.managerNs.Name}
 		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the RayCluster in the worker, updates the manager's RayCluster status", func() {
 			createdRayCluster := rayv1.RayCluster{}
@@ -1786,19 +1691,19 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should forward a serveConfigV2 update to the RayService on the worker if admitted", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 			utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
-		rayService := testingrayservice.MakeService("rayservice1", managerNs.Name).
-			Queue(managerLq.Name).
+		rayService := testingrayservice.MakeService("rayservice1", f.managerNs.Name).
+			Queue(f.managerLq.Name).
 			WithServeConfigV2("serve-config-v1").
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, rayService)
-		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadrayservice.GetWorkloadNameForRayService(rayService.Name, rayService.UID), Namespace: f.managerNs.Name}
 		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
 
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("checking the remote RayService is created with the initial serveConfigV2", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1825,7 +1730,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should run a TrainJob on worker if admitted", func() {
-		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+		admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 			utiltestingapi.MakePodSetAssignment("node").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj(),
 		)
 		testJobSet := testingjobset.MakeJobSet("", "").ReplicatedJobs(
@@ -1835,26 +1740,26 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}).
 			Obj()
 		testCtr := testingtrainjob.MakeClusterTrainingRuntime("test", testJobSet.Spec)
-		trainJob := testingtrainjob.MakeTrainJob("trainjob1", managerNs.Name).RuntimeRef(kftrainer.RuntimeRef{
+		trainJob := testingtrainjob.MakeTrainJob("trainjob1", f.managerNs.Name).RuntimeRef(kftrainer.RuntimeRef{
 			APIGroup: new("trainer.kubeflow.org"),
 			Name:     "test",
 			Kind:     new("ClusterTrainingRuntime"),
 		}).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			Obj()
 
 		util.MustCreate(worker2TestCluster.ctx, worker2TestCluster.client, testCtr.DeepCopy())
 		util.MustCreate(worker1TestCluster.ctx, worker1TestCluster.client, testCtr.DeepCopy())
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, testCtr)
 		util.MustCreateWithRetry(managerTestCluster.ctx, managerTestCluster.client, trainJob)
-		wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainJob.Name, trainJob.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadtrainjob.GetWorkloadNameForTrainJob(trainJob.Name, trainJob.UID), Namespace: f.managerNs.Name}
 		gomega.Eventually(func(g gomega.Gomega) {
 			createdWorkload := &kueue.Workload{}
 			g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
 		}, util.MediumTimeout, util.Interval).Should(gomega.Succeed())
 
 		util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission.Obj())
-		admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+		admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
 		ginkgo.By("changing the status of the TrainJob in the worker, updates the manager's TrainJob status", func() {
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -1915,11 +1820,11 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			return workload
 		}
 
-		job := testingjob.MakeJob("job", managerNs.Name).
+		job := testingjob.MakeJob("job", f.managerNs.Name).
 			Parallelism(1).
 			Completions(2).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(manager.ctx, manager.client, job)
 
@@ -1936,7 +1841,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		ginkgo.By("admit workload on the manager cluster")
 		util.SetQuotaReservation(manager.ctx, manager.client, workloadKey,
-			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 
@@ -1952,14 +1857,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		ginkgo.By("admit the workload on the worker1 cluster")
 		util.SetQuotaReservation(worker1.ctx, worker1.client, workloadKey,
-			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 
 		ginkgo.By("observe: the local workload admission check and local events reflect reservation on the worker1 cluster")
 		util.ExpectAdmissionCheckStateWithMessage(
 			manager.ctx, manager.client, workloadKey,
-			multiKueueAC.Name,
+			f.multiKueueAC.Name,
 			kueue.CheckStateReady,
 			`The workload was admitted on "worker1"`,
 		)
@@ -2031,7 +1936,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				oldWorkload := getWorkload(g, manager.ctx, manager.client, workloadKey)
 				g.Expect(workloadfinish.Finish(manager.ctx, manager.client, oldWorkload, kueue.WorkloadSliceReplaced, "Replaced to accommodate a new slice", util.RealClock)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 		})
@@ -2065,7 +1970,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("admit the new workload replacing the old workload in the worker1 cluster", func() {
-			util.SetQuotaReservation(worker1.ctx, worker1.client, newWorkloadKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			util.SetQuotaReservation(worker1.ctx, worker1.client, newWorkloadKey, utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 					Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -2077,7 +1982,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		ginkgo.By("observe: the new local workload admission check and local events reflect reservation in the worker1 cluster")
 		util.ExpectAdmissionCheckStateWithMessage(
 			manager.ctx, manager.client, newWorkloadKey,
-			multiKueueAC.Name,
+			f.multiKueueAC.Name,
 			kueue.CheckStateReady,
 			`The workload was admitted on "worker1"`,
 		)
@@ -2190,11 +2095,11 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 
 		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
 
-		job := testingjob.MakeJob("job", managerNs.Name).
+		job := testingjob.MakeJob("job", f.managerNs.Name).
 			Parallelism(1).
 			Completions(2).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(manager.ctx, manager.client, job)
 
@@ -2216,14 +2121,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		// (reserving quota to admit a slice) are emulated with SetQuotaReservation.
 		ginkgo.By("emulate the scheduler reserving quota for the old slice on the manager cluster", func() {
 			util.SetQuotaReservation(manager.ctx, manager.client, oldWorkloadKey,
-				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 		})
 
 		ginkgo.By("emulate the scheduler reserving quota for the old slice on the worker1 cluster, and observe it is dispatched there", func() {
 			util.SetQuotaReservation(worker1.ctx, worker1.client, oldWorkloadKey,
-				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 			gomega.Eventually(func(g gomega.Gomega) {
@@ -2262,7 +2167,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(manager.client.Status().Update(manager.ctx, newWorkload)).To(gomega.Succeed())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			util.SetQuotaReservation(manager.ctx, manager.client, newWorkloadKey,
-				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+				utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 					PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 						Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).Obj())
 		})
@@ -2298,7 +2203,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		headPodSet := utiltestingapi.MakePodSetAssignment("head").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()
 		workerPodSet := utiltestingapi.MakePodSetAssignment("workers-group-0").Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()
 		admission := func() *utiltestingapi.AdmissionWrapper {
-			return utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(headPodSet, workerPodSet)
+			return utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(headPodSet, workerPodSet)
 		}
 
 		getRayCluster := func(ctx context.Context, clnt client.Client, rc *rayv1.RayCluster) {
@@ -2317,9 +2222,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			return wl
 		}
 
-		raycluster := testingraycluster.MakeCluster("raycluster1", managerNs.Name).
+		raycluster := testingraycluster.MakeCluster("raycluster1", f.managerNs.Name).
 			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
-			Queue(managerLq.Name).
+			Queue(f.managerLq.Name).
 			ScaleFirstWorkerGroup(1).
 			Obj()
 		util.MustCreate(manager.ctx, manager.client, raycluster)
@@ -2354,7 +2259,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		ginkgo.By("observe: the local admission check reflects the admission on the worker1 cluster")
 		util.ExpectAdmissionCheckStateWithMessage(
 			manager.ctx, manager.client, workloadKey,
-			multiKueueAC.Name,
+			f.multiKueueAC.Name,
 			kueue.CheckStateReady,
 			`The workload was admitted on "worker1"`,
 		)
@@ -2461,18 +2366,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 	})
 
 	ginkgo.It("Should redo the admission process once the workload loses Admission in the worker cluster", func() {
-		admittedMetricBefore := util.GetMultiKueueWorkloadsAdmittedTotal(managerCq, "worker1")
-		job := testingjob.MakeJob("job", managerNs.Name).
+		admittedMetricBefore := util.GetMultiKueueWorkloadsAdmittedTotal(f.managerCq, "worker1")
+		job := testingjob.MakeJob("job", f.managerNs.Name).
 			ManagedBy(kueue.MultiKueueControllerName).
-			Queue(kueue.LocalQueueName(managerLq.Name)).
+			Queue(kueue.LocalQueueName(f.managerLq.Name)).
 			Obj()
 		util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
 
 		createdWorkload := &kueue.Workload{}
-		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+		wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: f.managerNs.Name}
 
 		ginkgo.By("setting workload reservation in the management cluster", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -2490,14 +2395,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("setting workload reservation in worker1, AC state is updated in manager and worker2 wl is removed", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
@@ -2511,7 +2416,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, createdWorkload)).To(utiltesting.BeNotFoundError())
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(managerCq, "worker1", admittedMetricBefore+1)
+			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(f.managerCq, "worker1", admittedMetricBefore+1)
 		})
 
 		ginkgo.By("preempting workload in worker1", func() {
@@ -2530,7 +2435,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				g.Expect(managerWl.Status.ClusterName).To(gomega.BeNil())
 				g.Expect(managerWl.Status.AdmissionChecks).To(gomega.ContainElement(gomega.BeComparableTo(
 					kueue.AdmissionCheckState{
-						Name:    kueue.AdmissionCheckReference(multiKueueAC.Name),
+						Name:    kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 						State:   kueue.CheckStatePending,
 						Message: "Reset to Pending after eviction. Previously: Retry",
 					},
@@ -2544,7 +2449,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("setting workload reservation in the management cluster again", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(managerTestCluster.ctx, managerTestCluster.client, wlLookupKey, admission)
@@ -2563,18 +2468,18 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.By("re-admitting the workload in worker1, the admitted metric counts the second admission", func() {
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).
 				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Flavor(corev1.ResourceCPU, multikueueTestFlavor).Obj()).
 				Obj()
 			util.SetQuotaReservation(worker1TestCluster.ctx, worker1TestCluster.client, wlLookupKey, admission)
 
 			util.ExpectAdmissionCheckStateWithMessage(
 				managerTestCluster.ctx, managerTestCluster.client, wlLookupKey,
-				multiKueueAC.Name,
+				f.multiKueueAC.Name,
 				kueue.CheckStateReady,
 				`The workload was admitted on "worker1"`,
 			)
-			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(managerCq, "worker1", admittedMetricBefore+2)
+			util.ExpectMultiKueueWorkloadsAdmittedTotalMetric(f.managerCq, "worker1", admittedMetricBefore+2)
 		})
 	})
 
@@ -2605,7 +2510,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 			}
 
 			rule1 := *utiltestingapi.MakeAdmissionCheckStrategyRule(
-				kueue.AdmissionCheckReference(multiKueueAC.Name),
+				kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 				kueue.ResourceFlavorReference(flavor1.Name),
 				kueue.ResourceFlavorReference(flavor2.Name),
 			).Obj()
@@ -2622,7 +2527,7 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				k8sClient := managerTestCluster.client
 				ctx := managerTestCluster.ctx
 				updatedCq := &kueue.ClusterQueue{}
-				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(managerCq), updatedCq)).Should(gomega.Succeed())
+				gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(f.managerCq), updatedCq)).Should(gomega.Succeed())
 
 				updatedCq.Spec.ResourceGroups = resourceGroups
 				updatedCq.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
@@ -2633,15 +2538,15 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.AfterEach(func() {
-			util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, managerCq, true)
+			util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, f.managerCq, true)
 			util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, flavor1, true)
 			util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, flavor2, true)
 			util.ExpectObjectToBeDeleted(managerTestCluster.ctx, managerTestCluster.client, additionalAc, true)
 		})
 
 		ginkgo.It("should assign the multikueue admission check even before admitted", framework.SlowSpec, func() {
-			jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
-				Queue(managerLq.Name).
+			jobSet := testingjobset.MakeJobSet("job-set", f.managerNs.Name).
+				Queue(f.managerLq.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				ReplicatedJobs(
 					testingjobset.ReplicatedJobRequirements{
@@ -2659,14 +2564,14 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				Obj()
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, jobSet)
 
-			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: f.managerNs.Name}
 			ginkgo.By("ensuring multikueue admission check reference is present and in pending state", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdWorkload := &kueue.Workload{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+					acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))
 					g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:  kueue.AdmissionCheckReference(multiKueueAC.Name),
+						Name:  kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 						State: kueue.CheckStatePending,
 					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message", "RetryCount")))
 				}, util.LongTimeout, util.Interval).Should(gomega.Succeed())
@@ -2674,8 +2579,8 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 		})
 
 		ginkgo.It("should keep multikueue admission check reference and properly clean up the remote workload when the connection to an admitting worker is lost", framework.SlowSpec, func() {
-			jobSet := testingjobset.MakeJobSet("job-set", managerNs.Name).
-				Queue(managerLq.Name).
+			jobSet := testingjobset.MakeJobSet("job-set", f.managerNs.Name).
+				Queue(f.managerLq.Name).
 				ManagedBy(kueue.MultiKueueControllerName).
 				ReplicatedJobs(
 					testingjobset.ReplicatedJobRequirements{
@@ -2693,9 +2598,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				Obj()
 			util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, jobSet)
 
-			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: managerNs.Name}
+			wlLookupKey := types.NamespacedName{Name: workloadjobset.GetWorkloadNameForJobSet(jobSet.Name, jobSet.UID), Namespace: f.managerNs.Name}
 
-			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(managerCq.Name)).PodSets(
+			admission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(f.managerCq.Name)).PodSets(
 				kueue.PodSetAssignment{
 					Name: "replicated-job-1",
 					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
@@ -2715,9 +2620,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				},
 			)
 
-			admitWorkloadAndCheckWorkerCopies(multiKueueAC.Name, wlLookupKey, admission)
+			admitWorkloadAndCheckWorkerCopies(f.multiKueueAC.Name, wlLookupKey, admission)
 
-			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, workerCluster2, managersConfigNamespace.Name)
+			restoreConnectionToWorker2 := util.BreakConnection(managerTestCluster.ctx, managerTestCluster.client, f.workerCluster2, managersConfigNamespace.Name)
 
 			ginkgo.By("waiting for quotaReservation to be removed", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
@@ -2731,9 +2636,9 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 				gomega.Eventually(func(g gomega.Gomega) {
 					createdWorkload := &kueue.Workload{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, createdWorkload)).To(gomega.Succeed())
-					acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(multiKueueAC.Name))
+					acs := admissioncheck.FindAdmissionCheck(createdWorkload.Status.AdmissionChecks, kueue.AdmissionCheckReference(f.multiKueueAC.Name))
 					g.Expect(acs).To(gomega.BeComparableTo(&kueue.AdmissionCheckState{
-						Name:       kueue.AdmissionCheckReference(multiKueueAC.Name),
+						Name:       kueue.AdmissionCheckReference(f.multiKueueAC.Name),
 						State:      kueue.CheckStatePending,
 						RetryCount: new(int32(1)),
 					}, cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime", "Message")))


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue
/area testing

#### What this PR does / why we need it:

This is a prerequisite step toward splitting the large MultiKueue integration
test file `test/integration/multikueue/jobs_test.go` into per-framework files
(mirroring the e2e layout: `job_test.go`, `kuberay_test.go`, ...). It builds on
the helper extraction from #14226.

It introduces a shared `multiKueueFixture` in `helpers_test.go`
(`setupMultiKueueFixture()` / `teardown()`) holding the manager/worker resources
every MultiKueue integration spec needs (namespaces, kubeconfig secrets,
`MultiKueueCluster`s, the `MultiKueueConfig`, the MultiKueue `AdmissionCheck`, and
the `ClusterQueue`/`LocalQueue`/`ResourceFlavor` on the manager and both workers),
and converts `jobs_test.go` to use it: its inline `BeforeEach`/`AfterEach` are
replaced by fixture calls, and every spec now reads the shared objects from the
fixture (`f.managerCq`, `f.managerNs`, ...).

Doing this up front means the remaining per-framework splits become pure
cut-paste moves with no setup duplication: once each framework's specs already
read from the fixture, moving them into their own file requires no edits.

No behavior change. The fixture bodies are the previous `BeforeEach`/`AfterEach`
verbatim, and the spec references are unchanged apart from the fixture-field
prefix.

Verified:
- `go vet ./test/integration/multikueue/` and `go test -c` (package compiles).
- Normalizing the `f.` prefix back off `jobs_test.go` and diffing against the
  original shows only the setup region changed: every spec body and the nested
  `When` block are byte-identical apart from the prefix.
- Ran the fixture-backed specs locally (job/jobSet admitted): pass.

#### Which issue(s) this PR fixes:

Part of #14165

#### Special notes for your reviewer:

This PR only extracts and adopts the fixture; it does not yet move any specs into
per-framework files. Follow-up PRs will move each framework's specs (KubeRay,
JobSet, Kubeflow, MPI, AppWrapper, Pod, TrainJob, Elastic, batch/Job, and the
generic connection/admission-check behaviors) out of `jobs_test.go` into
dedicated files; because the specs already read from the fixture, each move is a
straight cut-paste.

Reviewer tip: the only hand-written change is the setup swap (the `var` block and
the `BeforeEach`/`AfterEach` bodies become `f = setupMultiKueueFixture()` /
`f.teardown()`); `setupMultiKueueFixture`/`teardown` are the previous inline
bodies verbatim. Everything else in `jobs_test.go` is a mechanical
`x` -> `f.x` prefixing of the shared fixture fields.

(The branch is named `split-mk-jobs-kuberay` for historical reasons; this PR no
longer moves the KubeRay specs.)

AI tools were used to help prepare this change, per the
[Kubernetes AI tool usage policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MultiKueue integration test setup and cleanup with shared test fixtures.
  * Preserved coverage for job dispatch, status updates, admission retries, reconnection cleanup, workload slicing, scaling, and supported job types.
  * Added verification that test resources are fully removed after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->