### PR TITLE
Validate clientConnection qps and burst in the config

### DIFF
--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -77,7 +77,8 @@ type Configuration struct {
 	WaitForPodsReady *WaitForPodsReady `json:"waitForPodsReady,omitempty"`
 
 	// ClientConnection provides additional configuration options for Kubernetes
-	// API server client.
+	// API server client. Both fields are defaulted, so the section may be omitted.
+	// +optional
 	ClientConnection *ClientConnection `json:"clientConnection,omitempty"`
 
 	// Integrations provide configuration options for AI/ML/Batch frameworks

--- a/apis/config/v1beta1/configuration_types.go
+++ b/apis/config/v1beta1/configuration_types.go
@@ -457,13 +457,18 @@ type TLSOptions struct {
 }
 
 type ClientConnection struct {
-	// QPS controls the number of queries per second allowed for K8S api server
-	// connection.
+	// QPS controls the number of queries per second allowed for Kubernetes API
+	// server connections.
 	//
-	// Setting this to a negative value will disable client-side ratelimiting.
+	// A negative value disables client-side rate limiting. Zero is invalid.
+	// Defaults to 300.
+	// +optional
 	QPS *float32 `json:"qps,omitempty"`
 
-	// Burst allows extra queries to accumulate when a client is exceeding its rate.
+	// Burst controls the token bucket capacity.
+	// It must be greater than 0 when client-side rate limiting is enabled.
+	// Defaults to 500.
+	// +optional
 	Burst *int32 `json:"burst,omitempty"`
 }
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -524,13 +524,18 @@ type ClusterProfileAccessProvider struct {
 }
 
 type ClientConnection struct {
-	// QPS controls the number of queries per second allowed for K8S api server
-	// connection.
+	// QPS controls the number of queries per second allowed for Kubernetes API
+	// server connections.
 	//
-	// Setting this to a negative value will disable client-side ratelimiting.
+	// A negative value disables client-side rate limiting. Zero is invalid.
+	// Defaults to 300.
+	// +optional
 	QPS *float32 `json:"qps,omitempty"`
 
-	// Burst allows extra queries to accumulate when a client is exceeding its rate.
+	// Burst controls the token bucket capacity.
+	// It must be greater than 0 when client-side rate limiting is enabled.
+	// Defaults to 500.
+	// +optional
 	Burst *int32 `json:"burst,omitempty"`
 }
 

--- a/apis/config/v1beta2/configuration_types.go
+++ b/apis/config/v1beta2/configuration_types.go
@@ -79,7 +79,8 @@ type Configuration struct {
 	WaitForPodsReady *WaitForPodsReady `json:"waitForPodsReady,omitempty"`
 
 	// ClientConnection provides additional configuration options for Kubernetes
-	// API server client.
+	// API server client. Both fields are defaulted, so the section may be omitted.
+	// +optional
 	ClientConnection *ClientConnection `json:"clientConnection,omitempty"`
 
 	// Integrations provide configuration options for AI/ML/Batch frameworks

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -48,6 +48,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	configapiv1beta1 "sigs.k8s.io/kueue/apis/config/v1beta1"
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
@@ -98,6 +99,94 @@ func defaultControlOptions(namespace string) ctrl.Options {
 		LeaseDuration:                 new(configapi.DefaultLeaderElectionLeaseDuration),
 		RenewDeadline:                 new(configapi.DefaultLeaderElectionRenewDeadline),
 		RetryPeriod:                   new(configapi.DefaultLeaderElectionRetryPeriod),
+	}
+}
+
+// TestLoadAndValidateClientConnection exercises the production path
+// (decode -> default -> convert -> validate) for both config versions, so that
+// omitted values are defaulted and explicit zeros survive to validation.
+func TestLoadAndValidateClientConnection(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	if err := configapiv1beta1.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := configapi.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]struct {
+		config   string
+		wantErrs []string
+	}{
+		"v1beta2 omitted burst defaults and passes": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+clientConnection:
+  qps: 100
+`,
+		},
+		"v1beta2 zero qps is rejected": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+clientConnection:
+  qps: 0
+  burst: 100
+`,
+			wantErrs: []string{"clientConnection.qps"},
+		},
+		"v1beta2 zero burst is rejected": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+clientConnection:
+  qps: 100
+  burst: 0
+`,
+			wantErrs: []string{"clientConnection.burst"},
+		},
+		"v1beta1 zero qps is rejected after conversion": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+clientConnection:
+  qps: 0
+  burst: 100
+`,
+			wantErrs: []string{"clientConnection.qps"},
+		},
+		"v1beta1 zero burst is rejected after conversion": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta1
+kind: Configuration
+clientConnection:
+  qps: 100
+  burst: 0
+`,
+			wantErrs: []string{"clientConnection.burst"},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			file := filepath.Join(t.TempDir(), "config.yaml")
+			if err := os.WriteFile(file, []byte(tc.config), os.FileMode(0600)); err != nil {
+				t.Fatal(err)
+			}
+			_, cfg, err := Load(testScheme, file)
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			var gotErrs []string
+			for _, e := range validateClientConnection(&cfg) {
+				gotErrs = append(gotErrs, e.Field)
+			}
+			if diff := cmp.Diff(tc.wantErrs, gotErrs, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("validateClientConnection after Load (-want +got):\n%s", diff)
+			}
+			if len(tc.wantErrs) == 0 && (cfg.ClientConnection == nil || cfg.ClientConnection.Burst == nil) {
+				t.Errorf("Load did not default the client connection burst")
+			}
+		})
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -199,7 +199,7 @@ clientConnection:
 			for _, e := range Validate(&cfg, testScheme, jobs.NewIntegrationManager()) {
 				gotErrs = append(gotErrs, e.Field)
 			}
-			if diff := cmp.Diff(tc.wantErrs, gotErrs, cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.wantErrs, gotErrs); diff != "" {
 				t.Errorf("Validate after Load (-want +got):\n%s", diff)
 			}
 			if len(tc.wantErrs) == 0 && (cfg.ClientConnection == nil || cfg.ClientConnection.Burst == nil) {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -36,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clienttesting "k8s.io/client-go/testing"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -50,12 +51,11 @@ import (
 
 	configapiv1beta1 "sigs.k8s.io/kueue/apis/config/v1beta1"
 	configapi "sigs.k8s.io/kueue/apis/config/v1beta2"
+	"sigs.k8s.io/kueue/pkg/controller/jobs"
 	"sigs.k8s.io/kueue/pkg/controller/jobs/job"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	"sigs.k8s.io/kueue/pkg/util/waitforpodsready"
-
-	_ "sigs.k8s.io/kueue/pkg/controller/jobs"
 )
 
 var defaultWaitForPodsReady = &configapi.WaitForPodsReady{
@@ -104,13 +104,19 @@ func defaultControlOptions(namespace string) ctrl.Options {
 
 // TestLoadAndValidateClientConnection exercises the production path
 // (decode -> default -> convert -> validate) for both config versions, so that
-// omitted values are defaulted and explicit zeros survive to validation.
+// omitted values are defaulted and explicit zeros survive to validation. It goes
+// through the exported Validate that cmd/kueue/main.go calls, rather than the
+// clientConnection rule on its own, so that dropping the rule from Validate
+// fails here too.
 func TestLoadAndValidateClientConnection(t *testing.T) {
 	testScheme := runtime.NewScheme()
 	if err := configapiv1beta1.AddToScheme(testScheme); err != nil {
 		t.Fatal(err)
 	}
 	if err := configapi.AddToScheme(testScheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := clientgoscheme.AddToScheme(testScheme); err != nil {
 		t.Fatal(err)
 	}
 	cases := map[string]struct {
@@ -141,6 +147,19 @@ apiVersion: config.kueue.x-k8s.io/v1beta2
 kind: Configuration
 clientConnection:
   qps: 100
+  burst: 0
+`,
+			wantErrs: []string{"clientConnection.burst"},
+		},
+		// An omitted qps leaves the rule looking at a nil and returning early, so
+		// only Load defaulting it to 300 makes the explicit zero burst reachable.
+		// This also pins that defaulting leaves that zero alone rather than
+		// replacing it with 500.
+		"v1beta2 omitted qps defaults and zero burst is rejected": {
+			config: `
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+clientConnection:
   burst: 0
 `,
 			wantErrs: []string{"clientConnection.burst"},
@@ -177,11 +196,11 @@ clientConnection:
 				t.Fatalf("Load: %v", err)
 			}
 			var gotErrs []string
