### PR TITLE
Report the value the field path names in validation errors

### DIFF
--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -444,12 +444,12 @@ func validateAdmissionFairSharing(c *configapi.Configuration) field.ErrorList {
 	}
 	if afs.UsageSamplingInterval.Duration <= 0 {
 		allErrs = append(allErrs, field.Invalid(afsPath.Child("usageSamplingInterval"),
-			afs.UsageHalfLifeTime, "must be greater than 0"))
+			afs.UsageSamplingInterval, "must be greater than 0"))
 	}
 	for resName, weight := range afs.ResourceWeights {
 		if weight < 0 {
 			allErrs = append(allErrs, field.Invalid(afsResourceWeightsPath.Key(string(resName)),
-				afs.ResourceWeights, apimachineryvalidation.IsNegativeErrorMsg))
+				weight, apimachineryvalidation.IsNegativeErrorMsg))
 		}
 	}
 	return allErrs

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3312,3 +3312,55 @@ func TestValidateCustomLabels(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateAdmissionFairSharingErrorValues checks that each error reports the
+// value its field path names.
+func TestValidateAdmissionFairSharingErrorValues(t *testing.T) {
+	cases := map[string]struct {
+		afs       *configapi.AdmissionFairSharing
+		wantField string
+		wantValue any
+	}{
+		"half-life": {
+			afs: &configapi.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: -time.Second},
+				UsageSamplingInterval: metav1.Duration{Duration: time.Second},
+			},
+			wantField: "admissionFairSharing.usageHalfLifeTime",
+			wantValue: metav1.Duration{Duration: -time.Second},
+		},
+		"sampling interval": {
+			afs: &configapi.AdmissionFairSharing{
+				UsageHalfLifeTime:     metav1.Duration{Duration: 5 * time.Minute},
+				UsageSamplingInterval: metav1.Duration{Duration: -time.Second},
+			},
+			wantField: "admissionFairSharing.usageSamplingInterval",
+			wantValue: metav1.Duration{Duration: -time.Second},
+		},
+		"one resource weight of several": {
+			afs: &configapi.AdmissionFairSharing{
+				UsageSamplingInterval: metav1.Duration{Duration: time.Second},
+				ResourceWeights: map[corev1.ResourceName]float64{
+					corev1.ResourceCPU:    -0.5,
+					corev1.ResourceMemory: 1,
+				},
+			},
+			wantField: "admissionFairSharing.resourceWeights[cpu]",
+			wantValue: float64(-0.5),
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			errs := validateAdmissionFairSharing(&configapi.Configuration{AdmissionFairSharing: tc.afs})
+			if len(errs) != 1 {
+				t.Fatalf("got %d errors, want 1: %v", len(errs), errs)
+			}
+			if got := errs[0].Field; got != tc.wantField {
+				t.Errorf("Field = %q, want %q", got, tc.wantField)
+			}
+			if diff := cmp.Diff(tc.wantValue, errs[0].BadValue); diff != "" {
+				t.Errorf("BadValue mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/webhooks/workload_webhook.go
+++ b/pkg/webhooks/workload_webhook.go
@@ -305,7 +305,7 @@ func validateAdmission(obj, oldObj *kueue.Workload, path *field.Path) field.Erro
 		if count := ptr.Deref(ps.Count, 0); count > 0 {
 			for k, v := range ps.ResourceUsage {
 				if (resources.ResourceValue(k, v) % int64(count)) != 0 {
-					allErrs = append(allErrs, field.Invalid(psaPath.Child("resourceUsage").Key(string(k)), v, fmt.Sprintf("is not a multiple of %d", ps.Count)))
+					allErrs = append(allErrs, field.Invalid(psaPath.Child("resourceUsage").Key(string(k)), v, fmt.Sprintf("is not a multiple of %d", count)))
 				}
 			}
 		}

--- a/pkg/webhooks/workload_webhook_test.go
+++ b/pkg/webhooks/workload_webhook_test.go
@@ -62,6 +62,39 @@ func quotaReservedWithoutAdmission(now time.Time) *kueue.Workload {
 	return wl
 }
 
+// TestValidateAdmissionResourceUsageMultiple checks that the "not a multiple"
+// error names the pod count, not the address of the count pointer.
+func TestValidateAdmissionResourceUsageMultiple(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	wl := utiltestingapi.MakeWorkload(testWorkloadName, testWorkloadNamespace).
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+			Request(corev1.ResourceCPU, "1").
+			Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").
+			PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+				Assignment(corev1.ResourceCPU, "flv", "1").
+				Count(3).
+				Obj()).
+			Obj(), now).
+		Obj()
+
+	// The same base path the webhook passes, so the reported field is the one
+	// a user would see.
+	errs := validateAdmission(wl, wl, field.NewPath("status", "admission"))
+	if len(errs) != 1 {
+		t.Fatalf("got %d errors, want 1: %v", len(errs), errs)
+	}
+	if got, want := errs[0].Type, field.ErrorTypeInvalid; got != want {
+		t.Errorf("Type = %q, want %q", got, want)
+	}
+	if got, want := errs[0].Field, "status.admission.podSetAssignments[0].resourceUsage[cpu]"; got != want {
+		t.Errorf("Field = %q, want %q", got, want)
+	}
+	if got, want := errs[0].Detail, "is not a multiple of 3"; got != want {
+		t.Errorf("Detail = %q, want %q", got, want)
+	}
+}
+
 func TestValidateWorkload(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	specPath := field.NewPath("spec")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Three validation errors named a field and then reported something else.

`validateAdmissionFairSharing` builds two of them side by side. The `usageSamplingInterval` error carried the half-life:

```go
field.Invalid(afsPath.Child("usageSamplingInterval"), afs.UsageHalfLifeTime, "must be greater than 0")
```

and each `resourceWeights` error carried the whole map, although its path names one entry:

```go
field.Invalid(afsResourceWeightsPath.Key(string(resName)), afs.ResourceWeights, ...)
```

So a single negative weight prints every weight configured:

```
admissionFairSharing.resourceWeights[cpu]: Invalid value: {"cpu":-0.5,"memory":1}
```

The third is in the workload admission webhook, which formatted a `*int32` with `%d`:

```go
fmt.Sprintf("is not a multiple of %d", ps.Count)
```

so the message named the address of the count rather than the count:

```
is not a multiple of 13705537191720
```

#### Which issue(s) this PR fixes:

None filed; all three came out of reading the field paths against the values beside them.

#### Special notes for your reviewer:

The two `admissionFairSharing` mistakes arrived in the same commit and are worth fixing together, since the second is the one the first makes you look for.

They survived because `TestValidate` already covers all three of these paths and asserts the field while ignoring the value. The new table asserts both. Its half-life case is the control: it is green against `main`, where the other two are red, one on the map and one on the half-life.

The workload webhook test now passes the base path the webhook itself passes, `status.admission` rather than `status`, and asserts the field alongside the message, since the earlier version would have been just as green with the wrong path.

The `count > 0` guard is unchanged, so a nil `Count` still skips the check and nothing about what is accepted or rejected moves.

Placed the config test at the end of `validation_test.go` rather than after `TestValidateDeviceClassMappings`, because #14442 adds a test at that same anchor and whichever landed second would have conflicted for no reason.

#### Does this PR introduce a user-facing change?

```release-note
Fixed three validation errors that reported the wrong value: `admissionFairSharing.usageSamplingInterval` reported the half-life, a negative `admissionFairSharing.resourceWeights` entry reported every configured weight, and a Workload resource usage that is not a multiple of the pod count reported the address of the count.
```

#### AI usage

Prepared with AI assistance (Claude Code); disclosed per the project's AI contribution policy, and the commit carries no AI trailers.