### PR TITLE
TAS: improve clarity of domain and leaf state names

### DIFF
--- a/pkg/cache/scheduler/tas_balanced_placement.go
+++ b/pkg/cache/scheduler/tas_balanced_placement.go
@@ -34,11 +34,11 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 	idx := 0
 	if leaderCount > 0 {
 		sortedWithLeader = s.sortedDomainsWithLeader(domains, false)
-		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && s.stateOf(sortedWithLeader[idx]).leaderState > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedWithLeader) && s.domainStateOf(sortedWithLeader[idx]).leaderCount > 0; idx++ {
 			selectedDomainsCount++
 			lastDomainWithLeader = sortedWithLeader[idx]
-			remainingLeaderCount -= s.stateOf(sortedWithLeader[idx]).leaderState
-			remainingSliceCount -= s.stateOf(sortedWithLeader[idx]).sliceStateWithLeader
+			remainingLeaderCount -= s.domainStateOf(sortedWithLeader[idx]).leaderCount
+			remainingSliceCount -= s.domainStateOf(sortedWithLeader[idx]).sliceCountWithLeader
 		}
 		sortedWithoutLeader = s.sortedDomains(sortedWithLeader[idx:], false)
 	} else {
@@ -49,10 +49,10 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 		return false, 0, nil, nil
 	}
 
