### PR TITLE
[release-0.19] DRA: aggregate extended resources by original name before mapping to quota key

### DIFF
--- a/pkg/dra/extended_resources.go
+++ b/pkg/dra/extended_resources.go
@@ -93,106 +93,110 @@ func selectedDeviceClass(items []resourceapi.DeviceClass) *resourceapi.DeviceCla
 	return selected
 }
 
-// resolveContainerExtendedResources converts DRA-backed extended resources in a
-// container's requests into logical quota keys. For each extended resource, it looks
-// up DeviceClasses by spec.extendedResourceName, selects the one the scheduler would
-// allocate from, and uses that class's deviceClassMappings entry as the quota key;
-// otherwise the extendedResourceName itself is used. Returns the converted resources
-// and the set of original resource names that were replaced (for double-count prevention).
-func resolveContainerExtendedResources(
-	ctx context.Context,
-	cl client.Client,
-	mapper *ResourceMapper,
-	container corev1.Container,
-	containerPath *field.Path,
-) (corev1.ResourceList, sets.Set[corev1.ResourceName], field.ErrorList) {
-	log := ctrl.LoggerFrom(ctx)
+// extendedResourceRequests extracts a container's non-zero extended resource requests,
+// keyed by their original (unmapped) resource name. Quantities are not validated here:
+// the integer-only rule only applies to resources that turn out to be DRA-backed, which
+// isn't known until a DeviceClass is resolved for the name later in
+// ResolveExtendedResourceQuota. Validating here would reject fractional requests for
+// extended resources that aren't DRA-backed at all, which the standard (non-DRA) quota
+// path accepts.
+func extendedResourceRequests(container corev1.Container) corev1.ResourceList {
 	result := corev1.ResourceList{}
-	replaced := sets.New[corev1.ResourceName]()
-	var errs field.ErrorList
 
 	for resourceName, quantity := range container.Resources.Requests {
 		if quantity.IsZero() || !utilresource.IsExtendedResourceName(resourceName) {
 			continue
 		}
-
-		log.V(4).Info("Checking extended resource for DRA backing", "resource", resourceName, "quantity", quantity.String())
-
-		var dcList resourceapi.DeviceClassList
-		if err := cl.List(ctx, &dcList, client.MatchingFields{
-			"spec.extendedResourceName": string(resourceName),
-		}); err != nil {
-			errs = append(errs, field.InternalError(
-				containerPath.Child("resources", "requests", string(resourceName)),
-				fmt.Errorf("failed to list DeviceClasses for extended resource %q: %w", resourceName, err),
-			))
-			continue
-		}
-
-		if len(dcList.Items) == 0 {
-			log.V(4).Info("No DeviceClass found, not a DRA-backed extended resource", "resource", resourceName)
-			continue
-		}
-
-		qty, ok := quantity.AsInt64()
-		if !ok {
-			errs = append(errs, field.Invalid(
-				containerPath.Child("resources", "requests", string(resourceName)),
-				quantity.String(),
-				"extended resource quantity must be an integer",
-			))
-			continue
-		}
-
-		// The class the scheduler will allocate from, not whichever List returned first.
-		selected := selectedDeviceClass(dcList.Items)
-
-		// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
-		// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
-		// Otherwise, use the extendedResourceName directly.
-		quotaKey := resourceName
-		if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
-			quotaKey = logicalName
-			if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(selected.Name))) > 0 {
-				errs = append(errs, field.Invalid(
-					containerPath,
-					resourceName,
-					fmt.Sprintf(
-						"extended resource %s resolves to DeviceClass %s with counters configured;"+
-							" use ResourceClaimTemplates with CEL selectors for counter-based quota",
-						resourceName, selected.Name,
-					),
-				))
-			} else if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(selected.Name))) > 0 {
-				errs = append(errs, field.Invalid(
-					containerPath,
-					resourceName,
-					fmt.Sprintf(
-						"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
-							" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
-						resourceName, selected.Name,
-					),
-				))
-			}
-		}
-
-		chargeQuantity := *resource.NewQuantity(qty, resource.DecimalSI)
-
-		log.V(4).Info("Resolved extended resource to DRA quota key",
-			"resource", resourceName, "quotaKey", quotaKey, "quantity", chargeQuantity.String(),
-			"deviceClass", selected.Name)
-
-		replaced.Insert(resourceName)
-		result = utilresource.MergeResourceListKeepSum(result, corev1.ResourceList{
-			quotaKey: chargeQuantity,
-		})
+		result[resourceName] = quantity
 	}
