### PR TITLE
Stop an out-of-sync prebuilt Job before finishing its Workload

### DIFF
--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -98,6 +98,14 @@ type JobWithCustomStop interface {
 	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) (bool, error)
 }
 
+// JobWithStopAcknowledgement is implemented by integrations whose stop is carried out
+// asynchronously by another controller, so the framework can wait for that controller to confirm
+// it before releasing resources rather than trusting that submitting the stop removed the pods.
+type JobWithStopAcknowledgement interface {
+	// StopAcknowledged reports whether the stop is complete: no pods remain or will be recreated.
+	StopAcknowledged() bool
+}
+
 // JobWithFinalize is an optional interface that should be implemented by generic jobs
 // when custom finalization logic is needed for a job after it has finished.
 type JobWithFinalize interface {

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -101,6 +101,10 @@ type JobWithCustomStop interface {
 // JobWithStopAcknowledgement is implemented by integrations whose stop is carried out
 // asynchronously by another controller, so the framework can wait for that controller to confirm
 // it before releasing resources rather than trusting that submitting the stop removed the pods.
+//
+// Leaving it out is not a claim that the stop is synchronous. The framework then holds on IsActive
+// alone, which is where every integration was before this interface existed, so one whose
+// controller can still act on a pre-stop view is only as covered as its IsActive makes it.
 type JobWithStopAcknowledgement interface {
 	// StopAcknowledged reports whether the stop is complete: no pods remain or will be recreated.
 	StopAcknowledged() bool

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -99,10 +99,11 @@ type JobWithCustomStop interface {
 }
 
 // JobWithStopAcknowledgement is implemented by integrations whose stop is another controller's
-// work, so the framework can wait for it. Leaving it out falls back to IsActive alone.
+// work, so the framework can wait for it. What the report proves varies by integration: it cannot
+// tell this stop from an earlier one, and how far it reaches into the job's own children is up to
+// the integration. IsActive is read with it, and leaving it out falls back to IsActive alone.
 type JobWithStopAcknowledgement interface {
-	// StopAcknowledged reports whether that controller has said it acted on the stop. How far it
-	// reaches into the job's own children is up to the integration, so IsActive is read with it.
+	// StopAcknowledged reports whether that controller has said it acted on a stop.
 	StopAcknowledged() bool
 }
 

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -106,7 +106,9 @@ type JobWithCustomStop interface {
 // alone, which is where every integration was before this interface existed, so one whose
 // controller can still act on a pre-stop view is only as covered as its IsActive makes it.
 type JobWithStopAcknowledgement interface {
-	// StopAcknowledged reports whether the stop is complete: no pods remain or will be recreated.
+	// StopAcknowledged reports whether the controller that owns the job has reported acting on
+	// the stop. How far down its own children that reaches is up to the integration, so this is
+	// read together with IsActive rather than on its own.
 	StopAcknowledged() bool
 }
 

--- a/pkg/controller/jobframework/interface.go
+++ b/pkg/controller/jobframework/interface.go
@@ -98,17 +98,11 @@ type JobWithCustomStop interface {
 	Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, stopReason StopReason, eventMsg string) (bool, error)
 }
 
-// JobWithStopAcknowledgement is implemented by integrations whose stop is carried out
-// asynchronously by another controller, so the framework can wait for that controller to confirm
-// it before releasing resources rather than trusting that submitting the stop removed the pods.
-//
-// Leaving it out is not a claim that the stop is synchronous. The framework then holds on IsActive
-// alone, which is where every integration was before this interface existed, so one whose
-// controller can still act on a pre-stop view is only as covered as its IsActive makes it.
+// JobWithStopAcknowledgement is implemented by integrations whose stop is another controller's
+// work, so the framework can wait for it. Leaving it out falls back to IsActive alone.
 type JobWithStopAcknowledgement interface {
-	// StopAcknowledged reports whether the controller that owns the job has reported acting on
-	// the stop. How far down its own children that reaches is up to the integration, so this is
-	// read together with IsActive rather than on its own.
+	// StopAcknowledged reports whether that controller has said it acted on the stop. How far it
+	// reaches into the job's own children is up to the integration, so IsActive is read with it.
 	StopAcknowledged() bool
 }
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1015,7 +1015,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			return wl, nil
 		}
 
-		if inSync, err := r.ensurePrebuiltWorkloadInSync(ctx, wl, job); !inSync || err != nil {
+		if useWorkload, err := r.ensurePrebuiltWorkloadInSync(ctx, wl, job); !useWorkload || err != nil {
 			return nil, err
 		}
 		return wl, nil
@@ -1355,6 +1355,9 @@ func EnsurePrebuiltWorkloadOwnership(ctx context.Context, c client.Client, wl *k
 	return nil
 }
 
+// ensurePrebuiltWorkloadInSync reports whether the workload is the one to carry
+// on with. One that no longer matches its job is finished here, after the job is
+// stopped and its pods are gone, and handed back so the caller finalizes it.
 func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *kueue.Workload, job GenericJob) (bool, error) {
 	var (
 		equivalent bool
@@ -1367,13 +1370,28 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *ku
 		equivalent, err = EquivalentToWorkload(ctx, r.client, job, wl)
 	}
 
-	if !equivalent || err != nil {
-		if err != nil {
-			return false, err
-		}
-		// mark the workload as finished
-		msg := "The prebuilt workload is out of sync with its user job"
-		return false, workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock)
+	if err != nil {
+		return false, err
+	}
+	if equivalent {
+		return true, nil
+	}
+
+	// A job that ended keeps the reason it ended with, which the caller writes.
+	if _, _, finished := job.Finished(ctx); finished {
+		return true, nil
+	}
+
+	msg := "The prebuilt workload is out of sync with its user job"
+	// Finishing gives the quota back, and the pods hold it until the job stops.
+	if err := r.stopJob(ctx, job, wl, StopReasonNoMatchingWorkload, msg); err != nil {
+		return false, err
+	}
+	if job.IsActive() {
+		return false, nil
+	}
+	if err := workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock); err != nil {
+		return false, err
 	}
 	return true, nil
 }

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -316,6 +316,9 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err = r.ignoreUnretryableError(log, err)
 	}()
 
+	// loadJob normalizes req.NamespacedName in place (pod groups rewrite it to the lead pod),
+	// so keep the original for a later reload of the same job.
+	reconcileKey := req.NamespacedName
 	shouldFinalize, err := r.loadJob(ctx, &req.NamespacedName, job)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -420,8 +423,12 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	log.V(2).Info("Reconciling Job")
 
 	// 1. Attempt to retrieve an existing workload (if any) for this job.
