### PR TITLE
Clamp negative kueue_pod_scheduling_gate_removal_seconds observations

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1069,7 +1069,8 @@ func RecordWorkloadCreationLatency(jobKind string, latency time.Duration, custom
 }
 
 func RecordPodSchedulingGateRemovalSeconds(name string, clusterQueue kueue.ClusterQueueReference, isGroup bool, latency time.Duration, tracker *roletracker.RoleTracker) {
-	PodSchedulingGateRemovalSeconds.WithLabelValues(name, string(clusterQueue), strconv.FormatBool(isGroup), roletracker.GetRole(tracker)).Observe(latency.Seconds())
+	// latency spans the apiserver clock (LastTransitionTime) and the controller clock, so skew can make it negative.
+	PodSchedulingGateRemovalSeconds.WithLabelValues(name, string(clusterQueue), strconv.FormatBool(isGroup), roletracker.GetRole(tracker)).Observe(max(0, latency.Seconds()))
 }
 
 func QuotaReservedWorkload(cqName kueue.ClusterQueueReference, priorityClass string, waitTime time.Duration, customLabelValues []string, tracker *roletracker.RoleTracker) {

--- a/pkg/util/pod/pod_test.go
+++ b/pkg/util/pod/pod_test.go
@@ -477,3 +477,49 @@ func TestGetPodGroupName(t *testing.T) {
 		})
 	}
 }
+
+func TestRecordPodSchedulingGateRemovalSeconds(t *testing.T) {
+	const (
+		gateName = "example.com/gate"
+		cqName   = kueue.ClusterQueueReference("cq")
+	)
+
+	now := time.Now().Truncate(time.Second)
+
+	cases := map[string]struct {
+		admittedAt  time.Time
+		wantSeconds float64
+	}{
+		"controller clock ahead of the admitted transition": {
+			admittedAt:  now.Add(-3 * time.Second),
+			wantSeconds: 3,
+		},
+		"controller clock behind the admitted transition is clamped to zero": {
+			admittedAt:  now.Add(3 * time.Second),
+			wantSeconds: 0,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			metrics.PodSchedulingGateRemovalSeconds.Reset()
+
+			wl := utiltestingapi.MakeWorkload("wl", corev1.NamespaceDefault).
+				ReserveQuotaAt(utiltestingapi.MakeAdmission(cqName).Obj(), tc.admittedAt).
+				AdmittedAt(true, tc.admittedAt).
+				Obj()
+
+			RecordPodSchedulingGateRemovalSeconds(testingclock.NewFakeClock(now), gateName, wl, false, nil)
+
+			seconds, err := testutil.GetHistogramMetricValue(
+				metrics.PodSchedulingGateRemovalSeconds.WithLabelValues(gateName, string(cqName), "false", roletracker.RoleStandalone),
+			)
+			if err != nil {
+				t.Fatalf("Error getting PodSchedulingGateRemovalSeconds metric value: %v", err)
+			}
+			if seconds != tc.wantSeconds {
+				t.Errorf("Unexpected metric value: want %v, got %v", tc.wantSeconds, seconds)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area observability

#### What this PR does / why we need it:

`metrics.RecordPodSchedulingGateRemovalSeconds` observed its `latency` argument without clamping it. The caller, `pkg/util/pod.RecordPodSchedulingGateRemovalSeconds`, derives that value from the controller's clock and the persisted `WorkloadAdmitted` condition:

```go
latency := cl.Now().Sub(cond.LastTransitionTime.Time)
```

`LastTransitionTime` is stamped by the apiserver, while `Now()` reads the controller's clock. Skew between the two, a leader transition, or a wall-clock adjustment can place the transition time after `Now()`, making the duration negative.

A negative observation has no meaning for a latency histogram, and it makes the classic histogram's `_sum` decrease — Prometheus reads the drop as a counter reset, so `rate()` over that series returns garbage.

This clamps the observation to zero, matching `ReportWorkloadEvictionLatency`, which already guards the identical apiserver-versus-controller comparison.

#### Which issue(s) this PR fixes:

Fixes #14456

#### Special notes for your reviewer:

Deliberately kept separate from #14419, which fixes a label cardinality panic on the same helper.

Added a table-driven regression test in `pkg/util/pod/pod_test.go` using a fake clock, covering both the normal case and the case where `Now()` precedes the admitted transition time. Verified the test fails on the unpatched helper (`want 0, got -3`) and passes with the fix.

#### Does this PR introduce a user-facing change?
NO

```release-note
Observability: Fixed `kueue_pod_scheduling_gate_removal_seconds` observing negative durations when the controller clock trails the apiserver clock. The negative observations made the histogram's `_sum` decrease, which broke `rate()` over that series.
```

---

AI-disclosure: Assisted-by Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduling metrics accuracy when clock differences produce negative elapsed times.
  - Negative latency values are now recorded as zero instead of invalid durations.

- **Tests**
  - Added coverage for both positive and negative scheduling-gate removal elapsed times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->