### PR TITLE
Fair sharing: read the borrowing state from the borrowing flag

### DIFF
--- a/pkg/cache/scheduler/fair_sharing.go
+++ b/pkg/cache/scheduler/fair_sharing.go
@@ -58,10 +58,9 @@ func NegativeDRS() DRS {
 	return DRS{unweightedRatio: -1, dominantResource: "", fairWeight: defaultWeight}
 }
 
-// IsZero returns whether the DRS unweighted ratio is 0.
-// In the current implementation, DRS unweighted ratio is zero
-// if and only if it is not borrowing any resources.
-// This may change in the future if the DRS implementation changes.
+// IsZero returns whether the DRS unweighted ratio is 0. A node borrowing only
+// resources its cohort lends none of has a zero ratio, so ask IsBorrowing for
+// the borrowing state rather than reading it off this.
 func (d DRS) IsZero() bool {
 	return d.unweightedRatio == 0
 }
@@ -88,11 +87,11 @@ func (d DRS) isWeightZero() bool {
 }
 
 func (d DRS) PreciseWeightedShare() float64 {
+	if d.ZeroWeightBorrows() {
+		return math.Inf(1)
+	}
 	if d.IsZero() {
 		return 0.0
-	}
-	if d.isWeightZero() {
-		return math.Inf(1)
 	}
 	return d.unweightedRatio / d.fairWeight
 }
@@ -144,7 +143,7 @@ func (d DRS) roundedWeightedShare() (int64, corev1.ResourceName) {
 // borrowing state for a ClusterQueue/Cohort with a zero weight.
 // This is equivalent to PreciseWeightedShare returning +Inf.
 func (d DRS) ZeroWeightBorrows() bool {
-	return d.isWeightZero() && !d.IsZero()
+	return d.isWeightZero() && d.IsBorrowing()
 }
 
 func dominantResourceShare(node dominantResourceShareNode, wlReq resources.FlavorResourceQuantities) DRS {

--- a/pkg/cache/scheduler/fair_sharing_test.go
+++ b/pkg/cache/scheduler/fair_sharing_test.go
@@ -411,6 +411,51 @@ func TestDominantResourceShare(t *testing.T) {
 				},
 			},
 		},
