### PR TITLE
TAS: respect domain boundaries during node replacement

### DIFF
--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -8466,6 +8466,43 @@ func TestFindTopologyAssignmentsMultiLayerReplacement(t *testing.T) {
 		wantAssignment         *tas.TopologyAssignment
 		wantReason             string
 	}{
+		"replacement does not cross a string-prefix sibling domain": {
+			// rack-a and rack-ab are siblings. Once x1 becomes unhealthy, x2
+			// keeps the replacement constrained to rack-a. Since x2 has no
+			// spare capacity, x3 in rack-ab must not be used as the replacement.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("b1-rack-a-x1").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "rack-a").Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					NotReady().Obj(),
+				*testingnode.MakeNode("b1-rack-a-x2").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "rack-a").Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+				*testingnode.MakeNode("b1-rack-ab-x3").
+					Label(tasBlockLabel, "b1").Label(tasRackLabel, "rack-ab").Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourcePods: resource.MustParse("10")}).
+					Ready().Obj(),
+			},
+			existingTA: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x1"}}).
+				Domain(tas.TopologyDomainAssignment{Count: 1, Values: []string{"x2"}}).
+				Obj(),
+			admissionCount: 2,
+			unhealthyNode:  "x1",
+			topologyRequest: &kueue.PodSetTopologyRequest{
+				Required: new(tasRackLabel),
+			},
+			count: 2,
+			priorFlavorUsage: []workload.TopologyDomainRequests{
+				{
+					Values:            []string{"x2"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				},
+			},
+			wantReason: `topology "default" doesn't allow to fit any of 1 pod(s). Total nodes: 2; excluded: resource "cpu": 1, topologyDomain: 1`,
+		},
 		"replace unhealthy node in incomplete rack slice": {
 			//       b1
 			//   /        \

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1896,8 +1896,7 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 		return true
 	}
 	// Uses levelValues instead of leaf.id since for topologies with hostname as lowest level it points directly to the hostname