-			for _, e := range validateClientConnection(&cfg) {
+			for _, e := range Validate(&cfg, testScheme, jobs.NewIntegrationManager()) {
 				gotErrs = append(gotErrs, e.Field)
 			}
 			if diff := cmp.Diff(tc.wantErrs, gotErrs, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("validateClientConnection after Load (-want +got):\n%s", diff)
+				t.Errorf("Validate after Load (-want +got):\n%s", diff)
 			}
 			if len(tc.wantErrs) == 0 && (cfg.ClientConnection == nil || cfg.ClientConnection.Burst == nil) {
 				t.Errorf("Load did not default the client connection burst")

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -82,6 +82,9 @@ var (
 	visibilityServerBindPortPath          = field.NewPath("visibilityServer", "bindPort")
 	customLabelsPath                      = field.NewPath("metrics", "customLabels")
 	resourceQuotaCheckStrategyPath        = field.NewPath("resources", "quotaCheckStrategy")
+	clientConnectionPath                  = field.NewPath("clientConnection")
+	ccQPSPath                             = clientConnectionPath.Child("qps")
+	ccBurstPath                           = clientConnectionPath.Child("burst")
 	// Values in this map should never exceed metrics.MaxCustomLabelsForSourceKind.
 	maxCustomLabelsPerSourceKind = map[configapi.SourceKind]int{
 		configapi.SourceKindWorkload:     min(2, metrics.MaxCustomLabelsForSourceKind),
@@ -99,6 +102,7 @@ func Validate(c *configapi.Configuration, scheme *runtime.Scheme, integrationMan
 	allErrs = append(allErrs, validateMultiKueue(c, integrationManager)...)
 	allErrs = append(allErrs, validateFairSharing(c)...)
 	allErrs = append(allErrs, validateAdmissionFairSharing(c)...)
+	allErrs = append(allErrs, validateClientConnection(c)...)
 	allErrs = append(allErrs, validateInternalCertManagement(c)...)
 	allErrs = append(allErrs, validateResourceTransformations(c)...)
 	allErrs = append(allErrs, validateDeviceClassMappings(c)...)
@@ -407,6 +411,27 @@ var (
 		return ss
 	}()
 )
+
+func validateClientConnection(c *configapi.Configuration) field.ErrorList {
+	cc := c.ClientConnection
+	if cc == nil || cc.QPS == nil {
+		return nil
+	}
+	// A negative QPS disables client-side rate limiting. Otherwise the config
+	// builds a token bucket where Burst is the initial token count and QPS the
+	// replenish rate, so both must be positive for requests to keep flowing.
+	if *cc.QPS < 0 {
+		return nil
+	}
+	var allErrs field.ErrorList
+	if *cc.QPS == 0 {
+		allErrs = append(allErrs, field.Invalid(ccQPSPath, *cc.QPS, "must be greater than 0, or negative to disable client-side rate limiting"))
+	}
+	if cc.Burst != nil && *cc.Burst <= 0 {
+		allErrs = append(allErrs, field.Invalid(ccBurstPath, *cc.Burst, "must be greater than 0 when client-side rate limiting is enabled"))
+	}
+	return allErrs
+}
 
 func validateFairSharing(c *configapi.Configuration) field.ErrorList {
 	fs := c.FairSharing

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -825,6 +825,36 @@ func TestValidate(t *testing.T) {
 				},
 			},
 		},
+		"zero clientConnection.qps": {
+			cfg: &configapi.Configuration{
+				Integrations:     defaultIntegrations,
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(0)), Burst: new(int32(100))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "clientConnection.qps",
+				},
+			},
+		},
+		"zero clientConnection.burst": {
+			cfg: &configapi.Configuration{
+				Integrations:     defaultIntegrations,
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100)), Burst: new(int32(0))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeInvalid,
+					Field: "clientConnection.burst",
+				},
+			},
+		},
+		"valid clientConnection": {
+			cfg: &configapi.Configuration{
+				Integrations:     defaultIntegrations,
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100)), Burst: new(int32(200))},
+			},
+		},
 		"invalid .internalCertManagement.webhookSecretName": {
 			cfg: &configapi.Configuration{
 				Integrations: defaultIntegrations,
@@ -2890,9 +2920,10 @@ func TestValidateClientConnection(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
-					Type:   field.ErrorTypeInvalid,
-					Field:  "clientConnection.burst",
-					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+					Type:     field.ErrorTypeInvalid,
+					Field:    "clientConnection.burst",
+					BadValue: int32(0),
+					Detail:   "must be greater than 0 when client-side rate limiting is enabled",
 				},
 			},
 		},
