### PR TITLE
Automated cherry pick of #12587: Treat remote and local preemption gates independently

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -654,6 +654,9 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 }
 
 func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {
+	// Preemption gates should be treated independently on the remotes and manager,
+	// so any differences should not be considered as out-of-sync.
+	local.PreemptionGates = nil
 	remote.PreemptionGates = nil
 	return !equality.Semantic.DeepEqual(local, remote)
 }
@@ -1333,6 +1336,9 @@ func cloneForCreate(orig *kueue.Workload, origin string, preemptionGated bool) *
 	orig.Spec.DeepCopyInto(&remoteWl.Spec)
 
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) && preemptionGated {
+		// Preemption gates should be treated independently on the remotes and manager,
+		// so we avoid copying them over to the remote.
+		remoteWl.Spec.PreemptionGates = nil
 		mkPreemptionGate := kueue.PreemptionGate{Name: constants.MultiKueuePreemptionGate}
 		remoteWl.Spec.PreemptionGates = append(remoteWl.Spec.PreemptionGates, mkPreemptionGate)
 	}

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -420,8 +420,9 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				managerWl := &kueue.Workload{}
 				g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 				selectedWorker = util.GetClientForSelectedWorkerCluster(
+					g,
 					managerWl,
-					util.ClusterInfosForE2E(
+					util.DefaultClusterInfosForTests(
 						k8sWorker1Client,
 						ctx,
 						k8sWorker2Client,

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -421,16 +421,12 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 				selectedWorker = util.GetClientForSelectedWorkerCluster(
 					managerWl,
-					util.ClusterInfo{
-						Name:   "worker1",
-						Client: k8sWorker1Client,
-						Ctx:    ctx,
-					},
-					util.ClusterInfo{
-						Name:   "worker2",
-						Client: k8sWorker2Client,
-						Ctx:    ctx,
-					},
+					util.ClusterInfosForE2E(
+						k8sWorker1Client,
+						ctx,
+						k8sWorker2Client,
+						ctx,
+					)...,
 				)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -423,10 +423,10 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 					g,
 					managerWl,
 					util.DefaultClusterInfosForTests(
+						ctx,
 						k8sWorker1Client,
 						ctx,
 						k8sWorker2Client,
-						ctx,
 					)...,
 				)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())

--- a/test/e2e/multikueue/dra/dra_test.go
+++ b/test/e2e/multikueue/dra/dra_test.go
@@ -414,27 +414,30 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 				Namespace: managerNs.Name,
 			}
 
