### PR TITLE
TAS: stop dumping every leaf domain in the assumptions-violated error

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1616,13 +1616,41 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		remainingPrimary -= domState.state
 		result = append(result, dom)
 	}
+	// The error below is not gated by the verbosity level, so log a summary of
+	// the snapshot instead of the leaf domains themselves. There is one leaf per
+	// node when the lowest topology level is the hostname, so dumping them here
+	// grows the log line with the size of the cluster.
+	var lastDomainID utiltas.TopologyDomainID
+	if len(domains) > 0 {
+		lastDomainID = domains[len(domains)-1].id
+	}
 	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
 		"remainingCount", remainingPrimary,
 		"remainingLeaderCount", remainingLeaderCount,
 		"count", count,
+		"leaderCount", leaderCount,
 		"sliceSize", sliceSize,
-		"leaves", s.leaves)
+		"unconstrained", unconstrained,
+		"slices", slices,
+		"topologyName", s.topologyName,
+		"domainCount", len(domains),
+		"lastDomainID", lastDomainID,
+		"leafCount", len(s.leaves))
+	s.logLeafDomainsIfVerbose()
 	return nil
+}
+
+// logLeafDomainsIfVerbose logs the identifiers of the snapshot's leaf domains.
+// The line grows with the number of nodes in the topology, so it is emitted at
+// the same verbosity the scheduler dumps the whole snapshot at.
+func (s *TASFlavorSnapshot) logLeafDomainsIfVerbose() {
+	logV := s.log.V(6)
+	if !logV.Enabled() {
+		return
+	}
+	logV.Info("TAS flavor snapshot leaf domains",
+		"topologyName", s.topologyName,
+		"leafDomains", slices.Sorted(maps.Keys(s.leaves)))
 }
 
 // buildTopologyAssignmentForLevels build TopologyAssignment for levels starting from levelIdx

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1616,10 +1616,7 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		remainingPrimary -= domState.state
 		result = append(result, dom)
 	}
-	// The error below is not gated by the verbosity level, so log a summary of
-	// the snapshot instead of the leaf domains themselves. There is one leaf per
-	// node when the lowest topology level is the hostname, so dumping them here
-	// grows the log line with the size of the cluster.
+	// Error logs are not verbosity-gated; dumping leaves scales with cluster size.
 	var lastDomainID utiltas.TopologyDomainID
 	if len(domains) > 0 {
 		lastDomainID = domains[len(domains)-1].id
@@ -1640,9 +1637,8 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 	return nil
 }
 
-// logLeafDomainsIfVerbose logs the identifiers of the snapshot's leaf domains.
-// The line grows with the number of nodes in the topology, so it is emitted at
-// the same verbosity the scheduler dumps the whole snapshot at.
+// logLeafDomainsIfVerbose logs leaf domain IDs at V(6).
+// The list scales with node count, so it stays off the Error path.
 func (s *TASFlavorSnapshot) logLeafDomainsIfVerbose() {
 	logV := s.log.V(6)
 	if !logV.Enabled() {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1617,10 +1617,6 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		result = append(result, dom)
 	}
 	// Error logs are not verbosity-gated; dumping leaves scales with cluster size.
-	var lastDomainID utiltas.TopologyDomainID
-	if len(domains) > 0 {
-		lastDomainID = domains[len(domains)-1].id
-	}
 	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
 		"remainingCount", remainingPrimary,
 		"remainingLeaderCount", remainingLeaderCount,
@@ -1628,10 +1624,8 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		"leaderCount", leaderCount,
 		"sliceSize", sliceSize,
 		"unconstrained", unconstrained,
-		"slices", slices,
 		"topologyName", s.topologyName,
 		"domainCount", len(domains),
-		"lastDomainID", lastDomainID,
 		"leafCount", len(s.leaves))
 	s.logLeafDomainsIfVerbose()
 	return nil

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1499,8 +1499,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 	}
 }
 
