### PR TITLE
Automated cherry pick of #14342: chore: Replace requests.GetValue() with requests.ResourceValue() to align with Go idiomitic naming policy

### DIFF
--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -773,12 +773,12 @@ func TestPendingResources(t *testing.T) {
 	}
 
 	// Sum should equal wl1 + wl2 + wl3: CPU = 2+1+3 = 6000m, Memory = 1Gi+512Mi+2Gi.
-	wantCPU := wl1.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU) +
-		wl2.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU) +
-		wl3.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU)
-	wantMemory := wl1.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory) +
-		wl2.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory) +
-		wl3.TotalRequests[0].Requests.GetValue(corev1.ResourceMemory)
+	wantCPU := wl1.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU) +
+		wl2.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU) +
+		wl3.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU)
+	wantMemory := wl1.TotalRequests[0].Requests.ResourceValue(corev1.ResourceMemory) +
+		wl2.TotalRequests[0].Requests.ResourceValue(corev1.ResourceMemory) +
+		wl3.TotalRequests[0].Requests.ResourceValue(corev1.ResourceMemory)
 	if got[corev1.ResourceCPU] != wantCPU {
 		t.Errorf("CPU mismatch: want %d, got %d", wantCPU, got[corev1.ResourceCPU])
 	}
@@ -891,7 +891,7 @@ func TestPendingResourcesAfterLocalQueueResync(t *testing.T) {
 }
 
 func singleWorkloadCPU(wInfo *workload.Info) int64 {
-	return wInfo.TotalRequests[0].Requests.GetValue(corev1.ResourceCPU)
+	return wInfo.TotalRequests[0].Requests.ResourceValue(corev1.ResourceCPU)
 }
 
 func TestPendingInLocalQueueCountsInflight(t *testing.T) {

--- a/pkg/cache/scheduler/tas_non_tas_pod_cache.go
+++ b/pkg/cache/scheduler/tas_non_tas_pod_cache.go
@@ -136,7 +136,7 @@ func (n *nonTasUsageCache) removeNodeUsage(node string, usage resources.Requests
 	}
 	existing.Sub(usage)
 	existing.Sub(resources.OnePodRequest)
-	if pods := existing.GetValue(corev1.ResourcePods); pods <= 0 {
+	if pods := existing.ResourceValue(corev1.ResourcePods); pods <= 0 {
 		if pods < 0 {
 			log.V(0).Info("Unexpected negative pod count in nodeUsage", "node", node, "podCount", pods)
 		}

--- a/pkg/controller/core/workload_controller_test.go
+++ b/pkg/controller/core/workload_controller_test.go
@@ -2055,7 +2055,7 @@ func runReconcileTestCases(t *testing.T, cases map[string]reconcileTestCase, fak
 
 									if tc.wantDRAResourceTotal != nil {
 										if len(wlInfo.TotalRequests) > 0 && wlInfo.TotalRequests[0].Requests != nil {
-											gpuVal := wlInfo.TotalRequests[0].Requests.GetValue("gpu")
+											gpuVal := wlInfo.TotalRequests[0].Requests.ResourceValue("gpu")
 											if gpuVal > 0 {
 												if gpuVal != *tc.wantDRAResourceTotal {
 													t.Errorf("Expected gpu resource total to be %d, got %d", *tc.wantDRAResourceTotal, gpuVal)

--- a/pkg/dra/claims.go
+++ b/pkg/dra/claims.go
@@ -119,7 +119,7 @@ func countDevicesPerClass(claimSpec *resourcev1.ResourceClaimSpec) (resources.Re
 		// apiserver accepts up to MaxInt64), so accumulate with a saturating add
 		// (matching the scheduler's Amount arithmetic) rather than letting the
 		// sum wrap to a negative count.
-		out.Set(dc, utilmath.SaturatingAdd(out.GetValue(dc), q))
+		out.Set(dc, utilmath.SaturatingAdd(out.ResourceValue(dc), q))
 	}
 	return out, nil
 }

--- a/pkg/dra/claims_test.go
+++ b/pkg/dra/claims_test.go
@@ -765,7 +765,7 @@ func Test_countDevicesPerClass_overflow(t *testing.T) {
 			if len(errs) != 0 {
 				t.Fatalf("unexpected errors: %v", errs)
 			}
-			if got := out.GetValue("gpu"); got != tc.wantCount {
+			if got := out.ResourceValue("gpu"); got != tc.wantCount {
 				t.Errorf("count = %d, want %d", got, tc.wantCount)
 			}
 		})

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -33,7 +33,7 @@ func Equal(a, b Requests) bool {
 	}
 	equal := true
 	a.ForEach(func(name corev1.ResourceName, val int64) {
-		if equal && b.GetValue(name) != val {
+		if equal && b.ResourceValue(name) != val {
 			equal = false
 		}
 	})

--- a/pkg/resources/interface.go
+++ b/pkg/resources/interface.go
@@ -38,7 +38,7 @@ type Requests interface {
 	Mul(f int64)
 	CountIn(capacity Requests) int32
 	CountInWithLimitingResource(capacity Requests) (int32, corev1.ResourceName)
-	GetValue(name corev1.ResourceName) int64
+	ResourceValue(name corev1.ResourceName) int64
 	Set(name corev1.ResourceName, val int64)
 	ForEach(fn func(name corev1.ResourceName, val int64))
 	Iter() iter.Seq2[corev1.ResourceName, int64]

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -90,7 +90,7 @@ func (r MapRequests) Mul(f int64) {
 	}
 }
 
-func (r MapRequests) GetValue(name corev1.ResourceName) int64 {
+func (r MapRequests) ResourceValue(name corev1.ResourceName) int64 {
 	return r[name]
 }
 
@@ -198,7 +198,7 @@ func CountInWithLimitingResource(requests Requests, capacity Requests) (int32, c
 		limitingResource corev1.ResourceName
 	)
 	requests.ForEach(func(rName corev1.ResourceName, rValue int64) {
-		cap := capacity.GetValue(rName)
+		cap := capacity.ResourceValue(rName)
 		// find the minimum count matching all the resource quota.
 		var count int32
 		if rValue == 0 {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -770,7 +770,7 @@ func TestMapRequestsGetValue(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := tc.req.GetValue(tc.resource); got != tc.want {
+			if got := tc.req.ResourceValue(tc.resource); got != tc.want {
 				t.Errorf("unexpected GetValue(), want=%d, got=%d", tc.want, got)
 			}
 		})
@@ -832,7 +832,7 @@ func TestMapRequestsClone(t *testing.T) {
 			t.Errorf("cloned map mismatch (-want +got):\n%s", cmp.Diff(m, cloned))
 		}
 		cloned.Add(MapRequests{corev1.ResourceMemory: 1024})
-		if m.GetValue(corev1.ResourceMemory) != 0 {
+		if m.ResourceValue(corev1.ResourceMemory) != 0 {
 			t.Errorf("original map was mutated after modifying clone")
 		}
 	})

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -126,7 +126,7 @@ func (sr *SliceRequests) ForEach(fn func(name corev1.ResourceName, val int64)) {
 	}
 }
 
-func (sr *SliceRequests) GetValue(name corev1.ResourceName) int64 {
+func (sr *SliceRequests) ResourceValue(name corev1.ResourceName) int64 {
 	if sr == nil {
 		return 0
 	}
@@ -367,7 +367,7 @@ func (sr *SliceRequests) CountInWithLimitingResource(capacity Requests) (int32, 
 				capVal = (*capSR)[j].value
 			}
 		} else if capacity != nil {
-			capVal = capacity.GetValue(entry.name)
+			capVal = capacity.ResourceValue(entry.name)
 		}
 
 		count := int32(math.MaxInt32)

--- a/pkg/resources/slice_requests_fuzz_test.go
+++ b/pkg/resources/slice_requests_fuzz_test.go
@@ -353,8 +353,8 @@ func FuzzSliceRequestsEquivalence(f *testing.F) {
 			checkRequestsEquivalence(t, "Set", m1Copy, s1Copy)
 		case opGetValue:
 			res := fuzzResourceNames[int(opChoice)%len(fuzzResourceNames)]
-			mVal := m1.GetValue(res)
-			sVal := s1.GetValue(res)
+			mVal := m1.ResourceValue(res)
+			sVal := s1.ResourceValue(res)
 			if mVal != sVal {
 				t.Errorf("GetValue mismatch for %s: Map got %d, Slice got %d", res, mVal, sVal)
 			}

--- a/pkg/resources/slice_requests_test.go
+++ b/pkg/resources/slice_requests_test.go
@@ -372,7 +372,7 @@ func TestSliceRequests_GetValue(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			got := tc.req.GetValue(tc.res)
+			got := tc.req.ResourceValue(tc.res)
 			if got != tc.want {
 				t.Errorf("GetValue(%s) = %d, want %d", tc.res, got, tc.want)
 			}

--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -988,7 +988,7 @@ func (a *Assignment) append(requests resources.Requests, psAssignment *PodSetAss
 		// podSets that already have quota reserved in the old slice.
 		var requestAmount int64
 		if requests != nil {
-			requestAmount = requests.GetValue(resource)
+			requestAmount = requests.ResourceValue(resource)
 		}
 		if features.Enabled(features.ElasticJobsViaWorkloadSlices) && a.replaceWorkloadSlice != nil {
 			oldRequest := a.findOldPodSetRequest(psAssignment.Name, resource)
@@ -1010,7 +1010,7 @@ func (a *Assignment) findOldPodSetRequest(psName kueue.PodSetReference, resource
 
 	for _, oldPS := range a.replaceWorkloadSlice.TotalRequests {
 		if oldPS.Name == psName && oldPS.Requests != nil {
-			return oldPS.Requests.GetValue(resource)
+			return oldPS.Requests.ResourceValue(resource)
 		}
 	}
 
@@ -1100,7 +1100,7 @@ func (a *FlavorAssigner) findFlavorForPodSets(
 
 					// Subtract the resource usage of the preempted slice to request only the delta needed.
 					if preemptWorkloadRequests.Requests != nil {
-						val -= preemptWorkloadRequests.Requests.GetValue(rName)
+						val -= preemptWorkloadRequests.Requests.ResourceValue(rName)
 					}
 				}
 			}


### PR DESCRIPTION
Cherry pick of #14342 on release-0.19.

#14342: chore: Replace requests.GetValue() with requests.ResourceValue() to align with Go idiomitic naming policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
NONE
```