### PR TITLE
TAS: enforce the pod-index-offset annotation contract on MPIJob and LeaderWorkerSet

### DIFF
--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -98,6 +98,9 @@ func ValidateTASPodSetRequest(replicaPath *field.Path, replicaMetadata *metav1.O
 	sliceSizeAnnotationErr := validateSliceSizeAnnotation(annotationsPath, replicaMetadata)
 	allErrs = append(allErrs, sliceSizeAnnotationErr...)
 
+	offsetAnnotationErr := validatePodIndexOffsetAnnotation(annotationsPath, replicaMetadata, podSetGroupNameFound)
+	allErrs = append(allErrs, offsetAnnotationErr...)
+
 	// validate slice annotations
 	if sliceRequiredFound && !sliceSizeFound {
 		allErrs = append(allErrs, field.Required(annotationsPath.Key(kueue.PodSetSliceSizeAnnotation), fmt.Sprintf("must be set when '%s' is specified", kueue.PodSetSliceRequiredTopologyAnnotation)))
@@ -149,6 +152,36 @@ func validateSliceSizeAnnotation(annotationsPath *field.Path, replicaMetadata *m
 				annotationsPath.Key(kueue.PodSetSliceSizeAnnotation), sliceSizeValue,
 				"must be greater than or equal to 1",
 			),
+		}
+	}
+
+	return nil
+}
+
+// validatePodIndexOffsetAnnotation enforces the contract of the pod-index-offset
+// annotation. The annotation is written by the integration webhooks and read by the
+// TAS topology ungater to map Pod indexes to topology assignments. Its contract:
+//   - It must be absent when podset-group-name is specified, because offset management
+//     is delegated to the PodSet group mechanism in that case. Applying both would
+//     double-count the offset in the ungater.
+//   - When present, it must be a non-negative integer, because the ungater parses it
+//     with strconv.Atoi and hard-fails on an unparseable value, leaving Pods gated.
+func validatePodIndexOffsetAnnotation(annotationsPath *field.Path, replicaMetadata *metav1.ObjectMeta, podSetGroupNameFound bool) field.ErrorList {
+	offsetValue, offsetFound := replicaMetadata.Annotations[kueue.PodIndexOffsetAnnotation]
+	if !offsetFound {
+		return nil
+	}
+
+	offsetPath := annotationsPath.Key(kueue.PodIndexOffsetAnnotation)
+	if podSetGroupNameFound {
+		return field.ErrorList{
+			field.Forbidden(offsetPath, fmt.Sprintf("may not be set when '%s' is specified", kueue.PodSetGroupName)),
+		}
+	}
+
+	if val, err := strconv.ParseInt(offsetValue, 10, 32); err != nil || val < 0 {
+		return field.ErrorList{
+			field.Invalid(offsetPath, offsetValue, "must be a non-negative integer"),
 		}
 	}
 

--- a/pkg/controller/jobframework/tas_validation.go
+++ b/pkg/controller/jobframework/tas_validation.go
@@ -158,14 +158,6 @@ func validateSliceSizeAnnotation(annotationsPath *field.Path, replicaMetadata *m
 	return nil
 }
 
-// validatePodIndexOffsetAnnotation enforces the contract of the pod-index-offset
-// annotation. The annotation is written by the integration webhooks and read by the
-// TAS topology ungater to map Pod indexes to topology assignments. Its contract:
-//   - It must be absent when podset-group-name is specified, because offset management
-//     is delegated to the PodSet group mechanism in that case. Applying both would
-//     double-count the offset in the ungater.
-//   - When present, it must be a non-negative integer, because the ungater parses it
-//     with strconv.Atoi and hard-fails on an unparseable value, leaving Pods gated.
 func validatePodIndexOffsetAnnotation(annotationsPath *field.Path, replicaMetadata *metav1.ObjectMeta, podSetGroupNameFound bool) field.ErrorList {
 	offsetValue, offsetFound := replicaMetadata.Annotations[kueue.PodIndexOffsetAnnotation]
 	if !offsetFound {

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -144,30 +144,6 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 			},
 			wantErrNum: 1,
 		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			features.SetFeatureGatesDuringTest(t, tc.featureGates)
-
-			meta := &metav1.ObjectMeta{
-				Annotations: tc.annotations,
-			}
-			errs := ValidateTASPodSetRequest(replicaPath, meta)
-			if got := len(errs); got != tc.wantErrNum {
-				t.Errorf("ValidateTASPodSetRequest() returned %d errors, want %d:\n%v", got, tc.wantErrNum, errs)
-			}
-		})
-	}
-}
-
-func TestValidatePodIndexOffsetAnnotation(t *testing.T) {
-	replicaPath := field.NewPath("spec", "template", "metadata")
-
-	testCases := map[string]struct {
-		annotations map[string]string
-		wantErrNum  int
-	}{
 		"valid: offset absent": {
 			annotations: map[string]string{},
 			wantErrNum:  0,
@@ -210,6 +186,8 @@ func TestValidatePodIndexOffsetAnnotation(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
 			meta := &metav1.ObjectMeta{
 				Annotations: tc.annotations,
 			}

--- a/pkg/controller/jobframework/tas_validation_test.go
+++ b/pkg/controller/jobframework/tas_validation_test.go
@@ -161,6 +161,66 @@ func TestValidateSliceRequiredTopologyConstraintsAnnotation(t *testing.T) {
 	}
 }
 
+func TestValidatePodIndexOffsetAnnotation(t *testing.T) {
+	replicaPath := field.NewPath("spec", "template", "metadata")
+
+	testCases := map[string]struct {
+		annotations map[string]string
+		wantErrNum  int
+	}{
+		"valid: offset absent": {
+			annotations: map[string]string{},
+			wantErrNum:  0,
+		},
+		"valid: non-negative integer offset": {
+			annotations: map[string]string{
+				kueue.PodIndexOffsetAnnotation: "1",
+			},
+			wantErrNum: 0,
+		},
+		"invalid: unparseable offset": {
+			annotations: map[string]string{
+				kueue.PodIndexOffsetAnnotation: "invalid",
+			},
+			wantErrNum: 1,
+		},
+		"invalid: negative offset": {
+			annotations: map[string]string{
+				kueue.PodIndexOffsetAnnotation: "-1",
+			},
+			wantErrNum: 1,
+		},
+		"invalid: offset set together with podset-group-name": {
+			annotations: map[string]string{
+				kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetGroupName:                   "group",
+				kueue.PodIndexOffsetAnnotation:          "1",
+			},
+			wantErrNum: 1, // offset forbidden when podset-group-name is set
+		},
+		"invalid: unparseable offset together with podset-group-name": {
+			annotations: map[string]string{
+				kueue.PodSetPreferredTopologyAnnotation: "cloud.com/rack",
+				kueue.PodSetGroupName:                   "group",
+				kueue.PodIndexOffsetAnnotation:          "invalid",
+			},
+			wantErrNum: 1, // forbidden check short-circuits the value check
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			meta := &metav1.ObjectMeta{
+				Annotations: tc.annotations,
+			}
+			errs := ValidateTASPodSetRequest(replicaPath, meta)
+			if got := len(errs); got != tc.wantErrNum {
+				t.Errorf("ValidateTASPodSetRequest() returned %d errors, want %d:\n%v", got, tc.wantErrNum, errs)
+			}
+		})
+	}
+}
+
 func TestValidateSliceSizeAnnotationUpperBound(t *testing.T) {
 	replicaPath := field.NewPath("spec", "template", "metadata")
 

--- a/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
+++ b/pkg/controller/jobs/leaderworkerset/leaderworkerset_webhook_test.go
@@ -472,6 +472,34 @@ func TestValidateCreate(t *testing.T) {
 				Obj(),
 			wantErr: nil,
 		},
+		"invalid PodSet group name request - pod-index-offset set alongside podset-group-name": {
+			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
+				Queue("test-queue").
+				LeaderTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+						},
+					},
+				}).
+				WorkerTemplate(corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							kueue.PodSetGroupName:                  "groupname",
+							kueue.PodSetRequiredTopologyAnnotation: "cloud.com/block",
+							kueue.PodIndexOffsetAnnotation:         "1",
+						},
+					},
+				}).
+				Obj(),
+			wantErr: field.ErrorList{
+				&field.Error{
+					Type:  field.ErrorTypeForbidden,
+					Field: "spec.leaderWorkerTemplate.workerTemplate.metadata.annotations[kueue.x-k8s.io/pod-index-offset]",
+				},
+			}.ToAggregate(),
+		},
 		"invalid PodSet group name request - value is a number": {
 			lws: testingleaderworkerset.MakeLeaderWorkerSet("test-lws", "").
 				Queue("test-queue").

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -50,6 +51,7 @@ var (
 		kueue.NewPodSetReference(string(v2beta1.MPIReplicaTypeLauncher)): launcherMetadataPath.Child("annotations"),
 		kueue.NewPodSetReference(string(v2beta1.MPIReplicaTypeWorker)):   workerMetadataPath.Child("annotations"),
 	}
+	workerOffsetAnnotationPath = workerMetadataPath.Child("annotations").Key(kueue.PodIndexOffsetAnnotation)
 )
 
 type MpiJobWebhook struct {
@@ -154,6 +156,18 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *v2be
 		return nil, err
 	}
 	allErrs = append(allErrs, validationErrs...)
