### PR TITLE
Deactivate Workload when an admission check is rejected during eviction

### DIFF
--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -614,10 +614,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			updated = true
 			evicted = true
 		}
-// If the Workload is already evicted, the branch below calls `clientutil.PatchStatus`
-// instead of Evict(), which is the only place that clears DeactivationTarget. 
-// Left in place, that condition would still be true the next time this Workload is
-// activated, causing it to be deactivated again immediately.
+		// If the Workload is already evicted, the branch below calls `clientutil.PatchStatus`
+		// instead of Evict(), which is the only place that clears DeactivationTarget.
+		// Left in place, that condition would still be true the next time this Workload is
+		// activated, causing it to be deactivated again immediately.
 		if dtCond != nil || wl.Status.RequeueState != nil {
 			updated = true
 		}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -852,7 +852,10 @@ func isDisabledRequeuedByReason(w *kueue.Workload, reason string) bool {
 // reconcileMaxExecutionTime deactivates the workload if its MaximumExecutionTimeSeconds is exceeded or returns a retry after value.
 func (r *WorkloadReconciler) reconcileMaxExecutionTime(ctx context.Context, wl *kueue.Workload) (time.Duration, error) {
 	admittedCondition := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadAdmitted)
-	if admittedCondition == nil || admittedCondition.Status != metav1.ConditionTrue || wl.Spec.MaximumExecutionTimeSeconds == nil {
+	// A deactivated Workload keeps its Admitted condition until the Job controller releases the
+	// quota reservation, so without the IsActive check this would re-target it — and re-emit the
+	// warning — on every reconcile once the deactivation cleared the DeactivationTarget.
+	if !workload.IsActive(wl) || admittedCondition == nil || admittedCondition.Status != metav1.ConditionTrue || wl.Spec.MaximumExecutionTimeSeconds == nil {
 		return 0, nil
 	}
 

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -624,12 +624,13 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		prepare := func(wl *kueue.Workload) {
 			if dtCond != nil {
 				apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
-			}
-			if !evicted {
-				// Evict resets the checks on the transition path; an already-evicted Workload
-				// never reaches it, so a Rejected check would survive and re-deactivate the
-				// Workload as soon as it is reactivated.
-				workloadevict.ResetChecksOnEviction(wl, r.clock.Now())
+				// Consuming a DeactivationTarget on an already-evicted Workload (evicted is
+				// false) skips Evict(), the only other caller of ResetChecksOnEviction. Without
+				// this the checks keep whatever state they had, and a Rejected one would
+				// re-deactivate the Workload as soon as it is reactivated.
+				if !evicted {
+					workloadevict.ResetChecksOnEviction(wl, r.clock.Now())
+				}
 			}
 			if wl.Status.RequeueState != nil {
 				// Clear RequeueState using Merge Patch instead of SSA.

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -907,11 +907,13 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 		// Parent Workloads are not supposed to have admission checks.
 		return false, nil
 	}
-	if workloadevict.IsEvicted(wl) || (!workload.HasRetryChecks(wl) && !workload.HasRejectedChecks(wl)) {
+	if !workload.HasRetryChecks(wl) && !workload.HasRejectedChecks(wl) {
 		return false, nil
 	}
 	log := ctrl.LoggerFrom(ctx)
 	log.V(3).Info("Workload is evicted due to admission checks")
+	// Rejected is terminal, so it applies even mid-eviction: an external controller can set it
+	// after an earlier Retry already evicted the Workload and reset the checks to Pending.
 	if workload.HasRejectedChecks(wl) {
 		rejectedChecks := workload.RejectedChecks(wl)
 		message := buildAdmissionChecksMessage(rejectedChecks, kueue.CheckStateRejected)
@@ -926,6 +928,10 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 		return true, nil
 	}
 	// at this point we know a Workload has at least one Retry AdmissionCheck
+	// Retry evicts, so skip it while an eviction is already in flight.
+	if workloadevict.IsEvicted(wl) {
+		return false, nil
+	}
 	retryChecks := workload.RetryChecks(wl)
 	message := fmt.Sprintf("Evicted due to %s", buildAdmissionChecksMessage(retryChecks, kueue.CheckStateRetry))
 	exposeLqMetrics := r.cache.ShouldExposeLocalQueueMetricsForWorkload(log, wl)

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -614,12 +614,20 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			updated = true
 			evicted = true
 		}
-		if wl.Status.RequeueState != nil {
+		// An already-evicted Workload skips the Evict() call above, so its DeactivationTarget
+		// would never be cleaned up and would re-deactivate the Workload on re-activation.
+		if dtCond != nil || wl.Status.RequeueState != nil {
 			updated = true
 		}
 		prepare := func(wl *kueue.Workload) {
 			if dtCond != nil {
 				apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
+			}
+			if !evicted {
+				// Evict resets the checks on the transition path; an already-evicted Workload
+				// never reaches it, so a Rejected check would survive and re-deactivate the
+				// Workload as soon as it is reactivated.
+				workloadevict.ResetChecksOnEviction(wl, r.clock.Now())
 			}
 			if wl.Status.RequeueState != nil {
 				// Clear RequeueState using Merge Patch instead of SSA.
@@ -915,6 +923,11 @@ func (r *WorkloadReconciler) reconcileCheckBasedEviction(ctx context.Context, wl
 	// Rejected is terminal, so it applies even mid-eviction: an external controller can set it
 	// after an earlier Retry already evicted the Workload and reset the checks to Pending.
 	if workload.HasRejectedChecks(wl) {
+		// A deactivated Workload is already in its terminal state; re-targeting it would
+		// undo the DeactivationTarget cleanup and leave it permanently un-reactivatable.
+		if !workload.IsActive(wl) {
+			return false, nil
+		}
 		rejectedChecks := workload.RejectedChecks(wl)
 		message := buildAdmissionChecksMessage(rejectedChecks, kueue.CheckStateRejected)
 		err := workloadpatching.PatchAdmissionStatus(ctx, r.client, wl, r.clock, func(wl *kueue.Workload) (bool, error) {

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -614,8 +614,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			updated = true
 			evicted = true
 		}
-		// An already-evicted Workload skips the Evict() call above, so its DeactivationTarget
-		// would never be cleaned up and would re-deactivate the Workload on re-activation.
+// If the Workload is already evicted, the branch below calls `clientutil.PatchStatus`
+// instead of Evict(), which is the only place that clears DeactivationTarget. 
+// Left in place, that condition would still be true the next time this Workload is
+// activated, causing it to be deactivated again immediately.
 		if dtCond != nil || wl.Status.RequeueState != nil {
 			updated = true
 		}

--- a/pkg/controller/core/workload_controller.go
+++ b/pkg/controller/core/workload_controller.go
@@ -606,11 +606,11 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 		reason := kueue.WorkloadDeactivated
 		message := "The workload is deactivated"
 		dtCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
+		if dtCond != nil {
+			underlyingCause = kueue.EvictionUnderlyingCause(dtCond.Reason)
+			message = fmt.Sprintf("%s due to %s", message, dtCond.Message)
+		}
 		if !workloadevict.IsEvicted(&wl) {
-			if dtCond != nil {
-				underlyingCause = kueue.EvictionUnderlyingCause(dtCond.Reason)
-				message = fmt.Sprintf("%s due to %s", message, dtCond.Message)
-			}
 			updated = true
 			evicted = true
 		}
@@ -625,10 +625,13 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (r
 			if dtCond != nil {
 				apimeta.RemoveStatusCondition(&wl.Status.Conditions, kueue.WorkloadDeactivationTarget)
 				// Consuming a DeactivationTarget on an already-evicted Workload (evicted is
-				// false) skips Evict(), the only other caller of ResetChecksOnEviction. Without
-				// this the checks keep whatever state they had, and a Rejected one would
-				// re-deactivate the Workload as soon as it is reactivated.
+				// false) skips Evict(), so record the deactivation reason and reset the checks
+				// here. Otherwise the Evicted condition keeps the reason of the earlier
+				// eviction, and a Rejected check would re-deactivate the Workload as soon as it
+				// is reactivated.
 				if !evicted {
+					workloadevict.SetEvictedCondition(wl, r.clock.Now(),
+						workloadpatching.ReasonWithCause(reason, string(underlyingCause)), message)
 					workloadevict.ResetChecksOnEviction(wl, r.clock.Now())
 				}
 			}

--- a/pkg/controller/core/workload_controller_eviction_test.go
+++ b/pkg/controller/core/workload_controller_eviction_test.go
@@ -132,6 +132,95 @@ func TestReconcileEviction(t *testing.T) {
 				},
 			},
 		},
+		// The custom check is rejected after an earlier Retry evicted the Workload and reset both checks.
+		"already evicted workload with rejected checks gets deactivated": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				AdmittedAt(true, now).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				AdmissionChecks(
+					kueue.AdmissionCheckState{
+						Name:    "multikueue",
+						State:   kueue.CheckStatePending,
+						Message: "Reset to Pending after eviction. Previously: Retry",
+					},
+					kueue.AdmissionCheckState{
+						Name:  "custom-check",
+						State: kueue.CheckStateRejected,
+					},
+				).
+				Conditions(
+					metav1.Condition{
+						Type:    kueue.WorkloadQuotaReserved,
+						Status:  metav1.ConditionTrue,
+						Reason:  "AdmittedByTest",
+						Message: "Admitted by ClusterQueue q1",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadAdmitted,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ByTest",
+						Message: "Admitted by ClusterQueue q1",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadEvicted,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
+						Message: "Evicted due to AdmissionCheck in Retry state",
+					},
+				).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				AdmittedAt(true, now).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				AdmissionChecks(
+					kueue.AdmissionCheckState{
+						Name:    "multikueue",
+						State:   kueue.CheckStatePending,
+						Message: "Reset to Pending after eviction. Previously: Retry",
+					},
+					kueue.AdmissionCheckState{
+						Name:  "custom-check",
+						State: kueue.CheckStateRejected,
+					},
+				).
+				Conditions(
+					metav1.Condition{
+						Type:    kueue.WorkloadQuotaReserved,
+						Status:  metav1.ConditionTrue,
+						Reason:  "AdmittedByTest",
+						Message: "Admitted by ClusterQueue q1",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadAdmitted,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ByTest",
+						Message: "Admitted by ClusterQueue q1",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadEvicted,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
+						Message: "Evicted due to AdmissionCheck in Retry state",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadDeactivationTarget,
+						Status:  metav1.ConditionTrue,
+						Reason:  "AdmissionCheck",
+						Message: `AdmissionCheck in Rejected state: "custom-check"`,
+					},
+				).
+				Obj(),
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Namespace: "ns", Name: "wl"},
+					EventType: "Warning",
+					Reason:    "AdmissionCheckRejected",
+					Message:   `Deactivated due to AdmissionCheck in Rejected state: "custom-check"`,
+				},
+			},
+		},
 		"admitted workload with rejected checks gets deactivated, with message": {
 			workload: utiltestingapi.MakeWorkload("wl", "ns").
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).

--- a/pkg/controller/core/workload_controller_eviction_test.go
+++ b/pkg/controller/core/workload_controller_eviction_test.go
@@ -1182,8 +1182,8 @@ func TestReconcileEviction(t *testing.T) {
 					metav1.Condition{
 						Type:    kueue.WorkloadEvicted,
 						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
-						Message: "Evicted due to AdmissionCheck in Retry state",
+						Reason:  "DeactivatedDueToAdmissionCheck",
+						Message: `The workload is deactivated due to AdmissionCheck in Rejected state: "custom-check"`,
 					},
 				).
 				Obj(),

--- a/pkg/controller/core/workload_controller_eviction_test.go
+++ b/pkg/controller/core/workload_controller_eviction_test.go
@@ -1129,6 +1129,65 @@ func TestReconcileEviction(t *testing.T) {
 				}).
 				Obj(),
 		},
+		// Consuming a DeactivationTarget on an already-evicted Workload bypasses Evict, so the
+		// cleanup it performs has to happen on this path or the Rejected check survives.
+		"should reset the checks and clear the deactivation target when the Workload is already evicted": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				AdmittedAt(true, now).
+				AdmissionChecks(
+					kueue.AdmissionCheckState{
+						Name:    "multikueue",
+						State:   kueue.CheckStatePending,
+						Message: "Reset to Pending after eviction. Previously: Retry",
+					},
+					kueue.AdmissionCheckState{
+						Name:  "custom-check",
+						State: kueue.CheckStateRejected,
+					},
+				).
+				Conditions(
+					metav1.Condition{
+						Type:    kueue.WorkloadEvicted,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
+						Message: "Evicted due to AdmissionCheck in Retry state",
+					},
+					metav1.Condition{
+						Type:    kueue.WorkloadDeactivationTarget,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
+						Message: `AdmissionCheck in Rejected state: "custom-check"`,
+					},
+				).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				AdmittedAt(true, now).
+				AdmissionChecks(
+					kueue.AdmissionCheckState{
+						Name:    "multikueue",
+						State:   kueue.CheckStatePending,
+						Message: "Reset to Pending after eviction. Previously: Retry",
+					},
+					kueue.AdmissionCheckState{
+						Name:    "custom-check",
+						State:   kueue.CheckStatePending,
+						Message: "Reset to Pending after eviction. Previously: Rejected",
+					},
+				).
+				Conditions(
+					metav1.Condition{
+						Type:    kueue.WorkloadEvicted,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadEvictedByAdmissionCheck,
+						Message: "Evicted due to AdmissionCheck in Retry state",
+					},
+				).
+				Obj(),
+		},
 		"should set the Evicted condition with ClusterQueueStopped reason when the StopPolicy is HoldAndDrain": {
 			cq: utiltestingapi.MakeClusterQueue("cq").StopPolicy(kueue.HoldAndDrain).Obj(),
 			lq: utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj(),

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -885,6 +885,37 @@ func TestReconcile(t *testing.T) {
 				},
 			},
 		},
