### PR TITLE
Exclude workload-slice replacements from scheduling equivalence hashing

### DIFF
--- a/apis/kueue/v1beta2/topology_types.go
+++ b/apis/kueue/v1beta2/topology_types.go
@@ -102,6 +102,12 @@ const (
 	// associated with that Workload.
 	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
 	WorkloadSliceNameAnnotation = "kueue.x-k8s.io/workload-slice-name"
+
+	// WorkloadSliceReplacementForAnnotation is set on a new workload slice to indicate the key
+	// of the workload slice it is intended to replace (i.e., the "old" slice being scaled up
+	// from). It is only present on the newer, replacement side of a workload slice pair.
+	// This annotation is alpha-level for the ElasticJobsViaWorkloadSlices feature gate.
+	WorkloadSliceReplacementForAnnotation = "kueue.x-k8s.io/workload-slice-replacement-for"
 )
 
 // TopologySpec defines the desired state of Topology

--- a/keps/9694-scheduling-equivalence-hashing/README.md
+++ b/keps/9694-scheduling-equivalence-hashing/README.md
@@ -160,7 +160,7 @@ diagnostics, or add overhead, but cannot admit a Workload incorrectly.
 
 | Risk | Worst case | Mitigation | Status |
 |---|---|---|---|
-| [ElasticJobsViaWorkloadSlices shape gap](#elasticjobsviaworkloadslices) | A schedulable replacement is repeatedly deferred | Model replacement state or exclude replacements | **Open** |
+| [ElasticJobsViaWorkloadSlices shape gap](#elasticjobsviaworkloadslices) | A schedulable replacement is repeatedly deferred | Exclude replacement Workloads from class-wide handling | Mitigated |
 | [UsageBasedAdmissionFairSharing timestamp gap](#usagebasedadmissionfairsharing) | A Workload that can preempt is repeatedly deferred | Include the timestamp or exclude the combination | **Open** |
 | [Overly broad failure classification](#overly-broad-failure-classification) | Valid class members are deferred | Allowlist class-wide requeue reasons | Mitigated |
 | [Stale failed-class records](#stale-failed-class-records) | A class remains deferred after conditions change | Clear failed records on retry or restart | Mitigated |
@@ -169,7 +169,7 @@ diagnostics, or add overhead, but cannot admit a Workload incorrectly.
 | [Reduced diagnostics for bypassed Workloads](#reduced-diagnostics-for-bypassed-workloads) | A bypassed Workload lacks a detailed diagnosis | Preserve the representative's reason | Mitigated |
 | [Additional memory and queue work](#additional-memory-and-queue-work) | Pending state and heap scans add overhead | Bound records to classes between retries | Accepted |
 
-Only the two scheduling-shape gaps are open. The subsections below provide the
+One scheduling-shape gap remains open. The subsections below provide the
 trigger, user impact, mitigation, and residual risk for each row.
 
 #### Incomplete scheduling shape
@@ -184,8 +184,9 @@ trigger, user impact, mitigation, and residual risk for each row.
 3. **Mitigation:** Every new scheduling input must either be represented in the
    shape or cause the affected outcome to be excluded from class-wide handling.
 4. **Residual risk:** The current shape includes Pod placement and effective
-   requests, but does not model every input used by all scheduling paths. Two
-   known cases remain.
+   requests, but does not model every input used by all scheduling paths. One
+   known case remains open; the ElasticJobsViaWorkloadSlices case below is
+   mitigated by exclusion.
 
 ##### ElasticJobsViaWorkloadSlices
 
@@ -202,11 +203,13 @@ trigger, user impact, mitigation, and residual risk for each row.
    | W1 | 10 CPUs | 8 CPUs | 2 CPUs | yes |
    | W2 | 10 CPUs | 4 CPUs | 6 CPUs | no |
 
-3. **Mitigation:** Before stable, either add the replacement target and relevant
-   state to the scheduling shape or exclude replacement Workloads from
-   class-wide handling.
-4. **Residual risk:** Until then, a NoFit result from W2 can defer W1 without
-   evaluating it even though W1 fits.
+3. **Mitigation:** A Workload carrying the workload-slice replacement-target
+   annotation is assigned the unknown scheduling hash, opting it out of
+   class-wide bulk deferral entirely — it can neither become a representative
+   nor be bypassed based on another Workload's outcome.
+4. **Residual risk:** None. Replacement Workloads are always evaluated
+   individually, at the cost of losing the equivalence-hashing optimization for
+   them.
 
 ##### UsageBasedAdmissionFairSharing
 
@@ -538,9 +541,6 @@ Beta requires:
 
 Graduation to stable requires:
 
-- reevaluation of class-wide outcomes for ElasticJobsViaWorkloadSlices and a
-  decision to either include the replacement target and relevant state in the
-  scheduling shape or exclude affected Workloads from class-wide handling
 - reevaluation of PreemptionNoCandidates class-wide handling when
   UsageBasedAdmissionFairSharing is combined with LowerOrNewerEqualPriority,
   and a decision to either include the queue-order timestamp in the scheduling

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -390,6 +390,16 @@ func computeSchedulingHash(log logr.Logger, wl *kueue.Workload, totalRequests []
 	if !features.Enabled(features.SchedulingEquivalenceHashing) {
 		return SchedulingHashUnknown
 	}
+	// A workload-slice replacement is evaluated against the (unmodeled) state of the slice it
+	// replaces: the additional quota it needs is the delta between its own requests and what the
+	// replaced slice already holds. Two replacements can share an otherwise-identical scheduling
+	// shape while only one actually fits, so they must never be treated as equivalent — return
+	// the unknown hash to opt them out of class-wide bulk deferral entirely.
+	if features.Enabled(features.ElasticJobsViaWorkloadSlices) {
+		if _, found := wl.GetAnnotations()[kueue.WorkloadSliceReplacementForAnnotation]; found {
+			return SchedulingHashUnknown
+		}
+	}
 	effectivePriority := priority.EffectivePriority(log, wl)
 	podSetShapes := make([]map[string]any, 0, len(wl.Spec.PodSets))
 	for i, ps := range wl.Spec.PodSets {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3139,6 +3139,43 @@ func TestSchedulingHash(t *testing.T) {
 		})
 	}
 
+	t.Run("workload slice replacement is excluded from equivalence hashing", func(t *testing.T) {
+		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+			features.SchedulingEquivalenceHashing: true,
+			features.ElasticJobsViaWorkloadSlices: true,
+		})
+		plain := utiltestingapi.MakeWorkload("wl-plain", "ns").
+			Request(corev1.ResourceCPU, "1").Obj()
+		plainInfo := NewInfo(plain)
+		plainInfo.UpdateSchedulingHash(logr.Discard())
+		if plainInfo.SchedulingHash == SchedulingHashUnknown {
+			t.Fatal("precondition failed: non-replacement workload should get a real scheduling hash")
+		}
+
+		// Two replacement workloads with an otherwise-identical shape must not be
+		// treated as scheduling-equivalent to each other or to a non-replacement
+		// workload, since only the replaced slice's own state (not modeled in the
+		// hash) determines whether either one actually fits.
+		replacement1 := utiltestingapi.MakeWorkload("wl-repl-1", "ns").
+			Request(corev1.ResourceCPU, "1").Obj()
+		replacement1.Annotations = map[string]string{kueue.WorkloadSliceReplacementForAnnotation: "ns/old-slice-1"}
+		replacement1Info := NewInfo(replacement1)
+		replacement1Info.UpdateSchedulingHash(logr.Discard())
+
+		replacement2 := utiltestingapi.MakeWorkload("wl-repl-2", "ns").
+			Request(corev1.ResourceCPU, "1").Obj()
+		replacement2.Annotations = map[string]string{kueue.WorkloadSliceReplacementForAnnotation: "ns/old-slice-2"}
+		replacement2Info := NewInfo(replacement2)
+		replacement2Info.UpdateSchedulingHash(logr.Discard())
+
+		if replacement1Info.SchedulingHash != SchedulingHashUnknown {
+			t.Errorf("expected replacement workload to get the unknown hash, got %q", replacement1Info.SchedulingHash)
+		}
+		if replacement2Info.SchedulingHash != SchedulingHashUnknown {
+			t.Errorf("expected replacement workload to get the unknown hash, got %q", replacement2Info.SchedulingHash)
+		}
+	})
+
 	t.Run("DRA translation producing different TotalRequests produces different hash", func(t *testing.T) {
 		features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
 			features.SchedulingEquivalenceHashing: true,

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -75,11 +75,11 @@ func IsElasticWorkload(workload *kueue.Workload) bool {
 	return Enabled(workload)
 }
 
-const (
-	// WorkloadSliceReplacementFor is the annotation key set on a new workload slice to indicate
-	// the key of the workload slice it is intended to replace (i.e., the "old" slice being preempted).
-	WorkloadSliceReplacementFor = "kueue.x-k8s.io/workload-slice-replacement-for"
-)
+// WorkloadSliceReplacementFor is the annotation key set on a new workload slice to indicate
+// the key of the workload slice it is intended to replace (i.e., the "old" slice being preempted).
+// Defined in the kueue API package so packages that cannot import workloadslicing (e.g. workload,
+// to avoid an import cycle) can still check for it.
+const WorkloadSliceReplacementFor = kueue.WorkloadSliceReplacementForAnnotation
 
 // ReplacementForKey returns a value for workload "WorkloadSliceReplacementFor" annotation
 func ReplacementForKey(wl *kueue.Workload) *workload.Reference {

--- a/test/integration/singlecluster/scheduler/inadmissible/equivalence_test.go
+++ b/test/integration/singlecluster/scheduler/inadmissible/equivalence_test.go
@@ -26,6 +26,7 @@ import (
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workloadslicing"
 	"sigs.k8s.io/kueue/test/util"
 )
 
@@ -166,6 +167,34 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			ginkgo.By("verifying equivalent blocked workloads are bulk-moved to inadmissible")
 			util.ExpectPendingWorkloadsMetric(cq, 0, 10)
 			util.ExpectPendingSchedulingHashesMetric(cq, 0, 1)
+		})
+
+		ginkgo.It("Should not group workload-slice replacements into a shared equivalence class", func() {
+			// A workload-slice replacement is evaluated against the (unmodeled) state of
+			// the slice it replaces, so identical shapes can have different real outcomes.
+			// Replacements must therefore never share a bulk-move equivalence class, unlike
+			// the identical-shape case above which reports exactly one known hash.
+			cq = utiltestingapi.MakeClusterQueue("elastic-repl-cq").
+				QueueingStrategy(kueue.BestEffortFIFO).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+
+			queue := utiltestingapi.MakeLocalQueue("elastic-repl-queue", ns.Name).ClusterQueue("elastic-repl-cq").Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+
+			ginkgo.By("creating identical no-fit workloads, each replacing a different workload slice")
+			for i := range 10 {
+				util.MustCreate(ctx, k8sClient, utiltestingapi.MakeWorkload(fmt.Sprintf("repl-nofit-%d", i), ns.Name).
+					Queue(kueue.LocalQueueName(queue.Name)).
+					Annotation(workloadslicing.WorkloadSliceReplacementFor, fmt.Sprintf("%s/replaced-slice-%d", ns.Name, i)).
+					Request(corev1.ResourceCPU, "10").Obj())
+			}
+
+			ginkgo.By("verifying all replacements are inadmissible but none are counted toward a known equivalence class")
+			util.ExpectPendingWorkloadsMetric(cq, 0, 10)
+			util.ExpectPendingSchedulingHashesMetric(cq, 0, 0)
 		})
 	})
 })


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

`SchedulingEquivalenceHashing` groups pending Workloads in a BestEffortFIFO
`ClusterQueue` into equivalence classes by hashing their scheduling-relevant
shape (pod spec, effective requests, priority, etc). When one "representative"
Workload in a class gets a `NoFit` or `PreemptionNoCandidates` result, every
other Workload sharing that hash is bulk-moved to the inadmissible pool
without being individually evaluated.

This did not account for `ElasticJobsViaWorkloadSlices` replacement state. A
scale-up replacement Workload (annotated with
`kueue.x-k8s.io/workload-slice-replacement-for`) needs additional quota equal
to its own total request minus what the slice it replaces already holds. Two
replacement Workloads can have an identical total request (and therefore an
identical scheduling hash) while needing very different additional quota,
because the hash never modeled the replaced slice's state. A `NoFit` result
from one replacement could therefore wrongly bulk-defer a different,
genuinely schedulable replacement Workload without ever evaluating it.

This is a known, documented gap in `keps/9694-scheduling-equivalence-hashing/README.md`,
which lists two acceptable fixes: model the replaced slice's state in the
scheduling shape, or exclude replacement Workloads from class-wide handling.

#### Approach

`computeSchedulingHash` (`pkg/workload/workload.go`) now returns the
`SchedulingHashUnknown` sentinel for any Workload carrying the
`WorkloadSliceReplacementForAnnotation` annotation while
`ElasticJobsViaWorkloadSlices` is enabled. Every place that drives class-wide
bulk deferral (`pkg/cache/queue/cluster_queue.go`: `requeueIfNotPresent`,
`handleInadmissibleHash`, the skip-to-inadmissible check in
`PushOrUpdateActive`) already guards on `SchedulingHash != SchedulingHashUnknown`,
so a replacement Workload can neither become a bulk-move representative nor be
swept up by another Workload's failed-class record. This is the "exclude
affected Workloads from class-wide handling" option from the KEP.

The annotation key itself moved from an unexported literal in
`pkg/workloadslicing` to an exported constant in `apis/kueue/v1beta2`
(`WorkloadSliceReplacementForAnnotation`, alongside the existing sibling
`WorkloadSliceNameAnnotation`), because `pkg/workload` cannot import
`pkg/workloadslicing` (the latter already imports the former). The existing
`workloadslicing.WorkloadSliceReplacementFor` constant is now an alias to the
new value, so none of its ~9 existing call sites needed to change.

The KEP's risk table and the `ElasticJobsViaWorkloadSlices` risk subsection
were updated to reflect the exclusion mitigation, and the now-resolved bullet
was dropped from the "Stable" graduation criteria.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

- Two tests were added and confirmed to fail before this fix and pass after it:
  - `pkg/workload/workload_test.go` (`TestSchedulingHash` / "workload slice
    replacement is excluded from equivalence hashing"): unit-level, confirms
    `computeSchedulingHash` returns the unknown hash for annotated Workloads.
  - `test/integration/singlecluster/scheduler/inadmissible/equivalence_test.go`
    ("Should not group workload-slice replacements into a shared equivalence
    class"): envtest-backed, confirms 10 identical-shape replacement Workloads
    (each pointing at a different replaced-slice key) report zero *known*
    scheduling hashes via the `pending_scheduling_hashes` metric, instead of
    collapsing into one shared bucket the way an otherwise-identical
    non-replacement group does in the sibling test above it.
- Validation run: `go build ./...`, `go vet ./...`, `gofmt -l` on changed
  files, `golangci-lint run` on the touched packages (0 issues), and
  `go test ./pkg/...` — all pass. The integration suite
  (`test/integration/singlecluster/scheduler/inadmissible/...`) was run
  directly via `go test` against manually-provisioned envtest binaries and a
  manually-compiled CRD bundle, because this sandbox lacks the GNU `sed`
  binary the top-level `Makefile` hard-requires for any `make` target
  (including `make envtest` / `make test-integration`); installing `gnu-sed`
  system-wide was avoided to keep changes scoped to the repository. All 6
  specs in that package pass. `make verify` / `make generate` were not run:
  the only Go source change outside `apis/kueue/v1beta2` is a new
  package-level `const` (not a struct field), and `hack/genref/config.yaml`
  only walks struct-typed API packages for reference-doc generation, so no
  generated CRD manifest, deepcopy, or API-reference doc should be affected.
- This PR does not attempt to reproduce the KEP's full worked example (two
  replacements with the same total request where only one truly fits, via
  live preemption-target freeing) end-to-end; that admission-outcome
  machinery already has dedicated coverage elsewhere (e.g.
  `test/integration/singlecluster/scheduler/scheduler_test.go`,
  `pkg/scheduler/scheduler_test.go`). The guard added here is unconditional
  at the code level (any annotated Workload always gets the unknown hash), so
  proving zero known-hash membership is a strictly more general guarantee
  than replaying one specific admission scenario.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where `SchedulingEquivalenceHashing` could group `ElasticJobsViaWorkloadSlices` replacement Workloads with different replaced-slice state into the same scheduling equivalence class, letting a `NoFit` result from one replacement bulk-defer a different, actually-schedulable replacement Workload in a BestEffortFIFO `ClusterQueue`. Workload-slice replacements are now always evaluated individually.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #14230