### PR TITLE
Carry a leaf's affinity score by value, and stop adding it to itself

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -203,8 +203,10 @@ type podSetMatchKey struct {
 
 // matchedLeaf is a leaf the checker accepted and the score it gave it. The score
 // is a value because the state a candidate reads it from is cleared between runs.
+// The leaf itself is shared by every snapshot and never written, so it is kept
+// by pointer rather than looked up again on each hit.
 type matchedLeaf struct {
-	id    utiltas.TopologyDomainID
+	leaf  *leafDomain
 	score int64
 }
 
@@ -1818,9 +1820,8 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 		}
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
-			leaf := s.leaves[ml.id]
-			s.domainStateOf(&leaf.domain).affinityScore = ml.score
-			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
+			s.domainStateOf(&ml.leaf.domain).affinityScore = ml.score
+			s.fillLeafCounts(ml.leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
 		if s.isLowestLevelNode {
@@ -1855,7 +1856,7 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 		stats.TotalNodes += len(s.leaves)
 		result := make([]matchedLeaf, 0, len(s.leaves))
 		for candidate := range s.candidates() {
-			result = append(result, matchedLeaf{id: candidate.GetID(), score: candidate.GetAffinityScore()})
+			result = append(result, matchedLeaf{leaf: s.leaves[candidate.GetID()], score: candidate.GetAffinityScore()})
 		}
 		return result, stats, nil
 	}
@@ -1875,7 +1876,7 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 	}
 	matched := make([]matchedLeaf, 0, len(feasibleLeaves))
 	for _, candidate := range feasibleLeaves {
-		matched = append(matched, matchedLeaf{id: candidate.GetID(), score: candidate.GetAffinityScore()})
+		matched = append(matched, matchedLeaf{leaf: s.leaves[candidate.GetID()], score: candidate.GetAffinityScore()})
 	}
 	entry := &matchingLeavesCacheEntry{
 		leaves: matched,

--- a/pkg/cache/scheduler/tas_flavor_snapshot.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot.go
@@ -201,10 +201,17 @@ type podSetMatchKey struct {
 	PodSetName  string
 }
 
+// matchedLeaf is a leaf the checker accepted and the score it gave it. The score
+// is a value because the state a candidate reads it from is cleared between runs.
+type matchedLeaf struct {
+	id    utiltas.TopologyDomainID
+	score int64
+}
+
 // matchingLeavesCacheEntry stores the cached list of matching leaves and accumulated
 // exclusion stats for a specific podSetMatchKey.
 type matchingLeavesCacheEntry struct {
-	leaves []simulator.MatchedCandidate
+	leaves []matchedLeaf
 	stats  *tasExclusionStats
 }
 
@@ -1811,8 +1818,8 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 		}
 		state.stats.add(stats)
 		for _, ml := range matchingLeaves {
-			leaf := s.leaves[ml.GetID()]
-			s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
+			leaf := s.leaves[ml.id]
+			s.domainStateOf(&leaf.domain).affinityScore = ml.score
 			s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 		}
 	} else {
@@ -1825,7 +1832,7 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 
 			for _, ml := range feasibleLeaves {
 				leaf := s.leaves[ml.GetID()]
-				s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
+				s.domainStateOf(&leaf.domain).affinityScore = ml.GetAffinityScore()
 				s.fillLeafCounts(leaf, requirements, state, cachingRemainingResourcesEnabled)
 			}
 		} else {
@@ -1842,13 +1849,13 @@ func (s *TASFlavorSnapshot) fillInCounts(ctx context.Context, requirements *topo
 	return nil
 }
 
-func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements *topologyAssignmentPodRequirements) ([]simulator.MatchedCandidate, *tasExclusionStats, error) {
+func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements *topologyAssignmentPodRequirements) ([]matchedLeaf, *tasExclusionStats, error) {
 	if !s.isLowestLevelNode {
 		stats := newTASExclusionStats()
 		stats.TotalNodes += len(s.leaves)
-		result := make([]simulator.MatchedCandidate, 0, len(s.leaves))
+		result := make([]matchedLeaf, 0, len(s.leaves))
 		for candidate := range s.candidates() {
-			result = append(result, candidate)
+			result = append(result, matchedLeaf{id: candidate.GetID(), score: candidate.GetAffinityScore()})
 		}
 		return result, stats, nil
 	}
@@ -1866,8 +1873,12 @@ func (s *TASFlavorSnapshot) getMatchingLeaves(ctx context.Context, requirements 
 	if err != nil {
 		return nil, nil, err
 	}
+	matched := make([]matchedLeaf, 0, len(feasibleLeaves))
+	for _, candidate := range feasibleLeaves {
+		matched = append(matched, matchedLeaf{id: candidate.GetID(), score: candidate.GetAffinityScore()})
+	}
 	entry := &matchingLeavesCacheEntry{
-		leaves: feasibleLeaves,
+		leaves: matched,
 		stats:  leafStats,
 	}
 

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"iter"
 	"strings"
 	"testing"
 
@@ -1604,6 +1606,32 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 	})
 }
 
