### PR TITLE
Fix the flaky RuntimeClass integration test

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1001,6 +1001,24 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 				util.ExpectWorkloadsToBeAdmitted(ctx, k8sClient, wl)
 			})
 
+			quotaReservedEventCount := func() (int, error) {
+				return utiltesting.HasMatchingEventAppearedTimes(ctx, k8sClient, func(e *eventsv1.Event) bool {
+					return e.Reason == "QuotaReserved" &&
+						e.Type == corev1.EventTypeNormal &&
+						e.Regarding.Kind == "Workload" &&
+						e.Regarding.Name == wl.Name &&
+						e.Regarding.Namespace == wl.Namespace
+				})
+			}
+
+			ginkgo.By("waiting for the first 'quota reserved' event appearing for the workload", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					count, err := quotaReservedEventCount()
+					g.Expect(err).NotTo(gomega.HaveOccurred())
+					g.Expect(count).To(gomega.Equal(1))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
 			ginkgo.By("finishing the workload", func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
@@ -1024,15 +1042,9 @@ var _ = ginkgo.Describe("Workload controller interaction with scheduler", func()
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("checking no 'quota reserved' event appearing for the workload", func() {
+			ginkgo.By("checking no additional 'quota reserved' event appearing for the workload", func() {
 				gomega.Consistently(func(g gomega.Gomega) {
-					count, err := utiltesting.HasMatchingEventAppearedTimes(ctx, k8sClient, func(e *eventsv1.Event) bool {
-						return e.Reason == "QuotaReserved" &&
-							e.Type == corev1.EventTypeNormal &&
-							e.Regarding.Kind == "Workload" &&
-							e.Regarding.Name == wl.Name &&
-							e.Regarding.Namespace == wl.Namespace
-					})
+					count, err := quotaReservedEventCount()
 					g.Expect(err).NotTo(gomega.HaveOccurred())
 					g.Expect(count).To(gomega.Equal(1))
 				}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())


### PR DESCRIPTION
#### What type of PR is this?
/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14146

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced runtime-class-change integration coverage.
  * Added checks to confirm exactly one quota-reserved event is emitted during initial admission.
  * Verified that workload completion and runtime class changes do not emit additional events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->