### PR TITLE
Automated cherry pick of #13863: Allow preemption candidate recompute within scheduling cycle 

### DIFF
--- a/pkg/cache/scheduler/snapshot.go
+++ b/pkg/cache/scheduler/snapshot.go
@@ -70,11 +70,11 @@ func (s *Snapshot) AddWorkload(wl *workload.Info) {
 	cq.AddUsage(wl.Usage())
 }
 
-// SimulateWorkloadRemoval modifies the snapshot by removing the usage
+// SimulateWorkloadUsageRemoval modifies the snapshot by removing the usage
 // corresponding to the list of workloads from workloads' respective
 // ClusterQueues. It returns a function which can be used to restore
 // this usage.
-func (s *Snapshot) SimulateWorkloadRemoval(workloads []*workload.Info) func() {
+func (s *Snapshot) SimulateWorkloadUsageRemoval(workloads []*workload.Info) func() {
 	type cqUsage struct {
 		cq    kueue.ClusterQueueReference
 		usage workload.Usage
@@ -89,6 +89,20 @@ func (s *Snapshot) SimulateWorkloadRemoval(workloads []*workload.Info) func() {
 	return func() {
 		for _, cqUsage := range cqUsages {
 			s.ClusterQueue(cqUsage.cq).AddUsage(cqUsage.usage)
+		}
+	}
+}
+
+// SimulateWorkloadRemoval modifies the snapshot by removing the list
+// of workloads from workloads' respective ClusterQueues. It returns a
+// function which can be used to restore these workloads.
+func (s *Snapshot) SimulateWorkloadRemoval(workloads []*workload.Info) func() {
+	for _, w := range workloads {
+		s.RemoveWorkload(w)
+	}
+	return func() {
+		for _, w := range workloads {
+			s.AddWorkload(w)
 		}
 	}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -916,7 +916,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	RecomputePreemptionTargetsUponOverlap: {
-		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -916,7 +916,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	RecomputePreemptionTargetsUponOverlap: {
-		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -592,6 +592,10 @@ const (
 	// serveConfigV2 edit) onto the worker copy after admission, and to watch the manager
 	// job so such a change is forwarded promptly instead of on the next periodic requeue.
 	MultiKueueRemoteSpecSync featuregate.Feature = "MultiKueueRemoteSpecSync"
+
+	// Enable recomputing preemption targets if they overlap with another workload's targets
+	// within the same scheduling cycle.
+	RecomputePreemptionTargetsUponOverlap featuregate.Feature = "RecomputePreemptionTargetsUponOverlap"
 )
 
 func init() {
@@ -906,6 +910,9 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 
 	MultiKueueRemoteSpecSync: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+	},
+	RecomputePreemptionTargetsUponOverlap: {
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -597,7 +597,12 @@ const (
 	// issue: https://github.com/kubernetes-sigs/kueue/issues/13320
 	//
 	// Enable recomputing preemption targets if they overlap with another workload's targets
-	// within the same scheduling cycle.
+	// within the same scheduling cycle. This recomputation is done assuming that the earlier
+	// preemptions issued in this cycle are already completed. If the outcome of the new assuignment
+	// is Preempt, we issue preemptions for the new set of targets. If the outcome is Fit,
+	// it means that the preemptions issued by other workloads in this cycle are sufficient also
+	// for the considered workload to get it. We don't immediately admit this workload as we have
+	// to wait for these preemptions to complete.
 	RecomputeAssignmentUponPreemptionTargetsOverlap featuregate.Feature = "RecomputeAssignmentUponPreemptionTargetsOverlap"
 )
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -598,7 +598,7 @@ const (
 	//
 	// Enable recomputing preemption targets if they overlap with another workload's targets
 	// within the same scheduling cycle.
-	RecomputePreemptionTargetsUponOverlap featuregate.Feature = "RecomputePreemptionTargetsUponOverlap"
+	RecomputeAssignmentUponPreemptionTargetsOverlap featuregate.Feature = "RecomputeAssignmentUponPreemptionTargetsOverlap"
 )
 
 func init() {
@@ -915,8 +915,8 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 
-	RecomputePreemptionTargetsUponOverlap: {
-		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
+	RecomputeAssignmentUponPreemptionTargetsOverlap: {
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -593,6 +593,9 @@ const (
 	// job so such a change is forwarded promptly instead of on the next periodic requeue.
 	MultiKueueRemoteSpecSync featuregate.Feature = "MultiKueueRemoteSpecSync"
 
+	// owner: @pajakd
+	// issue: https://github.com/kubernetes-sigs/kueue/issues/13320
+	//
 	// Enable recomputing preemption targets if they overlap with another workload's targets
 	// within the same scheduling cycle.
 	RecomputePreemptionTargetsUponOverlap featuregate.Feature = "RecomputePreemptionTargetsUponOverlap"
@@ -911,6 +914,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	MultiKueueRemoteSpecSync: {
 		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
+
 	RecomputePreemptionTargetsUponOverlap: {
 		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -921,7 +921,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	RecomputeAssignmentUponPreemptionTargetsOverlap: {
-		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: false, PreRelease: featuregate.Alpha},
 	},
 }
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -916,7 +916,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	RecomputeAssignmentUponPreemptionTargetsOverlap: {
-		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Alpha},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -94,6 +94,13 @@ func (a *Assignment) UpdateForTASResult(log logr.Logger, cq *schdcache.ClusterQu
 	a.Usage.TAS = a.ComputeTASNetUsage(log, cq, wl, nil)
 }
 
+func (a *Assignment) SetRepresentativeMode(mode FlavorAssignmentMode) {
+	a.representativeMode = &mode
+	for i := range a.PodSets {
+		a.PodSets[i].updateMode(mode)
+	}
+}
+
 // ComputeTASNetUsage computes the net TAS usage for the assignment
 func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, prevAdmission *kueue.Admission) workload.TASUsage {
 	result := make(workload.TASUsage)
@@ -419,6 +426,10 @@ const (
 	// Preempt indicates that admission is possible given Quotas.
 	// Preemption may be impossible due to policy/limits/priorities.
 	Preempt
+	// FitPendingPreemptions indicates that the workload fits, but only
+	// because we are speculatively waiting for other in-flight preemptions
+	// in this scheduling cycle to finish.
+	FitPendingPreemptions
 	// Fit means that there is enough unused quota to assign to this Flavor
 	// without preeemption, potentially with borrowing.
 	Fit
@@ -430,6 +441,8 @@ func (m FlavorAssignmentMode) String() string {
 		return "NoFit"
 	case Preempt:
 		return "Preempt"
+	case FitPendingPreemptions:
+		return "FitPendingPreemptions"
 	case Fit:
 		return "Fit"
 	}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -426,10 +426,10 @@ const (
 	// Preempt indicates that admission is possible given Quotas.
 	// Preemption may be impossible due to policy/limits/priorities.
 	Preempt
-	// FitPendingPreemptions indicates that the workload fits, but only
-	// because we are speculatively waiting for other in-flight preemptions
-	// in this scheduling cycle to finish.
-	FitPendingPreemptions
+	// DeferredFit indicates that the workload fits, but we cannot
+	// admit it yet in this scheduling cycle as we are waiting
+	// e.g. for some preemptions to finish.
+	DeferredFit
 	// Fit means that there is enough unused quota to assign to this Flavor
 	// without preeemption, potentially with borrowing.
 	Fit
@@ -441,8 +441,8 @@ func (m FlavorAssignmentMode) String() string {
 		return "NoFit"
 	case Preempt:
 		return "Preempt"
-	case FitPendingPreemptions:
-		return "FitPendingPreemptions"
+	case DeferredFit:
+		return "DeferredFit"
 	case Fit:
 		return "Fit"
 	}

--- a/pkg/scheduler/preemption/preemption_oracle.go
+++ b/pkg/scheduler/preemption/preemption_oracle.go
@@ -68,7 +68,7 @@ func (p *PreemptionOracle) SimulatePreemption(
 	for i, c := range candidates {
 		workloadsToPreempt[i] = c.WorkloadInfo
 	}
-	revertRemoval := p.snapshot.SimulateWorkloadRemoval(workloadsToPreempt)
+	revertRemoval := p.snapshot.SimulateWorkloadUsageRemoval(workloadsToPreempt)
 	borrowAfterPreemptions, _ := classical.FindHeightOfLowestSubtreeThatFits(cq, fr, quantity)
 	revertRemoval()
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -451,7 +451,7 @@ func (s *Scheduler) processEntry(
 
 	// If the workload only fits because of other preemptions in this cycle,
 	// we must wait for those preemptions to complete.
-	if mode == flavorassigner.FitPendingPreemptions {
+	if mode == flavorassigner.DeferredFit {
 		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 		e.requeueReason = qcache.RequeueReasonPendingPreemption
@@ -706,7 +706,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	fitsCheck := fits(snapshot, cq, &usage, preemptedWorkloads, e.preemptionTargets)
 
 	needsTASRecompute := fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)
-	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputePreemptionTargetsUponOverlap)
+	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputeAssignmentUponPreemptionTargetsOverlap)
 
 	var revertRemoval func()
 	switch {
@@ -722,7 +722,8 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 		// Short-circuit, nothing to recompute.
 		return usage, schdcache.FitsCheckOk == fitsCheck
 	}
-
+	// Clear the last assignment so that we can start from the first flavor again and
+	// reach all flavors from the nomination.
 	e.LastAssignment = nil
 	e.NominationMapping = e.readResourceToFlavorMapping()
 	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
@@ -732,12 +733,13 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 			revertRemoval()
 		}
 		if e.assignment.RepresentativeMode() == flavorassigner.Fit {
-			e.assignment.SetRepresentativeMode(flavorassigner.FitPendingPreemptions)
+			e.assignment.SetRepresentativeMode(flavorassigner.DeferredFit)
 		}
 	}
 	usage = e.assignmentUsage(log)
 	fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)
 	log.V(2).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode())
+	// clear the assignment flavors as they are only used within a single scheduling cycle
 	e.NominationMapping = nil
 
 	return usage, schdcache.FitsCheckOk == fitsCheck

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -744,7 +744,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	}
 	usage = e.assignmentUsage(log)
 	fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)
-	log.V(2).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode())
+	log.V(3).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode(), "fitsCheck", fitsCheck)
 	// clear the assignment flavors as they are only used within a single scheduling cycle
 	e.NominationMapping = nil
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -708,35 +708,35 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	needsTASRecompute := fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)
 	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputePreemptionTargetsUponOverlap)
 
-	if needsTASRecompute || needsOverlapRecompute {
-		var revertUsage func()
-		if needsOverlapRecompute {
-			log.V(2).Info("Re-computing the assignment as preemption targets overlap")
-			// To get the projected cluster state after other preemptions complete,
-			// we simulate the removal of their victims.
-			victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
-			revertUsage = snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
-		} else {
-			log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
-		}
-		// Clear the last assignment so that we can start from the first flavor again and
-		// reach all flavors from the nomination.
-		e.LastAssignment = nil
-		e.NominationMapping = e.readResourceToFlavorMapping()
-		newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
-		e.recordAssignment(newAssignment, newTargets)
-		if revertUsage != nil {
-			revertUsage()
-			if e.assignment.RepresentativeMode() == flavorassigner.Fit {
-				e.assignment.SetRepresentativeMode(flavorassigner.FitPendingPreemptions)
-			}
-		}
-		usage = e.assignmentUsage(log)
-		fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)
-		log.V(2).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode())
-		// clear the assignment flavors as they are only used within a single scheduling cycle
-		e.NominationMapping = nil
+	var revertRemoval func()
+	if needsOverlapRecompute {
+		log.V(2).Info("Re-computing the assignment as preemption targets overlap")
+		// To get the projected cluster state after other preemptions complete,
+		// we simulate the removal of their victims.
+		victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
+		revertRemoval = snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
+	} else if needsTASRecompute {
+		log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
+	} else {
+		// Short-circuit, nothing to recompute.
+		return usage, schdcache.FitsCheckOk == fitsCheck
 	}
+
+	e.LastAssignment = nil
+	e.NominationMapping = e.readResourceToFlavorMapping()
+	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
+	e.recordAssignment(newAssignment, newTargets)
+	if revertRemoval != nil {
+		revertRemoval()
+		if e.assignment.RepresentativeMode() == flavorassigner.Fit {
+			e.assignment.SetRepresentativeMode(flavorassigner.FitPendingPreemptions)
+		}
+	}
+	usage = e.assignmentUsage(log)
+	fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)
+	log.V(2).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode())
+	e.NominationMapping = nil
+
 	return usage, schdcache.FitsCheckOk == fitsCheck
 }
 