+// additiveChecker scores the way the WAS checker does, reading a candidate's
+// score before writing it back. The assignment in fillInCounts rests on that
+// state being clear when the checker runs, and nothing else here holds it.
+type additiveChecker struct {
+	calls int
+}
+
+func (c *additiveChecker) FindFeasibleNodes(
+	_ context.Context,
+	candidates iter.Seq[simulator.Candidate],
+	requirements *simulator.PodRequirements,
+	_ *simulator.NodeExclusionStats,
+) ([]simulator.MatchedCandidate, error) {
+	c.calls++
+	var matched []simulator.MatchedCandidate
+	for candidate := range candidates {
+		mc, ok := candidate.(simulator.MatchedCandidate)
+		if !ok {
+			continue
+		}
+		mc.SetAffinityScore(mc.GetAffinityScore() + requirements.PreferredSchedulingTerms.Score(mc.GetNode()))
+		matched = append(matched, mc)
+	}
+	return matched, nil
+}
+
 func TestFillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T) {
 	for _, cacheMatches := range []bool{true, false} {
 		t.Run(fmt.Sprintf("TASCacheNodeMatchResults=%t", cacheMatches), func(t *testing.T) {
@@ -1629,8 +1657,9 @@ func fillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T, cacheMatches bool
 				corev1.ResourcePods: resource.MustParse("110"),
 			}).Ready().Obj(),
 	}
+	checker := &additiveChecker{}
 	snapshot := newTASFlavorSnapshot(log, "tas-topology",
-		newTopologyTree([]string{corev1.LabelHostname}, nodes, 0), nil, &defaultChecker{})
+		newTopologyTree([]string{corev1.LabelHostname}, nodes, 0), nil, checker)
 
 	terms, err := nodeaffinity.NewPreferredSchedulingTerms(
 		utiltesting.MakePreferredSchedulingTerms().Term(10, "pool", corev1.NodeSelectorOpIn, "fast").Obj())
@@ -1642,12 +1671,13 @@ func fillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T, cacheMatches bool
 		requests:        resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
 		matchKey:        &podSetMatchKey{WorkloadUID: types.UID("wl-uid"), PodSetName: "main"},
 	}
-	state := &findTopologyAssignmentState{stats: newTASExclusionStats()}
-	state.sliceSize = 1
-
 	want := map[tas.TopologyDomainID]int64{"node-a": 10, "node-b": 0}
 	domains := []*domain{&snapshot.leaves["node-a"].domain, &snapshot.leaves["node-b"].domain}
 	for _, run := range []string{"first", "second"} {
+		// A placement evaluation builds its own state, so sharing one here would
+		// let the exclusion stats carry over in a way production never sees.
+		state := &findTopologyAssignmentState{stats: newTASExclusionStats()}
+		state.sliceSize = 1
 		if err := snapshot.fillInCounts(ctx, requirements, state); err != nil {
 			t.Fatalf("%s: fillInCounts() error: %v", run, err)
 		}
@@ -1662,5 +1692,14 @@ func fillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T, cacheMatches bool
 		if got := snapshot.sortedDomains(domains, false)[0].id; got != "node-a" {
 			t.Errorf("%s run: the preferred domain is %q, want node-a", run, got)
 		}
+	}
+	// Without this the second run proves the result is stable, not that it came
+	// from the cache the result is supposed to have survived.
+	wantCalls := 2
+	if cacheMatches {
+		wantCalls = 1
+	}
+	if checker.calls != wantCalls {
+		t.Errorf("the checker ran %d times, want %d", checker.calls, wantCalls)
 	}
 }

