### PR TITLE
fix: PodsReady for SparkApplication framework when dynamic allocation is enabled.

### DIFF
--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller.go
@@ -317,6 +317,13 @@ func (j *SparkApplication) PodsReady(ctx context.Context, _ client.Client) bool 
 	// executors are stuck (e.g. unschedulable), which would let the
 	// waitForPodsReady timeout never fire on heterogeneous resource shortages.
 	expected := int(ptr.Deref(j.Spec.Executor.Instances, 0))
+	// When dynamic allocation is enabled, the actual number of executors can
+	// fluctuate between minExecutors and maxExecutors. Use minExecutors as the
+	// expected count since it's the guaranteed minimum. If neither the CRD
+	// field nor sparkConf is set, use Spec.Executor.Instances as default.
+	if j.Spec.DynamicAllocation != nil && j.Spec.DynamicAllocation.Enabled {
+		expected = int(ptr.Deref(j.Spec.DynamicAllocation.MinExecutors, int32(expected)))
+	}
 	if expected == 0 {
 		return true
 	}

--- a/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
+++ b/pkg/controller/jobs/sparkapplication/sparkapplication_controller_test.go
@@ -684,6 +684,14 @@ func TestReconciler(t *testing.T) {
 	// SparkApp variants used by the PodsReady cases.
 	sparkAppDriverRunningOnly := withDriverRunningOnly(withUID(testSparkApp.DeepCopy()), 2)
 	sparkAppAllExecutorsReady := withExecutorsRunning(withUID(testSparkApp.DeepCopy()), 2)
+	// Dynamic allocation variant: Instances=10, MinExecutors=5, 5 executors Running.
+	// PodsReady should use MinExecutors (5) as the expected count, not Instances (10).
+	sparkAppDynamicAllocation := withExecutorsRunning(withUID(testSparkApp.DeepCopy()), 5)
+	sparkAppDynamicAllocation.Spec.Executor.Instances = new(int32(10))
+	sparkAppDynamicAllocation.Spec.DynamicAllocation = &sparkappv1beta2.DynamicAllocation{
+		Enabled:      true,
+		MinExecutors: new(int32(5)),
+	}
 
 	cases := map[string]struct {
 		reconcilerOptions []jobframework.Option
@@ -739,6 +747,27 @@ func TestReconciler(t *testing.T) {
 			},
 			wantWorkloads: []kueue.Workload{
 				*makeAdmittedWorkload(sparkAppAllExecutorsReady).
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadPodsReady,
+						Status:  metav1.ConditionTrue,
+						Reason:  kueue.WorkloadStarted,
+						Message: "All pods reached readiness and the workload is running",
+					}).
+					Obj(),
+			},
+		},
+		"PodsReady becomes True/Started with dynamic allocation when MinExecutors executors are ready": {
+			reconcilerOptions: []jobframework.Option{
+				jobframework.WithManageJobsWithoutQueueName(true),
+				jobframework.WithManagedJobsNamespaceSelector(labels.Everything()),
+				jobframework.WithWaitForPodsReady(baseWaitForPodsReadyConf),
+			},
+			sparkApp: sparkAppDynamicAllocation,
+			workloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppDynamicAllocation).Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*makeAdmittedWorkload(sparkAppDynamicAllocation).
 					Condition(metav1.Condition{
 						Type:    kueue.WorkloadPodsReady,
 						Status:  metav1.ConditionTrue,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

When dynamic allocation is enabled, PodsReady() uses Spec.Executor.Instances as the expected executor count. However, with dynamic allocation, the actual number of executors can fluctuate between minExecutors and maxExecutors. When the Spark driver scales down, the spark-operator marks missing executor pods as ExecutorStateUnknown (not counted by PodsReady), causing the ready count to drop below Instances. This means PodsReady never returns true, and the workload is repeatedly requeued by waitForPodsReady.timeout.
This fix uses DynamicAllocation.MinExecutors as the expected count when dynamic allocation is enabled, since it's the guaranteed minimum.

#### Which issue(s) this PR fixes:

Fixes #11675

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
SparkApplication: Fixed a bug where workloads using dynamic allocation could remain unready after executor scale-down. Workloads are now considered ready when the configured minimum number of executors is running.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Spark application readiness detection when dynamic allocation is enabled.
  * Applications can now be marked ready once their configured minimum executor count is running, even if a higher executor count is specified.
  * Static allocation behavior remains unchanged.

* **Tests**
  * Added coverage for dynamic-allocation readiness scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->