-	wl, err := r.ensureOneWorkload(ctx, job, object)
+	wl, err := r.ensureOneWorkload(ctx, reconcileKey, job, object)
 	if err != nil {
+		// A prebuilt job still stopping ends the reconcile; its status change re-triggers us.
+		if errors.Is(err, errWaitingForStop) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -979,7 +986,7 @@ func (r *JobReconciler) syncWorkloadSlicePriority(ctx context.Context, job Gener
 // ensureOneWorkload will query for the single matched workload corresponding to job and return it.
 // If there are more than one workload, we should delete the excess ones.
 // The returned workload could be nil.
-func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, object client.Object) (*kueue.Workload, error) {
+func (r *JobReconciler) ensureOneWorkload(ctx context.Context, key types.NamespacedName, job GenericJob, object client.Object) (*kueue.Workload, error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	if prebuiltWorkload := PrebuiltWorkloadNameFor(job.Object()); prebuiltWorkload != "" {
@@ -1015,8 +1022,14 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, job GenericJob, o
 			return wl, nil
 		}
 
-		if useWorkload, err := r.ensurePrebuiltWorkloadInSync(ctx, wl, job); !useWorkload || err != nil {
+		state, err := r.ensurePrebuiltWorkloadInSync(ctx, key, wl, job)
+		switch {
+		case err != nil:
 			return nil, err
+		case state == prebuiltWaitingForStop:
+			return nil, errWaitingForStop
+		case state == prebuiltNoUsableWorkload:
+			return nil, nil
 		}
 		return wl, nil
 	}
@@ -1355,45 +1368,77 @@ func EnsurePrebuiltWorkloadOwnership(ctx context.Context, c client.Client, wl *k
 	return nil
 }
 
-// ensurePrebuiltWorkloadInSync reports whether the workload is the one to carry
-// on with. One that no longer matches its job is finished here, after the job is
-// stopped and its pods are gone, and handed back so the caller finalizes it.
-func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, wl *kueue.Workload, job GenericJob) (bool, error) {
+// prebuiltSyncState is the outcome of reconciling a prebuilt workload against its job.
+type prebuiltSyncState int
+
+const (
+	prebuiltUseWorkload      prebuiltSyncState = iota // carry on with the workload
+	prebuiltWaitingForStop                            // job is stopping; end the reconcile
+	prebuiltNoUsableWorkload                          // job is gone; fall back to the no-workload path
+)
+
+// errWaitingForStop ends the reconcile while a prebuilt job stops; its status change re-triggers us.
+var errWaitingForStop = errors.New("waiting for the job to stop")
+
+// ensurePrebuiltWorkloadInSync decides what to do with a prebuilt workload that may no longer
+// match its job. A mismatched workload is finished only after the job is stopped and its pods are
+// gone, so quota is never released while pods still hold it.
+func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key types.NamespacedName, wl *kueue.Workload, job GenericJob) (prebuiltSyncState, error) {
 	var (
 		equivalent bool
 		err        error
 	)
-
 	if cj, implements := job.(ComposableJob); implements {
 		equivalent, err = cj.EquivalentToWorkload(ctx, r.client, wl)
 	} else {
 		equivalent, err = EquivalentToWorkload(ctx, r.client, job, wl)
 	}
-
 	if err != nil {
-		return false, err
+		return prebuiltWaitingForStop, err
 	}
 	if equivalent {
-		return true, nil
+		return prebuiltUseWorkload, nil
 	}
 
-	// A job that ended keeps the reason it ended with, which the caller writes.
+	// A finished job keeps the reason it ended with, which the caller writes.
 	if _, _, finished := job.Finished(ctx); finished {
-		return true, nil
+		return prebuiltUseWorkload, nil
 	}
 
 	msg := "The prebuilt workload is out of sync with its user job"
-	// Finishing gives the quota back, and the pods hold it until the job stops.
 	if err := r.stopJob(ctx, job, wl, StopReasonNoMatchingWorkload, msg); err != nil {
-		return false, err
+		return prebuiltWaitingForStop, err
 	}
-	if job.IsActive() {
-		return false, nil
+	// Release quota only once the stop is real: IsActive can be a stale false, and an async
+	// controller may still create pods from a view older than the stop.
+	// TODO(#13308,#13163): obey QuotaReleaseStrategy here so OutOfSync matches eviction.
+	if job.IsActive() || !stopAcknowledged(job) {
+		return prebuiltWaitingForStop, nil
+	}
+	// The job may have finished while stopping; re-read before writing OutOfSync, which is
+	// permanent and, under MultiKueue, re-dispatches an already finished job.
+	reloadKey := key
+	if gone, err := r.loadJob(ctx, &reloadKey, job); err != nil {
+		return prebuiltWaitingForStop, err
+	} else if gone {
+		return prebuiltNoUsableWorkload, nil
+	}
+	if _, _, finished := job.Finished(ctx); finished {
+		return prebuiltUseWorkload, nil
 	}
 	if err := workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock); err != nil {
-		return false, err
+		return prebuiltWaitingForStop, err
 	}
-	return true, nil
+	return prebuiltUseWorkload, nil
+}
+
+// stopAcknowledged reports whether an async stop has been confirmed by its controller; jobs
+// stopped synchronously have nothing extra to wait for beyond IsActive.
+func stopAcknowledged(job GenericJob) bool {
+	if ack, ok := job.(JobWithStopAcknowledgement); ok {
+		return ack.StopAcknowledged()
+	}
+	return true
 }
 
 // expectedRunningPodSets gets the expected podsets during the job execution, returns nil if the workload has no reservation or

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -424,8 +424,11 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// 1. Attempt to retrieve an existing workload (if any) for this job.
 	wl, err := r.ensureOneWorkload(ctx, reconcileKey, job, object)
 	if err != nil {
-		// A prebuilt job still stopping ends the reconcile; its status change re-triggers us.
-		if errors.Is(err, errWaitingForStop) {
+		// Neither is retryable; only the stopping one is worth coming back to.
+		switch {
+		case errors.Is(err, errWaitingForStop):
+			return ctrl.Result{RequeueAfter: stopWaitRequeueAfter}, nil
+		case errors.Is(err, errFinishedJobGone):
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -1029,6 +1032,12 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, key types.Namespa
 			return nil, errWaitingForStop
 		case state == prebuiltNoUsableWorkload:
 			return nil, nil
+		case state == prebuiltFinishedJobGone:
+			// Removed here because every caller path that would do it reads the job first.
+			if err := workload.RemoveFinalizer(ctx, r.client, wl); err != nil {
+				return nil, err
+			}
+			return nil, errFinishedJobGone
 		}
 		return wl, nil
 	}
@@ -1374,10 +1383,17 @@ const (
 	prebuiltUseWorkload      prebuiltSyncState = iota // carry on with the workload
 	prebuiltWaitingForStop                            // job is stopping; end the reconcile
 	prebuiltNoUsableWorkload                          // job is gone; fall back to the no-workload path
+	prebuiltFinishedJobGone                           // workload is finished; its job is gone or replaced
 )
 
 // errWaitingForStop ends the reconcile while a prebuilt job stops; its status change re-triggers us.
 var errWaitingForStop = errors.New("waiting for the job to stop")
+
+// stopWaitRequeueAfter polls a stopping prebuilt job, in case its status update never comes.
+const stopWaitRequeueAfter = 2 * time.Second
+
+// errFinishedJobGone ends the reconcile so nothing downstream reads a job that is not the workload's.
+var errFinishedJobGone = errors.New("the finished workload's job is gone")
 
 // ensurePrebuiltWorkloadInSync decides what to do with a prebuilt workload that may no longer
 // match its job. A mismatched workload is finished only after the job is stopped and its pods are
@@ -1400,7 +1416,10 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	if err := r.correctOutOfSync(ctx, wl, job); err != nil {
 		return prebuiltWaitingForStop, err
 	}
-	if equivalent {
+	// Checked after the correction, which clears it for an ended job. A match does not restore the
+	// quota an earlier out-of-sync finish released, so the job still has to be stopped.
+	recovering := finishedOutOfSync(wl)
+	if equivalent && !recovering {
 		return prebuiltUseWorkload, nil
 	}
 
@@ -1411,7 +1430,12 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 
 	uid := job.Object().GetUID()
 	msg := "The prebuilt workload is out of sync with its user job"
-	stoppedNow, err := r.stopJob(ctx, job, wl, StopReasonNoMatchingWorkload, msg)
+	stopReason, stopMsg := StopReasonNoMatchingWorkload, msg
+	if recovering {
+		// The finish an earlier pass wrote is what stops the job now, not the mismatch.
+		stopReason, stopMsg = StopReasonWorkloadFinished, "The prebuilt workload is already finished"
+	}
+	stoppedNow, err := r.stopJob(ctx, job, wl, stopReason, stopMsg)
 	if err != nil {
 		return prebuiltWaitingForStop, err
 	}
@@ -1453,12 +1477,23 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	postWriteKey := key
 	if gone, err := r.loadJob(ctx, &postWriteKey, job); err != nil {
 		return prebuiltWaitingForStop, err
-	} else if !gone && job.Object().GetUID() == uid {
-		if err := r.correctOutOfSync(ctx, wl, job); err != nil {
-			return prebuiltWaitingForStop, err
-		}
+	} else if gone || job.Object().GetUID() != uid {
+		// Deleted, deleting, or replaced: finalizing it would strip another job's pod finalizer. A
+		// ComposableJob's UID is one member's, so a group that lost a member also lands here.
+		ctrl.LoggerFrom(ctx).V(3).Info("Releasing a finished prebuilt workload without finalizing its job, which the reload did not return",
+			"workload", klog.KObj(wl))
+		return prebuiltFinishedJobGone, nil
+	} else if err := r.correctOutOfSync(ctx, wl, job); err != nil {
+		return prebuiltWaitingForStop, err
 	}
 	return prebuiltUseWorkload, nil
+}
+
+// finishedOutOfSync reports whether wl finished with the out-of-sync reason.
+func finishedOutOfSync(wl *kueue.Workload) bool {
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
+	return cond != nil && cond.Status == metav1.ConditionTrue &&
+		cond.Reason == kueue.WorkloadFinishedReasonOutOfSync
 }
 
 // correctOutOfSync puts the reason a job ended with back on a workload that was finished as out of
@@ -1466,11 +1501,7 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 // re-dispatches on OutOfSync, so an already finished job would be run a second time.
 func (r *JobReconciler) correctOutOfSync(ctx context.Context, wl *kueue.Workload, job GenericJob) error {
 	message, success, finished := job.Finished(ctx)
-	if !finished {
-		return nil
-	}
-	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
-	if cond == nil || cond.Reason != kueue.WorkloadFinishedReasonOutOfSync {
+	if !finished || !finishedOutOfSync(wl) {
 		return nil
 	}
 	reason := kueue.WorkloadFinishedReasonSucceeded

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1432,8 +1432,9 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	return prebuiltUseWorkload, nil
 }
 
-// stopAcknowledged reports whether an async stop has been confirmed by its controller; jobs
-// stopped synchronously have nothing extra to wait for beyond IsActive.
+// stopAcknowledged reports whether an async stop has been confirmed by its controller. Without it
+// the wait is IsActive alone: true here is not a reading of the job, it is the absence of a
+// stronger one, and reversing it would hold every integration that has nothing else to report.
 func stopAcknowledged(job GenericJob) bool {
 	if ack, ok := job.(JobWithStopAcknowledgement); ok {
 		return ack.StopAcknowledged()

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -471,7 +471,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// and drop the finalizer.
 	if wl != nil && !wl.DeletionTimestamp.IsZero() {
 		log.V(2).Info("The workload is marked for deletion")
-		err := r.stopJob(ctx, job, wl, StopReasonWorkloadDeleted, "Workload is deleted")
+		_, err := r.stopJob(ctx, job, wl, StopReasonWorkloadDeleted, "Workload is deleted")
 		if err != nil {
 			log.Error(err, "Suspending job with deleted workload")
 		} else {
@@ -599,7 +599,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 	// 6. handle eviction
 	if evCond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadEvicted); evCond != nil && evCond.Status == metav1.ConditionTrue {
 		log.V(3).Info("Handling a job with evicted condition")
-		if err := r.stopJob(ctx, job, wl, StopReasonWorkloadEvicted, evCond.Message); err != nil {
+		if _, err := r.stopJob(ctx, job, wl, StopReasonWorkloadEvicted, evCond.Message); err != nil {
 			return ctrl.Result{}, err
 		}
 		if workload.HasQuotaReservation(wl) {
@@ -678,7 +678,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 			return ctrl.Result{}, nil
 		}
 		log.V(2).Info("Running job is not admitted by a cluster queue, suspending")
-		err := r.stopJob(ctx, job, wl, StopReasonNotAdmitted, "Not admitted by cluster queue")
+		_, err := r.stopJob(ctx, job, wl, StopReasonNotAdmitted, "Not admitted by cluster queue")
 		if err != nil {
 			log.Error(err, "Suspending job with non admitted workload")
 		}
@@ -1115,7 +1115,7 @@ func (r *JobReconciler) ensureOneWorkload(ctx context.Context, key types.Namespa
 			} else {
 				msg = "No matching Workload; restoring pod templates according to existent Workload"
 			}
-			if err := r.stopJob(ctx, job, w, StopReasonNoMatchingWorkload, msg); err != nil {
+			if _, err := r.stopJob(ctx, job, w, StopReasonNoMatchingWorkload, msg); err != nil {
 				return nil, fmt.Errorf("stopping job with no matching workload: %w", err)
 			}
 		}
@@ -1400,14 +1400,26 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 		return prebuiltUseWorkload, nil
 	}
 
-	// A finished job keeps the reason it ended with, which the caller writes.
+	// A finished job keeps the reason it ended with, which the caller writes. An earlier pass may
+	// have already written OutOfSync from a view taken before the job ended, and the caller is
+	// about to drop the finalizer on that reason, so this is the last place it can be put right.
 	if _, _, finished := job.Finished(ctx); finished {
+		if err := r.correctOutOfSync(ctx, wl, job); err != nil {
+			return prebuiltWaitingForStop, err
+		}
 		return prebuiltUseWorkload, nil
 	}
 
+	uid := job.Object().GetUID()
 	msg := "The prebuilt workload is out of sync with its user job"
-	if err := r.stopJob(ctx, job, wl, StopReasonNoMatchingWorkload, msg); err != nil {
+	stoppedNow, err := r.stopJob(ctx, job, wl, StopReasonNoMatchingWorkload, msg)
+	if err != nil {
 		return prebuiltWaitingForStop, err
+	}
+	// Nothing read in this pass can reflect a stop this pass submitted, so end it here. The stop
+	// is a spec change on the job we watch, which is what brings the next one.
+	if stoppedNow {
+		return prebuiltWaitingForStop, nil
 	}
 	// Release quota only once the stop is real: IsActive can be a stale false, and an async
 	// controller may still create pods from a view older than the stop.
@@ -1420,7 +1432,9 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	reloadKey := key
 	if gone, err := r.loadJob(ctx, &reloadKey, job); err != nil {
 		return prebuiltWaitingForStop, err
-	} else if gone {
+	} else if gone || job.Object().GetUID() != uid {
+		// A job deleted and recreated under the same name is a different job, and the workload
+		// this one carries is not its own.
 		return prebuiltNoUsableWorkload, nil
 	}
 	if _, _, finished := job.Finished(ctx); finished {
@@ -1440,7 +1454,7 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	postWriteKey := key
 	if gone, err := r.loadJob(ctx, &postWriteKey, job); err != nil {
 		return prebuiltWaitingForStop, err
-	} else if !gone {
+	} else if !gone && job.Object().GetUID() == uid {
 		if err := r.correctOutOfSync(ctx, wl, job); err != nil {
 			return prebuiltWaitingForStop, err
 		}
@@ -1616,8 +1630,9 @@ func (r *JobReconciler) startJob(ctx context.Context, job GenericJob, object cli
 }
 
 // stopJob will suspend the job, and also restore node affinity, reset job status if needed.
-// Returns whether any operation was done to stop the job or an error.
-func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.Workload, stopReason StopReason, eventMsg string) error {
+// It reports whether this call is what stopped the job, so a caller that has just changed the
+// object does not go on to read a status that cannot have caught up with the change yet.
+func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.Workload, stopReason StopReason, eventMsg string) (bool, error) {
 	object := job.Object()
 
 	info := GetPodSetsInfoFromWorkload(wl)
@@ -1627,7 +1642,7 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 		if stoppedNow {
 			r.record.Eventf(object, nil, corev1.EventTypeNormal, ReasonStopped, "Stopped", api.TruncateEventMessage(eventMsg))
 		}
-		return err
+		return stoppedNow, err
 	}
 
 	if jws, implements := job.(ComposableJob); implements {
@@ -1641,11 +1656,11 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 		for _, objStoppedNow := range stoppedNow {
 			r.record.Eventf(objStoppedNow, nil, corev1.EventTypeNormal, ReasonStopped, "Stopped", api.TruncateEventMessage(eventMsg))
 		}
-		return err
+		return len(stoppedNow) > 0, err
 	}
 
 	if job.IsSuspended() {
-		return nil
+		return false, nil
 	}
 
 	if err := clientutil.Patch(ctx, r.client, object, func() (bool, error) {
@@ -1655,11 +1670,11 @@ func (r *JobReconciler) stopJob(ctx context.Context, job GenericJob, wl *kueue.W
 		}
 		return true, nil
 	}); err != nil {
-		return err
+		return false, err
 	}
 
 	r.record.Eventf(object, nil, corev1.EventTypeNormal, ReasonStopped, "Stopped", api.TruncateEventMessage(eventMsg))
-	return nil
+	return true, nil
 }
 
 func (r *JobReconciler) finalizeJob(ctx context.Context, job GenericJob) error {
@@ -1896,7 +1911,7 @@ func (r *JobReconciler) handleJobWithNoWorkload(ctx context.Context, job Generic
 	prebuiltWorkload := PrebuiltWorkloadNameFor(job.Object())
 	if prebuiltWorkload != "" {
 		// Stop the job if not already suspended
-		if stopErr := r.stopJob(ctx, job, nil, StopReasonNoMatchingWorkload, "missing workload"); stopErr != nil {
+		if _, stopErr := r.stopJob(ctx, job, nil, StopReasonNoMatchingWorkload, "missing workload"); stopErr != nil {
 			return stopErr
 		}
 	}

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1396,17 +1396,19 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	if err != nil {
 		return prebuiltWaitingForStop, err
 	}
+	// An earlier pass may have written OutOfSync from a view taken before the job ended, and the
+	// caller is about to drop the finalizer on that reason. This runs before every path that
+	// returns, including the equivalent one, because a pair that matches again is still carrying
+	// the reason that pass left behind.
+	if err := r.correctOutOfSync(ctx, wl, job); err != nil {
+		return prebuiltWaitingForStop, err
+	}
 	if equivalent {
 		return prebuiltUseWorkload, nil
 	}
 
-	// A finished job keeps the reason it ended with, which the caller writes. An earlier pass may
-	// have already written OutOfSync from a view taken before the job ended, and the caller is
-	// about to drop the finalizer on that reason, so this is the last place it can be put right.
+	// A finished job keeps the reason it ended with, which the caller writes.
 	if _, _, finished := job.Finished(ctx); finished {
-		if err := r.correctOutOfSync(ctx, wl, job); err != nil {
-			return prebuiltWaitingForStop, err
-		}
 		return prebuiltUseWorkload, nil
 	}
 

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1434,7 +1434,37 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	if err := workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock); err != nil {
 		return prebuiltWaitingForStop, err
 	}
+	// The job can end during that write, and the caller finalizes on the reason it leaves behind,
+	// so read the job once more now that the write has been away and back. A job that is gone is
+	// past correcting. Load rewrites the key it is given, so this starts from the request's own.
+	postWriteKey := key
+	if gone, err := r.loadJob(ctx, &postWriteKey, job); err != nil {
+		return prebuiltWaitingForStop, err
+	} else if !gone {
+		if err := r.correctOutOfSync(ctx, wl, job); err != nil {
+			return prebuiltWaitingForStop, err
+		}
+	}
 	return prebuiltUseWorkload, nil
+}
+
+// correctOutOfSync puts the reason a job ended with back on a workload that was finished as out of
+// sync from a view taken before it ended. The reason is read rather than displayed: MultiKueue
+// re-dispatches on OutOfSync, so an already finished job would be run a second time.
+func (r *JobReconciler) correctOutOfSync(ctx context.Context, wl *kueue.Workload, job GenericJob) error {
+	message, success, finished := job.Finished(ctx)
+	if !finished {
+		return nil
+	}
+	cond := apimeta.FindStatusCondition(wl.Status.Conditions, kueue.WorkloadFinished)
+	if cond == nil || cond.Reason != kueue.WorkloadFinishedReasonOutOfSync {
+		return nil
+	}
+	reason := kueue.WorkloadFinishedReasonSucceeded
+	if !success {
+		reason = kueue.WorkloadFinishedReasonFailed
+	}
+	return workloadfinish.Rewrite(ctx, r.client, wl, reason, message, r.clock)
 }
 
 // stopSettled reports whether the stop is done with: nothing running, and, where the integration

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -316,8 +316,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 		err = r.ignoreUnretryableError(log, err)
 	}()
 
-	// loadJob normalizes req.NamespacedName in place (pod groups rewrite it to the lead pod),
-	// so keep the original for a later reload of the same job.
+	// loadJob normalizes this in place, so keep the original for a later reload of the same job.
 	reconcileKey := req.NamespacedName
 	shouldFinalize, err := r.loadJob(ctx, &req.NamespacedName, job)
 	if err != nil {
@@ -1396,10 +1395,8 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	if err != nil {
 		return prebuiltWaitingForStop, err
 	}
-	// An earlier pass may have written OutOfSync from a view taken before the job ended, and the
-	// caller is about to drop the finalizer on that reason. This runs before every path that
-	// returns, including the equivalent one, because a pair that matches again is still carrying
-	// the reason that pass left behind.
+	// Ahead of every path that returns, including the equivalent one: a pair that matches again
+	// still carries whatever reason an earlier pass left on the workload.
 	if err := r.correctOutOfSync(ctx, wl, job); err != nil {
 		return prebuiltWaitingForStop, err
 	}

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1412,7 +1412,7 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	// Release quota only once the stop is real: IsActive can be a stale false, and an async
 	// controller may still create pods from a view older than the stop.
 	// TODO(#13308,#13163): obey QuotaReleaseStrategy here so OutOfSync matches eviction.
-	if job.IsActive() || !stopAcknowledged(job) {
+	if !stopSettled(job) {
 		return prebuiltWaitingForStop, nil
 	}
 	// The job may have finished while stopping; re-read before writing OutOfSync, which is
@@ -1426,10 +1426,21 @@ func (r *JobReconciler) ensurePrebuiltWorkloadInSync(ctx context.Context, key ty
 	if _, _, finished := job.Finished(ctx); finished {
 		return prebuiltUseWorkload, nil
 	}
+	// Again on what the re-read returned. The check above ran against the object this reconcile
+	// started with, and the whole reason to re-read is that it may have moved since.
+	if !stopSettled(job) {
+		return prebuiltWaitingForStop, nil
+	}
 	if err := workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock); err != nil {
 		return prebuiltWaitingForStop, err
 	}
 	return prebuiltUseWorkload, nil
+}
+
+// stopSettled reports whether the stop is done with: nothing running, and, where the integration
+// can say so, its own controller agreeing.
+func stopSettled(job GenericJob) bool {
+	return !job.IsActive() && stopAcknowledged(job)
 }
 
 // stopAcknowledged reports whether an async stop has been confirmed by its controller. Without it

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1253,6 +1253,22 @@ type prebuiltJobState struct {
 	// suspendedAtWrite is what suspended was when the workload's status was
 	// last written, which is how the order between the two is asserted.
 	suspendedAtWrite bool
+	// finishedOnReread makes Finished report terminal only from the reload on, modeling a job
+	// that completes while stopping. finishedCalls counts the calls to detect the reload.
+	finishedOnReread bool
+	finishedCalls    int
+}
+
+// countingStopJob wraps a GenericJob mock and implements JobWithCustomStop so a second stop is
+// observable: a plain mock's generic stop would silently no-op once suspended.
+type countingStopJob struct {
+	*mocks.MockGenericJob
+	stops *int
+}
+
+func (j *countingStopJob) Stop(context.Context, client.Client, []podset.PodSetInfo, StopReason, string) (bool, error) {
+	*j.stops++
+	return true, nil
 }
 
 func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
@@ -1295,7 +1311,9 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			}).AnyTimes()
 		mgj.EXPECT().Finished(gomock.Any()).
 			DoAndReturn(func(context.Context) (string, bool, bool) {
-				return "by the job", st.success, st.finished
+				st.finishedCalls++
+				finished := st.finished || (st.finishedOnReread && st.finishedCalls >= 2)
+				return "by the job", st.success, finished
 			}).AnyTimes()
 
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
@@ -1419,4 +1437,38 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("a job that finishes while stopping keeps its own reason, not OutOfSync", func(t *testing.T) {
+		// Finished is false at the first check and true from the reload on: the job completed
+		// while stopping. The workload must finish as Succeeded — the input to MultiKueue's retry
+		// decision — never OutOfSync.
+		st := &prebuiltJobState{finishedOnReread: true, success: true}
+		ctx, cl, r, mgj, req := setup(t, st, false)
+
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonSucceeded {
+			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonSucceeded)
+		}
+	})
+
+	t.Run("the job is stopped exactly once and waiting never enters the missing-workload path", func(t *testing.T) {
+		st := &prebuiltJobState{active: true}
+		ctx, cl, r, mgj, req := setup(t, st, false)
+		stops := 0
+		// The old bool return turned "waiting" into wl==nil, so the reconciler fell into
+		// handleJobWithNoWorkload and stopped the job a second time as "missing workload".
+		job := &countingStopJob{MockGenericJob: mgj, stops: &stops}
+
+		if _, err := r.ReconcileGenericJob(ctx, req, job); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if stops != 1 {
+			t.Errorf("stopped %d times, want exactly 1", stops)
+		}
+		if reason := finishedReason(t, ctx, cl); reason != "" {
+			t.Errorf("workload finished for %q while its pods were still running", reason)
+		}
+	})
 }

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1302,6 +1302,8 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		// finishedOutOfSync starts the workload already finished as out of sync, which is what
 		// an earlier pass leaves behind when the correction could not be written.
 		finishedOutOfSync bool
+		// matching gives the job the pod set the workload reserved, so the pair is equivalent.
+		matching bool
 
 		wantErr           bool
 		wantStopped       bool
@@ -1381,6 +1383,15 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantErr:     true,
 			wantStopped: true,
 		},
+		// The pair matches again, which every other path treats as nothing to do. The reason an
+		// earlier pass left behind still has to be put right before the finalizer comes off.
+		"a workload finished as OutOfSync is corrected even once the pair matches again": {
+			state:             prebuiltJobState{finished: true, success: true},
+			matching:          true,
+			finishedOutOfSync: true,
+			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
+			wantFinalizerGone: true,
+		},
 		// An earlier pass finished the workload as out of sync and could not write the
 		// correction. The finalizer is still on, so the reason the job ended with can replace it.
 		"a workload already finished as OutOfSync is corrected before it is finalized": {
@@ -1406,7 +1417,11 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wlKey := types.NamespacedName{Namespace: "ns", Name: wlName}
 
 			// The job wants one pod against two reserved, so the pair no longer matches.
-			jobPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).Obj()}
+			jobCount := 1
+			if tc.matching {
+				jobCount = 2
+			}
+			jobPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", jobCount).Obj()}
 			wlPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 2).Obj()}
 
 			job := testingjob.MakeJob("job-1", "ns").

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1251,20 +1251,26 @@ type prebuiltJobState struct {
 	success   bool
 	restored  bool
 	// suspendedAtWrite is what suspended was when the workload's status was
-	// last written, which is how the order between the two is asserted.
+	// last written, and workloadWritten records that it was written at all.
 	suspendedAtWrite bool
+	workloadWritten  bool
 	// finishedOnReread makes Finished report terminal only from the reload on, modeling a job
-	// that completes while stopping. finishedCalls counts the calls to detect the reload.
+	// that completes while stopping. finishedCalls counts the calls to find the reload: the
+	// first pass reads it once before stopping, the second once more before the reload.
 	finishedOnReread bool
 	finishedCalls    int
-	// finishedAfterWrite makes Finished report terminal only from the read that follows the
-	// OutOfSync write, modeling a job that ends while that write is in flight.
+	// finishedAfterWrite makes Finished report terminal only once the workload's status has been
+	// written, modeling a job that ends while the OutOfSync write is in flight.
 	finishedAfterWrite bool
 	// activeOnReread makes IsActive report running only from the reload on, modeling a
 	// controller that created a pod from a view older than the stop. activeCalls counts the
 	// calls the same way.
 	activeOnReread bool
 	activeCalls    int
+	// uidChangesOnReload models a job deleted and recreated under the same name between the
+	// reconcile's own read and the reload. jobGets counts the reads to tell the two apart.
+	uidChangesOnReload bool
+	jobGets            int
 }
 
 // countingStopJob wraps a GenericJob mock and implements JobWithCustomStop so a second stop is
@@ -1290,6 +1296,12 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		countStops bool
 		// podsGoAway drops IsActive and reconciles again, which is how the wait ends.
 		podsGoAway bool
+		// secondPass reconciles again without changing anything. The pass that submits the stop
+		// never decides, so every case that reaches a decision needs one.
+		secondPass bool
+		// finishedOutOfSync starts the workload already finished as out of sync, which is what
+		// an earlier pass leaves behind when the correction could not be written.
+		finishedOutOfSync bool
 
 		wantErr           bool
 		wantStopped       bool
@@ -1309,6 +1321,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		// The job has no pods at this instant but is not suspended, so it is free to
 		// create one. Stopping it is what makes finishing the workload safe.
 		"a job with no pods yet is stopped before its workload is finished": {
+			secondPass:        true,
 			wantStopped:       true,
 			wantRestored:      true,
 			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
@@ -1333,6 +1346,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		// retry decision — never OutOfSync.
 		"a job that finishes while stopping keeps its own reason, not OutOfSync": {
 			state:        prebuiltJobState{finishedOnReread: true, success: true},
+			secondPass:   true,
 			wantStopped:  true,
 			wantRestored: true,
 			wantReason:   kueue.WorkloadFinishedReasonSucceeded,
@@ -1342,6 +1356,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		// after the write has to put the job's own reason back.
 		"a job that ends while the OutOfSync write is in flight has its reason corrected": {
 			state:             prebuiltJobState{finishedAfterWrite: true, success: true},
+			secondPass:        true,
 			wantStopped:       true,
 			wantRestored:      true,
 			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
@@ -1353,8 +1368,26 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		// started with, which is by then stale.
 		"a job that is running again at the reload is waited for, not marked OutOfSync": {
 			state:        prebuiltJobState{activeOnReread: true},
+			secondPass:   true,
 			wantStopped:  true,
 			wantRestored: true,
+		},
+		// Without the UID check the reload would hand this reconcile a different job that happens
+		// to carry the same name, and the workload it holds is not that job's.
+		// It falls through to the no-workload path, which is where a prebuilt job whose workload
+		// is not its own belongs, and that path reports the workload as not found.
+		"a job replaced under the same name between the read and the reload is not usable": {
+			state:       prebuiltJobState{suspended: true, uidChangesOnReload: true},
+			wantErr:     true,
+			wantStopped: true,
+		},
+		// An earlier pass finished the workload as out of sync and could not write the
+		// correction. The finalizer is still on, so the reason the job ended with can replace it.
+		"a workload already finished as OutOfSync is corrected before it is finalized": {
+			state:             prebuiltJobState{finished: true, success: true},
+			finishedOutOfSync: true,
+			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
+			wantFinalizerGone: true,
 		},
 		// The old bool return turned "waiting" into wl==nil, so the reconciler fell into
 		// handleJobWithNoWorkload and stopped the job a second time as "missing workload".
@@ -1382,12 +1415,20 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 				PrebuiltWorkloadLabel(wlName).
 				Suspend(st.suspended).
 				Obj()
-			wl := utiltestingapi.MakeWorkload(wlName, "ns").
+			wlWrapper := utiltestingapi.MakeWorkload(wlName, "ns").
 				PodSets(wlPodSets...).
 				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
 				Finalizers(kueue.ResourceInUseFinalizerName).
-				ControllerReference(gvk, "job-1", "job-1").
-				Obj()
+				ControllerReference(gvk, "job-1", "job-1")
+			if tc.finishedOutOfSync {
+				wlWrapper = wlWrapper.Condition(metav1.Condition{
+					Type:    kueue.WorkloadFinished,
+					Status:  metav1.ConditionTrue,
+					Reason:  kueue.WorkloadFinishedReasonOutOfSync,
+					Message: "The prebuilt workload is out of sync with its user job",
+				})
+			}
+			wl := wlWrapper.Obj()
 
 			mgj := mocks.NewMockGenericJob(mockctrl)
 			mgj.EXPECT().Object().Return(job).AnyTimes()
@@ -1408,8 +1449,8 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 				DoAndReturn(func(context.Context) (string, bool, bool) {
 					st.finishedCalls++
 					finished := st.finished ||
-						(st.finishedOnReread && st.finishedCalls >= 2) ||
-						(st.finishedAfterWrite && st.finishedCalls >= 3)
+						(st.finishedOnReread && st.finishedCalls >= 3) ||
+						(st.finishedAfterWrite && st.workloadWritten)
 					return "by the job", st.success, finished
 				}).AnyTimes()
 
@@ -1419,6 +1460,18 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 				WithStatusSubresource(job, wl).
 				WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(gvk), indexer.WorkloadOwnerIndexFunc(gvk)).
 				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := c.Get(ctx, key, obj, opts...); err != nil {
+							return err
+						}
+						if reloaded, isJob := obj.(*batchv1.Job); isJob {
+							st.jobGets++
+							if st.uidChangesOnReload && st.jobGets >= 2 {
+								reloaded.UID = "a-different-job"
+							}
+						}
+						return nil
+					},
 					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 						if _, isJob := obj.(*batchv1.Job); isJob && tc.failStop {
 							return errors.New("the job could not be stopped")
@@ -1428,6 +1481,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 					SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 						if _, isWorkload := obj.(*kueue.Workload); isWorkload {
 							st.suspendedAtWrite = st.suspended
+							st.workloadWritten = true
 						}
 						return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
 					},
@@ -1447,13 +1501,13 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 				t.Fatalf("ReconcileGenericJob() error = %v, wantErr %v", err, tc.wantErr)
 			}
 
-			if tc.podsGoAway {
+			if tc.podsGoAway || tc.secondPass {
 				var mid kueue.Workload
 				if err := cl.Get(ctx, wlKey, &mid); err != nil {
 					t.Fatalf("getting the workload: %v", err)
 				}
 				if cond := apimeta.FindStatusCondition(mid.Status.Conditions, kueue.WorkloadFinished); cond != nil && cond.Status == metav1.ConditionTrue {
-					t.Errorf("the workload was finished for %q while its pods were running", cond.Reason)
+					t.Errorf("the workload was finished for %q on the pass that submitted the stop", cond.Reason)
 				}
 				st.active = false
 				// The workload is handled here, so the reconcile has nothing left to

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1255,16 +1255,14 @@ type prebuiltJobState struct {
 	suspendedAtWrite bool
 	workloadWritten  bool
 	// finishedOnReread makes Finished report terminal only from the reload on, modeling a job
-	// that completes while stopping. finishedCalls counts the calls to find the reload: the
-	// first pass reads it once before stopping, the second once more before the reload.
+	// that completes while stopping. finishedCalls finds the reload: it is the third read.
 	finishedOnReread bool
 	finishedCalls    int
 	// finishedAfterWrite makes Finished report terminal only once the workload's status has been
 	// written, modeling a job that ends while the OutOfSync write is in flight.
 	finishedAfterWrite bool
-	// activeOnReread makes IsActive report running only from the reload on, modeling a
-	// controller that created a pod from a view older than the stop. activeCalls counts the
-	// calls the same way.
+	// activeOnReread makes IsActive report running only from the reload on, modeling a controller
+	// that created a pod from a view older than the stop. activeCalls counts them the same way.
 	activeOnReread bool
 	activeCalls    int
 	// uidChangesOnReload models a job deleted and recreated under the same name between the

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -1269,6 +1270,8 @@ type prebuiltJobState struct {
 	// reconcile's own read and the reload. jobGets counts the reads to tell the two apart.
 	uidChangesOnReload bool
 	jobGets            int
+	// uidChangesAfterWrite models the same recreation landing while the OutOfSync write is in flight.
+	uidChangesAfterWrite bool
 }
 
 // countingStopJob wraps a GenericJob mock and implements JobWithCustomStop so a second stop is
@@ -1281,6 +1284,18 @@ type countingStopJob struct {
 func (j *countingStopJob) Stop(context.Context, client.Client, []podset.PodSetInfo, StopReason, string) (bool, error) {
 	*j.stops++
 	return true, nil
+}
+
+// countingFinalizeJob wraps a GenericJob mock and implements JobWithFinalize so finalizing is
+// observable: only the pod integration implements it, and there it removes pod finalizers.
+type countingFinalizeJob struct {
+	*mocks.MockGenericJob
+	finalizes *int
+}
+
+func (j *countingFinalizeJob) Finalize(context.Context, client.Client) error {
+	*j.finalizes++
+	return nil
 }
 
 func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
@@ -1302,6 +1317,8 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		finishedOutOfSync bool
 		// matching gives the job the pod set the workload reserved, so the pair is equivalent.
 		matching bool
+		// countFinalizes swaps in a JobWithFinalize so finalizing the job is observable.
+		countFinalizes bool
 
 		wantErr           bool
 		wantStopped       bool
@@ -1309,6 +1326,11 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		wantReason        string
 		wantFinalizerGone bool
 		wantStops         int
+		wantFinalizes     int
+		// wantRequeue is the poll a pass that is still waiting for the stop has to leave behind.
+		wantRequeue bool
+		// wantStopMessage is the Stopped event's message, which names why the job was stopped.
+		wantStopMessage string
 	}{
 		"a job with running pods is stopped, and its workload waits until they are gone": {
 			state:             prebuiltJobState{active: true},
@@ -1317,15 +1339,21 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantRestored:      true,
 			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
 			wantFinalizerGone: true,
+			wantRequeue:       true,
+			wantStopMessage:   "The prebuilt workload is out of sync with its user job",
 		},
 		// The job has no pods at this instant but is not suspended, so it is free to
-		// create one. Stopping it is what makes finishing the workload safe.
+		// create one. Stopping it is what makes finishing the workload safe. It also anchors the
+		// replaced-job case below: same path, job unchanged.
 		"a job with no pods yet is stopped before its workload is finished": {
 			secondPass:        true,
+			countFinalizes:    true,
 			wantStopped:       true,
 			wantRestored:      true,
 			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
 			wantFinalizerGone: true,
+			wantFinalizes:     1,
+			wantRequeue:       true,
 		},
 		"a job that cannot be stopped keeps its quota": {
 			failStop:     true,
@@ -1350,6 +1378,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantStopped:  true,
 			wantRestored: true,
 			wantReason:   kueue.WorkloadFinishedReasonSucceeded,
+			wantRequeue:  true,
 		},
 		// The job ends while the OutOfSync write is in flight, so both checks before it read a
 		// running job. The reason left behind is what MultiKueue re-dispatches on, so the read
@@ -1361,6 +1390,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantRestored:      true,
 			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
 			wantFinalizerGone: true,
+			wantRequeue:       true,
 		},
 		// IsActive is false at the first check and true from the reload on: the external
 		// controller created a pod from a view older than the stop. The reload is the whole
@@ -1371,6 +1401,7 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			secondPass:   true,
 			wantStopped:  true,
 			wantRestored: true,
+			wantRequeue:  true,
 		},
 		// Without the UID check the reload would hand this reconcile a different job that happens
 		// to carry the same name, and the workload it holds is not that job's.
@@ -1398,12 +1429,38 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
 			wantFinalizerGone: true,
 		},
+		// The pair matches again, but the quota the earlier OutOfSync finish released does not come
+		// back with it. Releasing the workload here would leave the job running unaccounted for.
+		"a workload finished as OutOfSync stops a running job even once the pair matches again": {
+			state:             prebuiltJobState{active: true},
+			matching:          true,
+			finishedOutOfSync: true,
+			wantStopped:       true,
+			wantRestored:      true,
+			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
+			wantRequeue:       true,
+			wantStopMessage:   "The prebuilt workload is already finished",
+		},
+		// The read after the write returns a different job. Finalizing it would remove Kueue's
+		// finalizer from the replacement's pods; only the workload's own finalizer is owed.
+		"a job replaced under the same name during the OutOfSync write is not finalized": {
+			state:             prebuiltJobState{uidChangesAfterWrite: true},
+			secondPass:        true,
+			countFinalizes:    true,
+			wantStopped:       true,
+			wantRestored:      true,
+			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
+			wantFinalizerGone: true,
+			wantFinalizes:     0,
+			wantRequeue:       true,
+		},
 		// The old bool return turned "waiting" into wl==nil, so the reconciler fell into
 		// handleJobWithNoWorkload and stopped the job a second time as "missing workload".
 		"the job is stopped exactly once and waiting never enters the missing-workload path": {
-			state:      prebuiltJobState{active: true},
-			countStops: true,
-			wantStops:  1,
+			state:       prebuiltJobState{active: true},
+			countStops:  true,
+			wantStops:   1,
+			wantRequeue: true,
 		},
 	}
 
@@ -1479,7 +1536,8 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 						}
 						if reloaded, isJob := obj.(*batchv1.Job); isJob {
 							st.jobGets++
-							if st.uidChangesOnReload && st.jobGets >= 2 {
+							if (st.uidChangesOnReload && st.jobGets >= 2) ||
+								(st.uidChangesAfterWrite && st.workloadWritten) {
 								reloaded.UID = "a-different-job"
 							}
 						}
@@ -1500,18 +1558,26 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 					},
 				}).
 				Build()