@@ -746,7 +746,7 @@ func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usag
 	for _, target := range newTargets {
 		workloads = append(workloads, target.WorkloadInfo)
 	}
-	revertUsage := snapshot.SimulateWorkloadRemoval(workloads)
+	revertUsage := snapshot.SimulateWorkloadUsageRemoval(workloads)
 	defer revertUsage()
 	return cq.Fits(*usage)
 }
@@ -934,7 +934,7 @@ func updateAssignmentForTAS(
 			for _, target := range targets {
 				targetWorkloads = append(targetWorkloads, target.WorkloadInfo)
 			}
-			revertUsage := snapshot.SimulateWorkloadRemoval(targetWorkloads)
+			revertUsage := snapshot.SimulateWorkloadUsageRemoval(targetWorkloads)
 			tasResult = cq.FindTopologyAssignmentsForWorkload(
 				ctx,
 				tasRequests,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -455,6 +455,12 @@ func (s *Scheduler) processEntry(
 		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 		e.requeueReason = qcache.RequeueReasonPendingPreemption
+		// Clear LastAssignment to force a full re-evaluation of all flavors in the next cycle.
+		// Since we are deferring admission until in-flight preemptions complete, the cluster
+		// state will change. Retaining the current assignment could lock the workload into a
+		// suboptimal flavor, preventing it from claiming a more preferred flavor that might
+		// become available.
+		e.LastAssignment = nil
 		cq.AddUsage(usage)
 		return
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -727,8 +727,10 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	e.NominationMapping = e.readResourceToFlavorMapping()
 	newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
 	e.recordAssignment(newAssignment, newTargets)
-	if revertRemoval != nil {
-		revertRemoval()
+	if needsOverlapRecompute {
+		if revertRemoval != nil {
+			revertRemoval()
+		}
 		if e.assignment.RepresentativeMode() == flavorassigner.Fit {
 			e.assignment.SetRepresentativeMode(flavorassigner.FitPendingPreemptions)
 		}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -448,48 +448,24 @@ func (s *Scheduler) processEntry(
 		}
 	}
 
-	// We skip multiple-preemptions per cohort if any of the targets are overlapping,
-	// or recompute them if the RecomputePreemptionTargetsUponOverlap feature gate is enabled.
+	// If the workload only fits because of other preemptions in this cycle,
+	// we must wait for those preemptions to complete.
+	if features.Enabled(features.RecomputePreemptionTargetsUponOverlap) &&
+		e.assignment.RepresentativeMode() == flavorassigner.Fit &&
+		cq.Fits(usage) != schdcache.FitsCheckOk {
+		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
+		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
+		e.requeueReason = qcache.RequeueReasonPendingPreemption
+		cq.AddUsage(usage)
+		return
+	}
+
+	// We skip multiple-preemptions per cohort if any of the targets are overlapping.
 	if preemptedWorkloads.HasAny(e.preemptionTargets) {
-		if features.Enabled(features.RecomputePreemptionTargetsUponOverlap) {
-			log.V(2).Info("Re-computing the assignment as preemption targets overlap")
-			// The snapshot already includes usage from workloads admitted earlier in this cycle.
-			// To get the projected cluster state after their preemptions complete, we simulate
-			// the removal of their victims.
-			victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
-			revertUsage := snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
-			e.LastAssignment = nil
-			e.NominationMapping = e.readResourceToFlavorMapping()
-			newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
-			e.recordAssignment(newAssignment, newTargets)
-			revertUsage()
-			e.NominationMapping = nil
-
-			newMode := newAssignment.RepresentativeMode()
-			if newMode == flavorassigner.NoFit || (newMode == flavorassigner.Preempt && len(newTargets) == 0) {
-				// We failed to find alternative preemption targets for the preemptor after recomputation, so skip admission.
-				e.markSkipped("Workload has overlapping preemption targets with another workload")
-				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-				skippedPreemptions[cq.Name]++
-				return
-			}
-			if newMode == flavorassigner.Fit {
-				// The workload fits once the victims of the other overlapping preemptions
-				// are evicted, so wait for those preemptions to finish.
-				e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
-				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
-				e.requeueReason = qcache.RequeueReasonPendingPreemption
-				cq.AddUsage(usage)
-				return
-			}
-		}
-
-		if preemptedWorkloads.HasAny(e.preemptionTargets) {
-			e.markSkipped("Workload has overlapping preemption targets with another workload")
-			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-			skippedPreemptions[cq.Name]++
-			return
-		}
+		e.markSkipped("Workload has overlapping preemption targets with another workload")
+		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
+		skippedPreemptions[cq.Name]++
+		return
 	}
 
 	if !fits {
@@ -729,14 +705,30 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	preemptedWorkloads preemption.PreemptedWorkloads) (workload.Usage, bool) {
 	usage := e.assignmentUsage(log)
 	fitsCheck := fits(snapshot, cq, &usage, preemptedWorkloads, e.preemptionTargets)
-	if fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle) {
-		log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
+
+	needsTASRecompute := fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)
+	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputePreemptionTargetsUponOverlap)
+
+	if needsTASRecompute || needsOverlapRecompute {
+		var revertUsage func()
+		if needsOverlapRecompute {
+			log.V(2).Info("Re-computing the assignment as preemption targets overlap")
+			// To get the projected cluster state after other preemptions complete,
+			// we simulate the removal of their victims.
+			victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
+			revertUsage = snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
+		} else {
+			log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
+		}
 		// Clear the last assignment so that we can start from the first flavor again and
 		// reach all flavors from the nomination.
 		e.LastAssignment = nil
 		e.NominationMapping = e.readResourceToFlavorMapping()
 		newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
 		e.recordAssignment(newAssignment, newTargets)
+		if revertUsage != nil {
+			revertUsage()
+		}
 		usage = e.assignmentUsage(log)
 		fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)
 		log.V(2).Info("Re-computed assignment", "newMode", newAssignment.RepresentativeMode())

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -479,9 +479,9 @@ func (s *Scheduler) processEntry(
 				e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 				e.requeueReason = qcache.RequeueReasonPendingPreemption
+				cq.AddUsage(usage)
+				return
 			}
-
-			usage, fits = s.updateAssignmentIfNeeded(ctx, log, e, snapshot, cq, preemptedWorkloads)
 		}
 
 		if preemptedWorkloads.HasAny(e.preemptionTargets) {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -448,12 +448,48 @@ func (s *Scheduler) processEntry(
 		}
 	}
 
-	// We skip multiple-preemptions per cohort if any of the targets are overlapping
+	// We skip multiple-preemptions per cohort if any of the targets are overlapping,
+	// or recompute them if the RecomputePreemptionTargetsUponOverlap feature gate is enabled.
 	if preemptedWorkloads.HasAny(e.preemptionTargets) {
-		e.markSkipped("Workload has overlapping preemption targets with another workload")
-		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
-		skippedPreemptions[cq.Name]++
-		return
+		if features.Enabled(features.RecomputePreemptionTargetsUponOverlap) {
+			log.V(2).Info("Re-computing the assignment as preemption targets overlap")
+			// The snapshot already includes usage from workloads admitted earlier in this cycle.
+			// To get the projected cluster state after their preemptions complete, we simulate
+			// the removal of their victims.
+			victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
+			revertUsage := snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
+			e.LastAssignment = nil
+			e.NominationMapping = e.readResourceToFlavorMapping()
+			newAssignment, newTargets := s.getAssignments(ctx, &e.Info, snapshot)
+			e.recordAssignment(newAssignment, newTargets)
+			revertUsage()
+			e.NominationMapping = nil
+
+			newMode := newAssignment.RepresentativeMode()
+			if newMode == flavorassigner.NoFit || (newMode == flavorassigner.Preempt && len(newTargets) == 0) {
+				// We failed to find alternative preemption targets for the preemptor after recomputation, so skip admission.
+				e.markSkipped("Workload has overlapping preemption targets with another workload")
+				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
+				skippedPreemptions[cq.Name]++
+				return
+			}
+			if newMode == flavorassigner.Fit {
+				// The workload fits once the victims of the other overlapping preemptions
+				// are evicted, so wait for those preemptions to finish.
+				e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
+				e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
+				e.requeueReason = qcache.RequeueReasonPendingPreemption
+			}
+
+			usage, fits = s.updateAssignmentIfNeeded(ctx, log, e, snapshot, cq, preemptedWorkloads)
+		}
+
+		if preemptedWorkloads.HasAny(e.preemptionTargets) {
+			e.markSkipped("Workload has overlapping preemption targets with another workload")
+			e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForQuota
+			skippedPreemptions[cq.Name]++
+			return
+		}
 	}
 
 	if !fits {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -415,8 +415,10 @@ func (s *Scheduler) processEntry(
 	// The assignment was computed during nomination, but it may need to be refreshed.
 	// For example, TAS nominations for workloads from different CQs are computed
 	// independently, making them likely to choose conflicting topology domains.
+	// We may also recompute in case of overlapping preemption targets with another workload.
 	// Recompute when needed so CQs considered later in the cycle don't repeatedly
 	// lose to earlier CQs and starve for prolonged periods.
+	oldMode := e.assignment.RepresentativeMode()
 	usage, fits := s.updateAssignmentIfNeeded(ctx, log, e, snapshot, cq, preemptedWorkloads)
 	mode := e.assignment.RepresentativeMode()
 
@@ -451,8 +453,8 @@ func (s *Scheduler) processEntry(
 	// If the workload only fits because of other preemptions in this cycle,
 	// we must wait for those preemptions to complete.
 	if features.Enabled(features.RecomputePreemptionTargetsUponOverlap) &&
-		e.assignment.RepresentativeMode() == flavorassigner.Fit &&
-		cq.Fits(usage) != schdcache.FitsCheckOk {
+		oldMode == flavorassigner.Preempt &&
+		e.assignment.RepresentativeMode() == flavorassigner.Fit {
 		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 		e.requeueReason = qcache.RequeueReasonPendingPreemption

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -418,7 +418,6 @@ func (s *Scheduler) processEntry(
 	// We may also recompute in case of overlapping preemption targets with another workload.
 	// Recompute when needed so CQs considered later in the cycle don't repeatedly
 	// lose to earlier CQs and starve for prolonged periods.
-	oldMode := e.assignment.RepresentativeMode()
 	usage, fits := s.updateAssignmentIfNeeded(ctx, log, e, snapshot, cq, preemptedWorkloads)
 	mode := e.assignment.RepresentativeMode()
 
@@ -452,9 +451,7 @@ func (s *Scheduler) processEntry(
 
 	// If the workload only fits because of other preemptions in this cycle,
 	// we must wait for those preemptions to complete.
-	if features.Enabled(features.RecomputePreemptionTargetsUponOverlap) &&
-		oldMode == flavorassigner.Preempt &&
-		e.assignment.RepresentativeMode() == flavorassigner.Fit {
+	if mode == flavorassigner.FitPendingPreemptions {
 		e.inadmissibleMsg = "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete"
 		e.quotaReservedReason = kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads
 		e.requeueReason = qcache.RequeueReasonPendingPreemption
@@ -730,6 +727,9 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 		e.recordAssignment(newAssignment, newTargets)
 		if revertUsage != nil {
 			revertUsage()
+			if e.assignment.RepresentativeMode() == flavorassigner.Fit {
+				e.assignment.SetRepresentativeMode(flavorassigner.FitPendingPreemptions)
+			}
 		}
 		usage = e.assignmentUsage(log)
 		fitsCheck = fits(snapshot, cq, &usage, preemptedWorkloads, newTargets)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -709,15 +709,16 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 	needsOverlapRecompute := preemptedWorkloads.HasAny(e.preemptionTargets) && features.Enabled(features.RecomputePreemptionTargetsUponOverlap)
 
 	var revertRemoval func()
-	if needsOverlapRecompute {
+	switch {
+	case needsOverlapRecompute:
 		log.V(2).Info("Re-computing the assignment as preemption targets overlap")
 		// To get the projected cluster state after other preemptions complete,
 		// we simulate the removal of their victims.
 		victimsOfOtherPreemptions := slices.Collect(maps.Values(preemptedWorkloads))
 		revertRemoval = snapshot.SimulateWorkloadRemoval(victimsOfOtherPreemptions)
-	} else if needsTASRecompute {
+	case needsTASRecompute:
 		log.V(2).Info("Re-computing the assignment as it doesn't fit for TAS")
-	} else {
+	default:
 		// Short-circuit, nothing to recompute.
 		return usage, schdcache.FitsCheckOk == fitsCheck
 	}

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -36,6 +36,11 @@ import (
 func TestScheduleForFairSharing(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
+	cfg, cases := fairSharingTestConfigAndCases(now, fakeClock)
+	runScheduleTestCases(t, cfg, cases)
+}
+
+func fairSharingTestConfigAndCases(now time.Time, fakeClock *testingclock.FakeClock) (scheduleTestConfig, map[string]scheduleTestCase) {
 	ignoreEventMessageCmpOpts := cmp.Options{cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")}
 
 	resourceFlavors := []*kueue.ResourceFlavor{
@@ -3583,10 +3588,5 @@ func TestScheduleForFairSharing(t *testing.T) {
 			},
 		},
 	}
-	runScheduleTestCases(t, scheduleTestConfig{
-		queues:          queues,
-		clusterQueues:   clusterQueues,
-		resourceFlavors: resourceFlavors,
-		fakeClock:       fakeClock,
-	}, cases)
+	return scheduleTestConfig{queues: queues, clusterQueues: clusterQueues, resourceFlavors: resourceFlavors, fakeClock: fakeClock}, cases
 }

--- a/pkg/scheduler/scheduler_fs_test.go
+++ b/pkg/scheduler/scheduler_fs_test.go
@@ -25,9 +25,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -36,11 +38,6 @@ import (
 func TestScheduleForFairSharing(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
-	cfg, cases := fairSharingTestConfigAndCases(now, fakeClock)
-	runScheduleTestCases(t, cfg, cases)
-}
-
-func fairSharingTestConfigAndCases(now time.Time, fakeClock *testingclock.FakeClock) (scheduleTestConfig, map[string]scheduleTestCase) {
 	ignoreEventMessageCmpOpts := cmp.Options{cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")}
 
 	resourceFlavors := []*kueue.ResourceFlavor{
@@ -2733,6 +2730,9 @@ func fairSharingTestConfigAndCases(now time.Time, fakeClock *testingclock.FakeCl
 			// as we disallow overlapping preemption targets
 			// in the same cycle
 			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputeAssignmentUponPreemptionTargetsOverlap: false,
+			},
 			additionalClusterQueues: []kueue.ClusterQueue{
 				*utiltestingapi.MakeClusterQueue("other-alpha").
 					Cohort("other").
@@ -3588,5 +3588,10 @@ func fairSharingTestConfigAndCases(now time.Time, fakeClock *testingclock.FakeCl
 			},
 		},
 	}
-	return scheduleTestConfig{queues: queues, clusterQueues: clusterQueues, resourceFlavors: resourceFlavors, fakeClock: fakeClock}, cases
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:          queues,
+		clusterQueues:   clusterQueues,
+		resourceFlavors: resourceFlavors,
+		fakeClock:       fakeClock,
+	}, cases)
 }

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -758,3 +758,22 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 		fakeClock:       fakeClock,
 	}, cases)
 }
+
+func TestScheduleForFairSharingWithRecomputePreemptionTargetsUponOverlap(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+	cfg, cases := fairSharingTestConfigAndCases(now, fakeClock)
+
+	for name, tc := range cases {
+		if name == "multiple preemptions skip overlapping preemption targets" {
+			// This test case is designed to test the opposite behavior, so we exclude it.
+			continue
+		}
+		if tc.featureGates == nil {
+			tc.featureGates = make(map[featuregate.Feature]bool)
+		}
+		tc.featureGates[features.RecomputePreemptionTargetsUponOverlap] = true
+		cases[name] = tc
+	}
+	runScheduleTestCases(t, cfg, cases)
+}

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -23,11 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/component-base/featuregate"
 	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
-	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -132,10 +130,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			// featuregate, it refreshes its targets, finds wl-noisy-admitted from cq-noisy
 			// and preempts it in the same scheduling cycle.
 			enableFairSharing: true,
-			featureGates: map[featuregate.Feature]bool{
-				features.RecomputePreemptionTargetsUponOverlap: true,
-			},
-			cohorts: defaultCohorts(),
+			cohorts:           defaultCohorts(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-noisy-admitted", "eng-alpha").
 					UID("wl-noisy-admitted").
@@ -310,10 +305,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 		},
 		"with fair sharing: two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
 			enableFairSharing: true,
-			featureGates: map[featuregate.Feature]bool{
-				features.RecomputePreemptionTargetsUponOverlap: true,
-			},
-			cohorts: defaultCohorts(),
+			cohorts:           defaultCohorts(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
 					UID("wl-rest-admitted").
@@ -431,10 +423,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 		},
 		"two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
 			enableFairSharing: false,
-			featureGates: map[featuregate.Feature]bool{
-				features.RecomputePreemptionTargetsUponOverlap: true,
-			},
-			cohorts: defaultCohorts(),
+			cohorts:           defaultCohorts(),
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
 					UID("wl-rest-admitted").
@@ -568,9 +557,6 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			// When wl-pending-high-prio-1 is processed next, it is skipped due to overlapping targets
 			// on the default flavor rather than violating flavor stickiness to switch to the on-demand flavor.
 			enableFairSharing: true,
-			featureGates: map[featuregate.Feature]bool{
-				features.RecomputePreemptionTargetsUponOverlap: true,
-			},
 			cohorts: []kueue.Cohort{
 				*utiltestingapi.MakeCohort("root").Obj(),
 			},
@@ -756,23 +742,4 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 		resourceFlavors: resourceFlavors,
 		fakeClock:       fakeClock,
 	}, cases)
-}
-
-func TestScheduleForFairSharingWithRecomputePreemptionTargetsUponOverlap(t *testing.T) {
-	now := time.Now().Truncate(time.Second)
-	fakeClock := testingclock.NewFakeClock(now)
-	cfg, cases := fairSharingTestConfigAndCases(now, fakeClock)
-
-	for name, tc := range cases {
-		if name == "multiple preemptions skip overlapping preemption targets" {
-			// This test case is designed to test the opposite behavior, so we exclude it.
-			continue
-		}
-		if tc.featureGates == nil {
-			tc.featureGates = make(map[featuregate.Feature]bool)
-		}
-		tc.featureGates[features.RecomputePreemptionTargetsUponOverlap] = true
-		cases[name] = tc
-	}
-	runScheduleTestCases(t, cfg, cases)
 }

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -1,0 +1,760 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/featuregate"
+	testingclock "k8s.io/utils/clock/testing"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func defaultCohorts() []kueue.Cohort {
+	// Cohort hierarchy for this test suite:
+	//
+	//                     root-cohort (nominal: 3005)
+	//                   /              |              \
+	//         parent-cohort-a   parent-cohort-b   parent-cohort-c
+	//           (nominal: 0)     (nominal: 0)      (nominal: 0)
+	//            /        \            |                 |
+	//         cq-hero   cq-noisy    cq-tiny           cq-rest
+	//       (nom: 3000) (nom: 0)   (nom: 50)         (nom: 0)
+	return []kueue.Cohort{
+		*utiltestingapi.MakeCohort("root-cohort").ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "3005").Obj(),
+		).Obj(),
+		*utiltestingapi.MakeCohort("parent-cohort-a").Parent("root-cohort").ResourceGroup(
+			*utiltestingapi.MakeFlavorQuotas("default").
+				Resource(corev1.ResourceCPU, "0").Obj(),
+		).Obj(),
+		*utiltestingapi.MakeCohort("parent-cohort-b").Parent("root-cohort").Obj(),
+		*utiltestingapi.MakeCohort("parent-cohort-c").Parent("root-cohort").Obj(),
+	}
+}
+
+func TestScheduleRecomputePreemptionTargets(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	fakeClock := testingclock.NewFakeClock(now)
+
+	resourceFlavors := []*kueue.ResourceFlavor{
+		utiltestingapi.MakeResourceFlavor("default").Obj(),
+		utiltestingapi.MakeResourceFlavor("on-demand").Obj(),
+	}
+
+	clusterQueues := []kueue.ClusterQueue{
+		*utiltestingapi.MakeClusterQueue("cq-hero").
+			Cohort("parent-cohort-a").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "3000").Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+			}).Obj(),
+		*utiltestingapi.MakeClusterQueue("cq-noisy").
+			Cohort("parent-cohort-a").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "0").Obj(),
+			).
+			Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+			}).Obj(),
+		*utiltestingapi.MakeClusterQueue("cq-tiny").
+			Cohort("parent-cohort-b").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "50").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+			}).Obj(),
+		*utiltestingapi.MakeClusterQueue("cq-rest").
+			Cohort("parent-cohort-c").
+			ResourceGroup(
+				*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "0").Obj()).
+			Preemption(kueue.ClusterQueuePreemption{
+				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+			}).Obj(),
+	}
+
+	queues := []kueue.LocalQueue{
+		*utiltestingapi.MakeLocalQueue("lq-hero", "eng-alpha").ClusterQueue("cq-hero").Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-noisy", "eng-alpha").ClusterQueue("cq-noisy").Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-tiny", "eng-alpha").ClusterQueue("cq-tiny").Obj(),
+		*utiltestingapi.MakeLocalQueue("lq-rest", "eng-alpha").ClusterQueue("cq-rest").Obj(),
+	}
+
+	cases := map[string]scheduleTestCase{
+		"with fair sharing: hierarchical nominal-first prefers non-borrowing leaf CQ": {
+			// Admitted state:
+			// - w-noisy-admitted (cq-noisy): uses 3000 CPU (borrowed from cq-hero)
+			// - w-tiny-admitted (cq-tiny): uses 60 CPU (borrows 10 from root-cohort)
+			// - wl-rest-admitted (cq-rest): uses 2995 CPU (borrowed from root-cohort)
+			//
+			// Pending:
+			// - wl-h (cq-hero): requests 2990 CPU (fits within its nominal 3000 CPU, so cq-hero is not borrowing)
+			// - wl-t (cq-tiny): requests 10 CPU (already borrowing, needs to borrow even more)
+			//
+			// Since cq-rest is borrowing a lot of quota, both cq-hero and cq-tiny initially choose
+			// the same candidate for preemption (wl-rest-admitted from cq-rest).
+			// Within the scheduling cycle, wl-tiny-pending is considered before wl-hero (due to
+			// Fair Sharing prioritization). So, wl-hero would normally be requeued due to
+			// overlapping preemption targets. But with RecomputePreemptionTargetsUponOverlap
+			// featuregate, it refreshes its targets, finds wl-noisy-admitted from cq-noisy
+			// and preempts it in the same scheduling cycle.
+			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputePreemptionTargetsUponOverlap: true,
+			},
+			cohorts: defaultCohorts(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-noisy-admitted", "eng-alpha").
+					UID("wl-noisy-admitted").
+					Queue("lq-noisy").
+					Request(corev1.ResourceCPU, "3000").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-noisy").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3000").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-admitted", "eng-alpha").
+					UID("wl-tiny-admitted").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "60").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-tiny").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "60").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "2995").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2995").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2990").
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "10").
+					Creation(now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2990").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 5 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2990"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-noisy-admitted", "eng-alpha").
+					UID("wl-noisy-admitted").
+					Queue("lq-noisy").
+					Request(corev1.ResourceCPU, "3000").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-noisy").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3000").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-hero, JobUID: job-h-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-a/cq-hero; preemptee path: /root-cohort/parent-cohort-a/cq-noisy",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-hero, JobUID: job-h-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-a/cq-hero; preemptee path: /root-cohort/parent-cohort-a/cq-noisy",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "2995").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2995").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to Fair Sharing within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortFairSharing",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to Fair Sharing within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-admitted", "eng-alpha").
+					UID("wl-tiny-admitted").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "60").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-tiny").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "60").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "10").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 10 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/wl-noisy-admitted": *utiltestingapi.MakeAdmission("cq-noisy").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "3000").Obj()).Obj(),
+				"eng-alpha/wl-tiny-admitted":  *utiltestingapi.MakeAdmission("cq-tiny").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "60").Obj()).Obj(),
+				"eng-alpha/wl-rest-admitted":  *utiltestingapi.MakeAdmission("cq-rest").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "2995").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-hero": {"eng-alpha/wl-hero"},
+				"cq-tiny": {"eng-alpha/wl-tiny-pending"},
+			},
+		},
+		"with fair sharing: two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
+			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputePreemptionTargetsUponOverlap: true,
+			},
+			cohorts: defaultCohorts(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "6055").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2950").
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "50").
+					Creation(now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2950").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2950"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "6055").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "50").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 50 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/wl-rest-admitted": *utiltestingapi.MakeAdmission("cq-rest").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "6055").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-hero": {"eng-alpha/wl-hero"},
+				"cq-tiny": {"eng-alpha/wl-tiny-pending"},
+			},
+		},
+		"two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {
+			enableFairSharing: false,
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputePreemptionTargetsUponOverlap: true,
+			},
+			cohorts: defaultCohorts(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "6055").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2950").
+					Creation(now.Add(time.Second)).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "50").
+					Creation(now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
+					UID("wl-hero").
+					JobUID("job-h-uid").
+					Queue("lq-hero").
+					Request(corev1.ResourceCPU, "2950").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "Workload has overlapping preemption targets with another workload, but will fit after these preemptions complete",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2950"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-admitted", "eng-alpha").
+					UID("wl-rest-admitted").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "6055").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-tiny-pending, JobUID: job-t-uid) due to reclamation within the cohort; preemptor path: /root-cohort/parent-cohort-b/cq-tiny; preemptee path: /root-cohort/parent-cohort-c/cq-rest",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
+					UID("wl-tiny-pending").
+					JobUID("job-t-uid").
+					Queue("lq-tiny").
+					Request(corev1.ResourceCPU, "50").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 50 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("50"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"eng-alpha/wl-rest-admitted": *utiltestingapi.MakeAdmission("cq-rest").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "6055").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-hero": {"eng-alpha/wl-hero"},
+				"cq-tiny": {"eng-alpha/wl-tiny-pending"},
+			},
+		},
+
+		"flavor stickiness with RecomputePreemptionTargetsUponOverlap": {
+			// Admitted state:
+			// - wl-admitted-default (cq-1): uses 10 CPU on default flavor (borrowing 5)
+			// - wl-admitted-on-demand (cq-1): uses 10 CPU on on-demand flavor (borrowing 5)
+			//
+			// Pending:
+			// - wl-pending-high-prio-1 (cq-1): priority 11, requests 10 CPU (can fit by preempting its own admitted workloads)
+			// - wl-pending-high-prio-2 (cq-2): priority 10, requests 10 CPU (needs to borrow, can fit by reclaiming from cq-1)
+			//
+			// Since cq-1 has much higher usage (20 CPU) than cq-2 (0 CPU), under Fair Sharing,
+			// cq-2's pending workload (wl-pending-high-prio-2) is prioritized and processed first
+			// despite having a lower priority than wl-pending-high-prio-1.
+			//
+			// wl-pending-high-prio-2 chooses to preempt wl-admitted-default on the default flavor.
+			// When wl-pending-high-prio-1 is processed next, it is skipped due to overlapping targets
+			// on the default flavor rather than violating flavor stickiness to switch to the on-demand flavor.
+			enableFairSharing: true,
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputePreemptionTargetsUponOverlap: true,
+			},
+			cohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("root").Obj(),
+			},
+			additionalClusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("cq-1").
+					Cohort("root").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("cq-2").
+					Cohort("root").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(
+						*utiltestingapi.MakeFlavorQuotas("default").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+						*utiltestingapi.MakeFlavorQuotas("on-demand").
+							Resource(corev1.ResourceCPU, "5").Obj(),
+					).
+					Obj(),
+			},
+			additionalLocalQueues: []kueue.LocalQueue{
+				*utiltestingapi.MakeLocalQueue("lq-1", "default").ClusterQueue("cq-1").Obj(),
+				*utiltestingapi.MakeLocalQueue("lq-2", "default").ClusterQueue("cq-2").Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-admitted-default", "default").
+					UID("wl-admitted-default-uid").
+					Queue("lq-1").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted-on-demand", "default").
+					UID("wl-admitted-on-demand-uid").
+					Queue("lq-1").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-pending-high-prio-1", "default").
+					UID("wl-pending-high-prio-1-uid").
+					JobUID("job-high-prio-1-uid").
+					Queue("lq-1").
+					Priority(11).
+					Request(corev1.ResourceCPU, "10").
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-pending-high-prio-2", "default").
+					UID("wl-pending-high-prio-2-uid").
+					JobUID("job-high-prio-2-uid").
+					Queue("lq-2").
+					Priority(10).
+					Request(corev1.ResourceCPU, "10").
+					Creation(now.Add(time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-admitted-default", "default").
+					UID("wl-admitted-default-uid").
+					Queue("lq-1").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "10").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-pending-high-prio-2-uid, JobUID: job-high-prio-2-uid) due to Fair Sharing within the cohort; preemptor path: /root/cq-2; preemptee path: /root/cq-1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortFairSharing",
+						Message:            "Preempted to accommodate a workload (UID: wl-pending-high-prio-2-uid, JobUID: job-high-prio-2-uid) due to Fair Sharing within the cohort; preemptor path: /root/cq-2; preemptee path: /root/cq-1",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-admitted-on-demand", "default").
+					UID("wl-admitted-on-demand-uid").
+					Queue("lq-1").
+					Request(corev1.ResourceCPU, "10").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-1").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-pending-high-prio-1", "default").
+					UID("wl-pending-high-prio-1-uid").
+					JobUID("job-high-prio-1-uid").
+					Queue("lq-1").
+					Priority(11).
+					Request(corev1.ResourceCPU, "10").
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "Workload has overlapping preemption targets with another workload",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-pending-high-prio-2", "default").
+					UID("wl-pending-high-prio-2-uid").
+					JobUID("job-high-prio-2-uid").
+					Queue("lq-2").
+					Priority(10).
+					Request(corev1.ResourceCPU, "10").
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 10 more needed, insufficient unused quota for cpu in flavor on-demand, 10 more needed. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("10"),
+						},
+					}).
+					Obj(),
+			},
+			wantAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl-admitted-default":   *utiltestingapi.MakeAdmission("cq-1").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "default", "10").Obj()).Obj(),
+				"default/wl-admitted-on-demand": *utiltestingapi.MakeAdmission("cq-1").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-1": {"default/wl-pending-high-prio-1"},
+				"cq-2": {"default/wl-pending-high-prio-2"},
+			},
+			wantSkippedPreemptions: map[string]int{
+				"cq-1": 1,
+			},
+		},
+	}
+
+	runScheduleTestCases(t, scheduleTestConfig{
+		queues:          queues,
+		clusterQueues:   clusterQueues,
+		resourceFlavors: resourceFlavors,
+		fakeClock:       fakeClock,
+	}, cases)
+}

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -72,7 +72,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			).
 			Preemption(kueue.ClusterQueuePreemption{
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
-				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 			}).Obj(),
 		*utiltestingapi.MakeClusterQueue("cq-noisy").
 			Cohort("parent-cohort-a").
