### PR TITLE
Automated cherry pick of #14261: fix: ungate elastic pods when the enqueued slice finished mid-rollover

### DIFF
--- a/pkg/controller/elasticjobs/elastic_job_ungater.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater.go
@@ -118,23 +118,35 @@ func (r *elasticJobUngater) Reconcile(ctx context.Context, req reconcile.Request
 	log := ctrl.LoggerFrom(ctx)
 	log.V(2).Info("Reconcile ElasticJobUngater")
 
-	// req.Name is the chain's active (latest admitted, non-finished) slice: the
-	// enqueue handlers resolve it from whichever slice or pod triggered the event,
-	// so Reconcile always loads a live workload whose granted PodSet counts define
-	// how many pods may be ungated. If it is already gone (just finished/deleted),
-	// there is nothing to ungate.
+	// req.Name is whichever slice the enqueue handlers resolved as active when the
+	// event fired. It is only a snapshot: a requeue (e.g. after a pod-patch
+	// conflict) can re-run this against a slice that has since finished, so the
+	// eligibility check below redirects to the current active slice rather than
+	// trusting req.Name. If nothing in the chain is admitted anymore, there is
+	// nothing to ungate.
 	active := &kueue.Workload{}
 	if err := r.client.Get(ctx, req.NamespacedName, active); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	// The handlers only enqueue active elastic slices, but an enqueue can race a
-	// slice finishing or being evicted; re-check before ungating against its (now
-	// stale) granted counts. Eviction is two writes — the condition is set before
-	// the reservation is released — so an evicted slice still reports a
-	// reservation while its capacity is on the way out; exclude it here, matching
-	// workloadslicing.FindLatestActiveWorkload.
+	// The handlers only enqueue active elastic slices, but req.Name is a snapshot:
+	// by the time this runs (especially on a requeue after a pod-patch conflict),
+	// the enqueued slice may have finished as part of a scale rollover. Bailing
+	// here would strand any pending ungate until the next periodic resync, so
+	// redirect to the chain's current active slice instead. Eviction is two
+	// writes — the condition is set before the reservation is released — so an
+	// evicted slice still reports a reservation while its capacity is on the way
+	// out; treat it as ineligible too, matching workloadslicing.FindLatestActiveWorkload.
 	if !shouldUngate(active) || workload.IsEvicted(active) {
-		return reconcile.Result{}, nil
+		redirected, err := r.activeSlice(ctx, active)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		// No eligible active slice, or it is the same (still-ineligible) object we
+		// just loaded: nothing new to ungate against.
+		if redirected == nil || redirected.Name == active.Name {
+			return reconcile.Result{}, nil
+		}
+		active = redirected
 	}
 
 	// Expectations are keyed by the stable chain key (the origin slice name shared

--- a/pkg/controller/elasticjobs/elastic_job_ungater_test.go
+++ b/pkg/controller/elasticjobs/elastic_job_ungater_test.go
@@ -1032,6 +1032,98 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
+// TestReconcileRedirectsFromFinishedSlice reproduces the scale-rollover stall:
+// an enqueued reconcile (e.g. a requeue after a pod-patch conflict lost the race
+// to the TAS ungater) can re-run against the origin slice after it finished as
+// part of the scale-up. Reconcile must redirect to the chain's current active
+// slice and ungate, not bail on the finished slice and wait for a resync.
+func TestReconcileRedirectsFromFinishedSlice(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
+	now := time.Now().Truncate(time.Second)
+	ctx, _ := utiltesting.ContextWithLog(t)
+
+	// Origin slice: admitted at parallelism 1, then finished when the scale-up
+	// replacement took over.
+	origin := utiltestingapi.MakeWorkload("wl", "ns").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+		ControllerReference(rayClusterGVK, "ray", "ray-uid").
+		Creation(now.Add(-time.Minute)).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "flavor", "1").Obj()).
+				Obj(), now.Add(-time.Minute),
+		).
+		AdmittedAt(true, now.Add(-time.Minute)).
+		Finished().
+		Obj()
+	// Active slice: the scale-up replacement, admitted at parallelism 2, still
+	// pointing back at the origin name via the slice annotation.
+	active := utiltestingapi.MakeWorkload("wl-2", "ns").
+		Finalizers(kueue.ResourceInUseFinalizerName).
+		Annotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+		Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+		ControllerReference(rayClusterGVK, "ray", "ray-uid").
+		Creation(now).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(
+			utiltestingapi.MakeAdmission("cq").
+				PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+					Assignment(corev1.ResourceCPU, "flavor", "2").Obj()).
+				Obj(), now,
+		).
+		AdmittedAt(true, now).
+		Obj()
+
+	gatedPod := testingpod.MakePod("pod-0", "ns").
+		Annotation(kueue.WorkloadAnnotation, "wl").
+		Annotation(kueue.WorkloadSliceNameAnnotation, "wl").
+		Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+		Gate(kueue.ElasticJobSchedulingGate).
+		Obj()
+
+	clientBuilder := utiltesting.NewClientBuilder().
+		WithIndex(&corev1.Pod{}, coreindexer.WorkloadSliceNameKey, coreindexer.IndexPodWorkloadSliceName).
+		WithIndex(&kueue.Workload{}, coreindexer.OwnerReferenceIndexKey(rayClusterGVK), coreindexer.WorkloadOwnerIndexFunc(rayClusterGVK)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, clnt client.WithWatch, obj client.Object, _ client.Patch, _ ...client.PatchOption) error {
+				return clnt.Update(ctx, obj)
+			},
+		}).
+		WithObjects(gatedPod).
+		WithStatusSubresource(origin, active)
+	kClient := clientBuilder.Build()
+	for _, wl := range []*kueue.Workload{origin, active} {
+		if err := kClient.Create(ctx, wl); err != nil {
+			t.Fatalf("Could not create workload %s: %v", wl.Name, err)
+		}
+	}
+
+	ungater := &elasticJobUngater{
+		client:            kClient,
+		expectationsStore: expectations.NewStore(ControllerName),
+	}
+
+	// Reconcile keyed on the FINISHED origin slice, as a conflict-requeue would.
+	if _, err := ungater.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "wl"},
+	}); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	var got corev1.Pod
+	if err := kClient.Get(ctx, client.ObjectKeyFromObject(gatedPod), &got); err != nil {
+		t.Fatalf("Could not get pod after reconcile: %v", err)
+	}
+	for _, g := range got.Spec.SchedulingGates {
+		if g.Name == kueue.ElasticJobSchedulingGate {
+			t.Fatalf("pod still has elastic scheduling gate; expected ungate via redirect to active slice %q", active.Name)
+		}
+	}
+}
+
 func TestShouldUngate(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.ElasticJobsViaWorkloadSlices, true)
 	now := time.Now().Truncate(time.Second)


### PR DESCRIPTION
Cherry pick of #14261 on release-0.18.

#14261: fix: ungate elastic pods when the enqueued slice finished mid-rollover

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind bug


```release-note
Fixed a bug where elastic-job worker pods could remain SchedulingGated for up to ~90s after a scale rollover when the ungater requeued a slice that had already finished.
```