### PR TITLE
Automated cherry pick of #14275: Multiply integration test by RecomputeAssignmentUponPreemptionTargetsOverlap FG

### DIFF
--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -639,8 +639,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
 			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
-		},
-		)
+		})
 
 		ginkgo.It("Should preempt all necessary workloads in concurrent scheduling with the same priority (RecomputeAssignmentUponPreemptionTargetsOverlap=false)", func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RecomputeAssignmentUponPreemptionTargetsOverlap, false)
@@ -689,8 +688,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
 			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
-		},
-		)
+		})
 	})
 
 	ginkgo.Context("In a cohort with StrictFIFO", func() {

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -614,43 +614,44 @@ var _ = ginkgo.Describe("Preemption", func() {
 			}
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, betaWls...)
 
-				ginkgo.By("Creating preempting pods")
+					ginkgo.By("Creating preempting pods")
 
-				alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
-					Queue(kueue.LocalQueueName(alphaLQ.Name)).
-					Request(corev1.ResourceCPU, "2").
-					Obj()
-				util.MustCreate(ctx, k8sClient, alphaWl)
+					alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
+						Queue(kueue.LocalQueueName(alphaLQ.Name)).
+						Request(corev1.ResourceCPU, "2").
+						Obj()
+					util.MustCreate(ctx, k8sClient, alphaWl)
 
-				gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
-					Queue(kueue.LocalQueueName(gammaLQ.Name)).
-					Request(corev1.ResourceCPU, "2").
-					Obj()
-				util.MustCreate(ctx, k8sClient, gammaWl)
+					gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
+						Queue(kueue.LocalQueueName(gammaLQ.Name)).
+						Request(corev1.ResourceCPU, "2").
+						Obj()
+					util.MustCreate(ctx, k8sClient, gammaWl)
 
-				var evictedWorkloads []*kueue.Workload
+					var evictedWorkloads []*kueue.Workload
 
-				if !recomputeAssignment {
+					if !recomputeAssignment {
+						gomega.Eventually(func(g gomega.Gomega) {
+							evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+							g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
+						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+						ginkgo.By("Finishing eviction for first set of preempted workloads")
+						util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+						util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
+					}
+
 					gomega.Eventually(func(g gomega.Gomega) {
 						evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-						g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
+						g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
 					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-					ginkgo.By("Finishing eviction for first set of preempted workloads")
+					ginkgo.By("Finishing eviction for second set of preempted workloads")
 					util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-					util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
-				}
-
-				gomega.Eventually(func(g gomega.Gomega) {
-					evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-					g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
-				}, util.Timeout, util.Interval).Should(gomega.Succeed())
-
-				ginkgo.By("Finishing eviction for second set of preempted workloads")
-				util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
-				util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
-			})
+					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
+					util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
+				},
+			)
 		}
 	})
 

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -600,7 +600,7 @@ var _ = ginkgo.Describe("Preemption", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, gammaCQ.Name, gammaMidWl)
 		})
 
