### PR TITLE
Sort MPIJob update validation errors

### DIFF
--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -155,7 +155,7 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *v2be
 		return nil, err
 	}
 	allErrs = append(allErrs, validationErrs...)
-	slices.SortFunc(validationErrs, func(a, b *field.Error) int {
+	slices.SortFunc(allErrs, func(a, b *field.Error) int {
 		return cmp.Compare(a.Field, b.Field)
 	})
 	return nil, allErrs.ToAggregate()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area integrations

#### What this PR does / why we need it:

`ValidateUpdate` was sorting `validationErrs` after appending them to `allErrs`, so the returned errors were not sorted. This changes it to sort `allErrs` instead.

#### Which issue(s) this PR fixes:

Fixes #14476

#### Special notes for your reviewer:

I tried a regression test locally, but it needed unrelated validation errors just to expose the ordering, and there isn't an existing `ValidateUpdate` test to add a case to. I kept this to the one-line fix.

Tested with `go test ./pkg/controller/jobs/mpijob -count=1`.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update validation error ordering for more consistent and predictable error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->