### PR TITLE
Automated cherry pick of #14242: TAS: stop dumping every leaf domain in the assumptions-violated error

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1665,13 +1665,41 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		remainingPrimary -= dom.state
 		result = append(result, dom)
 	}
+	// The error below is not gated by the verbosity level, so log a summary of
+	// the snapshot instead of the leaf domains themselves. There is one leaf per
+	// node when the lowest topology level is the hostname, so dumping them here
+	// grows the log line with the size of the cluster.
+	var lastDomainID utiltas.TopologyDomainID
+	if len(domains) > 0 {
+		lastDomainID = domains[len(domains)-1].id
+	}
 	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
 		"remainingCount", remainingPrimary,
 		"remainingLeaderCount", remainingLeaderCount,
 		"count", count,
+		"leaderCount", leaderCount,
 		"sliceSize", sliceSize,
-		"leaves", s.leaves)
+		"unconstrained", unconstrained,
+		"slices", slices,
+		"topologyName", s.topologyName,
+		"domainCount", len(domains),
+		"lastDomainID", lastDomainID,
+		"leafCount", len(s.leaves))
+	s.logLeafDomainsIfVerbose()
 	return nil
+}
+
+// logLeafDomainsIfVerbose logs the identifiers of the snapshot's leaf domains.
+// The line grows with the number of nodes in the topology, so it is emitted at
+// the same verbosity the scheduler dumps the whole snapshot at.
+func (s *TASFlavorSnapshot) logLeafDomainsIfVerbose() {
+	logV := s.log.V(6)
+	if !logV.Enabled() {
+		return
+	}
+	logV.Info("TAS flavor snapshot leaf domains",
+		"topologyName", s.topologyName,
+		"leafDomains", slices.Sorted(maps.Keys(s.leaves)))
 }
 
 // buildTopologyAssignmentForLevels build TopologyAssignment for levels starting from levelIdx

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1665,14 +1665,7 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		remainingPrimary -= dom.state
 		result = append(result, dom)
 	}
