### PR TITLE
Keep bounded workload usage below the Unlimited sentinel

### DIFF
--- a/pkg/resources/amount.go
+++ b/pkg/resources/amount.go
@@ -109,13 +109,22 @@ func (a Amount) AsApproximateFloat64(name corev1.ResourceName) float64 {
 	return float64(a.value)
 }
 
-// Add returns a + b, propagating Unlimited and saturating bounded overflow at
-// math.MaxInt64.
+// boundedAmount keeps a saturated result one below the math.MaxInt64 Unlimited
+// sentinel, so a bounded total is never mistaken for "no limit".
+func boundedAmount(v int64) Amount {
+	if v == math.MaxInt64 {
+		v = math.MaxInt64 - 1
+	}
+	return Amount{value: v}
+}
+
+// Add returns a + b, propagating Unlimited and saturating bounded overflow just
+// below the math.MaxInt64 Unlimited sentinel.
 func (a Amount) Add(b Amount) Amount {
 	if a.isUnlimited() || b.isUnlimited() {
 		return Unlimited
 	}
-	return Amount{value: utilmath.SaturatingAdd(a.value, b.value)}
+	return boundedAmount(utilmath.SaturatingAdd(a.value, b.value))
 }
 
 // AddInt64 returns a + v.
@@ -123,7 +132,7 @@ func (a Amount) AddInt64(v int64) Amount {
 	if a.isUnlimited() {
 		return a
 	}
-	return Amount{value: utilmath.SaturatingAdd(a.value, v)}
+	return boundedAmount(utilmath.SaturatingAdd(a.value, v))
 }
 
 // Sub returns a - b. If a is Unlimited and b is bounded, the result stays

--- a/pkg/resources/amount_test.go
+++ b/pkg/resources/amount_test.go
@@ -157,11 +157,14 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		"Add saturates on bounded overflow becomes Unlimited": {
+		"Add saturates on bounded overflow stays below the sentinel": {
 			run: func(t *testing.T) {
 				got := NewAmount(math.MaxInt64 - 5).Add(NewAmount(100))
-				if !got.isUnlimited() {
-					t.Errorf("bounded saturated overflow should become Unlimited (MaxInt64 sentinel), got %v", got)
+				if got.isUnlimited() {
+					t.Errorf("bounded saturated overflow must stay below the Unlimited sentinel, got Unlimited")
+				}
+				if got.Int64() != math.MaxInt64-1 {
+					t.Errorf("bounded saturated overflow = %d, want MaxInt64-1", got.Int64())
 				}
 			},
 		},
@@ -214,11 +217,27 @@ func TestAmountArithmetic(t *testing.T) {
 				}
 			},
 		},
-		"AddInt64 saturates": {
+		"AddInt64 saturates below the sentinel": {
 			run: func(t *testing.T) {
 				got := NewAmount(math.MaxInt64 - 1).AddInt64(100)
-				if got.Int64() != math.MaxInt64 {
-					t.Errorf("got %d, want MaxInt64", got.Int64())
+				if got.isUnlimited() {
+					t.Errorf("AddInt64 bounded overflow must not become the Unlimited sentinel")
+				}
+				if got.Int64() != math.MaxInt64-1 {
+					t.Errorf("got %d, want MaxInt64-1", got.Int64())
+				}
+			},
+		},
+		"AddInt64 of a MaxInt64 request stays countable usage (#14105)": {
+			run: func(t *testing.T) {
+				// A PodSet request can reach MaxInt64 via a saturating Mul by the count;
+				// counted as usage it must stay bounded, or the CQ stops counting others.
+				got := NewAmount(0).AddInt64(math.MaxInt64)
+				if got.isUnlimited() {
+					t.Errorf("a MaxInt64 request must be counted as bounded usage, not Unlimited")
+				}
+				if got.Int64() != math.MaxInt64-1 {
+					t.Errorf("got %d, want MaxInt64-1", got.Int64())
 				}
 			},
 		},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`resources.Amount` reserves `math.MaxInt64` as the sentinel for "unlimited", and the type's own comment states the invariant it rests on:

```go
// math.MaxInt64 is the sentinel for "unlimited"; bounded amounts must never
// equal math.MaxInt64 (AmountFromQuantity enforces this at the quota boundary).
```

`AmountFromQuantity` holds up the quota side — a bounded quota is kept strictly below the sentinel. The workload-usage side is the other way in, and it did not. `Info.ResourceUsage` turns a PodSet's `int64` request into the `Amount` the quota tree counts through `AddInt64`, and both `Add` and `AddInt64` end in `SaturatingAdd`, which returns exactly `math.MaxInt64` on overflow. A usage total that saturates therefore lands on the sentinel and is indistinguishable from unlimited — and reaching it does not take an unrepresentable number: `totalRequestsFromPodSets` multiplies a per-pod request by the PodSet count with a saturating `Mul`, so a handful of pods asking for `2^62` of a countable resource is a product past `int64` that saturates exactly onto the sentinel.

From there the ClusterQueue reads that flavor's usage as unlimited. `Add` short-circuits on an unlimited receiver, so another workload's usage is never counted, while removing that same workload still subtracts — leaving the recorded usage negative.

This keeps bounded `Amount` arithmetic one step below the sentinel. `Add` and `AddInt64` funnel their saturated result through a small `boundedAmount` helper that maps `math.MaxInt64` to `math.MaxInt64 - 1`, so `AddInt64` cannot produce the sentinel and the invariant in the comment holds on both boundaries rather than one. `Unlimited` still propagates through the existing `isUnlimited` short-circuits — only genuinely-unlimited quota, constructed on the quota side, is the sentinel.

This is the clamp-and-continue shape the accounting path already uses everywhere else (`SaturatingAdd` / `SaturatingSub` / `SafeValue`, and `AmountFromQuantity` clamping to `Unlimited`), rather than rejecting a large-but-valid request: a huge request against a finite quota still does not fit, exactly as before.

Two cases in `TestAmountArithmetic` asserted the old behavior — bounded overflow becoming the sentinel — and now assert it stays below it, plus a new case pins the `MaxInt64`-request entry point. Each fails if the clamp is reverted. The regression is kept at the `Amount` layer, matching the sibling overflow fixes (#11156, #11182, #12945, #13585); the "other workloads stop being counted" consequence follows directly from a usage `Amount` never being `isUnlimited`.

#### Which issue(s) this PR fixes:

Fixes #14105

#### Special notes for your reviewer:

The two renamed test cases (`Add saturates on bounded overflow …`, `AddInt64 saturates`) previously locked in the sentinel-collision behavior this fixes, so their assertion change is the point, not incidental churn.

This PR was written in part with the assistance of generative AI. I have reviewed and verified every claim and every line myself.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where a Workload whose resource usage saturated onto the internal "unlimited" sentinel — for example a countable resource multiplied by a large PodSet count — was counted as unlimited usage. This stopped the ClusterQueue from counting other Workloads on that resource and could leave its recorded usage negative. Such usage is now kept as a bounded amount.
```
