### PR TITLE
fix(metrics): respect LocalQueue selector for unadmitted workloads

### DIFF
--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -1061,6 +1061,10 @@ func (m *Manager) resyncUnadmittedWorkloadsMetricsLocked(cqName kueue.ClusterQue
 }
 
 func (m *Manager) resyncLocalQueueUnadmittedWorkloadsMetricsLocked(lqRef queue.LocalQueueReference) {
+	lq := m.localQueues[lqRef]
+	if lq == nil || !m.lqMetrics.ShouldExposeLocalQueueMetrics(lq.labels) {
+		return
+	}
 	m.unadmittedWorkloads.resyncLQMetrics(lqRef, m)
 }
 
@@ -1101,20 +1105,24 @@ func (m *Manager) AddWorkloadUpdateWatcher(watcher WorkloadUpdateWatcher) {
 func (m *Manager) unadmittedQueueInfo(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
 	m.RLock()
 	defer m.RUnlock()
+	return m.unadmittedQueueInfoWithoutLock(wl)
+}
+
+func (m *Manager) unadmittedQueueInfoWithoutLock(wl *kueue.Workload) (kueue.ClusterQueueReference, bool) {
 	cqName, _ := m.ClusterQueueNameForWorkloadWithoutLock(wl)
-	lqExists := m.LocalQueueExistsWithoutLock(queue.KeyFromWorkload(wl))
-	return cqName, lqExists
+	lq, lqExists := m.localQueues[queue.KeyFromWorkload(wl)]
+	lqMetricsExposed := lqExists && m.lqMetrics.ShouldExposeLocalQueueMetrics(lq.labels)
+	return cqName, lqMetricsExposed
 }
 
 func (m *Manager) UpdateUnadmittedWorkload(log logr.Logger, wl *kueue.Workload) {
-	cqName, lqExists := m.unadmittedQueueInfo(wl)
-	m.unadmittedWorkloads.update(log, wl, cqName, lqExists, m)
+	cqName, lqMetricsExposed := m.unadmittedQueueInfo(wl)
+	m.unadmittedWorkloads.update(log, wl, cqName, lqMetricsExposed, m)
 }
 
 func (m *Manager) updateUnadmittedWorkloadWithoutLock(log logr.Logger, wl *kueue.Workload) {
-	cqName, _ := m.ClusterQueueNameForWorkloadWithoutLock(wl)
-	lqExists := m.LocalQueueExistsWithoutLock(queue.KeyFromWorkload(wl))
-	m.unadmittedWorkloads.update(log, wl, cqName, lqExists, m)
+	cqName, lqMetricsExposed := m.unadmittedQueueInfoWithoutLock(wl)
+	m.unadmittedWorkloads.update(log, wl, cqName, lqMetricsExposed, m)
 }
 
 func (m *Manager) RemoveUnadmittedWorkload(log logr.Logger, wlKey workload.Reference) {

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2373,6 +2373,51 @@ func TestUpdateUnadmittedWorkload_LQMetricsDisabled(t *testing.T) {
 	}
 }
 
+func TestUpdateUnadmittedWorkload_LocalQueueMetricsSelector(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
+	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+	metrics.LocalQueueUnadmittedWorkloads.Reset()
+	t.Cleanup(metrics.LocalQueueUnadmittedWorkloads.Reset)
+
+	ctx, log := utiltesting.ContextWithLog(t)
+	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
+	lq := utiltestingapi.MakeLocalQueue("lq", "ns").Label("team", "excluded").ClusterQueue("cq").Obj()
+	wl := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Obj()
+
+	kClient := utiltesting.NewFakeClient(wl)
+	manager := NewManagerForUnitTests(kClient, nil,
+		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{
+			Enabled:       true,
+			QueueSelector: labels.SelectorFromSet(map[string]string{"team": "included"}),
+		}),
+	)
+
+	if err := manager.AddClusterQueue(ctx, cq); err != nil {
+		t.Fatalf("failed to add ClusterQueue: %v", err)
+	}
+	if err := manager.AddLocalQueue(ctx, lq); err != nil {
+		t.Fatalf("failed to add LocalQueue: %v", err)
+	}
+
+	manager.UpdateUnadmittedWorkload(log, wl)
+
+	expectGaugeCount(t, metrics.LocalQueueUnadmittedWorkloads, 0, map[string]string{
+		"name":      lq.Name,
+		"namespace": lq.Namespace,
+	})
+
+	updatedLQ := lq.DeepCopy()
+	updatedLQ.Labels["team"] = "included"
+	if err := manager.UpdateLocalQueue(log, updatedLQ); err != nil {
+		t.Fatalf("failed to update LocalQueue: %v", err)
+	}
+	manager.ResyncLocalQueueGaugeMetrics(queue.Key(updatedLQ))
+	expectGaugeValue(t, metrics.LocalQueueUnadmittedWorkloads, map[string]string{
+		"name":      updatedLQ.Name,
+		"namespace": updatedLQ.Namespace,
+	}, 1)
+}
+
 func TestDeleteLocalQueue_UnadmittedWorkloads(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
 

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -2184,10 +2184,13 @@ func TestUpdateUnadmittedWorkload(t *testing.T) {
 	ctx, log := utiltesting.ContextWithLog(t)
 	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
 	lq := utiltestingapi.MakeLocalQueue("lq", "ns").ClusterQueue("cq").Obj()
+	excludedLQ := utiltestingapi.MakeLocalQueue("lq", "ns").Label("team", "excluded").ClusterQueue("cq").Obj()
 
 	cases := map[string]struct {
-		workload       *kueue.Workload
-		expectedStatus unadmittedWorkloadStatus
+		workload                     *kueue.Workload
+		expectedStatus               unadmittedWorkloadStatus
+		localQueueMetrics            *metrics.LocalQueueMetricsConfig
+		localQueueExcludedBySelector bool
 	}{
 		"workload with empty status conditions (fresh / disabled explicit status FG)": {
 			workload: utiltestingapi.MakeWorkload("wl-1", "ns").Queue("lq").Obj(),
@@ -2258,17 +2261,43 @@ func TestUpdateUnadmittedWorkload(t *testing.T) {
 				UnderlyingCause:     "",
 			},
 		},
+		"LocalQueue metrics selector excludes unadmitted workload metric": {
+			workload: utiltestingapi.MakeWorkload("wl-5", "ns").Queue("lq").Obj(),
+			expectedStatus: unadmittedWorkloadStatus{
+				ClusterQueue:        "cq",
+				LocalQueueName:      "lq",
+				LocalQueueNamespace: "ns",
+				Reason:              kueue.WorkloadAdmittedReasonNoReservation,
+				UnderlyingCause:     kueue.WorkloadQuotaReservedReasonPendingEvaluation,
+			},
+			localQueueMetrics: &metrics.LocalQueueMetricsConfig{
+				Enabled:       true,
+				QueueSelector: labels.SelectorFromSet(map[string]string{"team": "included"}),
+			},
+			localQueueExcludedBySelector: true,
+		},
 	}
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
+			if tc.localQueueExcludedBySelector {
+				features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
+				features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
+				metrics.LocalQueueUnadmittedWorkloads.Reset()
+				t.Cleanup(metrics.LocalQueueUnadmittedWorkloads.Reset)
+			}
+
+			queue := lq
+			if tc.localQueueExcludedBySelector {
+				queue = excludedLQ
+			}
 			kClient := utiltesting.NewFakeClient(tc.workload)
-			manager := NewManagerForUnitTests(kClient, nil)
+			manager := NewManagerForUnitTests(kClient, nil, WithLocalQueueMetrics(tc.localQueueMetrics))
 
 			if err := manager.AddClusterQueue(ctx, cq); err != nil {
 				t.Fatalf("failed to add ClusterQueue: %v", err)
 			}
-			if err := manager.AddLocalQueue(ctx, lq); err != nil {
+			if err := manager.AddLocalQueue(ctx, queue); err != nil {
 				t.Fatalf("failed to add LocalQueue: %v", err)
 			}
 
@@ -2279,7 +2308,6 @@ func TestUpdateUnadmittedWorkload(t *testing.T) {
 			if !ok {
 				t.Fatalf("expected workload to be tracked in unadmitted registry")
 			}
-
 			if diff := cmp.Diff(tc.expectedStatus, status); diff != "" {
 				t.Errorf("unexpected tracked status (-want,+got):\n%s", diff)
 			}
@@ -2288,10 +2316,16 @@ func TestUpdateUnadmittedWorkload(t *testing.T) {
 			if count, ok := manager.unadmittedWorkloads.perCQ[cqKey]; !ok || count != 1 {
 				t.Errorf("expected CQ status count to be 1, got count=%d, ok=%t", count, ok)
 			}
-
 			lqKey := tc.expectedStatus
 			if count, ok := manager.unadmittedWorkloads.perLQ[lqKey]; !ok || count != 1 {
 				t.Errorf("expected LQ status count to be 1, got count=%d, ok=%t", count, ok)
+			}
+
+			if tc.localQueueExcludedBySelector {
+				expectGaugeCount(t, metrics.LocalQueueUnadmittedWorkloads, 0, map[string]string{
+					"name":      queue.Name,
+					"namespace": queue.Namespace,
+				})
 			}
 
 			tc.workload.Status.Conditions = []metav1.Condition{
@@ -2371,51 +2405,6 @@ func TestUpdateUnadmittedWorkload_LQMetricsDisabled(t *testing.T) {
 	if len(manager.unadmittedWorkloads.perLQ) != 0 {
 		t.Errorf("expected LQ counts to be empty when LQ metrics are disabled, got %v", manager.unadmittedWorkloads.perLQ)
 	}
-}
-
-func TestUpdateUnadmittedWorkload_LocalQueueMetricsSelector(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.UnadmittedWorkloadsObservability, true)
-	features.SetFeatureGateDuringTest(t, features.LocalQueueMetrics, true)
-	metrics.LocalQueueUnadmittedWorkloads.Reset()
-	t.Cleanup(metrics.LocalQueueUnadmittedWorkloads.Reset)
-
-	ctx, log := utiltesting.ContextWithLog(t)
-	cq := utiltestingapi.MakeClusterQueue("cq").Obj()
-	lq := utiltestingapi.MakeLocalQueue("lq", "ns").Label("team", "excluded").ClusterQueue("cq").Obj()
-	wl := utiltestingapi.MakeWorkload("wl", "ns").Queue("lq").Obj()
-
-	kClient := utiltesting.NewFakeClient(wl)
-	manager := NewManagerForUnitTests(kClient, nil,
-		WithLocalQueueMetrics(&metrics.LocalQueueMetricsConfig{
-			Enabled:       true,
-			QueueSelector: labels.SelectorFromSet(map[string]string{"team": "included"}),
-		}),
-	)
-
-	if err := manager.AddClusterQueue(ctx, cq); err != nil {
-		t.Fatalf("failed to add ClusterQueue: %v", err)
-	}
-	if err := manager.AddLocalQueue(ctx, lq); err != nil {
-		t.Fatalf("failed to add LocalQueue: %v", err)
-	}
-
-	manager.UpdateUnadmittedWorkload(log, wl)
-
-	expectGaugeCount(t, metrics.LocalQueueUnadmittedWorkloads, 0, map[string]string{
-		"name":      lq.Name,
-		"namespace": lq.Namespace,
-	})
-
-	updatedLQ := lq.DeepCopy()
-	updatedLQ.Labels["team"] = "included"
-	if err := manager.UpdateLocalQueue(log, updatedLQ); err != nil {
-		t.Fatalf("failed to update LocalQueue: %v", err)
-	}
-	manager.ResyncLocalQueueGaugeMetrics(queue.Key(updatedLQ))
-	expectGaugeValue(t, metrics.LocalQueueUnadmittedWorkloads, map[string]string{
-		"name":      updatedLQ.Name,
-		"namespace": updatedLQ.Namespace,
-	}, 1)
 }
 
 func TestDeleteLocalQueue_UnadmittedWorkloads(t *testing.T) {

--- a/pkg/cache/queue/unadmitted_workloads.go
+++ b/pkg/cache/queue/unadmitted_workloads.go
@@ -75,7 +75,7 @@ func (u *unadmittedWorkloads) update(
 	log logr.Logger,
 	wl *kueue.Workload,
 	cqName kueue.ClusterQueueReference,
-	lqExists bool,
+	lqMetricsExposed bool,
 	m *Manager,
 ) {
 	u.rwm.Lock()
@@ -101,12 +101,12 @@ func (u *unadmittedWorkloads) update(
 	log.V(4).Info("Updating unadmitted workload tracking", "oldStatus", oldStatus, "newStatus", status)
 
 	if ok {
-		u.decrementStatusCounts(log, oldStatus, lqExists, m)
+		u.decrementStatusCounts(log, oldStatus, lqMetricsExposed, m)
 		delete(u.statuses, wlKey)
 	}
 	if status != nil {
 		u.statuses[wlKey] = *status
-		u.incrementStatusCounts(log, *status, lqExists, m)
+		u.incrementStatusCounts(log, *status, lqMetricsExposed, m)
 	}
 }
 
@@ -131,26 +131,26 @@ func (u *unadmittedWorkloads) remove(
 func (u *unadmittedWorkloads) incrementStatusCounts(
 	log logr.Logger,
 	status unadmittedWorkloadStatus,
-	lqExists bool,
+	lqMetricsExposed bool,
 	m *Manager,
 ) {
-	u.updateUnadmittedWorkloadMetric(log, status, 1, lqExists, m)
+	u.updateUnadmittedWorkloadMetric(log, status, 1, lqMetricsExposed, m)
 }
 
 func (u *unadmittedWorkloads) decrementStatusCounts(
 	log logr.Logger,
 	status unadmittedWorkloadStatus,
-	lqExists bool,
+	lqMetricsExposed bool,
 	m *Manager,
 ) {
-	u.updateUnadmittedWorkloadMetric(log, status, -1, lqExists, m)
+	u.updateUnadmittedWorkloadMetric(log, status, -1, lqMetricsExposed, m)
 }
 
 func (u *unadmittedWorkloads) updateUnadmittedWorkloadMetric(
 	log logr.Logger,
 	status unadmittedWorkloadStatus,
 	diff int,
-	lqExists bool,
+	lqMetricsExposed bool,
 	m *Manager,
 ) {
 	cqKey := status.ClusterQueueStatus()
@@ -197,7 +197,7 @@ func (u *unadmittedWorkloads) updateUnadmittedWorkloadMetric(
 	}
 
 	lqRefKey := queue.NewLocalQueueReference(status.LocalQueueNamespace, status.LocalQueueName)
-	if lqExists && status.ClusterQueue != "" {
+	if lqMetricsExposed && status.ClusterQueue != "" {
 		lqRef := metrics.LocalQueueReference{Name: status.LocalQueueName, Namespace: status.LocalQueueNamespace}
 		lqCustomLabels := m.customLabels.LQGet(lqRefKey)
 		if countLQ <= 0 {
@@ -223,7 +223,7 @@ func (u *unadmittedWorkloads) updateUnadmittedWorkloadMetric(
 			)
 		}
 	} else {
-		log.V(4).Info("Skipping LQ unadmitted metric report", "status", status, "qExists", lqExists)
+		log.V(4).Info("Skipping LQ unadmitted metric report", "status", status, "metricsExposed", lqMetricsExposed)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Made `kueue_local_queue_unadmitted_workloads` metric respect `metrics.localQueueMetrics.localQueueSelector`. Previously, this metric was emitted for LocalQueues excluded by the selector, unlike the other LocalQueue metrics. This change keeps the internal unadmitted workload counts so that metrics can be reported after a LocalQueue's labels start matching the selector.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed kueue_local_queue_unadmitted_workloads to respect the configured LocalQueue metrics selector
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LocalQueue unadmitted workload metrics so they are reported only when the queue matches the configured metric label selector.
  * Metrics now update correctly when a queue’s labels change to meet or no longer meet exposure criteria.
  * Improved handling of workload status counts and metric visibility for LocalQueues.
  * Workloads remain accurately tracked even when their LocalQueue metrics are excluded from reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->