@@ -82,7 +82,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			).
 			Preemption(kueue.ClusterQueuePreemption{
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
-				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 			}).Obj(),
 		*utiltestingapi.MakeClusterQueue("cq-tiny").
 			Cohort("parent-cohort-b").
@@ -91,7 +91,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 					Resource(corev1.ResourceCPU, "50").Obj()).
 			Preemption(kueue.ClusterQueuePreemption{
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
-				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 			}).Obj(),
 		*utiltestingapi.MakeClusterQueue("cq-rest").
 			Cohort("parent-cohort-c").
@@ -100,7 +100,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 					Resource(corev1.ResourceCPU, "0").Obj()).
 			Preemption(kueue.ClusterQueuePreemption{
 				ReclaimWithinCohort: kueue.PreemptionPolicyAny,
-				WithinClusterQueue:  kueue.PreemptionPolicyNever,
+				WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
 			}).Obj(),
 	}
 
@@ -315,6 +315,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
 						Obj(), now).
+					Priority(0).
 					AdmittedAt(true, now).
 					Obj(),
 				*utiltestingapi.MakeWorkload("wl-hero", "eng-alpha").
@@ -330,6 +331,13 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 					Queue("lq-tiny").
 					Request(corev1.ResourceCPU, "50").
 					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-pending", "eng-alpha").