-			r := NewReconciler(cl, &utiltesting.EventRecorder{})
+			recorder := &utiltesting.EventRecorder{}
+			r := NewReconciler(cl, recorder)
 			req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "job-1"}}
 
+			// The wrappers are alternatives: each replaces the mock, so a case picks one.
 			var genericJob GenericJob = mgj
-			stops := 0
-			if tc.countStops {
+			stops, finalizes := 0, 0
+			switch {
+			case tc.countStops:
 				genericJob = &countingStopJob{MockGenericJob: mgj, stops: &stops}
+			case tc.countFinalizes:
+				genericJob = &countingFinalizeJob{MockGenericJob: mgj, finalizes: &finalizes}
 			}
 
-			_, err := r.ReconcileGenericJob(ctx, req, genericJob)
+			res, err := r.ReconcileGenericJob(ctx, req, genericJob)
 			if gotErr := err != nil; gotErr != tc.wantErr {
 				t.Fatalf("ReconcileGenericJob() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if gotRequeue := res.RequeueAfter > 0; gotRequeue != tc.wantRequeue {
+				t.Errorf("the pass requeued = %v, want %v", gotRequeue, tc.wantRequeue)
 			}
 
 			if tc.podsGoAway || tc.secondPass {
@@ -1547,7 +1613,8 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			if st.restored != tc.wantRestored {
 				t.Errorf("the pod set info was restored = %v, want %v, which is how the workload reaches the stop", st.restored, tc.wantRestored)
 			}
-			if tc.wantReason == kueue.WorkloadFinishedReasonOutOfSync && !st.suspendedAtWrite {
+			// Only when this run finished it; a seeded reason comes from an earlier pass.
+			if tc.wantReason == kueue.WorkloadFinishedReasonOutOfSync && !tc.finishedOutOfSync && !st.suspendedAtWrite {
 				t.Error("the workload was finished before the job was stopped")
 			}
 			if gone := len(got.Finalizers) == 0; gone != tc.wantFinalizerGone {
@@ -1555,6 +1622,20 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			}
 			if stops != tc.wantStops {
 				t.Errorf("the job was stopped %d times, want %d", stops, tc.wantStops)
+			}
+			if finalizes != tc.wantFinalizes {
+				t.Errorf("the job was finalized %d times, want %d", finalizes, tc.wantFinalizes)
+			}
+			if tc.wantStopMessage != "" {
+				var stopped []string
+				for _, e := range recorder.RecordedEvents {
+					if e.Reason == ReasonStopped {
+						stopped = append(stopped, e.Message)
+					}
+				}
+				if !slices.Contains(stopped, tc.wantStopMessage) {
+					t.Errorf("the Stopped events said %q, want one saying %q", stopped, tc.wantStopMessage)
+				}
 			}
 		})
 	}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1242,3 +1242,181 @@ func TestReconcileGenericJob_EvictionClearsQuotaReservation(t *testing.T) {
 		})
 	}
 }