-	// TODO(#5322): Use util function that compare two DomainIDs
-	return strings.HasPrefix(string(utiltas.DomainID(leaf.levelValues)), string(requiredReplacementDomain))
+	return utiltas.HasPrefix(utiltas.DomainID(leaf.levelValues), requiredReplacementDomain)
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -1861,9 +1861,9 @@ func (s *TASFlavorSnapshot) remainingCapacityForLeaf(leaf *leafDomain, simulateE
 }
 
 func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topologyAssignmentPodRequirements, state *findTopologyAssignmentState, cachingRemainingResourcesEnabled bool) {
-	// While correcting the topologyAssignment with a failed node
-	// check if the leaf belongs to the required domain
-	if !belongsToRequiredDomain(leaf, requirements.requiredReplacementDomain) {
+	// leaf.id contains only the hostname for hostname-level topologies, while
+	// levelValues retain the full domain path needed for this ancestry check.
+	if !utiltas.DomainID(leaf.levelValues).BelongsTo(requirements.requiredReplacementDomain) {
 		state.stats.TopologyDomain++
 		return
 	}
@@ -1889,14 +1889,6 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 	}
 
 	leafDomainState.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
-}
-
-func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {
-	if requiredReplacementDomain == "" {
-		return true
-	}
-	// Uses levelValues instead of leaf.id since for topologies with hostname as lowest level it points directly to the hostname
-	return utiltas.HasPrefix(utiltas.DomainID(leaf.levelValues), requiredReplacementDomain)
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -26,8 +26,19 @@ import (
 
 type TopologyDomainID string
 
+const topologyDomainIDSeparator = ","
+
 func DomainID(levelValues []string) TopologyDomainID {
-	return TopologyDomainID(strings.Join(levelValues, ","))
+	return TopologyDomainID(strings.Join(levelValues, topologyDomainIDSeparator))
+}
+
+// HasPrefix reports whether prefix identifies the same topology domain as
+// domainID or one of its ancestors.
+func HasPrefix(domainID, prefix TopologyDomainID) bool {
+	if prefix == "" {
+		return true
+	}
+	return domainID == prefix || strings.HasPrefix(string(domainID), string(prefix)+topologyDomainIDSeparator)
 }
 
 // NodeNameFromDomainID returns the node name identified by the domain ID. It

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -32,13 +32,13 @@ func DomainID(levelValues []string) TopologyDomainID {
 	return TopologyDomainID(strings.Join(levelValues, topologyDomainIDSeparator))
 }
 
-// HasPrefix reports whether prefix identifies the same topology domain as
-// domainID or one of its ancestors.
-func HasPrefix(domainID, prefix TopologyDomainID) bool {
-	if prefix == "" {
+// BelongsTo reports whether d identifies targetDomain itself or one of its
+// descendants.
+func (d TopologyDomainID) BelongsTo(targetDomain TopologyDomainID) bool {
+	if targetDomain == "" {
 		return true
 	}
-	return domainID == prefix || strings.HasPrefix(string(domainID), string(prefix)+topologyDomainIDSeparator)
+	return d == targetDomain || strings.HasPrefix(string(d), string(targetDomain)+topologyDomainIDSeparator)
 }
 
 // NodeNameFromDomainID returns the node name identified by the domain ID. It

--- a/pkg/util/tas/tas_test.go
+++ b/pkg/util/tas/tas_test.go
@@ -22,6 +22,51 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func TestHasPrefix(t *testing.T) {
+	cases := map[string]struct {
+		domainID TopologyDomainID
+		prefix   TopologyDomainID
+		want     bool
+	}{
+		"empty prefix": {
+			domainID: DomainID([]string{"b1", "rack-a", "x1"}),
+			want:     true,
+		},
+		"same domain": {
+			domainID: DomainID([]string{"b1", "rack-a"}),
+			prefix:   DomainID([]string{"b1", "rack-a"}),
+			want:     true,
+		},
+		"ancestor domain": {
+			domainID: DomainID([]string{"b1", "rack-a", "x1"}),
+			prefix:   DomainID([]string{"b1", "rack-a"}),
+			want:     true,
+		},
+		"string-prefix sibling domain": {
+			domainID: DomainID([]string{"b1", "rack-ab", "x1"}),
+			prefix:   DomainID([]string{"b1", "rack-a"}),
+			want:     false,
+		},
+		"different root domain": {
+			domainID: DomainID([]string{"b2", "rack-a", "x1"}),
+			prefix:   DomainID([]string{"b1"}),
+			want:     false,
+		},
+		"descendant is not a prefix": {
+			domainID: DomainID([]string{"b1", "rack-a"}),
+			prefix:   DomainID([]string{"b1", "rack-a", "x1"}),
+			want:     false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := HasPrefix(tc.domainID, tc.prefix); got != tc.want {
+				t.Errorf("HasPrefix(%q, %q) = %t, want %t", tc.domainID, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestNodeNameFromDomainID(t *testing.T) {
 	cases := map[string]struct {
 		levels       []string

--- a/pkg/util/tas/tas_test.go
+++ b/pkg/util/tas/tas_test.go
@@ -22,7 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestTopologyDomainIDBelongsTo(t *testing.T) {
+func TestBelongsTo(t *testing.T) {
 	cases := map[string]struct {
 		domainID     TopologyDomainID
 		targetDomain TopologyDomainID

--- a/pkg/util/tas/tas_test.go
+++ b/pkg/util/tas/tas_test.go
@@ -22,46 +22,46 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestHasPrefix(t *testing.T) {
+func TestTopologyDomainIDBelongsTo(t *testing.T) {
 	cases := map[string]struct {
-		domainID TopologyDomainID
-		prefix   TopologyDomainID
-		want     bool
+		domainID     TopologyDomainID
+		targetDomain TopologyDomainID
+		want         bool
 	}{
-		"empty prefix": {
+		"empty target domain": {
 			domainID: DomainID([]string{"b1", "rack-a", "x1"}),
 			want:     true,
 		},
 		"same domain": {
-			domainID: DomainID([]string{"b1", "rack-a"}),
-			prefix:   DomainID([]string{"b1", "rack-a"}),
-			want:     true,
+			domainID:     DomainID([]string{"b1", "rack-a"}),
+			targetDomain: DomainID([]string{"b1", "rack-a"}),
+			want:         true,
 		},
 		"ancestor domain": {
-			domainID: DomainID([]string{"b1", "rack-a", "x1"}),
-			prefix:   DomainID([]string{"b1", "rack-a"}),
-			want:     true,
+			domainID:     DomainID([]string{"b1", "rack-a", "x1"}),
+			targetDomain: DomainID([]string{"b1", "rack-a"}),
+			want:         true,
 		},
 		"string-prefix sibling domain": {
-			domainID: DomainID([]string{"b1", "rack-ab", "x1"}),
-			prefix:   DomainID([]string{"b1", "rack-a"}),
-			want:     false,
+			domainID:     DomainID([]string{"b1", "rack-ab", "x1"}),
+			targetDomain: DomainID([]string{"b1", "rack-a"}),
+			want:         false,
 		},
 		"different root domain": {
-			domainID: DomainID([]string{"b2", "rack-a", "x1"}),
-			prefix:   DomainID([]string{"b1"}),
-			want:     false,
+			domainID:     DomainID([]string{"b2", "rack-a", "x1"}),
+			targetDomain: DomainID([]string{"b1"}),
+			want:         false,
 		},
-		"descendant is not a prefix": {
-			domainID: DomainID([]string{"b1", "rack-a"}),
-			prefix:   DomainID([]string{"b1", "rack-a", "x1"}),
-			want:     false,
+		"target descendant": {
+			domainID:     DomainID([]string{"b1", "rack-a"}),
+			targetDomain: DomainID([]string{"b1", "rack-a", "x1"}),
+			want:         false,
 		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := HasPrefix(tc.domainID, tc.prefix); got != tc.want {
-				t.Errorf("HasPrefix(%q, %q) = %t, want %t", tc.domainID, tc.prefix, got, tc.want)
+			if got := tc.domainID.BelongsTo(tc.targetDomain); got != tc.want {
+				t.Errorf("%q.BelongsTo(%q) = %t, want %t", tc.domainID, tc.targetDomain, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

During TAS node replacement, `belongsToRequiredDomain` compared the comma-separated representations of `TopologyDomainID` values with a raw string-prefix check. As a result, a required domain such as `b1,rack-a` also matched a sibling leaf such as `b1,rack-ab,x3`.

If the required rack had no replacement capacity, this could move the replacement Pod into the sibling rack and violate the required topology constraint.

This change adds a component-boundary-aware `HasPrefix` helper for `TopologyDomainID` and uses it for replacement-domain filtering. It includes unit coverage for the domain comparison and a replacement-assignment regression test for the `rack-a` / `rack-ab` case.

#### Which issue(s) this PR fixes:

Part of #5322

#### Special notes for your reviewer:

The scope is limited to making the existing domain comparison safe. It does not change the hostname leaf-domain ID representation discussed in #5322.

The replacement regression test fails without the fix because the assignment incorrectly includes the node in `rack-ab`; with the fix, replacement correctly reports that no node in `rack-a` has capacity.

Tests run:

```text
go test ./pkg/util/tas ./pkg/cache/scheduler
go test -race ./pkg/util/tas ./pkg/cache/scheduler
```

AI disclosure: I used an AI coding assistant to help trace the affected code path, develop the reproduction, and draft the change. I reviewed the implementation and verified the behavior and tests locally.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where node replacement treated sibling topology domains with a common string prefix as the same domain.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected topology-based node replacement to remain within the required rack or domain.
  * Prevented similarly prefixed sibling domains from being treated as valid matches.
  * Replacement now correctly fails when the eligible rack has no remaining capacity.

* **Tests**
  * Added coverage for nested domains, sibling names, empty domains, ancestors, descendants, and unrelated domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->