### PR TITLE
Add "Enabled()" confirmation to costly log output

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -816,7 +816,9 @@ func (c *clustersReconciler) setRemoteClientConfig(ctx context.Context, clusterN
 		ctrl.LoggerFrom(ctx).Error(err, "failed to set kubeConfig in the remote client")
 		return retryAfter, err
 	} else if retryAfter != nil {
-		ctrl.LoggerFrom(ctx).V(2).Info("reconnect deferred, backoff not elapsed", "retryAfter", retryAfter, "failedAttempts", client.getFailedConnAttempts())
+		if logV := ctrl.LoggerFrom(ctx).V(2); logV.Enabled() {
+			logV.Info("reconnect deferred, backoff not elapsed", "retryAfter", retryAfter, "failedAttempts", client.getFailedConnAttempts())
+		}
 		return retryAfter, nil
 	}
 	return nil, nil

--- a/pkg/controller/concurrentadmission/controller.go
+++ b/pkg/controller/concurrentadmission/controller.go
@@ -473,8 +473,10 @@ func (r *variantReconciler) deactivateMatchingVariants(ctx context.Context, vari
 		if match != nil && !match(v) {
 			continue
 		}
-		logFields := append([]any{"variant", klog.KObj(v), "flavor", concurrentadmission.GetVariantFlavor(v), "reason", reason}, logArgs...)
-		log.V(2).Info("Deactivating variant", logFields...)
+		if logV := log.V(2); logV.Enabled() {
+			logFields := append([]any{"variant", klog.KObj(v), "flavor", concurrentadmission.GetVariantFlavor(v), "reason", reason}, logArgs...)
+			logV.Info("Deactivating variant", logFields...)
+		}
 		if err := r.deactivateVariant(ctx, v, reason); err != nil {
 			return err
 		}
@@ -769,17 +771,20 @@ func firstCandidateVariant(log logr.Logger, admissibleVariants []*kueue.Workload
 		if workload.HasOpenPreemptionGate(wl, controllerconsts.ConcurrentAdmissionPreemptionGate) {
 			continue
 		}
-		wlLog := log.WithValues("candidateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
+		wlLog := log.V(4)
+		if wlLog.Enabled() {
+			wlLog = wlLog.WithValues("candidateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
+		}
 		if workload.BlockedOnPreemptionGatesCondition(wl) == nil {
 			quotaReserved := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadQuotaReserved)
 			if quotaReserved == nil {
-				wlLog.V(4).Info("Variant has not been evaluated for admission yet")
+				wlLog.Info("Variant has not been evaluated for admission yet")
 				return nil
 			}
-			wlLog.V(4).Info("Variant does not require preemption")
+			wlLog.Info("Variant does not require preemption")
 			continue
 		}
-		wlLog.V(4).Info("Variant is the candidate for ungating")
+		wlLog.Info("Variant is the candidate for ungating")
 		return wl
 	}
 	return nil
@@ -793,7 +798,9 @@ func latestOpenGateTime(log logr.Logger, admissibleVariants []*kueue.Workload) *
 			continue
 		}
 		if lastUngateTime == nil || openGate.LastTransitionTime.After(lastUngateTime.Time) {
-			log.V(4).Info("Variant has the latest preemption ungating time", "openPreemptionGateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
+			if logV := log.V(4); logV.Enabled() {
+				logV.Info("Variant has the latest preemption ungating time", "openPreemptionGateVariant", klog.KObj(wl), "flavor", concurrentadmission.GetVariantFlavor(wl))
+			}
 			lastUngateTime = &openGate.LastTransitionTime
 		}
 	}
@@ -812,7 +819,9 @@ func admissibleVariants(variants []kueue.Workload) []*kueue.Workload {
 
 func (r *variantReconciler) openPreemptionGate(ctx context.Context, variant *kueue.Workload) error {
 	log := ctrl.LoggerFrom(ctx)
-	log.V(2).Info("Opening preemption gate for variant", "variant", klog.KObj(variant), "flavor", concurrentadmission.GetVariantFlavor(variant))
+	if logV := log.V(2); logV.Enabled() {
+		logV.Info("Opening preemption gate for variant", "variant", klog.KObj(variant), "flavor", concurrentadmission.GetVariantFlavor(variant))
+	}
 	var opened bool
 	if err := workloadpatching.PatchAdmissionStatus(ctx, r.client, variant, r.clock, func(wl *kueue.Workload) (bool, error) {
 		opened = workload.OpenPreemptionGate(wl, controllerconsts.ConcurrentAdmissionPreemptionGate, metav1.NewTime(r.clock.Now()))

--- a/pkg/controller/tas/pod_usage_controller.go
+++ b/pkg/controller/tas/pod_usage_controller.go
@@ -231,9 +231,10 @@ func (r *PodUsageReconciler) drainPendingNodes(ctx context.Context) {
 		}
 	}
 	if cqNames.Len() > 0 {
-		log.V(3).
-			Info("Requeueing inadmissible workloads after non-TAS pod freed capacity",
+		if logV := log.V(3); logV.Enabled() {
+			logV.Info("Requeueing inadmissible workloads after non-TAS pod freed capacity",
 				"nodes", sets.List(nodes), "clusterQueues", sets.List(cqNames))
+		}
 		qcache.NotifyRetryInadmissible(r.queues, cqNames)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
I added "Enabled()" confirmation before we execute costly log output.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary logging overhead by checking configured verbosity levels before preparing detailed log messages.
* **Bug Fixes**
  * Preserved existing controller behavior and log output when the relevant verbosity is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->