### PR TITLE
[release-0.19] fix: ungate elastic pods after the chain-root workload slice is deleted (#14139)

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,6 +53,7 @@ import (
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 	"sigs.k8s.io/kueue/pkg/workload"
+	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
 	"sigs.k8s.io/kueue/pkg/workloadslicing"
 )
@@ -81,17 +83,22 @@ func SetupWithManager(mgr ctrl.Manager, cfg *configapi.Configuration, roleTracke
 		roleTracker:       roleTracker,
 	}
 	podHandler := elasticPodHandler{
+		client:            r.client,
 		expectationsStore: r.expectationsStore,
 	}
-	// Reconcile by the stable slice-chain key rather than by an individual
-	// workload, so every slice in a chain (and every pod that names any slice in
-	// it) maps to a single reconcile request. Reconcile then resolves the active
-	// slice from that key.
+	// Reconcile by the chain's active slice, resolved from whichever slice fired
+	// the event. Every slice maps to the single currently-admitted slice, whose
+	// granted counts cap ungating; Reconcile then loads it directly (no lookup
+	// through a possibly-deleted origin).
 	sliceKeyHandler := handler.TypedEnqueueRequestsFromMapFunc(
-		func(_ context.Context, wl *kueue.Workload) []reconcile.Request {
+		func(ctx context.Context, wl *kueue.Workload) []reconcile.Request {
+			active, err := r.activeSlice(ctx, wl)
+			if err != nil || active == nil {
+				return nil
+			}
 			return []reconcile.Request{{NamespacedName: types.NamespacedName{
-				Namespace: wl.Namespace,
-				Name:      workloadslicing.SliceName(wl),
+				Namespace: active.Namespace,
+				Name:      active.Name,
 			}}}
 		},
 	)
@@ -116,31 +123,31 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile ElasticJobUngater")
 
-	if !r.expectationsStore.Satisfied(log, req.NamespacedName) {
-		return reconcile.Result{}, errPendingUngateOps
-	}
-
-	// req.Name is the stable slice-chain key shared by every slice and pod in the
-	// chain (see workloadslicing.SliceName); it is the name of the chain's root
-	// slice. Load it to find the owning job, then resolve the active (latest
-	// admitted, non-finished) slice from the job's slice chain: it is the only
-	// one whose granted PodSet counts define how many pods may be ungated, so the
-	// cap is always taken from the live slice regardless of which slice (or which
-	// pod's stamped WorkloadAnnotation) triggered the event.
-	root := &kueue.Workload{}
-	if err := r.client.Get(ctx, req.NamespacedName, root); err != nil {
+	// req.Name is the chain's active (latest admitted, non-finished) slice: the
+	// enqueue handlers resolve it from whichever slice or pod triggered the event,
+	// so Reconcile always loads a live workload whose granted PodSet counts define
+	// how many pods may be ungated. If it is already gone (just finished/deleted),
+	// there is nothing to ungate.
+	active := &kueue.Workload{}
+	if err := r.client.Get(ctx, req.NamespacedName, active); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	active, err := r.activeSlice(ctx, root)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	if active == nil {
-		// Anomaly: the event was queued for an admitted, non-finished elastic slice
-		// (see shouldUngate), yet the chain has no active slice now — e.g. it just
-		// finished, or the root lost its controller owner between events.
-		log.V(2).Info("no active elastic slice resolved for the chain; skipping ungating", "workload", klog.KObj(root))
+	// The handlers only enqueue active elastic slices, but an enqueue can race a
+	// slice finishing or being evicted; re-check before ungating against its (now
+	// stale) granted counts. Eviction is two writes — the condition is set before
+	// the reservation is released — so an evicted slice still reports a
+	// reservation while its capacity is on the way out; exclude it here, matching
+	// workloadslicing.FindLatestActiveWorkload.
+	if !shouldUngate(active) || workloadevict.IsEvicted(active) {
 		return reconcile.Result{}, nil
+	}
+
+	// Expectations are keyed by the stable chain key (the origin slice name shared
+	// by every slice and pod in the chain), not by the rolling active-slice name,
+	// so in-flight ungate expectations survive a scale rollover.
+	sliceKey := types.NamespacedName{Namespace: active.Namespace, Name: workloadslicing.SliceName(active)}
+	if !r.expectationsStore.Satisfied(log, sliceKey) {
+		return reconcile.Result{}, errPendingUngateOps
 	}
 
 	pods, err := r.podsToUngate(ctx, active)
@@ -156,7 +163,7 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	for i := range pods {
 		uids[i] = pods[i].UID
 	}
-	r.expectationsStore.ExpectUIDs(log, req.NamespacedName, uids)
+	r.expectationsStore.ExpectUIDs(log, sliceKey, uids)
 
 	err = parallelize.Until(ctx, len(pods), func(i int) error {
 		pod := pods[i]
@@ -173,12 +180,12 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 			return changed || ungated, nil
 		})
 		if e != nil {
-			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+			r.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 			log.Error(e, "failed ungating elastic pod", "pod", klog.KObj(pod))
 			return e
 		}
 		if !ungated {
-			r.expectationsStore.ObservedUID(log, req.NamespacedName, pod.UID)
+			r.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 		} else {
 			utilpod.RecordPodSchedulingGateRemovalSeconds(r.clock, kueue.ElasticJobSchedulingGate, active, false)
 		}
@@ -343,23 +350,30 @@ func (r *elasticJobUngater) podsToUngate(ctx context.Context, wl *kueue.Workload
 	return gated, nil
 }
 
-// activeSlice resolves the active (latest quota-reserved, non-finished)
-// workload slice of the chain that anyWl belongs to, or nil if none qualifies
-// for ungating. It looks up the chain through the owning job's workload index,
-// reusing the same slice ordering as the rest of the slicing code
-// (workloadslicing.FindLatestActiveWorkload), but additionally requires full
-// admission: quota reservation alone is insufficient here, since
-// AdmissionChecks may still be pending and releasing the elastic gate
-// before then would let pods schedule ahead of apacity.
+// activeSlice resolves the chain's active slice for the workload anyWl belongs
+// to (see latestActiveSliceForOwner), or nil if none qualifies for ungating.
 func (r *elasticJobUngater) activeSlice(ctx context.Context, anyWl *kueue.Workload) (*kueue.Workload, error) {
 	owner := metav1.GetControllerOf(anyWl)
 	if owner == nil {
 		return nil, nil
 	}
+	return latestActiveSliceForOwner(ctx, r.client, anyWl.Namespace, owner)
+}
+
+func (h *elasticPodHandler) activeSliceForOwner(ctx context.Context, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
+	return latestActiveSliceForOwner(ctx, h.client, namespace, owner)
+}
+
+// latestActiveSliceForOwner resolves the latest active workload slice owned by the
+// given job (owner) in namespace, or nil if none qualifies for ungating. Quota
+// reservation alone is insufficient: AdmissionChecks may still be pending, and
+// releasing the elastic gate before then would let pods schedule ahead of
+// capacity, so full admission is required.
+func latestActiveSliceForOwner(ctx context.Context, c client.Client, namespace string, owner *metav1.OwnerReference) (*kueue.Workload, error) {
 	jobObject := &metav1.PartialObjectMetadata{
-		ObjectMeta: metav1.ObjectMeta{Namespace: anyWl.Namespace, Name: owner.Name},
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: owner.Name},
 	}
-	active, err := workloadslicing.FindLatestActiveWorkload(ctx, r.client, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
+	active, err := workloadslicing.FindLatestActiveWorkload(ctx, c, jobObject, schema.FromAPIVersionAndKind(owner.APIVersion, owner.Kind))
 	if err != nil || active == nil || !workload.IsAdmitted(active) {
 		return nil, err
 	}
@@ -395,6 +409,7 @@ func (r *elasticJobUngater) Generic(event.TypedGenericEvent[*kueue.Workload]) bo
 var _ handler.EventHandler = (*elasticPodHandler)(nil)
 
 type elasticPodHandler struct {
+	client            client.Client
 	expectationsStore *expectations.Store
 }
 
@@ -418,24 +433,52 @@ func (h *elasticPodHandler) queueReconcileForPod(ctx context.Context, object cli
 	if !isPod {
 		return
 	}
-	// Enqueue by the stable slice-chain key, not the pod's stamped
-	// WorkloadAnnotation. A pod minted after a scale-up still carries the previous
-	// (now Finished) slice's name, but the chain key is shared by every slice, so
-	// Reconcile can always resolve the active slice from it.
+	// Expectations are keyed by the stable chain key (the origin slice name the
+	// pod carries), so observations survive scale rollovers.
 	sliceName := podSliceName(pod)
 	if sliceName == "" {
 		return
 	}
-	key := types.NamespacedName{
-		Name:      sliceName,
-		Namespace: pod.Namespace,
-	}
+	sliceKey := types.NamespacedName{Name: sliceName, Namespace: pod.Namespace}
 	// Mark expectation as observed when the gate has been removed or the pod is deleted.
 	if !utilpod.HasGate(pod, kueue.ElasticJobSchedulingGate) || deleted {
-		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", key.String())
-		h.expectationsStore.ObservedUID(log, key, pod.UID)
+		log := ctrl.LoggerFrom(ctx).WithValues("pod", klog.KObj(pod), "workloadSlice", sliceKey.String())
+		h.expectationsStore.ObservedUID(log, sliceKey, pod.UID)
 	}
-	q.AddAfter(reconcile.Request{NamespacedName: key}, constants.UpdatesBatchPeriod)
+	// Enqueue the chain's active slice so Reconcile loads a live workload directly
+	// (a deleted origin slice no longer strands the pod). Resolve the owning job
+	// from the named slice if it still exists, otherwise from the pod's own
+	// controller owner-ref — the latter is what keeps ungating working after the
+	// origin slice the pod points at has been garbage-collected.
+	owner := h.ownerForPod(ctx, pod, sliceKey)
+	if owner == nil {
+		return
+	}
+	active, err := h.activeSliceForOwner(ctx, pod.Namespace, owner)
+	if err != nil || active == nil {
+		return
+	}
+	q.AddAfter(reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: active.Namespace,
+		Name:      active.Name,
+	}}, constants.UpdatesBatchPeriod)
+}
+
+// ownerForPod finds the job owning the pod's slice chain: prefer the controller
+// owner of the named slice when it still exists (pods are not always owned by the
+// job directly), and fall back to the pod's own controller owner-ref when that
+// slice has been deleted.
+func (h *elasticPodHandler) ownerForPod(ctx context.Context, pod *corev1.Pod, sliceKey types.NamespacedName) *metav1.OwnerReference {
+	slice := &kueue.Workload{}
+	switch err := h.client.Get(ctx, sliceKey, slice); {
+	case err == nil:
+		if owner := metav1.GetControllerOf(slice); owner != nil {
+			return owner
+		}
+	case !apierrors.IsNotFound(err):
+		return nil
+	}
+	return metav1.GetControllerOf(pod)
 }
 
 // podSliceName returns the slice-chain key for a pod: the WorkloadSliceName

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -1002,17 +1002,24 @@ func TestReconcile(t *testing.T) {
 				return
 			}
 
-			// The ungater reconciles by the stable slice-chain key, not by an
-			// individual workload name, so derive the request key from the chain.
-			key := types.NamespacedName{
-				Namespace: tc.workloads[0].Namespace,
-				Name:      workloadslicing.SliceName(&tc.workloads[0]),
+			// The ungater now reconciles by the chain's ACTIVE slice: the enqueue
+			// handlers resolve it via activeSlice, so mirror that here to pick the
+			// request key. Expectations stay keyed by the stable chain key (the
+			// active slice's origin name).
+			active, err := ungater.activeSlice(ctx, &tc.workloads[0])
+			if err != nil {
+				t.Fatalf("resolving active slice: %v", err)
 			}
+			if active == nil {
+				active = &tc.workloads[0]
+			}
+			key := types.NamespacedName{Namespace: active.Namespace, Name: active.Name}
+			sliceKey := types.NamespacedName{Namespace: active.Namespace, Name: workloadslicing.SliceName(active)}
 			if len(tc.expectUIDs) > 0 {
-				ungater.expectationsStore.ExpectUIDs(log, key, tc.expectUIDs)
+				ungater.expectationsStore.ExpectUIDs(log, sliceKey, tc.expectUIDs)
 			}
 
-			_, err := ungater.Reconcile(ctx, reconcile.Request{NamespacedName: key})
+			_, err = ungater.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 			if diff := gocmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
 				t.Errorf("Reconcile returned error (-want,+got):\n%s", diff)
 			}

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -4636,6 +4636,130 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Regression for the stranded-pod bug (kueue#14129): after a scale-up the
+		// origin (root) slice can be garbage-collected while a still-gated pod
+		// keeps pointing at the gone origin name (e.g. a RayService rollout
+		// deletes the old RayCluster and its Workloads). The ungater must recover
+		// the owning job from the pod and ungate against the surviving active
+		// slice, rather than bailing on the missing origin. Demonstrated here on a
+		// plain Job to show it is not Ray-specific.
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+		testJob := testingjob.MakeJob("deleted-origin", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(2).
+			Obj()
+
+		ginkgo.By("creating and admitting the job's origin workload slice")
+		util.MustCreate(ctx, k8sClient, testJob)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up parallelism to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testJob), testJob)).Should(gomega.Succeed())
+			testJob.Spec.Parallelism = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, testJob)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a rollout GC of the old workloads")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the Job")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(pkgconstants.PodSetLabel, string(activeSlice.Spec.PodSets[0].Name)).
+			OwnerReference(testJob.Name, jobGVK).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences[0].UID = testJob.UID
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should keep chain pods gated when the origin slice is deleted and no active slice survives", framework.SlowSpec, func() {
+		// Negative companion to the deleted-origin recovery test: when the origin
+		// slice is gone AND no admitted, non-finished slice remains, there is no
+		// granted count to ungate against, so the pod must stay gated rather than
+		// be let through against stale capacity.
+		jobGVK := batchv1.SchemeGroupVersion.WithKind("Job")
+		testJob := testingjob.MakeJob("deleted-origin-no-active", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "100m").
+			Parallelism(1).
+			Completions(1).
+			Obj()
+
+		ginkgo.By("creating and admitting the job's only workload slice")
+		util.MustCreate(ctx, k8sClient, testJob)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("deleting the only slice so the chain has no eligible active slice")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a gated pod that points at the deleted origin, owned by the Job")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(pkgconstants.PodSetLabel, string(kueue.DefaultPodSetName)).
+			OwnerReference(testJob.Name, jobGVK).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences[0].UID = testJob.UID
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the pod keeps its elastic scheduling gate, since no active slice grants capacity")
+		gomega.Consistently(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).Should(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
+		}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+	})
+
 	ginkgo.It("Should not wedge the reconciler when scaling down below the accumulated succeeded count", framework.SlowSpec, func() {
 		// Regression for kueue#12670: with job-completions-equal-parallelism,
 		// the workload's reclaimablePods count mirrors the Job's

--- a/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/raycluster/raycluster_controller_test.go
@@ -37,12 +37,14 @@ import (
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
-	"sigs.k8s.io/kueue/pkg/controller/constants"
+	"sigs.k8s.io/kueue/pkg/constants"
+	controllerconstants "sigs.k8s.io/kueue/pkg/controller/constants"
 	"sigs.k8s.io/kueue/pkg/controller/jobframework"
 	workloadraycluster "sigs.k8s.io/kueue/pkg/controller/jobs/raycluster"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingpod "sigs.k8s.io/kueue/pkg/util/testingjobs/pod"
 	testingraycluster "sigs.k8s.io/kueue/pkg/util/testingjobs/raycluster"
 	testingrayjob "sigs.k8s.io/kueue/pkg/util/testingjobs/rayjob"
 	"sigs.k8s.io/kueue/pkg/workload"
@@ -116,7 +118,7 @@ var _ = ginkgo.Describe("RayCluster controller", ginkgo.Label("job:ray", "area:j
 
 		ginkgo.By("checking the workload is updated with queue name when the job does")
 		var jobQueueName kueue.LocalQueueName = "test-queue"
-		createdJob.Labels = map[string]string{constants.QueueLabel: string(jobQueueName)}
+		createdJob.Labels = map[string]string{controllerconstants.QueueLabel: string(jobQueueName)}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, wlLookupKey, createdWorkload)).Should(gomega.Succeed())
@@ -269,9 +271,9 @@ var _ = ginkgo.Describe("Job controller RayCluster for workloads when only jobs 
 		ginkgo.By("checking the workload is created when queue name is set")
 		jobQueueName := "test-queue"
 		if createdJob.Labels == nil {
-			createdJob.Labels = map[string]string{constants.QueueLabel: jobQueueName}
+			createdJob.Labels = map[string]string{controllerconstants.QueueLabel: jobQueueName}
 		} else {
-			createdJob.Labels[constants.QueueLabel] = jobQueueName
+			createdJob.Labels[controllerconstants.QueueLabel] = jobQueueName
 		}
 		gomega.Expect(k8sClient.Update(ctx, createdJob)).Should(gomega.Succeed())
 		gomega.Eventually(func(g gomega.Gomega) {
@@ -341,7 +343,7 @@ var _ = ginkgo.Describe("Job controller when waitForPodsReady enabled", ginkgo.O
 			ginkgo.By("Create a job")
 			job := testingraycluster.MakeCluster(jobName, ns.Name).Obj()
 			jobQueueName := "test-queue"
-			job.Labels = map[string]string{constants.QueueLabel: jobQueueName}
+			job.Labels = map[string]string{controllerconstants.QueueLabel: jobQueueName}
 			util.MustCreate(ctx, k8sClient, job)
 			lookupKey := types.NamespacedName{Name: jobName, Namespace: ns.Name}
 			createdJob := &rayv1.RayCluster{}
@@ -922,7 +924,8 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		ginkgo.By("raycluster-b's workload remains pending with unreserved quota")
 		gomega.Eventually(func(g gomega.Gomega) {
 			workloads := &kueue.WorkloadList{}
-			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testRayClusterA.Namespace), client.MatchingLabels{constants.JobUIDLabel: string(testRayClusterB.UID)})).Should(gomega.Succeed())
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(testRayClusterA.Namespace), client.MatchingLabels{controllerconstants.JobUIDLabel: string(testRayClusterB.UID)})).
+				Should(gomega.Succeed())
 			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
 			testRayClusterBWorkload = &workloads.Items[0]
 			util.ExpectWorkloadsToBePending(ctx, k8sClient, testRayClusterBWorkload)
@@ -942,6 +945,86 @@ var _ = ginkgo.Describe("RayCluster with elastic jobs via workload-slices suppor
 		gomega.Eventually(func(g gomega.Gomega) {
 			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayClusterB), testRayClusterB)).Should(gomega.Succeed())
 			g.Expect(ptr.Deref(testRayClusterB.Spec.Suspend, false)).Should(gomega.BeFalse())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("Should ungate chain pods after the origin workload slice is deleted", framework.SlowSpec, func() {
+		// Reproduces the stranded-pod bug: after a scale-up the origin (root) slice
+		// can be garbage-collected (e.g. a RayService rollout deletes the old
+		// RayCluster and its Workloads), while a still-gated pod keeps pointing at
+		// the gone origin name. The ungater must recover the owning job from the
+		// pod and ungate against the surviving active slice, rather than bailing on
+		// the missing origin.
+		testRayCluster := testingraycluster.MakeCluster("foo", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Queue(localQueue.Name).
+			Request(rayv1.HeadNode, corev1.ResourceCPU, "1").
+			RequestWorkerGroup(corev1.ResourceCPU, "1").
+			WithEnableAutoscaling(new(true)).
+			ScaleFirstWorkerGroup(1).
+			Obj()
+
+		ginkgo.By("creating and admitting the raycluster's origin workload slice")
+		util.MustCreate(ctx, k8sClient, testRayCluster)
+		var originSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(1))
+			originSlice = &workloads.Items[0]
+			g.Expect(workload.IsAdmitted(originSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		originSliceName := originSlice.Name
+
+		ginkgo.By("scaling up the worker replicas to create a second (active) slice")
+		gomega.Eventually(func(g gomega.Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(testRayCluster), testRayCluster)).Should(gomega.Succeed())
+			testRayCluster.Spec.WorkerGroupSpecs[0].Replicas = new(int32(2))
+			g.Expect(k8sClient.Update(ctx, testRayCluster)).Should(gomega.Succeed())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		var activeSlice *kueue.Workload
+		gomega.Eventually(func(g gomega.Gomega) {
+			workloads := &kueue.WorkloadList{}
+			g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).Should(gomega.Succeed())
+			g.Expect(workloads.Items).Should(gomega.HaveLen(2))
+			activeSlice = nil
+			for i := range workloads.Items {
+				if !workloadfinish.IsFinished(&workloads.Items[i]) {
+					activeSlice = &workloads.Items[i]
+				}
+			}
+			g.Expect(activeSlice).ShouldNot(gomega.BeNil())
+			g.Expect(activeSlice.Name).ShouldNot(gomega.Equal(originSliceName))
+			g.Expect(workload.IsAdmitted(activeSlice)).Should(gomega.BeTrue())
+		}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+		ginkgo.By("deleting the origin slice to emulate a RayService rollout GC of the old RayCluster's workloads")
+		util.DeleteWorkloadSliceAndAwaitDeletion(ctx, k8sClient, types.NamespacedName{Namespace: ns.Name, Name: originSliceName})
+
+		ginkgo.By("creating a still-gated pod that points at the now-deleted origin slice, owned by the RayCluster")
+		gatedPod := testingpod.MakePod("worker-0", ns.Name).
+			Annotation(kueue.WorkloadAnnotation, originSliceName).
+			Annotation(kueue.WorkloadSliceNameAnnotation, originSliceName).
+			Label(constants.PodSetLabel, string(activeSlice.Spec.PodSets[1].Name)).
+			Gate(kueue.ElasticJobSchedulingGate).
+			Obj()
+		gatedPod.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion:         rayv1.SchemeGroupVersion.String(),
+			Kind:               "RayCluster",
+			Name:               testRayCluster.Name,
+			UID:                testRayCluster.UID,
+			Controller:         new(true),
+			BlockOwnerDeletion: new(true),
+		}}
+		util.MustCreate(ctx, k8sClient, gatedPod)
+
+		ginkgo.By("the ungater removes the elastic scheduling gate despite the origin slice being gone")
+		gomega.Eventually(func(g gomega.Gomega) {
+			var got corev1.Pod
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got)).To(gomega.Succeed())
+			g.Expect(got.Spec.SchedulingGates).ShouldNot(gomega.ContainElement(
+				corev1.PodSchedulingGate{Name: kueue.ElasticJobSchedulingGate}))
 		}, util.Timeout, util.Interval).Should(gomega.Succeed())
 	})
 })

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1455,6 +1455,29 @@ func FindNonFinishedWorkloads(workloads []kueue.Workload) []kueue.Workload {
 	return active
 }
 
