### PR TITLE
FairSharing: skip the preemption tournament when the preemptor's share is +Inf

### DIFF
--- a/pkg/scheduler/preemption/preemption.go
+++ b/pkg/scheduler/preemption/preemption.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -424,6 +425,22 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 		}
 
 		preemptorNewShare, targetOldShare := candCQ.ComputeShares()
+		if fsStrategyUnsatisfiable(preemptorNewShare, targetOldShare) {
+			// No candidate in this ClusterQueue can pass the strategy, so
+			// skip the per-candidate simulation. The candidates are still
+			// collected for rule S2-b, which recomputes the shares on a
+			// snapshot that this loop may have changed in the meantime.
+			if logV := preemptionCtx.log.V(4); logV.Enabled() {
+				logV.Info("Skipping FairSharing strategy evaluation, no candidate can pass",
+					"preemptorNewShare", schdcache.DRS(preemptorNewShare).PreciseWeightedShareSerialized(),
+					"targetClusterQueue", klog.KRef("", string(candCQ.GetTargetCq().Name)),
+					"targetOldShare", schdcache.DRS(targetOldShare).PreciseWeightedShareSerialized())
+			}
+			for candCQ.HasWorkload() {
+				retryCandidates = append(retryCandidates, candCQ.PopWorkload())
+			}
+			continue
+		}
 		strategyLog := newFsStrategyLog(preemptionCtx.log, candCQ, preemptorNewShare, targetOldShare)
 		for candCQ.HasWorkload() {
 			candWl := candCQ.PopWorkload()
@@ -450,6 +467,33 @@ func runFirstFsStrategy(preemptionCtx *preemptionCtx, candidates []*workload.Inf
 		strategyLog.flush()
 	}
 	return false, targets, retryCandidates
+}
+
+// fsStrategyUnsatisfiable reports whether, given the preemptor's and the
+// target's shares before any workload is removed, no candidate workload in
+// the target ClusterQueue can pass either FairSharing strategy. When it
+// returns true the per-candidate simulation in runFirstFsStrategy can be
+// skipped, because every candidate is guaranteed to fail.
+//
+// A DominantResourceShare of +Inf means the node borrows while having a fair
+// weight of 0, which the API defines as an infinite share. It cannot arise any
+// other way, since a non-zero weight is validated to be greater than 10^-9.
+// CompareDRS ranks such a node above every node that is not itself borrowing
+// on a zero weight, so it returns 1. Both strategies require the comparison to
+// be <= 0 or < 0, so both fail:
+//
+//   - LessThanInitialShare compares against targetOldShare directly, which
+//     this function already has.
+//   - LessThanOrEqualToFinalShare compares against the target's share after
+//     the candidate's usage is removed. Removing usage never changes the
+//     target node's fair weight, and the lendable capacity the usage is
+//     compared against is derived from quota alone, so the target's share
+//     after removal is at most its share before removal. A target whose share
+//     is not +Inf before removal is therefore not +Inf after removal either,
+//     and CompareDRS returns 1 for it as well.
+func fsStrategyUnsatisfiable(preemptorNewShare fairsharing.PreemptorNewShare, targetOldShare fairsharing.TargetOldShare) bool {
+	return math.IsInf(schdcache.DRS(preemptorNewShare).PreciseWeightedShare(), 1) &&
+		!math.IsInf(schdcache.DRS(targetOldShare).PreciseWeightedShare(), 1)
 }
 
 // runSecondFsStrategy implements Fair Sharing Rule S2-b. It returns

