### PR TITLE
fix(scheduler): dedup overlapping victims in fits()

### DIFF
--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -40,14 +40,18 @@ func (p PreemptedWorkloads) Insert(newTargets []*Target) {
 	}
 }
 
-// WorkloadsToRemove returns the union of workloads already preempted in this
-// scheduling cycle and the new preemption targets, deduplicated by workload key.
+// MergeWithTargets returns the union of workloads already preempted and
+// the new preemption targets, deduplicated by workload key.
 // The receiver is not mutated.
-func (p PreemptedWorkloads) WorkloadsToRemove(newTargets []*Target) []*workload.Info {
+func (p PreemptedWorkloads) MergeWithTargets(targets []*Target) PreemptedWorkloads {
 	merged := maps.Clone(p)
 	if merged == nil {
-		merged = make(PreemptedWorkloads, len(newTargets))
+		merged = make(PreemptedWorkloads, len(targets))
 	}
-	merged.Insert(newTargets)
-	return slices.Collect(maps.Values(merged))
+	merged.Insert(targets)
+	return merged
+}
+
+func (p PreemptedWorkloads) Workloads() []*workload.Info {
+	return slices.Collect(maps.Values(p))
 }

--- a/pkg/scheduler/preemption/preempted_workloads.go
+++ b/pkg/scheduler/preemption/preempted_workloads.go
@@ -17,6 +17,9 @@ limitations under the License.
 package preemption
 
 import (
+	"maps"
+	"slices"
+
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -35,4 +38,16 @@ func (p PreemptedWorkloads) Insert(newTargets []*Target) {
 	for _, target := range newTargets {
 		p[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
 	}
+}
+
+// WorkloadsToRemove returns the union of workloads already preempted in this
+// scheduling cycle and the new preemption targets, deduplicated by workload key.
+// The receiver is not mutated.
+func (p PreemptedWorkloads) WorkloadsToRemove(newTargets []*Target) []*workload.Info {
+	merged := maps.Clone(p)
+	if merged == nil {
+		merged = make(PreemptedWorkloads, len(newTargets))
+	}
+	merged.Insert(newTargets)
+	return slices.Collect(maps.Values(merged))
 }

--- a/pkg/scheduler/preemption/preempted_workloads_test.go
+++ b/pkg/scheduler/preemption/preempted_workloads_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package preemption
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestWorkloadsToRemove(t *testing.T) {
+	original := workloadInfoForTest("ns", "victim-a")
+	replacement := workloadInfoForTest("ns", "victim-a")
+	additional := workloadInfoForTest("ns", "victim-b")
+	originalKey := workload.Key(original.Obj)
+	additionalKey := workload.Key(additional.Obj)
+
+	preempted := PreemptedWorkloads{originalKey: original}
+	got := preempted.WorkloadsToRemove([]*Target{
+		{WorkloadInfo: replacement},
+		{WorkloadInfo: additional},
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("WorkloadsToRemove() returned %d workloads, want 2", len(got))
+	}
+	gotByKey := make(PreemptedWorkloads, len(got))
+	for _, info := range got {
+		gotByKey[workload.Key(info.Obj)] = info
+	}
+	if gotByKey[originalKey] != replacement {
+		t.Errorf("duplicate target was not deduplicated with the new target value")
+	}
+	if gotByKey[additionalKey] != additional {
+		t.Errorf("new target was not included")
+	}
+	if len(preempted) != 1 || preempted[originalKey] != original {
+		t.Errorf("WorkloadsToRemove() mutated receiver: %#v", preempted)
+	}
+}
+
+func TestWorkloadsToRemoveNilReceiver(t *testing.T) {
+	target := workloadInfoForTest("ns", "victim")
+	var preempted PreemptedWorkloads
+
+	got := preempted.WorkloadsToRemove([]*Target{{WorkloadInfo: target}})
+	if len(got) != 1 || workload.Key(got[0].Obj) != workload.Key(target.Obj) {
+		t.Fatalf("WorkloadsToRemove() = %#v, want the target workload", got)
+	}
+}
+
+func workloadInfoForTest(namespace, name string) *workload.Info {
+	return &workload.Info{Obj: &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}}
+}

--- a/pkg/scheduler/preemption/preempted_workloads_test.go
+++ b/pkg/scheduler/preemption/preempted_workloads_test.go
@@ -33,10 +33,10 @@ func TestWorkloadsToRemove(t *testing.T) {
 	additionalKey := workload.Key(additional.Obj)
 
 	preempted := PreemptedWorkloads{originalKey: original}
-	got := preempted.WorkloadsToRemove([]*Target{
+	got := preempted.MergeWithTargets([]*Target{
 		{WorkloadInfo: replacement},
 		{WorkloadInfo: additional},
-	})
+	}).Workloads()
 
 	if len(got) != 2 {
 		t.Fatalf("WorkloadsToRemove() returned %d workloads, want 2", len(got))
@@ -60,7 +60,7 @@ func TestWorkloadsToRemoveNilReceiver(t *testing.T) {
 	target := workloadInfoForTest("ns", "victim")
 	var preempted PreemptedWorkloads
 
-	got := preempted.WorkloadsToRemove([]*Target{{WorkloadInfo: target}})
+	got := preempted.MergeWithTargets([]*Target{{WorkloadInfo: target}}).Workloads()
 	if len(got) != 1 || workload.Key(got[0].Obj) != workload.Key(target.Obj) {
 		t.Fatalf("WorkloadsToRemove() = %#v, want the target workload", got)
 	}

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -755,10 +755,16 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 
 func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads,
 	newTargets []*preemption.Target) schdcache.FitsCheck {
-	workloads := slices.Collect(maps.Values(preemptedWorkloads))
-	for _, target := range newTargets {
-		workloads = append(workloads, target.WorkloadInfo)
+	// Dedup by workload.Key so a victim present in both preemptedWorkloads and
+	// newTargets is only subtracted once (see kubernetes-sigs/kueue#14155).
+	toRemove := maps.Clone(preemptedWorkloads)
+	if toRemove == nil {
+		toRemove = make(preemption.PreemptedWorkloads, len(newTargets))
 	}
+	for _, target := range newTargets {
+		toRemove[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
+	}
+	workloads := slices.Collect(maps.Values(toRemove))
 	revertUsage := snapshot.SimulateWorkloadUsageRemoval(workloads)
 	defer revertUsage()
 	return cq.Fits(*usage)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -755,16 +755,7 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 
 func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads,
 	newTargets []*preemption.Target) schdcache.FitsCheck {
-	// Dedup by workload.Key so a victim present in both preemptedWorkloads and
-	// newTargets is only subtracted once (see kubernetes-sigs/kueue#14155).
-	toRemove := maps.Clone(preemptedWorkloads)
-	if toRemove == nil {
-		toRemove = make(preemption.PreemptedWorkloads, len(newTargets))
-	}
-	for _, target := range newTargets {
-		toRemove[workload.Key(target.WorkloadInfo.Obj)] = target.WorkloadInfo
-	}
-	workloads := slices.Collect(maps.Values(toRemove))
+	workloads := preemptedWorkloads.WorkloadsToRemove(newTargets)
 	revertUsage := snapshot.SimulateWorkloadUsageRemoval(workloads)
 	defer revertUsage()
 	return cq.Fits(*usage)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -755,8 +755,8 @@ func (s *Scheduler) updateAssignmentIfNeeded(
 
 func fits(snapshot *schdcache.Snapshot, cq *schdcache.ClusterQueueSnapshot, usage *workload.Usage, preemptedWorkloads preemption.PreemptedWorkloads,
 	newTargets []*preemption.Target) schdcache.FitsCheck {
-	workloads := preemptedWorkloads.WorkloadsToRemove(newTargets)
-	revertUsage := snapshot.SimulateWorkloadUsageRemoval(workloads)
+	merged := preemptedWorkloads.MergeWithTargets(newTargets)
+	revertUsage := snapshot.SimulateWorkloadUsageRemoval(merged.Workloads())
 	defer revertUsage()
 	return cq.Fits(*usage)
 }

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -48,6 +48,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	"sigs.k8s.io/kueue/pkg/scheduler/preemption"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/limitrange"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
@@ -9102,5 +9103,82 @@ func TestLastAssignmentOutdated(t *testing.T) {
 				t.Errorf("LastAssignmentOutdated() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestFitsDedupsOverlappingVictims ensures fits() subtracts a victim only once when
+// it appears in both preemptedWorkloads and the entry's targets (kueue#14155).
+func TestFitsDedupsOverlappingVictims(t *testing.T) {
+	ctx, log := utiltesting.ContextWithLog(t)
+	now := time.Now()
+
+	cqObj := utiltestingapi.MakeClusterQueue("cq").
+		ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+			Resource(corev1.ResourceCPU, "10").
+			Obj()).
+		Obj()
+	flavor := utiltestingapi.MakeResourceFlavor("default").Obj()
+
+	victimWL := utiltestingapi.MakeWorkload("victim", "ns").
+		Request(corev1.ResourceCPU, "6").
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "6").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+	otherWL := utiltestingapi.MakeWorkload("other", "ns").
+		Request(corev1.ResourceCPU, "2").
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "default", "2").
+					Obj()).
+				Obj(),
+			now,
+		).
+		Obj()
+
+	cache := schdcache.New(utiltesting.NewFakeClient())
+	cache.AddOrUpdateResourceFlavor(log, flavor)
+	if err := cache.AddClusterQueue(ctx, cqObj); err != nil {
+		t.Fatalf("Failed to add ClusterQueue: %v", err)
+	}
+
+	snapshot, err := cache.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("Failed to build snapshot: %v", err)
+	}
+	cq := snapshot.ClusterQueue("cq")
+	if cq == nil {
+		t.Fatal("ClusterQueue snapshot missing")
+	}
+
+	victimInfo := workload.NewInfo(victimWL)
+	otherInfo := workload.NewInfo(otherWL)
+	snapshot.AddWorkload(victimInfo)
+	snapshot.AddWorkload(otherInfo)
+
+	// CQ usage is 8 CPU (victim 6 + other 2). Incoming needs 9.
+	// Freeing victim once leaves usage 2 → 8 free → 9 does not fit.
+	// Double-subtracting victim would leave usage -4 and wrongly report Ok.
+	incomingUsage := workload.Usage{
+		Quota: workload.ResourceUsage{
+			Assigned: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: corev1.ResourceCPU}: resources.NewAmount(9000),
+			},
+		},
+	}
+	preempted := preemption.PreemptedWorkloads{
+		workload.Key(victimWL): victimInfo,
+	}
+	targets := []*preemption.Target{{WorkloadInfo: victimInfo}}
+
+	got := fits(snapshot, cq, &incomingUsage, preempted, targets)
+	if got != schdcache.FitsCheckNoQuota {
+		t.Fatalf("fits() = %v, want %v (overlapping victim must be subtracted once)", got, schdcache.FitsCheckNoQuota)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
We want to merge #14178 I cherrypicked commits from that PR and resolved the conflicts.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14155

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduler preemption handling to remove only workloads affected by the selected preemption targets.
  * Prevented workloads from being removed more than once when they appear in multiple preemption records.
  * Improved fit evaluation accuracy for requests that depend on freeing preempted workloads.
  * Added safeguards for empty or unavailable preemption workload data.
  * Preserved existing workload information while incorporating newly selected preemption targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->