-	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && s.stateOf(sortedWithoutLeader[idx]).sliceState > 0; idx++ {
+	for idx = 0; remainingSliceCount > 0 && idx < len(sortedWithoutLeader) && s.domainStateOf(sortedWithoutLeader[idx]).sliceCount > 0; idx++ {
 		selectedDomainsCount++
 		lastDomain = sortedWithoutLeader[idx]
-		remainingSliceCount -= s.stateOf(sortedWithoutLeader[idx]).sliceState
+		remainingSliceCount -= s.domainStateOf(sortedWithoutLeader[idx]).sliceCount
 	}
 	if remainingSliceCount > 0 {
 		return false, 0, nil, nil
@@ -64,10 +64,10 @@ func evaluateGreedyAssignment(s *TASFlavorSnapshot, domains []*domain, sliceCoun
 func balanceThresholdValue(s *TASFlavorSnapshot, sliceCount int32, selectedDomainsCount int32, lastDomainWithLeader *domain, lastDomain *domain) int32 {
 	threshold := sliceCount / selectedDomainsCount
 	if lastDomainWithLeader != nil {
-		threshold = min(threshold, s.stateOf(lastDomainWithLeader).sliceStateWithLeader)
+		threshold = min(threshold, s.domainStateOf(lastDomainWithLeader).sliceCountWithLeader)
 	}
 	if lastDomain != nil {
-		threshold = min(threshold, s.stateOf(lastDomain).sliceState)
+		threshold = min(threshold, s.domainStateOf(lastDomain).sliceCount)
 	}
 	return threshold
 }
@@ -98,36 +98,36 @@ func selectOptimalDomainSetToFit(s *TASFlavorSnapshot, domains []*domain, sliceC
 	domainPlacements[0][leaderCount] = map[int32][]*domain{sliceCount * sliceSize: {}}
 
 	for _, d := range orderedDomains {
-		dState := s.stateOf(d)
+		domainState := s.domainStateOf(d)
 		for i := optimalNumberOfDomains; i > 0; i-- {
 			for _, beforeLeader := range slices.Sorted(maps.Keys(domainPlacements[i-1])) {
-				for _, beforeState := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
-					beforePlacement := domainPlacements[i-1][beforeLeader][beforeState]
-					if beforeLeader <= 0 && beforeState <= 0 {
+				for _, beforePods := range slices.Sorted(maps.Keys(domainPlacements[i-1][beforeLeader])) {
+					beforePlacement := domainPlacements[i-1][beforeLeader][beforePods]
+					if beforeLeader <= 0 && beforePods <= 0 {
 						continue
 					}
 					newPlacement := make([]*domain, len(beforePlacement), len(beforePlacement)+1)
 					copy(newPlacement, beforePlacement)
 					newPlacement = append(newPlacement, d)
 					// Case 1: Pick this domain with leader
-					if beforeLeader > 0 && dState.leaderState > 0 {
-						afterLeader := beforeLeader - dState.leaderState
-						afterState := beforeState - dState.stateWithLeader
+					if beforeLeader > 0 && domainState.leaderCount > 0 {
+						afterLeader := beforeLeader - domainState.leaderCount
+						afterPods := beforePods - domainState.podCountWithLeader
 						if domainPlacements[i][afterLeader] == nil {
 							domainPlacements[i][afterLeader] = make(map[int32][]*domain)
 						}
-						if _, alreadyThere := domainPlacements[i][afterLeader][afterState]; !alreadyThere {
-							domainPlacements[i][afterLeader][afterState] = newPlacement
+						if _, alreadyThere := domainPlacements[i][afterLeader][afterPods]; !alreadyThere {
+							domainPlacements[i][afterLeader][afterPods] = newPlacement
 						}
 					}
 					// Case 2: Pick this domain without leader
-					if dState.sliceState > 0 {
-						afterState := beforeState - dState.state
+					if domainState.sliceCount > 0 {
+						afterPods := beforePods - domainState.podCount
 						if domainPlacements[i][beforeLeader] == nil {
 							domainPlacements[i][beforeLeader] = make(map[int32][]*domain)
 						}
-						if _, alreadyThere := domainPlacements[i][beforeLeader][afterState]; !alreadyThere {
-							domainPlacements[i][beforeLeader][afterState] = newPlacement
+						if _, alreadyThere := domainPlacements[i][beforeLeader][afterPods]; !alreadyThere {
+							domainPlacements[i][beforeLeader][afterPods] = newPlacement
 						}
 					}
 				}
@@ -161,23 +161,23 @@ func placeSlicesOnDomainsBalanced(s *TASFlavorSnapshot, domains []*domain, slice
 	leadersLeft := leaderCount
 	var extraSlicesToTake int32
 	for _, domain := range resultDomains {
-		domainState := s.stateOf(domain)
+		domainState := s.domainStateOf(domain)
 		switch {
 		case leadersLeft > 0:
-			extraSlicesToTake = min(domainState.sliceStateWithLeader-threshold, extraSlicesLeft)
-			domainState.leaderState = 1
+			extraSlicesToTake = min(domainState.sliceCountWithLeader-threshold, extraSlicesLeft)
+			domainState.leaderCount = 1
 			leadersLeft--
 		case extraSlicesLeft > 0:
-			extraSlicesToTake = min(domainState.sliceState-threshold, extraSlicesLeft)
-			domainState.leaderState = 0
+			extraSlicesToTake = min(domainState.sliceCount-threshold, extraSlicesLeft)
+			domainState.leaderCount = 0
 		default:
-			domainState.leaderState = 0
+			domainState.leaderCount = 0
 			extraSlicesToTake = 0
 		}
-		domainState.state = (threshold + extraSlicesToTake) * sliceSize
-		domainState.sliceState = (threshold + extraSlicesToTake)
-		domainState.sliceStateWithLeader = domainState.sliceState
-		domainState.stateWithLeader = domainState.state - domainState.leaderState
+		domainState.podCount = (threshold + extraSlicesToTake) * sliceSize
+		domainState.sliceCount = (threshold + extraSlicesToTake)
+		domainState.sliceCountWithLeader = domainState.sliceCount
+		domainState.podCountWithLeader = domainState.podCount - domainState.leaderCount
 		extraSlicesLeft -= extraSlicesToTake
 	}
 	if extraSlicesLeft > 0 || leadersLeft > 0 {
@@ -193,7 +193,7 @@ func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 
 	var total int32
 	for _, d := range domains {
-		total += s.stateOf(d).state
+		total += s.domainStateOf(d).podCount
 	}
 
 	if total == 0 {
@@ -203,8 +203,8 @@ func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 	var entropy float64
 	totalF := float64(total)
 	for _, d := range domains {
-		if state := s.stateOf(d).state; state > 0 {
-			pI := float64(state) / totalF
+		if podCount := s.domainStateOf(d).podCount; podCount > 0 {
+			pI := float64(podCount) / totalF
 			entropy += -pI * math.Log2(pI)
 		}
 	}
@@ -212,10 +212,10 @@ func (s *TASFlavorSnapshot) calculateDomainsEntropy(domains []*domain) float64 {
 }
 
 func (s *TASFlavorSnapshot) compareDomainCapacityAndEntropy(a, b *domain) int {
-	if r := s.stateOf(b).leaderState - s.stateOf(a).leaderState; r != 0 {
+	if r := s.domainStateOf(b).leaderCount - s.domainStateOf(a).leaderCount; r != 0 {
 		return int(r)
 	}
-	if r := s.stateOf(b).sliceStateWithLeader - s.stateOf(a).sliceStateWithLeader; r != 0 {
+	if r := s.domainStateOf(b).sliceCountWithLeader - s.domainStateOf(a).sliceCountWithLeader; r != 0 {
 		return int(r)
 	}
 	aEntropy := s.calculateDomainsEntropy(a.children)
@@ -262,7 +262,7 @@ func findBestDomainsForBalancedPlacement(s *TASFlavorSnapshot, params *topologyA
 		threshold := balanceThresholdValue(s, sliceCount, selectedDomainsCount, lastDomainWithLeader, lastDomain)
 		thresholdWithLeaderReservation := threshold
 		if params.leaderCount > 0 && lastDomain != nil {
-			thresholdWithLeaderReservation = min(threshold, s.stateOf(lastDomain).sliceStateWithLeader)
+			thresholdWithLeaderReservation = min(threshold, s.domainStateOf(lastDomain).sliceCountWithLeader)
 		}
 		if threshold >= bestThreshold {
 			s.pruneDomainsBelowThreshold(candidateDomains, threshold, params.sliceSize, params.sliceLevelIdx, params.requestedLevelIdx, params.leaderCount > 0)
@@ -322,7 +322,7 @@ func getLowerLevelDomains(s *TASFlavorSnapshot, domains []*domain, levelIdx, sli
 }
 
 func (s *TASFlavorSnapshot) clearState(d *domain) {
-	st := s.stateOf(d)
+	st := s.domainStateOf(d)
 	*st = domainState{affinityScore: st.affinityScore}
 	for _, child := range d.children {
 		s.clearState(child)
@@ -330,10 +330,10 @@ func (s *TASFlavorSnapshot) clearState(d *domain) {
 }
 
 func (s *TASFlavorSnapshot) clearLeaderCapacity(d *domain) {
-	domainState := s.stateOf(d)
-	domainState.stateWithLeader = 0
-	domainState.sliceStateWithLeader = 0
-	domainState.leaderState = 0
+	domainState := s.domainStateOf(d)
+	domainState.podCountWithLeader = 0
+	domainState.sliceCountWithLeader = 0
+	domainState.leaderCount = 0
 	for _, child := range d.children {
 		s.clearLeaderCapacity(child)
 	}
@@ -363,13 +363,13 @@ func (s *TASFlavorSnapshot) cloneDomain(d *domain, parent *domain) *domain {
 }
 
 func (s *TASFlavorSnapshot) pruneDomainNodeBelowThreshold(d *domain, threshold int32, leaderRequired bool) {
-	domainState := s.stateOf(d)
-	if domainState.sliceState < threshold {
+	domainState := s.domainStateOf(d)
+	if domainState.sliceCount < threshold {
 		s.clearState(d)
 		return
 	}
 	// The domain can still be used for workers, but not as the leader host at this threshold.
-	if leaderRequired && domainState.leaderState > 0 && domainState.sliceStateWithLeader < threshold {
+	if leaderRequired && domainState.leaderCount > 0 && domainState.sliceCountWithLeader < threshold {
 		s.clearLeaderCapacity(d)
 	}
 }

--- a/pkg/cache/scheduler/tas_balanced_placement_test.go
+++ b/pkg/cache/scheduler/tas_balanced_placement_test.go
@@ -32,9 +32,9 @@ func domainIDs(domains []*domain) []string {
 	return utilslices.Map(domains, func(d **domain) string { return string((*d).id) })
 }
 
-func addDomainWithState(s *TASFlavorSnapshot, d *domain, st domainState) *domain {
-	d.idx = len(s.state)
-	s.state = append(s.state, st)
+func addDomainWithState(s *TASFlavorSnapshot, d *domain, state domainState) *domain {
+	d.idx = len(s.domainStates)
+	s.domainStates = append(s.domainStates, state)
 	return d
 }
 
@@ -42,41 +42,41 @@ func TestSelectOptimalDomainSetToFit(t *testing.T) {
 	d1 := testDomainSpec{
 		domain: domain{id: "d1", levelValues: []string{"d1"}},
 		state: domainState{
-			state:                9,
-			sliceState:           9,
-			leaderState:          1,
-			stateWithLeader:      8,
-			sliceStateWithLeader: 8,
+			podCount:             9,
+			sliceCount:           9,
+			leaderCount:          1,
+			podCountWithLeader:   8,
+			sliceCountWithLeader: 8,
 		},
 	}
 	d2 := testDomainSpec{
 		domain: domain{id: "d2", levelValues: []string{"d2"}},
 		state: domainState{
-			state:                6,
-			sliceState:           6,
-			leaderState:          0,
-			stateWithLeader:      6,
-			sliceStateWithLeader: 6,
+			podCount:             6,
+			sliceCount:           6,
+			leaderCount:          0,
+			podCountWithLeader:   6,
+			sliceCountWithLeader: 6,
 		},
 	}
 	d3 := testDomainSpec{
 		domain: domain{id: "d3", levelValues: []string{"d3"}},
 		state: domainState{
-			state:                4,
-			sliceState:           4,
-			leaderState:          1,
-			stateWithLeader:      3,
-			sliceStateWithLeader: 3,
+			podCount:             4,
+			sliceCount:           4,
+			leaderCount:          1,
+			podCountWithLeader:   3,
+			sliceCountWithLeader: 3,
 		},
 	}
 	d4 := testDomainSpec{
 		domain: domain{id: "d4", levelValues: []string{"d4"}},
 		state: domainState{
-			state:                2,
-			sliceState:           2,
-			leaderState:          0,
-			stateWithLeader:      2,
-			sliceStateWithLeader: 2,
+			podCount:             2,
+			sliceCount:           2,
+			leaderCount:          0,
+			podCountWithLeader:   2,
+			sliceCountWithLeader: 2,
 		},
 	}
 
@@ -151,7 +151,7 @@ func TestSelectOptimalDomainSetToFitStableTieBreak(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, log := utiltesting.ContextWithLog(t)
 			s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
-			equalState := domainState{state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3}
+			equalState := domainState{podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3}
 			domains := []*domain{
 				addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
 				addDomainWithState(s, &domain{id: "leaf-m", levelValues: []string{"block-b", "host-m"}}, equalState),
@@ -175,8 +175,8 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 	}{
 		"tie-breaking on level values when capacity and entropy are equal": {
 			domains: func(s *TASFlavorSnapshot) []*domain {
-				leaderState := domainState{leaderState: 1, sliceStateWithLeader: 5}
-				childState := domainState{state: 2}
+				leaderState := domainState{leaderCount: 1, sliceCountWithLeader: 5}
+				childState := domainState{podCount: 2}
 				return []*domain{
 					addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}, children: []*domain{
 						addDomainWithState(s, &domain{}, childState), addDomainWithState(s, &domain{}, childState),
@@ -195,17 +195,17 @@ func TestCompareDomainCapacityAndEntropy(t *testing.T) {
 			domains: func(s *TASFlavorSnapshot) []*domain {
 				return []*domain{
 					addDomainWithState(s, &domain{id: "lower-leader", levelValues: []string{"a"}, children: []*domain{
-						addDomainWithState(s, &domain{}, domainState{state: 50}), addDomainWithState(s, &domain{}, domainState{state: 50}),
-					}}, domainState{leaderState: 0, sliceStateWithLeader: 100}),
+						addDomainWithState(s, &domain{}, domainState{podCount: 50}), addDomainWithState(s, &domain{}, domainState{podCount: 50}),
+					}}, domainState{leaderCount: 0, sliceCountWithLeader: 100}),
 					addDomainWithState(s, &domain{id: "lower-capacity", levelValues: []string{"b"}, children: []*domain{
-						addDomainWithState(s, &domain{}, domainState{state: 2}), addDomainWithState(s, &domain{}, domainState{state: 2}),
-					}}, domainState{leaderState: 1, sliceStateWithLeader: 4}),
+						addDomainWithState(s, &domain{}, domainState{podCount: 2}), addDomainWithState(s, &domain{}, domainState{podCount: 2}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 4}),
 					addDomainWithState(s, &domain{id: "low-entropy", levelValues: []string{"c"}, children: []*domain{
-						addDomainWithState(s, &domain{}, domainState{state: 4}), addDomainWithState(s, &domain{}, domainState{state: 0}),
-					}}, domainState{leaderState: 1, sliceStateWithLeader: 5}),
+						addDomainWithState(s, &domain{}, domainState{podCount: 4}), addDomainWithState(s, &domain{}, domainState{podCount: 0}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 5}),
 					addDomainWithState(s, &domain{id: "high-entropy", levelValues: []string{"d"}, children: []*domain{
-						addDomainWithState(s, &domain{}, domainState{state: 2}), addDomainWithState(s, &domain{}, domainState{state: 2}),
-					}}, domainState{leaderState: 1, sliceStateWithLeader: 5}),
+						addDomainWithState(s, &domain{}, domainState{podCount: 2}), addDomainWithState(s, &domain{}, domainState{podCount: 2}),
+					}}, domainState{leaderCount: 1, sliceCountWithLeader: 5}),
 				}
 			},
 			want: []string{"high-entropy", "low-entropy", "lower-capacity", "lower-leader"},
@@ -230,51 +230,51 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 	d1 := testDomainSpec{
 		domain: domain{id: "d1", levelValues: []string{"d1"}},
 		state: domainState{
-			state:                18,
-			sliceState:           18,
-			stateWithLeader:      18,
-			leaderState:          0,
-			sliceStateWithLeader: 18,
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
 		},
 	}
 	d2 := testDomainSpec{
 		domain: domain{id: "d2", levelValues: []string{"d2"}},
 		state: domainState{
-			state:                18,
-			sliceState:           18,
-			stateWithLeader:      18,
-			leaderState:          0,
-			sliceStateWithLeader: 18,
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
 		},
 	}
 	d3 := testDomainSpec{
 		domain: domain{id: "d3", levelValues: []string{"d3"}},
 		state: domainState{
-			state:                18,
-			sliceState:           18,
-			stateWithLeader:      18,
-			leaderState:          0,
-			sliceStateWithLeader: 18,
+			podCount:             18,
+			sliceCount:           18,
+			podCountWithLeader:   18,
+			leaderCount:          0,
+			sliceCountWithLeader: 18,
 		},
 	}
 	d4 := testDomainSpec{
 		domain: domain{id: "d4", levelValues: []string{"d4"}},
 		state: domainState{
-			state:                10,
-			sliceState:           10,
-			stateWithLeader:      10,
-			leaderState:          0,
-			sliceStateWithLeader: 10,
+			podCount:             10,
+			sliceCount:           10,
+			podCountWithLeader:   10,
+			leaderCount:          0,
+			sliceCountWithLeader: 10,
 		},
 	}
 	d5 := testDomainSpec{
 		domain: domain{id: "d5", levelValues: []string{"d5"}},
 		state: domainState{
-			state:                2,
-			sliceState:           2,
-			stateWithLeader:      2,
-			leaderState:          0,
-			sliceStateWithLeader: 2,
+			podCount:             2,
+			sliceCount:           2,
+			podCountWithLeader:   2,
+			leaderCount:          0,
+			sliceCountWithLeader: 2,
 		},
 	}
 
@@ -293,8 +293,8 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 			sliceSize:   1,
 			threshold:   10,
 			want: map[string]domainState{
-				"d1": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
-				"d2": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
+				"d1": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
+				"d2": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
 			},
 		},
 		"simple placement on three domains": {
@@ -304,9 +304,9 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 			sliceSize:   1,
 			threshold:   13,
 			want: map[string]domainState{
-				"d1": {sliceState: 14, state: 14, stateWithLeader: 14, sliceStateWithLeader: 14, leaderState: 0},
-				"d2": {sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
-				"d3": {sliceState: 13, state: 13, stateWithLeader: 13, sliceStateWithLeader: 13, leaderState: 0},
+				"d1": {sliceCount: 14, podCount: 14, podCountWithLeader: 14, sliceCountWithLeader: 14, leaderCount: 0},
+				"d2": {sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
+				"d3": {sliceCount: 13, podCount: 13, podCountWithLeader: 13, sliceCountWithLeader: 13, leaderCount: 0},
 			},
 		},
 		"find smallest domain that fits": {
@@ -316,7 +316,7 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 			sliceSize:   1,
 			threshold:   2,
 			want: map[string]domainState{
-				"d5": {sliceState: 2, state: 2, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 0},
+				"d5": {sliceCount: 2, podCount: 2, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 0},
 			},
 		},
 		"correctly select domains": {
@@ -326,8 +326,8 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 			sliceSize:   1,
 			threshold:   10,
 			want: map[string]domainState{
-				"d1": {sliceState: 15, state: 15, stateWithLeader: 15, sliceStateWithLeader: 15, leaderState: 0},
-				"d4": {sliceState: 10, state: 10, stateWithLeader: 10, sliceStateWithLeader: 10, leaderState: 0},
+				"d1": {sliceCount: 15, podCount: 15, podCountWithLeader: 15, sliceCountWithLeader: 15, leaderCount: 0},
+				"d4": {sliceCount: 10, podCount: 10, podCountWithLeader: 10, sliceCountWithLeader: 10, leaderCount: 0},
 			},
 		},
 	}
@@ -342,7 +342,7 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 
 			gotStates := make(map[string]domainState, len(got))
 			for _, d := range got {
-				gotStates[string(d.id)] = *s.stateOf(d)
+				gotStates[string(d.id)] = *s.domainStateOf(d)
 			}
 			if diff := cmp.Diff(tc.want, gotStates, cmp.AllowUnexported(domainState{})); diff != "" {
 				t.Errorf("Unexpected domains (-want,+got):\n%s", diff)
@@ -354,7 +354,7 @@ func TestPlaceSlicesOnDomainsBalanced(t *testing.T) {
 func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 	_, log := utiltesting.ContextWithLog(t)
 	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
-	equalState := domainState{state: 3, sliceState: 3, stateWithLeader: 3, sliceStateWithLeader: 3}
+	equalState := domainState{podCount: 3, sliceCount: 3, podCountWithLeader: 3, sliceCountWithLeader: 3}
 	domains := []*domain{
 		addDomainWithState(s, &domain{id: "leaf-a", levelValues: []string{"block-b", "host-a"}}, equalState),
 		addDomainWithState(s, &domain{id: "leaf-z", levelValues: []string{"block-a", "host-z"}}, equalState),
@@ -372,8 +372,8 @@ func TestPlaceSlicesOnDomainsBalancedStableTieBreak(t *testing.T) {
 
 func TestPruneDomainsBelowThreshold(t *testing.T) {
 	domainStateValues := func(s *TASFlavorSnapshot, d *domain) [5]int32 {
-		st := s.stateOf(d)
-		return [5]int32{st.state, st.sliceState, st.stateWithLeader, st.sliceStateWithLeader, st.leaderState}
+		st := s.domainStateOf(d)
+		return [5]int32{st.podCount, st.sliceCount, st.podCountWithLeader, st.sliceCountWithLeader, st.leaderCount}
 	}
 
 	testCases := map[string]struct {
@@ -390,41 +390,41 @@ func TestPruneDomainsBelowThreshold(t *testing.T) {
 				leaderLeaf := addDomainWithState(s, &domain{
 					id: "leader-leaf",
 				}, domainState{
-					state:                6,
-					sliceState:           6,
-					leaderState:          1,
-					stateWithLeader:      5,
-					sliceStateWithLeader: 5,
+					podCount:             6,
+					sliceCount:           6,
+					leaderCount:          1,
+					podCountWithLeader:   5,
+					sliceCountWithLeader: 5,
 				})
 				leaderDomain := addDomainWithState(s, &domain{
 					id:       "leader-domain",
 					children: []*domain{leaderLeaf},
 				}, domainState{
-					state:                6,
-					sliceState:           6,
-					leaderState:          1,
-					stateWithLeader:      5,
-					sliceStateWithLeader: 5,
+					podCount:             6,
+					sliceCount:           6,
+					leaderCount:          1,
+					podCountWithLeader:   5,
+					sliceCountWithLeader: 5,
 				})
 				leaderLeaf.parent = leaderDomain
 				workerOnlyLeaf := addDomainWithState(s, &domain{
 					id: "worker-only-leaf",
 				}, domainState{
-					state:                5,
-					sliceState:           5,
-					leaderState:          1,
-					stateWithLeader:      4,
-					sliceStateWithLeader: 4,
+					podCount:             5,
+					sliceCount:           5,
+					leaderCount:          1,
+					podCountWithLeader:   4,
+					sliceCountWithLeader: 4,
 				})
 				workerOnlyDomain := addDomainWithState(s, &domain{
 					id:       "worker-only-domain",
 					children: []*domain{workerOnlyLeaf},
 				}, domainState{
-					state:                5,
-					sliceState:           5,
-					leaderState:          1,
-					stateWithLeader:      4,
-					sliceStateWithLeader: 4,
+					podCount:             5,
+					sliceCount:           5,
+					leaderCount:          1,
+					podCountWithLeader:   4,
+					sliceCountWithLeader: 4,
 				})
 				workerOnlyLeaf.parent = workerOnlyDomain
 				parentDomain := addDomainWithState(s, &domain{
@@ -477,14 +477,14 @@ func TestPruneDomainsBelowThresholdPreservesAffinityScore(t *testing.T) {
 	_, log := utiltesting.ContextWithLog(t)
 	s := newTASFlavorSnapshot(log, "dummy", newTopologyTree([]string{}, nil, 0), nil, &defaultChecker{})
 	prunedLeaf := addDomainWithState(s, &domain{id: "pruned-leaf"}, domainState{
-		sliceState:    1,
+		sliceCount:    1,
 		affinityScore: 100,
 	})
 	keptLeaf := addDomainWithState(s, &domain{id: "kept-leaf"}, domainState{
-		state:           4,
-		sliceState:      4,
-		stateWithLeader: 4,
-		affinityScore:   10,
+		podCount:           4,
+		sliceCount:         4,
+		podCountWithLeader: 4,
+		affinityScore:      10,
 	})
 	parent := addDomainWithState(s, &domain{
 		id:       "parent",
@@ -495,10 +495,10 @@ func TestPruneDomainsBelowThresholdPreservesAffinityScore(t *testing.T) {
 
 	s.pruneDomainsBelowThreshold([]*domain{parent}, 2, 1, 1, 0, false)
 
-	if got, want := s.stateOf(prunedLeaf).affinityScore, int64(100); got != want {
+	if got, want := s.domainStateOf(prunedLeaf).affinityScore, int64(100); got != want {
 		t.Errorf("Unexpected pruned leaf affinity score: got %d, want %d", got, want)
 	}
-	if got, want := s.stateOf(parent).affinityScore, int64(110); got != want {
+	if got, want := s.domainStateOf(parent).affinityScore, int64(110); got != want {
 		t.Errorf("Unexpected parent affinity score: got %d, want %d", got, want)
 	}
 }
@@ -508,11 +508,11 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 		id                   string
 		parentID             string
 		levelValues          []string
-		state                int32
-		sliceState           int32
-		stateWithLeader      int32
-		sliceStateWithLeader int32
-		leaderState          int32
+		podCount             int32
+		sliceCount           int32
+		podCountWithLeader   int32
+		sliceCountWithLeader int32
+		leaderCount          int32
 	}
 
 	testCases := map[string]struct {
@@ -525,9 +525,9 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 			domains: []domainSpec{
 				{id: "b1", levelValues: []string{"b1"}},
 				{id: "b2", levelValues: []string{"b2"}},
-				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, state: 3, sliceState: 3, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
-				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, state: 2, sliceState: 2, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
-				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, state: 4, sliceState: 4, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
+				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, podCount: 3, sliceCount: 3, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 1},
+				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, podCount: 2, sliceCount: 2, podCountWithLeader: 1, sliceCountWithLeader: 1, leaderCount: 1},
+				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, podCount: 4, sliceCount: 4, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 1},
 			},
 			params: topologyAssignmentParameters{
 				count:             8,
@@ -544,10 +544,10 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 				{id: "b1", levelValues: []string{"b1"}},
 				{id: "b2", levelValues: []string{"b2"}},
 				{id: "b3", levelValues: []string{"b3"}},
-				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, state: 2, sliceState: 2, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
-				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, state: 3, sliceState: 3, stateWithLeader: 1, sliceStateWithLeader: 1, leaderState: 1},
-				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, state: 4, sliceState: 4, stateWithLeader: 2, sliceStateWithLeader: 2, leaderState: 1},
-				{id: "b3/r1", parentID: "b3", levelValues: []string{"b3", "r1"}, state: 4, sliceState: 4, stateWithLeader: 3, sliceStateWithLeader: 3, leaderState: 1},
+				{id: "b1/r1", parentID: "b1", levelValues: []string{"b1", "r1"}, podCount: 2, sliceCount: 2, podCountWithLeader: 1, sliceCountWithLeader: 1, leaderCount: 1},
+				{id: "b2/r1", parentID: "b2", levelValues: []string{"b2", "r1"}, podCount: 3, sliceCount: 3, podCountWithLeader: 1, sliceCountWithLeader: 1, leaderCount: 1},
+				{id: "b2/r2", parentID: "b2", levelValues: []string{"b2", "r2"}, podCount: 4, sliceCount: 4, podCountWithLeader: 2, sliceCountWithLeader: 2, leaderCount: 1},
+				{id: "b3/r1", parentID: "b3", levelValues: []string{"b3", "r1"}, podCount: 4, sliceCount: 4, podCountWithLeader: 3, sliceCountWithLeader: 3, leaderCount: 1},
 			},
 			params: topologyAssignmentParameters{
 				count:             12,
@@ -571,11 +571,11 @@ func TestFindBestDomainsForBalancedPlacement(t *testing.T) {
 					id:          utiltas.TopologyDomainID(spec.id),
 					levelValues: spec.levelValues,
 				}, domainState{
-					state:                spec.state,
-					sliceState:           spec.sliceState,
-					stateWithLeader:      spec.stateWithLeader,
-					sliceStateWithLeader: spec.sliceStateWithLeader,
-					leaderState:          spec.leaderState,
+					podCount:             spec.podCount,
+					sliceCount:           spec.sliceCount,
+					podCountWithLeader:   spec.podCountWithLeader,
+					sliceCountWithLeader: spec.sliceCountWithLeader,
+					leaderCount:          spec.leaderCount,
 				})
 				if len(spec.parentID) == 0 {
 					s.domainsPerLevel[0][d.id] = d

--- a/pkg/cache/scheduler/tas_cache_test.go
+++ b/pkg/cache/scheduler/tas_cache_test.go
@@ -6217,7 +6217,7 @@ func TestFindTopologyAssignments(t *testing.T) {
 			},
 		},
 		// Proves cleanup necessity: the second PodSet excludes all nodes via selector.
-		// Without resetting temporary per-domain state (e.g. state/stateWithLeader), stale
+		// Without resetting temporary per-domain state (e.g. podCount/podCountWithLeader), stale
 		// values from the first PodSet would leak and produce a bogus assignment instead of failure.
 		"temporary state cleanup prevents leakage across PodSets": {
 			nodes: []corev1.Node{

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -53,7 +53,7 @@ var (
 // domainState is the per-snapshot mutable state of a domain during the
 // assignment algorithm, addressed by domain.idx.
 type domainState struct {
-	// state is a temporary state of the topology domains during the
+	// podCount is a temporary pod count of the topology domains during the
 	// assignment algorithm.
 	//
 	// In the first phase of the algorithm (traversal to the top the topology to
@@ -63,29 +63,29 @@ type domainState struct {
 	// In the second phase of the algorithm (traversal to the bottom to
 	// determine the actual assignments) it denotes the number of pods actually
 	// assigned to the given domain.
-	state int32
+	podCount int32
 
-	// sliceState is a temporary state of the topology domains during the
+	// sliceCount is a temporary slice count of the topology domains during the
 	// assignment algorithm that denotes the number of slices that can fit within
 	// that domain.
 	//
 	// For domains that are below the requested topology level the algorithm
 	// assigns 0 to that field as this field makes no sense for lower level
 	// domains.
-	sliceState int32
+	sliceCount int32
 
-	stateWithLeader      int32
-	sliceStateWithLeader int32
-	leaderState          int32
+	podCountWithLeader   int32
+	sliceCountWithLeader int32
+	leaderCount          int32
 
 	// affinityScore is the sum of weights of all preferred affinity terms that match the node.
 	// For non-leaf domains, it is the sum of affinity scores of all children.
 	affinityScore int64
 }
 
-// leafState is the per-snapshot mutable state of a leaf domain, addressed by
-// leafDomain.leafIdx.
-type leafState struct {
+// leafCapacity is the per-snapshot mutable capacity data of a leaf domain,
+// addressed by leafDomain.leafIdx.
+type leafCapacity struct {
 	// freeCapacity represents the total node capacity minus the non-TAS usage,
 	// coming from Pods which are not managed by workloads admitted by TAS
 	// (typically static Pods, DaemonSets, or Deployments).
@@ -118,11 +118,11 @@ func (c *leafCandidate) GetNode() *corev1.Node {
 }
 
 func (c *leafCandidate) SetAffinityScore(score int64) {
-	c.s.state[c.leaf.idx].affinityScore = score
+	c.s.domainStates[c.leaf.idx].affinityScore = score
 }
 
 func (c *leafCandidate) GetAffinityScore() int64 {
-	return c.s.state[c.leaf.idx].affinityScore
+	return c.s.domainStates[c.leaf.idx].affinityScore
 }
 
 type TASFlavorSnapshot struct {
@@ -136,13 +136,13 @@ type TASFlavorSnapshot struct {
 	// snapshots of the flavor. It must not be mutated.
 	*topologyTree
 
-	// state holds the per-snapshot mutable domain state, indexed by
+	// domainStates holds the per-snapshot mutable state for domains, indexed by
 	// domain.idx.
-	state []domainState
+	domainStates []domainState
 
-	// leafStates holds the per-snapshot mutable leaf state, indexed by
-	// leafDomain.leafIdx.
-	leafStates []leafState
+	// leafCapacities holds the per-snapshot mutable capacity data for leaves,
+	// indexed by leafDomain.leafIdx.
+	leafCapacities []leafCapacity
 
 	// leafCandidates adapts the shared leaves to the simulator's mutable
 	// candidate interface, indexed by leafDomain.leafIdx.
@@ -162,14 +162,15 @@ type TASFlavorSnapshot struct {
 	resourceFormatter *resources.ResourceFormatter
 }
 
-// stateOf returns the snapshot's mutable state of the given shared domain.
-func (s *TASFlavorSnapshot) stateOf(d *domain) *domainState {
-	return &s.state[d.idx]
+// domainStateOf returns the snapshot's mutable state of the given shared domain.
+func (s *TASFlavorSnapshot) domainStateOf(d *domain) *domainState {
+	return &s.domainStates[d.idx]
 }
 
-// leafStateOf returns the snapshot's mutable state of the given shared leaf.
-func (s *TASFlavorSnapshot) leafStateOf(l *leafDomain) *leafState {
-	return &s.leafStates[l.leafIdx]
+// leafCapacityOf returns the snapshot's mutable capacity data for the given
+// shared leaf.
+func (s *TASFlavorSnapshot) leafCapacityOf(l *leafDomain) *leafCapacity {
+	return &s.leafCapacities[l.leafIdx]
 }
 
 // candidates yields the snapshot's candidate adapters for all leaves.
@@ -186,12 +187,12 @@ func (s *TASFlavorSnapshot) candidates() iter.Seq[*leafCandidate] {
 // shallowCloneWithState returns a shallow copy of d with independent state
 // initialized from d's current state.
 //
-// WARNING: This may reallocate s.state. Callers must not retain pointers
-// returned by stateOf across this call.
+// WARNING: This may reallocate s.domainStates. Callers must not retain pointers
+// returned by domainStateOf across this call.
 func (s *TASFlavorSnapshot) shallowCloneWithState(d *domain) *domain {
 	clone := *d
-	clone.idx = len(s.state)
-	s.state = append(s.state, s.state[d.idx])
+	clone.idx = len(s.domainStates)
+	s.domainStates = append(s.domainStates, s.domainStates[d.idx])
 	return &clone
 }
 
@@ -241,15 +242,15 @@ func newTASFlavorSnapshot(
 		log:                log,
 		topologyName:       topologyName,
 		topologyTree:       tree,
-		state:              make([]domainState, tree.domainCount),
-		leafStates:         make([]leafState, len(tree.leaves)),
+		domainStates:       make([]domainState, tree.domainCount),
+		leafCapacities:     make([]leafCapacity, len(tree.leaves)),
 		leafCandidates:     make([]leafCandidate, len(tree.leaves)),
 		tolerations:        slices.Clone(tolerations),
 		feasibilityChecker: feasibilityChecker,
 		resourceFormatter:  options.resourceFormatter,
 	}
 	for _, leaf := range tree.leaves {
-		snapshot.leafStates[leaf.leafIdx].freeCapacity = leaf.capacity.Clone()
+		snapshot.leafCapacities[leaf.leafIdx].freeCapacity = leaf.capacity.Clone()
 		snapshot.leafCandidates[leaf.leafIdx] = leafCandidate{leaf: leaf, s: snapshot}
 	}
 	return snapshot
@@ -258,9 +259,9 @@ func newTASFlavorSnapshot(
 func (s *TASFlavorSnapshot) addNonTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	// domainID comes from topologyTree.nodeToDomain, while leaves is populated
 	// from the same node set by newTopologyTree, so the corresponding leaf exists.
-	leafState := s.leafStateOf(s.leaves[domainID])
-	leafState.freeCapacity.Sub(usage)
-	leafState.cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	leafCapacity.freeCapacity.Sub(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests, op usageOp, count int32) {
@@ -274,12 +275,12 @@ func (s *TASFlavorSnapshot) updateTASUsage(domainID utiltas.TopologyDomainID, us
 }
 
 func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Requests {
-	leafState := s.leafStateOf(leaf)
-	if leafState.cachedRemainingCapacity.IsEmpty() {
-		leafState.cachedRemainingCapacity = resources.NewLazyRequests(leafState.freeCapacity)
-		leafState.cachedRemainingCapacity.Sub(leafState.tasUsage)
+	leafCapacity := s.leafCapacityOf(leaf)
+	if leafCapacity.cachedRemainingCapacity.IsEmpty() {
+		leafCapacity.cachedRemainingCapacity = resources.NewLazyRequests(leafCapacity.freeCapacity)
+		leafCapacity.cachedRemainingCapacity.Sub(leafCapacity.tasUsage)
 	}
-	return leafState.cachedRemainingCapacity.Get()
+	return leafCapacity.cachedRemainingCapacity.Get()
 }
 
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -290,12 +291,12 @@ func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage
 		s.log.V(3).Info("skip accounting for TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	leafState := s.leafStateOf(s.leaves[domainID])
-	if leafState.tasUsage == nil {
-		leafState.tasUsage = resources.NewRequests()
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	if leafCapacity.tasUsage == nil {
+		leafCapacity.tasUsage = resources.NewRequests()
 	}
-	leafState.tasUsage.Add(usage)
-	leafState.cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity.tasUsage.Add(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
@@ -306,12 +307,12 @@ func (s *TASFlavorSnapshot) removeTASUsage(domainID utiltas.TopologyDomainID, us
 		s.log.V(3).Info("skip removing TAS usage in domain", "domain", domainID, "usage", usage)
 		return
 	}
-	leafState := s.leafStateOf(s.leaves[domainID])
-	if leafState.tasUsage == nil {
-		leafState.tasUsage = resources.NewRequests()
+	leafCapacity := s.leafCapacityOf(s.leaves[domainID])
+	if leafCapacity.tasUsage == nil {
+		leafCapacity.tasUsage = resources.NewRequests()
 	}
-	leafState.tasUsage.Sub(usage)
-	leafState.cachedRemainingCapacity = resources.LazyRequests{}
+	leafCapacity.tasUsage.Sub(usage)
+	leafCapacity.cachedRemainingCapacity = resources.LazyRequests{}
 }
 
 type domainCapacityDetails struct {
@@ -336,10 +337,10 @@ func (s *TASFlavorSnapshot) SerializeFreeCapacityPerDomain() (string, error) {
 	details := make(map[utiltas.TopologyDomainID]domainCapacityDetails, len(s.leaves))
 
 	for domainID, leaf := range s.leaves {
-		leafState := s.leafStateOf(leaf)
+		leafCapacity := s.leafCapacityOf(leaf)
 		details[domainID] = domainCapacityDetails{
-			FreeCapacity: s.resourceDetails(leafState.freeCapacity),
-			TasUsage:     s.resourceDetails(leafState.tasUsage),
+			FreeCapacity: s.resourceDetails(leafCapacity.freeCapacity),
+			TasUsage:     s.resourceDetails(leafCapacity.tasUsage),
 		}
 	}
 
@@ -1017,7 +1018,7 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 	for ; currentLevelIdx < len(s.domainsPerLevel)-1; currentLevelIdx++ {
 		// If we are "at" or "below" the requested slice topology level or we run the balanced placement algorithm
 		// we have to carefully assign pods to domains based on what we've assigned to parent domains,
-		// that's why we're iterating through each parent domain and assigning `domain.state` amount of pods
+		// that's why we're iterating through each parent domain and assigning `domain.podCount` amount of pods
 		// to its child domains.
 		sliceSizeOnLevel := state.sliceSize
 		if currentLevelIdx >= state.sliceLevelIdx {
@@ -1034,19 +1035,19 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 			sortedLowerDomains := s.sortedDomains(domain.children, state.unconstrained)
 
 			if sliceSizeOnLevel > 1 {
-				// For inner slice layers, recompute sliceState on the
+				// For inner slice layers, recompute sliceCount on the
 				// child domains based on the current inner slice size.
-				// The pre-populated sliceState was computed for the
+				// The pre-populated sliceCount was computed for the
 				// outermost slice level and is not valid here.
 				for _, d := range sortedLowerDomains {
-					dState := s.stateOf(d)
-					dState.sliceState = dState.state / sliceSizeOnLevel
-					dState.sliceStateWithLeader = dState.stateWithLeader / sliceSizeOnLevel
+					domainState := s.domainStateOf(d)
+					domainState.sliceCount = domainState.podCount / sliceSizeOnLevel
+					domainState.sliceCountWithLeader = domainState.podCountWithLeader / sliceSizeOnLevel
 				}
 			}
 
-			domainState := s.stateOf(domain)
-			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domainState.state, domainState.leaderState, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
+			domainState := s.domainStateOf(domain)
+			addCurrFitDomain := s.updateCountsToMinimumGeneric(sortedLowerDomains, domainState.podCount, domainState.leaderCount, sliceSizeOnLevel, state.unconstrained, sliceSizeOnLevel > 1)
 			newCurrFitDomain = append(newCurrFitDomain, addCurrFitDomain...)
 		}
 		currFitDomain = newCurrFitDomain
@@ -1059,14 +1060,14 @@ func (s *TASFlavorSnapshot) findTopologyAssignment(
 		var workerFitDomains []*domain
 		for _, domain := range currFitDomain {
 			// select domains with leaders
-			if leaderState := s.stateOf(domain).leaderState; leaderState > 0 {
+			if leaderCount := s.domainStateOf(domain).leaderCount; leaderCount > 0 {
 				copiedDomain := s.shallowCloneWithState(domain)
-				s.stateOf(copiedDomain).state = leaderState
+				s.domainStateOf(copiedDomain).podCount = leaderCount
 				leaderFitDomains = append(leaderFitDomains, copiedDomain)
 			}
 
 			// select domains with workers
-			if s.stateOf(domain).state > 0 {
+			if s.domainStateOf(domain).podCount > 0 {
 				workerFitDomains = append(workerFitDomains, domain)
 			}
 		}
@@ -1242,59 +1243,59 @@ func getSliceSizeWithSinglePodAsDefault(tr *kueue.PodSetTopologyRequest) (int32,
 	return size, ""
 }
 
-// findBestFitDomain returns the first domain with the smallest state that is
+// findBestFitDomain returns the first domain with the smallest podCount that is
 // greater than or equal to count.
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
 func (s *TASFlavorSnapshot) findBestFitDomain(domains []*domain, count int32, leaderCount int32) *domain {
-	getState := func(d *domain) int32 {
-		return s.stateOf(d).state
+	countForDomain := func(d *domain) int32 {
+		return s.domainStateOf(d).podCount
 	}
 	if leaderCount > 0 {
-		getState = func(d *domain) int32 {
-			return s.stateOf(d).stateWithLeader
+		countForDomain = func(d *domain) int32 {
+			return s.domainStateOf(d).podCountWithLeader
 		}
 	}
-	return s.findBestFitDomainBy(domains, count, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, count, countForDomain, leaderCount)
 }
 
 // findBestFitDomainForSlices returns the first domain with the smallest
-// sliceState that is greater than or equal to sliceCount.
+// slice count that is greater than or equal to sliceCount.
 // When leaders are requested, domains that cannot fit them are ignored.
 // If no domain fits, it returns the first domain to preserve the caller's
 // established ordering.
 func (s *TASFlavorSnapshot) findBestFitDomainForSlices(domains []*domain, sliceCount int32, leaderCount int32) *domain {
-	getState := func(d *domain) int32 {
-		return s.stateOf(d).sliceState
+	countForDomain := func(d *domain) int32 {
+		return s.domainStateOf(d).sliceCount
 	}
 	if leaderCount > 0 {
-		getState = func(d *domain) int32 {
-			return s.stateOf(d).sliceStateWithLeader
+		countForDomain = func(d *domain) int32 {
+			return s.domainStateOf(d).sliceCountWithLeader
 		}
 	}
-	return s.findBestFitDomainBy(domains, sliceCount, getState, leaderCount)
+	return s.findBestFitDomainBy(domains, sliceCount, countForDomain, leaderCount)
 }
 
-type domainStateGetter func(d *domain) int32
+type domainCountFunc func(d *domain) int32
 
-func (s *TASFlavorSnapshot) findBestFitDomainBy(domains []*domain, needed int32, state domainStateGetter, leaderCount int32) *domain {
+func (s *TASFlavorSnapshot) findBestFitDomainBy(domains []*domain, needed int32, countForDomain domainCountFunc, leaderCount int32) *domain {
 	candidates := s.topAffinityTierDomains(domains)
 	bestDomain := candidates[0]
-	bestDomainState := int32(math.MaxInt32)
+	bestDomainCount := int32(math.MaxInt32)
 	found := false
 
 	for _, domain := range candidates {
-		if s.stateOf(domain).leaderState < leaderCount {
+		if s.domainStateOf(domain).leaderCount < leaderCount {
 			continue
 		}
-		domainState := state(domain)
+		domainCount := countForDomain(domain)
 
-		if domainState >= needed && domainState < bestDomainState {
+		if domainCount >= needed && domainCount < bestDomainCount {
 			// choose the first occurrence of fitting domains
 			// to make it consecutive with other podSet's
 			bestDomain = domain
-			bestDomainState = domainState
+			bestDomainCount = domainCount
 			found = true
 		}
 	}
@@ -1320,7 +1321,7 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 	topDomain := sortedDomain[0]
 
 	sliceCount := state.count / state.sliceSize
-	if useBestFitAlgorithm(state.unconstrained) && s.stateOf(topDomain).sliceStateWithLeader >= sliceCount && s.stateOf(topDomain).leaderState >= state.leaderCount {
+	if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(topDomain).sliceCountWithLeader >= sliceCount && s.domainStateOf(topDomain).leaderCount >= state.leaderCount {
 		// optimize the potentially last domain
 		topDomain = s.findBestFitDomainForSlices(sortedDomain, sliceCount, state.leaderCount)
 	}
@@ -1333,35 +1334,35 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 
 	if useLeastFreeCapacityAlgorithm(state.unconstrained) {
 		for _, candidateDomain := range sortedDomain {
-			candidateDomainState := s.stateOf(candidateDomain)
-			candidateCapacity := candidateDomainState.sliceState
+			candidateDomainState := s.domainStateOf(candidateDomain)
+			candidateCapacity := candidateDomainState.sliceCount
 			if state.leaderCount > 0 {
-				if candidateDomainState.leaderState < state.leaderCount {
+				if candidateDomainState.leaderCount < state.leaderCount {
 					continue
 				}
-				candidateCapacity = candidateDomainState.sliceStateWithLeader
+				candidateCapacity = candidateDomainState.sliceCountWithLeader
 			}
 			if candidateCapacity >= sliceCount {
 				return searchLevelIdx, []*domain{candidateDomain}, ""
 			}
 		}
 		if state.required {
-			maxCapacityFound := s.stateOf(sortedDomain[len(sortedDomain)-1]).state
+			maxCapacityFound := s.domainStateOf(sortedDomain[len(sortedDomain)-1]).podCount
 			return 0, nil, notFitReason(maxCapacityFound, sliceCount)
 		}
 	}
-	if s.stateOf(topDomain).sliceStateWithLeader < sliceCount || s.stateOf(topDomain).leaderState < state.leaderCount {
+	if s.domainStateOf(topDomain).sliceCountWithLeader < sliceCount || s.domainStateOf(topDomain).leaderCount < state.leaderCount {
 		if state.required {
 			// Scan remaining domains to support preferred affinity before failing
 			if features.Enabled(features.TASRespectNodeAffinityPreferred) {
 				for i := 1; i < len(sortedDomain); i++ {
 					d := sortedDomain[i]
-					if s.stateOf(d).sliceStateWithLeader >= sliceCount && s.stateOf(d).leaderState >= state.leaderCount {
+					if s.domainStateOf(d).sliceCountWithLeader >= sliceCount && s.domainStateOf(d).leaderCount >= state.leaderCount {
 						return searchLevelIdx, []*domain{s.findBestFitDomainForSlices(sortedDomain[i:], sliceCount, state.leaderCount)}, ""
 					}
 				}
 			}
-			return 0, nil, notFitReason(s.stateOf(topDomain).sliceState, sliceCount)
+			return 0, nil, notFitReason(s.domainStateOf(topDomain).sliceCount, sliceCount)
 		}
 		if searchLevelIdx > 0 && !state.unconstrained {
 			return s.findLevelWithFitDomains(searchLevelIdx-1, state)
@@ -1378,16 +1379,16 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		// After assigning all leaders, sort the remaining domains by worker capacity
 		// and assign the remaining workers.
 		idx := 0
-		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && s.stateOf(sortedDomain[idx]).leaderState > 0; idx++ {
+		for ; remainingLeaderCount > 0 && idx < len(sortedDomain) && s.domainStateOf(sortedDomain[idx]).leaderCount > 0; idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && s.stateOf(sortedDomain[idx]).sliceStateWithLeader >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(sortedDomain[idx]).sliceCountWithLeader >= remainingSliceCount {
 				// optimize the last domain
 				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, remainingLeaderCount)
 			}
 			results = append(results, domain)
 
-			remainingLeaderCount -= s.stateOf(domain).leaderState
-			remainingSliceCount -= s.stateOf(domain).sliceStateWithLeader
+			remainingLeaderCount -= s.domainStateOf(domain).leaderCount
+			remainingSliceCount -= s.domainStateOf(domain).sliceCountWithLeader
 		}
 		if remainingLeaderCount > 0 {
 			return 0, nil, notFitReason(state.leaderCount-remainingLeaderCount, sliceCount)
@@ -1398,13 +1399,13 @@ func (s *TASFlavorSnapshot) findLevelWithFitDomains(
 		sortedDomain = s.sortedDomains(sortedDomain[idx:], state.unconstrained)
 		for idx := 0; remainingSliceCount > 0 && idx < len(sortedDomain); idx++ {
 			domain := sortedDomain[idx]
-			if useBestFitAlgorithm(state.unconstrained) && s.stateOf(sortedDomain[idx]).sliceState >= remainingSliceCount {
+			if useBestFitAlgorithm(state.unconstrained) && s.domainStateOf(sortedDomain[idx]).sliceCount >= remainingSliceCount {
 				// optimize the last domain
 				domain = s.findBestFitDomainForSlices(sortedDomain[idx:], remainingSliceCount, 0)
 			}
 			results = append(results, domain)
 
-			remainingSliceCount -= s.stateOf(domain).sliceState
+			remainingSliceCount -= s.domainStateOf(domain).sliceCount
 		}
 		if remainingSliceCount > 0 {
 			return 0, nil, notFitReason(sliceCount-remainingSliceCount, sliceCount)
@@ -1425,9 +1426,9 @@ func (s *TASFlavorSnapshot) topAffinityTierDomains(candidates []*domain) []*doma
 	if !features.Enabled(features.TASRespectNodeAffinityPreferred) || len(candidates) == 0 {
 		return candidates
 	}
-	score := s.stateOf(candidates[0]).affinityScore
+	score := s.domainStateOf(candidates[0]).affinityScore
 	for i, c := range candidates {
-		if s.stateOf(c).affinityScore != score {
+		if s.domainStateOf(c).affinityScore != score {
 			return candidates[:i]
 		}
 	}
@@ -1468,35 +1469,35 @@ func (s *TASFlavorSnapshot) consumeWithLeadersGeneric(
 	sliceSize int32,
 	slices bool,
 ) (*domain, bool) {
-	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && s.stateOf(domain).leaderState >= *remainingLeaderCount {
+	if useBestFitAlgorithm(unconstrained) && *withLeader >= *remainingPrimary && s.domainStateOf(domain).leaderCount >= *remainingLeaderCount {
 		// optimize the last domain
 		if slices {
 			domain = s.findBestFitDomainForSlices(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &s.stateOf(domain).sliceStateWithLeader
-			primary = &s.stateOf(domain).sliceState
+			withLeader = &s.domainStateOf(domain).sliceCountWithLeader
+			primary = &s.domainStateOf(domain).sliceCount
 		} else {
 			domain = s.findBestFitDomain(remainingDomains, *remainingPrimary, *remainingLeaderCount)
-			withLeader = &s.stateOf(domain).stateWithLeader
-			primary = &s.stateOf(domain).state
+			withLeader = &s.domainStateOf(domain).podCountWithLeader
+			primary = &s.domainStateOf(domain).podCount
 		}
 	}
 
-	domainState := s.stateOf(domain)
-	if *withLeader >= *remainingPrimary && domainState.leaderState >= *remainingLeaderCount {
+	domainState := s.domainStateOf(domain)
+	if *withLeader >= *remainingPrimary && domainState.leaderCount >= *remainingLeaderCount {
 		*primary = *remainingPrimary
-		domainState.leaderState = *remainingLeaderCount
-		domainState.state = *remainingPrimary * sliceSize
+		domainState.leaderCount = *remainingLeaderCount
+		domainState.podCount = *remainingPrimary * sliceSize
 		return domain, true
 	}
 	if *withLeader > *remainingPrimary {
 		*withLeader = *remainingPrimary
 	}
-	if domainState.leaderState > *remainingLeaderCount {
-		domainState.leaderState = *remainingLeaderCount
+	if domainState.leaderCount > *remainingLeaderCount {
+		domainState.leaderCount = *remainingLeaderCount
 	}
 	*primary = *withLeader
-	domainState.state = *withLeader * sliceSize
-	*remainingLeaderCount -= domainState.leaderState
+	domainState.podCount = *withLeader * sliceSize
+	*remainingLeaderCount -= domainState.leaderCount
 	*remainingPrimary -= *withLeader
 	return domain, false
 }
@@ -1514,22 +1515,22 @@ func (s *TASFlavorSnapshot) prioritizeLeaderDomain(domains []*domain, count, lea
 	if slicesEnabled {
 		requiredCapacity /= sliceSize
 		for _, domain := range domains {
-			availableCapacity += s.stateOf(domain).sliceState
+			availableCapacity += s.domainStateOf(domain).sliceCount
 		}
 	} else {
 		for _, domain := range domains {
-			availableCapacity += s.stateOf(domain).state
+			availableCapacity += s.domainStateOf(domain).podCount
 		}
 	}
 
 	for i, domain := range domains {
-		domainState := s.stateOf(domain)
-		if domainState.leaderState < leaderCount {
+		domainState := s.domainStateOf(domain)
+		if domainState.leaderCount < leaderCount {
 			continue
 		}
-		leaderPenalty := domainState.state - domainState.stateWithLeader
+		leaderPenalty := domainState.podCount - domainState.podCountWithLeader
 		if slicesEnabled {
-			leaderPenalty = domainState.sliceState - domainState.sliceStateWithLeader
+			leaderPenalty = domainState.sliceCount - domainState.sliceCountWithLeader
 		}
 		if availableCapacity-leaderPenalty < requiredCapacity {
 			continue
@@ -1566,13 +1567,23 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 					&remainingPrimary,
 					&remainingLeaderCount,
 					unconstrained,
-					&s.stateOf(dom).sliceStateWithLeader,
-					&s.stateOf(dom).sliceState,
+					&s.domainStateOf(dom).sliceCountWithLeader,
+					&s.domainStateOf(dom).sliceCount,
 					sliceSize,
 					true,
 				)
 			} else {
-				d, completed = s.consumeWithLeadersGeneric(dom, domains[i:], &remainingPrimary, &remainingLeaderCount, unconstrained, &s.stateOf(dom).stateWithLeader, &s.stateOf(dom).state, 1, false)
+				d, completed = s.consumeWithLeadersGeneric(
+					dom,
+					domains[i:],
+					&remainingPrimary,
+					&remainingLeaderCount,
+					unconstrained,
+					&s.domainStateOf(dom).podCountWithLeader,
+					&s.domainStateOf(dom).podCount,
+					1,
+					false,
+				)
 			}
 			result = append(result, d)
 			if completed {
@@ -1583,37 +1594,37 @@ func (s *TASFlavorSnapshot) updateCountsToMinimumGeneric(domains []*domain, coun
 
 		// No leaders remaining: handle tail without leaders
 		if slices {
-			if useBestFitAlgorithm(unconstrained) && s.stateOf(dom).sliceState >= remainingPrimary {
+			if useBestFitAlgorithm(unconstrained) && s.domainStateOf(dom).sliceCount >= remainingPrimary {
 				// optimize the last domain
 				dom = s.findBestFitDomainForSlices(domains[i:], remainingPrimary, 0)
 			}
-			domState := s.stateOf(dom)
-			domState.leaderState = 0
-			if domState.sliceState >= remainingPrimary {
-				domState.state = remainingPrimary * sliceSize
-				domState.sliceState = remainingPrimary
+			domainState := s.domainStateOf(dom)
+			domainState.leaderCount = 0
+			if domainState.sliceCount >= remainingPrimary {
+				domainState.podCount = remainingPrimary * sliceSize
+				domainState.sliceCount = remainingPrimary
 				result = append(result, dom)
 				return result
 			}
-			domState.state = domState.sliceState * sliceSize
-			remainingPrimary -= domState.sliceState
+			domainState.podCount = domainState.sliceCount * sliceSize
+			remainingPrimary -= domainState.sliceCount
 			result = append(result, dom)
 			continue
 		}
 
 		// pods (slices=false)
-		if useBestFitAlgorithm(unconstrained) && s.stateOf(dom).state >= remainingPrimary {
+		if useBestFitAlgorithm(unconstrained) && s.domainStateOf(dom).podCount >= remainingPrimary {
 			// optimize the last domain
 			dom = s.findBestFitDomain(domains[i:], remainingPrimary, 0)
 		}
-		domState := s.stateOf(dom)
-		domState.leaderState = 0
-		if domState.state >= remainingPrimary {
-			domState.state = remainingPrimary
+		domainState := s.domainStateOf(dom)
+		domainState.leaderCount = 0
+		if domainState.podCount >= remainingPrimary {
+			domainState.podCount = remainingPrimary
 			result = append(result, dom)
 			return result
 		}
-		remainingPrimary -= domState.state
+		remainingPrimary -= domainState.podCount
 		result = append(result, dom)
 	}
 	// Error logs are not verbosity-gated; dumping leaves scales with cluster size.
@@ -1650,13 +1661,13 @@ func (s *TASFlavorSnapshot) buildTopologyAssignmentForLevels(domains []*domain, 
 	}
 	assignment.Levels = s.levelKeys[levelIdx:]
 	for _, domain := range domains {
-		if s.stateOf(domain).state == 0 {
+		if s.domainStateOf(domain).podCount == 0 {
 			// It may happen when PodSet count is 0 or when using LeastFreeCapacity algorithm.
 			continue
 		}
 		assignment.Domains = append(assignment.Domains, utiltas.TopologyDomainAssignment{
 			Values: domain.levelValues[levelIdx:],
-			Count:  s.stateOf(domain).state,
+			Count:  s.domainStateOf(domain).podCount,
 		})
 	}
 	return assignment
@@ -1697,26 +1708,26 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		aState, bState := s.stateOf(a), s.stateOf(b)
-		if aState.leaderState != bState.leaderState {
-			return cmp.Compare(bState.leaderState, aState.leaderState)
+		aDomainState, bDomainState := s.domainStateOf(a), s.domainStateOf(b)
+		if aDomainState.leaderCount != bDomainState.leaderCount {
+			return cmp.Compare(bDomainState.leaderCount, aDomainState.leaderCount)
 		}
 
-		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
-			return cmp.Compare(bState.affinityScore, aState.affinityScore)
+		if respectNodeAffinityPreferred && aDomainState.affinityScore != bDomainState.affinityScore {
+			return cmp.Compare(bDomainState.affinityScore, aDomainState.affinityScore)
 		}
 
-		if aState.sliceStateWithLeader != bState.sliceStateWithLeader {
+		if aDomainState.sliceCountWithLeader != bDomainState.sliceCountWithLeader {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(aState.sliceStateWithLeader, bState.sliceStateWithLeader)
+				return cmp.Compare(aDomainState.sliceCountWithLeader, bDomainState.sliceCountWithLeader)
 			}
-			return cmp.Compare(bState.sliceStateWithLeader, aState.sliceStateWithLeader)
+			return cmp.Compare(bDomainState.sliceCountWithLeader, aDomainState.sliceCountWithLeader)
 		}
 
-		if aState.stateWithLeader != bState.stateWithLeader {
-			return cmp.Compare(aState.stateWithLeader, bState.stateWithLeader)
+		if aDomainState.podCountWithLeader != bDomainState.podCountWithLeader {
+			return cmp.Compare(aDomainState.podCountWithLeader, bDomainState.podCountWithLeader)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1727,31 +1738,31 @@ func (s *TASFlavorSnapshot) sortedDomainsWithLeader(domains []*domain, unconstra
 // This function sorts domains based on a specified algorithm: BestFit or LeastFreeCapacity.
 //
 // The sorting criteria are:
-// - **BestFit**: `sliceState` (descending), `state` (ascending), `levelValues` (ascending)
-// - **LeastFreeCapacity**: `sliceState` (ascending), `state` (ascending), `levelValues` (ascending)
+// - **BestFit**: `sliceCount` (descending), `podCount` (ascending), `levelValues` (ascending)
+// - **LeastFreeCapacity**: `sliceCount` (ascending), `podCount` (ascending), `levelValues` (ascending)
 //
-// `state` is always sorted ascending. This prioritizes domains that can accommodate slices with minimal leftover pod capacity.
+// `podCount` is always sorted ascending. This prioritizes domains that can accommodate slices with minimal leftover pod capacity.
 func (s *TASFlavorSnapshot) sortedDomains(domains []*domain, unconstrained bool) []*domain {
 	isLeastFreeCapacity := useLeastFreeCapacityAlgorithm(unconstrained)
 	respectNodeAffinityPreferred := features.Enabled(features.TASRespectNodeAffinityPreferred)
 	result := slices.Clone(domains)
 	slices.SortFunc(result, func(a, b *domain) int {
-		aState, bState := s.stateOf(a), s.stateOf(b)
-		if respectNodeAffinityPreferred && aState.affinityScore != bState.affinityScore {
-			return cmp.Compare(bState.affinityScore, aState.affinityScore)
+		aDomainState, bDomainState := s.domainStateOf(a), s.domainStateOf(b)
+		if respectNodeAffinityPreferred && aDomainState.affinityScore != bDomainState.affinityScore {
+			return cmp.Compare(bDomainState.affinityScore, aDomainState.affinityScore)
 		}
 
-		if aState.sliceState != bState.sliceState {
+		if aDomainState.sliceCount != bDomainState.sliceCount {
 			if isLeastFreeCapacity {
 				// Start from the domain with the least amount of free resources.
 				// Ascending order.
-				return cmp.Compare(aState.sliceState, bState.sliceState)
+				return cmp.Compare(aDomainState.sliceCount, bDomainState.sliceCount)
 			}
-			return cmp.Compare(bState.sliceState, aState.sliceState)
+			return cmp.Compare(bDomainState.sliceCount, aDomainState.sliceCount)
 		}
 
-		if aState.state != bState.state {
-			return cmp.Compare(aState.state, bState.state)
+		if aDomainState.podCount != bDomainState.podCount {
+			return cmp.Compare(aDomainState.podCount, bDomainState.podCount)
 		}
 
 		return s.compareDomainLevelValues(a, b)
@@ -1765,8 +1776,8 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 	// cleanup the state in case some remaining values are present from computing
 	// assignments for previous PodSets. Truncating to discard the state
 	// slots of domain copies made for the previous PodSet.
-	s.state = s.state[:s.domainCount]
-	clear(s.state)
+	s.domainStates = s.domainStates[:s.domainCount]
+	clear(s.domainStates)
 	cachingRemainingResourcesEnabled := features.Enabled(features.TASCachingRemainingResources)
 	if features.Enabled(features.TASCacheNodeMatchResults) {
 		matchingLeaves, stats, err := s.getMatchingLeaves(ctx, requirements)
@@ -1776,7 +1787,7 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
 			leaf := s.leaves[ml.GetID()]
-			s.stateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
+			s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
@@ -1789,7 +1800,7 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 
 			for _, ml := range feasibleLeaves {
 				leaf := s.leaves[ml.GetID()]
-				s.stateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
+				s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
 				s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 			}
 		} else {
@@ -1846,16 +1857,16 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 }
 
 func (s *TASFlavorSnapshot) remainingCapacityForLeaf(leaf *leafDomain, simulateEmpty, cachingRemainingResourcesEnabled bool) resources.LazyRequests {
-	leafState := s.leafStateOf(leaf)
+	leafCapacity := s.leafCapacityOf(leaf)
 	if cachingRemainingResourcesEnabled {
 		if simulateEmpty {
-			return resources.NewLazyRequests(leafState.freeCapacity)
+			return resources.NewLazyRequests(leafCapacity.freeCapacity)
 		}
 		return resources.NewLazyRequests(s.getRemainingCapacity(leaf))
 	}
-	remainingCapacity := resources.NewLazyRequests(leafState.freeCapacity)
+	remainingCapacity := resources.NewLazyRequests(leafCapacity.freeCapacity)
 	if !simulateEmpty {
-		remainingCapacity.Sub(leafState.tasUsage)
+		remainingCapacity.Sub(leafCapacity.tasUsage)
 	}
 	return remainingCapacity
 }
@@ -1873,22 +1884,22 @@ func (s *TASFlavorSnapshot) fillLeafCounts(leaf *leafDomain, requirements *topol
 		remainingCapacity.Sub(leafAssumedUsage)
 	}
 	var limitingRes corev1.ResourceName
-	leafDomainState := s.stateOf(&leaf.domain)
-	leafDomainState.state, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
+	leafDomainState := s.domainStateOf(&leaf.domain)
+	leafDomainState.podCount, limitingRes = requirements.requests.CountInWithLimitingResource(remainingCapacity.Get())
 
 	// Track resource exclusions: if this node can't fit even one pod,
 	// identify which resource is the bottleneck.
-	if leafDomainState.state == 0 && limitingRes != "" {
+	if leafDomainState.podCount == 0 && limitingRes != "" {
 		state.stats.recordResourceExclusion(limitingRes)
 	}
 
-	leafDomainState.leaderState = 0
+	leafDomainState.leaderCount = 0
 	if requirements.leaderRequests != nil && requirements.leaderRequests.CountIn(remainingCapacity.Get()) > 0 {
-		leafDomainState.leaderState = 1
+		leafDomainState.leaderCount = 1
 		remainingCapacity.Sub(requirements.leaderRequests)
 	}
 
-	leafDomainState.stateWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
+	leafDomainState.podCountWithLeader = requirements.requests.CountIn(remainingCapacity.Get())
 }
 
 func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas.TopologyDomainID) bool {
@@ -1901,13 +1912,13 @@ func belongsToRequiredDomain(leaf *leafDomain, requiredReplacementDomain utiltas
 }
 
 func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, sliceLevelIdx int, level int, sliceSizeAtLevel map[int]int32, leaderRequired bool) {
-	domainState := s.stateOf(domain)
+	domainState := s.domainStateOf(domain)
 	// logic for a leaf
 	if len(domain.children) == 0 {
 		if level == sliceLevelIdx {
-			// initialize the sliceState if leaf is the request slice level
-			domainState.sliceState = domainState.state / sliceSize
-			domainState.sliceStateWithLeader = domainState.stateWithLeader / sliceSize
+			// initialize the sliceCount if leaf is the request slice level
+			domainState.sliceCount = domainState.podCount / sliceSize
+			domainState.sliceCountWithLeader = domainState.podCountWithLeader / sliceSize
 		}
 		return
 	}
@@ -1915,9 +1926,9 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	childrenCapacity := int32(0)
 	sliceCapacity := int32(0)
 	hasWithLeaderCapacityContributor := false
-	minStateWithLeaderDifference := int32(math.MaxInt32)
-	minSliceStateWithLeaderDifference := int32(math.MaxInt32)
-	leaderState := int32(0)
+	minPodCountWithLeaderDifference := int32(math.MaxInt32)
+	minSliceCountWithLeaderDifference := int32(math.MaxInt32)
+	leaderCount := int32(0)
 	affinityScore := int64(0)
 
 	// When multi-layer constraints exist, children at a constrained level
@@ -1930,41 +1941,41 @@ func (s *TASFlavorSnapshot) fillInCountsHelper(domain *domain, sliceSize int32, 
 	for _, child := range domain.children {
 		s.fillInCountsHelper(child, sliceSize, sliceLevelIdx, childLevel, sliceSizeAtLevel, leaderRequired)
 
-		childDomainState := s.stateOf(child)
-		childState := childDomainState.state
-		childStateWithLeader := childDomainState.stateWithLeader
+		childDomainState := s.domainStateOf(child)
+		childPodCount := childDomainState.podCount
+		childPodCountWithLeader := childDomainState.podCountWithLeader
 		if hasInnerConstraint {
-			childState = (childDomainState.state / innerSize) * innerSize
-			childStateWithLeader = (childDomainState.stateWithLeader / innerSize) * innerSize
+			childPodCount = (childDomainState.podCount / innerSize) * innerSize
+			childPodCountWithLeader = (childDomainState.podCountWithLeader / innerSize) * innerSize
 		}
 
-		childrenCapacity += childState
-		sliceCapacity += childDomainState.sliceState
-		if !leaderRequired || childDomainState.leaderState > 0 {
+		childrenCapacity += childPodCount
+		sliceCapacity += childDomainState.sliceCount
+		if !leaderRequired || childDomainState.leaderCount > 0 {
 			hasWithLeaderCapacityContributor = true
-			minStateWithLeaderDifference = min(childState-childStateWithLeader, minStateWithLeaderDifference)
-			minSliceStateWithLeaderDifference = min(childDomainState.sliceState-childDomainState.sliceStateWithLeader, minSliceStateWithLeaderDifference)
+			minPodCountWithLeaderDifference = min(childPodCount-childPodCountWithLeader, minPodCountWithLeaderDifference)
+			minSliceCountWithLeaderDifference = min(childDomainState.sliceCount-childDomainState.sliceCountWithLeader, minSliceCountWithLeaderDifference)
 		}
-		leaderState = max(childDomainState.leaderState, leaderState)
+		leaderCount = max(childDomainState.leaderCount, leaderCount)
 		affinityScore += childDomainState.affinityScore
 	}
-	domainState.state = childrenCapacity
-	sliceStateWithLeader := int32(0)
+	domainState.podCount = childrenCapacity
+	sliceCountWithLeader := int32(0)
 	if hasWithLeaderCapacityContributor {
-		domainState.stateWithLeader = childrenCapacity - minStateWithLeaderDifference
-		sliceStateWithLeader = sliceCapacity - minSliceStateWithLeaderDifference
+		domainState.podCountWithLeader = childrenCapacity - minPodCountWithLeaderDifference
+		sliceCountWithLeader = sliceCapacity - minSliceCountWithLeaderDifference
 	} else {
-		domainState.stateWithLeader = 0
+		domainState.podCountWithLeader = 0
 	}
-	domainState.leaderState = leaderState
+	domainState.leaderCount = leaderCount
 	domainState.affinityScore = affinityScore
 	if level == sliceLevelIdx {
-		// initialize the sliceState for the requested slice level.
-		sliceCapacity = domainState.state / sliceSize
-		sliceStateWithLeader = domainState.stateWithLeader / sliceSize
+		// initialize the sliceCount for the requested slice level.
+		sliceCapacity = domainState.podCount / sliceSize
+		sliceCountWithLeader = domainState.podCountWithLeader / sliceSize
 	}
-	domainState.sliceState = sliceCapacity
-	domainState.sliceStateWithLeader = sliceStateWithLeader
+	domainState.sliceCount = sliceCapacity
+	domainState.sliceCountWithLeader = sliceCountWithLeader
 }
 
 func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCount, sliceSize int32, stats *tasExclusionStats) string {
@@ -1991,7 +2002,7 @@ func (s *TASFlavorSnapshot) notFitMessage(slicesFitCount, totalRequestsSlicesCou
 
 func (s *TASFlavorSnapshot) countSlicesInSubtree(d *domain, currentLevel, targetLevel int, sliceSize int32) int32 {
 	if currentLevel == targetLevel {
-		return s.stateOf(d).state / sliceSize
+		return s.domainStateOf(d).podCount / sliceSize
 	}
 	var total int32
 	for _, child := range d.children {
@@ -2009,13 +2020,13 @@ func (s *TASFlavorSnapshot) multiLayerNotFitMessage(
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "topology %q doesn't allow to fit", s.topologyName)
 
-	// Pick the domain with the highest sliceState to report the best-case
+	// Pick the domain with the highest sliceCount to report the best-case
 	// fit counts. Tie-break on domain ID for deterministic messages, since
 	// domainsPerLevel is map-backed and iteration order is random.
 	var bestDomain *domain
 	for _, d := range s.domainsPerLevel[requiredLevelIdx] {
-		if bestDomain == nil || s.stateOf(d).sliceState > s.stateOf(bestDomain).sliceState ||
-			(s.stateOf(d).sliceState == s.stateOf(bestDomain).sliceState && d.id < bestDomain.id) {
+		if bestDomain == nil || s.domainStateOf(d).sliceCount > s.domainStateOf(bestDomain).sliceCount ||
+			(s.domainStateOf(d).sliceCount == s.domainStateOf(bestDomain).sliceCount && d.id < bestDomain.id) {
 			bestDomain = d
 		}
 	}

--- a/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_bench_test.go
@@ -221,7 +221,7 @@ func runBenchmarkTASFlavorAssignment(b *testing.B, topo benchTopology, name stri
 		if failure := result.Failure(); failure != nil {
 			b.Fatalf("balanced placement preflight failed: %s", failure.Reason)
 		}
-		if len(snapshot.state) == snapshot.domainCount {
+		if len(snapshot.domainStates) == snapshot.domainCount {
 			b.Fatal("balanced placement preflight did not clone domain state")
 		}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -51,23 +51,23 @@ func addDomainsWithState(s *TASFlavorSnapshot, specs []testDomainSpec) []*domain
 	result := make([]*domain, len(specs))
 	for i, spec := range specs {
 		d := spec.domain
-		d.idx = len(s.state)
-		s.state = append(s.state, spec.state)
+		d.idx = len(s.domainStates)
+		s.domainStates = append(s.domainStates, spec.state)
 		result[i] = &d
 	}
 	return result
 }
 
-func newFreeCapacityTestSnapshot(states map[tas.TopologyDomainID]leafState) *TASFlavorSnapshot {
-	leaves := make(leafDomainByID, len(states))
-	leafStates := make([]leafState, 0, len(states))
-	for id, state := range states {
-		leaves[id] = &leafDomain{domain: domain{id: id}, leafIdx: len(leafStates)}
-		leafStates = append(leafStates, state)
+func newFreeCapacityTestSnapshot(capacities map[tas.TopologyDomainID]leafCapacity) *TASFlavorSnapshot {
+	leaves := make(leafDomainByID, len(capacities))
+	leafCapacities := make([]leafCapacity, 0, len(capacities))
+	for id, capacity := range capacities {
+		leaves[id] = &leafDomain{domain: domain{id: id}, leafIdx: len(leafCapacities)}
+		leafCapacities = append(leafCapacities, capacity)
 	}
 	return &TASFlavorSnapshot{
-		topologyTree: &topologyTree{leaves: leaves},
-		leafStates:   leafStates,
+		topologyTree:   &topologyTree{leaves: leaves},
+		leafCapacities: leafCapacities,
 	}
 }
 
@@ -80,7 +80,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 	}{
 		"domains with free capacity and TAS usage": {
 			snapshot: func() *TASFlavorSnapshot {
-				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{
 					"domain2": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU:    1000,
@@ -109,7 +109,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 		},
 		"domain with free capacity, but without TAS usage": {
 			snapshot: func() *TASFlavorSnapshot {
-				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{
 					"domain1": {
 						freeCapacity: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
 							corev1.ResourceCPU: 1000,
@@ -123,7 +123,7 @@ func TestFreeCapacityPerDomain(t *testing.T) {
 		},
 		"domain without free capacity and without TAS usage": {
 			snapshot: func() *TASFlavorSnapshot {
-				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafState{"domain1": {}})
+				return newFreeCapacityTestSnapshot(map[tas.TopologyDomainID]leafCapacity{"domain1": {}})
 			},
 			expected: `{"domain1":{"freeCapacity":{},"tasUsage":{}}}`,
 		},
@@ -595,9 +595,9 @@ func TestHasLevel(t *testing.T) {
 }
 
 // TestSortedDomainsWithLeader verifies the sorting criteria (in order of priority):
-// 1. leaderState - descending (always)
-// 2. sliceStateWithLeader - descending (BestFit) or ascending (LeastFreeCapacity)
-// 3. stateWithLeader - ascending (always, as tiebreaker)
+// 1. leaderCount - descending (always)
+// 2. sliceCountWithLeader - descending (BestFit) or ascending (LeastFreeCapacity)
+// 3. podCountWithLeader - ascending (always, as tiebreaker)
 // 4. levelValues - ascending (always, as final tiebreaker)
 func TestSortedDomainsWithLeader(t *testing.T) {
 	levels := []string{"block"}
@@ -615,18 +615,18 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
 					state: domainState{
 						affinityScore:        10,
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
 					state: domainState{
 						affinityScore:        100,
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 			},
@@ -640,40 +640,40 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
 					state: domainState{
 						affinityScore:        10,
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
 					state: domainState{
 						affinityScore:        100,
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
-		"leaderState descending: domains that can host leader come first": {
+		"leaderCount descending: domains that can host leader come first": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "no-leader", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          0,
-						sliceStateWithLeader: 10,
-						stateWithLeader:      10,
+						leaderCount:          0,
+						sliceCountWithLeader: 10,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "has-leader", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 1,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
 					},
 				},
 			},
@@ -687,138 +687,138 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 					domain: domain{id: "preferred-no-leader", levelValues: []string{"a"}},
 					state: domainState{
 						affinityScore:        100,
-						leaderState:          0,
-						sliceStateWithLeader: 0,
-						stateWithLeader:      0,
+						leaderCount:          0,
+						sliceCountWithLeader: 0,
+						podCountWithLeader:   0,
 					},
 				},
 				{
 					domain: domain{id: "non-preferred-has-leader", levelValues: []string{"b"}},
 					state: domainState{
 						affinityScore:        10,
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"non-preferred-has-leader", "preferred-no-leader"},
 		},
-		"BestFit: sliceStateWithLeader descending": {
+		"BestFit: sliceCountWithLeader descending": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 3,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 3,
+						podCountWithLeader:   1,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 1,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
 					},
 				},
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 2,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 2,
+						podCountWithLeader:   1,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
-		"LeastFreeCapacity: sliceStateWithLeader ascending": {
+		"LeastFreeCapacity: sliceCountWithLeader ascending": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 3,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 3,
+						podCountWithLeader:   1,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 1,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 1,
+						podCountWithLeader:   1,
 					},
 				},
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 2,
-						stateWithLeader:      1,
+						leaderCount:          1,
+						sliceCountWithLeader: 2,
+						podCountWithLeader:   1,
 					},
 				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
-		"BestFit: stateWithLeader ascending as tiebreaker": {
+		"BestFit: podCountWithLeader ascending as tiebreaker": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "large", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      100,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   100,
 					},
 				},
 				{
 					domain: domain{id: "small", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "medium", levelValues: []string{"c"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      50,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   50,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
-		"LeastFreeCapacity: stateWithLeader ascending as tiebreaker": {
+		"LeastFreeCapacity: podCountWithLeader ascending as tiebreaker": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "large", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      100,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   100,
 					},
 				},
 				{
 					domain: domain{id: "small", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "medium", levelValues: []string{"c"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      50,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   50,
 					},
 				},
 			},
@@ -830,25 +830,25 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						leaderState:          1,
-						sliceStateWithLeader: 5,
-						stateWithLeader:      10,
+						leaderCount:          1,
+						sliceCountWithLeader: 5,
+						podCountWithLeader:   10,
 					},
 				},
 			},
@@ -879,8 +879,8 @@ func TestSortedDomainsWithLeader(t *testing.T) {
 
 // TestSortedDomains verifies the sorting criteria (in order of priority):
 // 1. affinityScore - descending (when TASRespectNodeAffinityPreferred is enabled)
-// 2. sliceState - descending (BestFit) or ascending (LeastFreeCapacity)
-// 3. state - ascending (always, as tiebreaker)
+// 2. sliceCount - descending (BestFit) or ascending (LeastFreeCapacity)
+// 3. podCount - ascending (always, as tiebreaker)
 // 4. levelValues - ascending (always, as final tiebreaker)
 func TestSortedDomains(t *testing.T) {
 	levels := []string{"block"}
@@ -898,16 +898,16 @@ func TestSortedDomains(t *testing.T) {
 					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
 					state: domainState{
 						affinityScore: 10,
-						sliceState:    5,
-						state:         10,
+						sliceCount:    5,
+						podCount:      10,
 					},
 				},
 				{
 					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
 					state: domainState{
 						affinityScore: 100,
-						sliceState:    5,
-						state:         10,
+						sliceCount:    5,
+						podCount:      10,
 					},
 				},
 			},
@@ -921,124 +921,124 @@ func TestSortedDomains(t *testing.T) {
 					domain: domain{id: "low-affinity", levelValues: []string{"a"}},
 					state: domainState{
 						affinityScore: 10,
-						sliceState:    5,
-						state:         10,
+						sliceCount:    5,
+						podCount:      10,
 					},
 				},
 				{
 					domain: domain{id: "high-affinity", levelValues: []string{"b"}},
 					state: domainState{
 						affinityScore: 100,
-						sliceState:    5,
-						state:         10,
+						sliceCount:    5,
+						podCount:      10,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"low-affinity", "high-affinity"},
 		},
-		"BestFit: sliceState descending": {
+		"BestFit: sliceCount descending": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						sliceState: 3,
-						state:      1,
+						sliceCount: 3,
+						podCount:   1,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						sliceState: 1,
-						state:      1,
+						sliceCount: 1,
+						podCount:   1,
 					},
 				},
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						sliceState: 2,
-						state:      1,
+						sliceCount: 2,
+						podCount:   1,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"a", "c", "b"},
 		},
-		"LeastFreeCapacity: sliceState ascending": {
+		"LeastFreeCapacity: sliceCount ascending": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						sliceState: 3,
-						state:      1,
+						sliceCount: 3,
+						podCount:   1,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						sliceState: 1,
-						state:      1,
+						sliceCount: 1,
+						podCount:   1,
 					},
 				},
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						sliceState: 2,
-						state:      1,
+						sliceCount: 2,
+						podCount:   1,
 					},
 				},
 			},
 			unconstrained: true,
 			wantOrder:     []string{"b", "c", "a"},
 		},
-		"BestFit: state ascending as tiebreaker": {
+		"BestFit: podCount ascending as tiebreaker": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "large", levelValues: []string{"a"}},
 					state: domainState{
-						sliceState: 5,
-						state:      100,
+						sliceCount: 5,
+						podCount:   100,
 					},
 				},
 				{
 					domain: domain{id: "small", levelValues: []string{"b"}},
 					state: domainState{
-						sliceState: 5,
-						state:      10,
+						sliceCount: 5,
+						podCount:   10,
 					},
 				},
 				{
 					domain: domain{id: "medium", levelValues: []string{"c"}},
 					state: domainState{
-						sliceState: 5,
-						state:      50,
+						sliceCount: 5,
+						podCount:   50,
 					},
 				},
 			},
 			unconstrained: false,
 			wantOrder:     []string{"small", "medium", "large"},
 		},
-		"LeastFreeCapacity: state ascending as tiebreaker": {
+		"LeastFreeCapacity: podCount ascending as tiebreaker": {
 			domains: []testDomainSpec{
 				{
 					domain: domain{id: "large", levelValues: []string{"a"}},
 					state: domainState{
-						sliceState: 5,
-						state:      100,
+						sliceCount: 5,
+						podCount:   100,
 					},
 				},
 				{
 					domain: domain{id: "small", levelValues: []string{"b"}},
 					state: domainState{
-						sliceState: 5,
-						state:      10,
+						sliceCount: 5,
+						podCount:   10,
 					},
 				},
 				{
 					domain: domain{id: "medium", levelValues: []string{"c"}},
 					state: domainState{
-						sliceState: 5,
-						state:      50,
+						sliceCount: 5,
+						podCount:   50,
 					},
 				},
 			},
@@ -1050,22 +1050,22 @@ func TestSortedDomains(t *testing.T) {
 				{
 					domain: domain{id: "c", levelValues: []string{"c"}},
 					state: domainState{
-						sliceState: 5,
-						state:      10,
+						sliceCount: 5,
+						podCount:   10,
 					},
 				},
 				{
 					domain: domain{id: "a", levelValues: []string{"a"}},
 					state: domainState{
-						sliceState: 5,
-						state:      10,
+						sliceCount: 5,
+						podCount:   10,
 					},
 				},
 				{
 					domain: domain{id: "b", levelValues: []string{"b"}},
 					state: domainState{
-						sliceState: 5,
-						state:      10,
+						sliceCount: 5,
+						podCount:   10,
 					},
 				},
 			},
@@ -1530,7 +1530,7 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 	// One domain with capacity 1 cannot satisfy count 10.
 	callWithViolatedAssumptions := func(snapshot *TASFlavorSnapshot) []*domain {
 		dom := &domain{id: "rack-1", idx: 0}
-		snapshot.stateOf(dom).state = 1
+		snapshot.domainStateOf(dom).podCount = 1
 		return snapshot.updateCountsToMinimumGeneric([]*domain{dom}, 10, 0, 1, false, false)
 	}
 	wantErrorFields := map[string]any{

--- a/pkg/cache/scheduler/tas_topology_tree.go
+++ b/pkg/cache/scheduler/tas_topology_tree.go
@@ -27,14 +27,14 @@ import (
 
 // domain holds the static information about placement of a topology
 // domain in the hierarchy of topology domains.
-// Its per-snapshot mutable state lives in TASFlavorSnapshot.state,
+// Its per-snapshot mutable state lives in TASFlavorSnapshot.domainStates,
 // addressed by idx.
 type domain struct {
 	// id identifies the domain within its topology level
 	id utiltas.TopologyDomainID
 
 	// idx is the dense index of the domain within its topologyTree, used to
-	// address the per-snapshot state in TASFlavorSnapshot.state.
+	// address the per-snapshot state in TASFlavorSnapshot.domainStates.
 	idx int
 
 	// parent points to domain which is a parent in topology structure
@@ -49,13 +49,13 @@ type domain struct {
 }
 
 // leafDomain extends the domain with static information for the lowest-level
-// domain. Its per-snapshot mutable state lives in
-// TASFlavorSnapshot.leafStates, addressed by leafIdx.
+// domain. Its per-snapshot mutable capacity data lives in
+// TASFlavorSnapshot.leafCapacities, addressed by leafIdx.
 type leafDomain struct {
 	domain
 
 	// leafIdx is the dense index of the leaf within its topologyTree, used
-	// to address the per-snapshot state in TASFlavorSnapshot.leafStates.
+	// to address the per-snapshot capacity data in TASFlavorSnapshot.leafCapacities.
 	leafIdx int
 
 	// capacity is the static capacity of the leaf: the summed allocatable of

--- a/pkg/cache/scheduler/tas_topology_tree_test.go
+++ b/pkg/cache/scheduler/tas_topology_tree_test.go
@@ -141,12 +141,12 @@ func dumpSnapshotTree(t *testing.T, s *TASFlavorSnapshot) map[domainKey]snapshot
 			slices.SortFunc(d.Children, domainKey.compare)
 			if leaf, found := s.leaves[id]; found && &leaf.domain == dom {
 				d.Leaf = true
-				leafState := s.leafStateOf(leaf)
-				if leafState.freeCapacity != nil {
-					d.FreeCapacity = leafState.freeCapacity.Clone()
+				leafCapacity := s.leafCapacityOf(leaf)
+				if leafCapacity.freeCapacity != nil {
+					d.FreeCapacity = leafCapacity.freeCapacity.Clone()
 				}
-				if leafState.tasUsage != nil {
-					d.TASUsage = leafState.tasUsage.Clone()
+				if leafCapacity.tasUsage != nil {
+					d.TASUsage = leafCapacity.tasUsage.Clone()
 				}
 				if leaf.node != nil {
 					d.NodeName = leaf.node.Name
@@ -281,8 +281,8 @@ func TestSnapshotReuseAfterBalancedPlacement(t *testing.T) {
 	if failure := first.Failure(); failure != nil {
 		t.Fatalf("first assignment failed: %s", failure.Reason)
 	}
-	if len(snapshot.state) <= snapshot.domainCount {
-		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.state), snapshot.domainCount)
+	if len(snapshot.domainStates) <= snapshot.domainCount {
+		t.Fatalf("balanced placement created %d state slots for %d base domains, want clone state", len(snapshot.domainStates), snapshot.domainCount)
 	}
 
 	second := snapshot.FindTopologyAssignmentsForFlavor(ctx, requests)
@@ -370,8 +370,8 @@ func TestTopologyTreeInvalidation(t *testing.T) {
 				tasCache.SyncNode(node)
 			},
 			validate: func(t *testing.T, snapshot *TASFlavorSnapshot) {
-				n1State := snapshot.leafStateOf(snapshot.leaves[utiltas.TopologyDomainID("n1")])
-				if gotCapacity := n1State.freeCapacity.ResourceValue(corev1.ResourceCPU); gotCapacity != 8000 {
+				n1Capacity := snapshot.leafCapacityOf(snapshot.leaves[utiltas.TopologyDomainID("n1")])
+				if gotCapacity := n1Capacity.freeCapacity.ResourceValue(corev1.ResourceCPU); gotCapacity != 8000 {
 					t.Errorf("snapshot has cpu capacity %d, want 8000", gotCapacity)
 				}
 			},
@@ -493,8 +493,8 @@ func validateTopologyTreeStateIndexes(t *testing.T, tree *topologyTree) {
 	seen := make(map[int]*domain, tree.domainCount)
 	for _, levelDomains := range tree.domainsPerLevel {
 		for _, dom := range levelDomains {
-			if dom.idx < 0 || dom.idx >= len(snapshot.state) {
-				t.Errorf("domain %q has state index %d, outside [0, %d)", dom.levelValues, dom.idx, len(snapshot.state))
+			if dom.idx < 0 || dom.idx >= len(snapshot.domainStates) {
+				t.Errorf("domain %q has state index %d, outside [0, %d)", dom.levelValues, dom.idx, len(snapshot.domainStates))
 				continue
 			}
 			if other, found := seen[dom.idx]; found {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area tas

#### What this PR does / why we need it:

This is a follow up PR to naming feedback https://github.com/kubernetes-sigs/kueue/pull/13819#discussion_r3719952686

Several fields in domainState used generic state-based names even though they store pod, slice, and leader counts. This change gives them explicit count-based names and aligns the related snapshot fields and accessors.

```text
domainState.state                -> domainState.podCount
domainState.sliceState           -> domainState.sliceCount
domainState.stateWithLeader      -> domainState.podCountWithLeader
domainState.sliceStateWithLeader -> domainState.sliceCountWithLeader
domainState.leaderState          -> domainState.leaderCount
leafState                        -> leafCapacity
TASFlavorSnapshot.state          -> TASFlavorSnapshot.domainStates
TASFlavorSnapshot.leafStates     -> TASFlavorSnapshot.leafCapacities
stateOf                          -> domainStateOf
leafStateOf                      -> leafCapacityOf
```

Related locals, parameters, comments, and test fixtures were updated to match without any behavior change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal capacity and placement state handling for TAS scheduling.
  * Preserved balanced placement, leader-aware placement, fallback behavior, and capacity calculations.
  * Updated domain and leaf capacity tracking across scheduling and snapshot operations.

* **Tests**
  * Updated placement, capacity, topology, cleanup, and benchmark coverage to reflect the revised state handling.
  * Existing placement expectations and regression checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->