-// newObservedLogger returns a logger discarding its output, together with the
-// entries it observed, so that a test can assert on what was logged.
+// newObservedLogger returns a logger that discards output and an observer of its entries.
 func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs) {
 	logsObserver, observedLogs := observer.New(level)
 	logger := crzap.New(
@@ -1516,24 +1515,23 @@ func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs
 }
 
 func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
-	// The leaf domains are keyed by hostname, so the snapshot holds one leaf per
-	// node. Their identifiers must not end up in the error entry, which is not
-	// gated by the verbosity level.
+	// Error entries are not verbosity-gated, so leaf IDs must stay out of them.
 	newSnapshot := func(log logr.Logger) *TASFlavorSnapshot {
-		snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{corev1.LabelHostname}, nil, &defaultChecker{})
+		nodes := make([]*corev1.Node, 0, 2)
 		for _, name := range []string{"node-a", "node-b"} {
-			snapshot.addNode(node.MakeNode(name).
+			nodes = append(nodes, node.MakeNode(name).
 				Label(corev1.LabelHostname, name).
 				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).
 				Ready().
 				Obj())
 		}
-		return snapshot
+		return newTASFlavorSnapshot(log, "tas-topology", newTopologyTree([]string{corev1.LabelHostname}, nodes, 0), nil, &defaultChecker{})
 	}
