### PR TITLE
Fix PositionInLocalQueue collision for same-named LocalQueues across namespaces

### DIFF
--- a/pkg/visibility/storage/pending_workloads_cq.go
+++ b/pkg/visibility/storage/pending_workloads_cq.go
@@ -30,6 +30,7 @@ import (
 	visibility "sigs.k8s.io/kueue/apis/visibility/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	"sigs.k8s.io/kueue/pkg/constants"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 
 	_ "k8s.io/metrics/pkg/apis/metrics/install"
 )
@@ -73,14 +74,14 @@ func (m *pendingWorkloadsInCqREST) Get(_ context.Context, name string, opts runt
 	}
 	wls := make([]visibility.PendingWorkload, 0, min(limit, int64(len(pendingWorkloadsInfo))))
 
-	localQueuePositions := make(map[kueue.LocalQueueName]int32, 0)
+	localQueuePositions := make(map[utilqueue.LocalQueueReference]int32, 0)
 
 	for index := 0; index < int(offset+limit) && index < len(pendingWorkloadsInfo); index++ {
 		// Update positions in LocalQueue
 		wlInfo := pendingWorkloadsInfo[index]
-		queueName := wlInfo.Obj.Spec.QueueName
-		positionInLocalQueue := localQueuePositions[queueName]
-		localQueuePositions[queueName]++
+		queueKey := utilqueue.KeyFromWorkload(wlInfo.Obj)
+		positionInLocalQueue := localQueuePositions[queueKey]
+		localQueuePositions[queueKey]++
 
 		if index >= int(offset) {
 			// Add a workload to results

--- a/pkg/visibility/storage/pending_workloads_cq_test.go
+++ b/pkg/visibility/storage/pending_workloads_cq_test.go
@@ -39,6 +39,7 @@ import (
 func TestPendingWorkloadsInCQ(t *testing.T) {
 	const (
 		nsName   = "foo"
+		nsNameB  = "bar"
 		cqNameA  = "cqA"
 		lqNameA  = "lqA"
 		lqNameB  = "lqB"
@@ -355,6 +356,48 @@ func TestPendingWorkloadsInCQ(t *testing.T) {
 						Priority:               highPrio,
 						PositionInClusterQueue: 1,
 						PositionInLocalQueue:   1,
+					}},
+			},
+		},
+		"same LocalQueue name reused across different namespaces reports position within each namespace's own LocalQueue": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue(cqNameA).Obj(),
+			},
+			queues: []*kueue.LocalQueue{
+				utiltestingapi.MakeLocalQueue(lqNameA, nsName).ClusterQueue(cqNameA).Obj(),
+				utiltestingapi.MakeLocalQueue(lqNameA, nsNameB).ClusterQueue(cqNameA).Obj(),
+			},
+			workloads: []*kueue.Workload{
+				utiltestingapi.MakeWorkload("a", nsName).Queue(lqNameA).Priority(highPrio).Creation(now).Obj(),
+				utiltestingapi.MakeWorkload("b", nsNameB).Queue(lqNameA).Priority(highPrio).Creation(now.Add(time.Second)).Obj(),
+			},
+			req: &req{
+				queueName:   cqNameA,
+				queryParams: defaultQueryParams,
+			},
+			wantResp: &resp{
+				wantPendingWorkloads: []visibility.PendingWorkload{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "a",
+							Namespace:         nsName,
+							CreationTimestamp: metav1.NewTime(now),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 0,
+						PositionInLocalQueue:   0,
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "b",
+							Namespace:         nsNameB,
+							CreationTimestamp: metav1.NewTime(now.Add(time.Second)),
+						},
+						LocalQueueName:         lqNameA,
+						Priority:               highPrio,
+						PositionInClusterQueue: 1,
+						PositionInLocalQueue:   0,
 					}},
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The ClusterQueue `pendingworkloads` visibility endpoint computed each Workload's
`PositionInLocalQueue` by keying a per-request map on `Spec.QueueName` alone, which
is a bare LocalQueue name with no namespace. A LocalQueue is actually identified by
`(namespace, name)`, and one ClusterQueue routinely serves LocalQueues from many
namespaces — including the `default` LocalQueue that Kueue's own pod webhook and job
defaulting create in every namespace. Two LocalQueues that share a name in different
namespaces therefore shared one counter, so a Workload that was first in its own
LocalQueue could be reported at a nonzero position, as if it were queued behind
Workloads in an unrelated namespace's LocalQueue of the same name. The error only
ever inflates the reported position, never deflates it.

This PR keys the per-request position map on the full `(namespace, name)` LocalQueue
reference instead, using the existing `utilqueue.KeyFromWorkload` helper — the same
approach the sibling LocalQueue-scoped endpoint already uses to scope by namespace.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

This repo runs CI via Prow rather than GitHub Actions PR workflows, so there is no
GitHub Actions run on `main` to compare against. Locally I ran:
- `go build ./...`
- `go vet ./pkg/visibility/... ./pkg/util/queue/...`
- `golangci-lint run ./pkg/visibility/storage/...` (0 issues)
- `gofmt -l` on both changed files (no output)
- `go test ./pkg/visibility/... ./pkg/util/queue/...` (all pass)

I added a regression test with two LocalQueues named `lqA` in namespaces `foo` and
`bar`, each with one pending Workload, asserting both report `PositionInLocalQueue: 0`.
I verified this test fails without the fix (the second workload was reported at
position 1) and passes with it, by temporarily stashing the source change and
re-running the test.

No API, CRD, or generated files were touched, so `make verify`'s codegen-drift checks
are not applicable to this change.

#### Does this PR introduce a user-facing change?

```release-note
VisibilityOnDemand: Fixed a bug where the `PositionInLocalQueue` on the ClusterQueue `pendingworkloads` was being inflated when two LocalQueues in different namespaces share the same name (for example, the auto-created `default` LocalQueue).
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #14400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pending workload position tracking for LocalQueues with the same name in different namespaces.
  * Workloads now receive accurate positions within their respective queues and distinct cluster queues.

* **Tests**
  * Added coverage verifying namespace-specific queue handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->