### PR TITLE
LeaderWorkerSet: read a percentage maxSurge as a percentage

### DIFF
--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
@@ -298,8 +299,16 @@ func isRollingUpdateWithSurge(lws *leaderworkersetv1.LeaderWorkerSet) bool {
 	if lws.Spec.RolloutStrategy.RollingUpdateConfiguration == nil {
 		return false
 	}
-	maxSurge := int32(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge.IntValue())
-	return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	replicas := ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
+	// A percentage maxSurge is taken against the replicas the update started from,
+	// and rounds up, as the LeaderWorkerSet API documents. Anything else, including a
+	// quoted number, keeps the reading it has always had.
+	surge := &lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge
+	maxSurge, err := intstr.GetScaledValueFromIntOrPercent(surge, int(replicas), true)
+	if err != nil {
+		maxSurge = surge.IntValue()
+	}
+	return maxSurge > 0 && lws.Status.UpdatedReplicas < replicas
 }
 
 func (r *Reconciler) createWorkload(ctx context.Context, lws *leaderworkersetv1.LeaderWorkerSet, workloadName string, index int) error {

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_reconciler_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/component-base/featuregate"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -1008,6 +1009,101 @@ func TestReconciler(t *testing.T) {
 				lws.Status.UpdatedReplicas = 1
 				lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &leaderworkersetv1.RollingUpdateConfiguration{
 					MaxSurge: intstr.FromInt32(1),
+				}
+				return []leaderworkersetv1.LeaderWorkerSet{*lws}
+			}(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "1"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "2"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "0"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "1"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+				*utiltestingapi.MakeWorkload(GetWorkloadName(testLWS, testLWS, "2"), testNS).
+					OwnerReference(gvk, testLWS, testLWS).
+					Annotation(podconstants.IsGroupWorkloadAnnotationKey, podconstants.IsGroupWorkloadAnnotationValue).
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+							RestartPolicy("").
+							Image(utiltestingjobs.TestDefaultContainerImage).
+							Obj()).
+					Priority(0).
+					Obj(),
+			},
+		},
+		// LeaderWorkerSet documents maxSurge as an absolute number or a percentage of the
+		// replicas at the start of the update, so the case above has to hold in both forms.
+		"should keep surge workloads during active rolling update with a percentage maxSurge": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: false,
+			},
+			leaderWorkerSet: func() *leaderworkersetv1.LeaderWorkerSet {
+				lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Replicas(2).Obj()
+				lws.Status.Replicas = 3
+				lws.Status.UpdatedReplicas = 1
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &leaderworkersetv1.RollingUpdateConfiguration{
+					MaxSurge: intstr.FromString("50%"),
+				}
+				return lws
+			}(),
+			wantLeaderWorkerSets: func() []leaderworkersetv1.LeaderWorkerSet {
+				lws := leaderworkerset.MakeLeaderWorkerSet(testLWS, testNS).UID(testLWS).Replicas(2).Obj()
+				lws.Status.Replicas = 3
+				lws.Status.UpdatedReplicas = 1
+				lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &leaderworkersetv1.RollingUpdateConfiguration{
+					MaxSurge: intstr.FromString("50%"),
 				}
 				return []leaderworkersetv1.LeaderWorkerSet{*lws}
 			}(),
