### PR TITLE
Apply maximum execution time changes to compatible workload slices

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1002,7 +1002,7 @@ func updateWorkloadSliceMaximumExecutionTime(ctx context.Context, c client.Clien
 			if workload.IsAdmitted(wl) || ptr.Equal(wl.Spec.MaximumExecutionTimeSeconds, desired) {
 				return false, nil
 			}
-			wl.Spec.MaximumExecutionTimeSeconds = ptr.To(*desired)
+			wl.Spec.MaximumExecutionTimeSeconds = new(*desired)
 			return true, nil
 		}, clientutil.WithRetryOnConflict()); err != nil {
 			return fmt.Errorf("updating maximum execution time of workload slice %s: %w", workload.Key(wl), err)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -946,10 +946,10 @@ func (m *IntegrationManager) FindAncestorJobManagedByKueue(ctx context.Context, 
 	}
 }
 
-// syncWorkloadSliceFields applies priority and maximumExecutionTimeSeconds to
-// the slices a compatible scale decision leaves live. Slice compatibility only
-// considers the pod set shape, so changes to these fields arrive here with the
-// old values still on the slices.
+// syncWorkloadSliceFields keeps priority and maximumExecutionTimeSeconds up to date
+// on the Workload slice(s) that EnsureWorkloadSlices decided to keep. Slice
+// compatibility only considers the pod set shape, so changes to these fields
+// arrive here with the old values still on the slices.
 //
 // While a scale-up waits for quota the quota-reserved slice is kept alongside its
 // pending replacement and only the replacement is returned, but both are
@@ -1079,6 +1079,8 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 		}
 
 		// Workload slice compatibility is limited to the PodSet shape and counts.
+		// Any other changes will result in the slice being marked as incompatible,
+		// and the workload will fall back to being processed by the original ensureOneWorkload function.
 		wl, compatible, err := workloadslicing.EnsureWorkloadSlices(ctx, r.client, r.clock, podSets, object, job.GVK())
 		if err != nil {
 			return nil, err

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -946,16 +946,16 @@ func (m *IntegrationManager) FindAncestorJobManagedByKueue(ctx context.Context, 
 	}
 }
 
-// syncWorkloadSlicePriority applies a priority-class label change to the slices
-// a compatible scale decision leaves live. Slice compatibility only considers
-// the pod set shape, so the label change arrives here with the old priority
-// still on the slice.
+// syncWorkloadSliceFields applies priority and maximumExecutionTimeSeconds to
+// the slices a compatible scale decision leaves live. Slice compatibility only
+// considers the pod set shape, so changes to these fields arrive here with the
+// old values still on the slices.
 //
-// While a scale-up waits for quota the admitted slice is kept alongside its
+// While a scale-up waits for quota the quota-reserved slice is kept alongside its
 // pending replacement and only the replacement is returned, but both are
-// ordered against other Workloads during preemption, so updating one alone
-// would split the Job's priority. wl is nil when a new slice is to be created.
-func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
+// live and must follow these fields where the Workload API allows it. wl is nil
+// when a new slice is to be created.
+func (r *JobReconciler) syncWorkloadSliceFields(ctx context.Context, job GenericJob, object client.Object, wl *kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	// Quota-reserved rather than admitted: FindLatestActiveWorkload selects on
@@ -966,14 +966,49 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 	}
 	live := []*kueue.Workload{wl}
 	if retained != nil && (wl == nil || retained.Name != wl.Name) {
-		log.V(4).Info("Workload slice priority applies to the replacement and to the quota-reserved slice it is waiting behind",
+		log.V(4).Info("Workload slice priority and maximum execution time apply to the replacement and to the quota-reserved slice it is waiting behind",
 			"replacement", klog.KObj(wl), "retained", klog.KObj(retained))
 		live = append(live, retained)
 	}
 	// The quota-reserved/no-priorityClassRef legality check lives in
 	// UpdateWorkloadPriority so the ordinary Job and LeaderWorkerSet paths, which
 	// reach the shared helper without this caller's filtering, get the same guard.
-	return UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...)
+	if err := UpdateWorkloadPriority(ctx, r.client, r.record, job.Object(), getCustomPriorityClassFuncFromJob(job), live...); err != nil {
+		return err
+	}
+	return updateWorkloadSliceMaximumExecutionTime(ctx, r.client, object, live...)
+}
+
+func updateWorkloadSliceMaximumExecutionTime(ctx context.Context, c client.Client, obj client.Object, wls ...*kueue.Workload) error {
+	desired := MaximumExecutionTimeSecondsForObject(obj)
+	// A missing label is not an instruction to clear a value that may have come
+	// from another source, such as a Workload default.
+	if desired == nil {
+		return nil
+	}
+
+	for _, wl := range wls {
+		if wl == nil {
+			continue
+		}
+
+		// WithRetryOnConflict only re-Gets after a 409; refresh first so IsAdmitted
+		// reflects current status before we decide whether the timeout is mutable.
+		if err := c.Get(ctx, client.ObjectKeyFromObject(wl), wl); err != nil {
+			return fmt.Errorf("getting workload slice %s before maximum execution time sync: %w", workload.Key(wl), err)
+		}
+
+		if err := clientutil.Patch(ctx, c, wl, func() (bool, error) {
+			if workload.IsAdmitted(wl) || ptr.Equal(wl.Spec.MaximumExecutionTimeSeconds, desired) {
+				return false, nil
+			}
+			wl.Spec.MaximumExecutionTimeSeconds = ptr.To(*desired)
+			return true, nil
+		}, clientutil.WithRetryOnConflict()); err != nil {
+			return fmt.Errorf("updating maximum execution time of workload slice %s: %w", workload.Key(wl), err)
+		}
+	}
+	return nil
 }
 
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
@@ -1043,15 +1078,13 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			}
 		}
 
