### PR TITLE
Fix the stale FairSharing config in the Helm e2e values

### DIFF
--- a/pkg/config/e2e_config_test.go
+++ b/pkg/config/e2e_config_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	configapiv1beta1 "sigs.k8s.io/kueue/apis/config/v1beta1"
+	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
+)
+
+// TestE2EHelmValuesConfigsAreValid loads the controller configuration embedded in
+// the Helm e2e values files and validates it. The Helm e2e path is not exercised
+// by the presubmits, so a bad value there would otherwise go unnoticed, as a
+// fairSharing: {} block did once preemptionStrategies became required.
+func TestE2EHelmValuesConfigsAreValid(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{configapiv1beta1.AddToScheme, configapi.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	integrationManager := jobs.NewIntegrationManager()
+
+	files, err := filepath.Glob(filepath.Join("..", "..", "test", "e2e", "config", "*", "values.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no Helm e2e values files found")
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			raw, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var values struct {
+				ManagerConfig struct {
+					ControllerManagerConfigYaml string `json:"controllerManagerConfigYaml"`
+				} `json:"managerConfig"`
+			}
+			if err := yaml.Unmarshal(raw, &values); err != nil {
+				t.Fatalf("parse values.yaml: %v", err)
+			}
+			embedded := values.ManagerConfig.ControllerManagerConfigYaml
+			if embedded == "" {
+				t.Skip("no embedded controllerManagerConfigYaml")
+			}
+			configFile := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(configFile, []byte(embedded), 0600); err != nil {
+				t.Fatal(err)
+			}
+			_, cfg, err := Load(scheme, configFile)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if errs := Validate(&cfg, scheme, integrationManager); len(errs) > 0 {
+				t.Errorf("embedded controller config is invalid: %v", errs.ToAggregate())
+			}
+		})
+	}
+}

--- a/test/e2e/config/default/values.yaml
+++ b/test/e2e/config/default/values.yaml
@@ -52,7 +52,8 @@ managerConfig:
         LocalQueue.kueue.x-k8s.io: 5
         ClusterQueue.kueue.x-k8s.io: 5
         ResourceFlavor.kueue.x-k8s.io: 1
-    fairSharing: {}
+    fairSharing:
+      preemptionStrategies: ["LessThanOrEqualToFinalShare", "LessThanInitialShare"]
     clientConnection:
       qps: 300
       burst: 500


### PR DESCRIPTION
#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
`test/e2e/config/default/values.yaml` — the values consumed by the Helm e2e install (`test-e2e-*-helm`, `E2E_USE_HELM=true`) — embeds a v1beta2 controller `Configuration` whose `fairSharing` block is:

```yaml
fairSharing: {}
```

`fairSharing.preemptionStrategies` was intentionally made required for v1beta2 in #7948 (the native defaulter was removed, the field's `omitempty` was dropped, and empty-list validation was added; the v1beta1→v1beta2 conversion keeps a default only for upgrade compatibility). So `fairSharing: {}` fails config validation, and a Helm-based install stops the manager at startup with:

```
fairSharing.preemptionStrategies: Required value: must be specified
```

#7948 fixed the non-Helm e2e config (`test/e2e/config/default/controller_manager_config.yaml` already specifies the strategy pair) but missed this duplicated copy in the Helm values. The Kueue presubmits run `test-e2e-baseline`, not `test-e2e-baseline-helm`, so the Helm path — and this drift — is not covered.

This PR:
- sets the explicit strategy pair in the Helm values, matching the non-Helm config;
- adds `TestE2EHelmValuesConfigsAreValid`, which loads and runs full `config.Validate` on the controller config embedded in every `test/e2e/config/*/values.yaml`, so an invalid embedded config in any Helm e2e values file fails a unit test rather than only surfacing in an un-gated Helm e2e run.

#### Which issue(s) this PR fixes:
None filed separately; details above.

#### Special notes for your reviewer:
The added test fails with `fairSharing.preemptionStrategies: Required value: must be specified` against the pre-fix fixture. The v1beta2 API contract is unchanged — `fairSharing.preemptionStrategies` stays required.

Prepared with AI assistance (Claude Code): the failure was reproduced by reverting the fixture against the added test. Per the project's AI contribution policy this is disclosed here; the commit carries no AI trailers.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```
