### PR TITLE
Reuse helper function instead of resourceFlavors

### DIFF
--- a/pkg/controller/core/resourceflavor_controller.go
+++ b/pkg/controller/core/resourceflavor_controller.go
@@ -22,7 +22,6 @@ import (
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,6 +39,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
 )
 
@@ -224,8 +224,8 @@ func (r *ResourceFlavorReconciler) NotifyClusterQueueUpdate(oldCQ, newCQ *kueue.
 		return
 	}
 
-	oldFlavors := resourceFlavors(oldCQ)
-	newFlavors := resourceFlavors(newCQ)
+	oldFlavors := utilqueue.AllFlavors(oldCQ.Spec.ResourceGroups)
+	newFlavors := utilqueue.AllFlavors(newCQ.Spec.ResourceGroups)
 	if !oldFlavors.Equal(newFlavors) {
 		r.cqUpdateCh <- event.GenericEvent{Object: oldCQ}
 	}
@@ -292,14 +292,4 @@ func (r *ResourceFlavorReconciler) SetupWithManager(mgr ctrl.Manager, cfg *confi
 		}).
 		WatchesRawSource(source.Channel(r.cqUpdateCh, &h)).
 		Complete(WithLeadingManager(mgr, r, &kueue.ResourceFlavor{}, cfg))
-}
-
-func resourceFlavors(cq *kueue.ClusterQueue) sets.Set[kueue.ResourceFlavorReference] {
-	flavors := sets.New[kueue.ResourceFlavorReference]()
-	for _, rg := range cq.Spec.ResourceGroups {
-		for _, flavor := range rg.Flavors {
-			flavors.Insert(flavor.Name)
-		}
-	}
-	return flavors
 }

--- a/pkg/controller/core/resourceflavor_controller_test.go
+++ b/pkg/controller/core/resourceflavor_controller_test.go
@@ -27,7 +27,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -372,58 +371,6 @@ func TestCqHandlerGeneric(t *testing.T) {
 				cmpopts.EquateEmpty(),
 			); diff != "" {
 				t.Errorf("enqueued requests mismatch (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestResourceFlavors(t *testing.T) {
-	makeCQ := func(groups ...[]string) *kueue.ClusterQueue {
-		w := utiltestingapi.MakeClusterQueue("cq")
-		for _, flavors := range groups {
-			fqs := make([]kueue.FlavorQuotas, len(flavors))
-			for i, f := range flavors {
-				fqs[i] = *utiltestingapi.MakeFlavorQuotas(f).Resource(corev1.ResourceCPU, "10").Obj()
-			}
-			w = w.ResourceGroup(fqs...)
-		}
-		return w.Obj()
-	}
-
-	cases := map[string]struct {
-		cq   *kueue.ClusterQueue
-		want []kueue.ResourceFlavorReference
-	}{
-		"empty resource groups": {
-			cq:   makeCQ(),
-			want: nil,
-		},
-		"single group single flavor": {
-			cq:   makeCQ([]string{"flavor-a"}),
-			want: []kueue.ResourceFlavorReference{"flavor-a"},
-		},
-		"single group multiple flavors": {
-			cq:   makeCQ([]string{"flavor-a", "flavor-b"}),
-			want: []kueue.ResourceFlavorReference{"flavor-a", "flavor-b"},
-		},
-		"multiple groups": {
-			cq:   makeCQ([]string{"flavor-a"}, []string{"flavor-b"}),
-			want: []kueue.ResourceFlavorReference{"flavor-a", "flavor-b"},
-		},
-		"duplicate flavor across groups": {
-			cq:   makeCQ([]string{"flavor-a"}, []string{"flavor-a"}),
-			want: []kueue.ResourceFlavorReference{"flavor-a"},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got := sets.List(resourceFlavors(tc.cq))
-
-			if diff := cmp.Diff(tc.want, got,
-				cmpopts.EquateEmpty(),
-			); diff != "" {
-				t.Errorf("resourceFlavors mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

Reuse util function instead of implementing a custom one.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency when comparing ClusterQueue resource flavors.
  * Removed obsolete internal resource-flavor handling logic.

* **Tests**
  * Removed outdated tests for the retired resource-flavor extraction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->