### PR TITLE
ProvisioningRequest: do not require a retryStrategy to be set

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -71,6 +71,13 @@ var (
 	errInconsistentPodSetAssignments = errors.New("inconsistent podSet assignments")
 )
 
+// Defaults the ProvisioningRequestConfig CRD applies to retryStrategy.
+const (
+	defaultBackoffBaseSeconds int32 = 60
+	defaultBackoffMaxSeconds  int32 = 1800
+	defaultBackoffLimitCount  int32 = 3
+)
+
 var (
 	realClock = clock.RealClock{}
 )
@@ -611,9 +618,13 @@ func (c *Controller) syncCheckStates(
 					"accepted", isAccepted(pr),
 					"bookingExpired", isBookingExpired(pr),
 					"capacityRevoked", isCapacityRevoked(pr))
-				backoffBaseSeconds := *prc.Spec.RetryStrategy.BackoffBaseSeconds
-				backoffMaxSeconds := *prc.Spec.RetryStrategy.BackoffMaxSeconds
-				backoffLimitCount := *prc.Spec.RetryStrategy.BackoffLimitCount
+				// The CRD defaults these; a config that did not come through it may not.
+				backoffBaseSeconds, backoffMaxSeconds, backoffLimitCount := defaultBackoffBaseSeconds, defaultBackoffMaxSeconds, defaultBackoffLimitCount
+				if retry := prc.Spec.RetryStrategy; retry != nil {
+					backoffBaseSeconds = ptr.Deref(retry.BackoffBaseSeconds, backoffBaseSeconds)
+					backoffMaxSeconds = ptr.Deref(retry.BackoffMaxSeconds, backoffMaxSeconds)
+					backoffLimitCount = ptr.Deref(retry.BackoffLimitCount, backoffLimitCount)
+				}
 				switch {
 				case isFailed(pr):
 					if attempt := getAttempt(log, pr, wl.Name, check); attempt <= backoffLimitCount {

--- a/pkg/controller/admissionchecks/provisioning/controller_test.go
+++ b/pkg/controller/admissionchecks/provisioning/controller_test.go
@@ -2452,3 +2452,48 @@ func TestUpdateCheckMessage(t *testing.T) {
 		})
 	}
 }