+		// The state a Workload reaches once a max-execution-time deactivation has been carried
+		// out: inactive, evicted, and with the DeactivationTarget already consumed. Re-targeting
+		// it here would re-emit the warning on every reconcile.
+		"should not re-target an already deactivated workload that exceeded the maximum execution time": {
+			workload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				MaximumExecutionTimeSeconds(60).
+				AdmittedAt(true, now.Add(-2*time.Minute)).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated due to exceeding the maximum execution time",
+				}).
+				Obj(),
+			wantWorkload: utiltestingapi.MakeWorkload("wl", "ns").
+				Active(false).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+				MaximumExecutionTimeSeconds(60).
+				AdmittedAt(true, now.Add(-2*time.Minute)).
+				ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "ownername", "owneruid").
+				Condition(metav1.Condition{
+					Type:    kueue.WorkloadEvicted,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadDeactivated,
+					Message: "The workload is deactivated due to exceeding the maximum execution time",
+				}).
+				Obj(),
+		},
 		"should handle finished workload logic for orphaned workloads when FinishOrphanedWorkloads enabled": {
 			featureGates: map[featuregate.Feature]bool{features.FinishOrphanedWorkloads: true},
 			workload: utiltestingapi.MakeWorkload("wl", "ns").

--- a/pkg/workload/evict/evict.go
+++ b/pkg/workload/evict/evict.go
@@ -205,7 +205,7 @@ func Evict(
 func prepareForEviction(w *kueue.Workload, now time.Time, reason, message string) {
 	SetEvictedCondition(w, now, reason, message)
 	resetClusterNomination(w)
-	resetChecksOnEviction(w, now)
+	ResetChecksOnEviction(w, now)
 	resetUnhealthyNodes(w)
 	unsetBlockedOnPreemptionGatesCondition(w, now, reason, message)
 	closeAllPreemptionGates(w, now)
@@ -216,8 +216,9 @@ func resetClusterNomination(w *kueue.Workload) {
 	w.Status.NominatedClusterNames = nil
 }
 
-// resetChecksOnEviction sets all AdmissionChecks to Pending
-func resetChecksOnEviction(w *kueue.Workload, now time.Time) {
+// ResetChecksOnEviction sets all AdmissionChecks to Pending. Exported for the deactivation
+// path in the Workload controller, which bypasses Evict when the Workload is already evicted.
+func ResetChecksOnEviction(w *kueue.Workload, now time.Time) {
 	checks := w.Status.AdmissionChecks
 	for i := range checks {
 		if checks[i].State == kueue.CheckStatePending {

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -585,6 +585,8 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
 					_, evictedByCheck := workloadevict.IsEvictedByAdmissionCheck(&createdWl)
 					g.Expect(evictedByCheck).To(gomega.BeTrue())
+					// Retry evicts the Workload but must not deactivate it.
+					g.Expect(workload.IsActive(&createdWl)).To(gomega.BeTrue())
 					g.Expect(slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) kueue.CheckState {
 						return c.State
 					})).Should(gomega.ConsistOf(kueue.CheckStatePending, kueue.CheckStatePending))
@@ -688,6 +690,8 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
 					_, evictedByCheck := workloadevict.IsEvictedByAdmissionCheck(&createdWl)
 					g.Expect(evictedByCheck).To(gomega.BeTrue())
+					// Retry evicts the Workload but must not deactivate it.
+					g.Expect(workload.IsActive(&createdWl)).To(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -617,6 +617,116 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 				})
 			})
 		})