--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -31,9 +31,12 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/component-helpers/scheduling/corev1/nodeaffinity"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/resources"
 	"sigs.k8s.io/kueue/pkg/util/tas"
@@ -1599,4 +1602,65 @@ func TestUpdateCountsToMinimumGenericLogsLeafSummary(t *testing.T) {
 			t.Errorf("Observed leaf domain fields mismatch (-want +got):\n%s", diff)
 		}
 	})
+}
+
+func TestFillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T) {
+	for _, cacheMatches := range []bool{true, false} {
+		t.Run(fmt.Sprintf("TASCacheNodeMatchResults=%t", cacheMatches), func(t *testing.T) {
+			fillInCountsAffinityScoreIsStableAcrossRuns(t, cacheMatches)
+		})
+	}
+}
+
+func fillInCountsAffinityScoreIsStableAcrossRuns(t *testing.T, cacheMatches bool) {
+	features.SetFeatureGateDuringTest(t, features.TASRespectNodeAffinityPreferred, true)
+	features.SetFeatureGateDuringTest(t, features.TASCacheNodeMatchResults, cacheMatches)
+	ctx, log := utiltesting.ContextWithLog(t)
+
+	nodes := []*corev1.Node{
+		node.MakeNode("node-a").Label(corev1.LabelHostname, "node-a").Label("pool", "fast").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			}).Ready().Obj(),
+		node.MakeNode("node-b").Label(corev1.LabelHostname, "node-b").Label("pool", "slow").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("8"),
+				corev1.ResourcePods: resource.MustParse("110"),
+			}).Ready().Obj(),
+	}
+	snapshot := newTASFlavorSnapshot(log, "tas-topology",
+		newTopologyTree([]string{corev1.LabelHostname}, nodes, 0), nil, &defaultChecker{})
+
+	terms, err := nodeaffinity.NewPreferredSchedulingTerms(
+		utiltesting.MakePreferredSchedulingTerms().Term(10, "pool", corev1.NodeSelectorOpIn, "fast").Obj())
+	if err != nil {
+		t.Fatalf("NewPreferredSchedulingTerms() error: %v", err)
+	}
+	requirements := &topologyAssignmentPodRequirements{
+		podRequirements: simulator.PodRequirements{PreferredSchedulingTerms: terms},
+		requests:        resources.NewRequestsFromMap(map[corev1.ResourceName]int64{corev1.ResourceCPU: 1000}),
+		matchKey:        &podSetMatchKey{WorkloadUID: types.UID("wl-uid"), PodSetName: "main"},
+	}
+	state := &findTopologyAssignmentState{stats: newTASExclusionStats()}
+	state.sliceSize = 1
+
+	want := map[tas.TopologyDomainID]int64{"node-a": 10, "node-b": 0}
+	domains := []*domain{&snapshot.leaves["node-a"].domain, &snapshot.leaves["node-b"].domain}
+	for _, run := range []string{"first", "second"} {
+		if err := snapshot.fillInCounts(ctx, requirements, state); err != nil {
+			t.Fatalf("%s: fillInCounts() error: %v", run, err)
+		}
+		for id, wantScore := range want {
+			leaf := snapshot.leaves[id]
+			if got := snapshot.domainStateOf(&leaf.domain).affinityScore; got != wantScore {
+				t.Errorf("%s run: leaf %q affinityScore = %d, want %d", run, id, got, wantScore)
+			}
+		}
+		// node-b holds twice the CPU, so it leads on capacity whenever the
+		// preference stops separating the two.
+		if got := snapshot.sortedDomains(domains, false)[0].id; got != "node-a" {
+			t.Errorf("%s run: the preferred domain is %q, want node-a", run, got)
+		}
+	}
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

/area tas

#### What this PR does / why we need it:

A leaf's preferred affinity score came out at twice its value the first time a PodSet was evaluated, and zero every time after that.

The score lives in per-snapshot state, and the candidate the simulator is handed is a view onto it:

```go
func (c *leafCandidate) SetAffinityScore(score int64) {
	c.s.domainStates[c.leaf.idx].affinityScore = score
}

func (c *leafCandidate) GetAffinityScore() int64 {
	return c.s.domainStates[c.leaf.idx].affinityScore
}
```

The default checker writes the score there, and `fillInCounts` then added the candidate's score to the same field:

