### PR TITLE
ProvisioningRequest: Backport to release 0.18

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -478,7 +478,7 @@ func reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) (bool
 	})
 	managedResources := sets.New(prc.Spec.ManagedResources...)
 	needed := false
-	// Each managed PodSet checked. An assignment missing for a single PodSet 
+	// Each managed PodSet checked. An assignment missing for a single PodSet
 	// indicates the Workloads admission data is inconsistent regardless of other PodSets.
 	for i := range wl.Spec.PodSets {
 		ps := &wl.Spec.PodSets[i]
@@ -586,7 +586,6 @@ func (c *Controller) syncCheckStates(
 
 		for check, prc := range checkConfig {
 			checkState := *checksMap[check]
-			//nolint:gocritic // ignore ifElseChain
 			if prc == nil {
 				// the check is not active
 				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -167,7 +167,10 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		checkConfig[checkName] = prc
 	}
 
-	activeOrLastPRForChecks := c.activeOrLastPRForChecks(ctx, wl, checkConfig, provReqs.Items)
+	activeOrLastPRForChecks, err := c.activeOrLastPRForChecks(ctx, wl, checkConfig, provReqs.Items)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 
 	wlInfo := workloadInfo{
 		checkStates: make([]kueue.AdmissionCheckState, 0),
@@ -198,18 +201,22 @@ func (c *Controller) activeOrLastPRForChecks(
 	wl *kueue.Workload,
 	checkConfig map[kueue.AdmissionCheckReference]*kueue.ProvisioningRequestConfig,
 	ownedPRs []autoscaling.ProvisioningRequest,
-) map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest {
+) (map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest, error) {
 	activeOrLastPRForChecks := make(map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest)
 	log := ctrl.LoggerFrom(ctx)
 	for checkName, prc := range checkConfig {
 		if prc == nil {
 			continue
 		}
+		reqNeeded, err := reqIsNeeded(wl, prc)
+		if err != nil {
+			return nil, err
+		}
 		for i := range ownedPRs {
 			req := &ownedPRs[i]
 			// PRs relevant for the admission check
 			if matchesWorkloadAndCheck(req, wl.Name, checkName) {
-				if c.reqIsNeeded(wl, prc) && provReqSyncedWithConfig(req, prc) {
+				if reqNeeded && provReqSyncedWithConfig(req, prc) {
 					currPr, exists := activeOrLastPRForChecks[checkName]
 					if !exists || getAttempt(log, currPr, wl.Name, checkName) < getAttempt(log, req, wl.Name, checkName) {
 						activeOrLastPRForChecks[checkName] = req
@@ -218,7 +225,7 @@ func (c *Controller) activeOrLastPRForChecks(
 			}
 		}
 	}
-	return activeOrLastPRForChecks
+	return activeOrLastPRForChecks, nil
 }
 
 func (c *Controller) deleteUnusedProvisioningRequests(
@@ -256,7 +263,11 @@ func (c *Controller) syncOwnedProvisionRequest(
 			// the check is not active
 			continue
 		}
-		if !c.reqIsNeeded(wl, prc) {
+		reqNeeded, err := reqIsNeeded(wl, prc)
+		if err != nil {
+			return err
+		}
+		if !reqNeeded {
 			continue
 		}
 		ac := admissioncheck.FindAdmissionCheck(wlInfo.checkStates, checkName)
@@ -461,11 +472,28 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 	return nil
 }
 
-func (c *Controller) reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) bool {
-	mergedPodSets, err := mergePodSets(wl, &prc.Spec)
-	// Preserve the existing reconciliation path for inconsistent Workloads
-	// so it can report the underlying error.
-	return err != nil || len(mergedPodSets) > 0
+func reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) (bool, error) {
+	assignments := slices.ToRefMap(wl.Status.Admission.PodSetAssignments, func(psa *kueue.PodSetAssignment) kueue.PodSetReference {
+		return psa.Name
+	})
+	managedResources := sets.New(prc.Spec.ManagedResources...)
+	needed := false
+	// Each managed PodSet checked. An assignment missing for a single PodSet 
+	// indicates the Workloads admission data is inconsistent regardless of other PodSets.
+	for i := range wl.Spec.PodSets {
+		ps := &wl.Spec.PodSets[i]
+		if ps.Count <= 0 || (managedResources.Len() > 0 && !podUses(&ps.Template.Spec, managedResources)) {
+			continue
+		}
+		psa, found := assignments[ps.Name]
+		if !found {
+			return false, fmt.Errorf("%w: missing assignment for PodSet %q", errInconsistentPodSetAssignments, ps.Name)
+		}
+		if ptr.Deref(psa.Count, ps.Count) > 0 {
+			needed = true
+		}
+	}
+	return needed, nil
 }
 
 func requiredPodSets(podSets []kueue.PodSet, resources []corev1.ResourceName) []kueue.PodSetReference {
@@ -563,7 +591,9 @@ func (c *Controller) syncCheckStates(
 				// the check is not active
 				updated = updateCheckState(&checkState, kueue.CheckStatePending) || updated
 				updated = updateCheckMessage(&checkState, CheckInactiveMessage) || updated
-			} else if !c.reqIsNeeded(wl, prc) {
+			} else if reqNeeded, err := reqIsNeeded(wl, prc); err != nil {
+				return false, err
+			} else if !reqNeeded {
 				if updateCheckState(&checkState, kueue.CheckStateReady) {
 					updated = true
 					checkState.Message = NoRequestNeeded

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -462,7 +462,10 @@ func (c *Controller) syncProvisionRequestsPodTemplates(ctx context.Context, wl *
 }
 
 func (c *Controller) reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) bool {
-	return len(requiredPodSets(wl.Spec.PodSets, prc.Spec.ManagedResources)) > 0
+	mergedPodSets, err := mergePodSets(wl, &prc.Spec)
+	// Preserve the existing reconciliation path for inconsistent Workloads
+	// so it can report the underlying error.
+	return err != nil || len(mergedPodSets) > 0
 }
 
 func requiredPodSets(podSets []kueue.PodSet, resources []corev1.ResourceName) []kueue.PodSetReference {
@@ -470,7 +473,7 @@ func requiredPodSets(podSets []kueue.PodSet, resources []corev1.ResourceName) []
 	users := make([]kueue.PodSetReference, 0, len(podSets))
 	for i := range podSets {
 		ps := &podSets[i]
-		if len(resources) == 0 || podUses(&ps.Template.Spec, resourcesSet) {
+		if ps.Count > 0 && (len(resources) == 0 || podUses(&ps.Template.Spec, resourcesSet)) {
 			users = append(users, ps.Name)
 		}
 	}
@@ -918,11 +921,16 @@ func mergePodSets(
 			return nil, errInconsistentPodSetAssignments
 		}
 
+		count := ptr.Deref(psa.Count, ps.Count)
+		if count <= 0 {
+			continue
+		}
+
 		merged := false
 		if mergePolicy != nil {
 			for i, mps := range mergedPodSets {
 				if merged = canMergePodSets(mps.PodSet, ps, mergePolicy); merged {
-					mergedPodSets[i].Count += ptr.Deref(psa.Count, ps.Count)
+					mergedPodSets[i].Count += count
 					break
 				}
 			}
@@ -933,7 +941,7 @@ func mergePodSets(
 				Name:             psName,
 				PodSet:           ps,
 				PodSetAssignment: psa,
-				Count:            ptr.Deref(psa.Count, ps.Count),
+				Count:            count,
 			})
 		}
 	}

--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -314,7 +314,7 @@ func (c *Controller) syncOwnedProvisionRequest(
 			}
 			passProvReqParams(wl, req)
 
-			mergedPodSets, err := mergePodSets(wl, &prc.Spec)
+			mergedPodSets, err := mergePodSets(ctx, wl, &prc.Spec)
 			if err != nil {
 				return err
 			}
@@ -477,9 +477,6 @@ func reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) (bool
 		return psa.Name
 	})
 	managedResources := sets.New(prc.Spec.ManagedResources...)
-	needed := false
-	// Each managed PodSet checked. An assignment missing for a single PodSet
-	// indicates the Workloads admission data is inconsistent regardless of other PodSets.
 	for i := range wl.Spec.PodSets {
 		ps := &wl.Spec.PodSets[i]
 		if ps.Count <= 0 || (managedResources.Len() > 0 && !podUses(&ps.Template.Spec, managedResources)) {
@@ -490,10 +487,10 @@ func reqIsNeeded(wl *kueue.Workload, prc *kueue.ProvisioningRequestConfig) (bool
 			return false, fmt.Errorf("%w: missing assignment for PodSet %q", errInconsistentPodSetAssignments, ps.Name)
 		}
 		if ptr.Deref(psa.Count, ps.Count) > 0 {
-			needed = true
+			return true, nil
 		}
 	}
-	return needed, nil
+	return false, nil
 }
 
 func requiredPodSets(podSets []kueue.PodSet, resources []corev1.ResourceName) []kueue.PodSetReference {
@@ -934,9 +931,11 @@ type MergedPodSet struct {
 }
 
 func mergePodSets(
+	ctx context.Context,
 	wl *kueue.Workload,
 	prcSpec *kueue.ProvisioningRequestConfigSpec,
 ) ([]MergedPodSet, error) {
+	log := ctrl.LoggerFrom(ctx)
 	expectedPodSets := requiredPodSets(wl.Spec.PodSets, prcSpec.ManagedResources)
 	psaMap := slices.ToRefMap(wl.Status.Admission.PodSetAssignments, func(p *kueue.PodSetAssignment) kueue.PodSetReference { return p.Name })
 	podSetMap := slices.ToRefMap(wl.Spec.PodSets, func(ps *kueue.PodSet) kueue.PodSetReference { return ps.Name })
@@ -952,6 +951,7 @@ func mergePodSets(
 
 		count := ptr.Deref(psa.Count, ps.Count)
 		if count <= 0 {
+			log.V(4).Info("Skipping non-positive PodSet", "workload", klog.KObj(wl), "podSet", psName, "count", count)
 			continue
 		}
 

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -139,7 +139,7 @@ func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
 		},
 		"zero count does not block compatible merging": {
 			workload:    makeWorkload([]int32{1, 2, 3}, []int32{0, 2, 3}),
-			mergePolicy: ptr.To(kueue.IdenticalPodTemplates),
+			mergePolicy: new(kueue.IdenticalPodTemplates),
 			wantNames:   []kueue.PodSetReference{"ps1"},
 			wantCounts:  []int32{5},
 		},
@@ -195,7 +195,7 @@ func TestReqIsNeeded(t *testing.T) {
 		wantErr  error
 	}{
 		"positive admitted count needs request": {
-			workload: makeWorkload(1, ptr.To[int32](1), true),
+			workload: makeWorkload(1, new(int32(1)), true),
 			want:     true,
 		},
 		"missing admitted count falls back to spec count": {
@@ -203,7 +203,7 @@ func TestReqIsNeeded(t *testing.T) {
 			want:     true,
 		},
 		"zero admitted count does not need request": {
-			workload: makeWorkload(1, ptr.To[int32](0), true),
+			workload: makeWorkload(1, new(int32(0)), true),
 		},
 		"zero spec count does not require assignment": {
 			workload: makeWorkload(0, nil, false),
@@ -224,7 +224,7 @@ func TestReqIsNeeded(t *testing.T) {
 				).
 				ReserveQuotaAt(
 					utiltestingapi.MakeAdmission("q").
-						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](1)}).
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: new(int32(1))}).
 						Obj(),
 					time.Now(),
 				).
@@ -399,7 +399,7 @@ func TestReconcile(t *testing.T) {
 	allZeroCountWorkload := baseWorkload.DeepCopy()
 	for i := range allZeroCountWorkload.Spec.PodSets {
 		allZeroCountWorkload.Spec.PodSets[i].Count = 0
-		allZeroCountWorkload.Status.Admission.PodSetAssignments[i].Count = ptr.To[int32](0)
+		allZeroCountWorkload.Status.Admission.PodSetAssignments[i].Count = new(int32(0))
 	}
 
 	podSetMergePolicyAssignemnt := []kueue.PodSetAssignment{

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -169,6 +169,83 @@ func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
 	}
 }
 
+func TestReqIsNeeded(t *testing.T) {
+	makeWorkload := func(specCount int32, admissionCount *int32, includeAssignment bool) *kueue.Workload {
+		builder := utiltestingapi.MakeWorkload("wl", TestNamespace).
+			PodSets(*utiltestingapi.MakePodSet("ps", int(specCount)).
+				Request(corev1.ResourceCPU, "1").
+				Obj())
+		admission := utiltestingapi.MakeAdmission("q")
+		if includeAssignment {
+			admission = admission.PodSets(kueue.PodSetAssignment{
+				Name:  "ps",
+				Count: admissionCount,
+			})
+		}
+		return builder.ReserveQuotaAt(admission.Obj(), time.Now()).Obj()
+	}
+
+	prc := utiltestingapi.MakeProvisioningRequestConfig("config").
+		ManagedResources([]corev1.ResourceName{corev1.ResourceCPU}).
+		Obj()
+
+	cases := map[string]struct {
+		workload *kueue.Workload
+		want     bool
+		wantErr  error
+	}{
+		"positive admitted count needs request": {
+			workload: makeWorkload(1, ptr.To[int32](1), true),
+			want:     true,
+		},
+		"missing admitted count falls back to spec count": {
+			workload: makeWorkload(1, nil, true),
+			want:     true,
+		},
+		"zero admitted count does not need request": {
+			workload: makeWorkload(1, ptr.To[int32](0), true),
+		},
+		"zero spec count does not require assignment": {
+			workload: makeWorkload(0, nil, false),
+		},
+		"missing assignment returns inconsistency error": {
+			workload: makeWorkload(1, nil, false),
+			wantErr:  errInconsistentPodSetAssignments,
+		},
+		"needed podset does not short circuit later missing assignment": {
+			workload: utiltestingapi.MakeWorkload("wl", TestNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("ps1", 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj(),
+					*utiltestingapi.MakePodSet("ps2", 1).
+						Request(corev1.ResourceCPU, "1").
+						Obj(),
+				).
+				ReserveQuotaAt(
+					utiltestingapi.MakeAdmission("q").
+						PodSets(kueue.PodSetAssignment{Name: "ps1", Count: ptr.To[int32](1)}).
+						Obj(),
+					time.Now(),
+				).
+				Obj(),
+			wantErr: errInconsistentPodSetAssignments,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := reqIsNeeded(tc.workload, prc)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("unexpected error (-want/+got):\n%s", diff)
+			}
+			if got != tc.want {
+				t.Errorf("reqIsNeeded() = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReconcile(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
@@ -2284,7 +2361,10 @@ func TestActiveOrLastPRForChecks(t *testing.T) {
 				t.Fatalf("Setting up the provisioning request controller: %v", err)
 			}
 
-			gotResult := controller.activeOrLastPRForChecks(ctx, workload, checkConfig, tc.requests)
+			gotResult, err := controller.activeOrLastPRForChecks(ctx, workload, checkConfig, tc.requests)
+			if err != nil {
+				t.Fatalf("activeOrLastPRForChecks() error = %v", err)
+			}
 			if diff := cmp.Diff(tc.wantResult, gotResult, reqCmpOptions...); diff != "" {
 				t.Errorf("unexpected request %q (-want/+got):\n%s", name, diff)
 			}

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -147,7 +147,7 @@ func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := mergePodSets(tc.workload, &kueue.ProvisioningRequestConfigSpec{
+			got, err := mergePodSets(t.Context(), tc.workload, &kueue.ProvisioningRequestConfigSpec{
 				PodSetMergePolicy: tc.mergePolicy,
 			})
 			if err != nil {
@@ -212,7 +212,7 @@ func TestReqIsNeeded(t *testing.T) {
 			workload: makeWorkload(1, nil, false),
 			wantErr:  errInconsistentPodSetAssignments,
 		},
-		"needed podset does not short circuit later missing assignment": {
+		"needed podset short circuits later missing assignment": {
 			workload: utiltestingapi.MakeWorkload("wl", TestNamespace).
 				PodSets(
 					*utiltestingapi.MakePodSet("ps1", 1).
@@ -229,7 +229,7 @@ func TestReqIsNeeded(t *testing.T) {
 					time.Now(),
 				).
 				Obj(),
-			wantErr: errInconsistentPodSetAssignments,
+			want: true,
 		},
 	}
 

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -455,9 +455,12 @@ func TestReconcile(t *testing.T) {
 		},
 		"with only zero-count PodSets": {
 			workload: allZeroCountWorkload.DeepCopy(),
-			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
-			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
-			configs:  []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			requests: []autoscaling.ProvisioningRequest{
+				*baseRequest.DeepCopy(),
+			},
+			checks:  []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors: []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs: []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
 			wantWorkloads: map[string]*kueue.Workload{
 				allZeroCountWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *allZeroCountWorkload.DeepCopy()}).
 					AdmissionChecks(kueue.AdmissionCheckState{

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -101,6 +101,74 @@ func requestWithCondition(r *autoscaling.ProvisioningRequest, conditionType stri
 	return r
 }
 
+func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
+	makeWorkload := func(specCounts, admissionCounts []int32) *kueue.Workload {
+		podSets := make([]kueue.PodSet, len(specCounts))
+		assignments := make([]kueue.PodSetAssignment, len(admissionCounts))
+		for i := range specCounts {
+			name := kueue.PodSetReference(fmt.Sprintf("ps%d", i))
+			podSets[i] = *utiltestingapi.MakePodSet(name, int(specCounts[i])).
+				Request(corev1.ResourceCPU, "1").
+				Obj()
+			assignments[i] = kueue.PodSetAssignment{
+				Name:  name,
+				Count: ptr.To(admissionCounts[i]),
+			}
+		}
+		return utiltestingapi.MakeWorkload("wl", TestNamespace).
+			PodSets(podSets...).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("q").PodSets(assignments...).Obj(), time.Now()).
+			Obj()
+	}
+
+	cases := map[string]struct {
+		workload    *kueue.Workload
+		mergePolicy *kueue.ProvisioningRequestConfigPodSetMergePolicy
+		wantNames   []kueue.PodSetReference
+		wantCounts  []int32
+	}{
+		"zero spec count": {
+			workload:   makeWorkload([]int32{0, 2}, []int32{0, 2}),
+			wantNames:  []kueue.PodSetReference{"ps1"},
+			wantCounts: []int32{2},
+		},
+		"zero admission count override": {
+			workload:   makeWorkload([]int32{1, 2}, []int32{0, 2}),
+			wantNames:  []kueue.PodSetReference{"ps1"},
+			wantCounts: []int32{2},
+		},
+		"zero count does not block compatible merging": {
+			workload:    makeWorkload([]int32{1, 2, 3}, []int32{0, 2, 3}),
+			mergePolicy: ptr.To(kueue.IdenticalPodTemplates),
+			wantNames:   []kueue.PodSetReference{"ps1"},
+			wantCounts:  []int32{5},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := mergePodSets(tc.workload, &kueue.ProvisioningRequestConfigSpec{
+				PodSetMergePolicy: tc.mergePolicy,
+			})
+			if err != nil {
+				t.Fatalf("mergePodSets() error = %v", err)
+			}
+			gotNames := make([]kueue.PodSetReference, len(got))
+			gotCounts := make([]int32, len(got))
+			for i := range got {
+				gotNames[i] = got[i].Name
+				gotCounts[i] = got[i].Count
+			}
+			if diff := cmp.Diff(tc.wantNames, gotNames); diff != "" {
+				t.Errorf("unexpected PodSet names (-want/+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantCounts, gotCounts); diff != "" {
+				t.Errorf("unexpected PodSet counts (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestReconcile(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
@@ -251,6 +319,12 @@ func TestReconcile(t *testing.T) {
 		Parameters(kueue.GroupVersion.Group, ConfigKind, "config1").
 		Obj()
 
+	allZeroCountWorkload := baseWorkload.DeepCopy()
+	for i := range allZeroCountWorkload.Spec.PodSets {
+		allZeroCountWorkload.Spec.PodSets[i].Count = 0
+		allZeroCountWorkload.Status.Admission.PodSetAssignments[i].Count = ptr.To[int32](0)
+	}
+
 	podSetMergePolicyAssignemnt := []kueue.PodSetAssignment{
 		{
 			Name: "ps1",
@@ -376,6 +450,33 @@ func TestReconcile(t *testing.T) {
 					EventType: corev1.EventTypeNormal,
 					Reason:    "ProvisioningRequestCreated",
 					Message:   `Created ProvisioningRequest: "wl-check1-1"`,
+				},
+			},
+		},
+		"with only zero-count PodSets": {
+			workload: allZeroCountWorkload.DeepCopy(),
+			checks:   []kueue.AdmissionCheck{*baseCheck.DeepCopy()},
+			flavors:  []kueue.ResourceFlavor{*baseFlavor1.DeepCopy(), *baseFlavor2.DeepCopy()},
+			configs:  []kueue.ProvisioningRequestConfig{*baseConfigWithRetryStrategy.DeepCopy()},
+			wantWorkloads: map[string]*kueue.Workload{
+				allZeroCountWorkload.GetName(): (&utiltestingapi.WorkloadWrapper{Workload: *allZeroCountWorkload.DeepCopy()}).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateReady,
+						Message: NoRequestNeeded,
+					}, kueue.AdmissionCheckState{
+						Name:  "not-provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+			wantRequestsNotFound: []string{baseRequest.Name},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       client.ObjectKeyFromObject(allZeroCountWorkload),
+					EventType: corev1.EventTypeNormal,
+					Reason:    "AdmissionCheckUpdated",
+					Message:   `Admission check check1 updated state from Pending to Ready with message: the provisioning request is not needed`,
 				},
 			},
 		},

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -112,7 +112,7 @@ func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
 				Obj()
 			assignments[i] = kueue.PodSetAssignment{
 				Name:  name,
-				Count: ptr.To(admissionCounts[i]),
+				Count: new(admissionCounts[i]),
 			}
 		}
 		return utiltestingapi.MakeWorkload("wl", TestNamespace).

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -333,10 +333,14 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	return gated, nil
 }
 
-// activeSlice resolves the active (latest admitted, non-finished) workload slice
-// of the chain that anyWl belongs to, or nil if none qualifies. It looks up the
-// chain through the owning job's workload index, reusing the same slice ordering
-// as the rest of the slicing code (workloadslicing.FindLatestActiveWorkload).
+// activeSlice resolves the active (latest quota-reserved, non-finished)
+// workload slice of the chain that anyWl belongs to, or nil if none qualifies
+// for ungating. It looks up the chain through the owning job's workload index,
+// reusing the same slice ordering as the rest of the slicing code
+// (workloadslicing.FindLatestActiveWorkload), but additionally requires full
+// admission: quota reservation alone is insufficient here, since
+// AdmissionChecks may still be pending and releasing the elastic gate
+// before then would let pods schedule ahead of apacity.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
 	owner := metav1.GetControllerOf(anyWl)
 	if owner == nil {
@@ -345,7 +349,11 @@ func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Worklo
 	jobObject := &metav1.PartialObjectMetadata{
 		ObjectMeta: metav1.ObjectMeta{Namespace: anyWl.Namespace, Name: owner.Name},
 	}
-	return workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+	active, err := workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+	if err != nil || active == nil || !workload.IsAdmitted(active) {
+		return nil, err
+	}
+	return active, nil
 }
 
 // Workload predicates

--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -157,11 +158,15 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		pod := pods[i]
 		var ungated bool
 		e := utilclient.Patch(ctx, r.client, pod, func() (bool, error) {
+			changed, err := refreshPodAdmission(pod, active)
+			if err != nil {
+				return false, err
+			}
 			ungated = utilpod.Ungate(pod, kueue.ElasticJobSchedulingGate)
 			if ungated {
 				log.V(3).Info("ungating elastic pod", "pod", klog.KObj(pod))
 			}
-			return ungated, nil
+			return changed || ungated, nil
 		})
 		if e != nil {
 			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
@@ -170,6 +175,89 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 		return e
 	})
 	return reconcile.Result{}, err
+}
+
+type podAdmissionUpdate struct {
+	annotations  map[string]string
+	nodeSelector map[string]string
+}
+
+func admissionUpdateForPodSet(wl *kueue.Workload, podSetName kueue.PodSetReference) (podAdmissionUpdate, error) {
+	update := podAdmissionUpdate{
+		annotations:  make(map[string]string),
+		nodeSelector: make(map[string]string),
+	}
+	for _, check := range wl.Status.AdmissionChecks {
+		for _, psUpdate := range check.PodSetUpdates {
+			if psUpdate.Name != podSetName {
+				continue
+			}
+			for _, key := range []string{
+				autoscaling.ProvisioningRequestPodAnnotationKey,
+				autoscaling.ProvisioningClassPodAnnotationKey,
+			} {
+				if value, found := psUpdate.Annotations[key]; found {
+					if old, exists := update.annotations[key]; exists && old != value {
+						return podAdmissionUpdate{}, fmt.Errorf("conflicting %q annotation updates for PodSet %q", key, podSetName)
+					}
+					update.annotations[key] = value
+				}
+			}
+			for key, value := range psUpdate.NodeSelector {
+				if old, exists := update.nodeSelector[key]; exists && old != value {
+					return podAdmissionUpdate{}, fmt.Errorf("conflicting %q node selector updates for PodSet %q", key, podSetName)
+				}
+				update.nodeSelector[key] = value
+			}
+		}
+	}
+	return update, nil
+}
+
+func podAdmissionCompatible(pod *corev1.Pod, update podAdmissionUpdate) bool {
+	for key, value := range update.annotations {
+		if existing, found := pod.Annotations[key]; found && existing != value {
+			return false
+		}
+	}
+	for key, value := range update.nodeSelector {
+		if existing, found := pod.Spec.NodeSelector[key]; found && existing != value {
+			return false
+		}
+	}
+	return true
+}
+
+func refreshPodAdmission(pod *corev1.Pod, wl *kueue.Workload) (bool, error) {
+	update, err := admissionUpdateForPodSet(wl, kueue.PodSetReference(pod.Labels[constants.PodSetLabel]))
+	if err != nil {
+		return false, err
+	}
+	if !podAdmissionCompatible(pod, update) {
+		return false, fmt.Errorf("pod %s/%s has immutable admission metadata from a different ProvisioningRequest", pod.Namespace, pod.Name)
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = make(map[string]string, len(update.annotations))
+	}
+	changed := false
+	for key, value := range update.annotations {
+		// PRQ consume/class identity is immutable after first assignment.
+		if _, exists := pod.Annotations[key]; exists {
+			continue
+		}
+		pod.Annotations[key] = value
+		changed = true
+	}
+	if pod.Spec.NodeSelector == nil && len(update.nodeSelector) != 0 {
+		pod.Spec.NodeSelector = make(map[string]string, len(update.nodeSelector))
+	}
+	for key, value := range update.nodeSelector {
+		if pod.Spec.NodeSelector[key] != value {
+			pod.Spec.NodeSelector[key] = value
+			changed = true
+		}
+	}
+	return changed, nil
 }
 
 func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload) ([]*corev1.Pod, error) {
@@ -191,6 +279,7 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	granted := workload.ExtractPodSetCountsFromWorkload(wl)
 	gatedPerPodSet := make(map[kueue.PodSetReference][]*corev1.Pod)
 	ungatedPerPodSet := make(map[kueue.PodSetReference]int32)
+	admissionUpdates := make(map[kueue.PodSetReference]podAdmissionUpdate)
 	for i := range podList.Items {
 		p := &podList.Items[i]
 		if utilpod.IsTerminated(p) {
@@ -198,6 +287,20 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 		}
 		ps := kueue.PodSetReference(p.Labels[constants.PodSetLabel])
 		if utilpod.HasGate(p, kueue.ElasticJobSchedulingGate) {
+			update, found := admissionUpdates[ps]
+			if !found {
+				var err error
+				update, err = admissionUpdateForPodSet(wl, ps)
+				if err != nil {
+					return nil, err
+				}
+				admissionUpdates[ps] = update
+			}
+			if !podAdmissionCompatible(p, update) {
+				ctrl.LoggerFrom(ctx).Info("leaving elastic pod gated because immutable admission metadata is stale; recycle the pod after its template refreshes",
+					"pod", klog.KObj(p), "podSet", ps)
+				continue
+			}
 			gatedPerPodSet[ps] = append(gatedPerPodSet[ps], p)
 		} else {
 			// Already-ungated pods consume quota too.
@@ -258,7 +361,7 @@ func (r *elasticJobUngater) Update(e event.TypedUpdateEvent[*kueue.Workload]) bo
 func shouldUngate(wl *kueue.Workload) bool {
 	return workloadslicing.IsElasticWorkload(wl) &&
 		!workload.IsFinished(wl) &&
-		(workload.IsAdmitted(wl) || workload.HasQuotaReservation(wl))
+		workload.IsAdmitted(wl)
 }
 
 func (r *elasticJobUngater) Delete(event.TypedDeleteEvent[*kueue.Workload]) bool {

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -128,6 +129,41 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Obj(),
+			},
+		},
+		"keep pod gated while admission check is pending": {
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+					ControllerReference(rayClusterGVK, "ray", "ray-uid").
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("cq").
+							PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+								Assignment(corev1.ResourceCPU, "flavor", "1").
+								Obj()).
+							Obj(), now,
+					).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+			pods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
+					Obj(),
+			},
+			wantPods: []corev1.Pod{
+				*testingpod.MakePod("pod", "ns").
+					Annotation(kueue.WorkloadAnnotation, "wl").
+					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 			},
 		},
@@ -627,6 +663,20 @@ func TestReconcile(t *testing.T) {
 							Obj(), now,
 					).
 					AdmittedAt(true, now).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "provisioning",
+						State: kueue.CheckStateReady,
+						PodSetUpdates: []kueue.PodSetUpdate{{
+							Name: kueue.DefaultPodSetName,
+							Annotations: map[string]string{
+								autoscaling.ProvisioningRequestPodAnnotationKey: "wl-slice-1-provisioning-1",
+								autoscaling.ProvisioningClassPodAnnotationKey:   "atomic",
+							},
+							NodeSelector: map[string]string{
+								"autoscaling.gke.io/provisioning-request": "current-booking",
+							},
+						}},
+					}).
 					Obj(),
 				// Root slice, now Finished by the replacement. It is the chain key
 				// (reconcile target) and persists for the life of the job, so the
@@ -651,6 +701,8 @@ func TestReconcile(t *testing.T) {
 				*testingpod.MakePod("pod-from-parent", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Annotation(autoscaling.ProvisioningRequestPodAnnotationKey, "wl-provisioning-1").
+					Annotation(autoscaling.ProvisioningClassPodAnnotationKey, "atomic").
 					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
 				*testingpod.MakePod("pod-from-scale-up", "ns").
@@ -660,13 +712,23 @@ func TestReconcile(t *testing.T) {
 					Obj(),
 			},
 			wantPods: []corev1.Pod{
+				// A stale immutable consume value must keep the pod gated and
+				// must not consume capacity from the replacement request.
 				*testingpod.MakePod("pod-from-parent", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Annotation(autoscaling.ProvisioningRequestPodAnnotationKey, "wl-provisioning-1").
+					Annotation(autoscaling.ProvisioningClassPodAnnotationKey, "atomic").
+					Gate(kueue.ElasticJobSchedulingGate).
 					Obj(),
+				// A compatible gated pod receives the current request identity
+				// and selector before its elastic gate is removed.
 				*testingpod.MakePod("pod-from-scale-up", "ns").
 					Annotation(kueue.WorkloadAnnotation, "wl-slice-1").
 					Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+					Annotation(autoscaling.ProvisioningRequestPodAnnotationKey, "wl-slice-1-provisioning-1").
+					Annotation(autoscaling.ProvisioningClassPodAnnotationKey, "atomic").
+					NodeSelector("autoscaling.gke.io/provisioning-request", "current-booking").
 					Obj(),
 			},
 		},
@@ -958,6 +1020,55 @@ func TestReconcile(t *testing.T) {
 			}
 			if diff := gocmp.Diff(tc.wantPods, gotPods.Items, podCmpOpts...); diff != "" {
 				t.Errorf("Pods after reconcile (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestShouldUngate(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	now := time.Now().Truncate(time.Second)
+
+	admittedElasticWorkload := func() *utiltestingapi.WorkloadWrapper {
+		return utiltestingapi.MakeWorkload("wl", "ns").
+			Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+			AdmittedAt(true, now)
+	}
+
+	testCases := map[string]struct {
+		workload *kueue.Workload
+		want     bool
+	}{
+		"fully admitted elastic workload": {
+			workload: admittedElasticWorkload().Obj(),
+			want:     true,
+		},
+		"quota reserved with pending admission check": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmissionChecks(kueue.AdmissionCheckState{
+					Name:  "provisioning",
+					State: kueue.CheckStatePending,
+				}).
+				Obj(),
+		},
+		"finished admitted elastic workload": {
+			workload: admittedElasticWorkload().FinishedAt(now).Obj(),
+		},
+		"admitted non-elastic workload": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), now).
+				AdmittedAt(true, now).
+				Obj(),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if got := shouldUngate(tc.workload); got != tc.want {
+				t.Errorf("shouldUngate() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -122,21 +122,17 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkload returns the newest non-finished, non-evicted workload
-// slice owned by the provided job object/gvk that holds a quota reservation, or
-// nil if none qualifies. This is the chain's "active" slice: its granted PodSet
-// counts define the admitted capacity.
-//
-// Eviction is two writes: the condition is set first, and the reservation is
-// released after. A slice in between still reports a reservation while its
-// capacity is on the way out, so it is not the one to measure against.
+// FindLatestActiveWorkload returns the newest non-finished, admitted workload
+// slice owned by the provided job object/gvk, or nil if none qualifies. Quota
+// reservation alone is insufficient: AdmissionChecks may still be pending, so
+// pods must remain gated.
 func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
 	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
 	if err != nil {
 		return nil, err
 	}
 	for i := range slices.Backward(workloads) {
-		if workload.HasQuotaReservation(&workloads[i]) && !workload.IsEvicted(&workloads[i]) {
+		if workload.IsAdmitted(&workloads[i]) && !workload.IsEvicted(&workloads[i]) {
 			return &workloads[i], nil
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -122,17 +122,25 @@ func FindNotFinishedWorkloads(ctx context.Context, clnt client.Client, jobObject
 	}), nil
 }
 
-// FindLatestActiveWorkload returns the newest non-finished, admitted workload
-// slice owned by the provided job object/gvk, or nil if none qualifies. Quota
-// reservation alone is insufficient: AdmissionChecks may still be pending, so
-// pods must remain gated.
+// FindLatestActiveWorkload returns the newest non-finished, non-evicted workload
+// slice owned by the provided job object/gvk that holds a quota reservation, or
+// nil if none qualifies. This is the chain's "active" slice: its granted PodSet
+// counts define the admitted capacity.
+//
+// Eviction is two writes: the condition is set first, and the reservation is
+// released after. A slice in between still reports a reservation while its
+// capacity is on the way out, so it is not the one to measure against.
+//
+// Quota reservation alone does not mean every AdmissionCheck is Ready: callers
+// that must not act before full admission (e.g. releasing an elastic scheduling
+// gate) need an additional workload.IsAdmitted check on the result.
 func FindLatestActiveWorkload(ctx context.Context, clnt client.Client, jobObject client.Object, jobObjectGVK schema.GroupVersionKind) (*kueue.Workload, error) {
 	workloads, err := FindNotFinishedWorkloads(ctx, clnt, jobObject, jobObjectGVK)
 	if err != nil {
 		return nil, err
 	}
 	for i := range slices.Backward(workloads) {
-		if workload.IsAdmitted(&workloads[i]) && !workload.IsEvicted(&workloads[i]) {
+		if workload.HasQuotaReservation(&workloads[i]) && !workload.IsEvicted(&workloads[i]) {
 			return &workloads[i], nil
 		}
 	}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1406,10 +1406,9 @@ func TestFindLatestActiveWorkload(t *testing.T) {
 	now := time.Now()
 	admission := utiltestingapi.MakeAdmission("cq").Obj()
 
-	admitted := func(name string, created time.Time) *utiltestingapi.WorkloadWrapper {
+	live := func(name string, created time.Time) *utiltestingapi.WorkloadWrapper {
 		return testWorkload(name, testJobObject.Name, testJobObject.UID, created).
-			ReserveQuotaAt(admission, created).
-			AdmittedAt(true, created)
+			ReserveQuotaAt(admission, created)
 	}
 
 	cases := map[string]struct {
@@ -1417,42 +1416,46 @@ func TestFindLatestActiveWorkload(t *testing.T) {
 		want      string
 	}{
 		"none": {},
-		"quota reservation alone is not active": {
+		"the only reserved one": {
+			workloads: []kueue.Workload{*live("only", now).Obj()},
+			want:      "only",
+		},
+		"the newest reserved one": {
 			workloads: []kueue.Workload{
-				*testWorkload("reserved", testJobObject.Name, testJobObject.UID, now).
-					ReserveQuotaAt(admission, now).
+				*live("older", now.Add(-time.Minute)).Obj(),
+				*live("newer", now).Obj(),
+			},
+			want: "newer",
+		},
+		// A pending AdmissionCheck does not disqualify a slice from being the
+		// chain's active one: FindLatestActiveWorkload only tracks quota
+		// reservation. Callers that must wait for full admission apply their
+		// own additional check on the result.
+		"quota reservation is active even with a pending admission check": {
+			workloads: []kueue.Workload{
+				*live("reserved", now).
 					AdmissionChecks(kueue.AdmissionCheckState{
 						Name:  "provisioning",
 						State: kueue.CheckStatePending,
 					}).
 					Obj(),
 			},
-		},
-		"the only admitted one": {
-			workloads: []kueue.Workload{*admitted("only", now).Obj()},
-			want:      "only",
-		},
-		"the newest admitted one": {
-			workloads: []kueue.Workload{
-				*admitted("older", now.Add(-time.Minute)).Obj(),
-				*admitted("newer", now).Obj(),
-			},
-			want: "newer",
+			want: "reserved",
 		},
 		// Eviction sets its condition before the reservation is released, so a
 		// slice can still report one while its capacity is on the way out. The
 		// older slice is the one still holding capacity.
 		"a newer slice that is being evicted": {
 			workloads: []kueue.Workload{
-				*admitted("older", now.Add(-time.Minute)).Obj(),
-				*admitted("evicting", now).EvictedAt(now).Obj(),
+				*live("older", now.Add(-time.Minute)).Obj(),
+				*live("evicting", now).EvictedAt(now).Obj(),
 			},
 			want: "older",
 		},
 		"every slice is being evicted": {
 			workloads: []kueue.Workload{
-				*admitted("one", now.Add(-time.Minute)).EvictedAt(now).Obj(),
-				*admitted("two", now).EvictedAt(now).Obj(),
+				*live("one", now.Add(-time.Minute)).EvictedAt(now).Obj(),
+				*live("two", now).EvictedAt(now).Obj(),
 			},
 		},
 	}

--- a/pkg/workloadslicing/workloadslicing_test.go
+++ b/pkg/workloadslicing/workloadslicing_test.go
@@ -1406,9 +1406,10 @@ func TestFindLatestActiveWorkload(t *testing.T) {
 	now := time.Now()
 	admission := utiltestingapi.MakeAdmission("cq").Obj()
 
-	live := func(name string, created time.Time) *utiltestingapi.WorkloadWrapper {
+	admitted := func(name string, created time.Time) *utiltestingapi.WorkloadWrapper {
 		return testWorkload(name, testJobObject.Name, testJobObject.UID, created).
-			ReserveQuotaAt(admission, created)
+			ReserveQuotaAt(admission, created).
+			AdmittedAt(true, created)
 	}
 
 	cases := map[string]struct {
@@ -1416,14 +1417,25 @@ func TestFindLatestActiveWorkload(t *testing.T) {
 		want      string
 	}{
 		"none": {},
-		"the only reserved one": {
-			workloads: []kueue.Workload{*live("only", now).Obj()},
+		"quota reservation alone is not active": {
+			workloads: []kueue.Workload{
+				*testWorkload("reserved", testJobObject.Name, testJobObject.UID, now).
+					ReserveQuotaAt(admission, now).
+					AdmissionChecks(kueue.AdmissionCheckState{
+						Name:  "provisioning",
+						State: kueue.CheckStatePending,
+					}).
+					Obj(),
+			},
+		},
+		"the only admitted one": {
+			workloads: []kueue.Workload{*admitted("only", now).Obj()},
 			want:      "only",
 		},
-		"the newest reserved one": {
+		"the newest admitted one": {
 			workloads: []kueue.Workload{
-				*live("older", now.Add(-time.Minute)).Obj(),
-				*live("newer", now).Obj(),
+				*admitted("older", now.Add(-time.Minute)).Obj(),
+				*admitted("newer", now).Obj(),
 			},
 			want: "newer",
 		},
@@ -1432,15 +1444,15 @@ func TestFindLatestActiveWorkload(t *testing.T) {
 		// older slice is the one still holding capacity.
 		"a newer slice that is being evicted": {
 			workloads: []kueue.Workload{
-				*live("older", now.Add(-time.Minute)).Obj(),
-				*live("evicting", now).EvictedAt(now).Obj(),
+				*admitted("older", now.Add(-time.Minute)).Obj(),
+				*admitted("evicting", now).EvictedAt(now).Obj(),
 			},
 			want: "older",
 		},
 		"every slice is being evicted": {
 			workloads: []kueue.Workload{
-				*live("one", now.Add(-time.Minute)).EvictedAt(now).Obj(),
-				*live("two", now).EvictedAt(now).Obj(),
+				*admitted("one", now.Add(-time.Minute)).EvictedAt(now).Obj(),
+				*admitted("two", now).EvictedAt(now).Obj(),
 			},
 		},
 	}

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -179,6 +179,41 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Label("controller:provisioning", 
 			})
 		})
 
+		ginkgo.It("Should not create a provisioning request when all admitted PodSet counts are zero", framework.SlowSpec, func() {
+			zeroCountAdmission := utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(cq.Name)).
+				PodSets(
+					utiltestingapi.MakePodSetAssignment("ps1").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "0").
+						Count(0).
+						Obj(),
+					utiltestingapi.MakePodSetAssignment("ps2").
+						Assignment(corev1.ResourceCPU, kueue.ResourceFlavorReference(rf.Name), "0").
+						Count(0).
+						Obj(),
+				).
+				Obj()
+
+			ginkgo.By("Setting a quota reservation with zero admitted counts", func() {
+				util.SetQuotaReservation(ctx, k8sClient, wlKey, zeroCountAdmission)
+			})
+
+			ginkgo.By("Checking the admission check is ready because no request is needed", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).To(gomega.Succeed())
+					check := admissioncheck.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, kueue.AdmissionCheckReference(ac.Name))
+					g.Expect(check).NotTo(gomega.BeNil())
+					g.Expect(check.State).To(gomega.Equal(kueue.CheckStateReady))
+					g.Expect(check.Message).To(gomega.Equal(provisioning.NoRequestNeeded))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking no provisioning request is created", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, provReqKey, &createdRequest)).Should(utiltesting.BeNotFoundError())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("Should create provisioning requests after quota is reserved and preserve it when reservation is lost", framework.SlowSpec, func() {
 			ginkgo.By("Setting the quota reservation to the workload", func() {
 				util.SetQuotaReservation(ctx, k8sClient, wlKey, admission)


### PR DESCRIPTION
This is a backport of #13975 to `release-0.18`

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

Backports #13975 `ProvisioningRequest: skip PodSets with zero count` to `release-0.18` which unchanged in behavior from the version merged to `main`.

#### release-0.18 notes:

`release-0.18` predates the `main` branch split of the `pkg/workload` package into `workload`, `workload/finish` and `workload/evict` sub-packages. All backported changes use`release-0.18` existing single `workload` package `workload.IsAdmitted`, `workload.IsFinished`, `workload.IsEvicted`, `workload.HasQuotaReservation`. There is no behavior difference, only an path import diff.

#### Which issue(s) this PR fixes:

Fixes NONE

This  backports a follow-up compatibility fix for zero-count Workloads merged to `main` via #13975.

#### Special notes for your reviewer:

Validated on `release-0.18`:

```
go build ./...
go test ./pkg/workloadslicing/... ./pkg/controller/elasticjobs/... ./pkg/controller/admissionchecks/provisioning/...
go vet ./pkg/workloadslicing/... ./pkg/controller/elasticjobs/... ./pkg/controller/admissionchecks/provisioning/...
```

All unit tests pass, the targeted zero-count integration test passes (1 passed / 0 failed), `golangci-lint` reports 0 issues, and `gofmt` reports no formatting diffs.

Tested E2E on ephemeral GKE cluster. 

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices & ProvisioningRequest: Fixed scale-from-zero admission for elastic jobs. Kueue now
omits zero-count PodSets, which are invalid in a ProvisioningRequest. If there are no other PodSets requiring ProvisioningRequests the AdmissionCheck is marked Ready.
```
