### PR TITLE
Stop pod-level request calculation from mutating the PodSpec it reads

### DIFF
--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -74,6 +74,8 @@ func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 // https://github.com/kubernetes/kubernetes/issues/141241.
 func PodRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
 	spec := *podSpec
+	// Only the pod-level requests are aliased into the total (container totals are
+	// already deep-copied), so copying spec.Resources avoids a full-spec copy here.
 	if spec.Resources != nil {
 		spec.Resources = spec.Resources.DeepCopy()
 	}

--- a/pkg/resources/factory.go
+++ b/pkg/resources/factory.go
@@ -67,13 +67,25 @@ func NewRequestsFromResourceList(rl corev1.ResourceList) Requests {
 	return NewMapRequests(rl)
 }
 
+// PodRequests totals a PodSpec the way a Pod's own requests are totalled.
+// component-helpers assigns a pod-level request into that total and then adds
+// the overhead to it in place, so a quantity holding a decimal would be added to
+// through the spec's own copy. See
+// https://github.com/kubernetes/kubernetes/issues/141241.
+func PodRequests(podSpec *corev1.PodSpec) corev1.ResourceList {
+	spec := *podSpec
+	if spec.Resources != nil {
+		spec.Resources = spec.Resources.DeepCopy()
+	}
+	return resourcehelpers.PodRequests(&corev1.Pod{Spec: spec}, resourcehelpers.PodResourcesOptions{})
+}
+
 // NewRequestsFromPodSpec creates a Requests instance from a PodSpec based on feature gates.
 func NewRequestsFromPodSpec(podSpec *corev1.PodSpec) Requests {
 	if podSpec == nil {
 		return NewRequests()
 	}
-	rl := resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{})
-	return NewRequestsFromResourceList(rl)
+	return NewRequestsFromResourceList(PodRequests(podSpec))
 }
 
 // ToMap converts any Requests instance into a MapRequests map.

--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -24,7 +24,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/utils/ptr"
 
 	utilmath "sigs.k8s.io/kueue/pkg/util/math"
@@ -53,7 +52,7 @@ func NewMapRequests(rl corev1.ResourceList) MapRequests {
 }
 
 func NewMapRequestsFromPodSpec(podSpec *corev1.PodSpec) MapRequests {
-	return NewMapRequests(resourcehelpers.PodRequests(&corev1.Pod{Spec: *podSpec}, resourcehelpers.PodResourcesOptions{}))
+	return NewMapRequests(PodRequests(podSpec))
 }
 
 func (r MapRequests) Clone() Requests {

--- a/pkg/resources/requests_test.go
+++ b/pkg/resources/requests_test.go
@@ -915,3 +915,44 @@ func TestRequestsEqual(t *testing.T) {
 		})
 	}
 }
+
+// Only a quantity carrying a decimal is held behind a pointer, so the
+// whole-unit case is the control: without it a reader that stopped detaching
+// would still look right.
+func TestPodRequestsLeavesTheSpecAlone(t *testing.T) {
+	cases := map[string]struct {
+		podLevel string
+		want     MapRequests
+	}{
+		"pod-level request carrying a decimal": {
+			podLevel: "1.5Gi",
+			want:     MapRequests{corev1.ResourceMemory: 1636 * 1024 * 1024},
+		},
+		"pod-level request in whole units": {
+			podLevel: "1Gi",
+			want:     MapRequests{corev1.ResourceMemory: 1124 * 1024 * 1024},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "c"}},
+				Resources: &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(tc.podLevel)},
+				},
+				Overhead: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")},
+			}
+			borrowed := spec.DeepCopy()
+			// Twice: a total that moved is what says the spec moved.
+			for pass := 1; pass <= 2; pass++ {
+				got := NewMapRequests(PodRequests(spec))
+				if diff := cmp.Diff(tc.want, got); diff != "" {
+					t.Errorf("pass %d totalled differently (-want +got):\n%s", pass, diff)
+				}
+			}
+			if diff := cmp.Diff(borrowed, spec); diff != "" {
+				t.Errorf("PodRequests changed the spec it was given (-before,+after):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/util/sets"
-	resourcehelpers "k8s.io/component-helpers/resource"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/ptr"
@@ -693,7 +692,7 @@ func totalRequestsFromPodSets(wl *kueue.Workload, info *InfoOptions) []PodSetRes
 			Name:  ps.Name,
 			Count: count,
 		}
-		specRequests := resourcehelpers.PodRequests(&corev1.Pod{Spec: ps.Template.Spec}, resourcehelpers.PodResourcesOptions{})
+		specRequests := resources.PodRequests(&ps.Template.Spec)
 		effectiveRequests := dropExcludedResources(specRequests, info.excludedResourcePrefixes)
 		effectiveRequests = applyResourceTransformations(effectiveRequests, info.resourceTransformations)
 		if features.Enabled(features.KueueDRAIntegration) && info.preprocessedDRAResources != nil {

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3717,3 +3717,39 @@ func TestTotalExecutionTime(t *testing.T) {
 		})
 	}
 }