-	return result, replaced, errs
+	return result
+}
+
+// resolveQuotaKey looks up the DeviceClasses backing resourceName by
+// spec.extendedResourceName, selects the one the scheduler would allocate from, and
+// returns that class's deviceClassMappings entry as the quota key; otherwise
+// resourceName itself is used. Returns "" if resourceName is not DRA-backed (no
+// matching DeviceClass).
+func resolveQuotaKey(
+	ctx context.Context,
+	cl client.Client,
+	mapper *ResourceMapper,
+	resourceName corev1.ResourceName,
+	path *field.Path,
+) (corev1.ResourceName, field.ErrorList) {
+	log := ctrl.LoggerFrom(ctx)
+	log.V(4).Info("Checking extended resource for DRA backing", "resource", resourceName)
+
+	var dcList resourceapi.DeviceClassList
+	if err := cl.List(ctx, &dcList, client.MatchingFields{
+		"spec.extendedResourceName": string(resourceName),
+	}); err != nil {
+		return "", field.ErrorList{field.InternalError(
+			path.Child("resources", "requests", string(resourceName)),
+			fmt.Errorf("failed to list DeviceClasses for extended resource %q: %w", resourceName, err),
+		)}
+	}
+
+	if len(dcList.Items) == 0 {
+		log.V(4).Info("No DeviceClass found, not a DRA-backed extended resource", "resource", resourceName)
+		return "", nil
+	}
+
+	// The class the scheduler will allocate from, not whichever List returned first.
+	selected := selectedDeviceClass(dcList.Items)
+
+	// Determine the quota key. If the DeviceClass is also in deviceClassMappings,
+	// use the mapped logical name to unify quota with the ResourceClaimTemplate path.
+	// Otherwise, use the extendedResourceName directly.
+	quotaKey := resourceName
+	var errs field.ErrorList
+	if logicalName, found := mapper.Lookup(corev1.ResourceName(selected.Name)); found {
+		quotaKey = logicalName
+		if features.Enabled(features.KueueDRAIntegrationPartitionableDevices) && len(mapper.getCounterConfigs(corev1.ResourceName(selected.Name))) > 0 {
+			errs = append(errs, field.Invalid(
+				path,
+				resourceName,
+				fmt.Sprintf(
+					"extended resource %s resolves to DeviceClass %s with counters configured;"+
+						" use ResourceClaimTemplates with CEL selectors for counter-based quota",
+					resourceName, selected.Name,
+				),
+			))
+		} else if features.Enabled(features.KueueDRAIntegrationConsumableCapacity) && len(mapper.getCapacityConfigs(corev1.ResourceName(selected.Name))) > 0 {
+			errs = append(errs, field.Invalid(
+				path,
+				resourceName,
+				fmt.Sprintf(
+					"extended resource %s resolves to DeviceClass %s with capacity sources configured;"+
+						" use ResourceClaimTemplates with capacity.requests for capacity-based quota",
+					resourceName, selected.Name,
+				),
+			))
+		}
+	}
+	if len(errs) > 0 {
+		return "", errs
+	}
+
+	log.V(4).Info("Resolved extended resource to DRA quota key",
+		"resource", resourceName, "quotaKey", quotaKey, "deviceClass", selected.Name)
+	return quotaKey, nil
+}
+
+// containerExtendedResourceRequests pairs a container's non-zero extended resource
+// requests, keyed by original (unmapped) resource name, with the field path used to
+// report errors against that container.
+type containerExtendedResourceRequests struct {
+	path      *field.Path
+	resources corev1.ResourceList
 }
 
 // ResolveExtendedResourceQuota converts extended resource requests across all PodSets
 // into DRA logical quota resources. Per PodSet, init containers are aggregated with