--- a/pkg/scheduler/preemption/preemption_fair_test.go
+++ b/pkg/scheduler/preemption/preemption_fair_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package preemption
 
 import (
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clocktesting "k8s.io/utils/clock/testing"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	config "sigs.k8s.io/kueue/apis/config/v1beta2"
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
@@ -940,6 +943,170 @@ func TestFairPreemptions(t *testing.T) {
 			targetCQ:      "a",
 			wantPreempted: sets.New(targetKeyReason("/b_prem1", kueue.InCohortReclamationReason)),
 		},
+		// The preemptor has a fair weight of 0 and borrows, so its share is
+		// +Inf. The target borrows on a non-zero weight, so its share is
+		// finite. CompareDRS ranks the preemptor above the target no matter
+		// which of the target's workloads is removed, so neither strategy can
+		// pass and no target is returned.
+		"zero weight borrowing preemptor cannot preempt from a borrowing CQ with a non-zero weight": {
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("a").
+					Cohort("all").
+					FairWeight(resource.MustParse("0")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("all").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming:      unitWl.Clone().Name("a_incoming").Obj(),
+			targetCQ:      "a",
+			wantPreempted: sets.New[string](),
+		},
+		// Both the preemptor and the target have a fair weight of 0 and
+		// borrow, so both shares are +Inf. CompareDRS falls back to the
+		// unweighted ratios in that case, and a candidate can win, so the
+		// tournament must still run.
+		"zero weight borrowing preemptor can preempt from a borrowing CQ which also has zero weight": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "3").Obj()).Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("a").
+					Cohort("all").
+					FairWeight(resource.MustParse("0")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("all").
+					FairWeight(resource.MustParse("0")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming: utiltestingapi.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+			),
+		},
+		// Same shape as the case above, with non-zero fair weights on both
+		// sides. Neither share is +Inf, so the early exit must not trigger
+		// and the outcome is the same.
+		"non-zero weight borrowing preemptor preempts from a borrowing CQ": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("all").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "3").Obj()).Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("a").
+					Cohort("all").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("all").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "0").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b3").SimpleReserveQuota("b", "default", now).Obj(),
+			},
+			incoming: utiltestingapi.MakeWorkload("a_incoming", "").Request(corev1.ResourceCPU, "2").Obj(),
+			targetCQ: "a",
+			wantPreempted: sets.New(
+				targetKeyReason("/b1", kueue.InCohortFairSharingReason),
+			),
+		},
+		// Hierarchy:
+		//
+		//	ROOT ── A (weight 0, 1 CPU) ── p (weight 1, 2 CPU, preemptor)
+		//	     │                      └─ y (weight 1, 2 CPU)
+		//	     └─ x (weight 1, 1 CPU)
+		//
+		// The preemptor's almostLCA is p for target y, and A for target x.
+		// A borrows on a zero weight, so its share is +Inf and no candidate
+		// in x can pass the first strategy. The candidates from x must still
+		// be kept for the second strategy: the first strategy visits A's
+		// subtree first, and once y1 is preempted A stops borrowing, which
+		// brings A's share down to 0 and lets a candidate from x win.
+		"candidates skipped by the first strategy are still available to the second strategy": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("A").
+					Parent("ROOT").
+					FairWeight(resource.MustParse("0")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("p").
+					Cohort("A").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("y").
+					Cohort("A").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "2").Obj()).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("x").
+					Cohort("ROOT").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("p1", "").Request(corev1.ResourceCPU, "2").SimpleReserveQuota("p", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("y1", "").Request(corev1.ResourceCPU, "2").SimpleReserveQuota("y", "default", now).Obj(),
+				*utiltestingapi.MakeWorkload("y2", "").Request(corev1.ResourceCPU, "2").SimpleReserveQuota("y", "default", now).Obj(),
+				*unitWl.Clone().Name("x1").SimpleReserveQuota("x", "default", now).Obj(),
+				*unitWl.Clone().Name("x2").SimpleReserveQuota("x", "default", now).Obj(),
+			},
+			incoming: unitWl.Clone().Name("p_incoming").Obj(),
+			targetCQ: "p",
+			wantPreempted: sets.New(
+				targetKeyReason("/y1", kueue.InCohortFairSharingReason),
+				targetKeyReason("/x1", kueue.InCohortFairSharingReason),
+			),
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -1005,6 +1172,141 @@ func TestFairPreemptions(t *testing.T) {
 
 			if diff := cmp.Diff(beforeSnapshot, snapshotWorkingCopy, snapCmpOpts); diff != "" {
 				t.Errorf("Snapshot was modified (-initial,+end):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestFairPreemptionSkipsUnsatisfiableTournament checks that a target
+// ClusterQueue whose candidates provably cannot pass either strategy is
+// skipped without simulating each candidate, and that skipping it changes
+// neither the targets chosen nor the progress of the ordering.
+//
+// Both cases use the same topology, differing only in the preemptor's fair
+// weight. With a weight of 0 the borrowing preemptor's share is +Inf, so no
+// candidate can win and the tournament is skipped. With a weight of 1 the
+// share is finite and every candidate is simulated. The outcome is the same
+// either way.
+//
+// The exact skipped-queue count is also a spin check. The ordering only stops
+// yielding a ClusterQueue once its workloads are gone, so a skip which failed
+// to consume them would yield the same ClusterQueue forever.
+func TestFairPreemptionSkipsUnsatisfiableTournament(t *testing.T) {
+	now := time.Now()
+	unitWl := *utiltestingapi.MakeWorkload("unit", "").Request(corev1.ResourceCPU, "1")
+
+	cases := map[string]struct {
+		preemptorFairWeight     string
+		wantFirstStrategyEvals  int
+		wantSecondStrategyEvals int
+		wantSkippedQueues       int
+	}{
+		"zero weight preemptor: share is +Inf and the tournament is skipped": {
+			preemptorFairWeight:    "0",
+			wantFirstStrategyEvals: 0,
+			// The candidates are still handed to the second strategy, which
+			// evaluates the target ClusterQueue once.
+			wantSecondStrategyEvals: 1,
+			wantSkippedQueues:       1,
+		},
+		"non-zero weight preemptor: share is finite so the tournament runs": {
+			preemptorFairWeight: "1",
+			// The first strategy collapses both candidate workloads of
+			// ClusterQueue "b" into one log entry, so this is 1, not 2.
+			wantFirstStrategyEvals:  1,
+			wantSecondStrategyEvals: 1,
+			wantSkippedQueues:       0,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Count the FairSharing V(4) log entries. The first strategy logs
+			// one collapsed entry per candidate ClusterQueue, carrying a
+			// strategyEvaluations array (so its args include targetNewShare);
+			// the second strategy logs the same message without it, and a
+			// skipped tournament logs its own message. Counting them is how the
+			// test sees the work was skipped.
+			var firstStrategyEvals, secondStrategyEvals, skippedQueues int
+			log := funcr.New(func(_, args string) {
+				switch {
+				case strings.Contains(args, "Skipping FairSharing strategy evaluation"):
+					skippedQueues++
+				case strings.Contains(args, "Evaluating FairSharing strategy") && strings.Contains(args, "targetNewShare"):
+					firstStrategyEvals++
+				case strings.Contains(args, "Evaluating FairSharing strategy"):
+					secondStrategyEvals++
+				}
+			}, funcr.Options{Verbosity: 4})
+			ctx := ctrl.LoggerInto(t.Context(), log)
+
+			admitted := []kueue.Workload{
+				*unitWl.Clone().Name("a1").SimpleReserveQuota("a", "default", now).Obj(),
+				*unitWl.Clone().Name("b1").SimpleReserveQuota("b", "default", now).Obj(),
+				*unitWl.Clone().Name("b2").SimpleReserveQuota("b", "default", now).Obj(),
+			}
+			for i := range admitted {
+				admitted[i].UID = types.UID(admitted[i].Name)
+			}
+			cl := utiltesting.NewClientBuilder().
+				WithLists(&kueue.WorkloadList{Items: admitted}).
+				Build()
+			cqCache := schdcache.New(cl)
+			cqCache.AddOrUpdateResourceFlavor(log, utiltestingapi.MakeResourceFlavor("default").Obj())
+			clusterQueues := []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("a").
+					Cohort("all").
+					FairWeight(resource.MustParse(tc.preemptorFairWeight)).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).
+					Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("all").
+					FairWeight(resource.MustParse("1")).
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+						Resource(corev1.ResourceCPU, "1").Obj()).
+					Obj(),
+			}
+			for _, cq := range clusterQueues {
+				if err := cqCache.AddClusterQueue(ctx, cq); err != nil {
+					t.Fatalf("Couldn't add ClusterQueue to cache: %v", err)
+				}
+			}
+			snapshot, err := cqCache.Snapshot(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error while building snapshot: %v", err)
+			}
+
+			preemptor := New(cl, workload.Ordering{}, &utiltesting.EventRecorder{}, &config.FairSharing{},
+				false, clocktesting.NewFakeClock(now), nil, preemptexpectations.New(), nil)
+			wlInfo := workload.NewInfo(unitWl.Clone().Name("a_incoming").Obj())
+			wlInfo.ClusterQueue = "a"
+			targets := preemptor.GetTargets(ctx, *wlInfo, singlePodSetAssignment(
+				flavorassigner.ResourceAssignment{
+					corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+						Name: "default", Mode: flavorassigner.Preempt,
+					},
+				},
+			), snapshot)
+
+			// The preemptor's share is at or above the target's either way, so
+			// no candidate wins and nothing is preempted.
+			if len(targets) != 0 {
+				t.Errorf("Issued preemptions: got %d targets, want 0", len(targets))
+			}
+			if firstStrategyEvals != tc.wantFirstStrategyEvals {
+				t.Errorf("First strategy candidate simulations: got %d, want %d",
+					firstStrategyEvals, tc.wantFirstStrategyEvals)
+			}
+			if secondStrategyEvals != tc.wantSecondStrategyEvals {
+				t.Errorf("Second strategy evaluations: got %d, want %d",
+					secondStrategyEvals, tc.wantSecondStrategyEvals)
+			}
+			if skippedQueues != tc.wantSkippedQueues {
+				t.Errorf("Skipped target ClusterQueues: got %d, want %d",
+					skippedQueues, tc.wantSkippedQueues)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #14487

## What this does

When a FairSharing preemptor's DominantResourceShare is `+Inf` (it borrows while its cohort's fair weight is 0), `CompareDRS` ranks it above every finite-share target, so both default strategies reject every candidate. `runFirstFsStrategy` still evaluates the full per-candidate tournament (each walking to the cohort root) and `runSecondFsStrategy` iterates them again, all provably failing. On a saturated cluster this is `O(candidate workloads)` of wasted work per such preemption attempt, every cycle, and the dominant source of the `Evaluating FairSharing strategy` log at V(4).

`fsStrategyUnsatisfiable` detects the case (preemptor `+Inf`, target not) and skips the per-candidate loop, draining the candidates into `retryCandidates` so rule S2-b still runs on a snapshot the loop may have changed (it does not `DropQueue`). The zero-vs-zero case (target also `+Inf`) is deliberately not skipped: `CompareDRS` falls back to the raw ratio there and preemption can still pass.

Companion to #14348 (which collapses the per-candidate log); here the tournament is removed outright for the unsatisfiable case.

## Tests

`TestFairPreemptions` and `TestFairPreemptionSkipsUnsatisfiableTournament` (map-based, table-driven): the skip fires for +Inf-vs-finite (no preemption), does not fire for zero-vs-zero (preemption still possible), does not fire for a finite preemptor, and skipped candidates still reach the second strategy.

`gofmt`, `go vet`, `golangci-lint`, and `go test ./pkg/scheduler/preemption/...` pass.

## Disclosure

This change, including its description, was written with AI assistance and reviewed before submission.

```release-note
FairSharing: skip the FairSharing preemption tournament when the preemptor's dominant resource share is +Inf, since no candidate can be preempted, avoiding wasted per-candidate evaluation and its V(4) log volume.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fair-preemption handling for workloads with zero or infinite sharing weights.
  * Correctly skips unsatisfiable preemption scenarios, preventing unnecessary preemption attempts.
  * Preserves eligible candidates across applicable preemption strategies for more consistent scheduling behavior.

* **Tests**
  * Expanded coverage for zero-weight borrowing and unsatisfiable fair-preemption scenarios.
  * Added validation that skipped scenarios do not produce unintended preemptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->