+// DeleteWorkloadSliceAndAwaitDeletion deletes the named workload slice and waits
+// until it is gone, stripping the resource-in-use finalizer if it blocks removal.
+// Used by elastic-job tests to emulate a rollout garbage-collecting an origin
+// (root) slice while later slices and their pods still point at its name.
+func DeleteWorkloadSliceAndAwaitDeletion(ctx context.Context, k8sClient client.Client, key types.NamespacedName) {
+	ginkgo.GinkgoHelper()
+	slice := &kueue.Workload{}
+	gomega.Expect(k8sClient.Get(ctx, key, slice)).To(gomega.Succeed())
+	gomega.Expect(k8sClient.Delete(ctx, slice)).To(gomega.Succeed())
+	gomega.Eventually(func(g gomega.Gomega) {
+		wl := &kueue.Workload{}
+		err := k8sClient.Get(ctx, key, wl)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		g.Expect(err).To(gomega.Succeed())
+		if controllerutil.RemoveFinalizer(wl, kueue.ResourceInUseFinalizerName) {
+			g.Expect(client.IgnoreNotFound(k8sClient.Update(ctx, wl))).To(gomega.Succeed())
+		}
+		g.Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, wl))).To(gomega.BeTrue())
+	}, Timeout, Interval).Should(gomega.Succeed())
+}
+
 // ExpectWorkloadSliceAdmittedBeforeOldFinished watches workload events and asserts
 // that the old workload slice is not marked Finished before the new slice is Admitted.
 // The watcher must be started before the scale-up that triggers the replacement.


### PR DESCRIPTION
Cherry-pick of #14139 onto release-0.19.

Applied cleanly from the merged commit; no changes needed.

```release-note
ElasticJobsViaWorkloadSlices: Fixed elastic jobs (e.g. autoscaling RayClusters via `ElasticJobsViaWorkloadSlices`) leaving scaled-up pods stuck `SchedulingGated` after the origin workload slice was deleted.
```