### PR TITLE
Retry installation of the network for installing helmunit

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -73,7 +73,11 @@ SPARKOPERATOR_ROOT = $(shell $(GO_CMD) list -m -mod=readonly -f "{{.Dir}}" githu
 
 ##@ Tools
 
-NETWORK_INSTALL_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh --attempts 7 --delay 2 --exponential --stream -- env
+HELM_UNITTEST_PLUGIN_URL = https://github.com/helm-unittest/helm-unittest.git
+HELM_UNITTEST_PLUGIN_DIR = $(BIN_DIR)/helm-plugins/$(notdir $(HELM_UNITTEST_PLUGIN_URL))
+
+NETWORK_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh --attempts 7 --delay 2 --exponential --stream
+NETWORK_INSTALL_RETRY = $(NETWORK_RETRY) -- env
 
 .PHONY: golangci-lint
 golangci-lint: gomod-download-tools ## Download golangci-lint locally if necessary.
@@ -118,8 +122,16 @@ helm: gomod-download-tools ## Download helm locally if necessary.
 
 .PHONY: helm-unittest-plugin
 helm-unittest-plugin: helm ## Download helm-unittest locally if necessary.
-	@if ! HELM_PLUGINS=$(BIN_DIR)/helm-plugins $(HELM) plugin list | grep -q unittest; then \
-		HELM_PLUGINS=$(BIN_DIR)/helm-plugins $(HELM) plugin install https://github.com/helm-unittest/helm-unittest.git --version $(HELM_UNITTEST_PLUGIN_VERSION) --verify=false; \
+helm-unittest-plugin: helm ## Download helm-unittest locally if necessary.
+	@# Helm registers the plugin before running its install hook, so plugin list can include an unusable plugin.
+	@if ! HELM_PLUGINS=$(BIN_DIR)/helm-plugins $(HELM) unittest --help >/dev/null 2>&1; then \
+		if ! $(NETWORK_RETRY) \
+			--cleanup 'rm -rf "$(HELM_UNITTEST_PLUGIN_DIR)"' \
+			-- env HELM_PLUGINS=$(BIN_DIR)/helm-plugins \
+			$(HELM) plugin install $(HELM_UNITTEST_PLUGIN_URL) --version $(HELM_UNITTEST_PLUGIN_VERSION) --verify=false; then \
+			rm -rf "$(HELM_UNITTEST_PLUGIN_DIR)"; \
+			exit 1; \
+		fi; \
 	fi
 
 .PHONY: genref


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14327

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm unittest plugin installation reliability with retry handling.
  * Added validation to confirm the plugin is usable after installation.
  * Added cleanup of incomplete plugin installations when failures occur.

* **Chores**
  * Improved network retry configuration for installation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->