@@ -2370,5 +2466,31 @@ func TestReconcileWorkloadsDoesNotCancelTheOtherBranches(t *testing.T) {
 	}
 	if created.Spec.Priority == nil || *created.Spec.Priority != 100 {
 		t.Errorf("created Workload priority = %v, want the class value 100", created.Spec.Priority)
+	}
+}
+
+func TestIsRollingUpdateWithSurge(t *testing.T) {
+	cases := map[string]struct {
+		maxSurge intstr.IntOrString
+		want     bool
+	}{
+		"absolute":        {intstr.FromInt32(1), true},
+		"absolute zero":   {intstr.FromInt32(0), false},
+		"percentage":      {intstr.FromString("30%"), true},
+		"percentage all":  {intstr.FromString("100%"), true},
+		"percentage zero": {intstr.FromString("0%"), false},
+		"quoted number":   {intstr.FromString("2"), true},
+		"neither":         {intstr.FromString("some"), false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			lws := &leaderworkersetv1.LeaderWorkerSet{}
+			lws.Spec.Replicas = ptr.To[int32](4)
+			lws.Status.UpdatedReplicas = 1
+			lws.Spec.RolloutStrategy.RollingUpdateConfiguration = &leaderworkersetv1.RollingUpdateConfiguration{MaxSurge: tc.maxSurge}
+			if got := isRollingUpdateWithSurge(lws); got != tc.want {
+				t.Errorf("isRollingUpdateWithSurge() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/test/e2e/singlecluster/extended/leaderworkerset_test.go
+++ b/test/e2e/singlecluster/extended/leaderworkerset_test.go
@@ -682,10 +682,9 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			})
 		})
 
-		ginkgo.It("Rolling update with maxSurge creates workloads for surge pods and completes successfully", func() {
+		ginkgo.DescribeTable("Rolling update with maxSurge creates workloads for surge pods and completes successfully", func(surge intstr.IntOrString, maxSurge int) {
 			const (
 				lwsReplicas    = 4
-				maxSurge       = 2
 				maxUnavailable = 2
 			)
 
@@ -702,7 +701,7 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 				Type: leaderworkersetv1.RollingUpdateStrategyType,
 				RollingUpdateConfiguration: &leaderworkersetv1.RollingUpdateConfiguration{
 					MaxUnavailable: intstr.FromInt32(maxUnavailable),
-					MaxSurge:       intstr.FromInt32(maxSurge),
+					MaxSurge:       surge,
 				},
 			}
 
@@ -786,7 +785,10 @@ var _ = ginkgo.Describe("LeaderWorkerSet integration", ginkgo.Label("area:single
 			ginkgo.By("Delete the LeaderWorkerSet", func() {
 				util.ExpectObjectToBeDeleted(ctx, k8sClient, lws, true)
 			})
-		})
+		},
+			ginkgo.Entry("with an absolute maxSurge", intstr.FromInt32(2), 2),
+			ginkgo.Entry("with a percentage maxSurge", intstr.FromString("50%"), 2),
+		)
 
 		ginkgo.It("should admit and evict correctly when queue-name is set on pod templates", func() {
 			lws := leaderworkersettesting.MakeLeaderWorkerSet("lws", ns.Name).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`isRollingUpdateWithSurge` read `maxSurge` with `IntValue()`:

```go
maxSurge := int32(lws.Spec.RolloutStrategy.RollingUpdateConfiguration.MaxSurge.IntValue())
return maxSurge > 0 && lws.Status.UpdatedReplicas < ptr.Deref(lws.Spec.Replicas, defaultLeaderWorkerSetReplicas)
```

`MaxSurge` is an `IntOrString`, and `IntValue()` throws away the error from `strconv.Atoi`:

```go
func (intstr *IntOrString) IntValue() int {
	if intstr.Type == String {
		i, _ := strconv.Atoi(intstr.StrVal)
		return i
	}
	return int(intstr.IntVal)
}
```

So every percentage reads as zero, including `100%`, and a rolling update configured with a percentage is indistinguishable from one with no surge at all. LeaderWorkerSet documents the field as accepting both forms:

> maxSurge is the maximum number of replicas that can be scheduled above the original number of replicas. Value can be an absolute number (ex: 5) or a percentage of total replicas at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up.

What that costs is in `filterWorkloads`, whose own comment says it "ensures workloads exist for all groups including surge replicas". It does that by raising `replicas` to `status.Replicas` while a surge rolling update is in progress. With the check reading zero, the raise never happens, the loop only covers the groups spec asks for, and the surge groups' Workloads are left in `toDelete`.

Same LeaderWorkerSet, spec 2 replicas, status 3 because one surge group is still up, only the form of `maxSurge` differing:

```
maxSurge 1 (absolute)      toCreate=0 toUpdate=3 toDelete=[]
maxSurge 50% (percentage)  toCreate=0 toUpdate=2 toDelete=[group-2]
```

`GetScaledValueFromIntOrPercent` is the standard reader for this field. It rounds up, which is what the API documents, and it returns the error rather than folding it into a zero.

#### Which issue(s) this PR fixes:

None filed; I found this reading the surge path and it seemed smaller to send the fix than to describe it.

#### Special notes for your reviewer:

The new case is the existing `should keep surge workloads during active rolling update with maxSurge` with only the `maxSurge` form changed, so the pair pins both readings of the same state. Reverting the production change turns it red, and the diff names the missing Workload rather than failing on a count.

A malformed value still reads as no surge, since the function returns a bool and has no error path to give it to. That is what happens today through `IntValue`, so nothing changes there; the CRD marks the field `XIntOrString`, so a value that parses as neither should not reach this code.

`GetScaledValueFromIntOrPercent` is stricter than `IntValue` on one input, so the fallback is deliberate: it returns an error for a string that is not a percentage, where `IntValue` runs `Atoi`. Without the fallback, `maxSurge: "3"` would go from three to zero, which trades one wrong reading for another. The table covers all of it: absolute, zero, `30%`, `100%`, `0%`, `"2"`, and a string that is neither. Dropping the fallback turns only the quoted-number row red.

On the level this is tested at, since the reviewer skills in this repo ask for integration coverage on update paths. `test/integration/singlecluster/controller/jobs/` carries suites for sixteen job types and LeaderWorkerSet is not one of them. What this depends on is `status.replicas` running ahead of `spec.replicas`, which the LeaderWorkerSet controller produces and envtest does not, so an integration test would have to hand-write the status that the unit table already sets. Rolling updates are covered end to end in `test/e2e/singlecluster/extended/leaderworkerset_test.go`, with an absolute `maxSurge`.

I ran that e2e suite locally on this branch and on unmodified `main`, same cluster, same host:

```
this branch      20 Passed | 2 Failed
main             18 Passed | 4 Failed
```

The two that fail here are a strict subset of the four that fail on `main`, and all of them are `ReadyReplicas` timeouts on a four-core host running four ginkgo processes against a three-node kind cluster, on specs that never set `RolloutStrategy`. So the run says this change does not regress the suite rather than that it proves the fix. I am happy to add a percentage case to that file if you would rather have one covered there.

The scaled figure is only compared against zero here, so the rounding direction cannot change an outcome on its own. I used the documented one anyway rather than leave a second reading of the field in the tree.

`release-0.19` and `release-0.18` both carry the same `IntValue` read, so this looks like a cherry-pick candidate. I will open those once this lands, if that is the order you would like.

#### Does this PR introduce a user-facing change?

```release-note
LeaderWorkerSet: fix a rolling update with a percentage `maxSurge`, such as `50%`, having its surge groups' Workloads deleted while those groups were still running. The value was read as zero, so Kueue treated the update as having no surge.
```

---

This pull request was written in part with the assistance of generative AI. The behaviour above is what I reproduced and the API text is quoted from the vendored LeaderWorkerSet types.