+					UID("wl-rest-pending").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "4000").
+					Priority(10).
+					Creation(now.Add(2 * time.Second)).
 					Obj(),
 			},
 			wantWorkloads: []kueue.Workload{
@@ -364,6 +372,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 					UID("wl-rest-admitted").
 					Queue("lq-rest").
 					Request(corev1.ResourceCPU, "6055").
+					Priority(0).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("cq-rest").
 						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
 							Assignment(corev1.ResourceCPU, "default", "6055").Obj()).
@@ -384,6 +393,33 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-rest-pending", "eng-alpha").
+					UID("wl-rest-pending").
+					Queue("lq-rest").
+					Request(corev1.ResourceCPU, "4000").
+					Creation(now.Add(2 * time.Second)).
+					Priority(10).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 945 more needed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "main",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("4000"),
+						},
+					}).
 					Obj(),
 				*utiltestingapi.MakeWorkload("wl-tiny-pending", "eng-alpha").
 					UID("wl-tiny-pending").
@@ -419,6 +455,9 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
 				"cq-hero": {"eng-alpha/wl-hero"},
 				"cq-tiny": {"eng-alpha/wl-tiny-pending"},
+			},
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-rest": {"eng-alpha/wl-rest-pending"},
 			},
 		},
 		"two workloads reclaim nominal quota; RecomputePreemptionTargetsUponOverlap enabled": {

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -116,8 +116,8 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 	cases := map[string]scheduleTestCase{
 		"with fair sharing: hierarchical nominal-first prefers non-borrowing leaf CQ": {
 			// Admitted state:
-			// - w-noisy-admitted (cq-noisy): uses 3000 CPU (borrowed from cq-hero)
-			// - w-tiny-admitted (cq-tiny): uses 60 CPU (borrows 10 from root-cohort)
+			// - wl-noisy-admitted (cq-noisy): uses 3000 CPU (borrowed from cq-hero)
+			// - wl-tiny-admitted (cq-tiny): uses 60 CPU (borrows 10 from root-cohort)
 			// - wl-rest-admitted (cq-rest): uses 2995 CPU (borrowed from root-cohort)
 			//
 			// Pending:

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -691,7 +691,7 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 						Type:               kueue.WorkloadQuotaReserved,
 						Status:             metav1.ConditionFalse,
 						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
-						Message:            "Workload has overlapping preemption targets with another workload",
+						Message:            "couldn't assign flavors to pod set main: insufficient unused quota for cpu in flavor default, 10 more needed, skipping flavor on-demand as it is not found in the nomination mapping for resource cpu",
 						LastTransitionTime: metav1.NewTime(now),
 					}).
 					Condition(metav1.Condition{
@@ -742,11 +742,10 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 				"default/wl-admitted-on-demand": *utiltestingapi.MakeAdmission("cq-1").PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).Assignment(corev1.ResourceCPU, "on-demand", "10").Obj()).Obj(),
 			},
 			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