+
+// prebuiltJobState is the part of a job the out-of-sync path reads and moves.
+type prebuiltJobState struct {
+	suspended bool
+	active    bool
+	finished  bool
+	success   bool
+	restored  bool
+	// suspendedAtWrite is what suspended was when the workload's status was
+	// last written, which is how the order between the two is asserted.
+	suspendedAtWrite bool
+}
+
+func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
+	const wlName = "prebuilt"
+	gvk := batchv1.SchemeGroupVersion.WithKind("Job")
+
+	setup := func(t *testing.T, st *prebuiltJobState, failStop bool) (context.Context, client.Client, *JobReconciler, *mocks.MockGenericJob, controllerruntime.Request) {
+		t.Helper()
+		ctx, _ := utiltesting.ContextWithLog(t)
+		mockctrl := gomock.NewController(t)
+
+		// The job wants one pod against two reserved, so the pair no longer matches.
+		jobPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).Obj()}
+		wlPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 2).Obj()}
+
+		job := testingjob.MakeJob("job-1", "ns").
+			Queue("cq").
+			UID("job-1").
+			PrebuiltWorkloadLabel(wlName).
+			Suspend(st.suspended).
+			Obj()
+		wl := utiltestingapi.MakeWorkload(wlName, "ns").
+			PodSets(wlPodSets...).
+			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+			Finalizers(kueue.ResourceInUseFinalizerName).
+			ControllerReference(gvk, "job-1", "job-1").
+			Obj()
+
+		mgj := mocks.NewMockGenericJob(mockctrl)
+		mgj.EXPECT().Object().Return(job).AnyTimes()
+		mgj.EXPECT().GVK().Return(gvk).AnyTimes()
+		mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(jobPodSets, nil).AnyTimes()
+		mgj.EXPECT().IsSuspended().DoAndReturn(func() bool { return st.suspended }).AnyTimes()
+		mgj.EXPECT().IsActive().DoAndReturn(func() bool { return st.active }).AnyTimes()
+		mgj.EXPECT().Suspend().Do(func() { st.suspended = true }).AnyTimes()
+		mgj.EXPECT().RestorePodSetsInfo(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, info []podset.PodSetInfo) bool {
+				st.restored = len(info) > 0
+				return true
+			}).AnyTimes()
+		mgj.EXPECT().Finished(gomock.Any()).
+			DoAndReturn(func(context.Context) (string, bool, bool) {
+				return "by the job", st.success, st.finished
+			}).AnyTimes()
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+		builder := utiltesting.NewClientBuilder().
+			WithObjects(job, wl, ns).
+			WithStatusSubresource(job, wl).
+			WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(gvk), indexer.WorkloadOwnerIndexFunc(gvk))
+		builder = builder.WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				if _, isJob := obj.(*batchv1.Job); isJob && failStop {
+					return errors.New("the job could not be stopped")
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+			SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+					st.suspendedAtWrite = st.suspended
+				}
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
+			},
+		})
+		cl := builder.Build()
+		return ctx, cl, NewReconciler(cl, &utiltesting.EventRecorder{}), mgj,
+			controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "job-1"}}
+	}
+
+	finishedReason := func(t *testing.T, ctx context.Context, cl client.Client) string {
+		t.Helper()
+		var got kueue.Workload
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: wlName}, &got); err != nil {
+			t.Fatalf("getting the workload: %v", err)
+		}
+		cond := apimeta.FindStatusCondition(got.Status.Conditions, kueue.WorkloadFinished)
+		if cond == nil || cond.Status != metav1.ConditionTrue {
+			return ""
+		}
+		return cond.Reason
+	}
+
+	t.Run("the job is stopped and the workload waits for its pods", func(t *testing.T) {
+		st := &prebuiltJobState{active: true}
+		ctx, cl, r, mgj, req := setup(t, st, false)
+
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+			t.Fatalf("first reconcile: %v", err)
+		}
+		if !st.suspended {
+			t.Error("the job was not stopped")
+		}
+		if !st.restored {
+			t.Error("the pod set info was not restored, so the workload was not handed to the stop")
+		}
+		if reason := finishedReason(t, ctx, cl); reason != "" {
+			t.Errorf("the workload was finished for %q while its pods were running", reason)
+		}
+
+		st.active = false
+		// The workload is handled here, so the reconcile has nothing left to
+		// report, rather than the not-found it used to retry on.
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+			t.Fatalf("second reconcile: %v", err)
+		}
+		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonOutOfSync {
+			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonOutOfSync)
+		}
+		if !st.suspendedAtWrite {
+			t.Error("the workload was finished before the job was stopped")
+		}
+		var got kueue.Workload
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: wlName}, &got); err != nil {
+			t.Fatalf("getting the workload: %v", err)
+		}
+		if len(got.Finalizers) != 0 {
+			t.Errorf("the finished workload kept its finalizers: %v", got.Finalizers)
+		}
+	})
+
+	// The job has no pods at this instant but is not suspended, so it is free to
+	// create one. Stopping it is what makes finishing the workload safe.
+	t.Run("a job with no pods yet is stopped before its workload is finished", func(t *testing.T) {
+		st := &prebuiltJobState{}
+		ctx, cl, r, mgj, req := setup(t, st, false)
+
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+			t.Errorf("reconcile: %v", err)
+		}
+		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonOutOfSync {
+			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonOutOfSync)
+		}
+		if !st.suspendedAtWrite {
+			t.Error("the workload was finished before the job was stopped")
+		}
+	})
+
+	t.Run("a job that cannot be stopped keeps its quota", func(t *testing.T) {
+		st := &prebuiltJobState{}
+		ctx, cl, r, mgj, req := setup(t, st, true)
+
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err == nil {
+			t.Fatal("the reconcile reported success although the job could not be stopped")
+		}
+		if reason := finishedReason(t, ctx, cl); reason != "" {
+			t.Errorf("the workload was finished for %q although the stop failed", reason)
+		}
+	})
+
+	for name, success := range map[string]bool{"succeeded": true, "failed": false} {
+		t.Run("a job that "+name+" keeps its own reason", func(t *testing.T) {
+			st := &prebuiltJobState{finished: true, success: success}
+			ctx, cl, r, mgj, req := setup(t, st, false)
+
+			if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+				t.Fatalf("reconcile: %v", err)
+			}
+			want := kueue.WorkloadFinishedReasonSucceeded
+			if !success {
+				want = kueue.WorkloadFinishedReasonFailed
+			}
+			if reason := finishedReason(t, ctx, cl); reason != want {
+				t.Errorf("finished for %q, want %q", reason, want)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1280,219 +1280,200 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 	const wlName = "prebuilt"
 	gvk := batchv1.SchemeGroupVersion.WithKind("Job")
 
-	setup := func(t *testing.T, st *prebuiltJobState, failStop bool) (context.Context, client.Client, *JobReconciler, *mocks.MockGenericJob, controllerruntime.Request) {
-		t.Helper()
-		ctx, _ := utiltesting.ContextWithLog(t)
-		mockctrl := gomock.NewController(t)
+	testCases := map[string]struct {
+		state    prebuiltJobState
+		failStop bool
+		// countStops swaps in a JobWithCustomStop so a second stop is observable.
+		countStops bool
+		// podsGoAway drops IsActive and reconciles again, which is how the wait ends.
+		podsGoAway bool
 
-		// The job wants one pod against two reserved, so the pair no longer matches.
-		jobPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).Obj()}
-		wlPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 2).Obj()}
-
-		job := testingjob.MakeJob("job-1", "ns").
-			Queue("cq").
-			UID("job-1").
-			PrebuiltWorkloadLabel(wlName).
-			Suspend(st.suspended).
-			Obj()
-		wl := utiltestingapi.MakeWorkload(wlName, "ns").
-			PodSets(wlPodSets...).
-			ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
-			Finalizers(kueue.ResourceInUseFinalizerName).
-			ControllerReference(gvk, "job-1", "job-1").
-			Obj()
-
-		mgj := mocks.NewMockGenericJob(mockctrl)
-		mgj.EXPECT().Object().Return(job).AnyTimes()
-		mgj.EXPECT().GVK().Return(gvk).AnyTimes()
-		mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(jobPodSets, nil).AnyTimes()
-		mgj.EXPECT().IsSuspended().DoAndReturn(func() bool { return st.suspended }).AnyTimes()
-		mgj.EXPECT().IsActive().DoAndReturn(func() bool {
-			st.activeCalls++
-			return st.active || (st.activeOnReread && st.activeCalls >= 2)
-		}).AnyTimes()
-		mgj.EXPECT().Suspend().Do(func() { st.suspended = true }).AnyTimes()
-		mgj.EXPECT().RestorePodSetsInfo(gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ context.Context, info []podset.PodSetInfo) bool {
-				st.restored = len(info) > 0
-				return true
-			}).AnyTimes()
-		mgj.EXPECT().Finished(gomock.Any()).
-			DoAndReturn(func(context.Context) (string, bool, bool) {
-				st.finishedCalls++
-				finished := st.finished || (st.finishedOnReread && st.finishedCalls >= 2)
-				return "by the job", st.success, finished
-			}).AnyTimes()
-
-		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
-		builder := utiltesting.NewClientBuilder().
-			WithObjects(job, wl, ns).
-			WithStatusSubresource(job, wl).
-			WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(gvk), indexer.WorkloadOwnerIndexFunc(gvk))
-		builder = builder.WithInterceptorFuncs(interceptor.Funcs{
-			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-				if _, isJob := obj.(*batchv1.Job); isJob && failStop {
-					return errors.New("the job could not be stopped")
-				}
-				return c.Patch(ctx, obj, patch, opts...)
-			},
-			SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
-				if _, isWorkload := obj.(*kueue.Workload); isWorkload {
-					st.suspendedAtWrite = st.suspended
-				}
-				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
-			},
-		})
-		cl := builder.Build()
-		return ctx, cl, NewReconciler(cl, &utiltesting.EventRecorder{}), mgj,
-			controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "job-1"}}
-	}
-
-	finishedReason := func(t *testing.T, ctx context.Context, cl client.Client) string {
-		t.Helper()
-		var got kueue.Workload
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: wlName}, &got); err != nil {
-			t.Fatalf("getting the workload: %v", err)
-		}
-		cond := apimeta.FindStatusCondition(got.Status.Conditions, kueue.WorkloadFinished)
-		if cond == nil || cond.Status != metav1.ConditionTrue {
-			return ""
-		}
-		return cond.Reason
-	}
-
-	t.Run("the job is stopped and the workload waits for its pods", func(t *testing.T) {
-		st := &prebuiltJobState{active: true}
-		ctx, cl, r, mgj, req := setup(t, st, false)
-
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-			t.Fatalf("first reconcile: %v", err)
-		}
-		if !st.suspended {
-			t.Error("the job was not stopped")
-		}
-		if !st.restored {
-			t.Error("the pod set info was not restored, so the workload was not handed to the stop")
-		}
-		if reason := finishedReason(t, ctx, cl); reason != "" {
-			t.Errorf("the workload was finished for %q while its pods were running", reason)
-		}
-
-		st.active = false
-		// The workload is handled here, so the reconcile has nothing left to
-		// report, rather than the not-found it used to retry on.
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-			t.Fatalf("second reconcile: %v", err)
-		}
-		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonOutOfSync {
-			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonOutOfSync)
-		}
-		if !st.suspendedAtWrite {
-			t.Error("the workload was finished before the job was stopped")
-		}
-		var got kueue.Workload
-		if err := cl.Get(ctx, types.NamespacedName{Namespace: "ns", Name: wlName}, &got); err != nil {
-			t.Fatalf("getting the workload: %v", err)
-		}
-		if len(got.Finalizers) != 0 {
-			t.Errorf("the finished workload kept its finalizers: %v", got.Finalizers)
-		}
-	})
-
-	// The job has no pods at this instant but is not suspended, so it is free to
-	// create one. Stopping it is what makes finishing the workload safe.
-	t.Run("a job with no pods yet is stopped before its workload is finished", func(t *testing.T) {
-		st := &prebuiltJobState{}
-		ctx, cl, r, mgj, req := setup(t, st, false)
-
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-			t.Errorf("reconcile: %v", err)
-		}
-		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonOutOfSync {
-			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonOutOfSync)
-		}
-		if !st.suspendedAtWrite {
-			t.Error("the workload was finished before the job was stopped")
-		}
-	})
-
-	t.Run("a job that cannot be stopped keeps its quota", func(t *testing.T) {
-		st := &prebuiltJobState{}
-		ctx, cl, r, mgj, req := setup(t, st, true)
-
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err == nil {
-			t.Fatal("the reconcile reported success although the job could not be stopped")
-		}
-		if reason := finishedReason(t, ctx, cl); reason != "" {
-			t.Errorf("the workload was finished for %q although the stop failed", reason)
-		}
-	})
-
-	for name, success := range map[string]bool{"succeeded": true, "failed": false} {
-		t.Run("a job that "+name+" keeps its own reason", func(t *testing.T) {
-			st := &prebuiltJobState{finished: true, success: success}
-			ctx, cl, r, mgj, req := setup(t, st, false)
-
-			if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-				t.Fatalf("reconcile: %v", err)
-			}
-			want := kueue.WorkloadFinishedReasonSucceeded
-			if !success {
-				want = kueue.WorkloadFinishedReasonFailed
-			}
-			if reason := finishedReason(t, ctx, cl); reason != want {
-				t.Errorf("finished for %q, want %q", reason, want)
-			}
-		})
-	}
-
-	t.Run("a job that finishes while stopping keeps its own reason, not OutOfSync", func(t *testing.T) {
+		wantErr           bool
+		wantStopped       bool
+		wantRestored      bool
+		wantReason        string
+		wantFinalizerGone bool
+		wantStops         int
+	}{
+		"a job with running pods is stopped, and its workload waits until they are gone": {
+			state:             prebuiltJobState{active: true},
+			podsGoAway:        true,
+			wantStopped:       true,
+			wantRestored:      true,
+			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
+			wantFinalizerGone: true,
+		},
+		// The job has no pods at this instant but is not suspended, so it is free to
+		// create one. Stopping it is what makes finishing the workload safe.
+		"a job with no pods yet is stopped before its workload is finished": {
+			wantStopped:       true,
+			wantRestored:      true,
+			wantReason:        kueue.WorkloadFinishedReasonOutOfSync,
+			wantFinalizerGone: true,
+		},
+		"a job that cannot be stopped keeps its quota": {
+			failStop:     true,
+			wantErr:      true,
+			wantStopped:  true,
+			wantRestored: true,
+		},
+		"a job that succeeded keeps its own reason": {
+			state:      prebuiltJobState{finished: true, success: true},
+			wantReason: kueue.WorkloadFinishedReasonSucceeded,
+		},
+		"a job that failed keeps its own reason": {
+			state:      prebuiltJobState{finished: true},
+			wantReason: kueue.WorkloadFinishedReasonFailed,
+		},
 		// Finished is false at the first check and true from the reload on: the job completed
-		// while stopping. The workload must finish as Succeeded — the input to MultiKueue's retry
-		// decision — never OutOfSync.
-		st := &prebuiltJobState{finishedOnReread: true, success: true}
-		ctx, cl, r, mgj, req := setup(t, st, false)
-
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-			t.Fatalf("reconcile: %v", err)
-		}
-		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonSucceeded {
-			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonSucceeded)
-		}
-	})
-
-	t.Run("a job that is running again at the reload is waited for, not marked OutOfSync", func(t *testing.T) {
+		// while stopping. The workload must finish as Succeeded — the input to MultiKueue's
+		// retry decision — never OutOfSync.
+		"a job that finishes while stopping keeps its own reason, not OutOfSync": {
+			state:        prebuiltJobState{finishedOnReread: true, success: true},
+			wantStopped:  true,
+			wantRestored: true,
+			wantReason:   kueue.WorkloadFinishedReasonSucceeded,
+		},
 		// IsActive is false at the first check and true from the reload on: the external
 		// controller created a pod from a view older than the stop. The reload is the whole
 		// reason the second check exists — the first one ran against the object this reconcile
 		// started with, which is by then stale.
-		st := &prebuiltJobState{activeOnReread: true}
-		ctx, cl, r, mgj, req := setup(t, st, false)
-
-		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
-			t.Fatalf("reconcile: %v", err)
-		}
-		if reason := finishedReason(t, ctx, cl); reason != "" {
-			t.Errorf("finished for %q, want the workload still unfinished", reason)
-		}
-	})
-
-	t.Run("the job is stopped exactly once and waiting never enters the missing-workload path", func(t *testing.T) {
-		st := &prebuiltJobState{active: true}
-		ctx, cl, r, mgj, req := setup(t, st, false)
-		stops := 0
+		"a job that is running again at the reload is waited for, not marked OutOfSync": {
+			state:        prebuiltJobState{activeOnReread: true},
+			wantStopped:  true,
+			wantRestored: true,
+		},
 		// The old bool return turned "waiting" into wl==nil, so the reconciler fell into
 		// handleJobWithNoWorkload and stopped the job a second time as "missing workload".
-		job := &countingStopJob{MockGenericJob: mgj, stops: &stops}
+		"the job is stopped exactly once and waiting never enters the missing-workload path": {
+			state:      prebuiltJobState{active: true},
+			countStops: true,
+			wantStops:  1,
+		},
+	}
 
-		if _, err := r.ReconcileGenericJob(ctx, req, job); err != nil {
-			t.Fatalf("reconcile: %v", err)
-		}
-		if stops != 1 {
-			t.Errorf("stopped %d times, want exactly 1", stops)
-		}
-		if reason := finishedReason(t, ctx, cl); reason != "" {
-			t.Errorf("workload finished for %q while its pods were still running", reason)
-		}
-	})
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			mockctrl := gomock.NewController(t)
+			st := tc.state
+			wlKey := types.NamespacedName{Namespace: "ns", Name: wlName}
+
+			// The job wants one pod against two reserved, so the pair no longer matches.
+			jobPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 1).Obj()}
+			wlPodSets := []kueue.PodSet{*utiltestingapi.MakePodSet("main", 2).Obj()}
+
+			job := testingjob.MakeJob("job-1", "ns").
+				Queue("cq").
+				UID("job-1").
+				PrebuiltWorkloadLabel(wlName).
+				Suspend(st.suspended).
+				Obj()
+			wl := utiltestingapi.MakeWorkload(wlName, "ns").
+				PodSets(wlPodSets...).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission("cq").Obj(), time.Now()).
+				Finalizers(kueue.ResourceInUseFinalizerName).
+				ControllerReference(gvk, "job-1", "job-1").
+				Obj()
+
+			mgj := mocks.NewMockGenericJob(mockctrl)
+			mgj.EXPECT().Object().Return(job).AnyTimes()
+			mgj.EXPECT().GVK().Return(gvk).AnyTimes()
+			mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(jobPodSets, nil).AnyTimes()
+			mgj.EXPECT().IsSuspended().DoAndReturn(func() bool { return st.suspended }).AnyTimes()
+			mgj.EXPECT().IsActive().DoAndReturn(func() bool {
+				st.activeCalls++
+				return st.active || (st.activeOnReread && st.activeCalls >= 2)
+			}).AnyTimes()
+			mgj.EXPECT().Suspend().Do(func() { st.suspended = true }).AnyTimes()
+			mgj.EXPECT().RestorePodSetsInfo(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, info []podset.PodSetInfo) bool {
+					st.restored = len(info) > 0
+					return true
+				}).AnyTimes()
+			mgj.EXPECT().Finished(gomock.Any()).
+				DoAndReturn(func(context.Context) (string, bool, bool) {
+					st.finishedCalls++
+					finished := st.finished || (st.finishedOnReread && st.finishedCalls >= 2)
+					return "by the job", st.success, finished
+				}).AnyTimes()
+
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ns"}}
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(job, wl, ns).
+				WithStatusSubresource(job, wl).
+				WithIndex(&kueue.Workload{}, indexer.OwnerReferenceIndexKey(gvk), indexer.WorkloadOwnerIndexFunc(gvk)).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						if _, isJob := obj.(*batchv1.Job); isJob && tc.failStop {
+							return errors.New("the job could not be stopped")
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+					SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+						if _, isWorkload := obj.(*kueue.Workload); isWorkload {
+							st.suspendedAtWrite = st.suspended
+						}
+						return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+			r := NewReconciler(cl, &utiltesting.EventRecorder{})
+			req := controllerruntime.Request{NamespacedName: types.NamespacedName{Namespace: "ns", Name: "job-1"}}
+
+			var genericJob GenericJob = mgj
+			stops := 0
+			if tc.countStops {
+				genericJob = &countingStopJob{MockGenericJob: mgj, stops: &stops}
+			}
+
+			_, err := r.ReconcileGenericJob(ctx, req, genericJob)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("ReconcileGenericJob() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if tc.podsGoAway {
+				var mid kueue.Workload
+				if err := cl.Get(ctx, wlKey, &mid); err != nil {
+					t.Fatalf("getting the workload: %v", err)
+				}
+				if cond := apimeta.FindStatusCondition(mid.Status.Conditions, kueue.WorkloadFinished); cond != nil && cond.Status == metav1.ConditionTrue {
+					t.Errorf("the workload was finished for %q while its pods were running", cond.Reason)
+				}
+				st.active = false
+				// The workload is handled here, so the reconcile has nothing left to
+				// report, rather than the not-found it used to retry on.
+				if _, err := r.ReconcileGenericJob(ctx, req, genericJob); err != nil {
+					t.Fatalf("second reconcile: %v", err)
+				}
+			}
+
+			var got kueue.Workload
+			if err := cl.Get(ctx, wlKey, &got); err != nil {
+				t.Fatalf("getting the workload: %v", err)
+			}
+			gotReason := ""
+			if cond := apimeta.FindStatusCondition(got.Status.Conditions, kueue.WorkloadFinished); cond != nil && cond.Status == metav1.ConditionTrue {
+				gotReason = cond.Reason
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("the workload finished for %q, want %q", gotReason, tc.wantReason)
+			}
+			if st.suspended != tc.wantStopped {
+				t.Errorf("the job was stopped = %v, want %v", st.suspended, tc.wantStopped)
+			}
+			if st.restored != tc.wantRestored {
+				t.Errorf("the pod set info was restored = %v, want %v, which is how the workload reaches the stop", st.restored, tc.wantRestored)
+			}
+			if tc.wantReason == kueue.WorkloadFinishedReasonOutOfSync && !st.suspendedAtWrite {
+				t.Error("the workload was finished before the job was stopped")
+			}
+			if gone := len(got.Finalizers) == 0; gone != tc.wantFinalizerGone {
+				t.Errorf("the workload finalizers %v, want gone = %v", got.Finalizers, tc.wantFinalizerGone)
+			}
+			if stops != tc.wantStops {
+				t.Errorf("the job was stopped %d times, want %d", stops, tc.wantStops)
+			}
+		})
+	}
 }

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1257,6 +1257,11 @@ type prebuiltJobState struct {
 	// that completes while stopping. finishedCalls counts the calls to detect the reload.
 	finishedOnReread bool
 	finishedCalls    int
+	// activeOnReread makes IsActive report running only from the reload on, modeling a
+	// controller that created a pod from a view older than the stop. activeCalls counts the
+	// calls the same way.
+	activeOnReread bool
+	activeCalls    int
 }
 
 // countingStopJob wraps a GenericJob mock and implements JobWithCustomStop so a second stop is
@@ -1302,7 +1307,10 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		mgj.EXPECT().GVK().Return(gvk).AnyTimes()
 		mgj.EXPECT().PodSets(gomock.Any(), gomock.Any()).Return(jobPodSets, nil).AnyTimes()
 		mgj.EXPECT().IsSuspended().DoAndReturn(func() bool { return st.suspended }).AnyTimes()
-		mgj.EXPECT().IsActive().DoAndReturn(func() bool { return st.active }).AnyTimes()
+		mgj.EXPECT().IsActive().DoAndReturn(func() bool {
+			st.activeCalls++
+			return st.active || (st.activeOnReread && st.activeCalls >= 2)
+		}).AnyTimes()
 		mgj.EXPECT().Suspend().Do(func() { st.suspended = true }).AnyTimes()
 		mgj.EXPECT().RestorePodSetsInfo(gomock.Any(), gomock.Any()).
 			DoAndReturn(func(_ context.Context, info []podset.PodSetInfo) bool {
@@ -1450,6 +1458,22 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 		}
 		if reason := finishedReason(t, ctx, cl); reason != kueue.WorkloadFinishedReasonSucceeded {
 			t.Errorf("finished for %q, want %q", reason, kueue.WorkloadFinishedReasonSucceeded)
+		}
+	})
+
+	t.Run("a job that is running again at the reload is waited for, not marked OutOfSync", func(t *testing.T) {
+		// IsActive is false at the first check and true from the reload on: the external
+		// controller created a pod from a view older than the stop. The reload is the whole
+		// reason the second check exists — the first one ran against the object this reconcile
+		// started with, which is by then stale.
+		st := &prebuiltJobState{activeOnReread: true}
+		ctx, cl, r, mgj, req := setup(t, st, false)
+
+		if _, err := r.ReconcileGenericJob(ctx, req, mgj); err != nil {
+			t.Fatalf("reconcile: %v", err)
+		}
+		if reason := finishedReason(t, ctx, cl); reason != "" {
+			t.Errorf("finished for %q, want the workload still unfinished", reason)
 		}
 	})
 

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -1257,6 +1257,9 @@ type prebuiltJobState struct {
 	// that completes while stopping. finishedCalls counts the calls to detect the reload.
 	finishedOnReread bool
 	finishedCalls    int
+	// finishedAfterWrite makes Finished report terminal only from the read that follows the
+	// OutOfSync write, modeling a job that ends while that write is in flight.
+	finishedAfterWrite bool
 	// activeOnReread makes IsActive report running only from the reload on, modeling a
 	// controller that created a pod from a view older than the stop. activeCalls counts the
 	// calls the same way.
@@ -1334,6 +1337,16 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			wantRestored: true,
 			wantReason:   kueue.WorkloadFinishedReasonSucceeded,
 		},