-// max (sequential) and regular containers with sum (concurrent), then combined with max.
+// max (sequential) and regular containers with sum (concurrent), then combined with
+// max — per original resource name, before any two names sharing a quota key can
+// collapse into each other's contribution. The quota key for each original name is
+// resolved once per PodSet, from that name's own aggregated total.
 func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper *ResourceMapper, wl *kueue.Workload) (
 	map[kueue.PodSetReference]corev1.ResourceList,
 	map[kueue.PodSetReference]sets.Set[corev1.ResourceName],
@@ -209,26 +213,101 @@ func ResolveExtendedResourceQuota(ctx context.Context, cl client.Client, mapper 
 
 	for i := range wl.Spec.PodSets {
 		ps := &wl.Spec.PodSets[i]
-		replaced := sets.New[corev1.ResourceName]()
 		podSetPath := field.NewPath("spec", "podSets").Index(i).Child("template", "spec")
 
-		// Closure captures outer `replaced` set to accumulate across init and regular containers.
-		resolveContainers := func(containers []corev1.Container, pathSegment string, merge func(a, b corev1.ResourceList) corev1.ResourceList) corev1.ResourceList {
-			var result corev1.ResourceList
+		collect := func(containers []corev1.Container, pathSegment string) []containerExtendedResourceRequests {
+			var entries []containerExtendedResourceRequests
 			for j, container := range containers {
-				containerPath := podSetPath.Child(pathSegment).Index(j)
-				res, containerReplaced, errs := resolveContainerExtendedResources(ctx, cl, mapper, container, containerPath)
-				allErrs = append(allErrs, errs...)
-				replaced = replaced.Union(containerReplaced)
-				result = merge(result, res)
+				res := extendedResourceRequests(container)
+				if len(res) == 0 {
+					continue
+				}
+				entries = append(entries, containerExtendedResourceRequests{
+					path:      podSetPath.Child(pathSegment).Index(j),
+					resources: res,
+				})
 			}
-			return result
+			return entries
 		}
 
-		maxInitResources := resolveContainers(ps.Template.Spec.InitContainers, "initContainers", utilresource.MergeResourceListKeepMax)
-		sumRegularResources := resolveContainers(ps.Template.Spec.Containers, "containers", utilresource.MergeResourceListKeepSum)
+		initEntries := collect(ps.Template.Spec.InitContainers, "initContainers")
+		regularEntries := collect(ps.Template.Spec.Containers, "containers")
 
-		aggregated := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
+		// The field path of the first container an original resource name is seen in,
+		// for error reporting once that name is resolved below.
+		firstPath := map[corev1.ResourceName]*field.Path{}
+		var maxInitResources, sumRegularResources corev1.ResourceList
+		for _, e := range initEntries {
+			for name := range e.resources {
+				if _, ok := firstPath[name]; !ok {
+					firstPath[name] = e.path
+				}
+			}
+			maxInitResources = utilresource.MergeResourceListKeepMax(maxInitResources, e.resources)
+		}
+		for _, e := range regularEntries {
+			for name := range e.resources {
+				if _, ok := firstPath[name]; !ok {
+					firstPath[name] = e.path
+				}
+			}
+			sumRegularResources = utilresource.MergeResourceListKeepSum(sumRegularResources, e.resources)
+		}
+		podRequests := utilresource.MergeResourceListKeepMax(maxInitResources, sumRegularResources)
+
+		aggregated := corev1.ResourceList{}
+		replaced := sets.New[corev1.ResourceName]()
+		for resourceName, quantity := range podRequests {
+			quotaKey, errs := resolveQuotaKey(ctx, cl, mapper, resourceName, firstPath[resourceName])
+			if len(errs) > 0 {
+				allErrs = append(allErrs, errs...)
+				continue
+			}
+			if quotaKey == "" {
+				continue
+			}
+
+			// resourceName is confirmed DRA-backed: now hold it to the
+			// integer-only rule, checked per container rather than on the
+			// aggregate above, so two invalid fractional requests (e.g. two
+			// 500m requests summing to a valid 1) can't hide each other.
+			var intErrs field.ErrorList
+			for _, entries := range [][]containerExtendedResourceRequests{initEntries, regularEntries} {
+				for _, e := range entries {
+					qty, ok := e.resources[resourceName]
+					if !ok {
+						continue
+					}
+					if _, ok := qty.AsInt64(); !ok {
+						intErrs = append(intErrs, field.Invalid(
+							e.path.Child("resources", "requests", string(resourceName)),
+							qty.String(),
+							"extended resource quantity must be an integer",
+						))
+					}
+				}
+			}
+			if len(intErrs) > 0 {
+				allErrs = append(allErrs, intErrs...)
+				continue
+			}
+
+			// Each container's quantity passed the integer check above, but their
+			// sum can still overflow int64 (e.g. two containers requesting 9e18
+			// each), so the aggregate needs its own check rather than assuming ok.
+			intQty, ok := quantity.AsInt64()
+			if !ok {
+				allErrs = append(allErrs, field.Invalid(
+					firstPath[resourceName].Child("resources", "requests", string(resourceName)),
+					quantity.String(),
+					"total extended resource quantity overflows int64",
+				))
+				continue
+			}
+			replaced.Insert(resourceName)
+			aggregated = utilresource.MergeResourceListKeepSum(aggregated, corev1.ResourceList{quotaKey: *resource.NewQuantity(intQty, resource.DecimalSI)})
+		}
+
 		if len(aggregated) > 0 {
 			log.V(4).Info("Resolved extended resources for PodSet", "podSet", ps.Name, "resources", aggregated)
 			perPodSet[ps.Name] = aggregated

--- a/pkg/dra/extended_resources_test.go
+++ b/pkg/dra/extended_resources_test.go
@@ -206,6 +206,26 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 		},
 	}
 
+	// Two distinct extendedResourceNames, both mapped by the same deviceClassMappings
+	// entry to the logical key "gpu-claims".
+	classADeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "class-a",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("vendor.example/a"),
+		},
+	}
+
+	classBDeviceClass := &resourceapi.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "class-b",
+		},
+		Spec: resourceapi.DeviceClassSpec{
+			ExtendedResourceName: new("vendor.example/b"),
+		},
+	}
+
 	tests := []struct {
 		name           string
 		workload       *kueue.Workload
@@ -303,6 +323,33 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											"other.vendor.io/resource": resource.MustParse("1"),
+										},
+									},
+								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			want:          nil,
+		},
+		{
+			name: "workload with fractional quantity for extended resource not backed by DRA (no matching DeviceClass)",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Name:  "c",
+									Image: "pause",
+									Resources: corev1.ResourceRequirements{
+										Requests: corev1.ResourceList{
+											"other.vendor.io/resource": resource.MustParse("1500m"),
 										},
 									},
 								}},