-				"cq-1": {"default/wl-pending-high-prio-1"},
 				"cq-2": {"default/wl-pending-high-prio-2"},
 			},
-			wantSkippedPreemptions: map[string]int{
-				"cq-1": 1,
+			wantInadmissibleLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"cq-1": {"default/wl-pending-high-prio-1"},
 			},
 		},
 	}

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -121,8 +121,8 @@ func TestScheduleRecomputePreemptionTargets(t *testing.T) {
 			// - wl-rest-admitted (cq-rest): uses 2995 CPU (borrowed from root-cohort)
 			//
 			// Pending:
-			// - wl-h (cq-hero): requests 2990 CPU (fits within its nominal 3000 CPU, so cq-hero is not borrowing)
-			// - wl-t (cq-tiny): requests 10 CPU (already borrowing, needs to borrow even more)
+			// - wl-hero (cq-hero): requests 2990 CPU (fits within its nominal 3000 CPU, so cq-hero is not borrowing)
+			// - wl-tiny-pending (cq-tiny): requests 10 CPU (already borrowing, needs to borrow even more)
 			//
 			// Since cq-rest is borrowing a lot of quota, both cq-hero and cq-tiny initially choose
 			// the same candidate for preemption (wl-rest-admitted from cq-rest).

--- a/pkg/scheduler/scheduler_recompute_preemption_test.go
+++ b/pkg/scheduler/scheduler_recompute_preemption_test.go
@@ -26,6 +26,7 @@ import (
 	testingclock "k8s.io/utils/clock/testing"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
@@ -55,6 +56,8 @@ func defaultCohorts() []kueue.Cohort {
 }
 
 func TestScheduleRecomputePreemptionTargets(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.RecomputeAssignmentUponPreemptionTargetsOverlap, true)
+
 	now := time.Now().Truncate(time.Second)
 	fakeClock := testingclock.NewFakeClock(now)
 

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -5419,8 +5419,8 @@ func TestScheduleForTASPreemption(t *testing.T) {
 		},
 		"preempting workload recomputes both overlapping preemption targets and TAS topology assignment; both features enabled": {
 			featureGates: map[featuregate.Feature]bool{
-				features.RecomputePreemptionTargetsUponOverlap:       true,
-				features.TASRecomputeAssignmentWithinSchedulingCycle: true,
+				features.RecomputeAssignmentUponPreemptionTargetsOverlap: true,
+				features.TASRecomputeAssignmentWithinSchedulingCycle:     true,
 			},
 			nodes:           defaultTwoNodes,
 			topologies:      []kueue.Topology{defaultSingleLevelTopology},

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -3908,6 +3908,9 @@ func TestScheduleForTASPreemption(t *testing.T) {
 		Obj()
 	queues := []kueue.LocalQueue{
 		*utiltestingapi.MakeLocalQueue("tas-main", "default").ClusterQueue("tas-main").Obj(),
+		*utiltestingapi.MakeLocalQueue("tas-lq-a", "default").ClusterQueue("tas-cq-a").Obj(),
+		*utiltestingapi.MakeLocalQueue("tas-lq-b", "default").ClusterQueue("tas-cq-b").Obj(),
+		*utiltestingapi.MakeLocalQueue("tas-lq-c", "default").ClusterQueue("tas-cq-c").Obj(),
 	}
 	eventIgnoreMessage := cmpopts.IgnoreFields(utiltesting.EventRecord{}, "Message")
 	cases := map[string]tasScheduleTestCase{
@@ -5413,6 +5416,270 @@ func TestScheduleForTASPreemption(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "w3-pending", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
 				utiltesting.MakeEventRecord("default", "w3-pending", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
 			},
+		},
+		"preempting workload recomputes both overlapping preemption targets and TAS topology assignment; both features enabled": {
+			featureGates: map[featuregate.Feature]bool{
+				features.RecomputePreemptionTargetsUponOverlap:       true,
+				features.TASRecomputeAssignmentWithinSchedulingCycle: true,
+			},
+			nodes:           defaultTwoNodes,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			cohorts: []kueue.Cohort{
+				*utiltestingapi.MakeCohort("tas-cohort-main").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-cq-a").
+					Cohort("tas-cohort-main").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("5").BorrowingLimit("10").Append().
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("tas-cq-b").
+					Cohort("tas-cohort-main").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("5").BorrowingLimit("10").Append().
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeClusterQueue("tas-cq-c").
+					Cohort("tas-cohort-main").
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-default").
+						ResourceQuotaWrapper(corev1.ResourceCPU).NominalQuota("0").BorrowingLimit("10").Append().
+						Obj()).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-low-admitted", "default").
+					UID("wl-low-admitted-uid").
+					Queue("tas-lq-c").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-cq-c").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-mid-admitted", "default").
+					UID("wl-mid-admitted-uid").
+					Queue("tas-lq-c").
+					Priority(2).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-cq-c").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-high-1", "default").
+					UID("wl-high-1-uid").
+					JobUID("job-high-1-uid").
+					Queue("tas-lq-a").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Creation(now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-high-2", "default").
+					UID("wl-high-2-uid").
+					JobUID("job-high-2-uid").
+					Queue("tas-lq-b").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Creation(now.Add(time.Second)).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-high-1", "default").
+					UID("wl-high-1-uid").
+					JobUID("job-high-1-uid").
+					Queue("tas-lq-a").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Creation(now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set one: topology \"tas-single-level\" doesn't allow to fit any of 1 pod(s). Total nodes: 2; excluded: resource \"cpu\": 2. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-high-2", "default").
+					UID("wl-high-2-uid").
+					JobUID("job-high-2-uid").
+					Queue("tas-lq-b").
+					Priority(10).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Creation(now.Add(time.Second)).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadQuotaReserved,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads,
+						Message:            "couldn't assign flavors to pod set one: topology \"tas-single-level\" doesn't allow to fit any of 1 pod(s). Total nodes: 2; excluded: resource \"cpu\": 2. Pending the preemption of 1 workload(s)",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadAdmitted,
+						Status:             metav1.ConditionFalse,
+						Reason:             kueue.WorkloadAdmittedReasonNoReservation,
+						Message:            "The workload has no reservation",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					ResourceRequests(kueue.PodSetRequest{
+						Name: "one",
+						Resources: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("3"),
+						},
+					}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-low-admitted", "default").
+					UID("wl-low-admitted-uid").
+					Queue("tas-lq-c").
+					Priority(1).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-cq-c").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-high-1-uid, JobUID: job-high-1-uid) due to reclamation within the cohort; preemptor path: /tas-cohort-main/tas-cq-a; preemptee path: /tas-cohort-main/tas-cq-c",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-high-1-uid, JobUID: job-high-1-uid) due to reclamation within the cohort; preemptor path: /tas-cohort-main/tas-cq-a; preemptee path: /tas-cohort-main/tas-cq-c",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-mid-admitted", "default").
+					UID("wl-mid-admitted-uid").
+					Queue("tas-lq-c").
+					Priority(2).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-cq-c").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "3000m").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"y1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(),
+						now,
+					).
+					AdmittedAt(true, now).
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "3").
+						Obj()).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-high-2-uid, JobUID: job-high-2-uid) due to reclamation within the cohort; preemptor path: /tas-cohort-main/tas-cq-b; preemptee path: /tas-cohort-main/tas-cq-c",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-high-2-uid, JobUID: job-high-2-uid) due to reclamation within the cohort; preemptor path: /tas-cohort-main/tas-cq-b; preemptee path: /tas-cohort-main/tas-cq-c",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+			wantLeft: map[kueue.ClusterQueueReference][]workload.Reference{
+				"tas-cq-a": {"default/wl-high-1"},
+				"tas-cq-b": {"default/wl-high-2"},
+			},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-low-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-low-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-mid-admitted", "EvictedDueToPreempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-mid-admitted", "Preempted", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-high-1", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-high-1", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-high-2", "PreemptedWorkload", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-high-2", kueue.WorkloadQuotaReservedReasonWaitingForPreemptedWorkloads, corev1.EventTypeWarning).Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
 		},
 	}
 	runTASScheduleTestCases(t, tasScheduleTestConfig{

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -363,11 +363,11 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
-- name: RecomputePreemptionTargetsUponOverlap
+- name: RecomputeAssignmentUponPreemptionTargetsOverlap
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -365,9 +365,9 @@
     version: "0.15"
 - name: RecomputeAssignmentUponPreemptionTargetsOverlap
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.19"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -363,6 +363,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: RecomputePreemptionTargetsUponOverlap
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -368,7 +368,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.19"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -363,11 +363,11 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
-- name: RecomputePreemptionTargetsUponOverlap
+- name: RecomputeAssignmentUponPreemptionTargetsOverlap
   versionedSpecs:
-  - default: false
+  - default: true
     lockToDefault: false
-    preRelease: Alpha
+    preRelease: Beta
     version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -365,9 +365,9 @@
     version: "0.15"
 - name: RecomputeAssignmentUponPreemptionTargetsOverlap
   versionedSpecs:
-  - default: true
+  - default: false
     lockToDefault: false
-    preRelease: Beta
+    preRelease: Alpha
     version: "0.19"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -363,6 +363,12 @@
     lockToDefault: false
     preRelease: Beta
     version: "0.15"
+- name: RecomputePreemptionTargetsUponOverlap
+  versionedSpecs:
+  - default: false
+    lockToDefault: false
+    preRelease: Alpha
+    version: "0.20"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -368,7 +368,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.19"
 - name: RejectUpdatesToCQWithInvalidOnFlavors
   versionedSpecs:
   - default: false

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -429,6 +429,8 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 		)
 
 		ginkgo.BeforeEach(func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RecomputeAssignmentUponPreemptionTargetsOverlap, true)
+
 			createCohort(utiltestingapi.MakeCohort("cohort-a").Obj())
 
 			cqHero = createQueue(utiltestingapi.MakeClusterQueue("cq-hero").

--- a/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
+++ b/test/integration/singlecluster/scheduler/fairsharing/fair_sharing_test.go
@@ -421,6 +421,80 @@ var _ = ginkgo.Describe("Scheduler", ginkgo.Label("feature:fairsharing"), func()
 		})
 	})
 
