### PR TITLE
Resolve a pending Workload's nil priority in the visibility pending-workloads endpoint

### DIFF
--- a/pkg/visibility/storage/utils.go
+++ b/pkg/visibility/storage/utils.go
@@ -21,6 +21,7 @@ import (
 
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta2"
 	"sigs.k8s.io/kueue/pkg/constants"
+	"sigs.k8s.io/kueue/pkg/util/priority"
 	"sigs.k8s.io/kueue/pkg/workload"
 )
 
@@ -49,7 +50,7 @@ func newPendingWorkload(wlInfo *workload.Info, positionInLq int32, positionInCq 
 			CreationTimestamp: wlInfo.Obj.CreationTimestamp,
 		},
 		PositionInClusterQueue: int32(positionInCq),
-		Priority:               *wlInfo.Obj.Spec.Priority,
+		Priority:               priority.Priority(wlInfo.Obj),
 		LocalQueueName:         wlInfo.Obj.Spec.QueueName,
 		PositionInLocalQueue:   positionInLq,
 	}

--- a/pkg/visibility/storage/utils_test.go
+++ b/pkg/visibility/storage/utils_test.go
@@ -17,7 +17,13 @@ limitations under the License.
 package storage
 
 import (
+	"testing"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+	"sigs.k8s.io/kueue/pkg/workload"
 )
 
 type req struct {
@@ -29,4 +35,34 @@ type req struct {
 type resp struct {
 	wantErr              error
 	wantPendingWorkloads []visibility.PendingWorkload
+}
+
+func TestNewPendingWorkloadPriority(t *testing.T) {
+	// A Workload created when there was no global default priority class and
+	// the pod had no priority class keeps a nil Spec.Priority. The endpoint
+	// must resolve it to the default rather than dereferencing a nil pointer.
+	noPriority := utiltestingapi.MakeWorkload("a", "ns").Obj()
+	noPriority.Spec.Priority = nil
+
+	cases := map[string]struct {
+		wl           *kueue.Workload
+		wantPriority int32
+	}{
+		"a Workload with no priority resolves to the default": {
+			wl:           noPriority,
+			wantPriority: constants.DefaultPriority,
+		},
+		"an explicit priority is preserved": {
+			wl:           utiltestingapi.MakeWorkload("a", "ns").Priority(100).Obj(),
+			wantPriority: 100,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := newPendingWorkload(&workload.Info{Obj: tc.wl}, 0, 0)
+			if got.Priority != tc.wantPriority {
+				t.Errorf("Priority = %d, want %d", got.Priority, tc.wantPriority)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`newPendingWorkload` builds the visibility `PendingWorkload` response with `*wlInfo.Obj.Spec.Priority` (`pkg/visibility/storage/utils.go`). `Workload.Spec.Priority` is a `*int32` that is legitimately nil — a Workload created when there was no global default priority class and the pod had no priority class name keeps a nil priority. The rest of the codebase reads it through `priority.Priority`, whose doc comment explicitly handles this case.

A pending Workload with no priority therefore makes the `.../clusterqueues/<cq>/pendingworkloads` and `.../localqueues/<lq>/pendingworkloads` endpoints dereference a nil pointer. The apiserver panic filter turns it into a `500`, so a single such pending Workload breaks the endpoint for every caller until that Workload is admitted.

This reuses `priority.Priority`, which resolves a nil priority to `constants.DefaultPriority`, matching how priority is read everywhere else, and adds a unit test for `newPendingWorkload` covering the nil and explicit-priority cases.

Reproduced on a live cluster: creating a pending Workload with no `spec.priority` and calling the pending-workloads endpoint reliably returned `ServiceUnavailable`/`500` and logged a nil-pointer panic in the visibility handler; deleting that Workload restored the endpoint, and with this change the endpoint returns the workload with the default priority instead.

#### Which issue(s) this PR fixes:
Fixes #14399

#### Special notes for your reviewer:
Prepared with AI assistance (Claude Code): the bug was reproduced on a real cluster, and the fix was verified against the existing `priority.Priority` helper and the package unit tests. Per the project's AI contribution policy, this is disclosed here; the commit carries no AI trailers.

#### Does this PR introduce a user-facing change?
```release-note
VisibilityOnDemand: Fixed a panic in the pending-workloads endpoints when Prebuild Workloads (BYOW) w/o priority are created
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pending workloads now receive the correct default priority when no priority is specified.
  * Explicitly configured workload priorities continue to be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->