### PR TITLE
Take the larger of the pod overhead a PodSet carries and its class defines

### DIFF
--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -47,6 +47,11 @@ func WithIgnoreTopologyRequest() ComparePodSetsOption {
 // TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
 // the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
 func comparePodTemplate(a, b *corev1.PodSpec, opts *ComparePodSetsOptions) bool {
+	// The class the Pods will actually run under, and so the overhead they will
+	// actually carry, whatever the Workload says it is.
+	if !equality.Semantic.DeepEqual(a.RuntimeClassName, b.RuntimeClassName) {
+		return false
+	}
 	if !opts.ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
 		return false
 	}

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -39,6 +39,23 @@ func TestComparePodSetSlices(t *testing.T) {
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps2", 10).SetMinimumCount(5).Obj()},
 			wantEquivalent: true,
 		},
+		// The class decides the overhead the Pods will actually carry, so a
+		// prebuilt Workload naming a cheaper one is not the Job it stands for.
+		"different runtime class": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RuntimeClass("kata").Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RuntimeClass("runc").Obj()},
+			wantEquivalent: false,
+		},
+		"runtime class on one side only": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RuntimeClass("kata").Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).Obj()},
+			wantEquivalent: false,
+		},
+		"same runtime class": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RuntimeClass("kata").Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RuntimeClass("kata").Obj()},
+			wantEquivalent: true,
+		},
 		"different min count": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(2).Obj()},

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -57,8 +57,10 @@ const (
 //
 // The larger of the two rather than the class outright, because a PodSet copied
 // off a Pod that was already admitted carries what that Pod actually got, and a
-// class is free to be edited afterwards: only its handler is immutable. Taking
-// the maximum can leave the charge too high for such a PodSet, never too low.
+// class is free to be edited afterwards: only its handler is immutable. The
+// maximum is of those two values and no others: a Pod created while the class
+// defined more than either of them goes on carrying that, and is charged the
+// smaller figure. That generation gap is #14317.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	var errs []error
 	for i := range wl.Spec.PodSets {

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -53,8 +53,9 @@ const (
 // handlePodOverhead raises what a PodSet carries to the overhead its RuntimeClass
 // defines, taking the larger of the two rather than the class outright: only a
 // class's handler is immutable, so a PodSet copied off an already-admitted Pod can
-// carry more than the class now defines. A Pod admitted under an older and larger
-// generation carries more than either, and is charged the smaller: #14317.
+// carry more than the class now defines. It reconciles the two values visible at
+// this adjustment and nothing else: a reservation already taken is not rebuilt
+// when the class is edited afterwards, which is #14317.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	var errs []error
 	for i := range wl.Spec.PodSets {

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -24,7 +24,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -51,26 +50,29 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// fromAdmittedPod reports whether the PodSets were copied off a Pod the apiserver
-// already admitted, carrying what the class said then rather than what it says now.
-// An owner that does not resolve is not believed.
-func fromAdmittedPod(ctx context.Context, cl client.Client, wl *kueue.Workload) bool {
-	ref := metav1.GetControllerOf(wl)
-	if ref == nil || ref.Kind != "Pod" || ref.APIVersion != "v1" {
-		return false
+// builtFromPods reports whether the PodSets were copied off Pods that already
+// exist. A single Pod owns its Workload as the controller, a group is owned by
+// every member, so any Pod among the owners means the templates describe Pods
+// the apiserver has already held to a class, not ones it has yet to see.
+func builtFromPods(wl *kueue.Workload) bool {
+	for _, ref := range wl.OwnerReferences {
+		if ref.Kind == "Pod" && ref.APIVersion == "v1" {
+			return true
+		}
 	}
-	var pod corev1.Pod
-	if err := cl.Get(ctx, types.NamespacedName{Namespace: wl.Namespace, Name: ref.Name}, &pod); err != nil {
-		return false
-	}
-	return pod.UID == ref.UID
+	return false
 }
 
 // handlePodOverhead charges the overhead the named RuntimeClass defines. The
 // apiserver holds a Pod to that value when it creates one; nothing holds a
 // Workload to it at all.
+//
+// Workloads built from Pods are left alone rather than verified. What those
+// PodSets hold is what their Pods were admitted with, which is not what the
+// class says once it has been edited, and reading it back from each Pod is a
+// larger change than this one.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
-	if fromAdmittedPod(ctx, cl, wl) {
+	if builtFromPods(wl) {
 		return nil
 	}
 	var errs []error

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -51,14 +51,9 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// handlePodOverhead charges the overhead the named RuntimeClass defines. A Pod
-// carrying any other value is refused by the apiserver, so the class is the only
-// answer worth charging; a Workload is not a Pod and reaches here unchecked.
-// fromAdmittedPod reports whether the PodSets were copied off Pods that have
-// already been through admission. Their overhead is what the class said then,
-// and the class is free to say something else now. An owner that does not
-// resolve is not taken at its word, so a claim of one cannot keep an overhead
-// no Pod ever carried.
+// fromAdmittedPod reports whether the PodSets were copied off a Pod the apiserver
+// already admitted, carrying what the class said then rather than what it says now.
+// An owner that does not resolve is not believed.
 func fromAdmittedPod(ctx context.Context, cl client.Client, wl *kueue.Workload) bool {
 	ref := metav1.GetControllerOf(wl)
 	if ref == nil || ref.Kind != "Pod" || ref.APIVersion != "v1" {
@@ -71,6 +66,9 @@ func fromAdmittedPod(ctx context.Context, cl client.Client, wl *kueue.Workload) 
 	return pod.UID == ref.UID
 }
 
+// handlePodOverhead charges the overhead the named RuntimeClass defines. The
+// apiserver holds a Pod to that value when it creates one; nothing holds a
+// Workload to it at all.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	if fromAdmittedPod(ctx, cl, wl) {
 		return nil

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -50,12 +50,16 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// handlePodOverhead raises what a PodSet carries to the overhead its RuntimeClass
-// defines, taking the larger of the two rather than the class outright: only a
-// class's handler is immutable, so a PodSet copied off an already-admitted Pod can
-// carry more than the class now defines. It reconciles the two values visible at
-// this adjustment and nothing else: a reservation already taken is not rebuilt
-// when the class is edited afterwards, which is #14317.
+// We do not verify Pod's RuntimeClass legality here as this will be performed in admission controller.
+// As a result, the pod's Overhead is not always correct. E.g. if we set a non-existent runtime class name to
+// `pod.Spec.RuntimeClassName` and we also set the `pod.Spec.Overhead`, in real world, the pod creation will be
+// rejected due to the mismatch with RuntimeClass. However, in the future we assume that they are correct.
+//
+// The larger of the two overheads wins rather than the class outright: only a class's
+// handler is immutable, so a PodSet copied off an already-admitted Pod can carry more
+// than the class defines now. Only the two values visible at this adjustment are
+// reconciled; a reservation already taken is not rebuilt when the class is edited
+// afterwards, which is #14317.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	var errs []error
 	for i := range wl.Spec.PodSets {

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -50,17 +50,11 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// handlePodOverhead raises what a PodSet carries to the overhead the RuntimeClass
-// it names defines. The apiserver holds a Pod to that value when it creates one;
-// nothing holds a Workload to it, so one can name a class defining 250m, carry 1m,
-// and be charged the 1m its Pods will never run with.
-//
-// The larger of the two rather than the class outright, because a PodSet copied
-// off a Pod that was already admitted carries what that Pod actually got, and a
-// class is free to be edited afterwards: only its handler is immutable. The
-// maximum is of those two values and no others: a Pod created while the class
-// defined more than either of them goes on carrying that, and is charged the
-// smaller figure. That generation gap is #14317.
+// handlePodOverhead raises what a PodSet carries to the overhead its RuntimeClass
+// defines, taking the larger of the two rather than the class outright: only a
+// class's handler is immutable, so a PodSet copied off an already-admitted Pod can
+// carry more than the class now defines. A Pod admitted under an older and larger
+// generation carries more than either, and is charged the smaller: #14317.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	var errs []error
 	for i := range wl.Spec.PodSets {

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -50,23 +50,25 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// We do not verify Pod's RuntimeClass legality here as this will be performed in admission controller.
-// As a result, the pod's Overhead is not always correct. E.g. if we set a non-existent runtime class name to
-// `pod.Spec.RuntimeClassName` and we also set the `pod.Spec.Overhead`, in real world, the pod creation will be
-// rejected due to the mismatch with RuntimeClass. However, in the future we assume that they are correct.
+// handlePodOverhead charges the overhead the named RuntimeClass defines. A Pod
+// carrying any other value is refused by the apiserver, so the class is the only
+// answer worth charging; a Workload is not a Pod and reaches here unchecked.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
 	var errs []error
 	for i := range wl.Spec.PodSets {
 		podSpec := &wl.Spec.PodSets[i].Template.Spec
-		if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0 {
-			var runtimeClass nodev1.RuntimeClass
-			if err := cl.Get(ctx, types.NamespacedName{Name: *podSpec.RuntimeClassName}, &runtimeClass); err != nil {
-				errs = append(errs, fmt.Errorf("in podSet %s: %w", wl.Spec.PodSets[i].Name, err))
-				continue
-			}
-			if runtimeClass.Overhead != nil {
-				podSpec.Overhead = runtimeClass.Overhead.PodFixed
-			}
+		if podSpec.RuntimeClassName == nil {
+			continue
+		}
+		var runtimeClass nodev1.RuntimeClass
+		if err := cl.Get(ctx, types.NamespacedName{Name: *podSpec.RuntimeClassName}, &runtimeClass); err != nil {
+			errs = append(errs, fmt.Errorf("in podSet %s: %w", wl.Spec.PodSets[i].Name, err))
+			continue
+		}
+		// A class defining none means a Pod may carry none either.
+		podSpec.Overhead = nil
+		if runtimeClass.Overhead != nil {
+			podSpec.Overhead = runtimeClass.Overhead.PodFixed
 		}
 	}
 	return errs

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -50,31 +50,16 @@ const (
 	ErrLimitRangeConstraintsUnsatisfiedResources = "resources didn't satisfy LimitRange constraints"
 )
 
-// builtFromPods reports whether the PodSets were copied off Pods that already
-// exist. A single Pod owns its Workload as the controller, a group is owned by
-// every member, so any Pod among the owners means the templates describe Pods
-// the apiserver has already held to a class, not ones it has yet to see.
-func builtFromPods(wl *kueue.Workload) bool {
-	for _, ref := range wl.OwnerReferences {
-		if ref.Kind == "Pod" && ref.APIVersion == "v1" {
-			return true
-		}
-	}
-	return false
-}
-
-// handlePodOverhead charges the overhead the named RuntimeClass defines. The
-// apiserver holds a Pod to that value when it creates one; nothing holds a
-// Workload to it at all.
+// handlePodOverhead raises what a PodSet carries to the overhead the RuntimeClass
+// it names defines. The apiserver holds a Pod to that value when it creates one;
+// nothing holds a Workload to it, so one can name a class defining 250m, carry 1m,
+// and be charged the 1m its Pods will never run with.
 //
-// Workloads built from Pods are left alone rather than verified. What those
-// PodSets hold is what their Pods were admitted with, which is not what the
-// class says once it has been edited, and reading it back from each Pod is a
-// larger change than this one.
+// The larger of the two rather than the class outright, because a PodSet copied
+// off a Pod that was already admitted carries what that Pod actually got, and a
+// class is free to be edited afterwards: only its handler is immutable. Taking
+// the maximum can leave the charge too high for such a PodSet, never too low.
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
-	if builtFromPods(wl) {
-		return nil
-	}
 	var errs []error
 	for i := range wl.Spec.PodSets {
 		podSpec := &wl.Spec.PodSets[i].Template.Spec
@@ -86,11 +71,10 @@ func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload
 			errs = append(errs, fmt.Errorf("in podSet %s: %w", wl.Spec.PodSets[i].Name, err))
 			continue
 		}
-		// A class defining none means a Pod may carry none either.
-		podSpec.Overhead = nil
-		if runtimeClass.Overhead != nil {
-			podSpec.Overhead = runtimeClass.Overhead.PodFixed
+		if runtimeClass.Overhead == nil {
+			continue
 		}
+		podSpec.Overhead = resource.MergeResourceListKeepMax(podSpec.Overhead, runtimeClass.Overhead.PodFixed)
 	}
 	return errs
 }

--- a/pkg/workload/resources.go
+++ b/pkg/workload/resources.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -53,7 +54,27 @@ const (
 // handlePodOverhead charges the overhead the named RuntimeClass defines. A Pod
 // carrying any other value is refused by the apiserver, so the class is the only
 // answer worth charging; a Workload is not a Pod and reaches here unchecked.
+// fromAdmittedPod reports whether the PodSets were copied off Pods that have
+// already been through admission. Their overhead is what the class said then,
+// and the class is free to say something else now. An owner that does not
+// resolve is not taken at its word, so a claim of one cannot keep an overhead
+// no Pod ever carried.
+func fromAdmittedPod(ctx context.Context, cl client.Client, wl *kueue.Workload) bool {
+	ref := metav1.GetControllerOf(wl)
+	if ref == nil || ref.Kind != "Pod" || ref.APIVersion != "v1" {
+		return false
+	}
+	var pod corev1.Pod
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: wl.Namespace, Name: ref.Name}, &pod); err != nil {
+		return false
+	}
+	return pod.UID == ref.UID
+}
+
 func handlePodOverhead(ctx context.Context, cl client.Client, wl *kueue.Workload) []error {
+	if fromAdmittedPod(ctx, cl, wl) {
+		return nil
+	}
 	var errs []error
 	for i := range wl.Spec.PodSets {
 		podSpec := &wl.Spec.PodSets[i].Template.Spec

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -98,8 +98,8 @@ func TestAdjustResources(t *testing.T) {
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 2),
-								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 2048),
+								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
 							}).
 						Obj(),
 					*utiltestingapi.MakePodSet("d", 1).
@@ -158,11 +158,6 @@ func TestAdjustResources(t *testing.T) {
 						Obj(),
 					*utiltestingapi.MakePodSet("c", 1).
 						RuntimeClass("runtime-a").
-						PodOverHead(
-							corev1.ResourceList{
-								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
-							}).
 						Obj(),
 					*utiltestingapi.MakePodSet("d", 1).
 						RuntimeClass("runtime-d").

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package workload
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -25,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -749,9 +751,9 @@ func TestValidateLimitRange(t *testing.T) {
 	}
 }
 
-func provWorkload(overhead string, ownerUID types.UID) *kueue.Workload {
+func provWorkload(class, overhead string, ownerUID types.UID) *kueue.Workload {
 	wl := utiltestingapi.MakeWorkload("w", "ns").
-		PodSets(*utiltestingapi.MakePodSet("a", 1).RuntimeClass("rc").Obj()).Obj()
+		PodSets(*utiltestingapi.MakePodSet("a", 1).RuntimeClass(class).Obj()).Obj()
 	wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(overhead)}
 	if ownerUID != "" {
 		wl.OwnerReferences = []metav1.OwnerReference{{
@@ -769,22 +771,33 @@ func TestProvenance(t *testing.T) {
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "real-uid"}}
 
 	cases := map[string]struct {
-		wl   *kueue.Workload
-		want string
+		wl      *kueue.Workload
+		want    string
+		wantErr bool
 	}{
 		// The class said 250m when this Pod was admitted, and the Pod still says so.
-		"a verified Pod keeps what it was admitted with": {wl: provWorkload("250m", "real-uid"), want: "250m"},
+		"a verified Pod keeps what it was admitted with": {wl: provWorkload("rc", "250m", "real-uid"), want: "250m"},
 		// Nothing backs the claim, so it is a template and the class answers.
-		"an owner nothing resolves to is not a Pod": {wl: provWorkload("250m", "made-up"), want: "1m"},
-		"no owner at all is a template":             {wl: provWorkload("250m", ""), want: "1m"},
+		"an owner nothing resolves to is not a Pod": {wl: provWorkload("rc", "250m", "made-up"), want: "1m"},
+		"no owner at all is a template":             {wl: provWorkload("rc", "250m", ""), want: "1m"},
+		// AdjustResources only logs these, so the caller that can act on one has to see it here.
+		"a class that does not resolve is reported and changes nothing": {
+			wl: provWorkload("gone", "250m", ""), want: "250m", wantErr: true,
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().
 				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc}}).
 				WithObjects(pod).Build()
-			for _, err := range handlePodOverhead(ctx, cl, tc.wl) {
-				t.Logf("  lookup: %v", err)
+			errs := handlePodOverhead(ctx, cl, tc.wl)
+			if gotErr := len(errs) > 0; gotErr != tc.wantErr {
+				t.Errorf("errors = %v, want error %t", errs, tc.wantErr)
+			}
+			for _, err := range errs {
+				if !apierrors.IsNotFound(err) || !strings.Contains(err.Error(), "podSet a") {
+					t.Errorf("error does not name the podSet and the missing class: %v", err)
+				}
 			}
 			got := tc.wl.Spec.PodSets[0].Template.Spec.Overhead[corev1.ResourceCPU]
 			if got.String() != tc.want {

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -96,12 +96,13 @@ func TestAdjustResources(t *testing.T) {
 						Obj(),
 					*utiltestingapi.MakePodSet("b", 1).
 						Obj(),
+					// Larger than the class defines, so it is what the Pods carry.
 					*utiltestingapi.MakePodSet("c", 1).
 						RuntimeClass("runtime-a").
 						PodOverHead(
 							corev1.ResourceList{
-								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
-								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
+								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 2),
+								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 2048),
 							}).
 						Obj(),
 					*utiltestingapi.MakePodSet("d", 1).
@@ -158,8 +159,14 @@ func TestAdjustResources(t *testing.T) {
 						Obj(),
 					*utiltestingapi.MakePodSet("b", 1).
 						Obj(),
+					// The class defines none, so there is nothing to raise this to.
 					*utiltestingapi.MakePodSet("c", 1).
 						RuntimeClass("runtime-a").
+						PodOverHead(
+							corev1.ResourceList{
+								corev1.ResourceCPU:    defaultResourceQuantity(corev1.ResourceCPU, 1),
+								corev1.ResourceMemory: defaultResourceQuantity(corev1.ResourceMemory, 1024),
+							}).
 						Obj(),
 					*utiltestingapi.MakePodSet("d", 1).
 						RuntimeClass("runtime-d").
@@ -748,70 +755,70 @@ func TestValidateLimitRange(t *testing.T) {
 	}
 }
 
-// owners describes what built the Workload: the controller Pod a single Pod
-// sets, the plain references a group's members each add, or a Job.
-type owners int
+// podOwners is what the pod controller adds to a group's Workload: a plain
+// reference per member, none of them the controller.
+var podOwners = []metav1.OwnerReference{
+	{APIVersion: "v1", Kind: "Pod", Name: "p0", UID: "pod-0"},
+	{APIVersion: "v1", Kind: "Pod", Name: "p1", UID: "pod-1"},
+}
 
-const (
-	noOwner owners = iota
-	singlePod
-	podGroup
-	job
-)
-
-func provWorkload(class, overhead string, built owners) *kueue.Workload {
+func overheadWorkload(class string, overhead corev1.ResourceList, owners []metav1.OwnerReference) *kueue.Workload {
 	wl := utiltestingapi.MakeWorkload("w", "ns").
 		PodSets(*utiltestingapi.MakePodSet("a", 1).RuntimeClass(class).Obj()).Obj()
-	wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(overhead)}
-	switch built {
-	case singlePod:
-		wl.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "v1", Kind: "Pod", Name: "p", UID: "pod-uid",
-			Controller: new(true), BlockOwnerDeletion: new(true),
-		}}
-	case podGroup:
-		// SetOwnerReference, which is what the pod controller uses for a group,
-		// leaves Controller unset.
-		wl.OwnerReferences = []metav1.OwnerReference{
-			{APIVersion: "v1", Kind: "Pod", Name: "p0", UID: "pod-0"},
-			{APIVersion: "v1", Kind: "Pod", Name: "p1", UID: "pod-1"},
-		}
-	case job:
-		wl.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "batch/v1", Kind: "Job", Name: "j", UID: "job-uid",
-			Controller: new(true), BlockOwnerDeletion: new(true),
-		}}
-	}
+	wl.Spec.PodSets[0].Template.Spec.Overhead = overhead
+	wl.OwnerReferences = owners
 	return wl
 }
 
-func TestProvenance(t *testing.T) {
+func TestHandlePodOverhead(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
-	rc := utiltesting.MakeRuntimeClass("rc", "h").
-		PodOverhead(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1m")}).RuntimeClass
+	cpu := func(s string) corev1.ResourceList {
+		return corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(s)}
+	}
+	rc := utiltesting.MakeRuntimeClass("rc", "h").PodOverhead(cpu("250m")).RuntimeClass
+	bare := utiltesting.MakeRuntimeClass("bare", "h").RuntimeClass
 
 	cases := map[string]struct {
 		wl      *kueue.Workload
-		want    string
+		want    corev1.ResourceList
 		wantErr bool
 	}{
-		// The class said 250m when these Pods were admitted, and they still carry it.
-		"a Pod keeps what it was admitted with": {wl: provWorkload("rc", "250m", singlePod), want: "250m"},
-		// A group's members own it without any of them being the controller, so
-		// looking only at the controller reference would rewrite the whole group.
-		"a Pod group keeps it too": {wl: provWorkload("rc", "250m", podGroup), want: "250m"},
-		// No Pod exists yet, so the class answers for the ones that will.
-		"a Job is a template":           {wl: provWorkload("rc", "250m", job), want: "1m"},
-		"no owner at all is a template": {wl: provWorkload("rc", "250m", noOwner), want: "1m"},
+		"a PodSet carrying less than its class is raised to it": {
+			wl: overheadWorkload("rc", cpu("1m"), nil), want: cpu("250m"),
+		},
+		"a PodSet carrying none is given the class overhead": {
+			wl: overheadWorkload("rc", nil, nil), want: cpu("250m"),
+		},
+		// A StatefulSet builds its Workload from the parent template, which never
+		// passed the admission that writes overhead, and the pod controller adds
+		// the created Pods as owners afterwards. Neither costs it the class value.
+		"owning Pods do not stop the class from applying": {
+			wl: overheadWorkload("rc", nil, podOwners), want: cpu("250m"),
+		},
+		// Only handler is immutable, so a class can be lowered after a Pod was
+		// admitted under it, and that Pod still carries the older, larger value.
+		"a PodSet carrying more than its class keeps what it has": {
+			wl: overheadWorkload("rc", cpu("500m"), podOwners), want: cpu("500m"),
+		},
+		"a key the class does not define survives": {
+			wl: overheadWorkload("rc", corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")}, nil),
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+		},
+		"a class defining no overhead leaves the PodSet alone": {
+			wl: overheadWorkload("bare", cpu("250m"), nil), want: cpu("250m"),
+		},
 		// AdjustResources only logs these, so the caller that can act on one has to see it here.
 		"a class that does not resolve is reported and changes nothing": {
-			wl: provWorkload("gone", "250m", noOwner), want: "250m", wantErr: true,
+			wl: overheadWorkload("gone", cpu("250m"), nil), want: cpu("250m"), wantErr: true,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().
-				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc}}).
+				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc, bare}}).
 				Build()
 			errs := handlePodOverhead(ctx, cl, tc.wl)
 			if gotErr := len(errs) > 0; gotErr != tc.wantErr {
@@ -822,9 +829,8 @@ func TestProvenance(t *testing.T) {
 					t.Errorf("error does not name the podSet and the missing class: %v", err)
 				}
 			}
-			got := tc.wl.Spec.PodSets[0].Template.Spec.Overhead[corev1.ResourceCPU]
-			if got.String() != tc.want {
-				t.Errorf("overhead = %s, want %s", got.String(), tc.want)
+			if diff := cmp.Diff(tc.want, tc.wl.Spec.PodSets[0].Template.Spec.Overhead); diff != "" {
+				t.Errorf("Unexpected overhead (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -777,6 +777,10 @@ func TestHandlePodOverhead(t *testing.T) {
 	}
 	rc := utiltesting.MakeRuntimeClass("rc", "h").PodOverhead(cpu("250m")).RuntimeClass
 	bare := utiltesting.MakeRuntimeClass("bare", "h").RuntimeClass
+	mixed := utiltesting.MakeRuntimeClass("mixed", "h").PodOverhead(corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("100m"),
+		corev1.ResourceMemory: resource.MustParse("2Gi"),
+	}).RuntimeClass
 
 	cases := map[string]struct {
 		wl      *kueue.Workload
@@ -807,6 +811,18 @@ func TestHandlePodOverhead(t *testing.T) {
 				corev1.ResourceMemory: resource.MustParse("1Gi"),
 			},
 		},
+		// Larger on a different side for each resource, so taking whichever list
+		// wins on one of them cannot pass this.
+		"each resource takes its own larger value": {
+			wl: overheadWorkload("mixed", corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			}, nil),
+			want: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		},
 		"a class defining no overhead leaves the PodSet alone": {
 			wl: overheadWorkload("bare", cpu("250m"), nil), want: cpu("250m"),
 		},
@@ -818,7 +834,7 @@ func TestHandlePodOverhead(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().
-				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc, bare}}).
+				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc, bare, mixed}}).
 				Build()
 			errs := handlePodOverhead(ctx, cl, tc.wl)
 			if gotErr := len(errs) > 0; gotErr != tc.wantErr {

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -19,6 +19,9 @@ package workload
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
@@ -741,6 +744,51 @@ func TestValidateLimitRange(t *testing.T) {
 			got := ValidateLimitRange(ctx, cliBuilder.Build(), &Info{Obj: tc.workload})
 			if diff := cmp.Diff(tc.wantError, got); len(diff) != 0 {
 				t.Errorf("Unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func provWorkload(overhead string, ownerUID types.UID) *kueue.Workload {
+	wl := utiltestingapi.MakeWorkload("w", "ns").
+		PodSets(*utiltestingapi.MakePodSet("a", 1).RuntimeClass("rc").Obj()).Obj()
+	wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(overhead)}
+	if ownerUID != "" {
+		wl.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "v1", Kind: "Pod", Name: "p", UID: ownerUID,
+			Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true),
+		}}
+	}
+	return wl
+}
+
+func TestProvenance(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	rc := utiltesting.MakeRuntimeClass("rc", "h").
+		PodOverhead(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1m")}).RuntimeClass
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "real-uid"}}
+
+	cases := map[string]struct {
+		wl   *kueue.Workload
+		want string
+	}{
+		// The class said 250m when this Pod was admitted, and the Pod still says so.
+		"a verified Pod keeps what it was admitted with": {wl: provWorkload("250m", "real-uid"), want: "250m"},
+		// Nothing backs the claim, so it is a template and the class answers.
+		"an owner nothing resolves to is not a Pod": {wl: provWorkload("250m", "made-up"), want: "1m"},
+		"no owner at all is a template":             {wl: provWorkload("250m", ""), want: "1m"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			cl := utiltesting.NewClientBuilder().
+				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc}}).
+				WithObjects(pod).Build()
+			for _, err := range handlePodOverhead(ctx, cl, tc.wl) {
+				t.Logf("  lookup: %v", err)
+			}
+			got := tc.wl.Spec.PodSets[0].Template.Spec.Overhead[corev1.ResourceCPU]
+			if got.String() != tc.want {
+				t.Errorf("overhead = %s, want %s", got.String(), tc.want)
 			}
 		})
 	}

