### PR TITLE
Automated cherry pick of #14335: chore: Use return new(foo) instead of bar:=&foo; return bar

### DIFF
--- a/cmd/experimental/kueue-populator/pkg/config/config.go
+++ b/cmd/experimental/kueue-populator/pkg/config/config.go
@@ -91,8 +91,7 @@ func (c *Configuration) Validate() field.ErrorList {
 // If the path is empty, it returns the default configuration.
 func Load(path string) (*Configuration, error) {
 	if path == "" {
-		cfg := Default()
-		return &cfg, nil
+		return new(Default()), nil
 	}
 
 	data, err := os.ReadFile(path)

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -1127,22 +1127,19 @@ func TestValidateKubeconfig(t *testing.T) {
 	}{
 		"tokenFile not allowed": {
 			cfgFn: func() *clientcmdapi.Config {
-				c := kubeconfigBase.Clone().TokenFileAuthInfo("u", "/tmp/tokenfile").Obj()
-				return &c
+				return new(kubeconfigBase.Clone().TokenFileAuthInfo("u", "/tmp/tokenfile").Obj())
 			},
 			wantErr: true,
 		},
 		"insecure skip-tls": {
 			cfgFn: func() *clientcmdapi.Config {
-				c := kubeconfigBase.Clone().InsecureSkipTLSVerify("test", true).Obj()
-				return &c
+				return new(kubeconfigBase.Clone().InsecureSkipTLSVerify("test", true).Obj())
 			},
 			wantErr: true,
 		},
 		"certificate-authority file disallowed": {
 			cfgFn: func() *clientcmdapi.Config {
-				c := kubeconfigBase.Clone().CAFileCluster("test", "/tmp/ca").Obj()
-				return &c
+				return new(kubeconfigBase.Clone().CAFileCluster("test", "/tmp/ca").Obj())
 			},
 			wantErr: true,
 		},

--- a/pkg/dra/capacity_test.go
+++ b/pkg/dra/capacity_test.go
@@ -208,8 +208,7 @@ func TestComputeCapacityCharge(t *testing.T) {
 		}
 	}
 	ptrQty := func(s string) *resource.Quantity {
-		q := resource.MustParse(s)
-		return &q
+		return new(resource.MustParse(s))
 	}
 
 	tests := []struct {

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -54,8 +54,7 @@ func NewRequestsFromMap(m map[corev1.ResourceName]int64) Requests {
 		return NewRequests()
 	}
 	if features.Enabled(features.VectorizedResourceRequests) {
-		sr := toSliceRequests(MapRequests(m))
-		return &sr
+		return new(toSliceRequests(MapRequests(m)))
 	}
 	return MapRequests(m)
 }
@@ -63,8 +62,7 @@ func NewRequestsFromMap(m map[corev1.ResourceName]int64) Requests {
 // NewRequestsFromResourceList creates a Requests instance from a corev1.ResourceList based on feature gates.
 func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 	if features.Enabled(features.VectorizedResourceRequests) {
-		sr := ResourceListToSliceRequests(rl)
-		return &sr
+		return new(ResourceListToSliceRequests(rl))
 	}
 	return NewMapRequests(rl)
 }

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -162,8 +162,7 @@ func (sr *SliceRequests) Clone() Requests {
 	if sr == nil {
 		return (*SliceRequests)(nil)
 	}
-	res := slices.Clone(*sr)
-	return &res
+	return new(slices.Clone(*sr))
 }
 
 func (sr *SliceRequests) ScaledUp(f int64) Requests {

--- a/pkg/workloadslicing/workloadslicing.go
+++ b/pkg/workloadslicing/workloadslicing.go
@@ -87,8 +87,7 @@ func ReplacementForKey(wl *kueue.Workload) *workload.Reference {
 	if !found {
 		return nil
 	}
-	ref := workload.Reference(key)
-	return &ref
+	return new(workload.Reference(key))
 }
 
 // SliceName returns the workload slice name for the given workload.


### PR DESCRIPTION
Cherry pick of #14335 on release-0.19.

#14335: chore: Use return new(foo) instead of bar:=&foo; return bar

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```