### PR TITLE
fix(resource): deep copy resolved quantities in merge

### DIFF
--- a/pkg/util/resource/resource.go
+++ b/pkg/util/resource/resource.go
@@ -38,7 +38,7 @@ func mergeResourceList(a, b corev1.ResourceList, f resolveConflict) corev1.Resou
 		if va, exists := ret[k]; !exists {
 			ret[k] = vb.DeepCopy()
 		} else if f != nil {
-			ret[k] = f(va, vb)
+			ret[k] = f(va, vb).DeepCopy()
 		}
 	}
 	return ret

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -415,3 +415,24 @@ func TestIsExtendedResourceName(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
+	for _, q := range []string{"1.1Gi", "250m", "2Gi"} {
+		t.Run(q, func(t *testing.T) {
+			a := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1")}
+			b := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(q)}
+			want := b[corev1.ResourceMemory].DeepCopy()
+
+			got := MergeResourceListKeepMax(a, b)
+			v := got[corev1.ResourceMemory]
+			v.Add(resource.MustParse("1000"))
+			got[corev1.ResourceMemory] = v
+
+			after := b[corev1.ResourceMemory]
+			t.Logf("b was %s, is now %s", want.String(), after.String())
+			if want.Cmp(after) != 0 {
+				t.Errorf("mutating the merged result changed the input: %s became %s", want.String(), after.String())
+			}
+		})
+	}
+}

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -417,7 +417,14 @@ func TestIsExtendedResourceName(t *testing.T) {
 }
 
 func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
-	for _, q := range []string{"1.1Gi", "250m", "2Gi"} {
+	cases := map[string]string{
+		"": "1.1Gi",
+		"": "250m",
+		"": "2Gi",
+	}
+
+	for name, q := range cases {
+	  t.Run(name, func(...
 		t.Run(q, func(t *testing.T) {
 			a := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1")}
 			b := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(q)}

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -418,15 +418,14 @@ func TestIsExtendedResourceName(t *testing.T) {
 
 func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
 	cases := map[string]string{
-		"": "1.1Gi",
-		"": "250m",
-		"": "2Gi",
+		"decimal Gi quantity": "1.1Gi",
+		"milli quantity":      "250m",
+		"integer Gi quantity": "2Gi",
 	}
 
 	for name, q := range cases {
-	  t.Run(name, func(...
-		t.Run(q, func(t *testing.T) {
-			a := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1")}
+		t.Run(name, func(t *testing.T) {
+			a := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("0")}
 			b := corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(q)}
 			want := b[corev1.ResourceMemory].DeepCopy()
 

--- a/pkg/util/resource/resource_test.go
+++ b/pkg/util/resource/resource_test.go
@@ -437,8 +437,8 @@ func TestMergeKeepMaxOwnsItsResult(t *testing.T) {
 
 			after := b[corev1.ResourceMemory]
 			t.Logf("b was %s, is now %s", want.String(), after.String())
-			if want.Cmp(after) != 0 {
-				t.Errorf("mutating the merged result changed the input: %s became %s", want.String(), after.String())
+			if diff := cmp.Diff(want, after); diff != "" {
+				t.Errorf("mutating the merged result changed the input (-want +after):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->
/kind bug
#### What this PR does / why we need it:
This PR fixes issue #14375 by preventing MergeResourceListKeepMax from sharing mutable state with its second argument. Previously, mutating a value in the returned ResourceList could also mutate the input list.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #14375

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented merged resource quantities from unintentionally changing the original resource data.
  * Ensured results remain independent when handling decimal, milli, and integer quantity values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->