### PR TITLE
ProvisioningRequest: give every merged PodSet its update

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -65,10 +65,13 @@ const (
 	// 253 is the maximal length for a CRD name. We need to subtract one for '-', and the hash length.
 	objNameMaxPrefixLength = 252 - objNameHashLength
 	podTemplatesPrefix     = "ppt"
+	// The grouping a request was created with, which its immutable spec loses.
+	podSetGroupsAnnotation = "kueue.x-k8s.io/provisioning-podset-groups"
 )
 
 var (
 	errInconsistentPodSetAssignments = errors.New("inconsistent podSet assignments")
+	errInconsistentPodSetGroups      = errors.New("inconsistent podSet groups")
 )
 
 var (
@@ -319,6 +322,9 @@ func (c *Controller) syncOwnedProvisionRequest(
 
 			mergedPodSets, err := mergePodSets(ctx, wl, &prc.Spec)
 			if err != nil {
+				return err
+			}
+			if err := recordPodSetGroups(req, mergedPodSets); err != nil {
 				return err
 			}
 
@@ -657,10 +663,16 @@ func (c *Controller) syncCheckStates(
 						}
 					}
 				case isProvisioned(pr):
-					if updateCheckState(&checkState, kueue.CheckStateReady) {
+					if checkState.State != kueue.CheckStateReady {
+						// Before the check passes, so that a request whose grouping
+						// cannot be read holds it back instead of passing it empty.
+						psUpdates, err := podSetUpdates(ctx, wl, pr, prc)
+						if err != nil {
+							return false, err
+						}
 						updated = true
-						// add the pod podSetUpdates
-						checkState.PodSetUpdates = podSetUpdates(log, wl, pr, prc)
+						updateCheckState(&checkState, kueue.CheckStateReady)
+						checkState.PodSetUpdates = psUpdates
 						// propagate the message from the provisioning request status into the workload
 						// to change to the "successfully provisioned" message after provisioning
 						updateCheckMessage(&checkState, apimeta.FindStatusCondition(pr.Status.Conditions, autoscaling.Provisioned).Message)
@@ -703,14 +715,32 @@ func (c *Controller) syncCheckStates(
 	return nil
 }
 
-func podSetUpdates(log logr.Logger, wl *kueue.Workload, pr *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) []kueue.PodSetUpdate {
-	podSets := wl.Spec.PodSets
-	refMap := slices.ToMap(podSets, func(i int) (string, kueue.PodSetReference) {
-		return getProvisioningRequestPodTemplateName(pr.Name, podSets[i].Name), podSets[i].Name
-	})
-	return slices.Map(pr.Spec.PodSets, func(ps *autoscaling.PodSet) kueue.PodSetUpdate {
+func podSetUpdates(ctx context.Context, wl *kueue.Workload, pr *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) ([]kueue.PodSetUpdate, error) {
+	log := ctrl.LoggerFrom(ctx)
+	groups, err := podSetGroups(ctx, wl, pr, prc)
+	if err != nil {
+		return nil, err
+	}
+	if len(groups) != len(pr.Spec.PodSets) {
+		return nil, fmt.Errorf("%w: request %q holds %d podSets, the grouping describes %d",
+			errInconsistentPodSetGroups, pr.Name, len(pr.Spec.PodSets), len(groups))
+	}
+
+	known := sets.New[kueue.PodSetReference]()
+	for i := range wl.Spec.PodSets {
+		known.Insert(wl.Spec.PodSets[i].Name)
+	}
+	covered := sets.New[kueue.PodSetReference]()
+
+	updates := make([]kueue.PodSetUpdate, 0, len(wl.Spec.PodSets))
+	for i := range pr.Spec.PodSets {
+		ref := pr.Spec.PodSets[i].PodTemplateRef.Name
+		members := groups[ref]
+		if len(members) == 0 {
+			return nil, fmt.Errorf("%w: request %q references podTemplate %q, which stands for no podSet",
+				errInconsistentPodSetGroups, pr.Name, ref)
+		}
 		podSetUpdate := kueue.PodSetUpdate{
-			Name: refMap[ps.PodTemplateRef.Name],
 			Annotations: map[string]string{
 				autoscaling.ProvisioningRequestPodAnnotationKey: pr.Name,
 				autoscaling.ProvisioningClassPodAnnotationKey:   pr.Spec.ProvisioningClassName,
@@ -727,8 +757,65 @@ func podSetUpdates(log logr.Logger, wl *kueue.Workload, pr *autoscaling.Provisio
 				podSetUpdate.NodeSelector[nodeSelector.Key] = string(value)
 			}
 		}
-		return podSetUpdate
-	})
+		for _, name := range members {
+			if !known.Has(name) {
+				return nil, fmt.Errorf("%w: podTemplate %q stands for podSet %q, which the workload does not have",
+					errInconsistentPodSetGroups, ref, name)
+			}
+			if covered.Has(name) {
+				return nil, fmt.Errorf("%w: podSet %q is claimed by more than one podTemplate",
+					errInconsistentPodSetGroups, name)
+			}
+			covered.Insert(name)
+			forPodSet := *podSetUpdate.DeepCopy()
+			forPodSet.Name = name
+			updates = append(updates, forPodSet)
+		}
+	}
+	return updates, nil
+}
+
+// recordPodSetGroups writes onto the request which workload podSets each of its
+// podSets stands for. A merge policy folds several into one, and the request
+// keeps only the name of the group, so nothing else survives to say what the
+// capacity was asked for.
+func recordPodSetGroups(req *autoscaling.ProvisioningRequest, merged []MergedPodSet) error {
+	groups := make(map[string][]kueue.PodSetReference, len(merged))
+	for _, mps := range merged {
+		groups[getProvisioningRequestPodTemplateName(req.Name, mps.Name)] = mps.Names
+	}
+	raw, err := json.Marshal(groups)
+	if err != nil {
+		return fmt.Errorf("recording podSet groups on %q: %w", req.Name, err)
+	}
+	if req.Annotations == nil {
+		req.Annotations = make(map[string]string, 1)
+	}
+	req.Annotations[podSetGroupsAnnotation] = string(raw)
+	return nil
+}
+
+// podSetGroups reads back what the request was created for. A request made
+// before this was recorded has the grouping derived instead, which only holds
+// while the configuration has not regrouped the podSets since; the caller
+// checks that against the request rather than trusting it.
+func podSetGroups(ctx context.Context, wl *kueue.Workload, pr *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) (map[string][]kueue.PodSetReference, error) {
+	if raw, recorded := pr.Annotations[podSetGroupsAnnotation]; recorded {
+		groups := map[string][]kueue.PodSetReference{}
+		if err := json.Unmarshal([]byte(raw), &groups); err != nil {
+			return nil, fmt.Errorf("%w: reading %s from request %q: %w", errInconsistentPodSetGroups, podSetGroupsAnnotation, pr.Name, err)
+		}
+		return groups, nil
+	}
+	merged, err := mergePodSets(ctx, wl, &prc.Spec)
+	if err != nil {
+		return nil, err
+	}
+	groups := make(map[string][]kueue.PodSetReference, len(merged))
+	for _, mps := range merged {
+		groups[getProvisioningRequestPodTemplateName(pr.Name, mps.Name)] = mps.Names
+	}
+	return groups, nil
 }
 
 type acHandler struct {
@@ -927,7 +1014,9 @@ func limitObjectName(fullName string) string {
 }
 
 type MergedPodSet struct {
-	Name             kueue.PodSetReference
+	Name kueue.PodSetReference
+	// Names are the workload PodSets folded into this one, Name first.
+	Names            []kueue.PodSetReference
 	PodSet           *kueue.PodSet
 	PodSetAssignment *kueue.PodSetAssignment
 	Count            int32
@@ -963,6 +1052,7 @@ func mergePodSets(
 			for i, mps := range mergedPodSets {
 				if merged = canMergePodSets(mps.PodSet, ps, mergePolicy); merged {
 					mergedPodSets[i].Count += count
+					mergedPodSets[i].Names = append(mergedPodSets[i].Names, psName)
 					break
 				}
 			}
@@ -971,6 +1061,7 @@ func mergePodSets(
 		if !merged {
 			mergedPodSets = append(mergedPodSets, MergedPodSet{
 				Name:             psName,
+				Names:            []kueue.PodSetReference{psName},
 				PodSet:           ps,
 				PodSetAssignment: psa,
 				Count:            count,

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -168,6 +168,129 @@ func TestMergePodSetsSkipsZeroCounts(t *testing.T) {
 	}
 }
 
+func TestPodSetUpdates(t *testing.T) {
+	refA := getProvisioningRequestPodTemplateName("pr", "worker-a")
+	refB := getProvisioningRequestPodTemplateName("pr", "worker-b")
+	annotations := map[string]string{
+		autoscaling.ProvisioningRequestPodAnnotationKey: "pr",
+		autoscaling.ProvisioningClassPodAnnotationKey:   "class",
+	}
+
+	cases := map[string]struct {
+		// groups is the annotation the request was created with, empty for a
+		// request made before it was recorded.
+		groups      string
+		refs        []string
+		mergePolicy *kueue.ProvisioningRequestConfigPodSetMergePolicy
+		want        []kueue.PodSetUpdate
+		wantErr     error
+	}{
+		"one podSet each": {
+			groups: `{"` + refA + `":["worker-a"],"` + refB + `":["worker-b"]}`,
+			refs:   []string{refA, refB},
+			want: []kueue.PodSetUpdate{
+				{Name: "worker-a", Annotations: annotations},
+				{Name: "worker-b", Annotations: annotations},
+			},
+		},
+		"both members of a merged group": {
+			groups: `{"` + refA + `":["worker-a","worker-b"]}`,
+			refs:   []string{refA},
+			want: []kueue.PodSetUpdate{
+				{Name: "worker-a", Annotations: annotations},
+				{Name: "worker-b", Annotations: annotations},
+			},
+		},
+		"recorded grouping outlives a merge policy change": {
+			groups:      `{"` + refA + `":["worker-a","worker-b"]}`,
+			refs:        []string{refA},
+			mergePolicy: new(kueue.IdenticalPodTemplates),
+			want: []kueue.PodSetUpdate{
+				{Name: "worker-a", Annotations: annotations},
+				{Name: "worker-b", Annotations: annotations},
+			},
+		},
+		"derived when nothing was recorded": {
+			refs:        []string{refA},
+			mergePolicy: new(kueue.IdenticalPodTemplates),
+			want: []kueue.PodSetUpdate{
+				{Name: "worker-a", Annotations: annotations},
+				{Name: "worker-b", Annotations: annotations},
+			},
+		},
+		"derived grouping that does not account for the request": {
+			refs:    []string{refA},
+			wantErr: errInconsistentPodSetGroups,
+		},
+		"a podTemplate the grouping does not know": {
+			groups:  `{"` + refB + `":["worker-b"]}`,
+			refs:    []string{refA},
+			wantErr: errInconsistentPodSetGroups,
+		},
+		"a group standing for nothing": {
+			groups:  `{"` + refA + `":[]}`,
+			refs:    []string{refA},
+			wantErr: errInconsistentPodSetGroups,
+		},
+		"a podSet the workload does not have": {
+			groups:  `{"` + refA + `":["worker-c"]}`,
+			refs:    []string{refA},
+			wantErr: errInconsistentPodSetGroups,
+		},
+		"a podSet claimed twice": {
+			groups:  `{"` + refA + `":["worker-a"],"` + refB + `":["worker-a"]}`,
+			refs:    []string{refA, refB},
+			wantErr: errInconsistentPodSetGroups,
+		},
+		"a grouping that cannot be read": {
+			groups:  "not json",
+			refs:    []string{refA},
+			wantErr: errInconsistentPodSetGroups,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			wl := utiltestingapi.MakeWorkload("wl", TestNamespace).
+				PodSets(
+					*utiltestingapi.MakePodSet("worker-a", 1).Request(corev1.ResourceCPU, "1").Obj(),
+					*utiltestingapi.MakePodSet("worker-b", 1).Request(corev1.ResourceCPU, "1").Obj(),
+				).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("q").PodSets(
+					kueue.PodSetAssignment{Name: "worker-a", Count: new(int32(1))},
+					kueue.PodSetAssignment{Name: "worker-b", Count: new(int32(1))},
+				).Obj(), time.Now()).
+				Obj()
+
+			pr := &autoscaling.ProvisioningRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "pr"},
+				Spec:       autoscaling.ProvisioningRequestSpec{ProvisioningClassName: "class"},
+			}
+			if tc.groups != "" {
+				pr.Annotations = map[string]string{podSetGroupsAnnotation: tc.groups}
+			}
+			for _, ref := range tc.refs {
+				pr.Spec.PodSets = append(pr.Spec.PodSets, autoscaling.PodSet{
+					PodTemplateRef: autoscaling.Reference{Name: ref},
+					Count:          1,
+				})
+			}
+			prc := &kueue.ProvisioningRequestConfig{Spec: kueue.ProvisioningRequestConfigSpec{
+				ProvisioningClassName: "class",
+				PodSetMergePolicy:     tc.mergePolicy,
+			}}
+
+			got, err := podSetUpdates(t.Context(), wl, pr, prc)
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Fatalf("unexpected error (-want/+got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("unexpected podSetUpdates (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestReqIsNeeded(t *testing.T) {
 	makeWorkload := func(specCount int32, admissionCount *int32, includeAssignment bool) *kueue.Workload {
 		builder := utiltestingapi.MakeWorkload("wl", TestNamespace).

--- a/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/test/integration/singlecluster/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1483,6 +1483,12 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Label("controller:provisioning", 
 			prc = baseConfig.Clone().
 				RetryLimit(0).
 				PodSetMergePolicy(kueue.IdenticalWorkloadSchedulingRequirements).
+				PodSetUpdate(kueue.ProvisioningRequestPodSetUpdates{
+					NodeSelector: []kueue.ProvisioningRequestPodSetUpdatesNodeSelector{{
+						Key:                              "provisioned-node",
+						ValueFromProvisioningClassDetail: "node-pool",
+					}},
+				}).
 				Obj()
 			util.MustCreate(ctx, k8sClient, prc)
 
@@ -1589,6 +1595,69 @@ var _ = ginkgo.Describe("Provisioning", ginkgo.Label("controller:provisioning", 
 				gomega.Expect(mergedTemplate.Template.Spec.Containers).To(gomega.BeComparableTo(updatedWl.Spec.PodSets[0].Template.Spec.Containers, ignoreContainersDefaults))
 				gomega.Expect(mergedTemplate.Template.Spec.NodeSelector).To(gomega.BeComparableTo(map[string]string{"ns1": "ns1v"}))
 				gomega.Expect(mergedTemplate.ObjectMeta.GetLabels()).To(gomega.BeComparableTo(map[string]string{constants.ManagedByKueueLabelKey: constants.ManagedByKueueLabelValue}))
+			})
+
+			ginkgo.By("Removing the quota reservation from the workload", func() {
+				util.SetQuotaReservation(ctx, k8sClient, wlKey, nil)
+			})
+		})
+
+		ginkgo.It("Should update every merged PodSet once the ProvisioningRequest is provisioned", func() {
+			ginkgo.By("Setting the quota reservation to the workload", func() {
+				util.SetQuotaReservation(ctx, k8sClient, wlKey, admission)
+			})
+
+			ginkgo.By("Checking the request records which PodSets its one PodSet stands for", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, provReqKey, &createdRequest)).Should(gomega.Succeed())
+					g.Expect(createdRequest.Spec.PodSets).Should(gomega.HaveLen(1))
+					g.Expect(createdRequest.Annotations).Should(gomega.HaveKeyWithValue(
+						"kueue.x-k8s.io/provisioning-podset-groups",
+						fmt.Sprintf(`{"%s":["master","worker"]}`, createdRequest.Spec.PodSets[0].PodTemplateRef.Name),
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Setting the provision request as Provisioned", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, provReqKey, &createdRequest)).Should(gomega.Succeed())
+					createdRequest.Status.ProvisioningClassDetails = map[string]autoscaling.Detail{
+						"node-pool": "pool-xyz",
+					}
+					apimeta.SetStatusCondition(&createdRequest.Status.Conditions, metav1.Condition{
+						Type:   autoscaling.Provisioned,
+						Status: metav1.ConditionTrue,
+						Reason: "Provisioned",
+					})
+					g.Expect(k8sClient.Status().Update(ctx, &createdRequest)).Should(gomega.Succeed())
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+			})
+
+			ginkgo.By("Checking that both merged PodSets carry the whole update", func() {
+				gomega.Eventually(func(g gomega.Gomega) {
+					g.Expect(k8sClient.Get(ctx, wlKey, &updatedWl)).Should(gomega.Succeed())
+					state := admissioncheck.FindAdmissionCheck(updatedWl.Status.AdmissionChecks, kueue.AdmissionCheckReference(ac.Name))
+					g.Expect(state).ShouldNot(gomega.BeNil())
+					g.Expect(state.State).Should(gomega.Equal(kueue.CheckStateReady))
+					g.Expect(state.PodSetUpdates).Should(gomega.ConsistOf(
+						kueue.PodSetUpdate{
+							Name: "master",
+							Annotations: map[string]string{
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   "provisioning-class",
+							},
+							NodeSelector: map[string]string{"provisioned-node": "pool-xyz"},
+						},
+						kueue.PodSetUpdate{
+							Name: "worker",
+							Annotations: map[string]string{
+								autoscaling.ProvisioningRequestPodAnnotationKey: provReqKey.Name,
+								autoscaling.ProvisioningClassPodAnnotationKey:   "provisioning-class",
+							},
+							NodeSelector: map[string]string{"provisioned-node": "pool-xyz"},
+						},
+					))
+				}, util.Timeout, util.Interval).Should(gomega.Succeed())
 			})
 
 			ginkgo.By("Removing the quota reservation from the workload", func() {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area integrations

#### What this PR does / why we need it:

With `podSetMergePolicy` set, `mergePodSets` folds mergeable PodSets together and keeps only the first member's name:

```go
if merged = canMergePodSets(mps.PodSet, ps, mergePolicy); merged {
	mergedPodSets[i].Count += count
	break
}
```

The ProvisioningRequest then carries one PodSet per group, keyed to that name, and `podSetUpdates` walked `pr.Spec.PodSets` and emitted one `PodSetUpdate` each, named by looking the template name back up. The members folded into a group never appeared.

Nothing reports that. `getPodSetsInfoFromStatus` matches on the exact name and moves on:

```go
for _, podSetUpdate := range admissionCheck.PodSetUpdates {
	if podSetUpdate.Name == info.Name {
		...
		break
	}
}
```

So a PodSet without an update keeps its own template. With a `podSetUpdates.nodeSelector` in the config, which is how a provisioning class points pods at the nodes it just created, those pods are not held to the provisioned capacity: they can land elsewhere or fail to schedule, and nothing says why.

Two identical PodSets under `IdenticalPodTemplates`, running the real `mergePodSets` and `podSetUpdates`:

```
workload PodSets=2  merged PodSets=1
update for PodSet "worker-a" nodeSelector=map[provisioned-by:pool-1]
>>> PodSet "worker-b" gets no update
```

`MergedPodSet` now records the members it stands for, the grouping is recorded on the request when it is created, and `podSetUpdates` emits one update per member.

#### Which issue(s) this PR fixes:

None filed; I found this reading the merge path.

#### Special notes for your reviewer:

**Why the grouping is recorded rather than derived again.** My first version had `podSetUpdates` call `mergePodSets` a second time, in the later phase, and read the old request through it. That is not safe. A request's spec is immutable, but the configuration it was built from is not: `managedResources` and `podSetMergePolicy` can both change while a request is in flight, and neither is part of `provReqSyncedWithConfig`, so the request stays active. A request created with A+B represented by A can then be read back through a configuration that groups A and B separately: the old A ref still resolves, only A gets an update, and the check still passes. That is the same defect this PR is fixing, reached by a different route.

So `syncOwnedProvisionRequest` writes the mapping onto the request it is creating, under `kueue.x-k8s.io/provisioning-podset-groups`, and `podSetUpdates` reads it back. Requests created before this have nothing recorded, so their grouping is still derived; that path is checked against the request rather than trusted.

**What the mapping has to satisfy.** Every podTemplate the request names stands for at least one PodSet the workload has, no PodSet is claimed twice, and the number of groups matches the number of podSets in the request. A mismatch is an error, not an empty set of updates: the previous lookup returned a nil slice for an unknown ref, which is how the check could pass with a group unattended.

**Two things this does not fix.** A configuration change that regroups a request in flight now fails the check closed instead of updating the wrong PodSets, but the request is not recreated under the new configuration, so the workload waits until an operator intervenes. Doing better means giving stale requests a lifecycle, which is a larger change than this defect needs. And a workload whose check was already Ready before an upgrade is not revisited: `podSetUpdates` only runs on the transition, so this fixes new provisioning, not workloads already admitted with the missing updates.

**Coverage.** The existing `Should merge similar PodSets into one PodTemplate` checks the request and its templates, then removes the quota reservation. The request never reaches `Provisioned`, so `podSetUpdates` was never called from it, which is how this survived. The new integration case drives that transition and asserts the whole update for both members, including the nodeSelector resolved from the class details, which the fixture did not configure before. It also asserts what the request recorded, because `reqCmpOptions` ignores `ObjectMeta`, so nothing else would have noticed the annotation missing.

Each check was confirmed by removing it and watching a case fail: the group count, the empty group, the unknown PodSet, the PodSet claimed twice, reading the recorded grouping at all, and the original bug itself. Removing the annotation write turns the integration case red; before that assertion existed, the whole mechanism could have been a no-op and the suite stayed green.

**`Name` and `Names`** sitting next to each other in `MergedPodSet` is not lovely. I left `Name` alone because it keys the request's PodSet and its PodTemplate, and renaming it would touch code this bug has nothing to do with, but I will take a better name for the new field if you have one.

Rebased onto current main. `go build ./...`, `go vet ./...`, `golangci-lint`, the package unit tests and all 22 provisioning integration specs pass locally.

#### Does this PR introduce a user-facing change?

```release-note
ProvisioningRequest: fix pods of a PodSet that was merged into another by `podSetMergePolicy` starting without the annotations and nodeSelector from `podSetUpdates`, which left them free to schedule outside the provisioned capacity. Only the first PodSet of each merge group was updated. Workloads whose admission check had already passed are not revisited.
```

---

This pull request was written in part with the assistance of generative AI. The behaviour above is what I reproduced, and the integration case was run both ways.


#### One behaviour change worth naming

`podSetUpdates` could not fail before and now can. `mergePodSets` returns `errInconsistentPodSetAssignments` when a required PodSet has no assignment, and the new checks return `errInconsistentPodSetGroups` when the recorded mapping does not account for the request. `syncCheckStates` runs before `syncOwnedProvisionRequest` in the reconcile, so this is the earlier of the two places the first error can surface; the later one would have raised it a few lines on.

Both abort the status patch, which is the shape the existing `reqIsNeeded` error in the same function already has. It does mean a second admission check's staged update is dropped along with it, which is the coupling #14414 is about.

The updates are also computed before the check is marked Ready rather than after, so a request whose grouping cannot be read holds the check back instead of passing it empty.


#### Overlap with #14316

@sohankunkerkar's #14316 is open on this same file and reaches the same neighbourhood, so whichever of us lands second owes a rebase. Recording what I found so it is not a surprise:

- It turns `mergePodSets` into a method on `*Controller`, so a caller written against the free function has to move with it.
- It inserts a branch into `syncCheckStates` immediately above the one this PR touches, for an elastic scale-down whose merged set comes back empty.
- It adds `previousSlicePodSetCounts` next to `MergedPodSet`.

It also subtracts the previous slice's counts before merging, so a PodSet whose incremental count is zero drops out and the group's representative name can change. That is the case recording the grouping is meant to survive: the completion path reads what the request was created with instead of deriving a representative that may since have moved. Worth a combined test once one of us lands.


#### The rest of my provisioning changes

I have three other small ones open on this same file, so between them and #14316 whoever lands last does the rebasing. They are independent defects and none of them needs another to make sense:

- #14408 gives every merged PodSet its `PodSetUpdate`.
- #14414 stops one check without a request discarding the whole status patch.
- #14415 stops an unset `retryStrategy` panicking the reconcile.
- #14416 notices a parameter the config has dropped.

#14414 and #14415 are the closest pair: both sit in `syncCheckStates`, a dozen lines apart.
