### PR TITLE
Retry transient networking issues for upgrade tests

### DIFF
--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -99,14 +99,25 @@ function e2e_docker_pull_if_needed {
         -- docker pull "$image"
 }
 
+function e2e_download_url {
+    local url="$1"
+
+    # Make HTTP errors retryable instead of passing their response bodies to
+    # kubectl as manifests.
+    "${ROOT_DIR}/hack/testing/retry.sh" \
+        --attempts 7 --delay 2 --exponential -- \
+        curl -fsSL "${url}"
+}
+
 function e2e_kubectl_apply_url {
     local url="$1"
     shift
     local extra_args=("$@")
     local manifest
 
-    manifest=$("${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential -- curl -fsSL "${url}") || return 1
-    echo "${manifest}" | kubectl apply --server-side -f - "${extra_args[@]}"
+    manifest=$(e2e_download_url "${url}") || return 1
+    printf '%s\n' "${manifest}" |
+    kubectl apply --server-side -f - "${extra_args[@]}"
 }
 
 function e2e_wait_for_operator_in_install {
@@ -1558,6 +1569,7 @@ EOF
 # $1 kubeconfig
 function upgrade_test_flow {
     local old_version="${KUEUE_UPGRADE_FROM_VERSION}"
+    local manifest
 
     echo "Upgrade Test: $old_version -> current"
     echo "Old image: $KUEUE_OLD_VERSION_IMAGE"
@@ -1570,7 +1582,8 @@ function upgrade_test_flow {
 
     # Download manifests, rewrite the image reference to match the pre-loaded
     # image, and set imagePullPolicy to IfNotPresent so kind uses it directly.
-    curl -sL "${KUEUE_OLD_VERSION_MANIFEST}" | \
+    manifest=$(e2e_download_url "${KUEUE_OLD_VERSION_MANIFEST}") || return 1
+    printf '%s\n' "${manifest}" | \
       sed "s|registry.k8s.io/kueue/kueue:${old_version}|${KUEUE_OLD_VERSION_IMAGE}|g" | \
       sed 's|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g' | \
       kubectl apply --server-side -f -


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14333

#### Special notes for your reviewer:

This code reuses the same retry mechanism in `upgrade_test_flow` as we already had in `e2e_kubectl_apply_url`

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of automated environment setup by adding retryable downloads with explicit HTTP error handling.
  * Updated upgrade-test manifest retrieval to consistently apply required image and pull-policy adjustments.
  * Improved handling of downloaded deployment manifests when applying them during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->