### PR TITLE
Count a Pod slot and the PodSets before it in the final TAS check

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -432,16 +432,27 @@ type FlavorTASRequests []TASPodSetRequests
 // Fits checks if the snapshot has enough capacity to accommodate the workload
 func (s *TASFlavorSnapshot) Fits(flavorUsage workload.TASFlavorUsage) bool {
 	cachingEnabled := features.Enabled(features.TASCachingRemainingResources)
+	// An entry is one PodSet in one domain, so several can name a leaf and take it in turn.
+	remaining := make(map[utiltas.TopologyDomainID]resources.Requests, len(flavorUsage))
 	for _, domainUsage := range flavorUsage {
 		domainID := utiltas.DomainID(domainUsage.Values)
 		leaf, found := s.leaves[domainID]
 		if !found {
 			return false
 		}
-		remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
-		if domainUsage.SinglePodRequests.CountIn(remainingCapacity.Get()) < domainUsage.Count {
+		capacity, seen := remaining[domainID]
+		if !seen {
+			remainingCapacity := s.remainingCapacityForLeaf(leaf, false, cachingEnabled)
+			capacity = remainingCapacity.Get().Clone()
+			remaining[domainID] = capacity
+		}
+		// SinglePodRequests leaves out the node slot the assignment counted per Pod.
+		podRequests := domainUsage.SinglePodRequests.Clone()
+		podRequests.Add(resources.OnePodRequest)
+		if podRequests.CountIn(capacity) < domainUsage.Count {
 			return false
 		}
+		capacity.Sub(podRequests.ScaledUp(int64(domainUsage.Count)))
 	}
 	return true
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1459,6 +1459,7 @@ func TestTASCachingRemainingResourcesFeatureGate(t *testing.T) {
 				StatusAllocatable(corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("8"),
 					corev1.ResourceMemory: resource.MustParse("10Gi"),
+					corev1.ResourcePods:   resource.MustParse("110"),
 				}).
 				Ready().
 				Obj()
@@ -1599,4 +1600,126 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 			t.Errorf("Observed leaf domain fields mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestFits(t *testing.T) {
+	singlePod := func(cpu int64) resources.Requests {
+		return resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: cpu})
+	}
+	inDomain := func(reqs resources.Requests, count int32) workload.TopologyDomainRequests {
+		return workload.TopologyDomainRequests{Values: []string{"node-a"}, SinglePodRequests: reqs, Count: count}
+	}
+	cases := map[string]struct {
+		allocatable  corev1.ResourceList
+		admitted     resources.Requests
+		admittedPods int32
+		usage        workload.TASFlavorUsage
+		want         bool
+	}{
+		"a PodSet the node has room for": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(4000), 1)},
+			want:  true,
+		},
+		"a PodSet the node has no slot for": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("100"),
+				corev1.ResourcePods: resource.MustParse("1"),
+			},
+			admitted:     singlePod(1000),
+			admittedPods: 1,
+			usage:        workload.TASFlavorUsage{inDomain(singlePod(1000), 1)},
+			want:         false,
+		},
+		"two PodSets that fit alone but not together": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(4000), 1), inDomain(singlePod(4000), 1)},
+			want:  false,
+		},
+		"two PodSets the node has room for": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(4000), 1), inDomain(singlePod(4000), 1)},
+			want:  true,
+		},
+		"replicas past the first are counted too": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("3"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(2000), 2), inDomain(singlePod(4000), 1)},
+			want:  true,
+		},
+		"replicas past the first exhaust the CPU": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("7"),
+				corev1.ResourcePods: resource.MustParse("3"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(2000), 2), inDomain(singlePod(4000), 1)},
+			want:  false,
+		},
+		"replicas past the first exhaust the Pod slots": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("2"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(singlePod(2000), 2), inDomain(singlePod(4000), 1)},
+			want:  false,
+		},
+		"a PodSet asking for nothing but a slot": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("1"),
+			},
+			usage: workload.TASFlavorUsage{inDomain(resources.NewRequestsFromMap(map[corev1.ResourceName]int64{}), 1)},
+			want:  true,
+		},
+		"a PodSet asking for nothing when no slot is left": {
+			allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("1"),
+			},
+			admitted:     singlePod(1000),
+			admittedPods: 1,
+			usage:        workload.TASFlavorUsage{inDomain(resources.NewRequestsFromMap(map[corev1.ResourceName]int64{}), 1)},
+			want:         false,
+		},
+	}
+	for _, vectorized := range []bool{false, true} {
+		for _, caching := range []bool{false, true} {
+			for name, tc := range cases {
+				t.Run(fmt.Sprintf("%s [vectorized=%t caching=%t]", name, vectorized, caching), func(t *testing.T) {
+					features.SetFeatureGateDuringTest(t, features.VectorizedResourceRequests, vectorized)
+					features.SetFeatureGateDuringTest(t, features.TASCachingRemainingResources, caching)
+					_, log := utiltesting.ContextWithLog(t)
+					nodeObj := node.MakeNode("node-a").
+						Label(corev1.LabelHostname, "node-a").
+						StatusAllocatable(tc.allocatable).
+						Ready().
+						Obj()
+					snapshot := newTASFlavorSnapshot(log, "tas-topology",
+						newTopologyTree([]string{corev1.LabelHostname}, []*corev1.Node{nodeObj}, 0), nil, &defaultChecker{})
+					if tc.admitted != nil {
+						snapshot.updateTASUsage(tas.TopologyDomainID("node-a"), tc.admitted, add, tc.admittedPods)
+					}
+					if got := snapshot.Fits(tc.usage); got != tc.want {
+						t.Errorf("Fits() = %t, want %t", got, tc.want)
+					}
+					// The running deduction is local to the call, so asking twice
+					// has to give the same answer.
+					if got := snapshot.Fits(tc.usage); got != tc.want {
+						t.Errorf("Fits() asked a second time = %t, want %t", got, tc.want)
+					}
+				})
+			}
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area tas

#### What this PR does / why we need it:

`Fits` is what `updateAssignmentIfNeeded` calls before letting a nominated Workload through. Within one TAS flavor it answers a weaker question than the assignment that produced the nomination.

It never looks at Pod slots. `findTopologyAssignment` adds `resources.OnePodRequest` to what each Pod wants, and `updateTASUsage` records `pods` against the domain, so the capacity side tracks them. The request side doesn't: `SinglePodRequests` comes from `resources.NewRequestsFromPodSpec`, which holds container requests alone, and `CountIn` can only constrain on a resource the request names.

It also read untouched capacity for every entry in the list. A Workload with two PodSets in one domain produces two `TopologyDomainRequests` with the same values, and each was measured against the full remainder as though the other weren't there.

Both on a hostname-lowest topology against `01c45cacf`, with no feature gate involved:

```
Fits() with zero Pod slots left = true
two PodSets wanting 4 CPU each on a 4 CPU node: Fits=true
```

Where that would land is the same-cycle path. A `FitsCheckOk` short-circuits before `getAssignments` runs again, so an assignment nominated against the snapshot at the start of a cycle is approved on this check alone:

```go
needsTASRecompute := fitsCheck == schdcache.FitsCheckNoTAS && features.Enabled(features.TASRecomputeAssignmentWithinSchedulingCycle)
...
default:
	// Short-circuit, nothing to recompute.
	return usage, schdcache.FitsCheckOk == fitsCheck
```

`TASRecomputeAssignmentWithinSchedulingCycle` is Beta and on since 0.19, which is what makes this check load-bearing rather than advisory.

#### Which issue(s) this PR fixes:

Fixes #14437

#### Special notes for your reviewer:

**What this does not cover.** `ClusterQueueSnapshot.Fits` calls this once per flavor, so the `remaining` map starts empty for each of them. The assignment path does the opposite: `FindTopologyAssignments` builds one `aggregatedDomainUsages` and hands the same map to every hostname-lowest flavor, so two PodSets of one Workload that reach the same node through overlapping flavors see each other there. They still do not here. `TASHandleOverlappingFlavors` is Beta and on, so that is the default shape, not an opt-in one. Closing it means aggregating the candidate demand by node before any flavor is asked, which is a different change from this one and overlaps with the sibling-snapshot propagation in #14243 and #14366. I would rather land the within-flavor accounting first and keep that separate than grow this into the overlapping-flavor rework.

Counting the Pod slot means a leaf whose capacity has no `pods` entry now fits nothing. That is already true of the assignment path, which adds `OnePodRequest` unconditionally at `tas_flavor_snapshot.go:915`, so this makes the two agree rather than inventing a rule. A real node always reports `pods` in its allocatable. One fixture in this repo did not: `TestTASCachingRemainingResourcesFeatureGate` built its node with CPU and memory only, and I gave it a `pods` allocatable rather than special-casing the check. Every `StatusAllocatable` literal under `test/integration` already sets one, all 95 of them, and 459 of the 467 under `pkg` do, with the rest in benchmarks and cache tests that never reach `Fits`.

On the test level, since the obvious question is why there is no integration case. I wrote one: a node with a single Pod slot, two Workloads created together, asserting only one is admitted. It passes with this change and it passes without it, so it proves nothing and I am not sending it. The reason is that the assignment path already counts a Pod slot and threads `assumedUsage` between a Workload's PodSets, so the second Workload is turned away before the recheck runs at all.

That is worth stating plainly: I have not reproduced either shape end to end. What the change closes is a gap between the check that produces an assignment and the check that approves it later against a snapshot that has moved, and the tests pin that gap where it lives.

The table runs under both `VectorizedResourceRequests` and both `TASCachingRemainingResources`, since this path leans on `Clone`, on adding the map-backed `OnePodRequest` to either representation, on `ScaledUp`, and on a mutating `Sub`. Each case asks `Fits` twice, because the deduction is local to the call and a future change that spent the snapshot's own capacity would show up as a different second answer.

Three mutations are each caught by their own cases and nothing else: dropping the `OnePodRequest` line turns only the no-slot cases red, dropping the deduction turns only the together case red, and dropping the `ScaledUp(Count)` turns only the two multi-replica cases red. I had that last one wrong in the first revision of this PR, where every case used `Count: 1` and the scaling was never exercised.

#### Related work

- #14191 rewrites the same final-fit path for topologies whose lowest declared level is not `kubernetes.io/hostname`, where one serialized domain resolves to several physical leaves. A rebase either way has to keep both invariants from here, one Pod slot per Pod and a deduction that follows the leaf rather than the domain, since a single remaining-capacity vector per domain would let a 4 CPU node and a 4Gi node add up to a place for a Pod that needs both.
- #14243 and #14366 track propagating simulated and reserved usage to sibling snapshots for overlapping TAS flavors, which is the other half of the gap described above and not this one.

#### Does this PR introduce a user-facing change?

```release-note
TAS: fixed the final fit check within a TAS ResourceFlavor so PodSets sharing a topology domain draw on the same remaining node capacity rather than each measuring against all of it, and so each Pod counts a node Pod slot as it does during assignment.
```

---

This pull request was written in part with the assistance of generative AI. The two lines of output above come from a probe I ran against this code, and each half of the change was reverted separately against the tests in the diff.