@@ -2902,9 +2933,10 @@ func TestValidateClientConnection(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
-					Type:   field.ErrorTypeInvalid,
-					Field:  "clientConnection.burst",
-					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+					Type:     field.ErrorTypeInvalid,
+					Field:    "clientConnection.burst",
+					BadValue: int32(-1),
+					Detail:   "must be greater than 0 when client-side rate limiting is enabled",
 				},
 			},
 		},
@@ -2914,9 +2946,10 @@ func TestValidateClientConnection(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
-					Type:   field.ErrorTypeInvalid,
-					Field:  "clientConnection.qps",
-					Detail: "must be greater than 0, or negative to disable client-side rate limiting",
+					Type:     field.ErrorTypeInvalid,
+					Field:    "clientConnection.qps",
+					BadValue: float32(0),
+					Detail:   "must be greater than 0, or negative to disable client-side rate limiting",
 				},
 			},
 		},
@@ -2926,14 +2959,16 @@ func TestValidateClientConnection(t *testing.T) {
 			},
 			wantErr: field.ErrorList{
 				&field.Error{
-					Type:   field.ErrorTypeInvalid,
-					Field:  "clientConnection.qps",
-					Detail: "must be greater than 0, or negative to disable client-side rate limiting",
+					Type:     field.ErrorTypeInvalid,
+					Field:    "clientConnection.qps",
+					BadValue: float32(0),
+					Detail:   "must be greater than 0, or negative to disable client-side rate limiting",
 				},
 				&field.Error{
-					Type:   field.ErrorTypeInvalid,
-					Field:  "clientConnection.burst",
-					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+					Type:     field.ErrorTypeInvalid,
+					Field:    "clientConnection.burst",
+					BadValue: int32(0),
+					Detail:   "must be greater than 0 when client-side rate limiting is enabled",
 				},
 			},
 		},