-		ginkgo.It("Should preempt all necessary workloads in concurrent scheduling with the same priority", func() {
+		ginkgo.It("Should preempt all necessary workloads in concurrent scheduling with the same priority (RecomputeAssignmentUponPreemptionTargetsOverlap=true)", func() {
 			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RecomputeAssignmentUponPreemptionTargetsOverlap, true)
 
 			var betaWls []*kueue.Workload

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -614,45 +614,83 @@ var _ = ginkgo.Describe("Preemption", func() {
 			}
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, betaWls...)
 
-					ginkgo.By("Creating preempting pods")
+			ginkgo.By("Creating preempting pods")
 
-					alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
-						Queue(kueue.LocalQueueName(alphaLQ.Name)).
-						Request(corev1.ResourceCPU, "2").
-						Obj()
-					util.MustCreate(ctx, k8sClient, alphaWl)
+			alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, alphaWl)
 
-					gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
-						Queue(kueue.LocalQueueName(gammaLQ.Name)).
-						Request(corev1.ResourceCPU, "2").
-						Obj()
-					util.MustCreate(ctx, k8sClient, gammaWl)
+			gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
+				Queue(kueue.LocalQueueName(gammaLQ.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, gammaWl)
 
-					var evictedWorkloads []*kueue.Workload
+			var evictedWorkloads []*kueue.Workload
 
-					if !recomputeAssignment {
-						gomega.Eventually(func(g gomega.Gomega) {
-							evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-							g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
-						}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+				g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-						ginkgo.By("Finishing eviction for first set of preempted workloads")
-						util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-						util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
-					}
+			ginkgo.By("Finishing eviction for second set of preempted workloads")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
+		},
+		)
 
-					gomega.Eventually(func(g gomega.Gomega) {
-						evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-						g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
-					}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		ginkgo.It("Should preempt all necessary workloads in concurrent scheduling with the same priority (RecomputeAssignmentUponPreemptionTargetsOverlap=false)", func() {
+			features.SetFeatureGateDuringTest(ginkgo.GinkgoTB(), features.RecomputeAssignmentUponPreemptionTargetsOverlap, false)
+			var betaWls []*kueue.Workload
+			for i := range 3 {
+				wl := utiltestingapi.MakeWorkload(fmt.Sprintf("beta-%d", i), ns.Name).
+					Queue(kueue.LocalQueueName(betaLQ.Name)).
+					Request(corev1.ResourceCPU, "2").
+					Obj()
+				util.MustCreate(ctx, k8sClient, wl)
+				betaWls = append(betaWls, wl)
+			}
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, betaWls...)
 
-					ginkgo.By("Finishing eviction for second set of preempted workloads")
-					util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-					util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
-					util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
-				},
-			)
-		}
+			ginkgo.By("Creating preempting pods")
+
+			alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
+				Queue(kueue.LocalQueueName(alphaLQ.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, alphaWl)
+
+			gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
+				Queue(kueue.LocalQueueName(gammaLQ.Name)).
+				Request(corev1.ResourceCPU, "2").
+				Obj()
+			util.MustCreate(ctx, k8sClient, gammaWl)
+
+			var evictedWorkloads []*kueue.Workload
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+				g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing eviction for first set of preempted workloads")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
+
+			gomega.Eventually(func(g gomega.Gomega) {
+				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+				g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Finishing eviction for second set of preempted workloads")
+			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
+			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
+		},
+		)
 	})
 
 	ginkgo.Context("In a cohort with StrictFIFO", func() {

--- a/test/integration/singlecluster/scheduler/preemption_test.go
+++ b/test/integration/singlecluster/scheduler/preemption_test.go
@@ -614,32 +614,44 @@ var _ = ginkgo.Describe("Preemption", func() {
 			}
 			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, betaWls...)
 
-			ginkgo.By("Creating preempting pods")
+				ginkgo.By("Creating preempting pods")
 
-			alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
-				Queue(kueue.LocalQueueName(alphaLQ.Name)).
-				Request(corev1.ResourceCPU, "2").
-				Obj()
-			util.MustCreate(ctx, k8sClient, alphaWl)
+				alphaWl := utiltestingapi.MakeWorkload("alpha", ns.Name).
+					Queue(kueue.LocalQueueName(alphaLQ.Name)).
+					Request(corev1.ResourceCPU, "2").
+					Obj()
+				util.MustCreate(ctx, k8sClient, alphaWl)
 
-			gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
-				Queue(kueue.LocalQueueName(gammaLQ.Name)).
-				Request(corev1.ResourceCPU, "2").
-				Obj()
-			util.MustCreate(ctx, k8sClient, gammaWl)
+				gammaWl := utiltestingapi.MakeWorkload("gamma", ns.Name).
+					Queue(kueue.LocalQueueName(gammaLQ.Name)).
+					Request(corev1.ResourceCPU, "2").
+					Obj()
+				util.MustCreate(ctx, k8sClient, gammaWl)
 
-			var evictedWorkloads []*kueue.Workload
+				var evictedWorkloads []*kueue.Workload
 
-			gomega.Eventually(func(g gomega.Gomega) {
-				evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
-				g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
-			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				if !recomputeAssignment {
+					gomega.Eventually(func(g gomega.Gomega) {
+						evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+						g.Expect(evictedWorkloads).Should(gomega.HaveLen(1), "Number of evicted workloads")
+					}, util.Timeout, util.Interval).Should(gomega.Succeed())
 
-			ginkgo.By("Finishing eviction for second set of preempted workloads")
-			util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
-			util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
-			util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
-		})
+					ginkgo.By("Finishing eviction for first set of preempted workloads")
+					util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+					util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, alphaWl, gammaWl)
+				}
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					evictedWorkloads = util.FilterEvictedWorkloads(ctx, k8sClient, betaWls...)
+					g.Expect(evictedWorkloads).Should(gomega.HaveLen(2), "Number of evicted workloads")
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				ginkgo.By("Finishing eviction for second set of preempted workloads")
+				util.FinishEvictionForWorkloads(ctx, k8sClient, evictedWorkloads...)
+				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, alphaWl, gammaWl)
+				util.ExpectWorkloadsToBeAdmittedCount(ctx, k8sClient, 1, betaWls...)
+			})
+		}
 	})
 
 	ginkgo.Context("In a cohort with StrictFIFO", func() {


### PR DESCRIPTION
Cherry pick of #14275 on release-0.18.

#14275: Multiply integration test by RecomputeAssignmentUponPreemptionTargetsOverlap FG

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```