+
+// An admitted Workload takes its quota from the admission status but rebuilds
+// the topology request from the PodSpec, so the spec is read again every time
+// the Workload is looked at and the two can drift apart.
+func TestNewInfoLeavesAnAdmittedPodLevelRequestAlone(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+	levels := utiltas.Levels(utiltestingapi.MakeDefaultOneLevelTopology("default"))
+	wl := utiltestingapi.MakeWorkload("pod-level", "ns").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			PodLevelRequest(corev1.ResourceMemory, "1.5Gi").
+			PodOverHead(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("100Mi")}).
+			Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				ResourceUsage(corev1.ResourceMemory, "1636Mi").
+				TopologyAssignment(utiltestingapi.MakeTopologyAssignment(levels).
+					Domains(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 1).Obj()).
+					Obj()).
+				Obj()).
+			Obj(), time.Now()).
+		Obj()
+	borrowed := wl.DeepCopy()
+
+	want := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+		corev1.ResourceMemory: 1636 * 1024 * 1024,
+	})
+	for pass := 1; pass <= 2; pass++ {
+		got := NewInfo(wl).TotalRequests[0].TopologyRequest.DomainRequests[0].SinglePodRequests
+		if !resources.Equal(got, want) {
+			t.Errorf("pass %d placed %v, want %v", pass, resources.ToMap(got), resources.ToMap(want))
+		}
+	}
+	if diff := cmp.Diff(borrowed, wl); diff != "" {
+		t.Errorf("NewInfo changed the Workload it was given (-before,+after):\n%s", diff)
+	}
+}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3721,6 +3721,35 @@ func TestTotalExecutionTime(t *testing.T) {
 // An admitted Workload takes its quota from the admission status but rebuilds
 // the topology request from the PodSpec, so the spec is read again every time
 // the Workload is looked at and the two can drift apart.
+// A DRA logical name may match a pod-level request, since a mapping name only
+// has to be a label key. The merge adds into whatever the reader returned, so
+// this is the route that does not need an overhead to reach the same Quantity.
+func TestNewInfoLeavesAPodLevelRequestAloneWhenDRAChargesTheSameName(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, true)
+	wl := utiltestingapi.MakeWorkload("pod-level-dra", "ns").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+			PodLevelRequest(corev1.ResourceMemory, "1.5Gi").
+			Obj()).
+		Obj()
+	borrowed := wl.DeepCopy()
+
+	draResources := map[kueue.PodSetReference]corev1.ResourceList{
+		kueue.DefaultPodSetName: {corev1.ResourceMemory: resource.MustParse("1Gi")},
+	}
+	want := resources.NewRequestsFromMap(map[corev1.ResourceName]int64{
+		corev1.ResourceMemory: 2560 * 1024 * 1024,
+	})
+	for pass := 1; pass <= 2; pass++ {
+		got := NewInfo(wl, WithPreprocessedDRAResources(draResources, nil)).TotalRequests[0].Requests
+		if !resources.Equal(got, want) {
+			t.Errorf("pass %d charged %v, want %v", pass, resources.ToMap(got), resources.ToMap(want))
+		}
+	}
+	if diff := cmp.Diff(borrowed, wl); diff != "" {
+		t.Errorf("NewInfo changed the Workload it was given (-before,+after):\n%s", diff)
+	}
+}
+
 func TestNewInfoLeavesAnAdmittedPodLevelRequestAlone(t *testing.T) {
 	features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
 	levels := utiltas.Levels(utiltestingapi.MakeDefaultOneLevelTopology("default"))


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Reading a Workload's requests can rewrite the Workload. The list `resources.NewRequestsFromPodSpec` hands back shares a quantity with the PodSpec it was given, and the pod overhead is then added to that list in place.

It happens inside component-helpers. A pod-level request is put into the total by assignment:

```go
// k8s.io/component-helpers@v0.36.3/resource/helpers.go
for resourceName, quantity := range pod.Spec.Resources.Requests {
	if IsSupportedPodLevelResource(resourceName) {
		reqs[resourceName] = quantity
```

`Quantity` keeps its value either in an `int64Amount` or behind an `*inf.Dec`, and the assignment copies the struct, pointer included. `addResourceList` adds the overhead to that entry in place, which for the pointer form writes through to the caller.

Only some quantities take the pointer form. `ParseQuantity` uses the int64 path when a binary suffix has no fractional part, so `1Gi` is carried by value and `1.5Gi` is not, which is why this does not show up everywhere. Measured on a PodSpec with a pod-level `memory` and an overhead of `memory: 100Mi`, read three times:

| pod-level | after the first read | after the second | after the third |
| --- | --- | --- | --- |
| `1.5Gi` | 1636Mi | 1736Mi | 1836Mi |
| `1Gi` | 1Gi | 1Gi | 1Gi |

Each read starts from where the previous one left the spec.

An admitted Workload shows what that costs, because it takes its quota from `status.admission` but rebuilds the topology request from the PodSpec. The quota figure stays where the admission recorded it while the placement moves away from it:

| | quota | TAS single-pod request |
| --- | --- | --- |
| first `NewInfo` | 1636Mi | 1636Mi |
| second `NewInfo` | 1636Mi | 1736Mi |

Three places called component-helpers directly and everything else arrives through `NewRequestsFromPodSpec`, so the copy goes where they all pass rather than at any one of them, in `resources.PodRequests`. Besides the quota path, that reader is used by TAS placement and net usage, the flavor overlap check, pod LimitRange validation and the TAS pod usage controller.

#### Which issue(s) this PR fixes:

None filed here. The upstream one is kubernetes/kubernetes#141241.

#### Special notes for your reviewer:

`resources.PodRequests` is not new to this branch alone. #13995 adds a function of the same name in the same file for a different reason: it replaces the overhead with the chargeable part before the aggregation. It does not detach `spec.Resources`, so it centralises the reader and the aliasing together. The two bodies differ by the three lines here, and whichever lands first the other keeps only its own half. I kept them apart because this is a separate user-facing bug that needs its own release note, and because only a standalone change is worth cherry-picking to the release branches.

This is not Kueue's own bug and not a new one. kubernetes/kubernetes#141241 carries the same reproducer and kubernetes/kubernetes#141242 fixes it by copying the quantity, but neither is in v0.36.3, which is what this builds against, so the guard belongs here until Kueue consumes a release that has it.

Only `spec.Resources` is detached, not the whole PodSpec. Container and init-container requests are already copied on their way into the total, since `addResourceList` deep-copies whenever the key is new, so the pod-level list is the only one that needs it. Measured both ways rather than read.

`NewMapRequestsFromPodSpec` has no caller anywhere in the tree, tests included. It is routed through the same reader rather than deleted, so the two constructors cannot drift apart; removing an exported symbol is a separate decision from fixing one.

The whole-unit row is in the test for a reason. Without it a change that stopped detaching would still look green, because `1Gi` never carried the pointer in the first place.

I did not add an integration test. The aliasing is visible where the same object is read twice, and the unit level is where that is expressible; an integration test would assert on a Workload the suite reads once.

#### Does this PR introduce a user-facing change?

```release-note
Scheduling: Fixed a bug where calculating a Workload's resource requests could modify that Workload. A pod-level resource request holding a fraction, such as `1.5Gi`, shared its value with the total that the pod overhead is added to, so every calculation added the overhead again and the charge grew with it. An admitted Workload using TopologyAwareScheduling shows it most clearly: the quota usage stays where the admission recorded it while the topology request keeps moving away from it.
```

#### AI usage

This PR was written in part with the assistance of generative AI. I have reviewed and tested every change myself.


