### PR TITLE
Keep the partial preemption reservation from going negative

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -789,7 +789,7 @@ func quotaResourcesToReserve(e *entry, cq *schdcache.ClusterQueueSnapshot) resou
 			if cqQuota.BorrowingLimit == nil {
 				reservedUsage[fr] = usage
 			} else {
-				reservedUsage[fr] = resources.MinAmount(usage, cqQuota.Nominal.Add(*cqQuota.BorrowingLimit).Sub(cq.ResourceNode.Usage[fr]))
+				reservedUsage[fr] = resources.MaxAmount(resources.NewAmount(0), resources.MinAmount(usage, cqQuota.Nominal.Add(*cqQuota.BorrowingLimit).Sub(cq.ResourceNode.Usage[fr])))
 			}
 		} else {
 			reservedUsage[fr] = resources.MaxAmount(resources.NewAmount(0), resources.MinAmount(usage, cqQuota.Nominal.Sub(cq.ResourceNode.Usage[fr])))

--- a/pkg/scheduler/scheduler_reserve_test.go
+++ b/pkg/scheduler/scheduler_reserve_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/resources"
+	"sigs.k8s.io/kueue/pkg/scheduler/flavorassigner"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
+)
+
+func TestQuotaResourcesToReserveClampsAtZero(t *testing.T) {
+	const gpu = corev1.ResourceName("example.com/gpu")
+	fr := resources.FlavorResource{Flavor: "default", Resource: gpu}
+
+	cases := map[string]struct {
+		alreadyUsed int64
+		want        int64
+	}{
+		"within the borrowing limit reserves what is left": {alreadyUsed: 12, want: 3},
+		"over the borrowing limit reserves nothing":        {alreadyUsed: 20, want: 0},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			cache := schdcache.New(utiltesting.NewFakeClient())
+			cache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+			cqObj := utiltestingapi.MakeClusterQueue("cq").
+				Cohort("coh").
+				ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					ResourceQuotaWrapper(gpu).NominalQuota("10").BorrowingLimit("5").Append().
+					Obj()).
+				Obj()
+			if err := cache.AddClusterQueue(ctx, cqObj); err != nil {
+				t.Fatalf("AddClusterQueue: %v", err)
+			}
+			snapshot, err := cache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+			cq := snapshot.ClusterQueue("cq")
+			cq.AddUsage(workload.Usage{Quota: workload.ResourceUsage{Assigned: resources.FlavorResourceQuantities{fr: resources.NewAmount(tc.alreadyUsed)}}})
+
+			e := &entry{assignment: flavorassigner.Assignment{
+				Borrowing: 1,
+				PodSets: []flavorassigner.PodSetAssignment{{
+					Name:   kueue.DefaultPodSetName,
+					Status: *flavorassigner.NewStatus("insufficient quota"),
+					Flavors: flavorassigner.ResourceAssignment{
+						gpu: &flavorassigner.FlavorAssignment{Name: "default", Mode: flavorassigner.Preempt},
+					},
+				}},
+				Usage: workload.Usage{Quota: workload.ResourceUsage{
+					Assigned: resources.FlavorResourceQuantities{fr: resources.NewAmount(4)},
+				}},
+			}}
+
+			got := quotaResourcesToReserve(e, cq)
+			if got[fr].Int64() != tc.want {
+				t.Errorf("reserved %d, want %d", got[fr].Int64(), tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`quotaResourcesToReserve` has two branches for a preempting entry, and only one of them clamps:

```go
if e.assignment.Borrowing > 0 {
	if cqQuota.BorrowingLimit == nil {
		reservedUsage[fr] = usage
	} else {
		reservedUsage[fr] = resources.MinAmount(usage, cqQuota.Nominal.Add(*cqQuota.BorrowingLimit).Sub(cq.ResourceNode.Usage[fr]))
	}
} else {
	reservedUsage[fr] = resources.MaxAmount(resources.NewAmount(0), resources.MinAmount(usage, cqQuota.Nominal.Sub(cq.ResourceNode.Usage[fr])))
}
```

`Nominal + BorrowingLimit - Usage` is negative once usage sits above the cap, and nothing brings it back to zero. `reserveCapacityForUnreclaimablePreempt` then hands the result to `cq.AddUsage`, so instead of holding capacity back from the rest of the cycle, the reservation lowers the snapshot's usage and frees capacity that is not there.

A ClusterQueue with nominal 10 and borrowing limit 5, already using 20, against an entry that wants 4:

```
Borrowing>0 branch  (as written) -> -5
Borrowing==0 branch (clamped)    ->  0
```

Same shape of input, opposite sign, purely because one branch kept the guard and the other did not.

#### Which issue(s) this PR fixes:

None filed; I found this reading the two branches side by side.

#### Special notes for your reviewer:

Reaching it needs a ClusterQueue already over `nominal + borrowingLimit` while preemption finds no candidate targets and `reclaimWithinCohort` is not `Any`, so it is a quota or limit that shrank under an admitted workload rather than anything the normal admission path produces. The effect lasts one scheduling cycle. I could not construct it end to end, and the test drives `quotaResourcesToReserve` directly rather than the scheduler, so please read this as closing a gap between two branches rather than as a bug someone has hit.

There was no test for this function before. The new one pairs the over-limit case with a within-limit one, so the clamp is pinned without hiding the normal answer: reverting the production line leaves the within-limit case green and turns the other red on `reserved -5, want 0`.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a partial quota reservation during preemption reserving a negative amount for a ClusterQueue whose usage was already above its nominal quota plus borrowing limit, which briefly freed capacity in the snapshot instead of holding it.
```

---

This pull request was written in part with the assistance of generative AI. The figures above come from the test in the diff, run both ways.