-	// The error below is not gated by the verbosity level, so log a summary of
-	// the snapshot instead of the leaf domains themselves. There is one leaf per
-	// node when the lowest topology level is the hostname, so dumping them here
-	// grows the log line with the size of the cluster.
-	var lastDomainID utiltas.TopologyDomainID
-	if len(domains) > 0 {
-		lastDomainID = domains[len(domains)-1].id
-	}
+	// Error logs are not verbosity-gated; dumping leaves scales with cluster size.
 	s.log.Error(errCodeAssumptionsViolated, "unexpected remainingCount",
 		"remainingCount", remainingPrimary,
 		"remainingLeaderCount", remainingLeaderCount,
@@ -1680,10 +1673,8 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 		"leaderCount", leaderCount,
 		"sliceSize", sliceSize,
 		"unconstrained", unconstrained,
-		"slices", slices,
 		"topologyName", s.topologyName,
 		"domainCount", len(domains),
-		"lastDomainID", lastDomainID,
 		"leafCount", len(s.leaves))
 	s.logLeafDomainsIfVerbose()
 	return nil

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -18,13 +18,20 @@ package scheduler
 
 import (
 	"fmt"
+	"io"
+	"strings"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/onsi/gomega"
+	zaplog "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -1220,4 +1227,110 @@ func TestIsTopologyAssignmentStale(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newObservedLogger returns a logger discarding its output, together with the
+// entries it observed, so that a test can assert on what was logged.
+func newObservedLogger(level zapcore.Level) (logr.Logger, *observer.ObservedLogs) {
+	logsObserver, observedLogs := observer.New(level)
+	logger := crzap.New(
+		crzap.WriteTo(io.Discard),
+		crzap.Level(level),
+		func(o *crzap.Options) {
+			o.ZapOpts = append(o.ZapOpts, zaplog.WrapCore(func(zapcore.Core) zapcore.Core {
+				return logsObserver
+			}))
+		},
+	)
+	return logger, observedLogs
+}
+
+func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
+	// The leaf domains are keyed by hostname, so the snapshot holds one leaf per
+	// node. Their identifiers must not end up in the error entry, which is not
+	// gated by the verbosity level.
+	newSnapshot := func(log logr.Logger) *TASFlavorSnapshot {
+		snapshot := newTASFlavorSnapshot(log, "tas-topology", []string{corev1.LabelHostname}, nil)
+		for _, name := range []string{"node-a", "node-b"} {
+			snapshot.addNode(node.MakeNode(name).
+				Label(corev1.LabelHostname, name).
+				StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("8")}).
+				Ready().
+				Obj())
+		}
+		return snapshot
+	}
+	// A single domain with room for one pod cannot accommodate the ten requested
+	// ones, which violates the assumptions of the algorithm.
+	callWithViolatedAssumptions := func(snapshot *TASFlavorSnapshot) []*domain {
+		return snapshot.updateCountsToMinimumGeneric([]*domain{{id: "rack-1", state: 1}}, 10, 0, 1, false, false)
+	}
+	wantErrorFields := map[string]any{
+		"error":                "code assumptions violated",
+		"remainingCount":       int32(9),
+		"remainingLeaderCount": int32(0),
+		"count":                int32(10),
+		"leaderCount":          int32(0),
+		"sliceSize":            int32(1),
+		"unconstrained":        false,
+		"slices":               false,
+		"topologyName":         kueue.TopologyReference("tas-topology"),
+		"domainCount":          int64(1),
+		"lastDomainID":         tas.TopologyDomainID("rack-1"),
+		"leafCount":            int64(2),
+	}
+
+	t.Run("the error entry summarizes the leaf domains instead of dumping them", func(t *testing.T) {
+		log, observedLogs := newObservedLogger(zapcore.InfoLevel)
+		snapshot := newSnapshot(log)
+
+		if got := callWithViolatedAssumptions(snapshot); got != nil {
+			t.Fatalf("updateCountsToMinimumGeneric() = %v, want nil", got)
+		}
+
+		logs := observedLogs.TakeAll()
+		if len(logs) != 1 {
+			t.Fatalf("Observed %d log entries, want 1: %v", len(logs), logs)
+		}
+		if logs[0].Level != zapcore.ErrorLevel {
+			t.Errorf("Observed log level %v, want %v", logs[0].Level, zapcore.ErrorLevel)
+		}
+		fields := logs[0].ContextMap()
+		if diff := cmp.Diff(wantErrorFields, fields); diff != "" {
+			t.Errorf("Observed error fields mismatch (-want +got):\n%s", diff)
+		}
+		// Guard against the leaf domains reaching the entry under any other key.
+		for _, leafDomainID := range []string{"node-a", "node-b"} {
+			if rendered := fmt.Sprint(fields); strings.Contains(rendered, leafDomainID) {
+				t.Errorf("Observed error entry mentions leaf domain %q: %s", leafDomainID, rendered)
+			}
+		}
+	})
+
+	t.Run("the leaf domains are logged at high verbosity", func(t *testing.T) {
+		log, observedLogs := newObservedLogger(zapcore.Level(-6))
+		snapshot := newSnapshot(log)
+
+		if got := callWithViolatedAssumptions(snapshot); got != nil {
+			t.Fatalf("updateCountsToMinimumGeneric() = %v, want nil", got)
+		}
+
+		logs := observedLogs.TakeAll()
+		if len(logs) != 2 {
+			t.Fatalf("Observed %d log entries, want 2: %v", len(logs), logs)
+		}
+		if diff := cmp.Diff(wantErrorFields, logs[0].ContextMap()); diff != "" {
+			t.Errorf("Observed error fields mismatch (-want +got):\n%s", diff)
+		}
+		if logs[1].Level != zapcore.Level(-6) {
+			t.Errorf("Observed log level %v, want %v", logs[1].Level, zapcore.Level(-6))
+		}
+		wantLeafFields := map[string]any{
+			"topologyName": kueue.TopologyReference("tas-topology"),
+			"leafDomains":  []tas.TopologyDomainID{"node-a", "node-b"},
+		}
+		if diff := cmp.Diff(wantLeafFields, logs[1].ContextMap()); diff != "" {
+			t.Errorf("Observed leaf domain fields mismatch (-want +got):\n%s", diff)
+		}
+	})
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1273,10 +1273,8 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 		"leaderCount":          int32(0),
 		"sliceSize":            int32(1),
 		"unconstrained":        false,
-		"slices":               false,
 		"topologyName":         kueue.TopologyReference("tas-topology"),
 		"domainCount":          int64(1),
-		"lastDomainID":         tas.TopologyDomainID("rack-1"),
 		"leafCount":            int64(2),
 	}
 


### PR DESCRIPTION
Cherry pick of #14242 on release-0.18.

#14242: TAS: stop dumping every leaf domain in the assumptions-violated error

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
TAS: Reduced excessively large assumptions-violation logs to a short summary. Operators can view the individual leaf domain IDs at verbosity 6 when detailed diagnostics are needed.
```