### PR TITLE
chore: Replace EmptyRequests with NewRequests to aligh Go idiomitic naming policy

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -281,7 +281,7 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 		domainID := utiltas.DomainID(tr.Values)
 		_, found := c.usage[domainID]
 		if !found {
-			c.usage[domainID] = resources.CreateEmpty()
+			c.usage[domainID] = resources.NewRequests()
 		}
 		if op == subtract {
 			c.usage[domainID].Sub(tr.TotalRequests())

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -292,7 +292,7 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 	}
 	leafState := s.leafStateOf(s.leaves[domainID])
 	if leafState.tasUsage == nil {
-		leafState.tasUsage = resources.CreateEmpty()
+		leafState.tasUsage = resources.NewRequests()
 	}
 	leafState.tasUsage.Add(usage)
 	leafState.cachedRemainingCapacity = resources.LazyRequests{}
@@ -308,7 +308,7 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 	}
 	leafState := s.leafStateOf(s.leaves[domainID])
 	if leafState.tasUsage == nil {
-		leafState.tasUsage = resources.CreateEmpty()
+		leafState.tasUsage = resources.NewRequests()
 	}
 	leafState.tasUsage.Sub(usage)
 	leafState.cachedRemainingCapacity = resources.LazyRequests{}
@@ -712,7 +712,7 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.CreateEmpty()
+			assumedUsage[domainID] = resources.NewRequests()
 		}
 		assumedUsage[domainID].Add(usage)
 	}

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -121,7 +121,7 @@ func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources
 // Must be called under write lock.
 func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 	if _, found := n.nodeUsage[node]; !found {
-		n.nodeUsage[node] = resources.CreateEmpty()
+		n.nodeUsage[node] = resources.NewRequests()
 	}
 	n.nodeUsage[node].Add(usage)
 	n.nodeUsage[node].Add(resources.OnePodRequest)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -138,7 +138,7 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	expected := make(map[string]resources.Requests)
 	for _, pv := range cache.podUsage {
 		if _, found := expected[pv.node]; !found {
-			expected[pv.node] = resources.CreateEmpty()
+			expected[pv.node] = resources.NewRequests()
 		}
 		expected[pv.node].Add(pv.usage)
 		expected[pv.node].Add(resources.OnePodRequest)

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -221,7 +221,7 @@ func (t *topologyTree) initializeHelper(dom *domain) {
 
 func (t *topologyTree) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
 	if t.leaves[domainID].capacity == nil {
-		t.leaves[domainID].capacity = resources.CreateEmpty()
+		t.leaves[domainID].capacity = resources.NewRequests()
 	}
 	t.leaves[domainID].capacity.Add(capacity)
 }

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -60,7 +60,7 @@ func isAdminAccessRequest(req *resourcev1.ExactDeviceRequest) bool {
 // ResourceClaimSpec. Returns field errors for unsupported request features
 // (FirstAvailable, AllocationMode All). AdminAccess requests are skipped (zero quota).
 func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, field.ErrorList) {
-	out := resources.CreateEmpty()
+	out := resources.NewRequests()
 	if claimSpec == nil {
 		return out, nil
 	}

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -40,8 +40,8 @@ func Equal(a, b Requests) bool {
 	return equal
 }
 
-// CreateEmpty creates an empty Requests instance based on feature gates.
-func CreateEmpty() Requests {
+// NewRequests creates an empty Requests instance based on feature gates.
+func NewRequests() Requests {
 	if features.Enabled(features.VectorizedResourceRequests) {
 		return &SliceRequests{}
 	}
@@ -51,7 +51,7 @@ func CreateEmpty() Requests {
 // NewRequestsFromMap creates a Requests instance from a map based on feature gates.
 func NewRequestsFromMap(m map[corev1.ResourceName]int64) Requests {
 	if len(m) == 0 {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	if features.Enabled(features.VectorizedResourceRequests) {
 		sr := toSliceRequests(MapRequests(m))
@@ -72,7 +72,7 @@ func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 // NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
 func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
 	return NewRequestsFromResourceList(rl)

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -50,7 +50,7 @@ func (l *LazyRequests) ensureWritable() {
 		case !isEmpty(l.base):
 			l.cached = l.base.Clone()
 		default:
-			l.cached = CreateEmpty()
+			l.cached = NewRequests()
 		}
 	}
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -47,7 +47,7 @@ func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 
 func (frq FlavorResourceQuantities) FlattenFlavors() Requests {
 	if len(frq) == 0 {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	result := map[corev1.ResourceName]int64{}
 	for key, val := range frq {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -753,7 +753,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 	}
 
 	for _, podSets := range groupedRequests.InOrder {
-		requests := resources.CreateEmpty()
+		requests := resources.NewRequests()
 		psIDs := make([]int, len(podSets))
 		for idx, podset := range podSets {
 			psIDs[idx] = podset.originalIndex
@@ -1354,7 +1354,7 @@ func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {
 }
 
 func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.ResourceName]) resources.Requests {
-	filtered := resources.CreateEmpty()
+	filtered := resources.NewRequests()
 	req.ForEach(func(resName corev1.ResourceName, quantity int64) {
 		if allowList.Has(resName) {
 			filtered.Set(resName, quantity)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -567,7 +567,7 @@ func (i *Info) TASUsage() TASUsage {
 }
 
 func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.ResourceList {
-	reqs := resources.CreateEmpty()
+	reqs := resources.NewRequests()
 	for _, psReqs := range i.TotalRequests {
 		if psReqs.Requests != nil {
 			reqs.Add(psReqs.Requests)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In Go, we should use the `New` prefix to initialize a struct and return it.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized creation of empty resource request sets across scheduling, caching, workload, and device-resource calculations.
  * Renamed the empty request-set constructor to better reflect its purpose.
  * Preserved existing resource accounting, filtering, validation, and feature-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->