--- a/pkg/workload/resources_test.go
+++ b/pkg/workload/resources_test.go
@@ -20,9 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
-
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	nodev1 "k8s.io/api/node/v1"
@@ -751,14 +748,38 @@ func TestValidateLimitRange(t *testing.T) {
 	}
 }
 
-func provWorkload(class, overhead string, ownerUID types.UID) *kueue.Workload {
+// owners describes what built the Workload: the controller Pod a single Pod
+// sets, the plain references a group's members each add, or a Job.
+type owners int
+
+const (
+	noOwner owners = iota
+	singlePod
+	podGroup
+	job
+)
+
+func provWorkload(class, overhead string, built owners) *kueue.Workload {
 	wl := utiltestingapi.MakeWorkload("w", "ns").
 		PodSets(*utiltestingapi.MakePodSet("a", 1).RuntimeClass(class).Obj()).Obj()
 	wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{corev1.ResourceCPU: resource.MustParse(overhead)}
-	if ownerUID != "" {
+	switch built {
+	case singlePod:
 		wl.OwnerReferences = []metav1.OwnerReference{{
-			APIVersion: "v1", Kind: "Pod", Name: "p", UID: ownerUID,
-			Controller: ptr.To(true), BlockOwnerDeletion: ptr.To(true),
+			APIVersion: "v1", Kind: "Pod", Name: "p", UID: "pod-uid",
+			Controller: new(true), BlockOwnerDeletion: new(true),
+		}}
+	case podGroup:
+		// SetOwnerReference, which is what the pod controller uses for a group,
+		// leaves Controller unset.
+		wl.OwnerReferences = []metav1.OwnerReference{
+			{APIVersion: "v1", Kind: "Pod", Name: "p0", UID: "pod-0"},
+			{APIVersion: "v1", Kind: "Pod", Name: "p1", UID: "pod-1"},
+		}
+	case job:
+		wl.OwnerReferences = []metav1.OwnerReference{{
+			APIVersion: "batch/v1", Kind: "Job", Name: "j", UID: "job-uid",
+			Controller: new(true), BlockOwnerDeletion: new(true),
 		}}
 	}
 	return wl
@@ -768,28 +789,30 @@ func TestProvenance(t *testing.T) {
 	ctx, _ := utiltesting.ContextWithLog(t)
 	rc := utiltesting.MakeRuntimeClass("rc", "h").
 		PodOverhead(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1m")}).RuntimeClass
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns", UID: "real-uid"}}
 
 	cases := map[string]struct {
 		wl      *kueue.Workload
 		want    string
 		wantErr bool
 	}{
-		// The class said 250m when this Pod was admitted, and the Pod still says so.
-		"a verified Pod keeps what it was admitted with": {wl: provWorkload("rc", "250m", "real-uid"), want: "250m"},
-		// Nothing backs the claim, so it is a template and the class answers.
-		"an owner nothing resolves to is not a Pod": {wl: provWorkload("rc", "250m", "made-up"), want: "1m"},
-		"no owner at all is a template":             {wl: provWorkload("rc", "250m", ""), want: "1m"},
+		// The class said 250m when these Pods were admitted, and they still carry it.
+		"a Pod keeps what it was admitted with": {wl: provWorkload("rc", "250m", singlePod), want: "250m"},
+		// A group's members own it without any of them being the controller, so
+		// looking only at the controller reference would rewrite the whole group.
+		"a Pod group keeps it too": {wl: provWorkload("rc", "250m", podGroup), want: "250m"},
+		// No Pod exists yet, so the class answers for the ones that will.
+		"a Job is a template":           {wl: provWorkload("rc", "250m", job), want: "1m"},
+		"no owner at all is a template": {wl: provWorkload("rc", "250m", noOwner), want: "1m"},
 		// AdjustResources only logs these, so the caller that can act on one has to see it here.
 		"a class that does not resolve is reported and changes nothing": {
-			wl: provWorkload("gone", "250m", ""), want: "250m", wantErr: true,
+			wl: provWorkload("gone", "250m", noOwner), want: "250m", wantErr: true,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			cl := utiltesting.NewClientBuilder().
 				WithLists(&nodev1.RuntimeClassList{Items: []nodev1.RuntimeClass{rc}}).
-				WithObjects(pod).Build()
+				Build()
 			errs := handlePodOverhead(ctx, cl, tc.wl)
 			if gotErr := len(errs) > 0; gotErr != tc.wantErr {
 				t.Errorf("errors = %v, want error %t", errs, tc.wantErr)

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -718,6 +718,44 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 				})
 			})
 		})
+
+		// The class the Job names decides what its Pods are charged, so a prebuilt
+		// Workload that does not name it describes something else. Ownership is
+		// still taken, which is what makes the Finished condition the thing to
+		// read: this block has no ClusterQueue, so the Job stays suspended either
+		// way and asserting that would prove nothing.
+		ginkgo.It("Should finish a prebuilt workload that does not name the job's RuntimeClass", func() {
+			container := corev1.Container{
+				Name:  "c",
+				Image: "pause",
+			}
+			testingjob.SetContainerDefaults(&container)
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Containers(*container.DeepCopy()).
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			job := testingjob.MakeJob("job", ns.Name).
+				Queue("main").
+				PrebuiltWorkloadLabel("wl").
+				Containers(*container.DeepCopy()).
+				Obj()
+			job.Spec.Template.Spec.RuntimeClassName = new("kata")
+			util.MustCreate(ctx, k8sClient, job)
+
+			ginkgo.By("Check the job adopts it and then finishes it as out of sync", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					createdWl := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+					util.MustHaveOwnerReference(g, createdWl.OwnerReferences, job, k8sClient.Scheme())
+					g.Expect(createdWl.Status.Conditions).Should(utiltesting.HaveConditionStatusTrue(kueue.WorkloadFinished))
+					finished := apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadFinished)
+					g.Expect(finished.Reason).Should(gomega.Equal(kueue.WorkloadFinishedReasonOutOfSync))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
 	})
 
 	ginkgo.When("WorkloadIdentifierAnnotations feature gate is enabled", func() {

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -580,41 +580,6 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
-		// The class decides the overhead the Pods carry, so a Workload naming a
-		// different one is not standing for this Job.
-		ginkgo.It("Should not adopt a prebuilt workload naming another runtime class", func() {
-			container := corev1.Container{Name: "c", Image: "pause"}
-			testingjob.SetContainerDefaults(&container)
-
-			job := testingjob.MakeJob("job", ns.Name).
-				Queue("main").
-				PrebuiltWorkloadLabel("wl").
-				Containers(*container.DeepCopy()).
-				Obj()
-			job.Spec.Template.Spec.RuntimeClassName = ptr.To("kata")
-			util.MustCreate(ctx, k8sClient, job)
-
-			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
-				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
-					Containers(*container.DeepCopy()).
-					RuntimeClass("runc").
-					Obj()).
-				Obj()
-			util.MustCreate(ctx, k8sClient, wl)
-
-			ginkgo.By("Checking the job never takes the workload and stays suspended", func() {
-				gomega.Consistently(func(g gomega.Gomega) {
-					createdWl := kueue.Workload{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
-					g.Expect(createdWl.OwnerReferences).To(gomega.BeEmpty())
-
-					createdJob := batchv1.Job{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
-					g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
-				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
-			})
-		})
-
 		ginkgo.It("Should reconcile job when the workload is created later", func() {
 			container := corev1.Container{
 				Name:  "c",

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -580,6 +580,41 @@ var _ = ginkgo.Describe("Job controller", ginkgo.Label("job:batch", "area:jobs")
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		// The class decides the overhead the Pods carry, so a Workload naming a
+		// different one is not standing for this Job.
+		ginkgo.It("Should not adopt a prebuilt workload naming another runtime class", func() {
+			container := corev1.Container{Name: "c", Image: "pause"}
+			testingjob.SetContainerDefaults(&container)
+
+			job := testingjob.MakeJob("job", ns.Name).
+				Queue("main").
+				PrebuiltWorkloadLabel("wl").
+				Containers(*container.DeepCopy()).
+				Obj()
+			job.Spec.Template.Spec.RuntimeClassName = ptr.To("kata")
+			util.MustCreate(ctx, k8sClient, job)
+
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+					Containers(*container.DeepCopy()).
+					RuntimeClass("runc").
+					Obj()).
+				Obj()
+			util.MustCreate(ctx, k8sClient, wl)
+
+			ginkgo.By("Checking the job never takes the workload and stays suspended", func() {
+				gomega.Consistently(func(g gomega.Gomega) {
+					createdWl := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+					g.Expect(createdWl.OwnerReferences).To(gomega.BeEmpty())
+
+					createdJob := batchv1.Job{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+					g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("Should reconcile job when the workload is created later", func() {
 			container := corev1.Container{
 				Name:  "c",

--- a/test/integration/singlecluster/scheduler/workload_controller_test.go
+++ b/test/integration/singlecluster/scheduler/workload_controller_test.go
@@ -208,6 +208,45 @@ var _ = ginkgo.Describe("Workload controller with scheduler", func() {
 			util.ExpectObjectToBeDeleted(ctx, k8sClient, onDemandFlavor, true)
 		})
 
+		// A Workload is not a Pod, so it can carry an overhead the apiserver would
+		// never let a Pod carry beside this class.
+		ginkgo.It("Should charge the RuntimeClass overhead over the one the Workload carries", func() {
+			ginkgo.By("Create a Workload claiming a smaller overhead than the class defines", func() {
+				wl = utiltestingapi.MakeWorkload("one", ns.Name).
+					Queue(kueue.LocalQueueName(localQueue.Name)).
+					Request(corev1.ResourceCPU, "1").
+					RuntimeClass("kata").
+					Obj()
+				wl.Spec.PodSets[0].Template.Spec.Overhead = corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("1m"),
+				}
+				util.MustCreate(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					read := kueue.Workload{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &read)).Should(gomega.Succeed())
+					g.Expect(workload.HasQuotaReservation(&read)).Should(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Check the class overhead was charged, not the 1m", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(clusterQueue), &updatedCQ)).To(gomega.Succeed())
+					g.Expect(updatedCQ.Status).Should(gomega.BeComparableTo(kueue.ClusterQueueStatus{
+						PendingWorkloads:   0,
+						ReservingWorkloads: 1,
+						FlavorsReservation: []kueue.FlavorUsage{{
+							Name: kueue.ResourceFlavorReference(onDemandFlavor.Name),
+							Resources: []kueue.ResourceUsage{{
+								Name:  corev1.ResourceCPU,
+								Total: resource.MustParse("2"),
+							}},
+						}},
+					}, ignoreCqCondition, ignoreInClusterQueueStatus))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+		})
+
 		ginkgo.It("Should accumulate RuntimeClass's overhead", func() {
 			ginkgo.By("Create and wait for workload admission", func() {
 				wl = utiltestingapi.MakeWorkload("one", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`handlePodOverhead` only read the RuntimeClass when the PodSet template carried no overhead of its own:

```go
if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0 {
```

On a Pod that is safe, because the apiserver will not let the two disagree. Measured against v1.36.3 with a server-side dry run, against a RuntimeClass defining `cpu: 250m`:

```
overhead, no runtimeClassName        rejected: Pod Overhead set without corresponding RuntimeClass defined Overhead
overhead, runtimeClass not found     rejected: RuntimeClass "nosuchclass" not found
overhead 250m, class 250m            accepted
overhead 1m,   class 250m            rejected: Pod's Overhead doesn't match RuntimeClass's defined Overhead
```

Only the matching shape survives, so at create time the two always agree. A Workload is not a Pod, and nothing runs that check on `podSets[].template.spec`. One written directly, or a prebuilt Workload for a Job, can name a class defining `250m` while carrying `1m`. Kueue charged the `1m`; the Pods the Job creates go through the admission controller and get `250m`.

The class cannot simply win, though. A PodSet copied off a Pod that already exists carries what the apiserver actually gave that Pod, and the class is free to be edited afterwards, since only `handler` is immutable and the admission that writes the overhead runs on create. Rewriting such a PodSet from the class as it stands now can lower the charge below what the Pod it will ungate carries.

So take the larger of the two. A template carrying less than its class, or none at all, is charged the class. A PodSet carrying more keeps what it has. Against those two values the result is never the smaller one, which is the direction that matters: a PodSet whose class was lowered after its Pods were admitted keeps the larger figure its Pods are actually running with.

That holds where the maximum is taken and no further. What a Workload finally reserves is this figure after exclusions, resource transformations and DRA processing, and those can move it either way. A transformation may write a negative output factor as a per-unit allowance, so raising an overhead can lower the total it generates: with `example.com/base: 10` generating one `cost` per unit and `cpu` generating minus one, an overhead raised from 1 to 2 takes the final `cost` from 9 to 8. That is the configured policy doing what it was asked, and it is why the claim stops at the adjustment rather than at the quota.

#### Which issue(s) this PR fixes:

Fixes #14274

#### Special notes for your reviewer:

An earlier revision of this decided per Workload whether its PodSets had been copied off Pods, by looking for a `core/v1` Pod among the owner references, and left those alone. That is wrong twice over and both are worth recording.

A StatefulSet builds its Workload from `sts.Spec.Template.Spec`, which never passes the admission that writes overhead, so it normally carries none. The pod controller then adds the created Pods as plain owner references through `SetOwnerReference` and updates the Workload. On that update the rule started reading the Workload as Pod-built and stopped resolving the class, so a StatefulSet whose Pods carry `250m` went back to being charged for none. That was a regression against `main`, which resolves the class for any PodSet carrying no overhead. LeaderWorkerSet has the same shape.

The second problem is that owner references are user-settable. A hand-written Workload could name any `core/v1` Pod, related or not, and turn the lookup off, which left the bug this PR is closing reproducible with one extra line of metadata.

Taking the maximum needs neither question answered, so the helper and the whole notion of provenance are gone.

One behaviour change worth flagging rather than leaving to be found: the class is now resolved for every PodSet that names one, where before it was resolved only for those carrying no overhead. `AdjustResources` logs what `handlePodOverhead` returns without acting on it, so nothing that used to be admitted stops being admitted. What does change is that a Workload naming a class Kueue cannot read, while carrying overhead of its own, now logs an error on each adjustment where it used to be silent. That reads to me as the right answer, since the class is what decides whether the carried value is the larger of the two, but it is a new line in the log for Workloads that were quiet before, and it is still only a line: the errors go nowhere else, which is #9030.

The second commit is the half that makes the first one hold. Raising to the class the *Workload* names is only the right charge if that is also the class the *Job* names, and `comparePodTemplate` did not compare `runtimeClassName` at all, so a prebuilt Workload could point at a cheaper class, or at none, and still be accepted as equivalent. A Workload naming no class has nothing to raise it to, so without this the same undercharge comes back through a prebuilt Workload.

`Overhead` deliberately stays out of that comparison. A Job template never passes through the RuntimeClass admission that writes it, so the class name is the field carrying the provenance and the overhead is derived from it.

#13995 changes the same loop, adding a `ChargeableOverhead` call that drops a negative or `pods` entry from every PodSet before anything reads it. It sits above the `runtimeClassName` check there and has to stay above the guard here: this version returns early for a PodSet naming no class, so resolving the conflict by folding that line into the body would quietly stop normalizing those. The two compose in that order, an entry that will not be charged is dropped and what is left is raised to the class.

A failed lookup still leaves the template alone rather than zeroing it. Zero is not the conservative reading of a class nobody could resolve, and the errors from here are still only logged; making that fail closed is #9030 and is not claimed here.

The prebuilt path now has a case above the helper table: a Job naming a class whose prebuilt Workload names none is adopted and then finished for reason `OutOfSync`. That is the shape that would otherwise be charged for neither, since a Workload naming no class has nothing to raise its overhead to. It sits beside the existing case that asserts the same adoption without the Finished condition, so both directions of the comparison are pinned. Dropping the `RuntimeClassName` line from `comparePodTemplate` turns it red.

Verified rather than assumed. Reverting the `len(overhead) == 0` condition, and separately swapping the maximum for a minimum, each fail the suite; the minimum kills exactly the two cases that fix a direction, plus the existing `TestAdjustResources` expectation for a PodSet carrying more than its class. A PodSet carrying nothing while owned by Pods is a case, since that is the StatefulSet shape the earlier revision broke. `-race` is clean on both packages.

The upgrade shape in the release note is why I opened #14395 rather than widening this PR. Reaching the state it describes needs an admitted Workload and a running Job that stop matching, and neither side can move once quota is reserved: `validateImmutablePodSets` freezes the whole PodSet, template included, and a Job's `spec.template` is immutable to the apiserver. Calling `ValidateWorkloadUpdate` with a changed `runtimeClassName` is allowed before reservation and rejected after. Changing the comparison is the one thing that can reach it, and `git log -S comparePodTemplate` finds no field added since `c03612ea9` moved it into the framework, so this is the first PR that would. The ordering itself is untouched here, this PR does not open `reconciler.go`, and fixing a shared jobframework state machine inside an accounting change seemed the wrong place for it. I would rather #14395 landed first, and I have held this for that; the release note is what operators need if it does not.

#13912 is the other change to this function, and the more dangerous of the two to resolve mechanically. Its branch still carries `if podSpec.RuntimeClassName != nil && len(podSpec.Overhead) == 0` as an unchanged line and still assigns `podSpec.Overhead = rc.Overhead.PodFixed`, so taking its side of the conflict reopens #14274. Whichever lands second has to keep the shape rather than the lines: normalise what cannot be charged, resolve the class whenever one is named, then take the per-resource maximum.

#### Does this PR introduce a user-facing change?

```release-note
RuntimeClass: Take the larger of a PodSet's own pod overhead and its class's.

ACTION REQUIRED
Two things to check before upgrading, and they reach different Workloads.

The overhead reaches Workloads that name a RuntimeClass and have not yet reserved quota, including prebuilt ones. Check their ClusterQueues have room for the overhead their class defines, since that is the figure they will now be charged.

The prebuilt class check reaches Workloads that already hold quota, and that is the part worth acting on. A prebuilt Workload naming a different class from its Job, or naming none while its Job names one, is equivalent to it under the current binary and is not under this one. Neither object has to change for that to flip. The first reconcile after the restart finishes such a Workload for reason `OutOfSync`, and if its Job is running, the quota goes back to the ClusterQueue while the Pods keep going. That ordering is #14395 and is older than this PR. Bring the two class names into agreement before upgrading, or drain those Jobs first.

Where a Workload names a RuntimeClass and that class can be read, Kueue now takes each overhead resource as the larger of what the PodSet carries and what the class defines, rather than only what the PodSet carries. A PodSet that carries less than its class, or none at all, is charged what the class defines; one that carries more keeps what it has, since it may have been copied from a Pod admitted before the class was edited. That applies to every Workload PodSet, however the Workload was adopted. Separately, a prebuilt Workload must name the same RuntimeClass as its Job to be accepted for it. That second check lives in the shared PodSet comparison, so adoption paths that do not run through it are unchanged by this PR rather than made stricter.

This can increase the quota a Workload needs, for any Workload whose embedded overhead was smaller than its RuntimeClass defines, and it stops a prebuilt Workload that omits the class its Job names from being accepted for that Job. Pod groups and elastic Workload Slices are matched by PodSet name and count alone, so that second check does not reach them; their template equivalence is #14374. The overhead of their PodSets is still raised. A Workload that already holds a quota reservation is not re-charged. Its requests are rebuilt from the usage recorded in `status.admission` rather than from `spec.podSets`, and a RuntimeClass update only revisits Workloads whose quota is not yet reserved, so the corrected figure applies the next time the request is built from the PodSets. #14317 tracks that gap.

The larger figure is what accounting starts from; configured exclusions and resource transformations still apply to it afterwards, so a transformation written with a negative output factor can carry the final total in the other direction.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I reviewed and tested every change myself.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pod comparisons now detect differences in runtime classes, including when only one pod specifies a runtime class.
  * Runtime class overhead is applied consistently when calculating workload resource usage.
  * Resource accounting preserves the larger overhead value and reports missing runtime class errors appropriately.
  * Prebuilt workloads with mismatched runtime classes are correctly marked out of sync.

* **Tests**
  * Added coverage for runtime class matching, overhead handling, quota accounting, and prebuilt workload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







