### PR TITLE
[release-0.18] TAS: apply overlapping-flavor usage only to domains the flavor holds (#14174)

### DIFF
--- a/pkg/cache/scheduler/snapshot_test.go
+++ b/pkg/cache/scheduler/snapshot_test.go
@@ -18,9 +18,11 @@ package scheduler
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -33,7 +35,9 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/cache/hierarchy"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
@@ -51,12 +55,21 @@ var snapCmpOpts = cmp.Options{
 func TestSnapshot(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	testCases := map[string]struct {
-		cqs          []*kueue.ClusterQueue
-		cohorts      []*kueue.Cohort
-		rfs          []*kueue.ResourceFlavor
-		topologies   []*kueue.Topology
-		wls          []*kueue.Workload
-		wantSnapshot Snapshot
+		cqs        []*kueue.ClusterQueue
+		cohorts    []*kueue.Cohort
+		rfs        []*kueue.ResourceFlavor
+		topologies []*kueue.Topology
+		wls        []*kueue.Workload
+		// nodes are synced into the TAS cache before the snapshot.
+		nodes []*corev1.Node
+		// tasFlavorUsage records raw TAS usage on a flavor before the snapshot.
+		tasFlavorUsage map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests
+		// relabeledFlavors are reapplied after tasFlavorUsage, moving a flavor off
+		// the nodes its usage was recorded on.
+		relabeledFlavors []*kueue.ResourceFlavor
+		wantSnapshot     Snapshot
+		// wantTASUsage asserts per-flavor domain usage (and that none was skipped).
+		wantTASUsage map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests
 	}{
 		"empty": {},
 		"independent clusterQueues": {
@@ -852,10 +865,139 @@ func TestSnapshot(t *testing.T) {
 				},
 			},
 		},
+		// The next three cases exercise how Cache.Snapshot feeds
+		// TASHandleOverlappingFlavors usage into each flavor's snapshot (#10659).
+		"overlapping flavors selecting disjoint nodes take only their own usage": {
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-zone-a").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-zone-b").TopologyName("topology").NodeLabel("zone", "b").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-zone-a").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-zone-b").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+				node.MakeNode("x2").Label(corev1.LabelHostname, "x2").Label("zone", "b").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-zone-a": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-zone-b": {{
+					Values:            []string{"x2"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-zone-a": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+				"tas-zone-b": {"x2": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000, corev1.ResourcePods: 1})},
+			},
+		},
+		"overlapping flavors differing only in taints share the usage of their node (#10659)": {
+			// Both flavors select x1; counting per-flavor would double-count it.
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-shared").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-dedicated").TopologyName("topology").NodeLabel("zone", "a").
+					Taint(corev1.Taint{Key: "dedicated", Value: "special", Effect: corev1.TaintEffectNoSchedule}).Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-shared").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-dedicated").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-shared": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-dedicated": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-shared":    {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+				"tas-dedicated": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+			},
+		},
+		"overlapping flavor that moved to other nodes still counts on the node holding its usage": {
+			// tas-moved is relabelled to zone=b after its usage was recorded on
+			// x1; tas-stay still selects x1 and must still count that usage.
+			topologies: []*kueue.Topology{utiltestingapi.MakeDefaultOneLevelTopology("topology")},
+			rfs: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-stay").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+				utiltestingapi.MakeResourceFlavor("tas-moved").TopologyName("topology").NodeLabel("zone", "a").Obj(),
+			},
+			cqs: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("cq").ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("tas-stay").Resource(corev1.ResourceCPU, "100").Obj(),
+					*utiltestingapi.MakeFlavorQuotas("tas-moved").Resource(corev1.ResourceCPU, "100").Obj(),
+				).Obj(),
+			},
+			nodes: []*corev1.Node{
+				node.MakeNode("x1").Label(corev1.LabelHostname, "x1").Label("zone", "a").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("2"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).Ready().Obj(),
+			},
+			tasFlavorUsage: map[kueue.ResourceFlavorReference][]workload.TopologyDomainRequests{
+				"tas-stay": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+				"tas-moved": {{
+					Values:            []string{"x1"},
+					SinglePodRequests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+					Count:             1,
+				}},
+			},
+			relabeledFlavors: []*kueue.ResourceFlavor{
+				utiltestingapi.MakeResourceFlavor("tas-moved").TopologyName("topology").NodeLabel("zone", "b").Obj(),
+			},
+			wantTASUsage: map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests{
+				"tas-stay": {"x1": resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 2000, corev1.ResourcePods: 2})},
+				// tas-moved has no leaf now, so it accounts nothing.
+				"tas-moved": {},
+			},
+		},
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			if tc.wantTASUsage != nil {
+				// These cases exercise the gated overlapping-flavor usage
+				// aggregation, which depends on TAS being enabled.
+				features.SetFeatureGateDuringTest(t, features.TopologyAwareScheduling, true)
+				features.SetFeatureGateDuringTest(t, features.TASHandleOverlappingFlavors, true)
+			}
 			ctx, log := utiltesting.ContextWithLog(t)
 			cache := New(utiltesting.NewFakeClient())
 			for _, cq := range tc.cqs {
@@ -877,13 +1019,81 @@ func TestSnapshot(t *testing.T) {
 			for _, wl := range tc.wls {
 				cache.AddOrUpdateWorkload(log, wl)
 			}
-			snapshot, err := cache.Snapshot(ctx)
+			for _, n := range tc.nodes {
+				cache.TASCache().SyncNode(n)
+			}
+			for flavor, usage := range tc.tasFlavorUsage {
+				flavorCache := cache.TASCache().Get(flavor)
+				if flavorCache == nil {
+					t.Fatalf("TAS flavor cache for %q was not created", flavor)
+				}
+				flavorCache.addUsage(log, workload.Reference("default/"+string(flavor)), usage)
+			}
+			// Reapplying a flavor after its usage was recorded moves it onto
+			// other nodes while the usage stays on the node it left.
+			for _, rf := range tc.relabeledFlavors {
+				flavorCache := cache.TASCache().Get(kueue.ResourceFlavorReference(rf.Name))
+				if flavorCache == nil {
+					t.Fatalf("TAS flavor cache for %q was not created", rf.Name)
+				}
+				flavorCache.flavor.NodeLabels = rf.Spec.NodeLabels
+			}
+
+			// A domain of a node a flavor does not select carries no usage it can
+			// account, so Cache.Snapshot must skip it without logging a line per
+			// such domain.
+			var skippedDomains []utiltas.TopologyDomainID
+			snapshotCtx := ctx
+			if tc.wantTASUsage != nil {
+				capturingLog := funcr.NewJSON(func(obj string) {
+					entry := make(map[string]any)
+					if err := json.Unmarshal([]byte(obj), &entry); err != nil {
+						t.Errorf("Failed to parse log entry %q: %v", obj, err)
+						return
+					}
+					if entry["msg"] == "skip accounting for TAS usage in domain" {
+						skippedDomains = append(skippedDomains, utiltas.TopologyDomainID(fmt.Sprint(entry["domain"])))
+					}
+				}, funcr.Options{Verbosity: 3})
+				snapshotCtx = logr.NewContext(ctx, capturingLog)
+			}
+			snapshot, err := cache.Snapshot(snapshotCtx)
 			if err != nil {
 				t.Fatalf("unexpected error while building snapshot: %v", err)
 			}
-			if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
+
+			if tc.wantTASUsage != nil {
+				if len(skippedDomains) > 0 {
+					t.Errorf("Snapshot reported skipped TAS usage for domains %v, want none", skippedDomains)
+				}
+				cqName := kueue.ClusterQueueReference(tc.cqs[0].Name)
+				cqSnapshot := snapshot.ClusterQueue(cqName)
+				if cqSnapshot == nil {
+					t.Fatalf("ClusterQueue %q is missing from the snapshot", cqName)
+				}
+				gotTASUsage := make(map[kueue.ResourceFlavorReference]map[utiltas.TopologyDomainID]resources.Requests, len(tc.wantTASUsage))
+				for flavor := range tc.wantTASUsage {
+					flavorSnapshot := cqSnapshot.TASFlavors[flavor]
+					if flavorSnapshot == nil {
+						t.Fatalf("flavor %q is missing from the ClusterQueue snapshot", flavor)
+					}
+					// A leaf's usage is nil until first updated; skip those.
+					domainUsage := make(map[utiltas.TopologyDomainID]resources.Requests)
+					for domainID, leaf := range flavorSnapshot.leaves {
+						if leaf.tasUsage != nil {
+							domainUsage[domainID] = leaf.tasUsage
+						}
+					}
+					gotTASUsage[flavor] = domainUsage
+				}
+				usageCmpOpts := cmp.Options{cmp.Comparer(resources.Equal)}
+				if diff := cmp.Diff(tc.wantTASUsage, gotTASUsage, usageCmpOpts...); diff != "" {
+					t.Errorf("unexpected TAS usage in the flavor snapshots (-want,+got):\n%s", diff)
+				}
+			} else if diff := cmp.Diff(tc.wantSnapshot, *snapshot, snapCmpOpts...); len(diff) != 0 {
 				t.Errorf("Unexpected Snapshot (-want,+got):\n%s", diff)
 			}
+
 			for _, cq := range snapshot.ClusterQueues() {
 				for i := range cq.ResourceGroups {
 					rg := &cq.ResourceGroups[i]

--- a/pkg/cache/scheduler/tas_flavor.go
+++ b/pkg/cache/scheduler/tas_flavor.go
@@ -142,9 +142,7 @@ func (c *TASFlavorCache) snapshot(
 	if features.Enabled(features.TASHandleOverlappingFlavors) && aggregatedDomainUsages != nil {
 		tasDomainUsages = aggregatedDomainUsages
 	}
-	for domainID, usage := range tasDomainUsages {
-		snapshot.addTASUsage(domainID, usage)
-	}
+	snapshot.addTASUsageForHeldDomains(tasDomainUsages)
 	c.nonTasUsageCache.forEachNodeUsage(func(nodeName string, usage resources.Requests) {
 		if domainID, ok := nodeToDomain[nodeName]; ok {
 			snapshot.addNonTASUsage(domainID, usage)

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -318,6 +318,31 @@ func (s *TASFlavorSnapshot) getRemainingCapacity(leaf *leafDomain) resources.Req
 	return leaf.cachedRemainingCapacity.Get()
 }
 
+// hasDomain reports whether the domain has a leaf in the snapshot, i.e. whether
+// it holds a node the flavor selects.
+func (s *TASFlavorSnapshot) hasDomain(domainID utiltas.TopologyDomainID) bool {
+	return s.leaves[domainID] != nil
+}
+
+// addTASUsageForHeldDomains adds usage only for domains this snapshot has a leaf
+// for. With TASHandleOverlappingFlavors, usages can cover far more domains than
+// the flavor selects, so it walks whichever side is smaller.
+func (s *TASFlavorSnapshot) addTASUsageForHeldDomains(usages map[utiltas.TopologyDomainID]resources.Requests) {
+	if len(s.leaves) < len(usages) {
+		for domainID := range s.leaves {
+			if usage, found := usages[domainID]; found {
+				s.addTASUsage(domainID, usage)
+			}
+		}
+		return
+	}
+	for domainID, usage := range usages {
+		if s.hasDomain(domainID) {
+			s.addTASUsage(domainID, usage)
+		}
+	}
+}
+
 func (s *TASFlavorSnapshot) addTASUsage(domainID utiltas.TopologyDomainID, usage resources.Requests) {
 	if s.leaves[domainID] == nil {
 		// this can happen if there is an admitted workload for which the


### PR DESCRIPTION
Manual cherry-pick of #14174 onto `release-0.18`. The automated cherry-pick (from `/cherrypick release-0.18`) failed to apply because #14174 was rebased onto current `main`, which diverged from this branch.

The production fix applied cleanly. Adaptations for `release-0.18`:
- The test reads a leaf's usage via `leaf.tasUsage` directly, since this branch has no `leafCapacityOf` accessor.
- The three scenarios are consolidated into the existing `TestSnapshot` table. The relabel case sets the cached flavor's `NodeLabels` directly, since this branch has no in-place ResourceFlavor relabel path (`AddOrUpdateResourceFlavor` is add-only here).
- The perf benchmark from #14174 is omitted: it depends on TAS cache internals (the simulator/formatter and the `snapshot` signature) that differ on this branch. The fix's correctness is covered by the three `TestSnapshot` cases.

`gofmt`, `go vet`, and `go test ./pkg/cache/scheduler/...` pass.

/cc @tenzen-y

```release-note
TAS: Fixed a bug where cross-flavor TAS usage was matched against topology domains a ResourceFlavor does not hold, adding redundant per-node work and V(3) log lines to every scheduling cycle.
```
