### PR TITLE
Automated cherry pick of #14325: chore: Replace EmptyRequests with NewRequests to aligh Go idiomitic naming policy

### DIFF
--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -195,7 +195,7 @@ func (c *TASFlavorCache) updateUsage(topologyRequests []workload.TopologyDomainR
 		domainID := utiltas.DomainID(tr.Values)
 		_, found := c.usage[domainID]
 		if !found {
-			c.usage[domainID] = resources.CreateEmpty()
+			c.usage[domainID] = resources.NewRequests()
 		}
 		if op == subtract {
 			c.usage[domainID].Sub(tr.TotalRequests())

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -307,7 +307,7 @@ func (s *TASFlavorSnapshot) initializeHelper(dom *domain) {
 
 func (s *TASFlavorSnapshot) addCapacity(domainID utiltas.TopologyDomainID, capacity resources.Requests) {
 	if s.leaves[domainID].freeCapacity == nil {
-		s.leaves[domainID].freeCapacity = resources.CreateEmpty()
+		s.leaves[domainID].freeCapacity = resources.NewRequests()
 	}
 	s.leaves[domainID].freeCapacity.Add(capacity)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -348,7 +348,7 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.CreateEmpty()
+		s.leaves[domainID].tasUsage = resources.NewRequests()
 	}
 	s.leaves[domainID].tasUsage.Add(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -363,7 +363,7 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		return
 	}
 	if s.leaves[domainID].tasUsage == nil {
-		s.leaves[domainID].tasUsage = resources.CreateEmpty()
+		s.leaves[domainID].tasUsage = resources.NewRequests()
 	}
 	s.leaves[domainID].tasUsage.Sub(usage)
 	s.leaves[domainID].cachedRemainingCapacity = resources.LazyRequests{}
@@ -766,7 +766,7 @@ func addAssumedUsage(assumedUsage map[utiltas.TopologyDomainID]resources.Request
 func addUsagePerDomain(assumedUsage map[utiltas.TopologyDomainID]resources.Requests, usagePerDomain map[utiltas.TopologyDomainID]resources.Requests) {
 	for domainID, usage := range usagePerDomain {
 		if assumedUsage[domainID] == nil {
-			assumedUsage[domainID] = resources.CreateEmpty()
+			assumedUsage[domainID] = resources.NewRequests()
 		}
 		assumedUsage[domainID].Add(usage)
 	}

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -121,7 +121,7 @@ func (n *nonTasUsageCache) forEachNodeUsage(fn func(node string, usage resources
 // Must be called under write lock.
 func (n *nonTasUsageCache) addNodeUsage(node string, usage resources.Requests) {
 	if _, found := n.nodeUsage[node]; !found {
-		n.nodeUsage[node] = resources.CreateEmpty()
+		n.nodeUsage[node] = resources.NewRequests()
 	}
 	n.nodeUsage[node].Add(usage)
 	n.nodeUsage[node].Add(resources.OnePodRequest)

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache_test.go
@@ -138,7 +138,7 @@ func verifyNodeUsageConsistency(t *testing.T, cache *nonTasUsageCache) {
 	expected := make(map[string]resources.Requests)
 	for _, pv := range cache.podUsage {
 		if _, found := expected[pv.node]; !found {
-			expected[pv.node] = resources.CreateEmpty()
+			expected[pv.node] = resources.NewRequests()
 		}
 		expected[pv.node].Add(pv.usage)
 		expected[pv.node].Add(resources.OnePodRequest)

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -56,7 +56,7 @@ type celDeviceRequest struct {
 // ResourceClaimSpec. Returns field errors for unsupported request features
 // (FirstAvailable, AdminAccess, AllocationMode All).
 func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Requests, field.ErrorList) {
-	out := resources.CreateEmpty()
+	out := resources.NewRequests()
 	if claimSpec == nil {
 		return out, nil
 	}

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -40,8 +40,8 @@ func Equal(a, b Requests) bool {
 	return equal
 }
 
-// CreateEmpty creates an empty Requests instance based on feature gates.
-func CreateEmpty() Requests {
+// NewRequests creates an empty Requests instance based on feature gates.
+func NewRequests() Requests {
 	if features.Enabled(features.VectorizedResourceRequests) {
 		return &SliceRequests{}
 	}
@@ -51,7 +51,7 @@ func CreateEmpty() Requests {
 // NewRequestsFromMap creates a Requests instance from a map based on feature gates.
 func NewRequestsFromMap(m map[corev1.ResourceName]int64) Requests {
 	if len(m) == 0 {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	if features.Enabled(features.VectorizedResourceRequests) {
 		sr := toSliceRequests(MapRequests(m))
@@ -72,7 +72,7 @@ func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 // NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
 func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
 	return NewRequestsFromResourceList(rl)

--- a/pkg/resources/lazy_requests.go
+++ b/pkg/resources/lazy_requests.go
@@ -50,7 +50,7 @@ func (l *LazyRequests) ensureWritable() {
 		case !isEmpty(l.base):
 			l.cached = l.base.Clone()
 		default:
-			l.cached = CreateEmpty()
+			l.cached = NewRequests()
 		}
 	}
 }

--- a/pkg/resources/resource.go
+++ b/pkg/resources/resource.go
@@ -47,7 +47,7 @@ func (frq FlavorResourceQuantities) MarshalJSON() ([]byte, error) {
 
 func (frq FlavorResourceQuantities) FlattenFlavors() Requests {
 	if len(frq) == 0 {
-		return CreateEmpty()
+		return NewRequests()
 	}
 	result := map[corev1.ResourceName]int64{}
 	for key, val := range frq {

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -749,7 +749,7 @@ func (a *FlavorAssigner) assignFlavors(ctx context.Context, log logr.Logger, cou
 	}
 
 	for _, podSets := range groupedRequests.InOrder {
-		requests := resources.CreateEmpty()
+		requests := resources.NewRequests()
 		psIDs := make([]int, len(podSets))
 		for idx, podset := range podSets {
 			psIDs[idx] = podset.originalIndex
@@ -1350,7 +1350,7 @@ func (a *FlavorAssigner) canPreemptWhileBorrowing() bool {
 }
 
 func filterRequestedResources(req resources.Requests, allowList sets.Set[corev1.ResourceName]) resources.Requests {
-	filtered := resources.CreateEmpty()
+	filtered := resources.NewRequests()
 	req.ForEach(func(resName corev1.ResourceName, quantity int64) {
 		if allowList.Has(resName) {
 			filtered.Set(resName, quantity)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -546,7 +546,7 @@ func (i *Info) TASUsage() TASUsage {
 }
 
 func (i *Info) SumTotalRequests(formatter *resources.ResourceFormatter) corev1.ResourceList {
-	reqs := resources.CreateEmpty()
+	reqs := resources.NewRequests()
 	for _, psReqs := range i.TotalRequests {
 		if psReqs.Requests != nil {
 			reqs.Add(psReqs.Requests)


### PR DESCRIPTION
Cherry pick of #14325 on release-0.19.

#14325: chore: Replace EmptyRequests with NewRequests to aligh Go idiomitic naming policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```