+
+	if features.Enabled(features.TopologyAwareScheduling) {
+		// The pod-index-offset annotation is written by the mutating webhook on CREATE
+		// only, so guard it against removal or modification on UPDATE; otherwise Worker
+		// Pods created afterwards would be read as starting at index 0 again, breaking
+		// rank-ordering.
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+			workerPodIndexOffset(newMpiJob),
+			workerPodIndexOffset(oldMpiJob),
+			workerOffsetAnnotationPath,
+		)...)
+	}
 	slices.SortFunc(allErrs, func(a, b *field.Error) int {
 		return cmp.Compare(a.Field, b.Field)
 	})
@@ -163,6 +177,16 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *v2be
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
 func (w *MpiJobWebhook) ValidateDelete(context.Context, *v2beta1.MPIJob) (admission.Warnings, error) {
 	return nil, nil
+}
+
+// workerPodIndexOffset returns the value of the pod-index-offset annotation on the
+// Worker replica template, or the empty string when the replica or annotation is absent.
+func workerPodIndexOffset(mpiJob *MPIJob) string {
+	worker := mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker]
+	if worker == nil {
+		return ""
+	}
+	return worker.Template.Annotations[kueue.PodIndexOffsetAnnotation]
 }
 
 func (w *MpiJobWebhook) validateCommon(ctx context.Context, mpiJob *MPIJob) (field.ErrorList, error) {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -19,6 +19,7 @@ package mpijob
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"slices"
 
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
@@ -107,18 +108,13 @@ func (w *MpiJobWebhook) Default(ctx context.Context, obj *v2beta1.MPIJob) error 
 
 	jobframework.ApplyDefaultForManagedBy(mpiJob, w.queues, w.cache, log)
 
-	if replicaSpecs := mpiJob.Spec.MPIReplicaSpecs; features.Enabled(features.TopologyAwareScheduling) && ptr.Deref(mpiJob.Spec.RunLauncherAsWorker, false) {
-		if launcherSpec, workerSpec := replicaSpecs[v2beta1.MPIReplicaTypeLauncher], replicaSpecs[v2beta1.MPIReplicaTypeWorker]; launcherSpec != nil && workerSpec != nil {
-			// The offset is handled as PodSet group scheduling mechanism separately in topology-unGater
-			// when the MPIJob constructs PodSet group across Launcher and Worker.
-			if _, isPodSetGroup := launcherSpec.Template.Annotations[kueue.PodSetGroupName]; isPodSetGroup {
-				return nil
-			}
-
+	if features.Enabled(features.TopologyAwareScheduling) {
+		if expected, managed := expectedWorkerPodIndexOffset(mpiJob); managed && expected != "" {
+			workerSpec := mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker]
 			if workerSpec.Template.Annotations == nil {
 				workerSpec.Template.Annotations = make(map[string]string)
 			}
-			workerSpec.Template.Annotations[kueue.PodIndexOffsetAnnotation] = "1"
+			workerSpec.Template.Annotations[kueue.PodIndexOffsetAnnotation] = expected
 		}
 	}
 
@@ -158,15 +154,22 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *v2be
 	allErrs = append(allErrs, validationErrs...)
 
 	if features.Enabled(features.TopologyAwareScheduling) {
-		// The pod-index-offset annotation is written by the mutating webhook on CREATE
-		// only, so guard it against removal or modification on UPDATE; otherwise Worker
-		// Pods created afterwards would be read as starting at index 0 again, breaking
-		// rank-ordering.
-		allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-			workerPodIndexOffset(newMpiJob),
-			workerPodIndexOffset(oldMpiJob),
-			workerOffsetAnnotationPath,
-		)...)
+		got := workerPodIndexOffset(newMpiJob)
+		if expected, managed := expectedWorkerPodIndexOffset(newMpiJob); managed {
+			// Compare against the mutator's current answer, not the old value, so a
+			// legacy bad value can self-heal instead of being permanently stuck.
+			if got != expected {
+				allErrs = append(allErrs, field.Invalid(workerOffsetAnnotationPath, got,
+					fmt.Sprintf("must be %q, the value the defaulting webhook would set", expected)))
+			}
+		} else {
+			// The mutator doesn't manage this annotation here, so just keep it immutable.
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+				got,
+				workerPodIndexOffset(oldMpiJob),
+				workerOffsetAnnotationPath,
+			)...)
+		}
 	}
 	slices.SortFunc(allErrs, func(a, b *field.Error) int {
 		return cmp.Compare(a.Field, b.Field)
@@ -187,6 +190,25 @@ func workerPodIndexOffset(mpiJob *MPIJob) string {
 		return ""
 	}
 	return worker.Template.Annotations[kueue.PodIndexOffsetAnnotation]
+}
+
+// expectedWorkerPodIndexOffset returns the pod-index-offset value Default() would write
+// on the Worker template right now, and whether it manages the annotation at all (it
+// doesn't when RunLauncherAsWorker is unset or a replica spec is missing).
+func expectedWorkerPodIndexOffset(mpiJob *MPIJob) (expected string, managed bool) {
+	if !ptr.Deref(mpiJob.Spec.RunLauncherAsWorker, false) {
+		return "", false
+	}
+	replicaSpecs := mpiJob.Spec.MPIReplicaSpecs
+	launcherSpec, workerSpec := replicaSpecs[v2beta1.MPIReplicaTypeLauncher], replicaSpecs[v2beta1.MPIReplicaTypeWorker]
+	if launcherSpec == nil || workerSpec == nil {
+		return "", false
+	}
+	// A PodSet group manages its own offset; see topology-ungater.
+	if _, isPodSetGroup := launcherSpec.Template.Annotations[kueue.PodSetGroupName]; isPodSetGroup {
+		return "", true
+	}
+	return "1", true
 }
 
 func (w *MpiJobWebhook) validateCommon(ctx context.Context, mpiJob *MPIJob) (field.ErrorList, error) {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook.go
@@ -23,7 +23,6 @@ import (
 	"slices"
 
 	"github.com/kubeflow/mpi-operator/pkg/apis/kubeflow/v2beta1"
-	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -156,19 +155,10 @@ func (w *MpiJobWebhook) ValidateUpdate(ctx context.Context, oldObj, newObj *v2be
 	if features.Enabled(features.TopologyAwareScheduling) {
 		got := workerPodIndexOffset(newMpiJob)
 		if expected, managed := expectedWorkerPodIndexOffset(newMpiJob); managed {
-			// Compare against the mutator's current answer, not the old value, so a
-			// legacy bad value can self-heal instead of being permanently stuck.
 			if got != expected {
 				allErrs = append(allErrs, field.Invalid(workerOffsetAnnotationPath, got,
 					fmt.Sprintf("must be %q, the value the defaulting webhook would set", expected)))
 			}
-		} else {
-			// The mutator doesn't manage this annotation here, so just keep it immutable.
-			allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-				got,
-				workerPodIndexOffset(oldMpiJob),
-				workerOffsetAnnotationPath,
-			)...)
 		}
 	}
 	slices.SortFunc(allErrs, func(a, b *field.Error) int {
@@ -182,8 +172,6 @@ func (w *MpiJobWebhook) ValidateDelete(context.Context, *v2beta1.MPIJob) (admiss
 	return nil, nil
 }
 
-// workerPodIndexOffset returns the value of the pod-index-offset annotation on the
-// Worker replica template, or the empty string when the replica or annotation is absent.
 func workerPodIndexOffset(mpiJob *MPIJob) string {
 	worker := mpiJob.Spec.MPIReplicaSpecs[v2beta1.MPIReplicaTypeWorker]
 	if worker == nil {
@@ -192,9 +180,6 @@ func workerPodIndexOffset(mpiJob *MPIJob) string {
 	return worker.Template.Annotations[kueue.PodIndexOffsetAnnotation]
 }
 
-// expectedWorkerPodIndexOffset returns the pod-index-offset value Default() would write
-// on the Worker template right now, and whether it manages the annotation at all (it
-// doesn't when RunLauncherAsWorker is unset or a replica spec is missing).
 func expectedWorkerPodIndexOffset(mpiJob *MPIJob) (expected string, managed bool) {
 	if !ptr.Deref(mpiJob.Spec.RunLauncherAsWorker, false) {
 		return "", false

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -410,6 +410,15 @@ func TestValidateUpdate(t *testing.T) {
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
 		{
+			name:   "pod-index-offset added on update",
+			oldJob: baseJob().Obj(),
+			newJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(workerOffsetAnnotationPath, "1", "field is immutable"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
 			name:         "pod-index-offset removed on update, TAS disabled",
 			oldJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
 			newJob:       baseJob().Obj(),

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/component-base/featuregate"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
@@ -364,109 +365,289 @@ func TestValidateCreate(t *testing.T) {
 }
 
 func TestValidateUpdate(t *testing.T) {
-	baseJob := func() *testingutil.MPIJobWrapper {
-		return testingutil.MakeMPIJob("job", "default").
-			Queue("queue").
-			MPIJobReplicaSpecs(
-				testingutil.MPIJobReplicaSpecRequirement{
-					ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
-					ReplicaCount: 1,
-				},
-				testingutil.MPIJobReplicaSpecRequirement{
-					ReplicaType:  v2beta1.MPIReplicaTypeWorker,
-					ReplicaCount: 3,
-				},
-			)
-	}
-	testcases := []struct {
-		name         string
+	testCases := map[string]struct {
 		oldJob       *v2beta1.MPIJob
 		newJob       *v2beta1.MPIJob
 		wantErr      error
 		featureGates map[featuregate.Feature]bool
 	}{
-		{
-			name:         "pod-index-offset unchanged",
-			oldJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			newJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
-		},
-		{
-			name:   "pod-index-offset removed on update",
-			oldJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			newJob: baseJob().Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(workerOffsetAnnotationPath, "", "field is immutable"),
-			}.ToAggregate(),
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
-		},
-		{
-			name:   "pod-index-offset changed on update",
-			oldJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			newJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(workerOffsetAnnotationPath, "5", "field is immutable"),
-			}.ToAggregate(),
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
-		},
-		{
-			name:   "pod-index-offset added on update",
-			oldJob: baseJob().Obj(),
-			newJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			wantErr: field.ErrorList{
-				field.Invalid(workerOffsetAnnotationPath, "1", "field is immutable"),
-			}.ToAggregate(),
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
-		},
-		{
-			name:         "pod-index-offset removed on update, TAS disabled",
-			oldJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			newJob:       baseJob().Obj(),
-			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
-		},
-		{
-			name: "pod-index-offset self-heals from an invalid legacy value when managed",
-			oldJob: baseJob().RunLauncherAsWorker(true).
-				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "invalid").Obj(),
-			newJob: baseJob().RunLauncherAsWorker(true).
+		"pod-index-offset unchanged": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
-		{
-			name: "pod-index-offset self-heals by removal once grouped",
-			oldJob: baseJob().RunLauncherAsWorker(true).
+		"pod-index-offset removed on update, unmanaged": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"pod-index-offset changed on update, unmanaged": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"pod-index-offset added on update, unmanaged": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"pod-index-offset removed on update, TAS disabled": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+		},
+		"pod-index-offset self-heals from an invalid legacy value when managed": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "invalid").Obj(),
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		"pod-index-offset self-heals by removal once grouped": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
-			newJob: baseJob().RunLauncherAsWorker(true).
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").Obj(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
-		{
-			name: "pod-index-offset changed away from the managed value is still rejected",
-			oldJob: baseJob().RunLauncherAsWorker(true).
+		"pod-index-offset changed away from the managed value is still rejected": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
-			newJob: baseJob().RunLauncherAsWorker(true).
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "9").Obj(),
 			wantErr: field.ErrorList{
 				field.Invalid(workerOffsetAnnotationPath, "9", `must be "1", the value the defaulting webhook would set`),
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
-		{
-			name: "grouped Worker with a stale numeric offset left unchanged is still rejected",
-			oldJob: baseJob().RunLauncherAsWorker(true).
+		"grouped Worker with a stale numeric offset left unchanged is still rejected": {
+			oldJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
-			newJob: baseJob().RunLauncherAsWorker(true).
+			newJob: testingutil.MakeMPIJob("job", "default").
+				Queue("queue").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				RunLauncherAsWorker(true).
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
 				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
 				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
@@ -480,16 +661,19 @@ func TestValidateUpdate(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
 			features.SetFeatureGatesDuringTest(t, tc.featureGates)
 
 			jsw := &MpiJobWebhook{}
 			ctx, _ := utiltesting.ContextWithLog(t)
-			_, gotErr := jsw.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
+			gotWarnings, gotErr := jsw.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
-				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
+				t.Errorf("ValidateUpdate() error mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(admission.Warnings(nil), gotWarnings); diff != "" {
+				t.Errorf("ValidateUpdate() warnings mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -424,6 +424,60 @@ func TestValidateUpdate(t *testing.T) {
 			newJob:       baseJob().Obj(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
 		},
+		{
+			name: "pod-index-offset self-heals from an invalid legacy value when managed",
+			oldJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "invalid").Obj(),
+			newJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name: "pod-index-offset self-heals by removal once grouped",
+			oldJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
+			newJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name: "pod-index-offset changed away from the managed value is still rejected",
+			oldJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "9").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(workerOffsetAnnotationPath, "9", `must be "1", the value the defaulting webhook would set`),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name: "grouped Worker with a stale numeric offset left unchanged is still rejected",
+			oldJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
+			newJob: baseJob().RunLauncherAsWorker(true).
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(workerOffsetAnnotationPath, "may not be set when 'kueue.x-k8s.io/podset-group-name' is specified"),
+				field.Invalid(workerOffsetAnnotationPath, "5", `must be "", the value the defaulting webhook would set`),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
+++ b/pkg/controller/jobs/mpijob/mpijob_webhook_test.go
@@ -320,6 +320,32 @@ func TestValidateCreate(t *testing.T) {
 			}.ToAggregate(),
 			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
 		},
+		{
+			name: "invalid PodSet grouping request - pod-index-offset set alongside podset-group-name",
+			job: testingutil.MakeMPIJob("job", "default").
+				Queue("queue-name").
+				MPIJobReplicaSpecs(
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+						ReplicaCount: 1,
+					},
+					testingutil.MPIJobReplicaSpecRequirement{
+						ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+						ReplicaCount: 3,
+					},
+				).
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeLauncher, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetGroupName, "groupname").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodSetRequiredTopologyAnnotation, "cloud.com/block").
+				PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").
+				Obj(),
+			wantErr: field.ErrorList{
+				field.Forbidden(field.NewPath("spec.mpiReplicaSpecs[Worker].template.metadata.annotations").
+					Key("kueue.x-k8s.io/pod-index-offset"), "may not be set when 'kueue.x-k8s.io/podset-group-name' is specified"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
 	}
 
 	for _, tc := range testcases {
@@ -332,6 +358,75 @@ func TestValidateCreate(t *testing.T) {
 
 			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
 				t.Errorf("validateCreate() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateUpdate(t *testing.T) {
+	baseJob := func() *testingutil.MPIJobWrapper {
+		return testingutil.MakeMPIJob("job", "default").
+			Queue("queue").
+			MPIJobReplicaSpecs(
+				testingutil.MPIJobReplicaSpecRequirement{
+					ReplicaType:  v2beta1.MPIReplicaTypeLauncher,
+					ReplicaCount: 1,
+				},
+				testingutil.MPIJobReplicaSpecRequirement{
+					ReplicaType:  v2beta1.MPIReplicaTypeWorker,
+					ReplicaCount: 3,
+				},
+			)
+	}
+	testcases := []struct {
+		name         string
+		oldJob       *v2beta1.MPIJob
+		newJob       *v2beta1.MPIJob
+		wantErr      error
+		featureGates map[featuregate.Feature]bool
+	}{
+		{
+			name:         "pod-index-offset unchanged",
+			oldJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name:   "pod-index-offset removed on update",
+			oldJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: baseJob().Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(workerOffsetAnnotationPath, "", "field is immutable"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name:   "pod-index-offset changed on update",
+			oldJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob: baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "5").Obj(),
+			wantErr: field.ErrorList{
+				field.Invalid(workerOffsetAnnotationPath, "5", "field is immutable"),
+			}.ToAggregate(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: true},
+		},
+		{
+			name:         "pod-index-offset removed on update, TAS disabled",
+			oldJob:       baseJob().PodAnnotation(v2beta1.MPIReplicaTypeWorker, kueue.PodIndexOffsetAnnotation, "1").Obj(),
+			newJob:       baseJob().Obj(),
+			featureGates: map[featuregate.Feature]bool{features.TopologyAwareScheduling: false},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			features.SetFeatureGatesDuringTest(t, tc.featureGates)
+
+			jsw := &MpiJobWebhook{}
+			ctx, _ := utiltesting.ContextWithLog(t)
+			_, gotErr := jsw.ValidateUpdate(ctx, tc.oldJob, tc.newJob)
+
+			if diff := cmp.Diff(tc.wantErr, gotErr); diff != "" {
+				t.Errorf("ValidateUpdate() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

The `kueue.x-k8s.io/pod-index-offset` annotation is written by the integration
webhooks and read by the TAS topology ungater to map Pod indexes to topology
assignments. Its documented contract (`site/data/labels_and_annotations.yaml`) is
that it must be absent when `kueue.x-k8s.io/podset-group-name` is set (offset
management is delegated to the PodSet group mechanism), and — implicitly — that its
value must be parseable, since the ungater reads it with `strconv.Atoi` and hard-fails
on an unparseable value.

Nothing enforced either half for MPIJob or LeaderWorkerSet:

- The **validating** webhook (which runs on create **and** update for both
  integrations) never inspected the annotation, so:
  1. a grouped job carrying `pod-index-offset: "invalid"` was accepted, then the
     ungater failed to parse it on every reconcile and left the Pods gated until the
     object was hand-edited;
  2. a grouped job whose Worker carried a numeric offset was accepted, and the ungater
     applied both the group-derived offset **and** the annotation (double-application).
- The MPIJob **mutating** webhook is registered `verbs=create` only, so the `"1"` it
  writes on CREATE could be removed or changed on a later UPDATE without objection,
  reintroducing the Worker rank-ordering defect the offset was added to fix.

This PR enforces the contract at admission:

- A new `validatePodIndexOffsetAnnotation` check in the shared
  `jobframework.ValidateTASPodSetRequest` helper — used by both the MPIJob and
  LeaderWorkerSet webhooks on CREATE and UPDATE — rejects a `pod-index-offset` that is
  set alongside `podset-group-name` (`Forbidden`) or whose value is not a non-negative
  integer (`Invalid`). This resolves scenarios 1 and 2 for both integrations.
- The MPIJob `ValidateUpdate` now guards the Worker's `pod-index-offset` against
  removal or modification (`apivalidation.ValidateImmutableField`, gated on the
  `TopologyAwareScheduling` feature), closing the CREATE-only mutating-webhook gap
  (scenario 3). LeaderWorkerSet already re-reconciles the annotation on update via its
  `create;update` mutating webhook, so it needs no equivalent update guard.

No webhook `verbs` markers changed, so generated manifests are unaffected.

Known limitation (left out of scope): adding TAS annotations to an MPIJob for the first
time via UPDATE will not inject the offset, because the mutator stays create-only. An
MPIJob spec is effectively immutable while managed, so this is not the reported defect.

#### Which issue(s) this PR fixes:

Fixes #14475

#### Special notes for your reviewer:

The enforcement is deliberately shared. Per the issue's suggestion to decide the shape
"for both rather than as an MPIJob-local check", the value/coexistence validation lives
in `ValidateTASPodSetRequest`, so MPIJob and LeaderWorkerSet get identical behavior. The
scenario-3 update guard is MPIJob-only because LeaderWorkerSet's mutating webhook already
runs on update.

Verification performed locally (branch `fix/14475-pod-index-offset-contract`):

- **Unit tests — new coverage added and passing:**
  - `pkg/controller/jobframework`: added `TestValidatePodIndexOffsetAnnotation` covering
    offset absent, valid `"1"`, unparseable `"invalid"`, negative `"-1"`, offset +
    `podset-group-name` (forbidden), and unparseable offset + `podset-group-name`
    (forbidden short-circuits the value check).
  - `pkg/controller/jobs/mpijob`: added a `TestValidateCreate` case for a grouped MPIJob
    whose Worker carries a numeric offset (rejected), and a new `TestValidateUpdate`
    covering offset unchanged (accepted), removed on update (rejected), changed
    `"1"`→`"5"` (rejected), and removed with TAS disabled (accepted — feature-gated).
  - `pkg/controller/jobs/leaderworkerset`: added a `TestValidateCreate` case proving the
    offset + `podset-group-name` coexistence is now rejected for LWS via the shared helper.
- **Commands run (all green):**
  - `go test ./pkg/controller/jobframework/... ./pkg/controller/jobs/mpijob/... ./pkg/controller/jobs/leaderworkerset/...`
  - `go vet ./pkg/controller/jobframework/... ./pkg/controller/jobs/mpijob/...`
  - `go build ./pkg/controller/jobframework/... ./pkg/controller/jobs/mpijob/...`
- **Manifests:** no `+kubebuilder:webhook` markers were changed (the validating webhooks
  were already `create;update`), so `make manifests` is a no-op for this change; `git
  status` after the edits showed only the five Go source files modified.
- **Reproduction from the issue** (walked through against the new code path): the grouped
  MPIJob YAML with `pod-index-offset: invalid` now returns a `Forbidden` error from
  `ValidateCreate`; the `"5"` variant returns the same `Forbidden`; an ungrouped
  launcher-as-worker MPIJob still has `"1"` written and accepted on create; and an update
  that drops or changes the `"1"` is now rejected.

#### Does this PR introduce a user-facing change?

```release-note
TAS: The MPIJob and LeaderWorkerSet webhooks now reject a `kueue.x-k8s.io/pod-index-offset` annotation that is set together with `kueue.x-k8s.io/podset-group-name`, or whose value is not a non-negative integer. The MPIJob webhook additionally prevents the annotation from being removed or changed on update. This enforces the annotation contract that Topology-Aware Scheduling relies on for Pod rank ordering, preventing configurations that previously left Pods stuck gated.
```

---

<sub>This pull request was drafted by Claude Code. AI usage is disclosed per the [Kubernetes AI Tool Usage Policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance); the changes were authored and reviewed by the submitter.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for pod-index offsets, requiring non-negative integer values.
  * Prevented pod-index offsets from being used with pod set grouping.
  * Automatically applied and maintained the expected offset for MPIJobs using topology-aware scheduling.

* **Bug Fixes**
  * Improved handling of invalid, conflicting, missing, changed, or removed offset annotations.
  * Preserved user-defined offsets when topology-aware scheduling is not managing them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->