+		"a zero-weight ClusterQueue borrowing only what nobody lends": {
+			usage: resources.FlavorResourceQuantities{
+				{Flavor: "default", Resource: "example.com/gpu"}: resources.NewAmount(3),
+			},
+			clusterQueue: utiltestingapi.MakeClusterQueue("cq").
+				Cohort("test-cohort").
+				FairWeight(resource.MustParse("0")).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("2").LendingLimit("0").Append().
+						Obj(),
+				).Obj(),
+			lendingClusterQueue: utiltestingapi.MakeClusterQueue("lending-cq").
+				Cohort("test-cohort").
+				FairWeight(resource.MustParse("1")).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("default").
+						ResourceQuotaWrapper("example.com/gpu").NominalQuota("64").LendingLimit("0").Append().
+						Obj(),
+				).Obj(),
+			flvResQ: resources.FlavorResourceQuantities{},
+			want: []fairSharingResult{
+				{
+					Name:      "cq",
+					NodeType:  nodeTypeCq,
+					DrName:    "",
+					DrValue:   math.MaxInt64,
+					Borrowing: true,
+				},
+				{
+					Name:      "lending-cq",
+					NodeType:  nodeTypeCq,
+					DrName:    "",
+					DrValue:   0,
+					Borrowing: false,
+				},
+				{
+					Name:      "test-cohort",
+					NodeType:  nodeTypeCohort,
+					DrName:    "",
+					DrValue:   0,
+					Borrowing: false,
+				},
+			},
+		},
 		"multiple flavors": {
 			usage: resources.FlavorResourceQuantities{
 				{Flavor: "on-demand", Resource: corev1.ResourceCPU}: resources.NewAmount(15_000),
@@ -989,7 +1034,7 @@ func TestZeroWeightBorrows(t *testing.T) {
 		want bool
 	}{
 		"zero weight and borrowing returns true": {
-			drs:  DRS{fairWeight: 0, unweightedRatio: 100},
+			drs:  DRS{fairWeight: 0, unweightedRatio: 100, borrowing: true},
 			want: true,
 		},
 		"zero weight and not borrowing returns false": {
@@ -997,8 +1042,14 @@ func TestZeroWeightBorrows(t *testing.T) {
 			want: false,
 		},
 		"non-zero weight and borrowing returns false": {
-			drs:  DRS{fairWeight: 1, unweightedRatio: 100},
+			drs:  DRS{fairWeight: 1, unweightedRatio: 100, borrowing: true},
 			want: false,
+		},
+		// The ratio stays at zero when nothing in the cohort is lendable, so it
+		// is the flag and not the ratio that says the node is borrowing.
+		"zero weight borrowing what nobody lends returns true": {
+			drs:  DRS{fairWeight: 0, unweightedRatio: 0, borrowing: true},
+			want: true,
 		},
 	}
 	for name, tc := range cases {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area fair-sharing

#### What this PR does / why we need it:

`dominantResourceShare` sets the borrowing flag from the node's own subtree quota, and raises the ratio only for resources the cohort actually lends:

```go
drs.borrowing = true
...
for rName, b := range borrowing {
	if lr := lendable[rName]; lr.CmpInt64(0) > 0 {
		...
		drs.unweightedRatio = ratio
	}
}
```

`zeroWeightBorrows` did not read that flag. It asked whether the ratio was non-zero and used it as a stand-in:

```go
func (d DRS) zeroWeightBorrows() bool {
	return d.isWeightZero() && !d.IsZero()
}
```

`IsZero`'s own doc admitted the stand-in and asserted it holds: "DRS unweighted ratio is zero if and only if it is not borrowing any resources". It doesn't. A node borrowing only resources with zero lendable is borrowing with a zero ratio, and then:

- `zeroWeightBorrows` is false, so `CompareDRS` skips both of its zero-weight branches
- `roundedWeightedShare` returns `0` rather than the `MaxInt64` its own comment promises "when the FairSharing weight is 0, and the ClusterQueue or Cohort is borrowing"
- `PreciseWeightedShare` returns `0.0`, because the `IsZero` shortcut is reached before the zero-weight branch

So a zero-weight ClusterQueue, which fair sharing defines as the first to be preempted and the last to be scheduled, is ranked as the last to be preempted and the first to be scheduled. Same ClusterQueue, same over-borrow, only the lendability of the borrowed resource differing:

```
borrows a lendable resource      borrowing=true zeroWeightBorrows=true  preciseShare=+Inf roundedShare=9223372036854775807
borrows a zero-lendable resource borrowing=true zeroWeightBorrows=false preciseShare=0    roundedShare=0
```

`zeroWeightBorrows` now asks `IsBorrowing`, which is where that state already lives, and `PreciseWeightedShare` answers the zero-weight case before the zero-ratio shortcut. `IsZero` keeps its meaning and loses the sentence claiming it stands for something else.

#### Which issue(s) this PR fixes:

None filed; I found this reading the ratio guard against the flag above it.

#### Special notes for your reviewer:

I could not build the state through normal scheduling, and I would rather say so than imply otherwise. Admitting into it needs the usage to already exceed the subtree quota on a resource with zero lendable, which the assigner would refuse, so it takes an admitted workload outliving the quota it was admitted under: a lending limit withdrawn, a nominal quota lowered, or a cohort re-parented. What the change closes is the gap between a documented contract and the code, not something I have watched happen.

The new case sits in `TestDominantResourceShare` beside the existing `A resource with zero lendable`, which is the same shape with a non-zero weight and a second borrow on a lendable resource, and is rescued by that second borrow. Reverting `zeroWeightBorrows` alone turns the new case red on the ClusterQueue's `DrValue`.

`PreciseWeightedShare` feeds `kueue_cluster_queue_weighted_share` and the equivalent cohort metric, so a zero-weight borrower that reported `0` will now report `+Inf` there. That is already what a zero-weight borrower on a lendable resource reports today, so this makes the two agree rather than introducing a new value.

#### Does this PR introduce a user-facing change?

```release-note
Fair sharing: fixed a zero-weight ClusterQueue or Cohort that borrows only resources its cohort lends none of being ranked as if it were not borrowing, which made it the last preemption candidate instead of the first.
```

---

This pull request was written in part with the assistance of generative AI. The two lines of output above come from a probe I ran against this code.
