### PR TITLE
test: synchronize workload admission before execution time check

### DIFF
--- a/test/integration/singlecluster/controller/core/workload_controller_test.go
+++ b/test/integration/singlecluster/controller/core/workload_controller_test.go
@@ -1651,6 +1651,7 @@ var _ = ginkgo.Describe("Workload controller with resource retention", func() {
 					g.Expect(k8sClient.Get(ctx, wlKey, wl)).To(gomega.Succeed())
 					g.Expect(workload.IsAdmitted(wl)).To(gomega.BeTrue())
 				}, util.Timeout, util.Interval).Should(gomega.Succeed())
+				util.ExpectAdmittedActiveWorkloadsGaugeMetric(kueue.ClusterQueueReference(clusterQueue.Name), 1)
 			})
 
 			ginkgo.By("waiting for at least 1s of execution time so AccumulatedPastExecutionTimeSeconds > 0 after eviction", func() {


### PR DESCRIPTION
/kind flake
/area testing

#### What this PR does / why we need it:

Synchronize the evict/readmit execution-time integration test with scheduler cache
processing by waiting for the admitted-active Workload gauge before eviction.

#### Which issue(s) this PR fixes:

Related to #14473

#### Special notes for your reviewer:

AI usage: Used AI assistance for code exploration and drafting. I reviewed the
change and ran the targeted validation.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```