### PR TITLE
fix: fix concurrent admission variant preemption ordering

### DIFF
--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -772,7 +772,7 @@ func firstCandidateVariant(log logr.Logger, admissibleVariants []*kueue.Workload
 		wlLog := log.WithValues("candidateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
 		if workload.BlockedOnPreemptionGatesCondition(wl) == nil {
 			quotaReserved := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
-			if quotaReserved == nil || quotaReserved.Reason == kueue.WorkloadQuotaReservedReasonPendingEvaluation {
+			if quotaReserved == nil {
 				wlLog.V(4).Info("Variant has not been evaluated for admission yet")
 				return nil
 			}

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -771,6 +771,11 @@ func firstCandidateVariant(log logr.Logger, admissibleVariants []*kueue.Workload
 		}
 		wlLog := log.WithValues("candidateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
 		if workload.BlockedOnPreemptionGatesCondition(wl) == nil {
+			quotaReserved := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
+			if quotaReserved == nil || quotaReserved.Reason == kueue.WorkloadQuotaReservedReasonPendingEvaluation {
+				wlLog.V(4).Info("Variant has not been evaluated for admission yet")
+				return nil
+			}
 			wlLog.V(4).Info("Variant does not require preemption")
 			continue
 		}

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -77,18 +77,8 @@ func evaluatedForAdmissionCondition(t time.Time) metav1.Condition {
 	return metav1.Condition{
 		Type:               kueue.WorkloadQuotaReserved,
 		Status:             metav1.ConditionFalse,
-		Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+		Reason:             kueue.WorkloadPending, //nolint:staticcheck // SA1019: legacy reason
 		Message:            "Workload does not fit",
-		LastTransitionTime: metav1.NewTime(t),
-	}
-}
-
-func pendingAdmissionEvaluationCondition(t time.Time) metav1.Condition {
-	return metav1.Condition{
-		Type:               kueue.WorkloadQuotaReserved,
-		Status:             metav1.ConditionFalse,
-		Reason:             kueue.WorkloadQuotaReservedReasonPendingEvaluation,
-		Message:            "Workload is pending evaluation in the scheduling queue",
 		LastTransitionTime: metav1.NewTime(t),
 	}
 }
@@ -2313,14 +2303,7 @@ func TestFirstCandidateVariant(t *testing.T) {
 				PreemptionGates(caGate()).
 				Obj(),
 		},
-		"waits when the preferred variant is pending evaluation": {
-			first: utiltestingapi.MakeWorkload("preferred", "default").
-				AllowedFlavors("on-demand").
-				PreemptionGates(caGate()).
-				Condition(pendingAdmissionEvaluationCondition(now)).
-				Obj(),
-		},
-		"skips a preferred variant evaluated without preemption": {
+		"skips a preferred variant with an existing quota reservation condition": {
 			first: utiltestingapi.MakeWorkload("preferred", "default").
 				AllowedFlavors("on-demand").
 				PreemptionGates(caGate()).

--- a/pkg/controller/concurrentadmission/controller_test.go
+++ b/pkg/controller/concurrentadmission/controller_test.go
@@ -73,6 +73,26 @@ func blockedOnPreemptionCondition(t time.Time) metav1.Condition {
 	}
 }
 
+func evaluatedForAdmissionCondition(t time.Time) metav1.Condition {
+	return metav1.Condition{
+		Type:               kueue.WorkloadQuotaReserved,
+		Status:             metav1.ConditionFalse,
+		Reason:             kueue.WorkloadQuotaReservedReasonWaitingForQuota,
+		Message:            "Workload does not fit",
+		LastTransitionTime: metav1.NewTime(t),
+	}
+}
+
+func pendingAdmissionEvaluationCondition(t time.Time) metav1.Condition {
+	return metav1.Condition{
+		Type:               kueue.WorkloadQuotaReserved,
+		Status:             metav1.ConditionFalse,
+		Reason:             kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+		Message:            "Workload is pending evaluation in the scheduling queue",
+		LastTransitionTime: metav1.NewTime(t),
+	}
+}
+
 func caGate() kueue.PreemptionGate {
 	return kueue.PreemptionGate{Name: constants.ConcurrentAdmissionPreemptionGate}
 }
@@ -573,6 +593,50 @@ func TestReconcile(t *testing.T) {
 					Request(corev1.ResourceCPU, "1").
 					PreemptionGates(caGate()).
 					PreemptionGateStates(caGateState(kueue.PreemptionGatePositionClosed, fakeNow)).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+		},
+		"waits for a more-preferred variant to be evaluated before ungating a lower-preference variant": {
+			parentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			variantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq").
+					AllowedFlavors("on-demand").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+			},
+			wantParentWorkload: utiltestingapi.MakeWorkload("wl-12345", "default").
+				Queue("lq").
+				Label(constants.ConcurrentAdmissionParentLabelKey, "true").
+				Obj(),
+			wantVariantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-variant-on-demand", "default").
+					Queue("lq").
+					AllowedFlavors("on-demand").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
+					Obj(),
+				*utiltestingapi.MakeWorkload("wl-variant-spot", "default").
+					Queue("lq").
+					AllowedFlavors("spot").
+					Request(corev1.ResourceCPU, "1").
+					PreemptionGates(caGate()).
+					Condition(blockedOnPreemptionCondition(fakeNow)).
 					ControllerReference(kueue.SchemeGroupVersion.WithKind("Workload"), "wl-12345", "").
 					Obj(),
 			},
@@ -2228,6 +2292,51 @@ func TestReconcile(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestFirstCandidateVariant(t *testing.T) {
+	now := time.Now()
+	blocked := utiltestingapi.MakeWorkload("blocked", "default").
+		AllowedFlavors("spot").
+		PreemptionGates(caGate()).
+		Condition(blockedOnPreemptionCondition(now)).
+		Obj()
+
+	testCases := map[string]struct {
+		first *kueue.Workload
+		want  *kueue.Workload
+	}{
+		"waits when the preferred variant has no evaluation condition": {
+			first: utiltestingapi.MakeWorkload("preferred", "default").
+				AllowedFlavors("on-demand").
+				PreemptionGates(caGate()).
+				Obj(),
+		},
+		"waits when the preferred variant is pending evaluation": {
+			first: utiltestingapi.MakeWorkload("preferred", "default").
+				AllowedFlavors("on-demand").
+				PreemptionGates(caGate()).
+				Condition(pendingAdmissionEvaluationCondition(now)).
+				Obj(),
+		},
+		"skips a preferred variant evaluated without preemption": {
+			first: utiltestingapi.MakeWorkload("preferred", "default").
+				AllowedFlavors("on-demand").
+				PreemptionGates(caGate()).
+				Condition(evaluatedForAdmissionCondition(now)).
+				Obj(),
+			want: blocked,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := firstCandidateVariant(ctrl.Log, []*kueue.Workload{tc.first, blocked})
+			if got != tc.want {
+				t.Errorf("firstCandidateVariant() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test
/kind flake
/area testing

#### Which issue(s) this PR fixes:

Fixes #14245

#### Does this PR introduce a user-facing change?

```release-note
ConcurrentAdmission: Fix preemption ordering by waiting for more-preferred variants to be evaluated for admission before opening the preemption gate for a less-preferred variant.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admission handling when a preferred variant is still awaiting quota evaluation.
  * Prevented lower-preference variants from being selected prematurely while evaluation is incomplete.
  * Ensured variants without a completed quota evaluation are correctly deferred.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->