+	ginkgo.When("RecomputeAssignmentUponPreemptionTargetsOverlap with multiple flavors", func() {
+		var (
+			cqHero *kueue.ClusterQueue
+			cqTiny *kueue.ClusterQueue
+			cqRest *kueue.ClusterQueue
+		)
+
+		ginkgo.BeforeEach(func() {
+			createCohort(utiltestingapi.MakeCohort("cohort-a").Obj())
+
+			cqHero = createQueue(utiltestingapi.MakeClusterQueue("cq-hero").
+				Cohort("cohort-a").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+						Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavor2.Name).
+						Resource(corev1.ResourceCPU, "100").Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).Obj())
+
+			cqTiny = createQueue(utiltestingapi.MakeClusterQueue("cq-tiny").
+				Cohort("cohort-a").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+						Resource(corev1.ResourceCPU, "50").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavor2.Name).
+						Resource(corev1.ResourceCPU, "50").Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).Obj())
+			cqRest = createQueue(utiltestingapi.MakeClusterQueue("cq-rest").
+				Cohort("cohort-a").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas(flavor1.Name).
+						Resource(corev1.ResourceCPU, "0").Obj(),
+					*utiltestingapi.MakeFlavorQuotas(flavor2.Name).
+						Resource(corev1.ResourceCPU, "0").Obj(),
+				).
+				Preemption(kueue.ClusterQueuePreemption{
+					ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+				}).Obj())
+		})
+
+		ginkgo.It("hero workload sticks to preferred flavor if overlap resolved", framework.SlowSpec, func() {
+			ginkgo.By("Admitting initial workloads")
+			wlA := createWorkloadWithPriority(cqRest.Name, "150", 10) // flavor1
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlA)
+
+			wlB := createWorkloadWithPriority(cqRest.Name, "150", 10) // flavor2
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlB)
+
+			ginkgo.By("Creating competing workloads")
+			wlHero := createWorkloadWithPriority(cqHero.Name, "100", 100)
+			wlTiny := createWorkloadWithPriority(cqTiny.Name, "50", 50)
+
+			ginkgo.By("Waiting for preemption and eviction")
+			util.ExpectWorkloadsToBePreempted(ctx, k8sClient, wlA)
+			util.FinishEvictionForWorkloads(ctx, k8sClient, wlA)
+
+			ginkgo.By("Hero and Tiny workloads are admitted in preferred flavor")
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wlHero, wlTiny)
+
+			// Verify that wlB was NOT preempted (flavor2 untouched)
+			gomega.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wlB), wlB)).To(gomega.Succeed())
+			gomega.Expect(wlB.Status.Conditions).NotTo(gomega.ContainElement(gomega.HaveField("Type", kueue.WorkloadPreempted)))
+		})
+	})
+
 	ginkgo.When("using hierarchical cohorts", func() {
 		ginkgo.It("admits workloads respecting fair share", func() {
 			//         root

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -627,14 +627,6 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.MustCreate(ctx, k8sClient, gammaWl)
 
 			var evictedWorkloads []*kueue.Workload
-			gomega.Eventually(func(g gomega.Gomega) {
-				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-				g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-			ginkgo.By("Finishing eviction for first set of preempted workloads")
-			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
 
 			gomega.Eventually(func(g gomega.Gomega) {
 				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -601,6 +601,8 @@ var _ = ginkgo.Describe("Preemption", func() {
 		})
 
 		ginkgo.It("Should preempt all necessary workloads in concurrent scheduling with the same priority", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RecomputeAssignmentUponPreemptionTargetsOverlap, true)
+
 			var betaWls []*kueue.Workload
 			for i := range 3 {
 				wl := utiltestingapi.MakeWorkload(fmt.Sprintf("beta-%d", i), ns.Name).


### PR DESCRIPTION
Cherry pick of #13863 on release-0.19.

#13863: Allow preemption candidate recompute within scheduling cycle 

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Scheduling: Kueue now recomputes an assignment calculated during nomination if its preemption targets overlap
with targets selected for workloads processed earlier in the same scheduling cycle. This fixes a starvation scenario
in which a large “hero” workload, on a busy cluster, could repeatedly conflict with earlier workloads on preemption
targets and remain unscheduled; see #13320 for details.

The behavior is controlled by the Beta `RecomputeAssignmentUponPreemptionTargetsOverlap` feature gate.
```