-		// Workload slices allow modifications only to PodSet.Count.
-		// Any other changes will result in the slice being marked as incompatible,
-		// and the workload will fall back to being processed by the original ensureOneWorkload function.
+		// Workload slice compatibility is limited to the PodSet shape and counts.
 		wl, compatible, err := workloadslicing.EnsureWorkloadSlices(ctx, r.client, r.clock, podSets, object, job.GVK())
 		if err != nil {
 			return nil, err
 		}
 		if compatible {
-			if err := r.syncWorkloadSlicePriority(ctx, job, object, wl); err != nil {
+			if err := r.syncWorkloadSliceFields(ctx, job, object, wl); err != nil {
 				return nil, err
 			}
 			return wl, nil

--- a/pkg/controller/jobframework/workload_slice_test.go
+++ b/pkg/controller/jobframework/workload_slice_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	controllerconsts "sigs.k8s.io/kueue/pkg/controller/constants"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	testingjob "sigs.k8s.io/kueue/pkg/util/testingjobs/job"
+)
+
+func TestUpdateWorkloadSliceMaximumExecutionTime(t *testing.T) {
+	quotaReserved := metav1.Condition{
+		Type:   kueue.WorkloadQuotaReserved,
+		Status: metav1.ConditionTrue,
+	}
+	notAdmitted := metav1.Condition{
+		Type:   kueue.WorkloadAdmitted,
+		Status: metav1.ConditionFalse,
+	}
+	admitted := metav1.Condition{
+		Type:   kueue.WorkloadAdmitted,
+		Status: metav1.ConditionTrue,
+	}
+
+	makeJob := func(maximumExecutionTime *int32) client.Object {
+		job := testingjob.MakeJob("job", "ns")
+		if maximumExecutionTime != nil {
+			job.Label(controllerconsts.MaxExecTimeSecondsLabel, strconv.FormatInt(int64(*maximumExecutionTime), 10))
+		}
+		return job.Obj()
+	}
+	makeWorkload := func(name string, maximumExecutionTime int32, conditions ...metav1.Condition) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, "ns").
+			MaximumExecutionTimeSeconds(maximumExecutionTime).
+			Conditions(conditions...).
+			Obj()
+	}
+	makeWorkloadWithoutTimeout := func(name string, conditions ...metav1.Condition) *kueue.Workload {
+		return utiltestingapi.MakeWorkload(name, "ns").
+			Conditions(conditions...).
+			Obj()
+	}
+
+	timeout5 := int32(5)
+	timeout10 := int32(10)
+	cases := map[string]struct {
+		job             client.Object
+		workloads       []*kueue.Workload
+		workloadsToSync []*kueue.Workload
+		wantWorkloads   []*kueue.Workload
+	}{
+		"adds an explicit timeout to a pending slice": {
+			job: makeJob(&timeout10),
+			workloads: []*kueue.Workload{
+				makeWorkloadWithoutTimeout("pending"),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("pending", timeout10),
+			},
+		},
+		"updates the timeout after quota reservation but before admission": {
+			job: makeJob(&timeout10),
+			workloads: []*kueue.Workload{
+				makeWorkload("reserved", timeout5, quotaReserved, notAdmitted),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("reserved", timeout10, quotaReserved, notAdmitted),
+			},
+		},
+		"refreshes stale admission status before updating the timeout": {
+			job: makeJob(&timeout10),
+			workloads: []*kueue.Workload{
+				makeWorkload("reserved", timeout5, quotaReserved, notAdmitted),
+			},
+			workloadsToSync: []*kueue.Workload{
+				makeWorkload("reserved", timeout5, quotaReserved, admitted),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("reserved", timeout10, quotaReserved, notAdmitted),
+			},
+		},
+		"refreshes stale admission status before keeping the admitted timeout": {
+			job: makeJob(&timeout10),
+			workloads: []*kueue.Workload{
+				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+			},
+			workloadsToSync: []*kueue.Workload{
+				makeWorkload("admitted", timeout5, quotaReserved, notAdmitted),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+			},
+		},
+		"keeps the timeout on an admitted slice": {
+			job: makeJob(&timeout10),
+			workloads: []*kueue.Workload{
+				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+			},
+		},
+		"keeps the timeout when the owner has no explicit value": {
+			job: makeJob(nil),
+			workloads: []*kueue.Workload{
+				makeWorkload("pending", timeout5),
+			},
+			wantWorkloads: []*kueue.Workload{
+				makeWorkload("pending", timeout5),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+
+			objects := make([]client.Object, len(tc.workloads))
+			for i := range tc.workloads {
+				objects[i] = tc.workloads[i]
+			}
+			k8sClient := utiltesting.NewClientBuilder().
+				WithObjects(objects...).
+				WithStatusSubresource(&kueue.Workload{}).
+				Build()
+
+			live := tc.workloadsToSync
+			if live == nil {
+				live = make([]*kueue.Workload, len(tc.workloads))
+				for i := range tc.workloads {
+					live[i] = &kueue.Workload{}
+					if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tc.workloads[i]), live[i]); err != nil {
+						t.Fatalf("getting workload before update: %v", err)
+					}
+				}
+			}
+
+			if err := updateWorkloadSliceMaximumExecutionTime(ctx, k8sClient, tc.job, live...); err != nil {
+				t.Fatalf("updateWorkloadSliceMaximumExecutionTime() error: %v", err)
+			}
+
+			compareOptions := cmp.Options{
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta"),
+				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
+			}
+			for i := range tc.wantWorkloads {
+				got := &kueue.Workload{}
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(tc.wantWorkloads[i]), got); err != nil {
+					t.Fatalf("getting workload after update: %v", err)
+				}
+				if diff := cmp.Diff(tc.wantWorkloads[i], got, compareOptions...); diff != "" {
+					t.Errorf("unexpected workload (-want/+got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/workload_slice_test.go
+++ b/pkg/controller/jobframework/workload_slice_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package jobframework
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,27 +46,6 @@ func TestUpdateWorkloadSliceMaximumExecutionTime(t *testing.T) {
 		Status: metav1.ConditionTrue,
 	}
 
-	makeJob := func(maximumExecutionTime *int32) client.Object {
-		job := testingjob.MakeJob("job", "ns")
-		if maximumExecutionTime != nil {
-			job.Label(controllerconsts.MaxExecTimeSecondsLabel, strconv.FormatInt(int64(*maximumExecutionTime), 10))
-		}
-		return job.Obj()
-	}
-	makeWorkload := func(name string, maximumExecutionTime int32, conditions ...metav1.Condition) *kueue.Workload {
-		return utiltestingapi.MakeWorkload(name, "ns").
-			MaximumExecutionTimeSeconds(maximumExecutionTime).
-			Conditions(conditions...).
-			Obj()
-	}
-	makeWorkloadWithoutTimeout := func(name string, conditions ...metav1.Condition) *kueue.Workload {
-		return utiltestingapi.MakeWorkload(name, "ns").
-			Conditions(conditions...).
-			Obj()
-	}
-
-	timeout5 := int32(5)
-	timeout10 := int32(10)
 	cases := map[string]struct {
 		job             client.Object
 		workloads       []*kueue.Workload
@@ -74,63 +53,114 @@ func TestUpdateWorkloadSliceMaximumExecutionTime(t *testing.T) {
 		wantWorkloads   []*kueue.Workload
 	}{
 		"adds an explicit timeout to a pending slice": {
-			job: makeJob(&timeout10),
+			job: testingjob.MakeJob("job", "ns").Label(controllerconsts.MaxExecTimeSecondsLabel, "10").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkloadWithoutTimeout("pending"),
+				utiltestingapi.MakeWorkload("pending", "ns").
+					Request(corev1.ResourceCPU, "1").
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("pending", timeout10),
+				utiltestingapi.MakeWorkload("pending", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(10).
+					Obj(),
 			},
 		},
 		"updates the timeout after quota reservation but before admission": {
-			job: makeJob(&timeout10),
+			job: testingjob.MakeJob("job", "ns").Label(controllerconsts.MaxExecTimeSecondsLabel, "10").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkload("reserved", timeout5, quotaReserved, notAdmitted),
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, notAdmitted).
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("reserved", timeout10, quotaReserved, notAdmitted),
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(10).
+					Conditions(quotaReserved, notAdmitted).
+					Obj(),
 			},
 		},
 		"refreshes stale admission status before updating the timeout": {
-			job: makeJob(&timeout10),
+			job: testingjob.MakeJob("job", "ns").Label(controllerconsts.MaxExecTimeSecondsLabel, "10").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkload("reserved", timeout5, quotaReserved, notAdmitted),
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, notAdmitted).
+					Obj(),
 			},
 			workloadsToSync: []*kueue.Workload{
-				makeWorkload("reserved", timeout5, quotaReserved, admitted),
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, admitted).
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("reserved", timeout10, quotaReserved, notAdmitted),
+				utiltestingapi.MakeWorkload("reserved", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(10).
+					Conditions(quotaReserved, notAdmitted).
+					Obj(),
 			},
 		},
 		"refreshes stale admission status before keeping the admitted timeout": {
-			job: makeJob(&timeout10),
+			job: testingjob.MakeJob("job", "ns").Label(controllerconsts.MaxExecTimeSecondsLabel, "10").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+				utiltestingapi.MakeWorkload("admitted", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, admitted).
+					Obj(),
 			},
 			workloadsToSync: []*kueue.Workload{
-				makeWorkload("admitted", timeout5, quotaReserved, notAdmitted),
+				utiltestingapi.MakeWorkload("admitted", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, notAdmitted).
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+				utiltestingapi.MakeWorkload("admitted", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, admitted).
+					Obj(),
 			},
 		},
 		"keeps the timeout on an admitted slice": {
-			job: makeJob(&timeout10),
+			job: testingjob.MakeJob("job", "ns").Label(controllerconsts.MaxExecTimeSecondsLabel, "10").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+				utiltestingapi.MakeWorkload("admitted", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, admitted).
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("admitted", timeout5, quotaReserved, admitted),
+				utiltestingapi.MakeWorkload("admitted", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Conditions(quotaReserved, admitted).
+					Obj(),
 			},
 		},
 		"keeps the timeout when the owner has no explicit value": {
-			job: makeJob(nil),
+			job: testingjob.MakeJob("job", "ns").Obj(),
 			workloads: []*kueue.Workload{
-				makeWorkload("pending", timeout5),
+				utiltestingapi.MakeWorkload("pending", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Obj(),
 			},
 			wantWorkloads: []*kueue.Workload{
-				makeWorkload("pending", timeout5),
+				utiltestingapi.MakeWorkload("pending", "ns").
+					Request(corev1.ResourceCPU, "1").
+					MaximumExecutionTimeSeconds(5).
+					Obj(),
 			},
 		},
 	}