-			var assignedWorkerCluster client.Client
-			var assignedClusterName string
-
+			var selectedWorker util.ClusterInfo
 			ginkgo.By("Waiting for workload to be admitted")
 			gomega.Eventually(func(g gomega.Gomega) {
 				managerWl := &kueue.Workload{}
 				g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
-				g.Expect(managerWl.Status.ClusterName).NotTo(gomega.BeNil())
-
-				assignedClusterName = *managerWl.Status.ClusterName
-				if assignedClusterName == workerCluster1.Name {
-					assignedWorkerCluster = k8sWorker1Client
-				} else {
-					assignedWorkerCluster = k8sWorker2Client
-				}
+				selectedWorker = util.GetClientForSelectedWorkerCluster(
+					managerWl,
+					util.ClusterInfo{
+						Name:   "worker1",
+						Client: k8sWorker1Client,
+						Ctx:    ctx,
+					},
+					util.ClusterInfo{
+						Name:   "worker2",
+						Client: k8sWorker2Client,
+						Ctx:    ctx,
+					},
+				)
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By(fmt.Sprintf("Verifying workload on %s has 2 GPU resource usage (1 per pod)", assignedClusterName))
+			ginkgo.By(fmt.Sprintf("Verifying workload on %s has 2 GPU resource usage (1 per pod)", selectedWorker.Name))
 			workerWl := &kueue.Workload{}
 			gomega.Eventually(func(g gomega.Gomega) {
-				g.Expect(assignedWorkerCluster.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
+				g.Expect(selectedWorker.Client.Get(selectedWorker.Ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
 				g.Expect(workload.HasQuotaReservation(workerWl)).To(gomega.BeTrue())
 				g.Expect(workerWl.Status.Admission).NotTo(gomega.BeNil())
 
@@ -445,7 +448,7 @@ var _ = ginkgo.Describe("MultiKueue with DRA", ginkgo.Label("feature:dra", "area
 
 			ginkgo.By("Finishing the job's pods")
 			listOpts := util.GetListOptsFromLabel(fmt.Sprintf("batch.kubernetes.io/job-name=%s", job.Name))
-			if assignedClusterName == workerCluster1.Name {
+			if selectedWorker.Name == workerCluster1.Name {
 				util.WaitForActivePodsAndTerminate(ctx, k8sWorker1Client, worker1RestClient, worker1Cfg, job.Namespace, 2, 0, listOpts)
 			} else {
 				util.WaitForActivePodsAndTerminate(ctx, k8sWorker2Client, worker2RestClient, worker2Cfg, job.Namespace, 2, 0, listOpts)

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -767,6 +767,67 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 			})
 		})
 
+		ginkgo.It("Should treat manager-level and worker-level preemption gates independently", func() {
+			job := testingjob.MakeJob("job-with-gates", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "0.1").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				TerminationGracePeriod(1).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+
+			ginkgo.By("Creating the job", func() {
+				util.MustCreate(ctx, k8sManagerClient, job)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+			managerWl := &kueue.Workload{}
+			ginkgo.By("Waiting for the workload to be created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			dummyGateName := "dummy-gate"
+			ginkgo.By("Adding a dummy preemption gate to the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					managerWl.Spec.PreemptionGates = []kueue.PreemptionGate{{Name: dummyGateName}}
+					g.Expect(k8sManagerClient.Update(ctx, managerWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			workerWl := &kueue.Workload{}
+			var workerClient client.Client
+			var initialUID types.UID
+			ginkgo.By("Waiting for the workload to be created on one of the workers", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					if err := k8sWorker1Client.Get(ctx, wlLookupKey, workerWl); err == nil {
+						initialUID = workerWl.UID
+						workerClient = k8sWorker1Client
+					} else {
+						gomega.Expect(k8sWorker2Client.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
+						initialUID = workerWl.UID
+						workerClient = k8sWorker2Client
+					}
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is not continuously recreated on workers", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(workerClient.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
+					g.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
+					g.Expect(workerWl.UID).To(gomega.Equal(initialUID))
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the remote workload does not contain the manager workload's dummy gate", func() {
+				gomega.Expect(workerClient.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
+				gomega.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
+			})
+		})
+
 		ginkgo.It("should not trigger concurrent preemptions", func() {
 			// Fits only in worker1
 			lowJob1 := testingjob.MakeJob("low-job1", managerNs.Name).

--- a/test/e2e/multikueue/sequential/e2e_test.go
+++ b/test/e2e/multikueue/sequential/e2e_test.go
@@ -767,67 +767,6 @@ var _ = ginkgo.Describe("MultiKueue Sequential", func() {
 			})
 		})
 
-		ginkgo.It("Should treat manager-level and worker-level preemption gates independently", func() {
-			job := testingjob.MakeJob("job-with-gates", managerNs.Name).
-				Queue(kueue.LocalQueueName(managerLq.Name)).
-				RequestAndLimit(corev1.ResourceCPU, "0.1").
-				RequestAndLimit(corev1.ResourceMemory, "0.1G").
-				TerminationGracePeriod(1).
-				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
-				Obj()
-
-			ginkgo.By("Creating the job", func() {
-				util.MustCreate(ctx, k8sManagerClient, job)
-			})
-
-			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
-
-			managerWl := &kueue.Workload{}
-			ginkgo.By("Waiting for the workload to be created", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			dummyGateName := "dummy-gate"
-			ginkgo.By("Adding a dummy preemption gate to the workload", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(k8sManagerClient.Get(ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
-					managerWl.Spec.PreemptionGates = []kueue.PreemptionGate{{Name: dummyGateName}}
-					g.Expect(k8sManagerClient.Update(ctx, managerWl)).To(gomega.Succeed())
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			workerWl := &kueue.Workload{}
-			var workerClient client.Client
-			var initialUID types.UID
-			ginkgo.By("Waiting for the workload to be created on one of the workers", func() {
-				gomega.Eventually(func(g gomega.Gomega) {
-					if err := k8sWorker1Client.Get(ctx, wlLookupKey, workerWl); err == nil {
-						initialUID = workerWl.UID
-						workerClient = k8sWorker1Client
-					} else {
-						gomega.Expect(k8sWorker2Client.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
-						initialUID = workerWl.UID
-						workerClient = k8sWorker2Client
-					}
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the workload is not continuously recreated on workers", func() {
-				gomega.Consistently(func(g gomega.Gomega) {
-					g.Expect(workerClient.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
-					g.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
-					g.Expect(workerWl.UID).To(gomega.Equal(initialUID))
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-			})
-
-			ginkgo.By("Checking that the remote workload does not contain the manager workload's dummy gate", func() {
-				gomega.Expect(workerClient.Get(ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
-				gomega.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
-			})
-		})
-
 		ginkgo.It("should not trigger concurrent preemptions", func() {
 			// Fits only in worker1
 			lowJob1 := testingjob.MakeJob("low-job1", managerNs.Name).

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -571,34 +571,30 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 			})
 
 			workerWl := &kueue.Workload{}
-			var workerClient client.Client
-			var workerCtx context.Context
-			var initialUID types.UID
-			ginkgo.By("Waiting for the workload to be created on one of the workers", func() {
+			ginkgo.By("Checking that the workload gets admitted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, workerWl); err == nil {
-						initialUID = workerWl.UID
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					clusterName := managerWl.Status.ClusterName
+					g.Expect(clusterName).ToNot(gomega.BeNil())
+					var workerClient client.Client
+					var workerCtx context.Context
+					if *clusterName == "worker1" {
 						workerClient = worker1TestCluster.client
 						workerCtx = worker1TestCluster.ctx
 					} else {
-						gomega.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
-						initialUID = workerWl.UID
 						workerClient = worker2TestCluster.client
 						workerCtx = worker2TestCluster.ctx
 					}
+
+					// When the gates are not treated independently, a mismatch between the gates will cause
+					// the workload to never get admitted and be continuously recreated.
+					// See: https://github.com/kubernetes-sigs/kueue/issues/12543
+					g.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(workerWl)).To(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("Checking that the workload is not continuously recreated on workers", func() {
-				gomega.Consistently(func(g gomega.Gomega) {
-					g.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
-					g.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
-					g.Expect(workerWl.UID).To(gomega.Equal(initialUID))
-				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
-			})
-
 			ginkgo.By("Checking that the remote workload does not contain the manager workload's dummy gate", func() {
-				gomega.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
 				gomega.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
 			})
 		})

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -575,8 +575,9 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 					selectedWorker := util.GetClientForSelectedWorkerCluster(
+						g,
 						managerWl,
-						util.ClusterInfosForE2E(
+						util.DefaultClusterInfosForTests(
 							worker1TestCluster.client,
 							worker1TestCluster.ctx,
 							worker2TestCluster.client,

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -576,16 +576,12 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 					selectedWorker := util.GetClientForSelectedWorkerCluster(
 						managerWl,
-						util.ClusterInfo{
-							Name:   "worker1",
-							Client: worker1TestCluster.client,
-							Ctx:    worker1TestCluster.ctx,
-						},
-						util.ClusterInfo{
-							Name:   "worker2",
-							Client: worker2TestCluster.client,
-							Ctx:    worker2TestCluster.ctx,
-						},
+						util.ClusterInfosForE2E(
+							worker1TestCluster.client,
+							worker1TestCluster.ctx,
+							worker2TestCluster.client,
+							worker2TestCluster.ctx,
+						)...,
 					)
 
 					// When the gates are not treated independently, a mismatch between the gates will cause

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -574,22 +574,24 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 			ginkgo.By("Checking that the workload gets admitted", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
-					clusterName := managerWl.Status.ClusterName
-					g.Expect(clusterName).ToNot(gomega.BeNil())
-					var workerClient client.Client
-					var workerCtx context.Context
-					if *clusterName == "worker1" {
-						workerClient = worker1TestCluster.client
-						workerCtx = worker1TestCluster.ctx
-					} else {
-						workerClient = worker2TestCluster.client
-						workerCtx = worker2TestCluster.ctx
-					}
+					selectedWorker := util.GetClientForSelectedWorkerCluster(
+						managerWl,
+						util.ClusterInfo{
+							Name:   "worker1",
+							Client: worker1TestCluster.client,
+							Ctx:    worker1TestCluster.ctx,
+						},
+						util.ClusterInfo{
+							Name:   "worker2",
+							Client: worker2TestCluster.client,
+							Ctx:    worker2TestCluster.ctx,
+						},
+					)
 
 					// When the gates are not treated independently, a mismatch between the gates will cause
 					// the workload to never get admitted and be continuously recreated.
 					// See: https://github.com/kubernetes-sigs/kueue/issues/12543
-					g.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
+					g.Expect(selectedWorker.Client.Get(selectedWorker.Ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(workerWl)).To(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -578,10 +578,10 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 						g,
 						managerWl,
 						util.DefaultClusterInfosForTests(
-							worker1TestCluster.client,
 							worker1TestCluster.ctx,
-							worker2TestCluster.client,
+							worker1TestCluster.client,
 							worker2TestCluster.ctx,
+							worker2TestCluster.client,
 						)...,
 					)
 

--- a/test/integration/multikueue/scheduler/scheduler_test.go
+++ b/test/integration/multikueue/scheduler/scheduler_test.go
@@ -539,6 +539,70 @@ var _ = ginkgo.Describe("MultiKueue with scheduler", ginkgo.Label("area:multikue
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.MultiKueueOrchestratedPreemption, true)
 		})
 
+		ginkgo.It("Should treat manager-level and worker-level preemption gates independently", func() {
+			job := testingjob.MakeJob("job-with-gates", managerNs.Name).
+				Queue(kueue.LocalQueueName(managerLq.Name)).
+				RequestAndLimit(corev1.ResourceCPU, "0.1").
+				RequestAndLimit(corev1.ResourceMemory, "0.1G").
+				TerminationGracePeriod(1).
+				Image(util.GetAgnHostImage(), util.BehaviorWaitForDeletion).
+				Obj()
+
+			ginkgo.By("Creating the job", func() {
+				util.MustCreate(managerTestCluster.ctx, managerTestCluster.client, job)
+			})
+
+			wlLookupKey := types.NamespacedName{Name: workloadjob.GetWorkloadNameForJob(job.Name, job.UID), Namespace: managerNs.Name}
+
+			managerWl := &kueue.Workload{}
+			ginkgo.By("Waiting for the workload to be created", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			dummyGateName := "dummy-gate"
+			ginkgo.By("Adding a dummy preemption gate to the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
+					managerWl.Spec.PreemptionGates = []kueue.PreemptionGate{{Name: dummyGateName}}
+					g.Expect(managerTestCluster.client.Update(managerTestCluster.ctx, managerWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			workerWl := &kueue.Workload{}
+			var workerClient client.Client
+			var workerCtx context.Context
+			var initialUID types.UID
+			ginkgo.By("Waiting for the workload to be created on one of the workers", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					if err := worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, workerWl); err == nil {
+						initialUID = workerWl.UID
+						workerClient = worker1TestCluster.client
+						workerCtx = worker1TestCluster.ctx
+					} else {
+						gomega.Expect(worker2TestCluster.client.Get(worker2TestCluster.ctx, wlLookupKey, workerWl)).To(gomega.Succeed())
+						initialUID = workerWl.UID
+						workerClient = worker2TestCluster.client
+						workerCtx = worker2TestCluster.ctx
+					}
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the workload is not continuously recreated on workers", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
+					g.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
+					g.Expect(workerWl.UID).To(gomega.Equal(initialUID))
+				}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that the remote workload does not contain the manager workload's dummy gate", func() {
+				gomega.Expect(workerClient.Get(workerCtx, wlLookupKey, workerWl)).To(gomega.Succeed())
+				gomega.Expect(workerWl.Spec.PreemptionGates).To(gomega.Not(gomega.ContainElement(kueue.PreemptionGate{Name: dummyGateName})))
+			})
+		})
+
 		ginkgo.It("should not trigger concurrent preemptions", func() {
 			// Fits only in worker1
 			lowJob1 := testingjob.MakeJob("low-job1", managerNs.Name).

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -285,10 +285,10 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 						g,
 						managerWl,
 						util.DefaultClusterInfosForTests(
-							worker1TestCluster.client,
 							worker1TestCluster.ctx,
-							worker2TestCluster.client,
+							worker1TestCluster.client,
 							worker2TestCluster.ctx,
+							worker2TestCluster.client,
 						)...,
 					)
 

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -283,16 +283,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 					selectedWorker = util.GetClientForSelectedWorkerCluster(
 						managerWl,
-						util.ClusterInfo{
-							Name:   "worker1",
-							Client: worker1TestCluster.client,
-							Ctx:    worker1TestCluster.ctx,
-						},
-						util.ClusterInfo{
-							Name:   "worker2",
-							Client: worker2TestCluster.client,
-							Ctx:    worker2TestCluster.ctx,
-						},
+						util.ClusterInfosForE2E(
+							worker1TestCluster.client,
+							worker1TestCluster.ctx,
+							worker2TestCluster.client,
+							worker2TestCluster.ctx,
+						)...,
 					)
 
 					g.Expect(selectedWorker.Client.Get(selectedWorker.Ctx, wlLookupKey, wl)).To(gomega.Succeed())

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
@@ -277,26 +276,26 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			var assignedWorkerCluster client.Client
-			var assignedWorkerCtx context.Context
-			var assignedClusterName string
+			var selectedWorker util.ClusterInfo
 			ginkgo.By("checking which worker cluster was assigned", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					managerWl := &kueue.Workload{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
-					g.Expect(managerWl.Status.ClusterName).NotTo(gomega.BeNil())
+					selectedWorker = util.GetClientForSelectedWorkerCluster(
+						managerWl,
+						util.ClusterInfo{
+							Name:   "worker1",
+							Client: worker1TestCluster.client,
+							Ctx:    worker1TestCluster.ctx,
+						},
+						util.ClusterInfo{
+							Name:   "worker2",
+							Client: worker2TestCluster.client,
+							Ctx:    worker2TestCluster.ctx,
+						},
+					)
 
-					assignedClusterName = *managerWl.Status.ClusterName
-					g.Expect(assignedClusterName).To(gomega.Or(gomega.Equal(workerCluster1.Name), gomega.Equal(workerCluster2.Name)))
-					if assignedClusterName == workerCluster1.Name {
-						assignedWorkerCluster = worker1TestCluster.client
-						assignedWorkerCtx = worker1TestCluster.ctx
-					} else {
-						assignedWorkerCluster = worker2TestCluster.client
-						assignedWorkerCtx = worker2TestCluster.ctx
-					}
-
-					g.Expect(assignedWorkerCluster.Get(assignedWorkerCtx, wlLookupKey, wl)).To(gomega.Succeed())
+					g.Expect(selectedWorker.Client.Get(selectedWorker.Ctx, wlLookupKey, wl)).To(gomega.Succeed())
 					g.Expect(wl.Spec.PodSets).Should(gomega.BeComparableTo([]kueue.PodSet{{
 						Name:  kueue.DefaultPodSetName,
 						Count: 1,
@@ -309,12 +308,12 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 			})
 
 			ginkgo.By("verify the workload is admitted in the assigned worker cluster", func() {
-				util.ExpectWorkloadsToBeAdmitted(assignedWorkerCtx, assignedWorkerCluster, wl)
+				util.ExpectWorkloadsToBeAdmitted(selectedWorker.Ctx, selectedWorker.Client, wl)
 			})
 
 			ginkgo.By("verify TopologyAssignment for the workload in the assigned worker cluster", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
-					g.Expect(assignedWorkerCluster.Get(assignedWorkerCtx, wlLookupKey, wl)).Should(gomega.Succeed())
+					g.Expect(selectedWorker.Client.Get(selectedWorker.Ctx, wlLookupKey, wl)).Should(gomega.Succeed())
 					g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
 					g.Expect(wl.Status.Admission.PodSetAssignments).Should(gomega.HaveLen(1))
 					g.Expect(wl.Status.Admission.PodSetAssignments[0].TopologyAssignment).Should(gomega.BeComparableTo(

--- a/test/integration/multikueue/tas/tas_test.go
+++ b/test/integration/multikueue/tas/tas_test.go
@@ -282,8 +282,9 @@ var _ = ginkgo.Describe("Topology Aware Scheduling", ginkgo.Label("area:multikue
 					managerWl := &kueue.Workload{}
 					g.Expect(managerTestCluster.client.Get(managerTestCluster.ctx, wlLookupKey, managerWl)).To(gomega.Succeed())
 					selectedWorker = util.GetClientForSelectedWorkerCluster(
+						g,
 						managerWl,
-						util.ClusterInfosForE2E(
+						util.DefaultClusterInfosForTests(
 							worker1TestCluster.client,
 							worker1TestCluster.ctx,
 							worker2TestCluster.client,

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -297,6 +297,26 @@ type ClusterInfo struct {
 	Ctx    context.Context
 }
 
+func ClusterInfosForE2E(
+	client1 client.Client,
+	ctx1 context.Context,
+	client2 client.Client,
+	ctx2 context.Context,
+) []ClusterInfo {
+	return []ClusterInfo{
+		{
+			Name:   "worker1",
+			Client: client1,
+			Ctx:    ctx1,
+		},
+		{
+			Name:   "worker2",
+			Client: client2,
+			Ctx:    ctx2,
+		},
+	}
+}
+
 func GetClientForSelectedWorkerCluster(
 	managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
 	ginkgo.GinkgoHelper()

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -297,6 +297,8 @@ type ClusterInfo struct {
 	Ctx    context.Context
 }
 
+//revive:disable:context-as-argument
+
 func DefaultClusterInfosForTests(
 	ctx1 context.Context,
 	client1 client.Client,
@@ -316,6 +318,8 @@ func DefaultClusterInfosForTests(
 		},
 	}
 }
+
+//revive:enable:context-as-argument
 
 func GetClientForSelectedWorkerCluster(g gomega.Gomega, managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
 	ginkgo.GinkgoHelper()

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -297,7 +297,7 @@ type ClusterInfo struct {
 	Ctx    context.Context
 }
 
-func ClusterInfosForE2E(
+func DefaultClusterInfosForTests(
 	client1 client.Client,
 	ctx1 context.Context,
 	client2 client.Client,
@@ -317,11 +317,11 @@ func ClusterInfosForE2E(
 	}
 }
 
-func GetClientForSelectedWorkerCluster(managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
+func GetClientForSelectedWorkerCluster(g gomega.Gomega, managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
 	ginkgo.GinkgoHelper()
 
 	clusterName := managerWl.Status.ClusterName
-	gomega.Expect(clusterName).ToNot(gomega.BeNil())
+	g.Expect(clusterName).ToNot(gomega.BeNil())
 
 	for _, cluster := range clusters {
 		if cluster.Name == *clusterName {

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -298,10 +298,10 @@ type ClusterInfo struct {
 }
 
 func DefaultClusterInfosForTests(
-	client1 client.Client,
 	ctx1 context.Context,
-	client2 client.Client,
+	client1 client.Client,
 	ctx2 context.Context,
+	client2 client.Client,
 ) []ClusterInfo {
 	return []ClusterInfo{
 		{

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -290,3 +290,26 @@ func ExpectWorkloadsToBeAdmittedAndGetWorkerName(ctx context.Context, k8sClient 
 	}, MediumTimeout, Interval).Should(gomega.Succeed())
 	return workerName
 }
+
+type ClusterInfo struct {
+	Name   string
+	Client client.Client
+	Ctx    context.Context
+}
+
+func GetClientForSelectedWorkerCluster(
+	managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
+	ginkgo.GinkgoHelper()
+
+	clusterName := managerWl.Status.ClusterName
+	gomega.Expect(clusterName).ToNot(gomega.BeNil())
+
+	for _, cluster := range clusters {
+		if cluster.Name == *clusterName {
+			return cluster
+		}
+	}
+
+	ginkgo.Fail("none of the supplied clusters was selected")
+	return ClusterInfo{}
+}

--- a/test/util/multikueue.go
+++ b/test/util/multikueue.go
@@ -317,8 +317,7 @@ func ClusterInfosForE2E(
 	}
 }
 
-func GetClientForSelectedWorkerCluster(
-	managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
+func GetClientForSelectedWorkerCluster(managerWl *kueue.Workload, clusters ...ClusterInfo) ClusterInfo {
 	ginkgo.GinkgoHelper()
 
 	clusterName := managerWl.Status.ClusterName


### PR DESCRIPTION
Cherry pick of #12587 on release-0.18.

#12587: Treat remote and local preemption gates independently

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
MultiKueue: Stop considering `spec.PreemptionGates` when syncing workloads. The preemption gates on the manager and worker clusters are treated independently - they are not copied from the manager to the workers and differences between them are not considered as out-of-sync. This fixes an issue where creating a MultiKueue workload with a preemption gate would cause an infinite loop of sync and deletions on the worker clusters.
```