### PR TITLE
Report the scheduler library when it is the only reason nodes were excluded

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -493,8 +493,10 @@ func newTASExclusionStats() *tasExclusionStats {
 	return &tasExclusionStats{}
 }
 
+// hasExclusions reports whether formatReasons has anything to say.
 func (s *tasExclusionStats) hasExclusions() bool {
-	return s.NodeSelector > 0 || s.Affinity > 0 || len(s.Taints) > 0 || s.TopologyDomain > 0 || len(s.Resources) > 0
+	return s.NodeSelector > 0 || s.Affinity > 0 || len(s.Taints) > 0 || s.TopologyDomain > 0 ||
+		s.SchedulerLibraryNoFit > 0 || len(s.Resources) > 0
 }
 
 func (s *tasExclusionStats) formatReasons() string {

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -34,6 +34,7 @@ import (
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/tas"
@@ -1599,4 +1600,39 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 			t.Errorf("Observed leaf domain fields mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestExclusionStatsReportEveryReasonTheyFormat(t *testing.T) {
+	cases := map[string]struct {
+		stats *tasExclusionStats
+		want  string
+	}{
+		"the scheduler library on its own": {
+			stats: &tasExclusionStats{
+				NodeExclusionStats: simulator.NodeExclusionStats{SchedulerLibraryNoFit: 2},
+			},
+			want: "schedulerLibraryNoFit: 2",
+		},
+		"the scheduler library beside another reason": {
+			stats: &tasExclusionStats{
+				NodeExclusionStats: simulator.NodeExclusionStats{NodeSelector: 1, SchedulerLibraryNoFit: 2},
+			},
+			want: "nodeSelector: 1, schedulerLibraryNoFit: 2",
+		},
+		"nothing excluded": {
+			stats: &tasExclusionStats{},
+			want:  "",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			var got string
+			if tc.stats.hasExclusions() {
+				got = tc.stats.formatReasons()
+			}
+			if got != tc.want {
+				t.Errorf("reported %q, want %q", got, tc.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area tas

/area was

#### What this PR does / why we need it:

`formatReasons` has known how to print `schedulerLibraryNoFit` since the simulator interface landed. `hasExclusions` never learned about it:

```go
func (s *tasExclusionStats) hasExclusions() bool {
	return s.NodeSelector > 0 || s.Affinity > 0 || len(s.Taints) > 0 || s.TopologyDomain > 0 || len(s.Resources) > 0
}
```

That's the gate on whether the caller appends the summary at all, in both `notFitMessage` and `multiLayerNotFitMessage`:

```go
if stats.hasExclusions() {
	fmt.Fprintf(&builder, ". Total nodes: %d; excluded: %s", stats.TotalNodes, stats.formatReasons())
}
```

So when the scheduler library is the only thing rejecting nodes, the string it would have printed is thrown away. The Workload's message stops at the fit count, and the operator is left with a topology that doesn't fit and no reason:

```
scheduler library alone      hasExclusions=false  formatReasons="schedulerLibraryNoFit: 5"
one nodeSelector as well     hasExclusions=true   formatReasons="nodeSelector: 1, schedulerLibraryNoFit: 4"
```

Adding one rejection of any other kind brings the whole summary back, scheduler library count included, which is what makes this easy to miss.

#### Which issue(s) this PR fixes:

None filed; I found this reading the two functions against each other while looking at something else in the same file.

#### Special notes for your reviewer:

The test pins the two functions against each other rather than the message text, since the defect is that they disagree about the same field. Reverting the production line turns the scheduler library case red on `reported "", want "schedulerLibraryNoFit: 2"` and leaves the other two green, so the existing reasons keep the answer they had.

I had the build tag backwards in an earlier version of this description and want to correct it here rather than quietly. The simulator carries `//go:build !exclude_scheduler_library`, so it is compiled in by default and the stub only takes over when someone builds it out. Driving this end to end is therefore possible: turn on `SchedulerLibraryIntegration` and give it a Pod the library rejects for a reason nothing else rejects it for.

I did not write that. The gate is Alpha and off by default, nothing in the repo enables it in a test today, and standing up the first such harness for a message that is missing a clause seemed out of proportion. Say the word if you would rather have it and I will.

#### Does this PR introduce a user-facing change?

```release-note
TAS: fixed the "Total nodes; excluded" summary being left off a Workload's message when the scheduler library integration was the only thing that rejected nodes.
```

---

This pull request was written in part with the assistance of generative AI. The two lines of output above come from a probe I ran against this code, and I ran the test in the diff both ways.