### PR TITLE
[release-0.18] Use exponential backoff consistently for retry.sh callers

### DIFF
--- a/Makefile-test.mk
+++ b/Makefile-test.mk
@@ -21,10 +21,10 @@ GO_TEST_FLAGS ?= -race
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION ?= 1.36
 
-ENVTEST_RETRY_ATTEMPTS ?= 4
-ENVTEST_RETRY_DELAY ?= 5
+ENVTEST_RETRY_ATTEMPTS ?= 7
+ENVTEST_RETRY_DELAY ?= 2
 KUBEBUILDER_ASSETS = $(or \
-	$(shell $(PROJECT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(shell $(PROJECT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) --exponential -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
 	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 
 TEST_LOG_LEVEL ?= -3

--- a/cmd/experimental/kueue-populator/Makefile
+++ b/cmd/experimental/kueue-populator/Makefile
@@ -20,10 +20,10 @@ GINKGO := $(BIN_DIR)/ginkgo
 GOTESTSUM := $(BIN_DIR)/gotestsum
 ARTIFACTS ?= $(ROOT_DIR)/artifacts
 ENVTEST_K8S_VERSION ?= 1.36
-ENVTEST_RETRY_ATTEMPTS ?= 4
-ENVTEST_RETRY_DELAY ?= 5
+ENVTEST_RETRY_ATTEMPTS ?= 7
+ENVTEST_RETRY_DELAY ?= 2
 KUBEBUILDER_ASSETS = $(or \
-	$(shell $(ROOT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(shell $(ROOT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) --exponential -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
 	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 INTEGRATION_NPROCS ?= 4
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen

--- a/cmd/experimental/kueue-priority-booster/Makefile
+++ b/cmd/experimental/kueue-priority-booster/Makefile
@@ -19,10 +19,10 @@ GINKGO := $(BIN_DIR)/ginkgo
 GOTESTSUM := $(BIN_DIR)/gotestsum
 ARTIFACTS ?= $(ROOT_DIR)/artifacts
 ENVTEST_K8S_VERSION ?= 1.35
-ENVTEST_RETRY_ATTEMPTS ?= 4
-ENVTEST_RETRY_DELAY ?= 5
+ENVTEST_RETRY_ATTEMPTS ?= 7
+ENVTEST_RETRY_DELAY ?= 2
 KUBEBUILDER_ASSETS = $(or \
-	$(shell $(ROOT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
+	$(shell $(ROOT_DIR)/hack/testing/retry.sh --attempts $(ENVTEST_RETRY_ATTEMPTS) --delay $(ENVTEST_RETRY_DELAY) --exponential -- $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path), \
 	$(error setup-envtest failed to download binaries. KUBEBUILDER_ASSETS is empty))
 INTEGRATION_NPROCS ?= 4
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen

--- a/hack/testing/e2e-common.sh
+++ b/hack/testing/e2e-common.sh
@@ -900,7 +900,7 @@ kind: ResourceFlavor
 metadata:
   name: webhook-probe
 EOF
-    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 10 --delay 5 --stream -- \
+    "${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential --stream -- \
         kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} create --dry-run=server -f "${probe_manifest}"
 }
 

--- a/hack/testing/linkchecker/verify.sh
+++ b/hack/testing/linkchecker/verify.sh
@@ -26,7 +26,7 @@ echo "Building linkchecker Docker image..."
 "${DOCKER}" build --load -f "${SOURCE_DIR}/Dockerfile" -t linkchecker "${SOURCE_DIR}"
 
 echo "Running linkchecker..."
-"${ROOT_DIR}/hack/testing/retry.sh" --attempts 5 --delay 5 --stream -- \
+"${ROOT_DIR}/hack/testing/retry.sh" --attempts 7 --delay 2 --exponential --stream -- \
     "${DOCKER}" run --rm linkchecker --no-warnings --ignore-url='^mailto:' --ignore-url='^tel:' https://kueue.sigs.k8s.io/
 
 echo "Link check completed successfully"


### PR DESCRIPTION
Cherry pick of #14359 for release-0.18.

```release-note
NONE
```