### PR TITLE
ProvisioningRequest: notice a parameter the config has dropped

### DIFF
--- a/pkg/controller/admissionchecks/provisioning/controller.go
+++ b/pkg/controller/admissionchecks/provisioning/controller.go
@@ -219,7 +219,7 @@ func (c *Controller) activeOrLastPRForChecks(
 			req := &ownedPRs[i]
 			// PRs relevant for the admission check
 			if matchesWorkloadAndCheck(req, wl.Name, checkName) {
-				if reqNeeded && provReqSyncedWithConfig(req, prc) {
+				if reqNeeded && provReqSyncedWithConfig(wl, req, prc) {
 					currPr, exists := activeOrLastPRForChecks[checkName]
 					if !exists || getAttempt(log, currPr, wl.Name, checkName) < getAttempt(log, req, wl.Name, checkName) {
 						activeOrLastPRForChecks[checkName] = req

--- a/pkg/controller/admissionchecks/provisioning/provisioning.go
+++ b/pkg/controller/admissionchecks/provisioning/provisioning.go
@@ -106,14 +106,24 @@ func parametersKueueToProvisioning(in map[string]kueue.Parameter) map[string]aut
 	return out
 }
 
-// provReqSyncedWithConfig checks if the provisioning request has the same provisioningClassName as the provisioning request config
-// and contains all the parameters from the config
-func provReqSyncedWithConfig(req *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) bool {
+// provReqSyncedWithConfig checks if the provisioning request has the same provisioningClassName as the
+// provisioning request config, and carries the config's parameters and no others of its own.
+func provReqSyncedWithConfig(wl *kueue.Workload, req *autoscaling.ProvisioningRequest, prc *kueue.ProvisioningRequestConfig) bool {
 	if req.Spec.ProvisioningClassName != prc.Spec.ProvisioningClassName {
 		return false
 	}
 	for k, vCfg := range prc.Spec.Parameters {
 		if vReq, found := req.Spec.Parameters[k]; !found || string(vReq) != string(vCfg) {
+			return false
+		}
+	}
+	// The workload's own annotations land in the same map, so only a parameter
+	// belonging to neither side is one the config has since dropped.
+	for k := range req.Spec.Parameters {
+		if _, fromConfig := prc.Spec.Parameters[k]; fromConfig {
+			continue
+		}
+		if _, fromWorkload := wl.Annotations[constants.ProvReqAnnotationPrefix+k]; !fromWorkload {
 			return false
 		}
 	}

--- a/pkg/controller/admissionchecks/provisioning/provisioning_test.go
+++ b/pkg/controller/admissionchecks/provisioning/provisioning_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioning
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscaling "k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest/autoscaling.x-k8s.io/v1"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/constants"
+)
+
+func TestProvReqSyncedWithConfig(t *testing.T) {
+	req := func(params map[string]autoscaling.Parameter) *autoscaling.ProvisioningRequest {
+		return &autoscaling.ProvisioningRequest{Spec: autoscaling.ProvisioningRequestSpec{
+			ProvisioningClassName: "queued", Parameters: params,
+		}}
+	}
+	cases := map[string]struct {
+		annotations map[string]string
+		reqParams   map[string]autoscaling.Parameter
+		cfgParams   map[string]kueue.Parameter
+		want        bool
+	}{
+		"config and request agree": {
+			reqParams: map[string]autoscaling.Parameter{"a": "1"},
+			cfgParams: map[string]kueue.Parameter{"a": "1"},
+			want:      true,
+		},
+		"config changed a value": {
+			reqParams: map[string]autoscaling.Parameter{"a": "1"},
+			cfgParams: map[string]kueue.Parameter{"a": "2"},
+			want:      false,
+		},
+		"config dropped a parameter": {
+			reqParams: map[string]autoscaling.Parameter{"a": "1", "b": "2"},
+			cfgParams: map[string]kueue.Parameter{"a": "1"},
+			want:      false,
+		},
+		"the workload put the extra parameter there": {
+			annotations: map[string]string{constants.ProvReqAnnotationPrefix + "b": "2"},
+			reqParams:   map[string]autoscaling.Parameter{"a": "1", "b": "2"},
+			cfgParams:   map[string]kueue.Parameter{"a": "1"},
+			want:        true,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			wl := &kueue.Workload{ObjectMeta: metav1.ObjectMeta{Annotations: tc.annotations}}
+			prc := &kueue.ProvisioningRequestConfig{Spec: kueue.ProvisioningRequestConfigSpec{
+				ProvisioningClassName: "queued", Parameters: tc.cfgParams,
+			}}
+			if got := provReqSyncedWithConfig(wl, req(tc.reqParams), prc); got != tc.want {
+				t.Errorf("provReqSyncedWithConfig() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area integrations

#### What this PR does / why we need it:

`provReqSyncedWithConfig` decides whether an existing ProvisioningRequest still matches its config, and it only ever looked one way:

```go
for k, vCfg := range prc.Spec.Parameters {
	if vReq, found := req.Spec.Parameters[k]; !found || string(vReq) != string(vCfg) {
		return false
	}
}
return true
```

That answers "did the config add or change a parameter" and not "did it drop one". A parameter the config used to set stays on the request forever: still passed to the autoscaler, and reported as synced, so the request is neither updated nor recreated.

```
config still has both    synced=true    (correct)
config changed a value   synced=false   (correct)
config dropped one       synced=true    (the request keeps the parameter)
```

The obvious fix is wrong here, which is most of why this PR is worth reading. Comparing the two maps for equality would be a regression, because the request's parameters do not all come from the config:

```go
func passProvReqParams(wl *kueue.Workload, req *autoscaling.ProvisioningRequest) {
	...
	for annotation, val := range admissioncheck.FilterProvReqAnnotations(wl.Annotations) {
		paramName := strings.TrimPrefix(annotation, constants.ProvReqAnnotationPrefix)
		req.Spec.Parameters[paramName] = autoscaling.Parameter(val)
	}
}
```

Every workload carrying a `provreq.kueue.x-k8s.io/` annotation puts parameters in that same map. Under map equality each of them would be permanently out of sync, and the request would be deleted and recreated on every reconcile, which is the shape of #12542.

So the check rejects a parameter that belongs to neither side: not in the config, and not in the workload's annotations.

#### Which issue(s) this PR fixes:

None filed.

#### Special notes for your reviewer:

The function now takes the workload. Its one caller already had it in scope.

The table has four rows, and the one that matters most is the last: a workload annotation supplying a parameter the config does not, which must stay synced. Dropping the new loop turns only the removed-parameter row red and leaves that one green, so the test pins both the fix and the thing the fix must not break.

I left the other half of this alone. `prcHandler.Update` requeues on a `managedResources` change, and that change moves which PodSets belong in the request rather than which parameters, so answering it means comparing the request's PodSets against what the merge would now produce. That is the area #14316 is currently reworking, and it is a different question from this one.

#### Does this PR introduce a user-facing change?

```release-note
ProvisioningRequest: a parameter removed from a ProvisioningRequestConfig is now noticed, where before the existing ProvisioningRequest kept it and still counted as synced. Parameters supplied by a workload's provreq annotations are unaffected.
```

---

This pull request was written in part with the assistance of generative AI. The three outcomes above come from the test in the diff.


#### The rest of my provisioning changes

I have three other small ones open on this same file, so between them and #14316 whoever lands last does the rebasing. They are independent defects and none of them needs another to make sense:

- #14408 gives every merged PodSet its `PodSetUpdate`.
- #14414 stops one check without a request discarding the whole status patch.
- #14415 stops an unset `retryStrategy` panicking the reconcile.
- #14416 notices a parameter the config has dropped.

#14414 and #14415 are the closest pair: both sit in `syncCheckStates`, a dozen lines apart.