-	// A single domain with room for one pod cannot accommodate the ten requested
-	// ones, which violates the assumptions of the algorithm.
+	// One domain with capacity 1 cannot satisfy count 10.
 	callWithViolatedAssumptions := func(snapshot *TASFlavorSnapshot) []*domain {
-		return snapshot.updateCountsToMinimumGeneric([]*domain{{id: "rack-1", state: 1}}, 10, 0, 1, false, false)
+		dom := &domain{id: "rack-1", idx: 0}
+		snapshot.stateOf(dom).state = 1
+		return snapshot.updateCountsToMinimumGeneric([]*domain{dom}, 10, 0, 1, false, false)
 	}
 	wantErrorFields := map[string]any{
 		"error":                "code assumptions violated",
@@ -1569,7 +1567,7 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 		if diff := cmp.Diff(wantErrorFields, fields); diff != "" {
 			t.Errorf("Observed error fields mismatch (-want +got):\n%s", diff)
 		}
-		// Guard against the leaf domains reaching the entry under any other key.
+		// Leaf IDs must not appear under any error field.
 		for _, leafDomainID := range []string{"node-a", "node-b"} {
 			if rendered := fmt.Sprint(fields); strings.Contains(rendered, leafDomainID) {
 				t.Errorf("Observed error entry mentions leaf domain %q: %s", leafDomainID, rendered)

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -18,13 +18,20 @@ package scheduler
 
 import (
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/gomega"
+	zaplog "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -1490,4 +1497,110 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 			g.Expect(snapshot.Fits(flavorUsage)).To(gomega.BeTrue())
 		})
 	}
+}
+
+// newObservedLogger returns a logger discarding its output, together with the
+// entries it observed, so that a test can assert on what was logged.
+func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs) {
+	logsObserver, observedLogs := observer.New(level)
+	logger := crzap.New(
+		crzap.WriteTo(io.Discard),
+		crzap.Level(level),
+		func(o *crzap.Options) {
+			o.ZapOpts = append(o.ZapOpts, zaplog.WrapCore(func(zapcore.Core) zapcore.Core {
+				return logsObserver
+			}))
+		},
+	)
+	return logger, observedLogs
+}
+
+func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
+	// The leaf domains are keyed by hostname, so the snapshot holds one leaf per
+	// node. Their identifiers must not end up in the error entry, which is not
+	// gated by the verbosity level.
+	newSnapshot := func(log logr.Logger) *TASFlavorSnapshot {
+		snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{corev1.LabelHostname}, nil, &defaultChecker{})
+		for _, name := range []string{"node-a", "node-b"} {
+			snapshot.addNode(node.MakeNode(name).
+				Label(corev1.LabelHostname, name).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).
+				Ready().
+				Obj())
+		}
+		return snapshot
+	}
+	// A single domain with room for one pod cannot accommodate the ten requested
+	// ones, which violates the assumptions of the algorithm.
+	callWithViolatedAssumptions := func(snapshot *TASFlavorSnapshot) []*domain {
+		return snapshot.updateCountsToMinimumGeneric([]*domain{{id: "rack-1", state: 1}}, 10, 0, 1, false, false)
+	}
+	wantErrorFields := map[string]any{
+		"error":                "code assumptions violated",
+		"remainingCount":       int32(9),
+		"remainingLeaderCount": int32(0),
+		"count":                int32(10),
+		"leaderCount":          int32(0),
+		"sliceSize":            int32(1),
+		"unconstrained":        false,
+		"slices":               false,
+		"topologyName":         kueue.TopologyReference("tas-topology"),
+		"domainCount":          int64(1),
+		"lastDomainID":         tas.TopologyDomainID("rack-1"),
+		"leafCount":            int64(2),
+	}
+
+	t.Run("the error entry summarizes the leaf domains instead of dumping them", func(t *testing.T) {
+		log, observedLogs := newObservedLogger(zapcore.InfoLevel)
+		snapshot := newSnapshot(log)
+
+		if got := callWithViolatedAssumptions(snapshot); got != nil {
+			t.Fatalf("updateCountsToMinimumGeneric() = %v, want nil", got)
+		}
+
+		logs := observedLogs.TakeAll()
+		if len(logs) != 1 {
+			t.Fatalf("Observed %d log entries, want 1: %v", len(logs), logs)
+		}
+		if logs[0].Level != zapcore.ErrorLevel {
+			t.Errorf("Observed log level %v, want %v", logs[0].Level, zapcore.ErrorLevel)
+		}
+		fields := logs[0].ContextMap()
+		if diff := cmp.Diff(wantErrorFields, fields); diff != "" {
+			t.Errorf("Observed error fields mismatch (-want +got):\n%s", diff)
+		}
+		// Guard against the leaf domains reaching the entry under any other key.
+		for _, leafDomainID := range []string{"node-a", "node-b"} {
+			if rendered := fmt.Sprint(fields); strings.Contains(rendered, leafDomainID) {
+				t.Errorf("Observed error entry mentions leaf domain %q: %s", leafDomainID, rendered)
+			}
+		}
+	})
+
+	t.Run("the leaf domains are logged at high verbosity", func(t *testing.T) {
+		log, observedLogs := newObservedLogger(zapcore.Level(-6))
+		snapshot := newSnapshot(log)
+
+		if got := callWithViolatedAssumptions(snapshot); got != nil {
+			t.Fatalf("updateCountsToMinimumGeneric() = %v, want nil", got)
+		}
+
+		logs := observedLogs.TakeAll()
+		if len(logs) != 2 {
+			t.Fatalf("Observed %d log entries, want 2: %v", len(logs), logs)
+		}
+		if diff := cmp.Diff(wantErrorFields, logs[0].ContextMap()); diff != "" {
+			t.Errorf("Observed error fields mismatch (-want +got):\n%s", diff)
+		}
+		if logs[1].Level != zapcore.Level(-6) {
+			t.Errorf("Observed log level %v, want %v", logs[1].Level, zapcore.Level(-6))
+		}
+		wantLeafFields := map[string]any{
+			"topologyName": kueue.TopologyReference("tas-topology"),
+			"leafDomains":  []tas.TopologyDomainID{"node-a", "node-b"},
+		}
+		if diff := cmp.Diff(wantLeafFields, logs[1].ContextMap()); diff != "" {
+			t.Errorf("Observed leaf domain fields mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1541,10 +1541,8 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 		"leaderCount":          int32(0),
 		"sliceSize":            int32(1),
 		"unconstrained":        false,
-		"slices":               false,
 		"topologyName":         kueue.TopologyReference("tas-topology"),
 		"domainCount":          int64(1),
-		"lastDomainID":         tas.TopologyDomainID("rack-1"),
 		"leafCount":            int64(2),
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

When `updateCountsToMinimumGeneric` runs out of domains, it logs `unexpected remainingCount` at Error and includes the whole `leaves` map. With a hostname lowest topology level that is one entry per node, so the line grows with the cluster. Error is not gated by verbosity, so an operator cannot shrink this by logging less. The encoder also drops the unexported leaf fields, so the dump was mostly just the domain IDs anyway.

This change keeps the Error entry but logs a short summary instead (`topologyName`, `leafCount`, `domainCount`, `lastDomainID`, plus `leaderCount` / `unconstrained` / `slices`). The leaf domain identifiers move to V(6), the same level the scheduler already uses for full snapshot dumps. 

#### Which issue(s) this PR fixes:
Fixes #14241

#### Special notes for your reviewer:

The probability for this log message is very low but still want to ensure log is not flooded in case this fires. Related to the log-volume theme in #14169 / #14174, but a different site: that work removes high-frequency V(3) skip lines; this one shrinks a rare Error payload that scales with node count.

#### Does this PR introduce a user-facing change?
```release-note
TAS: Reduced excessively large assumptions-violation logs to a short summary. Operators can view the individual leaf domain IDs at verbosity 6 when detailed diagnostics are needed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic logging for unexpected count errors by showing concise snapshot details instead of overwhelming full data dumps.
  * Detailed leaf information is now available only at high verbosity levels, keeping standard logs easier to read and reducing log noise.

* **Tests**
  * Added coverage validating summarized error output and verbosity-controlled diagnostic details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->