### PR TITLE
Keep a saturated request saturated when it is scaled down

### DIFF
--- a/pkg/resources/requests.go
+++ b/pkg/resources/requests.go
@@ -80,7 +80,7 @@ func (r MapRequests) Divide(f int64) {
 			// resources computed initially for all (0) Pods, and thus r[k] = 0.
 			continue
 		}
-		r[k] /= f
+		r[k] = utilmath.SaturatingDiv(r[k], f)
 	}
 }
 

--- a/pkg/resources/slice_requests.go
+++ b/pkg/resources/slice_requests.go
@@ -197,7 +197,7 @@ func (sr *SliceRequests) Divide(f int64) {
 		if (*sr)[i].value == 0 && f == 0 {
 			continue
 		}
-		(*sr)[i].value /= f
+		(*sr)[i].value = utilmath.SaturatingDiv((*sr)[i].value, f)
 	}
 }
 

--- a/pkg/util/math/math.go
+++ b/pkg/util/math/math.go
@@ -105,3 +105,12 @@ func SaturatingMul(a, b int64) int64 {
 	}
 	return res
 }
+
+// SaturatingDiv divides a by f but leaves the math.MaxInt64 / math.MinInt64
+// sentinels unchanged, so a saturated total stays saturated when scaled down.
+func SaturatingDiv(a, f int64) int64 {
+	if a == stdmath.MaxInt64 || a == stdmath.MinInt64 {
+		return a
+	}
+	return a / f
+}

--- a/pkg/util/math/math_test.go
+++ b/pkg/util/math/math_test.go
@@ -101,3 +101,26 @@ func TestSaturatingSub(t *testing.T) {
 		})
 	}
 }
+
+func TestSaturatingDiv(t *testing.T) {
+	cases := map[string]struct {
+		a    int64
+		f    int64
+		want int64
+	}{
+		"positive":                    {a: 6, f: 3, want: 2},
+		"negative":                    {a: -6, f: 3, want: -2},
+		"truncates":                   {a: 7, f: 3, want: 2},
+		"max int stays max":           {a: stdmath.MaxInt64, f: 3, want: stdmath.MaxInt64},
+		"min int stays min":           {a: stdmath.MinInt64, f: 3, want: stdmath.MinInt64},
+		"max int divided by one":      {a: stdmath.MaxInt64, f: 1, want: stdmath.MaxInt64},
+		"bounded near max is divided": {a: stdmath.MaxInt64 - 1, f: 2, want: (stdmath.MaxInt64 - 1) / 2},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := SaturatingDiv(tc.a, tc.f); got != tc.want {
+				t.Errorf("SaturatingDiv(%d, %d) = %d, want %d", tc.a, tc.f, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -3717,3 +3717,23 @@ func TestTotalExecutionTime(t *testing.T) {
 		})
 	}
 }
+
+func TestScaledToKeepsASaturatedRequestSaturated(t *testing.T) {
+	// 3 Pods x MaxInt64/2 overflows, so the aggregate saturates to the sentinel.
+	// Scaling it down must keep it saturated, not divide it into a finite undercharge (#14371).
+	half := resource.NewQuantity(math.MaxInt64/2, resource.DecimalSI)
+	wl := utiltestingapi.MakeWorkload("w", "ns").
+		PodSets(*utiltestingapi.MakePodSet("main", 3).
+			Request("example.com/gpu", half.String()).Obj()).
+		Obj()
+
+	total := NewInfo(wl).TotalRequests[0]
+	if agg := total.Requests.ResourceValue("example.com/gpu"); agg != math.MaxInt64 {
+		t.Fatalf("precondition: aggregate over 3 Pods should saturate to MaxInt64, got %d", agg)
+	}
+
+	got := total.ScaledTo(1).Requests.ResourceValue("example.com/gpu")
+	if got != math.MaxInt64 {
+		t.Errorf("ScaledTo(1) = %d, want MaxInt64 (a saturated request must stay saturated when scaled down)", got)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`resources.Amount` treats `math.MaxInt64` as the `Unlimited` sentinel, and the arithmetic around it is written to respect that: `Add`, `AddInt64`, `Sub`, `SubInt64` and `Cmp` all check `isUnlimited()` first, and `Requests.Mul` saturates through `SaturatingMul` so an overflowing product becomes the sentinel rather than wrapping.

`Divide` was the one operation that did not know about it. Both backends divided the raw value:

```go
// pkg/resources/requests.go
func (r MapRequests) Divide(f int64) {
	for k := range r {
		...
		r[k] /= f
	}
}
```

So once a total saturated to the sentinel, dividing it produced an ordinary finite number that no longer represented anything. `PodSetResources.ScaledTo` divides by the old count and multiplies by the new one, which turned "this workload wants more than can be represented" into "this workload wants a third of `MaxInt64`", and that smaller number was recorded as usage. Three non-test paths divide, all on the admitted-usage side: `ScaledTo` (reached from `Assignment.TotalRequestsFor` and the partial-admission branch of the flavor assigner), `SinglePodRequests` (through `ScaledDown`, feeding the TAS topology domain requests), and the reclaimable-Pod scale-down.

This adds `SaturatingDiv` to the existing `Saturating{Add,Sub,Mul}` family — it divides normally but leaves the `math.MaxInt64` / `math.MinInt64` saturation sentinels unchanged — and routes both `Divide` backends through it. A request that could not be represented before scaling no longer becomes representable because it was scaled down; dividing the sentinel stays the sentinel, the same way subtracting from it already does.

Measured with the reproduction from the issue: three Pods asking `MaxInt64/2` each aggregate to the sentinel, and `ScaledTo(1)` now returns the sentinel instead of `MaxInt64/3`. `TestScaledToKeepsASaturatedRequestSaturated` pins that end-to-end and fails without the change (it records `3074457345618258602`); `TestSaturatingDiv` covers the helper.

#### Which issue(s) this PR fixes:

Fixes #14371

#### Special notes for your reviewer:

The `(0, 0)` divide-by-zero skip in both `Divide` loops is kept — `SaturatingDiv` only short-circuits the sentinels, so the all-zero-Pods scale-down path is unchanged.

This PR was written in part with the assistance of generative AI. I have reviewed and verified every claim and every line myself.

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug where scaling down a Workload's resource request that had saturated to the internal "unlimited" sentinel (for example a countable resource that overflowed when multiplied by the PodSet count) turned it back into a smaller, finite value, undercharging the ClusterQueue at partial admission and for topology-aware scheduling. Such a request now stays saturated when scaled.
```

---

**Note on the sentinel premise.** #15026 removes `math.MaxInt64` as the `Unlimited` sentinel in `resources.Amount`. The fix here is in the `Requests` domain, which keeps its int64 saturation, so `SaturatingDiv` and the behaviour it restores are unaffected. The paragraphs above that explain the problem through `Amount` need rewording once #15026 merges.