@@ -164,7 +194,6 @@ func TestUpdateWorkloadSliceMaximumExecutionTime(t *testing.T) {
 			}
 
 			compareOptions := cmp.Options{
-				cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(kueue.Workload{}, "TypeMeta"),
 				cmpopts.IgnoreFields(metav1.ObjectMeta{}, "ResourceVersion"),
 			}

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -3288,8 +3288,9 @@ func TestReconciler(t *testing.T) {
 		},
 		// A scale-up waiting for quota keeps the admitted slice alongside its
 		// pending replacement, and normalizeActiveSlices returns only the
-		// replacement. Both are live, so both have to follow the label.
-		"the workload slice and its retained admitted slice both follow the label": {
+		// replacement. Both are live, but only the pending replacement can update
+		// its maximum execution time.
+		"the pending workload slice updates its timeout while the retained admitted slice keeps it": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
 				features.AssignQueueLabelsForPods:     true,
@@ -3299,6 +3300,7 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
@@ -3306,6 +3308,7 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
@@ -3315,17 +3318,20 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("admitted", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(5).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(baseWPCWrapper.Value).
 					WorkloadPriorityClassRef(baseWPCWrapper.Name).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					AdmittedAt(true, now).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
 					Obj(),
 				*utiltestingapi.MakeWorkload("replacement", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(5).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(baseWPCWrapper.Value).
@@ -3339,17 +3345,20 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("admitted", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(5).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(highWPCWrapper.Value).
 					WorkloadPriorityClassRef(highWPCWrapper.Name).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueueName)).Obj(), now).
+					AdmittedAt(true, now).
 					Labels(map[string]string{
 						controllerconsts.JobUIDLabel: "test-uid",
 					}).
 					Obj(),
 				*utiltestingapi.MakeWorkload("replacement", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(10).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(highWPCWrapper.Value).
@@ -3377,10 +3386,10 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
-		// Scaling up an admitted slice returns no slice at all, because a new one
-		// is about to be created. The admitted slice is still live and still has to
-		// follow the label.
-		"the admitted slice follows the label when a scale-up replaces it": {
+		// Scaling up a quota-reserved slice returns no slice at all, because a new
+		// one is about to be created. The retained slice is still live and can
+		// update its timeout until admission.
+		"the quota-reserved slice updates its timeout when a scale-up replaces it": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling:      false,
 				features.AssignQueueLabelsForPods:     true,
@@ -3390,6 +3399,7 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
@@ -3397,6 +3407,7 @@ func TestReconciler(t *testing.T) {
 				Clone().
 				Suspend(true).
 				SetAnnotation(constants.ElasticJobAnnotation, "true").
+				Label(controllerconsts.MaxExecTimeSecondsLabel, "10").
 				WorkloadPriorityClass(highWPCWrapper.Name).
 				UID("test-uid").
 				Obj(),
@@ -3406,6 +3417,7 @@ func TestReconciler(t *testing.T) {
 			workloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("admitted", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(5).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(baseWPCWrapper.Value).
@@ -3419,6 +3431,7 @@ func TestReconciler(t *testing.T) {
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("admitted", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(10).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 5).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(highWPCWrapper.Value).
@@ -3430,6 +3443,7 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 				*utiltestingapi.MakeWorkload("job-job-2e122", "ns").
 					Finalizers(kueue.ResourceInUseFinalizerName).
+					MaximumExecutionTimeSeconds(10).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localQueueName).
 					Priority(highWPCWrapper.Value).

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -5426,6 +5426,83 @@ var _ = ginkgo.Describe("Job with elastic jobs via workload-slices support", gin
 		})
 	})
 
+	ginkgo.It("Should update the timeout on a quota-reserved workload slice before admission", func() {
+		admissionCheck := utiltestingapi.MakeAdmissionCheck("slice-timeout-check").
+			ControllerName("example.com/slice-timeout-check").
+			Obj()
+		util.MustCreate(ctx, k8sClient, admissionCheck)
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(util.DeleteObject(ctx, k8sClient, admissionCheck)).To(gomega.Succeed())
+		})
+		util.SetAdmissionCheckActive(ctx, k8sClient, admissionCheck, metav1.ConditionTrue)
+
+		ginkgo.By("configuring an admission check that keeps the reserved slice from admission", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+				clusterQueue.Spec.AdmissionChecksStrategy = &kueue.AdmissionChecksStrategy{
+					AdmissionChecks: []kueue.AdmissionCheckStrategyRule{{
+						Name: kueue.AdmissionCheckReference(admissionCheck.Name),
+					}},
+				}
+				g.Expect(k8sClient.Update(ctx, clusterQueue)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), clusterQueue)).To(gomega.Succeed())
+				active := apimeta.FindStatusCondition(clusterQueue.Status.Conditions, kueue.ClusterQueueActive)
+				g.Expect(active).NotTo(gomega.BeNil())
+				g.Expect(active.Status).To(gomega.Equal(metav1.ConditionTrue))
+				g.Expect(active.ObservedGeneration).To(gomega.Equal(clusterQueue.Generation))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		job := testingjob.MakeJob("job-reserved-slice-timeout", ns.Name).
+			SetAnnotation(workloadslicing.EnabledAnnotationKey, workloadslicing.EnabledAnnotationValue).
+			Label(constants.MaxExecTimeSecondsLabel, "5").
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			Request(corev1.ResourceCPU, "1000m").
+			Parallelism(1).
+			Suspend(true).
+			Obj()
+		util.MustCreate(ctx, k8sClient, job)
+
+		var originalSlice *kueue.Workload
+		ginkgo.By("waiting for the admission check to hold the quota-reserved slice", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				workloads := &kueue.WorkloadList{}
+				g.Expect(k8sClient.List(ctx, workloads, client.InNamespace(ns.Name))).To(gomega.Succeed())
+				g.Expect(workloads.Items).To(gomega.HaveLen(1))
+				wl := &workloads.Items[0]
+				g.Expect(workload.HasQuotaReservation(wl)).To(gomega.BeTrue())
+				g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+				g.Expect(wl.Status.AdmissionChecks).To(gomega.HaveLen(1))
+				g.Expect(wl.Status.AdmissionChecks[0].Name).To(gomega.Equal(kueue.AdmissionCheckReference(admissionCheck.Name)))
+				g.Expect(wl.Status.AdmissionChecks[0].State).To(gomega.Equal(kueue.CheckStatePending))
+				g.Expect(wl.Spec.MaximumExecutionTimeSeconds).To(gomega.Equal(new(int32(5))))
+				originalSlice = wl.DeepCopy()
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("changing the explicit timeout while the slice remains unadmitted", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), job)).To(gomega.Succeed())
+				job.Labels[constants.MaxExecTimeSecondsLabel] = "10"
+				g.Expect(k8sClient.Update(ctx, job)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("keeping the same reservation while updating the timeout through the API server", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				wl := &kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(originalSlice), wl)).To(gomega.Succeed())
+				g.Expect(wl.UID).To(gomega.Equal(originalSlice.UID))
+				g.Expect(wl.Spec.PodSets[0].Count).To(gomega.Equal(originalSlice.Spec.PodSets[0].Count))
+				g.Expect(wl.Spec.MaximumExecutionTimeSeconds).To(gomega.Equal(new(int32(10))))
+				g.Expect(workload.HasQuotaReservation(wl)).To(gomega.BeTrue())
+				g.Expect(workload.IsAdmitted(wl)).To(gomega.BeFalse())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("Should leave an admitted workload slice alone when the new class does not exist", func() {
 		features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.ElasticJobsViaWorkloadSlices, true)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Compatible workload slices are matched by PodSet shape and count. Changing a Job's `maximumExecutionTimeSeconds` therefore takes the compatible early-return path and leaves the live Workload slice with its previous timeout.

This change synchronizes the Job's timeout to compatible live slices that are not admitted, including clearing the timeout when the Job label is removed. A retained `Admitted=True` slice keeps its existing timeout. Slice compatibility remains limited to PodSet shape and count, so timeout changes do not recreate Workloads.

#### Which issue(s) this PR fixes:

Part of #13836

#### Special notes for your reviewer:

The Workload API rejects timeout changes while a Workload remains Admitted=True, so a retained admitted slice keeps its existing timeout and the new value applies to non-admitted or replacement slices.

Tests cover adding, updating, and clearing timeouts across pending, quota-reserved but not admitted, admitted, replacement, scale-up, and stale-status cases. An integration test verifies both updating and clearing the timeout through the API server after quota reservation and before admission, while preserving the Workload UID and quota reservation.

AI tools were used to assist with implementation and review. The final diff was manually reviewed and validated.

#### Does this PR introduce a user-facing change?

```release-note
ElasticJobsViaWorkloadSlices: Fixed a bug where changes to or removal of the Job's maximum execution time label were not applied to compatible non-admitted Workload slices.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job maximum-execution-time changes now synchronize with applicable workload slices.
  * Removing a job timeout clears it from pending and reserved, unadmitted slices.
  * Admitted slices retain their established execution-time settings.
  * Priority and execution-time settings remain consistent during replacements and reconciliation.
  * Reserved and pending slices update in place without losing their reservation.

* **Tests**
  * Added coverage for timeout updates, clearing behavior, slice retention, scaling, and admission states.
  * Added integration coverage for removing a timeout while admission remains pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
