### PR TITLE
ProvisioningRequest: skip the check without a request, not the whole patch

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -601,7 +601,9 @@ func (c *Controller) syncCheckStates(
 			} else {
 				pr := activeOrLastPRForChecks[check]
 				if pr == nil {
-					return false, nil
+					// Leaving this check alone rather than the whole patch: the others
+					// have already staged their states into wlPatch.
+					continue
 				}
 				log.V(3).Info("Synchronizing admission check state based on provisioning request", "wl", klog.KObj(wl),
 					"check", check,

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -2452,3 +2452,71 @@ func TestUpdateCheckMessage(t *testing.T) {
 		})
 	}
 }
+
+// One check has no ProvisioningRequest yet. Does the other one's transition survive?
+func findCheck(states []kueue.AdmissionCheckState, name kueue.AdmissionCheckReference) *kueue.AdmissionCheckState {
+	for i := range states {
+		if states[i].Name == name {
+			return &states[i]
+		}
+	}
+	return nil
+}
+
+func TestSyncCheckStatesKeepsASiblingCheckWithoutARequest(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	builder, ctx := getClientBuilder(ctx)
+
+	wl := utiltestingapi.MakeWorkload("wl", TestNamespace).
+		PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("q").PodSets(
+			kueue.PodSetAssignment{Name: "main", Count: new(int32(1))}).Obj(), time.Now()).
+		AdmissionChecks(
+			kueue.AdmissionCheckState{Name: "with-request", State: kueue.CheckStatePending},
+			kueue.AdmissionCheckState{Name: "without-request", State: kueue.CheckStatePending}).
+		Obj()
+
+	builder = builder.WithObjects(wl).WithStatusSubresource(wl)
+	controller, err := NewController(builder.Build(), &utiltesting.EventRecorder{}, nil)
+	if err != nil {
+		t.Fatalf("Setting up the controller: %v", err)
+	}
+
+	prc := utiltestingapi.MakeProvisioningRequestConfig("config").
+		RetryStrategy(&kueue.ProvisioningRequestRetryStrategy{
+			BackoffLimitCount:  new(int32(3)),
+			BackoffBaseSeconds: new(int32(60)),
+			BackoffMaxSeconds:  new(int32(1800)),
+		}).Obj()
+	provisioned := &autoscaling.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr", Namespace: TestNamespace},
+		Status: autoscaling.ProvisioningRequestStatus{Conditions: []metav1.Condition{{
+			Type: autoscaling.Provisioned, Status: metav1.ConditionTrue, Reason: "Provisioned",
+			LastTransitionTime: metav1.Now(),
+		}}},
+	}
+
+	if err := controller.syncCheckStates(ctx, wl, &workloadInfo{},
+		map[kueue.AdmissionCheckReference]*kueue.ProvisioningRequestConfig{
+			"with-request":    prc,
+			"without-request": prc,
+		},
+		map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest{
+			"with-request":    provisioned,
+			"without-request": nil,
+		}); err != nil {
+		t.Fatalf("syncCheckStates: %v", err)
+	}
+
+	got := &kueue.Workload{}
+	if err := controller.client.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	for _, cs := range got.Status.AdmissionChecks {
+		t.Logf("check %q state=%s", cs.Name, cs.State)
+	}
+	state := findCheck(got.Status.AdmissionChecks, "with-request")
+	if state == nil || state.State != kueue.CheckStateReady {
+		t.Errorf("the check with a request was not persisted as Ready, got %v", state)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area integrations

#### What this PR does / why we need it:

`syncCheckStates` handles every provisioning admission check on a workload inside one status patch. A check that needs a ProvisioningRequest and does not have one yet returned from the callback:

```go
pr := activeOrLastPRForChecks[check]
if pr == nil {
	return false, nil
}
```

That is not a skip. `PatchStatus` treats a `false` answer as "nothing to write" and never issues the patch, so anything the loop had already staged for the other checks is dropped, including a check that had just gone `Provisioned` and staged `Ready`. The map is iterated in random order, so which check is lost varies.

The events go out anyway. `updated` and `recorderMessages` are declared outside the callback, and the caller reads the closure variable rather than the callback's answer:

```go
updated := false
err := workloadpatching.PatchStatus(..., func(wlPatch *kueue.Workload) (bool, error) { ... })
...
if updated {
	for i := range recorderMessages {
		c.record.Eventf(wl, ..., "AdmissionCheckUpdated", ...)
	}
}
```

So the workload gets an `AdmissionCheckUpdated` event for a transition that was not saved, and gets it again on every reconcile until the other check obtains a request. Normally that settles in a pass or two. It does not settle if the other check is stuck, and then a check that is ready to go stays `Pending` behind it.

Skipping just that check fixes both halves: the callback ends up answering with the same variable the events are gated on, so a patch that does not happen no longer announces itself.

Two checks, one with a `Provisioned` request and one without:

```
with the fix       with-request Ready     without-request Pending
without the fix    with-request Pending   without-request Pending
```

#### Which issue(s) this PR fixes:

None filed; I found this reading the callback's early return against the closure variables above it.

#### Special notes for your reviewer:

The test calls `syncCheckStates` directly, since the state it needs is one check's entry in `activeOrLastPRForChecks` being nil while another's is a provisioned request, and that is a moment inside a reconcile rather than something a fixture reaches on its own.

Reverting the `continue` turns it red on the surviving check's state rather than on an event count, which is the part that matters: the events were only ever a symptom of the patch not going out.

While writing it I found that a `ProvisioningRequestConfig` without a `retryStrategy` panics this same function on an unguarded dereference a few lines below. Every existing test here passes a config that carries one, which is why nothing catches it. That is a separate defect and I am sending it separately rather than widening this one.

#### Does this PR introduce a user-facing change?

```release-note
ProvisioningRequest: fixed one admission check waiting for its ProvisioningRequest discarding the status updates of the workload's other provisioning checks, which also emitted AdmissionCheckUpdated events for transitions that were never saved.
```

---

This pull request was written in part with the assistance of generative AI. The two lines of output above come from the test in the diff, run both ways.


#### Overlap with #14316

@sohankunkerkar's #14316 is open on this same file and reaches the same neighbourhood, so whichever of us lands second owes a rebase. Recording what I found so it is not a surprise:

- It turns `mergePodSets` into a method on `*Controller`, so a caller written against the free function has to move with it.
- It inserts a branch into `syncCheckStates` immediately above the one this PR touches, for an elastic scale-down whose merged set comes back empty.
- It adds `previousSlicePodSetCounts` next to `MergedPodSet`.

None of it is the same defect, and neither change makes the other unnecessary. I am happy to rebase onto it once it lands, or to go first if that is easier for review.


#### The rest of my provisioning changes

I have three other small ones open on this same file, so between them and #14316 whoever lands last does the rebasing. They are independent defects and none of them needs another to make sense:

- #14408 gives every merged PodSet its `PodSetUpdate`.
- #14414 stops one check without a request discarding the whole status patch.
- #14415 stops an unset `retryStrategy` panicking the reconcile.
- #14416 notices a parameter the config has dropped.

#14414 and #14415 are the closest pair: both sit in `syncCheckStates`, a dozen lines apart.