+		// The job ends while the OutOfSync write is in flight, so both checks before it read a
+		// running job. The reason left behind is what MultiKueue re-dispatches on, so the read
+		// after the write has to put the job's own reason back.
+		"a job that ends while the OutOfSync write is in flight has its reason corrected": {
+			state:             prebuiltJobState{finishedAfterWrite: true, success: true},
+			wantStopped:       true,
+			wantRestored:      true,
+			wantReason:        kueue.WorkloadFinishedReasonSucceeded,
+			wantFinalizerGone: true,
+		},
 		// IsActive is false at the first check and true from the reload on: the external
 		// controller created a pod from a view older than the stop. The reload is the whole
 		// reason the second check exists — the first one ran against the object this reconcile
@@ -1394,7 +1407,9 @@ func TestReconcileGenericJob_PrebuiltOutOfSync(t *testing.T) {
 			mgj.EXPECT().Finished(gomock.Any()).
 				DoAndReturn(func(context.Context) (string, bool, bool) {
 					st.finishedCalls++
-					finished := st.finished || (st.finishedOnReread && st.finishedCalls >= 2)
+					finished := st.finished ||
+						(st.finishedOnReread && st.finishedCalls >= 2) ||
+						(st.finishedAfterWrite && st.finishedCalls >= 3)
 					return "by the job", st.success, finished
 				}).AnyTimes()
 

--- a/pkg/controller/jobframework/stop_reason.go
+++ b/pkg/controller/jobframework/stop_reason.go
@@ -21,6 +21,7 @@ type StopReason string
 const (
 	StopReasonWorkloadDeleted    StopReason = "WorkloadDeleted"
 	StopReasonWorkloadEvicted    StopReason = "WorkloadEvicted"
+	StopReasonWorkloadFinished   StopReason = "WorkloadFinished"
 	StopReasonNoMatchingWorkload StopReason = "NoMatchingWorkload"
 	StopReasonNotAdmitted        StopReason = "NotAdmitted"
 )

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -212,10 +212,15 @@ func (j *Job) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.Po
 		}
 	}
 
+	// An already stopped job comes back here on every reconcile that waits for it, so report
+	// whether there is anything left to write rather than patching an unchanged object.
 	if err := clientutil.Patch(ctx, c, object, func() (bool, error) {
-		j.RestorePodSetsInfo(ctx, podSetsInfo)
-		delete(j.Annotations, StoppingAnnotation)
-		return true, nil
+		changed := j.RestorePodSetsInfo(ctx, podSetsInfo)
+		if _, stopping := j.Annotations[StoppingAnnotation]; stopping {
+			delete(j.Annotations, StoppingAnnotation)
+			changed = true
+		}
+		return changed, nil
 	}); err != nil {
 		return false, fmt.Errorf("restore info: %w", err)
 	}

--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -144,6 +144,7 @@ var _ jobframework.GenericJob = (*Job)(nil)
 var _ jobframework.JobWithReclaimablePods = (*Job)(nil)
 var _ jobframework.JobWithCustomStop = (*Job)(nil)
 var _ jobframework.JobWithManagedBy = (*Job)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*Job)(nil)
 
 func (j *Job) Object() client.Object {
 	return (*batchv1.Job)(j)
@@ -159,6 +160,23 @@ func (j *Job) IsSuspended() bool {
 
 func (j *Job) IsActive() bool {
 	return j.Status.Active != 0
+}
+
+// StopAcknowledged reports whether the Job controller processed the suspend (set JobSuspended).
+// A zero status.Active can be a stale snapshot while the controller still creates pods.
+func (j *Job) StopAcknowledged() bool {
+	return jobControllerSuspended(j)
+}
+
+// jobControllerSuspended reports the JobSuspended status condition, set by the controller —
+// unlike IsSuspended, which reads the spec Kueue itself writes.
+func jobControllerSuspended(j *Job) bool {
+	for _, c := range j.Status.Conditions {
+		if c.Type == batchv1.JobSuspended {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
 }
 
 func (j *Job) Suspend() {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4307,6 +4307,57 @@ func TestReconciler(t *testing.T) {
 			},
 			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
+		"when the prebuilt workload is not equivalent to a job with running pods": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:  false,
+				features.AssignQueueLabelsForPods: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(false).
+				Active(1).
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				Obj(),
+			// Suspended, and the workload keeps its quota and its finalizer
+			// until the pod is gone.
+			wantJob: *baseJobWrapper.
+				Clone().
+				Active(1).
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").PriorityClass("test-pc").Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").PriorityClass("test-pc").Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "The prebuilt workload is out of sync with its user job",
+				},
+			},
+		},
 		"when the prebuilt workload is not equivalent to the job": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,
@@ -4333,9 +4384,10 @@ func TestReconciler(t *testing.T) {
 					Priority(100).
 					Obj(),
 			},
+			// The job is stopped before the workload is finished, and the
+			// finished workload then gives up its finalizer.
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
-					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").PriorityClass("test-pc").Obj()).
 					Queue("test-queue").
 					WorkloadPriorityClassRef("test-wpc").
@@ -4357,10 +4409,15 @@ func TestReconciler(t *testing.T) {
 					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
 					EventType: "Normal",
 					Reason:    "Stopped",
-					Message:   "missing workload",
+					Message:   "The prebuilt workload is out of sync with its user job",
+				},
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "FinishedWorkload",
+					Message:   "Workload 'ns/prebuilt-workload' is declared finished",
 				},
 			},
-			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"the workload is not admitted, tolerations and node selector change": {
 			featureGates: map[featuregate.Feature]bool{

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4364,10 +4364,10 @@ func TestReconciler(t *testing.T) {
 
 				features.AssignQueueLabelsForPods: true,
 			},
+			// Already suspended, and the Job controller has acknowledged it, so this reconcile
+			// decides rather than submitting the stop.
 			job: baseJobWrapper.
 				Clone().
-				Suspend(false).
-				// The Job controller has acknowledged the suspend, so the workload may finish.
 				Condition(batchv1.JobCondition{Type: batchv1.JobSuspended, Status: corev1.ConditionTrue}).
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
@@ -4411,12 +4411,6 @@ func TestReconciler(t *testing.T) {
 				{
 					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
 					EventType: "Normal",
-					Reason:    "Stopped",
-					Message:   "The prebuilt workload is out of sync with its user job",
-				},
-				{
-					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
-					EventType: "Normal",
 					Reason:    "FinishedWorkload",
 					Message:   "Workload 'ns/prebuilt-workload' is declared finished",
 				},
@@ -4427,11 +4421,10 @@ func TestReconciler(t *testing.T) {
 				features.TopologyAwareScheduling:  false,
 				features.AssignQueueLabelsForPods: true,
 			},
-			// No JobSuspended condition: the Job controller has not confirmed the stop, so the
-			// workload keeps its quota and finalizer instead of being finished as OutOfSync.
+			// Suspended already, but with no JobSuspended condition: the Job controller has not
+			// confirmed the stop, so the workload keeps its quota and finalizer.
 			job: baseJobWrapper.
 				Clone().
-				Suspend(false).
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
@@ -4461,14 +4454,6 @@ func TestReconciler(t *testing.T) {
 					}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
 					Obj(),
-			},
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
-					EventType: "Normal",
-					Reason:    "Stopped",
-					Message:   "The prebuilt workload is out of sync with its user job",
-				},
 			},
 		},
 		"the workload is not admitted, tolerations and node selector change": {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4367,11 +4367,14 @@ func TestReconciler(t *testing.T) {
 			job: baseJobWrapper.
 				Clone().
 				Suspend(false).
+				// The Job controller has acknowledged the suspend, so the workload may finish.
+				Condition(batchv1.JobCondition{Type: batchv1.JobSuspended, Status: corev1.ConditionTrue}).
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
+				Condition(batchv1.JobCondition{Type: batchv1.JobSuspended, Status: corev1.ConditionTrue}).
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
 				Obj(),
@@ -4416,6 +4419,55 @@ func TestReconciler(t *testing.T) {
 					EventType: "Normal",
 					Reason:    "FinishedWorkload",
 					Message:   "Workload 'ns/prebuilt-workload' is declared finished",
+				},
+			},
+		},
+		"when the prebuilt workload is out of sync but the suspend is not yet acknowledged": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:  false,
+				features.AssignQueueLabelsForPods: true,
+			},
+			// No JobSuspended condition: the Job controller has not confirmed the stop, so the
+			// workload keeps its quota and finalizer instead of being finished as OutOfSync.
+			job: baseJobWrapper.
+				Clone().
+				Suspend(false).
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").PriorityClass("test-pc").Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).Request(corev1.ResourceCPU, "1").PriorityClass("test-pc").Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "The prebuilt workload is out of sync with its user job",
 				},
 			},
 		},

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package job
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -587,6 +588,52 @@ var (
 		cmpopts.IgnoreFields(kueue.AdmissionCheckState{}, "LastTransitionTime"),
 	}
 )