+
+// A ProvisioningRequestConfig that never went through the CRD's defaulting.
+func TestSyncCheckStatesWithoutARetryStrategy(t *testing.T) {
+	ctx, _ := utiltesting.ContextWithLog(t)
+	builder, ctx := getClientBuilder(ctx)
+
+	wl := utiltestingapi.MakeWorkload("wl", TestNamespace).
+		PodSets(*utiltestingapi.MakePodSet("main", 1).Request(corev1.ResourceCPU, "1").Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("q").PodSets(
+			kueue.PodSetAssignment{Name: "main", Count: new(int32(1))}).Obj(), time.Now()).
+		AdmissionChecks(kueue.AdmissionCheckState{Name: "check", State: kueue.CheckStatePending}).
+		Obj()
+
+	builder = builder.WithObjects(wl).WithStatusSubresource(wl)
+	controller, err := NewController(builder.Build(), &utiltesting.EventRecorder{}, nil)
+	if err != nil {
+		t.Fatalf("Setting up the controller: %v", err)
+	}
+
+	provisioned := &autoscaling.ProvisioningRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "pr", Namespace: TestNamespace},
+		Status: autoscaling.ProvisioningRequestStatus{Conditions: []metav1.Condition{{
+			Type: autoscaling.Provisioned, Status: metav1.ConditionTrue, Reason: "Provisioned",
+			LastTransitionTime: metav1.Now(),
+		}}},
+	}
+
+	if err := controller.syncCheckStates(ctx, wl, &workloadInfo{},
+		map[kueue.AdmissionCheckReference]*kueue.ProvisioningRequestConfig{
+			"check": utiltestingapi.MakeProvisioningRequestConfig("config").Obj(),
+		},
+		map[kueue.AdmissionCheckReference]*autoscaling.ProvisioningRequest{
+			"check": provisioned,
+		}); err != nil {
+		t.Fatalf("syncCheckStates: %v", err)
+	}
+
+	got := &kueue.Workload{}
+	if err := controller.client.Get(ctx, client.ObjectKeyFromObject(wl), got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Status.AdmissionChecks) == 0 || got.Status.AdmissionChecks[0].State != kueue.CheckStateReady {
+		t.Errorf("check state = %v, want Ready", got.Status.AdmissionChecks)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area integrations

#### What this PR does / why we need it:

`syncCheckStates` reads the retry settings as soon as a check needs a request and has one:

```go
backoffBaseSeconds := *prc.Spec.RetryStrategy.BackoffBaseSeconds
backoffMaxSeconds := *prc.Spec.RetryStrategy.BackoffMaxSeconds
backoffLimitCount := *prc.Spec.RetryStrategy.BackoffLimitCount
```

Four dereferences with nothing checked. `RetryStrategy` is `+optional` on a pointer field, and what fills it is the CRD:

```go
// +kubebuilder:default={backoffLimitCount:3,backoffBaseSeconds:60,backoffMaxSeconds:1800}
RetryStrategy *ProvisioningRequestRetryStrategy `json:"retryStrategy,omitempty"`
```

There is no defaulting webhook for `ProvisioningRequestConfig`, so that default is the only thing standing between this line and a nil pointer. A config that reaches the reconcile without having been through it panics the provisioning controller.

I did not go looking for this. It panicked under me while I was writing a test for something else in the same function, with a config built by `MakeProvisioningRequestConfig`, which does not set a retry strategy. Every existing test that reaches this path passes `baseConfigWithRetryStrategy`, so the suite has been stepping around it.

Reading the three through the defaults the CRD documents costs nothing when the CRD did its job and keeps the reconcile alive when it did not.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

I want to be straight about how reachable this is, because the answer is "less than a panic usually suggests". Anything created through the apiserver against the current CRD carries the block. Getting here needs a config that skipped that: a controller reading against an older schema, or a caller assembling the struct itself. So this is hardening a path the API normally protects, not a bug someone is hitting.

What made me send it anyway is that the protection is entirely outside this repo's control at that line, and the failure is a panic in a scheduling-path reconcile rather than an error the caller can handle.

The test uses a config with no retry strategy, which is exactly the shape that panicked. Reverting the production change turns it red on the panic rather than on an assertion.

The constants repeat what the CRD marker says. I would rather have read them from one place, but the marker is a comment as far as Go is concerned, so the two have to agree by inspection either way.

#### Does this PR introduce a user-facing change?

```release-note
ProvisioningRequest: the controller no longer panics on a ProvisioningRequestConfig whose retryStrategy is unset, which the CRD normally defaults; the documented defaults are used instead.
```

---

This pull request was written in part with the assistance of generative AI. The panic above is one I hit rather than one I reasoned about.


#### Overlap with #14316

@sohankunkerkar's #14316 is open on this same file and reaches the same neighbourhood, so whichever of us lands second owes a rebase. Recording what I found so it is not a surprise:

- It turns `mergePodSets` into a method on `*Controller`, so a caller written against the free function has to move with it.
- It inserts a branch into `syncCheckStates` immediately above the one this PR touches, for an elastic scale-down whose merged set comes back empty.
- It adds `previousSlicePodSetCounts` next to `MergedPodSet`.

None of it is the same defect, and neither change makes the other unnecessary. I am happy to rebase onto it once it lands, or to go first if that is easier for review.


#### The rest of my provisioning changes

I have three other small ones open on this same file, so between them and #14316 whoever lands last does the rebasing. They are independent defects and none of them needs another to make sense:

- #14408 gives every merged PodSet its `PodSetUpdate`.
- #14414 stops one check without a request discarding the whole status patch.
- #14415 stops an unset `retryStrategy` panicking the reconcile.
- #14416 notices a parameter the config has dropped.

#14414 and #14415 are the closest pair: both sit in `syncCheckStates`, a dozen lines apart.