@@ -2942,7 +2977,7 @@ func TestValidateClientConnection(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got := validateClientConnection(tc.cfg)
-			if diff := cmp.Diff(tc.wantErr, got, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
+			if diff := cmp.Diff(tc.wantErr, got); diff != "" {
 				t.Errorf("validateClientConnection() returned unexpected error (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -2856,6 +2856,99 @@ func TestValidateDeviceClassMappings(t *testing.T) {
 	}
 }
 
+func TestValidateClientConnection(t *testing.T) {
+	testCases := map[string]struct {
+		cfg     *configapi.Configuration
+		wantErr field.ErrorList
+	}{
+		"nil clientConnection": {
+			cfg: &configapi.Configuration{},
+		},
+		"valid qps and burst": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100)), Burst: new(int32(200))},
+			},
+		},
+		"negative qps disables rate limiting": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(-1)), Burst: new(int32(0))},
+			},
+		},
+		"nil qps is ignored": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{Burst: new(int32(200))},
+			},
+		},
+		"omitted burst passes, defaulting fills it": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100))},
+			},
+		},
+		"zero burst is rejected": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100)), Burst: new(int32(0))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "clientConnection.burst",
+					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+				},
+			},
+		},
+		"negative burst is rejected": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(100)), Burst: new(int32(-1))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "clientConnection.burst",
+					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+				},
+			},
+		},
+		"zero qps is rejected": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(0)), Burst: new(int32(100))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "clientConnection.qps",
+					Detail: "must be greater than 0, or negative to disable client-side rate limiting",
+				},
+			},
+		},
+		"zero qps and zero burst report both fields": {
+			cfg: &configapi.Configuration{
+				ClientConnection: &configapi.ClientConnection{QPS: new(float32(0)), Burst: new(int32(0))},
+			},
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "clientConnection.qps",
+					Detail: "must be greater than 0, or negative to disable client-side rate limiting",
+				},
+				&field.Error{
+					Type:   field.ErrorTypeInvalid,
+					Field:  "clientConnection.burst",
+					Detail: "must be greater than 0 when client-side rate limiting is enabled",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got := validateClientConnection(tc.cfg)
+			if diff := cmp.Diff(tc.wantErr, got, cmpopts.IgnoreFields(field.Error{}, "BadValue")); diff != "" {
+				t.Errorf("validateClientConnection() returned unexpected error (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestValidateCustomLabels(t *testing.T) {
 	testCases := map[string]struct {
 		cfg     *configapi.Configuration

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -225,20 +225,23 @@ Defaults to 1.</p>
 <tbody>
     
   
-<tr><td><code>qps</code> <B>[Required]</B><br/>
+<tr><td><code>qps</code><br/>
 <code>float32</code>
 </td>
 <td>
-   <p>QPS controls the number of queries per second allowed for K8S api server
-connection.</p>
-<p>Setting this to a negative value will disable client-side ratelimiting.</p>
+   <p>QPS controls the number of queries per second allowed for Kubernetes API
+server connections.</p>
+<p>A negative value disables client-side rate limiting. Zero is invalid.
+Defaults to 300.</p>
 </td>
 </tr>
-<tr><td><code>burst</code> <B>[Required]</B><br/>
+<tr><td><code>burst</code><br/>
 <code>int32</code>
 </td>
 <td>
-   <p>Burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+   <p>Burst controls the token bucket capacity.
+It must be greater than 0 when client-side rate limiting is enabled.
+Defaults to 500.</p>
 </td>
 </tr>
 </tbody>

--- a/site/content/en/docs/reference/kueue-config.v1beta1.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta1.md
@@ -93,12 +93,12 @@ and passing the readiness probe) within the specified time. If the timeout
 is exceeded, then the workload is evicted.</p>
 </td>
 </tr>
-<tr><td><code>clientConnection</code> <B>[Required]</B><br/>
+<tr><td><code>clientConnection</code><br/>
 <a href="#config-kueue-x-k8s-io-v1beta1-ClientConnection"><code>ClientConnection</code></a>
 </td>
 <td>
    <p>ClientConnection provides additional configuration options for Kubernetes
-API server client.</p>
+API server client. Both fields are defaulted, so the section may be omitted.</p>
 </td>
 </tr>
 <tr><td><code>integrations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -93,12 +93,12 @@ and passing the readiness probe) within the specified time. If the timeout
 is exceeded, then the workload is evicted.</p>
 </td>
 </tr>
-<tr><td><code>clientConnection</code> <B>[Required]</B><br/>
+<tr><td><code>clientConnection</code><br/>
 <a href="#config-kueue-x-k8s-io-v1beta2-ClientConnection"><code>ClientConnection</code></a>
 </td>
 <td>
    <p>ClientConnection provides additional configuration options for Kubernetes
-API server client.</p>
+API server client. Both fields are defaulted, so the section may be omitted.</p>
 </td>
 </tr>
 <tr><td><code>integrations</code> <B>[Required]</B><br/>

--- a/site/content/en/docs/reference/kueue-config.v1beta2.md
+++ b/site/content/en/docs/reference/kueue-config.v1beta2.md
@@ -221,20 +221,23 @@ Defaults to 1.</p>
 <tbody>
     
   
-<tr><td><code>qps</code> <B>[Required]</B><br/>
+<tr><td><code>qps</code><br/>
 <code>float32</code>
 </td>
 <td>
-   <p>QPS controls the number of queries per second allowed for K8S api server
-connection.</p>
-<p>Setting this to a negative value will disable client-side ratelimiting.</p>
+   <p>QPS controls the number of queries per second allowed for Kubernetes API
+server connections.</p>
+<p>A negative value disables client-side rate limiting. Zero is invalid.
+Defaults to 300.</p>
 </td>
 </tr>
-<tr><td><code>burst</code> <B>[Required]</B><br/>
+<tr><td><code>burst</code><br/>
 <code>int32</code>
 </td>
 <td>
-   <p>Burst allows extra queries to accumulate when a client is exceeding its rate.</p>
+   <p>Burst controls the token bucket capacity.
+It must be greater than 0 when client-side rate limiting is enabled.
+Defaults to 500.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`cmd/kueue/main.go` builds a shared client-go token-bucket rate limiter from `clientConnection` when `qps >= 0`:

```go
if *cfg.ClientConnection.QPS >= 0.0 {
    kubeConfig.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(
        *cfg.ClientConnection.QPS, int(*cfg.ClientConnection.Burst))
}
```

Nothing validates the values, and the REST client calls `RateLimiter.Wait(ctx)` on every request, so:

- `burst: 0` → `Wait(1)` fails immediately with `rate: Wait(n=1) exceeds limiter's burst 0`, i.e. every API call errors.
- `qps: 0` (with a non-zero burst) → the first `burst` requests succeed, then the bucket never replenishes and later requests block until the context is canceled or its deadline expires, waiting indefinitely when it has neither.
- `qps < 0` → intentionally disables client-side rate limiting (kept).

`burst`/`qps` are pointers defaulted with `cmp.Or`, so an explicit `0` survives defaulting.

This adds `validateClientConnection`: when the limiter is enabled (`qps >= 0`), `qps` must be `> 0` and `burst` must be `> 0`. Validation runs after defaulting (the manager path is `Load → decode → default → convert → Validate`), so omitted values keep their `300`/`500` defaults. The rule is shared by both config versions — a v1beta1 config is converted into v1beta2 before validation — so the `qps`/`burst` godoc is updated in both v1beta1 and v1beta2 (now documented as optional, defaulted, with zero invalid) and the generated references are refreshed.

`clientConnection` itself was missing `+optional`, so the reference listed the whole section as required while the defaulter has always allowed it to be omitted. That marker is added in both versions, and the reference no longer says `[Required]` for it. Its siblings carry the same gap: `namespace`, `internalCertManagement`, `waitForPodsReady` and `integrations` are all defaulted and all still listed as required. That is older than this change and left alone here.

#### Which issue(s) this PR fixes:
None filed separately; details above. This fills the input-validation gap left when #2462 switched Kueue to an explicit shared token bucket.

#### Special notes for your reviewer:
- Behaviour confirmed against `k8s.io/client-go/util/flowcontrol`: `NewTokenBucketRateLimiter(300, 0).Wait(ctx)` returns `exceeds limiter's burst 0`; `NewTokenBucketRateLimiter(0, 3)` grants 3 requests then times out.
- The rule is reached through the exported `Validate` in two places, so deleting its one line from `Validate` fails the tests rather than only stopping the validation. `TestValidate` carries it alongside every other validator in that table, and `TestLoadAndValidateClientConnection` runs the real decode/default/convert/validate path for both versions through the same exported entry point. `TestValidateClientConnection` covers the predicate boundaries and error aggregation against the rule directly.
- `TestValidateClientConnection` compares the whole `field.Error`, `BadValue` included, rather than ignoring it. An error that names the right field path and reports the wrong value is what #14445 is fixing elsewhere, and it survives a test that only checks the path. With the value compared, making the burst error report the qps value fails here, including in the case where both are zero and differ only in type.
- One load-path case supplies only `burst: 0`. The rule returns early on a nil `qps`, so that case reaches the burst error only once `Load` has defaulted `qps` to `300`, and it fails if defaulting ever replaces the explicit zero with `500`.
- An earlier revision added a `field.Required` for a nil `burst`; I removed it. `Validate` runs after defaulting (proven by `TestLoad`), so `burst` is never nil on the manager path, and a nil-only check made the validator's undefaulted-object contract inconsistent. Omitted `burst` is covered by the load-path test instead.

#### Does this PR introduce a user-facing change?
```release-note
Fixed invalid `clientConnection` settings that could make the Kubernetes client unusable. A `burst` of `0` causes requests to fail immediately at the client-side rate limiter, while a `qps` of `0` permits only the initial burst and then cannot replenish tokens. With rate limiting enabled, Kueue now rejects a `qps` of `0` and any non-positive `burst`; use a negative `qps` to disable client-side rate limiting.
```


