### PR TITLE
Bound job-min-parallelism before truncating to int32

### DIFF
--- a/pkg/controller/jobs/job/job_controller.go
+++ b/pkg/controller/jobs/job/job_controller.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"strings"
@@ -458,7 +459,7 @@ func (j *Job) podsCount() int32 {
 
 func (j *Job) minPodsCount() *int32 {
 	if strVal, found := j.GetAnnotations()[JobMinParallelismAnnotation]; found {
-		if iVal, err := strconv.Atoi(strVal); err == nil {
+		if iVal, err := strconv.Atoi(strVal); err == nil && iVal > 0 && iVal <= math.MaxInt32 {
 			return new(int32(iVal))
 		}
 	}

--- a/pkg/controller/jobs/job/job_webhook.go
+++ b/pkg/controller/jobs/job/job_webhook.go
@@ -157,7 +157,7 @@ func (w *JobWebhook) validatePartialAdmissionCreate(job *Job) field.ErrorList {
 		v, err := strconv.Atoi(strVal)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, job.Annotations[JobMinParallelismAnnotation], err.Error()))
-		} else if int32(v) >= job.podsCount() || v <= 0 {
+		} else if v >= int(job.podsCount()) || v <= 0 {
 			allErrs = append(allErrs, field.Invalid(minPodsCountAnnotationsPath, v, fmt.Sprintf("should be between 0 and %d", job.podsCount()-1)))
 		}
 		if workloadslicing.Enabled(job.Object()) {

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -103,6 +103,17 @@ func TestValidateCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "partial admission annotation overflowing int32 is rejected",
+			job: testingutil.MakeJob("job", "default").
+				Parallelism(4).
+				Completions(6).
+				SetAnnotation(JobMinParallelismAnnotation, "2147483648").
+				Obj(),
+			wantValidationErrs: field.ErrorList{
+				field.Invalid(minPodsCountAnnotationsPath, 2147483648, "should be between 0 and 3"),
+			},
+		},
+		{
 			name: "valid partial admission annotation",
 			job: testingutil.MakeJob("job", "default").
 				Parallelism(4).

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -68,8 +68,10 @@ func TestJobMinPodsCount(t *testing.T) {
 		want       *int32
 	}{
 		"valid":           {"3", new(int32(3))},
+		"max int32":       {"2147483647", new(int32(2147483647))},
 		"overflows int32": {"2147483648", nil},
 		"not positive":    {"0", nil},
+		"negative":        {"-1", nil},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobs/job/job_webhook_test.go
+++ b/pkg/controller/jobs/job/job_webhook_test.go
@@ -62,6 +62,26 @@ var (
 	workloadPriorityClassNamePath  = labelsPath.Key(constants.WorkloadPriorityClassLabel)
 )
 
+func TestJobMinPodsCount(t *testing.T) {
+	cases := map[string]struct {
+		annotation string
+		want       *int32
+	}{
+		"valid":           {"3", new(int32(3))},
+		"overflows int32": {"2147483648", nil},
+		"not positive":    {"0", nil},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			job := (*Job)(testingutil.MakeJob("job", "default").
+				SetAnnotation(JobMinParallelismAnnotation, tc.annotation).Obj())
+			if diff := cmp.Diff(tc.want, job.minPodsCount()); diff != "" {
+				t.Errorf("minPodsCount() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestValidateCreate(t *testing.T) {
 	testcases := []struct {
 		name               string


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
`validatePartialAdmissionCreate` (`pkg/controller/jobs/job/job_webhook.go`) parses the `kueue.x-k8s.io/job-min-parallelism` annotation into an `int`, then range-checks it after converting to `int32`:

```go
v, err := strconv.Atoi(strVal)
...
} else if int32(v) >= job.podsCount() || v <= 0 {
```

`job.podsCount()` returns `int32`, so `v` is truncated to `int32` before the comparison. A value `>= 2^31` (e.g. `2147483648`) wraps to a negative `int32`, so `int32(v) >= job.podsCount()` is false and `v <= 0` is false, so the check passes and the out-of-range value flows on (`minPodsCount()` truncates it the same way, yielding a negative parallelism).

Compare the parsed `int` against the pod count widened to `int`, so no truncation happens.

#### Which issue(s) this PR fixes:
None filed separately; details above.

#### Special notes for your reviewer:
The added `TestValidateCreate` case (`job-min-parallelism: 2147483648`) is accepted by the pre-fix code and rejected after. It only triggers with an absurd annotation value (>= ~2.1 billion), so this is defensive.

Prepared with AI assistance (Claude Code); disclosed per the project's AI contribution policy, and the commit carries no AI trailers.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for partial-admission settings with very large values.
  * Invalid annotation values that exceed supported ranges are now rejected with a clear validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->