### PR TITLE
Fix release automation to set the release link after publishing

### DIFF
--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -61,7 +61,7 @@ runs:
         # Fill in the release link in the release issue checklist. Callers opt out
         # via "update-release-issue: false" for release candidates, since the
         # checklist tracks the final release link only.
-        if [[ -n "$ISSUE_NUMBER" && "$UPDATE_RELEASE_ISSUE" == "true" ]]; then
+        if [[ "$UPDATE_RELEASE_ISSUE" == "true" ]]; then
           ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$TARGET_REPO" --json body --jq '.body' || true)
           if [[ -n "$ISSUE_BODY" && "$ISSUE_BODY" == *"<!-- RELEASE_LINK -->"* ]]; then
             NEW_ISSUE_BODY=${ISSUE_BODY//<!-- RELEASE_LINK -->/${RELEASE_URL}}

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -53,4 +53,18 @@ runs:
         fi
 
         RELEASE_URL="https://github.com/${TARGET_REPO}/releases/tag/${VERSION}"
+
+        # Fill in the release link in the release issue checklist. Skip release
+        # candidates (tagged with a "-rc.N" suffix) since the checklist tracks the
+        # final release link only.
+        if [[ -n "$ISSUE_NUMBER" && ! "$VERSION" =~ -rc\.[0-9]+$ ]]; then
+          ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$TARGET_REPO" --json body --jq '.body' || true)
+          if [[ -n "$ISSUE_BODY" && "$ISSUE_BODY" == *"<!-- RELEASE_LINK -->"* ]]; then
+            NEW_ISSUE_BODY=${ISSUE_BODY//<!-- RELEASE_LINK -->/${RELEASE_URL}}
+            gh issue edit "$ISSUE_NUMBER" --repo "$TARGET_REPO" --body "$NEW_ISSUE_BODY" || {
+              echo "!!! Failed to update release issue body with release link." >&2
+            }
+          fi
+        fi
+
         echo "message=✅ Release \`$VERSION\` has been successfully published. Link: ${RELEASE_URL}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/publish-release/action.yml
+++ b/.github/actions/publish-release/action.yml
@@ -8,6 +8,9 @@ inputs:
   repo:
     description: Target repository in owner/name format
     required: true
+  update-release-issue:
+    description: Whether to fill in the release link in the release issue checklist. Set to "false" for release candidates, since the checklist tracks the final release link only.
+    required: true
 
 outputs:
   message:
@@ -25,6 +28,7 @@ runs:
         VERSION: ${{ inputs.version }}
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         TARGET_REPO: ${{ inputs.repo }}
+        UPDATE_RELEASE_ISSUE: ${{ inputs.update-release-issue }}
       run: |
         RELEASE_STATE=$(gh release view "$VERSION" --repo "$TARGET_REPO" --json isDraft \
             --jq 'if .isDraft then "draft" else "published" end' 2>/dev/null || echo "")
@@ -54,10 +58,10 @@ runs:
 
         RELEASE_URL="https://github.com/${TARGET_REPO}/releases/tag/${VERSION}"
 
-        # Fill in the release link in the release issue checklist. Skip release
-        # candidates (tagged with a "-rc.N" suffix) since the checklist tracks the
-        # final release link only.
-        if [[ -n "$ISSUE_NUMBER" && ! "$VERSION" =~ -rc\.[0-9]+$ ]]; then
+        # Fill in the release link in the release issue checklist. Callers opt out
+        # via "update-release-issue: false" for release candidates, since the
+        # checklist tracks the final release link only.
+        if [[ -n "$ISSUE_NUMBER" && "$UPDATE_RELEASE_ISSUE" == "true" ]]; then
           ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$TARGET_REPO" --json body --jq '.body' || true)
           if [[ -n "$ISSUE_BODY" && "$ISSUE_BODY" == *"<!-- RELEASE_LINK -->"* ]]; then
             NEW_ISSUE_BODY=${ISSUE_BODY//<!-- RELEASE_LINK -->/${RELEASE_URL}}

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -268,6 +268,7 @@ jobs:
         with:
           version: ${{ steps.rc-version.outputs.version }}
           repo: ${{ github.repository }}
+          update-release-issue: false
 
       - name: Report Success
         if: ${{ success() }}
@@ -642,6 +643,7 @@ jobs:
         with:
           version: ${{ needs.authorize.outputs.version }}
           repo: ${{ github.repository }}
+          update-release-issue: true
 
       - name: Report Success
         if: ${{ success() }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR is disclosed as AI-assisted per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

The release-tracking issue template (`.github/ISSUE_TEMPLATE/NEW_RELEASE.md`) has a checklist line for the `/publish-release` ChatOps command whose `<!-- RELEASE_LINK -->` marker is meant to be replaced with the published release URL. The `publish-release` composite action never did this — it only posted the URL as a bot comment, leaving the marker in the issue body untouched forever.

This PR applies the same marker-replacement idiom already used elsewhere in the release automation (`hack/releasing/prepare_pull.sh`, `promote_pull.sh`, `ci_pull.sh` for their respective markers) directly inside `.github/actions/publish-release/action.yml`: after a successful publish, fetch the issue body, replace `<!-- RELEASE_LINK -->` with the release URL, and edit the issue. The `gh issue view` fetch is guarded with `|| true` (matching the same guard in the three scripts above) so a transient failure there can't turn an already-successful publish into a reported failure. The update is skipped for release-candidate versions (`-rc.N` suffix) since those aren't part of the tracked issue checklist and would otherwise burn the one-shot marker replacement with the wrong link.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14311

#### Special notes for your reviewer:

This is a GitHub Actions composite action (YAML + embedded bash) with no corresponding Go package, so there's no `go build`/`go test` to run. Validation performed locally:

- `python3 -c "import yaml; yaml.safe_load(open('.github/actions/publish-release/action.yml'))"` — confirms the YAML is well-formed.
- Extracted the embedded `run:` script and ran `bash -n` against it — confirms it parses.
- Ran `shellcheck` against the extracted script — exits 0, no findings.

I was not able to exercise this against a live release/issue (requires real repo-write credentials and an in-flight release issue that this environment doesn't have, and the repo has no local Actions runner). The change mirrors the exact `gh issue view ... || true` / string-replace-marker / `gh issue edit --body` pattern already proven out by `prepare_pull.sh`, `promote_pull.sh`, and `ci_pull.sh` for their own markers on the same issue, so I'm confident in the approach, but flagging the live-run gap explicitly for reviewers who run the release process.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release publishing now automatically adds the release URL to the associated release issue when enabled and applicable.
  * Release candidate builds do not update the release issue, preventing premature release links from being added.
  * Release workflows now clearly control whether release issue updates are enabled.

* **Bug Fixes**
  * Problems retrieving or updating the release issue are logged without interrupting the release publishing process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->