+
+func TestStop(t *testing.T) {
+	// JobWithCustomStop requires Stop to be idempotent and to make no API calls once the job is
+	// stopped, and the framework reads the returned bool as "this call is what stopped it".
+	batchJob := utiltestingjob.MakeJob("job", "ns").Suspend(false).Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	writes := 0
+	cl := utiltesting.NewClientBuilder().
+		WithObjects(batchJob).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				writes++
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+			SubResourcePatch: func(ctx context.Context, c client.Client, sub string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+				writes++
+				return c.SubResource(sub).Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
+	job := fromObject(batchJob)
+
+	stoppedNow, err := job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
+	if err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if !stoppedNow {
+		t.Error("the first Stop did not report stopping the job")
+	}
+	if writes == 0 {
+		t.Error("the first Stop wrote nothing, so it cannot have suspended the job")
+	}
+
+	writes = 0
+	stoppedNow, err = job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
+	if err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+	if stoppedNow {
+		t.Error("the second Stop reported stopping an already stopped job, so the wait never ends")
+	}
+	if writes != 0 {
+		t.Errorf("the second Stop made %d API calls against an already stopped job", writes)
+	}
+}
 
 func TestReconciler(t *testing.T) {
 	// the clock is primarily used with second rounded times

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -100,9 +100,9 @@ func (j *JobSet) IsActive() bool {
 	return false
 }
 
-// StopAcknowledged reports whether the JobSet controller carried out the suspend. IsActive sums the
-// child Jobs' active counts, which are zero before those Jobs exist as well as after they are gone.
-// Only a reported "not suspended" holds; an absent condition is not a reading.
+// StopAcknowledged reports whether the JobSet controller has suspended the child Jobs it saw: it
+// writes their spec and sets this condition in the same call. The Job controllers still have to act
+// on that, which is what IsActive is read for. Only a reported "not suspended" holds.
 func (j *JobSet) StopAcknowledged() bool {
 	cond := apimeta.FindStatusCondition(j.Status.Conditions, string(jobsetapi.JobSetSuspended))
 	return cond == nil || cond.Status == metav1.ConditionTrue

--- a/pkg/controller/jobs/jobset/jobset_controller.go
+++ b/pkg/controller/jobs/jobset/jobset_controller.go
@@ -77,6 +77,7 @@ type JobSet jobsetapi.JobSet
 var _ jobframework.GenericJob = (*JobSet)(nil)
 var _ jobframework.JobWithReclaimablePods = (*JobSet)(nil)
 var _ jobframework.JobWithManagedBy = (*JobSet)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*JobSet)(nil)
 
 func fromObject(obj runtime.Object) *JobSet {
 	return (*JobSet)(obj.(*jobsetapi.JobSet))
@@ -97,6 +98,14 @@ func (j *JobSet) IsActive() bool {
 		}
 	}
 	return false
+}
+
+// StopAcknowledged reports whether the JobSet controller carried out the suspend. IsActive sums the
+// child Jobs' active counts, which are zero before those Jobs exist as well as after they are gone.
+// Only a reported "not suspended" holds; an absent condition is not a reading.
+func (j *JobSet) StopAcknowledged() bool {
+	cond := apimeta.FindStatusCondition(j.Status.Conditions, string(jobsetapi.JobSetSuspended))
+	return cond == nil || cond.Status == metav1.ConditionTrue
 }
 
 func (j *JobSet) Suspend() {

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -411,6 +411,44 @@ func TestRestorePodSetsInfo(t *testing.T) {
 	}
 }
 
+func TestStopAcknowledged(t *testing.T) {
+	suspended := func(status metav1.ConditionStatus) []metav1.Condition {
+		return []metav1.Condition{{Type: string(jobset.JobSetSuspended), Status: status}}
+	}
+	testCases := map[string]struct {
+		conditions []metav1.Condition
+		want       bool
+	}{
+		"no conditions: nothing reported, so nothing to wait on": {
+			want: true,
+		},
+		"another condition only: still nothing reported about the suspend": {
+			conditions: []metav1.Condition{{
+				Type:   string(jobset.JobSetCompleted),
+				Status: metav1.ConditionTrue,
+			}},
+			want: true,
+		},
+		"suspended false: the controller reports it running, so the stop is not carried out": {
+			conditions: suspended(metav1.ConditionFalse),
+			want:       false,
+		},
+		"suspended true: the controller carried out the stop": {
+			conditions: suspended(metav1.ConditionTrue),
+			want:       true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			j := (*JobSet)(&jobset.JobSet{Status: jobset.JobSetStatus{Conditions: tc.conditions}})
+			if got := j.StopAcknowledged(); got != tc.want {
+				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestReconciler(t *testing.T) {
 	baseWPCWrapper := utiltestingapi.MakeWorkloadPriorityClass("test-wpc").
 		PriorityValue(100)

--- a/pkg/controller/jobs/jobset/jobset_controller_test.go
+++ b/pkg/controller/jobs/jobset/jobset_controller_test.go
@@ -412,9 +412,6 @@ func TestRestorePodSetsInfo(t *testing.T) {
 }
 
 func TestStopAcknowledged(t *testing.T) {
-	suspended := func(status metav1.ConditionStatus) []metav1.Condition {
-		return []metav1.Condition{{Type: string(jobset.JobSetSuspended), Status: status}}
-	}
 	testCases := map[string]struct {
 		conditions []metav1.Condition
 		want       bool
@@ -430,12 +427,18 @@ func TestStopAcknowledged(t *testing.T) {
 			want: true,
 		},
 		"suspended false: the controller reports it running, so the stop is not carried out": {
-			conditions: suspended(metav1.ConditionFalse),
-			want:       false,
+			conditions: []metav1.Condition{{
+				Type:   string(jobset.JobSetSuspended),
+				Status: metav1.ConditionFalse,
+			}},
+			want: false,
 		},
 		"suspended true: the controller carried out the stop": {
-			conditions: suspended(metav1.ConditionTrue),
-			want:       true,
+			conditions: []metav1.Condition{{
+				Type:   string(jobset.JobSetSuspended),
+				Status: metav1.ConditionTrue,
+			}},
+			want: true,
 		},
 	}
 

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -179,9 +179,6 @@ func TestPriorityClass(t *testing.T) {
 }
 
 func TestStopAcknowledged(t *testing.T) {
-	suspended := func(status corev1.ConditionStatus) []kftraining.JobCondition {
-		return []kftraining.JobCondition{{Type: kftraining.JobSuspended, Status: status}}
-	}
 	testcases := map[string]struct {
 		conditions []kftraining.JobCondition
 		want       bool
@@ -194,12 +191,18 @@ func TestStopAcknowledged(t *testing.T) {
 			want:       true,
 		},
 		"suspended false: the operator reports it running, so the stop is not carried out": {
-			conditions: suspended(corev1.ConditionFalse),
-			want:       false,
+			conditions: []kftraining.JobCondition{{
+				Type:   kftraining.JobSuspended,
+				Status: corev1.ConditionFalse,
+			}},
+			want: false,
 		},
 		"suspended true: the operator carried out the stop": {
-			conditions: suspended(corev1.ConditionTrue),
-			want:       true,
+			conditions: []kftraining.JobCondition{{
+				Type:   kftraining.JobSuspended,
+				Status: corev1.ConditionTrue,
+			}},
+			want: true,
 		},
 	}
 

--- a/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
+++ b/pkg/controller/jobs/kubeflow/jobs/pytorchjob/pytorchjob_controller_test.go
@@ -178,6 +178,41 @@ func TestPriorityClass(t *testing.T) {
 	}
 }
 
+func TestStopAcknowledged(t *testing.T) {
+	suspended := func(status corev1.ConditionStatus) []kftraining.JobCondition {
+		return []kftraining.JobCondition{{Type: kftraining.JobSuspended, Status: status}}
+	}
+	testcases := map[string]struct {
+		conditions []kftraining.JobCondition
+		want       bool
+	}{
+		"no conditions: nothing reported, so nothing to wait on": {
+			want: true,
+		},
+		"another condition only: still nothing reported about the suspend": {
+			conditions: []kftraining.JobCondition{{Type: kftraining.JobRunning, Status: corev1.ConditionTrue}},
+			want:       true,
+		},
+		"suspended false: the operator reports it running, so the stop is not carried out": {
+			conditions: suspended(corev1.ConditionFalse),
+			want:       false,
+		},
+		"suspended true: the operator carried out the stop": {
+			conditions: suspended(corev1.ConditionTrue),
+			want:       true,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			job := fromObject(&kftraining.PyTorchJob{Status: kftraining.JobStatus{Conditions: tc.conditions}})
+			if got := job.StopAcknowledged(); got != tc.want {
+				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestOrderedReplicaTypes(t *testing.T) {
 	testcases := map[string]struct {
 		job              kftraining.PyTorchJob

--- a/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
+++ b/pkg/controller/jobs/kubeflow/kubeflowjob/kubeflowjob_controller.go
@@ -42,6 +42,7 @@ var _ jobframework.GenericJob = (*KubeflowJob)(nil)
 var _ jobframework.JobWithPriorityClass = (*KubeflowJob)(nil)
 var _ jobframework.JobWithCustomValidation = (*KubeflowJob)(nil)
 var _ jobframework.JobWithManagedBy = (*KubeflowJob)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*KubeflowJob)(nil)
 
 func (j *KubeflowJob) Object() client.Object {
 	return j.KFJobControl.Object()
@@ -138,6 +139,22 @@ func (j *KubeflowJob) IsActive() bool {
 		}
 	}
 	return false
+}
+
+// StopAcknowledged reports whether the training operator carried out the suspend. It zeroes the
+// replicas' active counts in the same status write that sets Suspended, so only a reported "not
+// suspended" holds.
+func (j *KubeflowJob) StopAcknowledged() bool {
+	status := j.KFJobControl.JobStatus()
+	if status == nil {
+		return true
+	}
+	for _, c := range status.Conditions {
+		if c.Type == kftraining.JobSuspended {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return true
 }
 
 func (j *KubeflowJob) PodsReady(ctx context.Context, _ client.Client) bool {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -437,8 +437,13 @@ func (p *Pod) PodSets(ctx context.Context, _ client.Client) ([]kueue.PodSet, err
 // its grace period status. This allows quota to be released as soon as
 // preempted pods begin terminating.
 func (p *Pod) IsActive() bool {
-	for i := range p.list.Items {
-		pod := p.list.Items[i]
+	// A single (non-group) Pod is not in p.list; read its own object, as Stop does.
+	pods := p.list.Items
+	if !p.isGroup {
+		pods = []corev1.Pod{p.pod}
+	}
+	for i := range pods {
+		pod := pods[i]
 
 		// Pods that are not in the Running phase are never considered Active.
 		if pod.Status.Phase != corev1.PodRunning {

--- a/pkg/controller/jobs/pod/pod_controller.go
+++ b/pkg/controller/jobs/pod/pod_controller.go
@@ -422,7 +422,7 @@ func (p *Pod) PodSets(ctx context.Context, _ client.Client) ([]kueue.PodSet, err
 
 // IsActive reports whether a Pod or PodGroup should be considered active.
 //
-// For regular Pod, return value is always false.
+// For a regular Pod, return true if that Pod itself is active.
 //
 // For Pod group, return true if there is at least a single Active pod in the group.
 // A Pod is considered active if it is in the Running phase and has not exceeded
@@ -681,6 +681,10 @@ func getRoleHash(p corev1.Pod) (string, error) {
 
 // Load loads all pods in the group
 func (p *Pod) Load(ctx context.Context, c client.Client, key *types.NamespacedName) (removeFinalizers bool, err error) {
+	// Reloading the same wrapper must not report an emptied group as still present.
+	p.isFound, p.isGroup = false, false
+	p.pod, p.list = corev1.Pod{}, corev1.PodList{}
+
 	nsKey := strings.Split(key.Namespace, "/")
 
 	if len(nsKey) == 1 {

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -7082,19 +7082,66 @@ func TestPod_IsActive(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 
 	type fields struct {
-		pod  corev1.Pod
-		list corev1.PodList
+		pod     corev1.Pod
+		list    corev1.PodList
+		isGroup bool
 	}
 	tests := map[string]struct {
 		fields                 fields
 		enableFastQuotaRelease bool
 		want                   bool
 	}{
-		"RegularPod": {
+		"SinglePod_NotFound_Inactive": {
+			want: false,
+		},
+		"SinglePod_Running_Active": {
+			fields: fields{
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "single"},
+					Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			want: true,
+		},
+		"SinglePod_Succeeded_Inactive": {
+			fields: fields{
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "single"},
+					Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+				},
+			},
+			want: false,
+		},
+		"SinglePod_TerminatingWithinGrace_Active": {
+			fields: fields{
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:                       "single-terminating",
+						DeletionTimestamp:          new(metav1.NewTime(now.Add(-10 * time.Second))),
+						DeletionGracePeriodSeconds: new(int64(90)),
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
+			want: true,
+		},
+		"SinglePod_FastQuotaRelease_Terminating_Inactive": {
+			enableFastQuotaRelease: true,
+			fields: fields{
+				pod: corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:                       "single-terminating",
+						DeletionTimestamp:          new(metav1.NewTime(now.Add(-10 * time.Second))),
+						DeletionGracePeriodSeconds: new(int64(90)),
+					},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning},
+				},
+			},
 			want: false,
 		},
 		"PodGroup_NotActive": {
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7119,6 +7166,7 @@ func TestPod_IsActive(t *testing.T) {
 		},
 		"PodGroup_Active": {
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7153,6 +7201,7 @@ func TestPod_IsActive(t *testing.T) {
 		"FastQuotaRelease_PodWithDeletionTimestamp_Inactive": {
 			enableFastQuotaRelease: true,
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7171,6 +7220,7 @@ func TestPod_IsActive(t *testing.T) {
 		"FastQuotaRelease_Disabled_PodWithDeletionTimestampWithinGrace_Active": {
 			enableFastQuotaRelease: false,
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7189,6 +7239,7 @@ func TestPod_IsActive(t *testing.T) {
 		"FastQuotaRelease_MixedGroup_SomeTerminating_SomeRunning": {
 			enableFastQuotaRelease: true,
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7211,6 +7262,7 @@ func TestPod_IsActive(t *testing.T) {
 		"FastQuotaRelease_AllTerminating": {
 			enableFastQuotaRelease: true,
 			fields: fields{
+				isGroup: true,
 				list: corev1.PodList{
 					Items: []corev1.Pod{
 						{
@@ -7239,9 +7291,10 @@ func TestPod_IsActive(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGateDuringTest(t, features.FastQuotaReleaseInPodIntegration, tt.enableFastQuotaRelease)
 			p := &Pod{
-				pod:   tt.fields.pod,
-				list:  tt.fields.list,
-				clock: testingclock.NewFakeClock(now),
+				pod:     tt.fields.pod,
+				list:    tt.fields.list,
+				isGroup: tt.fields.isGroup,
+				clock:   testingclock.NewFakeClock(now),
 			}
 			if got := p.IsActive(); got != tt.want {
 				t.Errorf("IsActive() = %v, want %v", got, tt.want)

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -6202,21 +6202,49 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Obj(),
 			},
-			// Stop deletes the pods, and finishing the workload takes their
-			// finalizer off, so the deletion goes through.
-			wantPods: []corev1.Pod{},
+			// This reconcile is the one that stops the pods, so it ends there. The workload keeps
+			// its quota until a later pass reads a group that the stop has reached.
+			wantPods: []corev1.Pod{
+				*basePodWrapper.
+					Clone().
+					Name("pod1").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					StatusPhase(corev1.PodPending).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					StatusConditions(corev1.PodCondition{
+						Type:    ConditionTypeTerminationTarget,
+						Status:  corev1.ConditionTrue,
+						Reason:  "NoMatchingWorkload",
+						Message: "The prebuilt workload is out of sync with its user job",
+					}).
+					Obj(),
+				*basePodWrapper.
+					Clone().
+					Name("pod2").
+					ManagedByKueueLabel().
+					PrebuiltWorkloadLabel("prebuilt-workload").
+					KueueFinalizer().
+					StatusPhase(corev1.PodPending).
+					GroupNameLabel("test-group").
+					GroupTotalCount("2").
+					StatusConditions(corev1.PodCondition{
+						Type:    ConditionTypeTerminationTarget,
+						Status:  corev1.ConditionTrue,
+						Reason:  "NoMatchingWorkload",
+						Message: "The prebuilt workload is out of sync with its user job",
+					}).
+					Obj(),
+			},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localTestQueueName).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
-					Condition(metav1.Condition{
-						Type:    kueue.WorkloadFinished,
-						Status:  metav1.ConditionTrue,
-						Reason:  "OutOfSync",
-						Message: "The prebuilt workload is out of sync with its user job",
-					}).
 					Obj(),
 			},
 			wantEvents: []utiltesting.EventRecord{
@@ -6231,12 +6259,6 @@ func TestReconciler(t *testing.T) {
 					EventType: "Normal",
 					Reason:    "Stopped",
 					Message:   "The prebuilt workload is out of sync with its user job",
-				},
-				{
-					Key:       types.NamespacedName{Name: "pod1", Namespace: "ns"},
-					EventType: "Normal",
-					Reason:    "FinishedWorkload",
-					Message:   "Workload 'ns/prebuilt-workload' is declared finished",
 				},
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -6202,43 +6202,11 @@ func TestReconciler(t *testing.T) {
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod2", "test-uid").
 					Obj(),
 			},
-			wantPods: []corev1.Pod{
-				*basePodWrapper.
-					Clone().
-					Name("pod1").
-					ManagedByKueueLabel().
-					PrebuiltWorkloadLabel("prebuilt-workload").
-					KueueFinalizer().
-					StatusPhase(corev1.PodPending).
-					GroupNameLabel("test-group").
-					GroupTotalCount("2").
-					StatusConditions(corev1.PodCondition{
-						Type:    ConditionTypeTerminationTarget,
-						Status:  corev1.ConditionTrue,
-						Reason:  "NoMatchingWorkload",
-						Message: "missing workload",
-					}).
-					Obj(),
-				*basePodWrapper.
-					Clone().
-					Name("pod2").
-					ManagedByKueueLabel().
-					PrebuiltWorkloadLabel("prebuilt-workload").
-					KueueFinalizer().
-					StatusPhase(corev1.PodPending).
-					GroupNameLabel("test-group").
-					GroupTotalCount("2").
-					StatusConditions(corev1.PodCondition{
-						Type:    ConditionTypeTerminationTarget,
-						Status:  corev1.ConditionTrue,
-						Reason:  "NoMatchingWorkload",
-						Message: "missing workload",
-					}).
-					Obj(),
-			},
+			// Stop deletes the pods, and finishing the workload takes their
+			// finalizer off, so the deletion goes through.
+			wantPods: []corev1.Pod{},
 			wantWorkloads: []kueue.Workload{
 				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
-					Finalizers(kueue.ResourceInUseFinalizerName).
 					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).Request(corev1.ResourceCPU, "1").Obj()).
 					Queue(localTestQueueName).
 					OwnerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod1", "test-uid").
@@ -6256,17 +6224,22 @@ func TestReconciler(t *testing.T) {
 					Key:       types.NamespacedName{Name: "pod1", Namespace: "ns"},
 					EventType: "Normal",
 					Reason:    "Stopped",
-					Message:   "missing workload",
+					Message:   "The prebuilt workload is out of sync with its user job",
 				},
 				{
 					Key:       types.NamespacedName{Name: "pod2", Namespace: "ns"},
 					EventType: "Normal",
 					Reason:    "Stopped",
-					Message:   "missing workload",
+					Message:   "The prebuilt workload is out of sync with its user job",
+				},
+				{
+					Key:       types.NamespacedName{Name: "pod1", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "FinishedWorkload",
+					Message:   "Workload 'ns/prebuilt-workload' is declared finished",
 				},
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
-			wantErr:         jobframework.ErrPrebuiltWorkloadNotFound,
 		},
 		"when workload is deactivated by kueue; objectRetentionPolicies.workloads.afterDeactivatedByKueue=0; should delete the job": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -50,6 +50,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
 	"sigs.k8s.io/kueue/pkg/podset"
+	"sigs.k8s.io/kueue/pkg/util/expectations"
 	utilpod "sigs.k8s.io/kueue/pkg/util/pod"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -6892,6 +6893,60 @@ func TestReconciler_ErrorFinalizingPod(t *testing.T) {
 
 			if diff := cmp.Diff([]kueue.Workload{*wantWl}, gotWorkloads.Items, defaultWorkloadCmpOpts...); diff != "" {
 				t.Errorf("Workloads after second reconcile (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	const groupName = "grp"
+
+	cases := map[string]struct {
+		// emptiedOnReload deletes every member before the second load, which is what a group whose
+		// pods were finalized between two loads of the same wrapper looks like.
+		emptiedOnReload      bool
+		wantRemoveFinalizers bool
+	}{
+		"a group emptied between two loads of the same wrapper is reported gone": {
+			emptiedOnReload:      true,
+			wantRemoveFinalizers: true,
+		},
+		"a group that kept a member is still reported present": {},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, _ := utiltesting.ContextWithLog(t)
+			podA := testingpod.MakePod("pod-a", "ns").Label(podconstants.GroupNameLabel, groupName).Obj()
+			podB := testingpod.MakePod("pod-b", "ns").Label(podconstants.GroupNameLabel, groupName).Obj()
+
+			cl := utiltesting.NewClientBuilder().
+				WithObjects(podA, podB).
+				WithIndex(&corev1.Pod{}, PodGroupNameCacheKey, IndexPodGroupName).
+				Build()
+
+			p := &Pod{excessPodExpectations: expectations.NewStore("test")}
+			key := types.NamespacedName{Name: groupName, Namespace: "group/ns"}
+			if _, err := p.Load(ctx, cl, &key); err != nil {
+				t.Fatalf("first Load: %v", err)
+			}
+
+			if err := cl.Delete(ctx, podA); err != nil {
+				t.Fatalf("deleting pod-a: %v", err)
+			}
+			if tc.emptiedOnReload {
+				if err := cl.Delete(ctx, podB); err != nil {
+					t.Fatalf("deleting pod-b: %v", err)
+				}
+			}
+
+			reloadKey := types.NamespacedName{Name: groupName, Namespace: "group/ns"}
+			gotRemoveFinalizers, err := p.Load(ctx, cl, &reloadKey)
+			if err != nil {
+				t.Fatalf("second Load: %v", err)
+			}
+			if gotRemoveFinalizers != tc.wantRemoveFinalizers {
+				t.Errorf("the reload reported removeFinalizers = %v, want %v", gotRemoveFinalizers, tc.wantRemoveFinalizers)
 			}
 		})
 	}

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -23,6 +23,7 @@ import (
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,17 +93,11 @@ func (j *RayCluster) IsActive() bool {
 	return j.Status.State == rayv1.Ready
 }
 
-// StopAcknowledged reports whether KubeRay finished the suspend: RayClusterSuspended is set only
-// after every pod is deleted. A status KubeRay wrote for an earlier generation says nothing about
-// this stop, since a resume it has not caught up with yet still reads suspended. An observed
-// generation of zero is not a reading, so it is left alone; older KubeRay without the condition
-// falls back to the Suspended state.
+// StopAcknowledged reports whether KubeRay deleted every pod: it sets RayClusterSuspended only
+// then, for the generation it read. Older KubeRay reports no such condition; read the state.
 func (j *RayCluster) StopAcknowledged() bool {
-	if j.Status.ObservedGeneration != 0 && j.Status.ObservedGeneration < j.Generation {
-		return false
-	}
-	if len(j.Status.Conditions) > 0 {
-		return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayClusterSuspended))
+	if cond := meta.FindStatusCondition(j.Status.Conditions, string(rayv1.RayClusterSuspended)); cond != nil {
+		return j.Status.ObservedGeneration == j.Generation && cond.Status == metav1.ConditionTrue
 	}
 	return j.Status.State == rayv1.Suspended
 }

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -93,8 +93,14 @@ func (j *RayCluster) IsActive() bool {
 }
 
 // StopAcknowledged reports whether KubeRay finished the suspend: RayClusterSuspended is set only
-// after every pod is deleted. Older KubeRay without the condition falls back to the Suspended state.
+// after every pod is deleted. A status KubeRay wrote for an earlier generation says nothing about
+// this stop, since a resume it has not caught up with yet still reads suspended. An observed
+// generation of zero is not a reading, so it is left alone; older KubeRay without the condition
+// falls back to the Suspended state.
 func (j *RayCluster) StopAcknowledged() bool {
+	if j.Status.ObservedGeneration != 0 && j.Status.ObservedGeneration < j.Generation {
+		return false
+	}
 	if len(j.Status.Conditions) > 0 {
 		return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayClusterSuspended))
 	}

--- a/pkg/controller/jobs/raycluster/raycluster_controller.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller.go
@@ -22,6 +22,7 @@ import (
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	rayutils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -77,6 +78,7 @@ type RayCluster rayv1.RayCluster
 
 var _ jobframework.GenericJob = (*RayCluster)(nil)
 var _ jobframework.JobWithManagedBy = (*RayCluster)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*RayCluster)(nil)
 
 func (j *RayCluster) Object() client.Object {
 	return (*rayv1.RayCluster)(j)
@@ -88,6 +90,15 @@ func (j *RayCluster) IsSuspended() bool {
 
 func (j *RayCluster) IsActive() bool {
 	return j.Status.State == rayv1.Ready
+}
+
+// StopAcknowledged reports whether KubeRay finished the suspend: RayClusterSuspended is set only
+// after every pod is deleted. Older KubeRay without the condition falls back to the Suspended state.
+func (j *RayCluster) StopAcknowledged() bool {
+	if len(j.Status.Conditions) > 0 {
+		return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayClusterSuspended))
+	}
+	return j.Status.State == rayv1.Suspended
 }
 
 func (j *RayCluster) Suspend() {

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -831,6 +831,28 @@ func TestStopAcknowledged(t *testing.T) {
 			},
 			want: true,
 		},
+		// Older KubeRay reports the state, not the condition, but still reports other conditions.
+		"an unrelated condition does not hide the legacy suspended state": {
+			status: rayv1.RayClusterStatus{
+				State: rayv1.Suspended,
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.HeadPodReady),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: true,
+		},
+		// KubeRay writes the generation into the same status as the condition.
+		"suspended reported without a generation: not acknowledged": {
+			generation: 2,
+			status: rayv1.RayClusterStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: false,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -765,9 +765,32 @@ func TestReconciler(t *testing.T) {
 
 func TestStopAcknowledged(t *testing.T) {
 	testCases := map[string]struct {
-		status rayv1.RayClusterStatus
-		want   bool
+		generation int64
+		status     rayv1.RayClusterStatus
+		want       bool
 	}{
+		"suspended, but reported for an earlier generation: not acknowledged": {
+			generation: 2,
+			status: rayv1.RayClusterStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: false,
+		},
+		"suspended and reported for this generation: acknowledged": {
+			generation: 2,
+			status: rayv1.RayClusterStatus{
+				ObservedGeneration: 2,
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: true,
+		},
 		"provisioning, no conditions yet: stop not acknowledged": {
 			status: rayv1.RayClusterStatus{State: ""},
 			want:   false,
@@ -812,7 +835,10 @@ func TestStopAcknowledged(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			j := (*RayCluster)(&rayv1.RayCluster{Status: tc.status})
+			j := (*RayCluster)(&rayv1.RayCluster{
+				ObjectMeta: metav1.ObjectMeta{Generation: tc.generation},
+				Status:     tc.status,
+			})
 			if got := j.StopAcknowledged(); got != tc.want {
 				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
 			}

--- a/pkg/controller/jobs/raycluster/raycluster_controller_test.go
+++ b/pkg/controller/jobs/raycluster/raycluster_controller_test.go
@@ -762,3 +762,60 @@ func TestReconciler(t *testing.T) {
 		}
 	}
 }
+
+func TestStopAcknowledged(t *testing.T) {
+	testCases := map[string]struct {
+		status rayv1.RayClusterStatus
+		want   bool
+	}{
+		"provisioning, no conditions yet: stop not acknowledged": {
+			status: rayv1.RayClusterStatus{State: ""},
+			want:   false,
+		},
+		"ready, no conditions: stop not acknowledged": {
+			status: rayv1.RayClusterStatus{State: rayv1.Ready},
+			want:   false,
+		},
+		"suspended state, no conditions (older KubeRay): acknowledged": {
+			status: rayv1.RayClusterStatus{State: rayv1.Suspended},
+			want:   true,
+		},
+		"conditions present, not suspended: not acknowledged": {
+			status: rayv1.RayClusterStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.HeadPodReady),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: false,
+		},
+		"conditions present, suspending in progress: not acknowledged": {
+			// Pods are still being deleted, so the stop is not complete.
+			status: rayv1.RayClusterStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.RayClusterSuspending),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: false,
+		},
+		"conditions present, suspended: all Pods deleted, acknowledged": {
+			status: rayv1.RayClusterStatus{
+				Conditions: []metav1.Condition{{
+					Type:   string(rayv1.RayClusterSuspended),
+					Status: metav1.ConditionTrue,
+				}},
+			},
+			want: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			j := (*RayCluster)(&rayv1.RayCluster{Status: tc.status})
+			if got := j.StopAcknowledged(); got != tc.want {
+				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -128,6 +128,7 @@ var _ jobframework.JobWithCustomAnnotations = (*RayService)(nil)
 var _ jobframework.JobWithManagedBy = (*RayService)(nil)
 var _ jobframework.ElasticWorkloadNameProvider = (*RayService)(nil)
 var _ jobframework.JobWithSkip = (*RayService)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*RayService)(nil)
 
 func (j *RayService) Object() client.Object {
 	return (*rayv1.RayService)(j)
@@ -139,6 +140,22 @@ func (j *RayService) IsSuspended() bool {
 
 func (j *RayService) IsActive() bool {
 	return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayServiceReady))
+}
+
+// StopAcknowledged reports whether neither the active nor pending RayCluster still holds pods.
+// RayServiceReady is serve-readiness, not pod existence, so the cluster slots are tracked instead.
+func (j *RayService) StopAcknowledged() bool {
+	return !rayServiceClusterActive(j.Status.ActiveServiceStatus) &&
+		!rayServiceClusterActive(j.Status.PendingServiceStatus)
+}
+
+// rayServiceClusterActive reports whether a cluster slot may still hold pods: it names a cluster
+// KubeRay has not reported suspended.
+func rayServiceClusterActive(s rayv1.RayServiceStatus) bool {
+	if s.RayClusterName == "" {
+		return false
+	}
+	return !meta.IsStatusConditionTrue(s.RayClusterStatus.Conditions, string(rayv1.RayClusterSuspended))
 }
 
 func (j *RayService) Suspend() {

--- a/pkg/controller/jobs/rayservice/rayservice_controller.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller.go
@@ -142,9 +142,12 @@ func (j *RayService) IsActive() bool {
 	return meta.IsStatusConditionTrue(j.Status.Conditions, string(rayv1.RayServiceReady))
 }
 
-// StopAcknowledged reports whether neither the active nor pending RayCluster still holds pods.
-// RayServiceReady is serve-readiness, not pod existence, so the cluster slots are tracked instead.
+// StopAcknowledged reports whether neither cluster slot still holds pods. RayServiceReady is
+// serve-readiness, so read the slots instead, and only for the generation KubeRay reported.
 func (j *RayService) StopAcknowledged() bool {
+	if j.Status.ObservedGeneration != j.Generation {
+		return false
+	}
 	return !rayServiceClusterActive(j.Status.ActiveServiceStatus) &&
 		!rayServiceClusterActive(j.Status.PendingServiceStatus)
 }

--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -621,8 +621,9 @@ func TestStopAcknowledged(t *testing.T) {
 		RayClusterStatus: rayv1.RayClusterStatus{Conditions: []metav1.Condition{{Type: string(rayv1.RayClusterSuspended), Status: metav1.ConditionTrue}}},
 	}
 	testCases := map[string]struct {
-		status rayv1.RayServiceStatuses
-		want   bool
+		generation int64
+		status     rayv1.RayServiceStatuses
+		want       bool
 	}{
 		"not acknowledged - Ready is false but an active RayCluster still exists": {
 			status: rayv1.RayServiceStatuses{ActiveServiceStatus: activeCluster},
@@ -640,10 +641,24 @@ func TestStopAcknowledged(t *testing.T) {
 			status: rayv1.RayServiceStatuses{},
 			want:   true,
 		},
+		// KubeRay writes the slots and the generation it read in the same status.
+		"not acknowledged - the slots were not written for this generation": {
+			generation: 2,
+			status:     rayv1.RayServiceStatuses{ObservedGeneration: 1},
+			want:       false,
+		},
+		"not acknowledged - a service KubeRay has not reported on at all": {
+			generation: 1,
+			status:     rayv1.RayServiceStatuses{},
+			want:       false,
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			j := (*RayService)(&rayv1.RayService{Status: tc.status})
+			j := (*RayService)(&rayv1.RayService{
+				ObjectMeta: metav1.ObjectMeta{Generation: tc.generation},
+				Status:     tc.status,
+			})
 			if got := j.StopAcknowledged(); got != tc.want {
 				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
 			}

--- a/pkg/controller/jobs/rayservice/rayservice_controller_test.go
+++ b/pkg/controller/jobs/rayservice/rayservice_controller_test.go
@@ -614,6 +614,43 @@ func TestIsActive(t *testing.T) {
 	}
 }
 
+func TestStopAcknowledged(t *testing.T) {
+	activeCluster := rayv1.RayServiceStatus{RayClusterName: "active"}
+	suspendedCluster := rayv1.RayServiceStatus{
+		RayClusterName:   "active",
+		RayClusterStatus: rayv1.RayClusterStatus{Conditions: []metav1.Condition{{Type: string(rayv1.RayClusterSuspended), Status: metav1.ConditionTrue}}},
+	}
+	testCases := map[string]struct {
+		status rayv1.RayServiceStatuses
+		want   bool
+	}{
+		"not acknowledged - Ready is false but an active RayCluster still exists": {
+			status: rayv1.RayServiceStatuses{ActiveServiceStatus: activeCluster},
+			want:   false,
+		},
+		"not acknowledged - a pending RayCluster still exists": {
+			status: rayv1.RayServiceStatuses{PendingServiceStatus: activeCluster},
+			want:   false,
+		},
+		"acknowledged - active RayCluster suspended, no pending": {
+			status: rayv1.RayServiceStatuses{ActiveServiceStatus: suspendedCluster},
+			want:   true,
+		},
+		"acknowledged - no RayClusters": {
+			status: rayv1.RayServiceStatuses{},
+			want:   true,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			j := (*RayService)(&rayv1.RayService{Status: tc.status})
+			if got := j.StopAcknowledged(); got != tc.want {
+				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPodsReady(t *testing.T) {
 	testCases := map[string]struct {
 		rayService *RayService

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -311,9 +311,7 @@ func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []pods
 		return false, errors.New("jobs are still active")
 	}
 
-	// A job that is already stopped comes back here on every reconcile that waits for it, so the
-	// restore reports whether it had anything to undo and the return says whether this call is
-	// what stopped the job.
+	// An already stopped job comes back here on every reconcile that waits for it.
 	restored := false
 	if err := clientutil.Patch(ctx, c, t.Object(), func() (bool, error) {
 		restored = t.RestorePodSetsInfo(ctx, podSetsInfo)

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -298,31 +298,41 @@ func (t *TrainJob) RunWithPodSetsInfo(ctx context.Context, c client.Client, podS
 }
 
 func (t *TrainJob) Stop(ctx context.Context, c client.Client, podSetsInfo []podset.PodSetInfo, _ jobframework.StopReason, _ string) (bool, error) {
+	suspended := false
 	if !t.IsSuspended() {
 		t.Suspend()
 		if err := c.Update(ctx, t.Object()); err != nil {
 			return false, fmt.Errorf("error suspending trainjob: %w", err)
 		}
+		suspended = true
 	}
 
 	if t.IsActive() {
 		return false, errors.New("jobs are still active")
 	}
 
+	// A job that is already stopped comes back here on every reconcile that waits for it, so the
+	// restore reports whether it had anything to undo and the return says whether this call is
+	// what stopped the job.
+	restored := false
 	if err := clientutil.Patch(ctx, c, t.Object(), func() (bool, error) {
-		if !t.RestorePodSetsInfo(ctx, podSetsInfo) {
-			return false, errors.New("error restoring info to the trainjob")
-		}
-		return true, nil
+		restored = t.RestorePodSetsInfo(ctx, podSetsInfo)
+		return restored, nil
 	}); err != nil {
 		return false, err
 	}
-	return true, nil
+	return suspended || restored, nil
 }
 
 func (t *TrainJob) RestorePodSetsInfo(_ context.Context, _ []podset.PodSetInfo) bool {
 	kueueRuntimePatch := getKueueRuntimePatch(t)
-	if kueueRuntimePatch == nil {
+	// The manager is a plain string the user can also set, so the patch this finds is not
+	// necessarily one this controller built.
+	if kueueRuntimePatch == nil ||
+		kueueRuntimePatch.TrainingRuntimeSpec == nil ||
+		kueueRuntimePatch.TrainingRuntimeSpec.Template == nil ||
+		kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec == nil ||
+		len(kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs) == 0 {
 		return false
 	}
 	kueueRuntimePatch.TrainingRuntimeSpec.Template.Spec.ReplicatedJobs = nil

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -99,6 +99,7 @@ var _ jobframework.GenericJob = (*TrainJob)(nil)
 var _ jobframework.JobWithCustomStop = (*TrainJob)(nil)
 var _ jobframework.JobWithReclaimablePods = (*TrainJob)(nil)
 var _ jobframework.JobWithManagedBy = (*TrainJob)(nil)
+var _ jobframework.JobWithStopAcknowledgement = (*TrainJob)(nil)
 
 func NewJob() jobframework.GenericJob {
 	return &TrainJob{}
@@ -124,6 +125,13 @@ func (t *TrainJob) IsActive() bool {
 		}
 	}
 	return false
+}
+
+// StopAcknowledged reports whether the trainer controller carried out the suspend. The JobsStatus
+// active counts trail the child JobSet, so only a reported "not suspended" holds.
+func (t *TrainJob) StopAcknowledged() bool {
+	cond := apimeta.FindStatusCondition(t.Status.Conditions, kftrainer.TrainJobSuspended)
+	return cond == nil || cond.Status == metav1.ConditionTrue
 }
 
 func (t *TrainJob) Suspend() {

--- a/pkg/controller/jobs/trainjob/trainjob_controller.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller.go
@@ -127,8 +127,9 @@ func (t *TrainJob) IsActive() bool {
 	return false
 }
 
-// StopAcknowledged reports whether the trainer controller carried out the suspend. The JobsStatus
-// active counts trail the child JobSet, so only a reported "not suspended" holds.
+// StopAcknowledged reports whether the trainer controller has run since the suspend: it applies the
+// child JobSet and only then sets this condition from the parent spec. The JobSet and the Jobs under
+// it still have to act, which is what IsActive is read for.
 func (t *TrainJob) StopAcknowledged() bool {
 	cond := apimeta.FindStatusCondition(t.Status.Conditions, kftrainer.TrainJobSuspended)
 	return cond == nil || cond.Status == metav1.ConditionTrue

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -55,6 +55,41 @@ var (
 	}
 )
 
+func TestStopAcknowledged(t *testing.T) {
+	suspended := func(status metav1.ConditionStatus) []metav1.Condition {
+		return []metav1.Condition{{Type: kftrainerapi.TrainJobSuspended, Status: status}}
+	}
+	testCases := map[string]struct {
+		conditions []metav1.Condition
+		want       bool
+	}{
+		"no conditions: nothing reported, so nothing to wait on": {
+			want: true,
+		},
+		"another condition only: still nothing reported about the suspend": {
+			conditions: []metav1.Condition{{Type: kftrainerapi.TrainJobComplete, Status: metav1.ConditionTrue}},
+			want:       true,
+		},
+		"suspended false: the controller reports it running, so the stop is not carried out": {
+			conditions: suspended(metav1.ConditionFalse),
+			want:       false,
+		},
+		"suspended true: the controller carried out the stop": {
+			conditions: suspended(metav1.ConditionTrue),
+			want:       true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			job := (*TrainJob)(&kftrainerapi.TrainJob{Status: kftrainerapi.TrainJobStatus{Conditions: tc.conditions}})
+			if got := job.StopAcknowledged(); got != tc.want {
+				t.Errorf("StopAcknowledged() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestRunWithPodsetsInfo(t *testing.T) {
 	toleration1 := corev1.Toleration{
 		Key:      "t1k",

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -56,9 +56,6 @@ var (
 )
 
 func TestStopAcknowledged(t *testing.T) {
-	suspended := func(status metav1.ConditionStatus) []metav1.Condition {
-		return []metav1.Condition{{Type: kftrainerapi.TrainJobSuspended, Status: status}}
-	}
 	testCases := map[string]struct {
 		conditions []metav1.Condition
 		want       bool
@@ -71,12 +68,18 @@ func TestStopAcknowledged(t *testing.T) {
 			want:       true,
 		},
 		"suspended false: the controller reports it running, so the stop is not carried out": {
-			conditions: suspended(metav1.ConditionFalse),
-			want:       false,
+			conditions: []metav1.Condition{{
+				Type:   kftrainerapi.TrainJobSuspended,
+				Status: metav1.ConditionFalse,
+			}},
+			want: false,
 		},
 		"suspended true: the controller carried out the stop": {
-			conditions: suspended(metav1.ConditionTrue),
-			want:       true,
+			conditions: []metav1.Condition{{
+				Type:   kftrainerapi.TrainJobSuspended,
+				Status: metav1.ConditionTrue,
+			}},
+			want: true,
 		},
 	}
 

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package trainjob
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	jobsetapi "sigs.k8s.io/jobset/api/jobset/v1alpha2"
 
@@ -55,10 +57,9 @@ var (
 	}
 )
 
-func TestStopIsIdempotent(t *testing.T) {
-	// The framework reads the returned bool as "this call is what stopped the job" and ends the
-	// reconcile when it is true, so a stop that keeps reporting true never lets the workload
-	// finish.
+func TestStop(t *testing.T) {
+	// JobWithCustomStop requires Stop to be idempotent and to make no API calls once the job is
+	// stopped, and the framework reads the returned bool as "this call is what stopped it".
 	trainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").
 		Suspend(true).
 		RuntimePatches([]kftrainerapi.RuntimePatch{
@@ -70,7 +71,20 @@ func TestStopIsIdempotent(t *testing.T) {
 		Obj()
 
 	ctx, _ := utiltesting.ContextWithLog(t)
-	cl := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme).WithObjects(trainJob).Build()
+	writes := 0
+	cl := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme).
+		WithObjects(trainJob).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				writes++
+				return c.Update(ctx, obj, opts...)
+			},
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				writes++
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		}).
+		Build()
 	job := (*TrainJob)(trainJob)
 
 	stoppedNow, err := job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
@@ -80,13 +94,20 @@ func TestStopIsIdempotent(t *testing.T) {
 	if !stoppedNow {
 		t.Error("the first Stop did not report stopping the job")
 	}
+	if writes == 0 {
+		t.Error("the first Stop wrote nothing, so it cannot have restored the pod set info")
+	}
 
+	writes = 0
 	stoppedNow, err = job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
 	if err != nil {
 		t.Fatalf("second Stop: %v", err)
 	}
 	if stoppedNow {
 		t.Error("the second Stop reported stopping an already stopped job, so the wait never ends")
+	}
+	if writes != 0 {
+		t.Errorf("the second Stop made %d API calls against an already stopped job", writes)
 	}
 }
 
@@ -423,6 +444,40 @@ func TestRestorePodSetsInfo(t *testing.T) {
 				Obj(),
 			wantReturn: true,
 		},
+		"should report no change when the kueue RuntimePatch is already cleared": {
+			trainJob: testTrainJob.Clone().
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+						EmptyMetadata().
+						Obj(),
+				}).
+				Obj(),
+			wantTrainJob: testTrainJob.Clone().
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+						EmptyMetadata().
+						Obj(),
+				}).
+				Obj(),
+			wantReturn: false,
+		},
+		"should report no change when only another manager holds a RuntimePatch": {
+			trainJob: testTrainJob.Clone().
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatch("example.com/user-manager").
+						ReplicatedJobs(testingtrainjob.MakeReplicatedJobPatch("user-provided").Obj()).
+						Obj(),
+				}).
+				Obj(),
+			wantTrainJob: testTrainJob.Clone().
+				RuntimePatches([]kftrainerapi.RuntimePatch{
+					testingtrainjob.MakeRuntimePatch("example.com/user-manager").
+						ReplicatedJobs(testingtrainjob.MakeReplicatedJobPatch("user-provided").Obj()).
+						Obj(),
+				}).
+				Obj(),
+			wantReturn: false,
+		},
 	}
 
 	for name, tc := range cases {
@@ -430,10 +485,10 @@ func TestRestorePodSetsInfo(t *testing.T) {
 			kTrainJob := (*TrainJob)(tc.trainJob)
 			ret := kTrainJob.RestorePodSetsInfo(t.Context(), []podset.PodSetInfo{})
 			if ret != tc.wantReturn {
-				t.Errorf("RunWithPodSetsInfo() unexpected return value. got: %v. want :%v", ret, tc.wantReturn)
+				t.Errorf("RestorePodSetsInfo() unexpected return value. got: %v. want :%v", ret, tc.wantReturn)
 			}
 			if diff := cmp.Diff(tc.wantTrainJob, tc.trainJob, tjobCmpOpts); diff != "" {
-				t.Errorf("RunWithPodSetsInfo() mismatch (-want,+got):\n%s", diff)
+				t.Errorf("RestorePodSetsInfo() mismatch (-want,+got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/trainjob/trainjob_controller_test.go
+++ b/pkg/controller/jobs/trainjob/trainjob_controller_test.go
@@ -55,6 +55,41 @@ var (
 	}
 )
 
+func TestStopIsIdempotent(t *testing.T) {
+	// The framework reads the returned bool as "this call is what stopped the job" and ends the
+	// reconcile when it is true, so a stop that keeps reporting true never lets the workload
+	// finish.
+	trainJob := testingtrainjob.MakeTrainJob("trainjob", "ns").
+		Suspend(true).
+		RuntimePatches([]kftrainerapi.RuntimePatch{
+			testingtrainjob.MakeRuntimePatch(runtimePatchManagerName).
+				EmptyMetadata().
+				ReplicatedJobs(testingtrainjob.MakeReplicatedJobPatch("node").Obj()).
+				Obj(),
+		}).
+		Obj()
+
+	ctx, _ := utiltesting.ContextWithLog(t)
+	cl := utiltesting.NewClientBuilder(kftrainerapi.AddToScheme).WithObjects(trainJob).Build()
+	job := (*TrainJob)(trainJob)
+
+	stoppedNow, err := job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
+	if err != nil {
+		t.Fatalf("first Stop: %v", err)
+	}
+	if !stoppedNow {
+		t.Error("the first Stop did not report stopping the job")
+	}
+
+	stoppedNow, err = job.Stop(ctx, cl, nil, jobframework.StopReasonNoMatchingWorkload, "out of sync")
+	if err != nil {
+		t.Fatalf("second Stop: %v", err)
+	}
+	if stoppedNow {
+		t.Error("the second Stop reported stopping an already stopped job, so the wait never ends")
+	}
+}
+
 func TestStopAcknowledged(t *testing.T) {
 	testCases := map[string]struct {
 		conditions []metav1.Condition

--- a/pkg/workload/finish/finish.go
+++ b/pkg/workload/finish/finish.go
@@ -54,6 +54,15 @@ func Finish(ctx context.Context, c client.Client, wl *kueue.Workload, reason, ms
 	return nil
 }
 
+// Rewrite replaces the reason and message on a workload that is already finished. Finish leaves a
+// condition that is set alone, and a reason written from a view of the job that has since moved on
+// has to be correctable before anything reads it.
+func Rewrite(ctx context.Context, c client.Client, wl *kueue.Workload, reason, msg string, clock clock.Clock) error {
+	return patching.PatchAdmissionStatus(ctx, c, wl, clock, func(wl *kueue.Workload) (bool, error) {
+		return setFinishedCondition(wl, clock.Now(), reason, msg), nil
+	})
+}
+
 // IsFinished returns true if the workload is finished.
 func IsFinished(w *kueue.Workload) bool {
 	return apimeta.IsStatusConditionTrue(w.Status.Conditions, kueue.WorkloadFinished)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`ensurePrebuiltWorkloadInSync` finished a prebuilt Workload as soon as it stopped matching its Job:

```go
// mark the workload as finished
msg := "The prebuilt workload is out of sync with its user job"
return false, workloadfinish.Finish(ctx, r.client, wl, kueue.WorkloadFinishedReasonOutOfSync, msg, r.clock)
```

Finishing is what returns the quota. The Workload controller takes the `StatusFinished` branch and calls `cache.DeleteWorkload`. Nothing had stopped the Job at that point, so an admitted Workload whose Job was running handed its capacity to the next Workload in line while its Pods kept running.

Four things have to hold on this path, and none of them did.

**A Job that has already ended keeps the reason it ended with.** This code runs before the shared handling of a finished Job, and returning `false` made `ensureOneWorkload` discard the Workload that this handling needs:

```go
if message, success, finished := job.Finished(ctx); finished {
	if wl != nil && !workloadfinish.IsFinished(wl) {
		reason := kueue.WorkloadFinishedReasonSucceeded
```

A completed Job therefore recorded `OutOfSync` instead of `Succeeded` or `Failed`. Other code reads that reason. `multikueue/workload.go:402` treats a remote `OutOfSync` as a synchronization failure and resets the admission check to `Retry`, so completed work could be dispatched a second time.

**The Job stops first, and it stops with its Workload in hand,** so `RestorePodSetsInfo` receives the PodSetInfo that admission applied rather than the `nil` that the no-Workload path passes.

**A stop that fails leaves the quota alone.**

**The Workload goes back to the caller once it is safely finished,** so the branch above the finished-Job handling can take its finalizer off:

```go
if wl != nil && workloadfinish.IsFinished(wl) {
	if err := r.finalizeJob(ctx, job); err != nil {
```

Discarding it left that branch unreachable. The finalizer stayed on and every later reconcile returned `ErrPrebuiltWorkloadNotFound` for a state it had already handled.

#### Which issue(s) this PR fixes:

Part of #14395

I am deliberately not closing it. RayJob, MPIJob and SparkApplication still finish from an
inactive status before their controllers have observed the stop, for the reasons in the table
below, and #14486 tracks them.

#### Special notes for your reviewer:

##### Why waiting on IsActive() alone is not enough

`IsActive()` is not a dependable "the Pods are gone" signal across integrations. `Pod.IsActive()` only scanned the group list, so a single non-group Pod was never examined and read `false` right after `Stop`. `RayCluster` and `RayService` answer it from readiness, so a provisioning or not-ready object that still holds Pods also reads `false`. For `batch/v1`, `status.active == 0` can predate the Job controller observing our `spec.suspend=true` patch.

Overloading `IsActive()` itself regressed admission, because a newly suspended Job with no Pods must still get its Workload created. The finish therefore gates on a new optional `JobWithStopAcknowledgement`: it waits for `IsActive()` to be false and for `StopAcknowledged()` to be true. Admission and eviction keep using `IsActive()` unchanged.

##### Which integrations implement it, and why the others do not

I checked every integration that reaches `ReconcileGenericJob`, and let the upstream API decide rather than adding a method everywhere:

| Integration | Stop observed through | Why |
|---|---|---|
| `batch/Job` | `JobSuspended` condition | the Job controller sets it once it has processed the suspend |
| JobSet | `Suspended` condition | the controller writes `spec.suspend` on the child Jobs and sets it in the same call, and maintains it in both directions |
| RayCluster | `RayClusterSuspended` for the reported generation, else `status.state` | `Suspending` holds until the Pods are deleted, and `calculateStatus` writes the generation into the same status, so a condition without a matching one was written for another spec. The state is read only when that condition is absent, which is what an older KubeRay looks like |
| RayService | both cluster slots suspended, for the reported generation | `RayServiceReady` reports serve readiness, not Pod existence, and slots a reconcile has not reached yet read empty rather than settled |
| Kubeflow (PyTorch, TF, Paddle, XGBoost, JAX) | `Suspended` condition | the training operator zeroes the replicas' active counts in the same status write that sets it |
| TrainJob | `Suspended` condition | the trainer controller applies the child JobSet and only then sets it, so it marks a reconcile that has seen the suspend |
| AppWrapper | not needed | `IsActive()` already reads `QuotaReserved`, a condition its controller writes rather than a count |
| Pod | not needed | `Pod.Stop` deletes the Pods itself |
| RayJob | no signal available | KubeRay writes `status.observedGeneration` for RayCluster and RayService only, and `JobDeploymentStatus: New` is the zero value, so "not yet seen" and "nothing created" cannot be told apart |
| MPIJob | no signal available | mpi-operator declares `JobSuspended` but never writes it; on suspend it writes `JobRunning=False` with an unexported reason |
| SparkApplication | no signal available | `SparkApplicationStatus` carries neither conditions nor `observedGeneration` |

The last three keep the `IsActive()`-only wait, which is still more than `main` does today, and #14486 tracks them. I left them out on purpose. An acknowledgement the framework cannot actually observe would be one we invented, and since `errWaitingForStop` ends the reconcile without a requeue, a wait that no status change can end becomes a permanent quota stall.

That is also why an absent condition still counts as acknowledged rather than the reverse, which is the part of this I am least comfortable with. Reading it the other way is the stricter contract, but it stalls: on a MultiKueue manager the training operator skips a Job whose `managedBy` points elsewhere (`pytorchjob_controller.go:135`), the adapter only mirrors the remote status, and MultiKueue deletes remote objects rather than suspending them, so `JobSuspended` never arrives and the quota is never released. What none of these conditions prove on their own is how far down the child chain the stop has reached; that is what `IsActive()` is read alongside them for, and what a context-taking check over the owned children would answer properly. #13308 is already reworking `IsActive` into `IsActive(ctx)`, and that seems the right place for it rather than a second interface change here.

##### What the acknowledgement does not prove

Two limits are worth stating rather than leaving to be found. The report says a controller acted on
*a* stop, not on this one: none of these APIs carries a token or a generation for the suspend
itself, so a `Suspended` condition that outlived a resume can acknowledge the stop that follows it.
And a parent's report covers the parent — JobSet writes its condition after patching the child Job
specs but before those controllers act on them, and TrainJob writes its own from `spec.suspend`
alone, without reading the JobSet below it.

That is why `IsActive()` is still read alongside it rather than replaced by it, and why an absent
condition is read as acknowledged rather than pending: a Job managed from a MultiKueue manager has
no local controller to write one, and failing closed there would hold its finalizer for good. The
narrowest honest claim is that this closes the window each parent controller can report on, not
that the stop has reached every Pod. #14486 tracks making the observation current-stop and
child-aware.

##### The pass that submits the stop does not decide

Nothing a reconcile reads can reflect a stop that same reconcile submitted. `IsActive()` and
`StopAcknowledged()` both read the Job status as it was loaded at the top of the pass, which is
before our own `spec.suspend` write, and the reload after it goes through the manager's cache,
which controller-runtime does not promise is read-after-write coherent.

So `stopJob` now reports whether it was the call that stopped the Job, and the prebuilt path ends
the reconcile when it was. The stop is a spec change on the Job we already watch, so the next pass
follows from it. This matters most for the integrations whose acknowledgement cannot distinguish
"not reported yet" from "stopped": before it, a JobSet with no `Suspended` condition and no child
Jobs yet could be finished on a snapshot taken strictly before Kueue suspended it.

`JobWithCustomStop` already required that a `Stop` be idempotent, make no API calls once the job is
stopped, and report whether it was the call that stopped it. Neither `batch/Job` nor `TrainJob` held
to that, and nothing asked them to until this became state-machine control: TrainJob answered true on
every call, which would have left an out-of-sync TrainJob waiting forever. Both now report an actual
mutation, and each has a `TestStop` that calls `Stop` twice and counts the writes the second call
makes. `RestorePodSetsInfo` carries the same "did anything change" contract, which the other
integrations already answered that way.

##### Reading the Job on both sides of the OutOfSync write

The Job is re-read before the write, because it can complete, or be started again by a controller
working from a pre-stop view, while it is stopping. The reload also checks the UID: a Job deleted
and recreated under the same name is a different Job, and the Workload this one carries is not its
own.

It is read once more after the write, because it can also complete during the write itself, and the
caller finalizes on whatever reason that write left behind. A Workload finished as `OutOfSync` then
gets the Job's own reason put back. `workloadfinish.Finish` leaves an already-set condition alone,
so the correction patches the condition directly. If that correction cannot be written, the next
pass retries it before the finalizer comes off, which is the last point at which it is still
possible.

That second read can also come back holding a different Job, or none at all: the original can be
deleted, or deleted and recreated under the same name, while the write is in flight. `loadJob`
normalizes in place, so the wrapper is then holding the replacement. Skipping only the correction
was not enough, because the caller goes on to run its custom Workload conditions and `finalizeJob`
against whatever the wrapper holds, and `Pod` is the one integration that implements
`JobWithFinalize`: its `Finalize` takes the Kueue finalizer off the pods it is holding by then. That
case now returns its own state, and the Workload's finalizer — the only thing it is still owed — is
all that comes off. Nothing that reads the Job runs.

The identity there is the object's UID, which is exact for a single-object Job and cannot be for a
pod group, whose `Object()` is whichever member `Load` picked. A group that merely lost a member
reads as replaced and lands in the same branch. I have left the guard as it is and filed #14533
rather than widen this PR, since the alternative is a new identity for composable jobs.

I want to be clear about what those reads do and do not buy. They repair the record, and they
remove the window between the last read and the write landing, which is where the input to #13047
was being decided. They are not a barrier. Under MultiKueue the manager may already have observed
the `OutOfSync` and reset its admission check, and in that case the re-dispatch has happened and
the remote Workload is deleted along with it. Closing that off completely belongs on the consuming
side in `multikueue/workload.go`, and I would rather raise it with the author of #13047 than change
that contract here.

##### Existing test expectations that change

`when the prebuilt workload is not equivalent to the job` in the Job integration expected the
reconcile to return `ErrPrebuiltWorkloadNotFound` and the Workload to keep
`kueue.x-k8s.io/resource-in-use`. Those were the retry loop and the finalizer leak described above.
The reconcile now returns cleanly and the finalizer comes off. Its fixture starts suspended, so
that this reconcile is the one that decides rather than the one that submits the stop; a second
case withholds the `JobSuspended` condition and asserts the Workload keeps its quota.

The Pod integration case keeps its Pods. `Pod.Stop` sets `TerminationTarget` and calls `c.Delete`,
and the Workload is finished on a later pass, so this reconcile leaves them Terminating with the
Kueue finalizer that `Pod.Finalize` removes once the Workload is finished.

The `Stopped` event message changes from `missing workload` to the out-of-sync message, since the
stop now happens on the path that knows why, and to the already-finished message when an earlier
pass had finished the Workload before the Job was stopped.

`batch/Job`'s `Stop` no longer patches an object it has nothing left to change. A waiting reconcile
reaches it on every pass now, and its last patch was unconditional.

##### How this state is reached at all

This is the part of #14395 worth reading first, because the mismatch cannot be built through the API. `validateImmutablePodSets` freezes the PodSets once the Workload has a quota reservation, and a Job's `spec.template` is immutable to the apiserver, so neither object can move into a mismatch. What moves is the comparison. Any change that adds a field to `comparePodTemplate` makes a previously equivalent pair non-equivalent under the new binary with neither object touched. `git log -S comparePodTemplate` finds only `c03612ea9`, the move into the framework, so nothing has done it yet. #14289 would be the first, which is how I came to look at this, and I have held that PR for this one.

##### One more fix in the same path

`ensurePrebuiltWorkloadInSync` now returns a three-state result rather than a bool. The old `false` conflated "waiting for stop" with "no usable Workload", so a waiting reconcile fell into `handleJobWithNoWorkload` and stopped the Job a second time as "missing workload", which is a second API call on an already-stopped `JobWithCustomStop`. A custom-stop mock asserts the stop runs exactly once.

##### Loading the same wrapper three times

This path now loads the same `GenericJob` wrapper up to three times in one reconcile — the
reconcile's own read, the one before the `OutOfSync` write and the one after it — and `Pod.Load`
was written for a single call. Neither of its branches ever clears `isFound`, so a group whose
members were all finalized between two loads still reported itself present, and the reload handed
back `removeFinalizers=false` for a group that was gone. It now clears what it recomputes before
reading. `TestLoad` empties the group between two loads of one wrapper and asserts the reload
reports it gone; the case that keeps a member is the control that makes the first one mean
something.

The `IsActive` doc on the same type went stale earlier in this series: it still said the return
value is always false for a regular Pod, which stopped being true when that path started reading
`p.pod`.

##### A Workload already finished as out of sync still has to stop its Job

The correction runs before the equivalence check, so a Job that has ended gets its own reason back
even once the pair matches again. A Job that had *not* ended was still let through: the pair matched,
the Workload was already finished, and the reconcile took it straight to the finalizer without ever
stopping the Job. The quota went when that earlier `OutOfSync` was written, and matching again does
not bring it back, so this is the leak this PR opens with, reached from the other side. An existing
`OutOfSync` finish now forces the stop unless the Job is terminal.

That makes the wait something that has to end. `errWaitingForStop` returned an empty result, so
liveness rested entirely on a later status event, and a Workload whose Job stopped producing them
kept its finalizer for good. Waiting now leaves a bounded `RequeueAfter` behind, at the same two
seconds `multikueue/workload.go` uses for its own deferred sync. The watch is still what normally
brings the next pass; the poll is there so that "no more events" stops meaning "never".

The stop a finished Workload forces is not a mismatch, so it no longer says it is one.
`StopReasonWorkloadFinished` is new, with the message `The prebuilt workload is already finished`.
`batch/v1` does not read the reason at all, but `Pod` writes it into the `TerminationTarget`
condition on each pod, which is where an operator looks.

##### How the tests were checked

`TestReconcileGenericJob_PrebuiltOutOfSync` drives the reconciler with a stateful mock. `Suspend()` moves the state the later assertions read, `IsActive()` and `Finished()` are answered from it and can flip at each re-read, and an interceptor records whether the Job was already stopped at the moment the Workload's status was written, so the ordering is asserted rather than inferred. One case runs two reconciles, and its second one asserts a plain `nil`, since the not-found retry is what this removes.

Breaking each barrier in turn shows which case holds it:

```
# the post-reload barrier removed
--- FAIL: .../a_job_that_is_running_again_at_the_reload_is_waited_for,_not_marked_OutOfSync
        the workload finished for "OutOfSync", want ""

# stopSettled forced to true
--- FAIL: .../a_job_that_is_running_again_at_the_reload_is_waited_for,_not_marked_OutOfSync
--- FAIL: .../the_job_is_stopped_exactly_once_and_waiting_never_enters_the_missing-workload_path
--- FAIL: .../a_job_with_running_pods_is_stopped,_and_its_workload_waits_until_they_are_gone
        the workload was finished for "OutOfSync" while its pods were running

# the post-write correction disabled
--- FAIL: .../a_job_that_ends_while_the_OutOfSync_write_is_in_flight_has_its_reason_corrected
        the workload finished for "OutOfSync", want "Succeeded"

# the stop pass allowed to decide
--- FAIL: .../a_job_with_no_pods_yet_is_stopped_before_its_workload_is_finished
--- FAIL: .../a_job_that_finishes_while_stopping_keeps_its_own_reason,_not_OutOfSync
--- FAIL: .../a_job_that_ends_while_the_OutOfSync_write_is_in_flight_has_its_reason_corrected
        the workload was finished for "OutOfSync" on the pass that submitted the stop

# the reload UID check removed
--- FAIL: .../a_job_replaced_under_the_same_name_between_the_read_and_the_reload_is_not_usable

# the post-write UID check removed
--- FAIL: .../a_job_replaced_under_the_same_name_during_the_OutOfSync_write_is_not_finalized
        the job was finalized 1 times, want 0

# an existing OutOfSync finish allowed to skip the stop
--- FAIL: .../a_workload_finished_as_OutOfSync_stops_a_running_job_even_once_the_pair_matches_again
        the job was stopped = false, want true
        the workload finalizers [], want gone = false
        the Stopped events said [], want one saying "The prebuilt workload is already finished"

# the bounded requeue removed (all eight cases that end a pass still waiting)
--- FAIL: .../a_job_with_running_pods_is_stopped,_and_its_workload_waits_until_they_are_gone
        the pass requeued = false, want true

# the pre-finalize correction removed
--- FAIL: .../a_workload_already_finished_as_OutOfSync_is_corrected_before_it_is_finalized

# the correction moved back behind the equivalence check
--- FAIL: .../a_workload_finished_as_OutOfSync_is_corrected_even_once_the_pair_matches_again
--- FAIL: .../a_workload_already_finished_as_OutOfSync_is_corrected_before_it_is_finalized

# TrainJob's restore patching unconditionally again
--- FAIL: TestStop
        the second Stop made 1 API calls against an already stopped job

# the RayCluster generation guard removed
--- FAIL: TestStopAcknowledged/suspended,_but_reported_for_an_earlier_generation:_not_acknowledged
```

The Job integration carries the same shape against the real `batch/v1` wrapper rather than a mock. `when the prebuilt workload is not equivalent to a job with running pods` gives the Job `status.active: 1` and asserts it is suspended while the Workload keeps its quota, its conditions and its finalizer. `when the prebuilt workload is out of sync but the suspend is not yet acknowledged` withholds the `JobSuspended` condition and asserts the same.

##### Not covered here

A stable identity for composable jobs. The UID the reload compares is exact for a single-object Job
and member-derived for a pod group, so a group that lost a member reads as replaced; #14533 carries
the reproducer and the other sites worth auditing. Making `Load` survive being called twice is in
this PR; deciding what a group's identity should be is not. Giving a group an identity of its own changes
what `Object()` means for it, which is more than this path should be deciding.

An integration test for either reload case. The replacement one needs the delete and recreate to
land between the write and the read, which envtest cannot drive deterministically — it would be a
flaky test standing in for a deterministic one. The already-finished one is a state transition the
unit test decides, and the mutation list above is what shows it decides it correctly.

A MultiKueue case for the re-dispatch above. The behaviour it would exercise lives in `multikueue/workload.go`, which this PR does not touch. What changes is that a completed Job no longer produces the `OutOfSync` that path keys on, and that is asserted where it is decided.

Related: #13308, #13163 and #13224 for `QuotaReleaseStrategy`, where a `TODO` marks the point at which this release should later follow that strategy so `OutOfSync` matches eviction under `OnTerminalBestEffort`, and #10076 for terminating-Pod capacity accounting.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a prebuilt Workload that stops matching its Job releasing its quota while the Job's Pods were still running. The Job is now stopped first, the reconcile that submits the stop no longer decides on a status that cannot reflect it, and the Workload is finished for reason `OutOfSync` only once no Pods are active and, where the integration's API reports it, the controller that owns the Job has said it acted on the suspend. That report covers Job, JobSet, RayCluster, RayService, TrainJob and the Kubeflow training jobs (PyTorchJob, TFJob, PaddleJob, XGBoostJob, JAXJob); it is what each parent controller reports about itself, it says a stop was acted on rather than that it was this one, and how far it reaches into that Job's own children varies by integration. A Job that has already completed, or that completes while its Workload is being finished, keeps `Succeeded` or `Failed` instead, and the finished Workload gives up its finalizer rather than leaving the reconcile retrying. A Workload that an earlier version had already finished as `OutOfSync` while its Job kept running now stops that Job before its finalizer is released, even if the pair has since come back into sync, and reports `WorkloadFinished` as the stop reason rather than a mismatch. RayJob, MPIJob and SparkApplication are unchanged: their APIs report no stop acknowledgement, so they keep waiting on active Pods alone.
```

---

I used generative AI while preparing this pull request, including the stop-acknowledgement work in the later commits. Every claim above is backed by code I read in this tree or in the pinned upstream modules, and every test case was run against the unmodified file as well as the patched one.

