### PR TITLE
Reject conflicting node-label values from flavors assigned to one PodSet

### DIFF
--- a/pkg/podset/podset.go
+++ b/pkg/podset/podset.go
@@ -84,6 +84,9 @@ func FromAssignment(ctx context.Context, client client.Client, assignment *kueue
 		if err := client.Get(ctx, types.NamespacedName{Name: string(flvRef)}, &flv); err != nil {
 			return info, err
 		}
+		if err := utilmaps.HaveConflict(info.NodeSelector, flv.Spec.NodeLabels); err != nil {
+			return info, BadPodSetsUpdateError("nodeSelector", err)
+		}
 		utilmaps.Copy(&info.NodeSelector, flv.Spec.NodeLabels)
 		info.Tolerations = append(info.Tolerations, flv.Spec.Tolerations...)
 

--- a/pkg/podset/podset_test.go
+++ b/pkg/podset/podset_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podset
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -256,6 +257,40 @@ func TestFromAssignment(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestFromAssignmentConflictingFlavorNodeLabels verifies that two assigned
+// flavors that set the same node-label key to different values are reported
+// as a conflict, rather than silently resolved by map-iteration order.
+func TestFromAssignmentConflictingFlavorNodeLabels(t *testing.T) {
+	const zoneKey = "topology.kubernetes.io/zone"
+	flavorA := utiltestingapi.MakeResourceFlavor("flavor-a").
+		NodeLabel(zoneKey, "zone-a").
+		Obj()
+	flavorB := utiltestingapi.MakeResourceFlavor("flavor-b").
+		NodeLabel(zoneKey, "zone-b").
+		Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	client := utiltesting.NewClientBuilder().
+		WithLists(&kueue.ResourceFlavorList{Items: []kueue.ResourceFlavor{*flavorA.DeepCopy(), *flavorB.DeepCopy()}}).
+		Build()
+
+	assignment := &kueue.PodSetAssignment{
+		Name: "main",
+		Flavors: map[corev1.ResourceName]kueue.ResourceFlavorReference{
+			corev1.ResourceCPU:            kueue.ResourceFlavorReference(flavorA.Name),
+			corev1.ResourceName("gpu.io"): kueue.ResourceFlavorReference(flavorB.Name),
+		},
+	}
+	podSet := kueue.PodSet{Count: 1}
+
+	for range 20 {
+		_, gotErr := FromAssignment(ctx, client, assignment, &podSet)
+		if !errors.Is(gotErr, ErrInvalidPodSetUpdate) {
+			t.Fatalf("FromAssignment() error = %v, want error wrapping %v", gotErr, ErrInvalidPodSetUpdate)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`FromAssignment` in `pkg/podset/podset.go` builds a Pod's `nodeSelector` by iterating `assignment.Flavors` (a Go map, so iteration order is randomized) and copying each assigned flavor's `Spec.NodeLabels` into the result with `utilmaps.Copy`, which is last-writer-wins and does not detect conflicts. When a single PodSet is assigned two different ResourceFlavors that both set the same node-label key to different values, the resulting `nodeSelector` value is whichever flavor the map happened to be visited last — nondeterministic across reconciles of the same Workload.

`PodSetInfo.Merge` already treats this same class of conflict (on `NodeSelector`, `Annotations`, `Labels`) as a hard error via `utilmaps.HaveConflict` before copying. This PR applies the same check to the flavor-label copy in `FromAssignment`, so a genuine conflict between two assigned flavors now surfaces as an admission error (wrapping `ErrInvalidPodSetUpdate`, already handled by `podset.IsPermanent` in `pkg/controller/jobframework/reconciler.go` to fail the workload cleanly) instead of resolving randomly.

#### Which issue(s) this PR fixes:
Fixes #

#### Special notes for your reviewer:

This is a narrow fix scoped to `pkg/podset/podset.go` (3 lines) plus a regression test (`pkg/podset/podset_test.go`). No other call sites needed changes — all three callers of `FromAssignment` already propagate the returned error.

Validation:
- `go build ./...` passes.
- `go test ./pkg/podset/... ./pkg/controller/jobframework/... ./pkg/controller/admissionchecks/provisioning/... ./pkg/controller/tas/...` all pass.
- `golangci-lint run ./pkg/podset/...` reports 0 issues.
- Added `TestFromAssignmentConflictingFlavorNodeLabels`, which assigns two ResourceFlavors that both set `topology.kubernetes.io/zone` to different values to one PodSet and asserts the call fails with `ErrInvalidPodSetUpdate`, run across 20 iterations to cover Go's randomized map-iteration order. Verified this test fails 10/10 times when the `podset.go` fix is reverted (`git stash push -- pkg/podset/podset.go`), and passes consistently with the fix applied — i.e. it reproduces the reported nondeterminism and proves the fix.
- No CRD/API changes, so no codegen/manifest regeneration was required.
- This repo's PR CI runs on Prow rather than the GitHub Actions in `.github/workflows/` (those only cover release chatops, krew, SBOM, and dependabot sync), so the commands above are the closest locally-runnable mirror of what CI enforces for a change of this kind.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a PodSet assigned two ResourceFlavors that set the same node-label key to different values could get a nondeterministic `nodeSelector` value, varying across reconciles. Kueue now rejects such an assignment as a conflict instead of silently picking one value by map-iteration order.
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #14409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Conflicting node labels from assigned resource flavors are now detected and rejected.
  - Invalid pod set updates return a clear error instead of silently merging conflicting values.
- **Tests**
  - Added regression coverage to verify consistent error handling for conflicting flavor labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->