### PR TITLE
DRA: drop negative extended-resource requests before quota aggregation

### DIFF
--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -186,7 +186,7 @@ func resolveQuotaKey(
 	return quotaKey, nil
 }
 
-// containerExtendedResourceRequests pairs a container's non-zero extended resource
+// containerExtendedResourceRequests pairs a container's positive extended resource
 // requests, keyed by original (unmapped) resource name, with the field path used to
 // report errors against that container.
 type containerExtendedResourceRequests struct {

--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -93,8 +93,11 @@ func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceCla
 	return selected
 }
 
-// extendedResourceRequests extracts a container's non-zero extended resource requests,
-// keyed by their original (unmapped) resource name. Quantities are not validated here:
+// extendedResourceRequests extracts a container's positive extended resource requests,
+// keyed by their original (unmapped) resource name. A zero or negative quantity is
+// dropped here rather than merged into a logical quota key later, since a negative
+// value could otherwise cancel out part of another resource's charge under the same
+// key (e.g. a ResourceClaimTemplate). Quantities are not validated here:
 // the integer-only rule only applies to resources that turn out to be DRA-backed, which
 // isn't known until a DeviceClass is resolved for the name later in
 // ResolveExtendedResourceQuota. Validating here would reject fractional requests for
@@ -104,7 +107,7 @@ func extendedResourceRequests(container corev1.Container) corev1.ResourceList {
 	result := corev1.ResourceList{}
 
 	for resourceName, quantity := range container.Resources.Requests {
-		if quantity.IsZero() || !utilresource.IsExtendedResourceName(resourceName) {
+		if quantity.Sign() <= 0 || !utilresource.IsExtendedResourceName(resourceName) {
 			continue
 		}
 		result[resourceName] = quantity

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -615,6 +615,50 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			// vendor.example/a and vendor.example/b share the "gpu-claims" quota key.
+			// The negative request for b must be dropped before aggregation, not
+			// merged in and left to offset a's positive charge.
+			name: "positive and negative extended resource names sharing a quota key: negative does not offset positive",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"vendor.example/a": resource.MustParse("5"),
+											"vendor.example/b": resource.MustParse("-3"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{classADeviceClass, classBDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "gpu-claims",
+					DeviceClassNames: []corev1.ResourceName{"class-a", "class-b"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"gpu-claims": resource.MustParse("5"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("vendor.example/a"),
+			},
+		},
+		{
 			name: "workload with non-integer extended resource quantity",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -272,6 +272,33 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			name: "workload with negative extended resource request is not charged",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"example.com/gpu": resource.MustParse("-3"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want:          nil,
+		},
+		{
 			name: "workload with multiple extended resources",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dra

#### What this PR does / why we need it:

`extendedResourceRequests` in `pkg/dra/extended_resources.go` builds the per-container
extended-resource request list that `ResolveExtendedResourceQuota` aggregates into a
DRA logical quota charge. It only skipped a request when `quantity.IsZero()`, so a
negative extended-resource request quantity was kept, converted to a negative `int64`,
and merged into the aggregated quota map alongside any other resource sharing the same
logical quota key. A negative charge like that can silently cancel out part of a
legitimate positive charge (e.g. a `ResourceClaimTemplate` mapped to the same logical
key), understating what a workload is actually charged for.

With the `WorkloadValidateResourcesAreNonNegative` webhook validation enabled (the
default since v0.20), a negative value in a container's `resources.requests` is already
rejected on Workload create/update, so this is not reachable through normal API usage
today. It can still reach this code path in two narrower cases: the feature gate is
explicitly disabled, or the Workload object was created/persisted before that
validation existed (or while the gate was off) and has not been updated since, since
the webhook only validates on write, not on every reconcile. This PR is
defense-in-depth for the DRA extended-resource path specifically, matching the same
"a negative should never become a logical charge" contract other parts of Kueue's quota
accounting already enforce.

This PR changes the skip condition in `extendedResourceRequests` from `quantity.IsZero()`
to `quantity.Sign() <= 0`, dropping negative quantities the same way zero quantities are
already dropped, before they can be merged into any logical quota key.

#### Which issue(s) this PR fixes:

Fixes #14216

#### Special notes for your reviewer:

Scope is intentionally limited to the one function that builds the request lists fed
into `ResolveExtendedResourceQuota`'s aggregation (`MergeResourceListKeepMax` /
`MergeResourceListKeepSum` in `pkg/util/resource`), since that is the only place a
negative quantity can enter the aggregated map. `NeedsDRAReconcile` in the same file
still uses `!qty.IsZero()` to decide whether DRA reconciliation runs at all; a
negative-only request there now still triggers a reconcile that resolves to no charge,
which is a harmless extra reconcile cycle rather than a correctness issue, so it was
left out of this minimal fix.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed a bug where a negative extended-resource request quantity (reachable only when the `WorkloadValidateResourcesAreNonNegative` validation is disabled, or on a Workload created before that validation existed) could be merged as a negative DRA quota charge, silently offsetting a legitimate charge on the same logical resource. Negative extended-resource requests are now dropped the same way zero-valued ones already are.
```

---
AI assistance: this change was drafted with Claude Code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Negative extended-resource requests are now ignored during quota aggregation.
  * Negative requests no longer offset valid positive requests for the same quota.
  * Only positive extended-resource quantities contribute to quota calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->