+
+		// Deactivating an already-evicted Workload skips Evict(), so the DeactivationTarget
+		// cleanup and the check reset it performs must not be lost: the user has to be able
+		// to reactivate the Workload afterwards.
+		ginkgo.It("should allow reactivating a workload deactivated by a check rejected during eviction", func() {
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				Queue("queue").
+				Obj()
+			wlKey := client.ObjectKeyFromObject(wl)
+			createdWl := kueue.Workload{}
+			ginkgo.By("creating the workload, the check conditions should be added", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string {
+						return string(c.Name)
+					})).Should(gomega.ConsistOf("check1", "check2"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting quota reservation and the checks ready, should admit the workload", func() {
+				podSet := kueue.PodSetAssignment{
+					Name: kueue.DefaultPodSetName,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: kueue.ResourceFlavorReference(flavor1.Name),
+					},
+				}
+				util.SetQuotaReservation(
+					ctx,
+					k8sClient,
+					wlKey,
+					utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(podSet).Obj(),
+				)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					}, util.RealClock)
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check2",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(&createdWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting a retry check condition, should evict the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check2",
+						State:   kueue.CheckStateRetry,
+						Message: "check retry",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					_, evictedByCheck := workloadevict.IsEvictedByAdmissionCheck(&createdWl)
+					g.Expect(evictedByCheck).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting a rejected check condition while the eviction is still in progress", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateRejected,
+						Message: "check rejected",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking the workload is deactivated, the deactivation target is cleared and the checks are reset", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(workload.IsActive(&createdWl)).To(gomega.BeFalse())
+					g.Expect(apimeta.FindStatusCondition(createdWl.Status.Conditions, kueue.WorkloadDeactivationTarget)).To(gomega.BeNil())
+					g.Expect(slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) kueue.CheckState {
+						return c.State
+					})).Should(gomega.ConsistOf(kueue.CheckStatePending, kueue.CheckStatePending))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Reactivating the workload, it should stay active", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					createdWl.Spec.Active = new(true)
+					g.Expect(k8sClient.Update(ctx, &createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Consistently(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(workload.IsActive(&createdWl)).To(gomega.BeTrue())
+				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+			})
+		})
 	})
 
 	ginkgo.When("changing the priority value of PriorityClass changes the priority of the workload", func() {

--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -516,6 +516,107 @@ var _ = ginkgo.Describe("Workload controller", ginkgo.Label("controller:workload
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 		})
+		// An external controller can reject a check after another check already started an eviction,
+		// leaving the Workload admitted with a Rejected check unless the rejection is still handled.
+		ginkgo.It("should deactivate an admitted workload when a check is rejected while an eviction is in progress", func() {
+			wl := utiltestingapi.MakeWorkload("wl", ns.Name).
+				Queue("queue").
+				Obj()
+			wlKey := client.ObjectKeyFromObject(wl)
+			createdWl := kueue.Workload{}
+			ginkgo.By("creating the workload, the check conditions should be added", func() {
+				util.MustCreate(ctx, k8sClient, wl)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) string {
+						return string(c.Name)
+					})).Should(gomega.ConsistOf("check1", "check2"))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting quota reservation and the checks ready, should admit the workload", func() {
+				podSet := kueue.PodSetAssignment{
+					Name: kueue.DefaultPodSetName,
+					Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+						corev1.ResourceCPU: kueue.ResourceFlavorReference(flavor1.Name),
+					},
+				}
+				util.SetQuotaReservation(
+					ctx,
+					k8sClient,
+					wlKey,
+					utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(clusterQueue.Name)).PodSets(podSet).Obj(),
+				)
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					}, util.RealClock)
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check2",
+						State:   kueue.CheckStateReady,
+						Message: "check ready",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(&createdWl)).To(gomega.BeTrue())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting a retry check condition, should evict the workload and reset the checks", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check2",
+						State:   kueue.CheckStateRetry,
+						Message: "check retry",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					_, evictedByCheck := workloadevict.IsEvictedByAdmissionCheck(&createdWl)
+					g.Expect(evictedByCheck).To(gomega.BeTrue())
+					g.Expect(slices.Map(createdWl.Status.AdmissionChecks, func(c *kueue.AdmissionCheckState) kueue.CheckState {
+						return c.State
+					})).Should(gomega.ConsistOf(kueue.CheckStatePending, kueue.CheckStatePending))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("setting a rejected check condition while the eviction is still in progress", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &createdWl)).To(gomega.Succeed())
+					g.Expect(workload.IsAdmitted(&createdWl)).To(gomega.BeTrue())
+					workloadpatching.SetAdmissionCheckState(&createdWl.Status.AdmissionChecks, kueue.AdmissionCheckState{
+						Name:    "check1",
+						State:   kueue.CheckStateRejected,
+						Message: "check rejected",
+					}, util.RealClock)
+					g.Expect(k8sClient.Status().Update(ctx, &createdWl)).To(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking if the workload is deactivated and an event is emitted", func() {
+				updatedWl := &kueue.Workload{}
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, updatedWl)).To(gomega.Succeed())
+					g.Expect(workload.IsActive(updatedWl)).To(gomega.BeFalse())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectEventAppeared(ctx, k8sClient, eventsv1.Event{
+					Reason: "AdmissionCheckRejected",
+					Type:   corev1.EventTypeWarning,
+					Note:   `Deactivated due to AdmissionCheck in Rejected state: "check1" (check rejected)`,
+				})
+			})
+		})
 	})
 
 	ginkgo.When("changing the priority value of PriorityClass changes the priority of the workload", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

`reconcileCheckBasedEviction` bailed out on `IsEvicted` before either of its branches, so a `Rejected` AdmissionCheck set while an eviction was still in flight was silently dropped — no `DeactivationTarget`, no event, and the Workload kept `Admitted=True` next to a `Rejected` check.

This PR moves the `IsEvicted` guard below the `Rejected` branch, so it only protects the `Retry` path:

| Case | Workload state | Before | After |
|---|---|---|---|
| 1 | `Rejected` check, **evicted** | ignored — nothing written | deactivated + event |
| 2 | `Rejected` check, not evicted | deactivated + event | unchanged |
| 3 | `Retry` check, **evicted** | skipped | unchanged — still skipped |

Case 1 is the bug. Case 3 is why the guard is moved rather than deleted: a `Retry` must not evict a Workload that is already being evicted.

Rejection is terminal, and `SetDeactivationTarget` only writes a condition whose consumer flips `spec.Active=false` independently of `Evicted`. `apimeta.SetStatusCondition` makes repeat reconciles a no-op, so no extra requests.

Easiest to hit under MultiKueue — a worker-side eviction flips the MultiKueue check to `Retry`, which evicts the manager Workload and resets every check to `Pending` — but the handling itself is not MultiKueue specific.

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/kueue/issues/10807

#### Special notes for your reviewer:

- New Unit test case added for validating eviction scenario

#### Does this PR introduce a user-facing change?

```release-note
AdmissionChecks: Fix a bug where the Workload has an Admitted=True condition regardless of AdmissionCheck Rejection state.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rejected admission checks during workload eviction.
  * Workloads are deactivated correctly, including cleanup of stale deactivation targets.
  * Reactivated workloads now reset admission checks appropriately.
  * Retried checks continue to skip workloads with an eviction in progress.
  * Added coverage for eviction-state transitions and related warning events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->