### PR TITLE
Automated cherry pick of #13336: test: move WAS e2e to the scheduling.k8s.io/v1beta1 PodGroup API

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -511,7 +511,7 @@ apiServer:
   - name: enable-aggregator-routing
     value: \"true\"
   - name: runtime-config
-    value: \"scheduling.k8s.io/v1alpha3=true\"
+    value: \"scheduling.k8s.io/v1beta1=true\"
   - name: v
     value: \"3\"
 "' "$patched_config"
@@ -527,7 +527,7 @@ controllerManager:
 apiServer:
   extraArgs:
     enable-aggregator-routing: \"true\"
-    runtime-config: \"scheduling.k8s.io/v1alpha3=true\"
+    runtime-config: \"scheduling.k8s.io/v1beta1=true\"
     v: \"3\"
 "]' "$patched_config"
 


### PR DESCRIPTION
Cherry pick of #13336 on release-0.18.

#13336: test: move WAS e2e to the scheduling.k8s.io/v1beta1 PodGroup API

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind failing-test

Fixes #14264

```release-note
NONE
```