@@ -480,6 +527,67 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 			},
 		},
 		{
+			// vendor.example/a and vendor.example/b both map to the "gpu-claims" quota
+			// key, but each is charged against the OTHER container kind (init vs.
+			// regular), so the max/sum aggregation only ever sees one contribution
+			// per key if the mapping happens before aggregation across containers.
+			// The correct charge is the sum of each name's own Pod aggregation:
+			// max(A's init contribution, A's regular contribution) is 5 for A alone,
+			// and likewise 5 for B alone, so the quota key must be charged 10, not
+			// max(5, 5) = 5.
+			name: "two extended resource names sharing a quota key are not collapsed by cross-container aggregation",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								InitContainers: []corev1.Container{
+									{
+										Name:  "init",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"vendor.example/a": resource.MustParse("5"),
+											},
+										},
+									},
+								},
+								Containers: []corev1.Container{
+									{
+										Name:  "c",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"vendor.example/b": resource.MustParse("5"),
+											},
+										},
+									},
+								},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{classADeviceClass, classBDeviceClass},
+			mapperMappings: []configapi.DeviceClassMapping{
+				{
+					Name:             "gpu-claims",
+					DeviceClassNames: []corev1.ResourceName{"class-a", "class-b"},
+				},
+			},
+			want: map[kueue.PodSetReference]corev1.ResourceList{
+				"main": {
+					"gpu-claims": resource.MustParse("10"),
+				},
+			},
+			wantReplaced: map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+				"main": sets.New[corev1.ResourceName]("vendor.example/a", "vendor.example/b"),
+			},
+		},
+		{
 			name: "workload with non-integer extended resource quantity",
 			workload: &kueue.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
@@ -498,6 +606,55 @@ func TestResolveExtendedResourceQuota(t *testing.T) {
 										},
 									},
 								}},