```go
for _, ml := range matchingLeaves {
	leaf := s.leaves[ml.GetID()]
	s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
```

So a cold evaluation doubled it. A warm one lost it, because `fillInCounts` opens with `clear(s.domainStates)` and a cache hit returns the stored candidates without running the checker again, so `GetAffinityScore` reads the field that was just cleared. `matchingLeavesCacheEntry` held `leaves` and `stats`, and neither carried the score.

Two nodes in one rack, one matching a single preferred term of weight 10, evaluated twice against one snapshot, with the cache on and then off:

```
TASCacheNodeMatchResults=true   first run 20, second run 0    want 10
TASCacheNodeMatchResults=false  first run 20, second run 20   want 10
```

With the cache off there is nothing to lose the score to, so it is doubled every time rather than doubled once and then dropped. Both come from the same line, and only one of them changes a decision. Giving `node-b` twice the CPU, so that it leads on capacity once the preference stops separating the two, the same run picks a different node the second time through:

```
second run: the preferred domain is "node-b", want node-a
```

Doubling a score does not reorder anything, since 20 beats 0 exactly as 10 does. Losing it does.

The cache now holds the leaf id and its score as values, and both paths assign rather than accumulate.

#### Which issue(s) this PR fixes:

Fixes #14438

#### Special notes for your reviewer:

`affinityScore` is the first thing `sortedDomains` and `sortedDomainsWithLeader` look at after the leader count, and `fillInCountsHelper` sums it up the tree, which is why the test asserts the chosen domain and not only the number. `TASCacheNodeMatchResults` is Beta and on since 0.19, which is what makes both branches reachable in one process: a PodSet evaluated during preemption and again during admission takes different ones.

`TASRespectNodeAffinityPreferred` is still Alpha and off by default, so this reaches nobody who has not opted in. It does mean the feature did not do what it says for anyone who had.

The non-cached path is fixed by the same change from `+=` to `=`, since the checker has already written the score into the state that line reads. The `!isLowestLevelNode` path never runs a checker, so its leaves carry the cleared zero they carry today.

The test asserts the score on two successive evaluations of one snapshot, in both states of `TASCacheNodeMatchResults`. Reverting the production file to what is on `main` turns every cell red, and the two states fail differently, so neither is idle.

The WAS checker reads before it writes:

```go
newAffinityScore := leaf.GetAffinityScore() + requirements.PreferredSchedulingTerms.Score(leaf.GetNode())
leaf.SetAffinityScore(newAffinityScore)
```

That is unchanged and stays correct against a cleared state, where it reads zero and writes the term's score. It would double if anything wrote the state before it, which nothing does.

#### Does this PR introduce a user-facing change?

```release-note
TAS: fixed the preferred node affinity score being counted twice on a topology domain's first evaluation and dropped entirely on later ones, which could send the same Workload to a different domain on the second evaluation against one snapshot.
```

---

This pull request was written in part with the assistance of generative AI. The output above comes from the test in the diff, run against the unmodified file.

#### Landing order, and what a rebase must not undo

#14191 rewrites this same path. Its branch still returns `[]simulator.MatchedCandidate` from `getMatchingLeaves` and still adds through the candidate:

```go
s.domainStateOf(&leaf.domain).affinityScore += ml.GetAffinityScore()
```

Both halves of the bug are in that line and the type above it, so merging it after this one without carrying the change across would put the regression back rather than only conflict textually. Whichever lands second should keep one immutable record holding every value the caller needs after the checker has run: the leaf, the score, and the feasible capacity #14191 adds.

#14308 replaces the checker with `simulator.SimulatorSnapshot`. If it lands first, the fake in this test moves to that interface.

#### Backport

`release-0.19` only. It carries the same `leaf.affinityScore += ml.GetAffinityScore()` in both branches of `fillInCounts`. `release-0.18` predates the simulator abstraction and still holds `matchedLeaf{leaf *leafDomain; affinityScore int64}`, so the cached score is a value there and the regression cannot occur.

#### On the test topology

The reproducer in the issue used a rack above two hostnames. The case here is hostname-only, because the lifetime being fixed is the leaf's own score; the roll-up into a parent is unchanged and already covered elsewhere in this file. `node-b` holds twice the CPU, so it wins on capacity the moment the preference stops separating the two, which is what makes the placement assertion fail rather than only the score.

