### PR TITLE
Guard TruncateAssignment against a nil assignment

### DIFF
--- a/pkg/cache/scheduler/tas_flavor_snapshot_test.go
+++ b/pkg/cache/scheduler/tas_flavor_snapshot_test.go
@@ -1340,6 +1340,11 @@ func TestTruncateAssignment(t *testing.T) {
 		newCount   int32
 		want       *tas.TopologyAssignment
 	}{
+		"nil assignment": {
+			assignment: nil,
+			newCount:   3,
+			want:       nil,
+		},
 		"truncate to zero": {
 			assignment: &tas.TopologyAssignment{
 				Levels: []string{"hostname"},

--- a/pkg/util/tas/tas_assignment.go
+++ b/pkg/util/tas/tas_assignment.go
@@ -526,7 +526,10 @@ func CountPodsInAssignment(ta *TopologyAssignment) int32 {
 
 // TruncateAssignment reduces an assignment to fit newCount pods (removes from end).
 func TruncateAssignment(ta *TopologyAssignment, newCount int32) *TopologyAssignment {
-	if ta == nil || newCount <= 0 {
+	if ta == nil {
+		return nil
+	}
+	if newCount <= 0 {
 		return &TopologyAssignment{Levels: ta.Levels, Domains: nil}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`TruncateAssignment` (`pkg/util/tas/tas_assignment.go`) guards `ta == nil` and `newCount <= 0` in one branch, but the branch body dereferences `ta.Levels`:

```go
if ta == nil || newCount <= 0 {
    return &TopologyAssignment{Levels: ta.Levels, Domains: nil} // panics when ta == nil
}
```

So a nil `TopologyAssignment` panics this exported helper. The sole in-tree caller (`handleScaleDown` in `pkg/cache/scheduler/tas_elastic_workloads.go`) passes a non-nil assignment today, so this is latent, but the guard is self-defeating for any other caller.

Split the check so a nil assignment returns nil, and keep the `newCount <= 0` behaviour unchanged.

#### Which issue(s) this PR fixes:
None filed separately; details above.

#### Special notes for your reviewer:
The added `TestTruncateAssignment` case (`assignment: nil`) panics with a nil-pointer dereference against the pre-fix code and passes after.

Prepared with AI assistance (Claude Code); disclosed per the project's AI contribution policy, and the commit carries no AI trailers.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assignment truncation handling for empty or missing assignments.
  * Preserved topology information when truncating to nonpositive counts.

* **Tests**
  * Added coverage verifying that missing assignments remain unchanged when truncation is requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->