+							},
+						},
+					}},
+				},
+			},
+			deviceClasses: []*resourceapi.DeviceClass{gpuDeviceClass},
+			wantErr: field.ErrorList{
+				field.Invalid(
+					field.NewPath("spec", "podSets").Index(0).
+						Child("template", "spec", "containers").Index(0).
+						Child("resources", "requests", "example.com/gpu"),
+					"",
+					"",
+				),
+			},
+		},
+		{
+			// Each container's quantity fits int64 on its own, but their sum
+			// overflows it. Charging the aggregate without re-checking would
+			// silently charge nothing instead of rejecting the request.
+			name: "workload with per-container integer quantities that overflow int64 when summed",
+			workload: &kueue.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "wl", Namespace: "ns1"},
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{{
+						Name:  "main",
+						Count: 1,
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  "c1",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("9e18"),
+											},
+										},
+									},
+									{
+										Name:  "c2",
+										Image: "pause",
+										Resources: corev1.ResourceRequirements{
+											Requests: corev1.ResourceList{
+												"example.com/gpu": resource.MustParse("9e18"),
+											},
+										},
+									},
+								},
 							},
 						},
 					}},


### PR DESCRIPTION
Cherry pick of #14200 on release-0.19, requested by @sohankunkerkar. The bot could not apply it on either release branch.

The branch carries the same shape the fix addresses: the quota key was resolved before each original extended resource name had been totalled, so two names that a `deviceClassMappings` entry sends to one key could collapse into each other's contribution. The tests come across with the change, and reverting the per-name aggregation on this branch turns them red, the same way it does on main.

Only one thing had to be decided. The single conflict was `keps/2941-DRA/README.md`, and the KEP is left out. #14124 did the same when it brought #14044 to this branch, carrying the two Go files and not the KEP, so the branch's copy already describes the earlier flow and leaving it alone does not make it any less accurate.

`pkg/dra/extended_resources.go` and `pkg/dra/extended_resources_test.go` are byte identical to the merged commit.

Verified on the branch rather than assumed. Applying only the new test file to this branch, without the production change, fails `two extended resource names sharing a quota key are not collapsed by cross-container aggregation`, so the defect is here and this is what closes it. With the change in place `go build ./...` and `go test ./pkg/dra/...` pass.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed quota undercount when two extended resource names sharing a deviceClassMappings key were requested by different containers in the same PodSet.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I resolved the conflict and ran the checks above myself.

/assign sohankunkerkar
/cc pujitha24

/kind bug
