### PR TITLE
fix: emit Warning Event when WorkloadPriorityClass is not found

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1457,10 +1457,6 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 	}
 	err = r.prepareWorkload(ctx, job, newWl, wl.Spec.Active)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			r.record.Eventf(object, nil, corev1.EventTypeWarning, "PriorityClassNotFound", "PriorityClassNotFound",
-				"Could not find priority class: %v", err)
-		}
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
 	wl.Spec = newWl.Spec
@@ -1698,6 +1694,10 @@ func (r *JobReconciler) prepareWorkload(ctx context.Context, job GenericJob, wl 
 	}
 
 	if err := PrepareWorkloadPriority(ctx, r.client, job.Object(), wl, getCustomPriorityClassFuncFromJob(job)); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.record.Eventf(job.Object(), wl, corev1.EventTypeWarning, "PriorityClassNotFound", "PriorityClassNotFound",
+				"Could not find priority class: %v", err)
+		}
 		return err
 	}
 
@@ -1819,10 +1819,6 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 	err = r.prepareWorkload(ctx, job, wl, wl.Spec.Active)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			r.record.Eventf(object, nil, corev1.EventTypeWarning, "PriorityClassNotFound", "PriorityClassNotFound",
-				"Could not find priority class: %v", err)
-		}
 		return err
 	}
 	if err = r.client.Create(ctx, wl); err != nil {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1457,6 +1457,10 @@ func (r *JobReconciler) updateWorkloadToMatchJob(ctx context.Context, job Generi
 	}
 	err = r.prepareWorkload(ctx, job, newWl, wl.Spec.Active)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.record.Eventf(object, nil, corev1.EventTypeWarning, "PriorityClassNotFound", "PriorityClassNotFound",
+				"Could not find priority class: %v", err)
+		}
 		return nil, fmt.Errorf("can't construct workload for update: %w", err)
 	}
 	wl.Spec = newWl.Spec
@@ -1815,6 +1819,10 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	}
 	err = r.prepareWorkload(ctx, job, wl, wl.Spec.Active)
 	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.record.Eventf(object, nil, corev1.EventTypeWarning, "PriorityClassNotFound", "PriorityClassNotFound",
+				"Could not find priority class: %v", err)
+		}
 		return err
 	}
 	if err = r.client.Create(ctx, wl); err != nil {


### PR DESCRIPTION
## What this PR does

When a Job references a WorkloadPriorityClass that doesn't exist, the reconciler silently returns an error. Users have no visibility into what went wrong — the only way to diagnose the issue is by reading the kueue controller manager logs, which may require admin privileges.

This PR adds a Warning Event on the Job object when the priority class is not found, so users can diagnose the issue via `kubectl get events` in the Job's namespace.

## Changes

- In `handleJobWithNoWorkload`: emit a `PriorityClassNotFound` Warning Event before returning the error
- In `updateWorkloadToMatchJob`: same treatment for the update path

## Verification

- `go build ./pkg/controller/jobframework/...` — passes
- `go test ./pkg/controller/jobframework/... -count=1` — passes

Ref: #3439

```release-note
Emit a Warning Event on the Job object when the referenced WorkloadPriorityClass is not found.
```