### PR TITLE
MultiKueue: drop the stale remote when a workload finishes OutOfSync

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/kueue/pkg/util/api"
 	utilmaps "sigs.k8s.io/kueue/pkg/util/maps"
 	"sigs.k8s.io/kueue/pkg/util/roletracker"
+	stringsutils "sigs.k8s.io/kueue/pkg/util/strings"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 	workloadfinish "sigs.k8s.io/kueue/pkg/workload/finish"
@@ -394,26 +395,24 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		return reconcile.Result{}, errors.Join(errs...)
 	}
 
-	// 3. Finish the local workload when the remote workload is finished.
-	if remoteFinishedCond, remote := group.bestMatchByCondition(kueue.WorkloadFinished); remoteFinishedCond != nil {
-		// A remote OutOfSync finish is a sync failure, not a job completion: reset to Retry to
-		// re-dispatch rather than finishing (which would strand the manager Job). Always return so
-		// it never falls through to Finish; patch only while still Ready so a re-reconcile can't
-		// see Retry and wrongly finish. Elastic workloads use OutOfSync for slice replacement.
-		if remoteFinishedCond.Reason == kueue.WorkloadFinishedReasonOutOfSync && !group.IsElasticWorkload() {
-			if acs == nil || acs.State != kueue.CheckStateReady {
-				log.V(3).Info("Skipping remote OutOfSync reset, admission check is not Ready", "workerCluster", remote)
-				return reconcile.Result{}, nil
-			}
-			msg := fmt.Sprintf("Remote workload on worker cluster %q is out of sync with its user job, resetting for re-dispatch", remote)
-			if err := w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, msg); err != nil {
-				log.Error(err, "Resetting admission check after remote OutOfSync", "workerCluster", remote)
-				return reconcile.Result{}, err
-			}
-			w.recorder.Eventf(group.local, nil, corev1.EventTypeWarning, "MultiKueue", "MultiKueue", api.TruncateEventMessage(acs.Message))
+	// 3. Discard remote workloads that finished as OutOfSync. Such a finish is a sync failure,
+	// not a job completion, so the workload is reset for re-dispatch instead of being finished
+	// below (which would strand the manager Job). Elastic workloads use OutOfSync for slice
+	// replacement, so they are left to the Finished handling.
+	if !group.IsElasticWorkload() {
+		reset, err := w.resetOutOfSyncRemotes(ctx, group, acs)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		if reset {
+			// The check just moved to Retry; let the eviction it triggers run before
+			// touching the group any further.
 			return reconcile.Result{}, nil
 		}
+	}
 
+	// 4. Finish the local workload when the remote workload is finished.
+	if remoteFinishedCond, remote := group.bestMatchByCondition(kueue.WorkloadFinished); remoteFinishedCond != nil {
 		// NOTE: we can have a race condition setting the wl status here, and it being updated by the job controller,
 		// it should not be problematic, but the "From remote xxxx:" could be lost ....
 
@@ -439,7 +438,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		return reconcile.Result{}, workloadfinish.Finish(ctx, w.client, group.local, remoteFinishedCond.Reason, remoteFinishedCond.Message, w.clock)
 	}
 
-	// 4. Handle workload eviction
+	// 5. Handle workload eviction
 	remoteEvictCond, evictedRemote := group.bestMatchByCondition(kueue.WorkloadEvicted)
 	if remoteEvictCond != nil {
 		remoteCl := group.remoteClients[evictedRemote].getClient()
@@ -488,7 +487,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 	}
 
-	// 5. Delete workloads that are out of sync or are not in the chosen worker,
+	// 6. Delete workloads that are out of sync or are not in the chosen worker,
 	// except for two cases (in which we'll update the remote workload accorddingly):
 	// - elastic workloads which have been scaled down
 	// - workloads for which workload priority has changed
@@ -536,11 +535,11 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		}
 	}
 
-	// 6. Get the admitting remote.
+	// 7. Get the admitting remote.
 	conditionToCheck := kueue.WorkloadAdmitted
 	remoteCond, admittingRemote := group.bestMatchByCondition(conditionToCheck)
 
-	// 6a. No admitted remote is visible while the admission check is still Ready. The
+	// 7a. No admitted remote is visible while the admission check is still Ready. The
 	// reachability of the admitting worker decides the response:
 	//   - A known admitting worker that is unreachable (e.g. its watch is reconnecting): the
 	//     remote is likely still running, so keep the workload admitted and retry only once the
@@ -569,7 +568,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		return reconcile.Result{}, w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, "Admitting remote no longer exists")
 	}
 
-	// 6b. An admitting remote is visible: converge onto it.
+	// 7b. An admitting remote is visible: converge onto it.
 	if remoteCond != nil {
 		// remove the non-selected worker workloads
 		for rem, remWl := range group.remotes {
@@ -635,7 +634,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
-	// 7. Open the preemption gate if applicable
+	// 8. Open the preemption gate if applicable
 	var requeueAfterSynchronize time.Duration
 	if features.Enabled(features.MultiKueueOrchestratedPreemption) {
 		remWlName, requeueIn := w.workloadToOpenPreemptionGate(ctx, group)
@@ -651,7 +650,7 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		requeueAfterSynchronize = requeueIn
 	}
 
-	// 8. Skip nomination while eviction is still in progress or the
+	// 9. Skip nomination while eviction is still in progress or the
 	// admission check is not yet Pending.
 	if workload.ShouldSkipClusterNomination(acs, group.local, group.IsElasticWorkload()) {
 		log.V(3).Info("Skipping cluster nomination phase")
@@ -663,6 +662,68 @@ func (w *wlReconciler) reconcileGroup(ctx context.Context, group *wlGroup) (reco
 		res.RequeueAfter = requeueAfterSynchronize
 	}
 	return res, err
+}
+
+// isFinishedOutOfSync reports whether a remote workload finished because it no longer
+// matches the user job it was created for.
+func isFinishedOutOfSync(remWl *kueue.Workload) bool {
+	cond := apimeta.FindStatusCondition(remWl.Status.Conditions, kueue.WorkloadFinished)
+	return cond != nil && cond.Status == metav1.ConditionTrue && cond.Reason == kueue.WorkloadFinishedReasonOutOfSync
+}
+
+// resetOutOfSyncRemotes deletes every remote workload that finished as OutOfSync and, while
+// the admission check is still Ready, resets it to Retry so the workload gets dispatched
+// again. It reports whether the check was reset.
+//
+// Deleting the remotes even when the check is no longer Ready is what keeps the group from
+// deadlocking. An OutOfSync remote stays Finished forever, and the Retry set here makes the
+// core controller evict the workload, which puts the check back to Pending. So from the
+// second pass on the check is never Ready again, and a surviving OutOfSync remote would
+// match in every later reconcile and short-circuit reconcileGroup ahead of the nomination
+// step: the workload would keep its quota, the check would stay Pending, and the manager job
+// would never be dispatched anywhere nor finish. Dropping the remotes here makes the branch
+// self-clearing; the nomination step re-creates them.
+func (w *wlReconciler) resetOutOfSyncRemotes(ctx context.Context, group *wlGroup, acs *kueue.AdmissionCheckState) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var outOfSyncRemotes []string
+	for remote, remWl := range group.remotes {
+		if remWl != nil && isFinishedOutOfSync(remWl) {
+			outOfSyncRemotes = append(outOfSyncRemotes, remote)
+		}
+	}
+	if len(outOfSyncRemotes) == 0 {
+		return false, nil
+	}
+	// Sorted so the message and the deletion order don't depend on map iteration order.
+	slices.Sort(outOfSyncRemotes)
+
+	for _, remote := range outOfSyncRemotes {
+		if err := client.IgnoreNotFound(group.RemoveRemoteObjects(ctx, remote)); err != nil {
+			log.V(2).Error(err, "Deleting out of sync remote objects", "workerCluster", remote)
+			return false, err
+		}
+		group.remotes[remote] = nil
+	}
+
+	if acs == nil || acs.State != kueue.CheckStateReady {
+		// An earlier pass already reset the check for re-dispatch. The stale remotes are gone
+		// now, so the caller can keep reconciling and dispatch the workload again.
+		log.V(3).Info("Skipping remote OutOfSync reset, admission check is not Ready", "workerClusters", outOfSyncRemotes)
+		return false, nil
+	}
+
+	quoted := make([]string, len(outOfSyncRemotes))
+	for i, remote := range outOfSyncRemotes {
+		quoted[i] = fmt.Sprintf("%q", remote)
+	}
+	msg := fmt.Sprintf("Remote workload on worker cluster %s is out of sync with its user job, resetting for re-dispatch", stringsutils.Join(quoted, ", "))
+	if err := w.updateACS(ctx, group.local, acs, kueue.CheckStateRetry, msg); err != nil {
+		log.Error(err, "Resetting admission check after remote OutOfSync", "workerClusters", outOfSyncRemotes)
+		return false, err
+	}
+	w.recorder.Eventf(group.local, nil, corev1.EventTypeWarning, "MultiKueue", "MultiKueue", api.TruncateEventMessage(acs.Message))
+	return true, nil
 }
 
 func isRemoteSpecOutOfSync(local, remote kueue.WorkloadSpec) bool {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -706,10 +706,16 @@ func (w *wlReconciler) resetOutOfSyncRemotes(ctx context.Context, group *wlGroup
 		group.remotes[remote] = nil
 	}
 
-	if acs == nil || acs.State != kueue.CheckStateReady {
-		// An earlier pass already reset the check for re-dispatch. The stale remotes are gone
-		// now, so the caller can keep reconciling and dispatch the workload again.
-		log.V(3).Info("Skipping remote OutOfSync reset, admission check is not Ready", "workerClusters", outOfSyncRemotes)
+	// Only the admitting remote going OutOfSync means the workload has to be dispatched again.
+	// A stale OutOfSync remote on some other worker must not reset a Ready check: the admitting
+	// remote may still be running, or may have genuinely finished, and the Finished handling in
+	// reconcileGroup has to be allowed to observe that.
+	admitting := ptr.Deref(group.local.Status.ClusterName, "")
+	if acs == nil || acs.State != kueue.CheckStateReady || !slices.Contains(outOfSyncRemotes, admitting) {
+		// An earlier pass already reset the check for re-dispatch, or the OutOfSync remote is
+		// not the admitting one. The stale remotes are gone either way, so the caller can keep
+		// reconciling.
+		log.V(3).Info("Skipping remote OutOfSync reset", "workerClusters", outOfSyncRemotes, "admittingCluster", admitting)
 		return false, nil
 	}
 

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -1178,6 +1178,99 @@ func TestWlReconcile(t *testing.T) {
 					Obj(),
 			},
 		},
+		"remote wl finished OutOfSync on a non-admitting worker: the genuine finish on the admitting worker still wins": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload was admitted on "worker1"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.DeepCopy(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
+					Obj(),
+			},
+			// worker1 is the admitting remote and it finished genuinely, before worker2 did.
+			worker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						Reason:             "ByTest",
+						Message:            "by test",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Obj(),
+			},
+			// worker2 holds a leftover OutOfSync remote that must not trigger a re-dispatch of
+			// a job that already completed on worker1.
+			useSecondWorker: true,
+			worker2Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						Reason:             kueue.WorkloadFinishedReasonOutOfSync,
+						Message:            "The prebuilt workload is out of sync with its user job",
+						LastTransitionTime: metav1.NewTime(now.Add(time.Minute)),
+					}).
+					Obj(),
+			},
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStateReady,
+						Message: `The workload was admitted on "worker1"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Condition(metav1.Condition{Type: kueue.WorkloadFinished, Status: metav1.ConditionTrue, Reason: "ByTest", Message: `by test`}).
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().
+					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
+					Obj(),
+			},
+			// The admitting remote is left alone; only the stale worker2 remote is dropped.
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadFinished,
+						Status:             metav1.ConditionTrue,
+						Reason:             "ByTest",
+						Message:            "by test",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Obj(),
+			},
+			wantWorker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Condition(batchv1.JobCondition{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}).
+					Obj(),
+			},
+			wantWorker2Workloads: nil,
+		},
 		"the local Job is marked finished, the remote objects are removed": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -910,24 +910,10 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().Active(1).Obj(),
 			},
-			wantWorker1Workloads: []kueue.Workload{
-				*baseWorkloadBuilder.Clone().
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
-					Condition(metav1.Condition{
-						Type:    kueue.WorkloadFinished,
-						Status:  metav1.ConditionTrue,
-						Reason:  kueue.WorkloadFinishedReasonOutOfSync,
-						Message: "The prebuilt workload is out of sync with its user job",
-					}).
-					Obj(),
-			},
-			wantWorker1Jobs: []batchv1.Job{
-				*baseJobBuilder.Clone().
-					PrebuiltWorkloadLabel("wl1").
-					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
-					Obj(),
-			},
+			// The stale remote is dropped together with the reset: it can never be admitted
+			// again, so it must not survive into the re-dispatch that the Retry triggers.
+			wantWorker1Workloads: nil,
+			wantWorker1Jobs:      nil,
 			wantEvents: []utiltesting.EventRecord{
 				{
 					Key:       client.ObjectKeyFromObject(baseWorkloadBuilder.DeepCopy()),
@@ -937,7 +923,7 @@ func TestWlReconcile(t *testing.T) {
 				},
 			},
 		},
-		"remote wl finished OutOfSync but admission check already Retry: intercept without finishing (idempotent re-reconcile)": {
+		"remote wl finished OutOfSync but admission check already Retry: drop the stale remote without finishing (idempotent re-reconcile)": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			reconcileFor: "wl1",
 			managersWorkloads: []kueue.Workload{
@@ -990,7 +976,40 @@ func TestWlReconcile(t *testing.T) {
 			wantManagersJobs: []batchv1.Job{
 				*baseJobManagedByKueueBuilder.Clone().Active(1).Obj(),
 			},
-			wantWorker1Workloads: []kueue.Workload{
+			// The stale remote is dropped even though the check is no longer Ready: it can
+			// never be admitted again, and keeping it would match on every later reconcile
+			// and stop the workload from ever being dispatched again.
+			wantWorker1Workloads: nil,
+			wantWorker1Jobs:      nil,
+		},
+		"remote wl finished OutOfSync and the eviction already reset the check to Pending: drop the stale remote and dispatch again": {
+			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
+			reconcileFor: "wl1",
+			// State the workload lands in once the Retry above made the core controller evict
+			// it: the check is back to Pending and ClusterName was cleared, but the workload
+			// has already re-reserved quota, so the "no quota reservation" cleanup no longer
+			// removes the remote left behind on the worker.
+			managersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStatePending,
+						Message: `Reset to Pending after eviction. Previously: "Retry"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					Obj(),
+			},
+			managersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().Active(1).Obj(),
+			},
+			worker1Jobs: []batchv1.Job{
+				*baseJobBuilder.Clone().
+					PrebuiltWorkloadLabel("wl1").
+					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
+					Obj(),
+			},
+			worker1Workloads: []kueue.Workload{
 				*baseWorkloadBuilder.Clone().
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
@@ -1002,12 +1021,30 @@ func TestWlReconcile(t *testing.T) {
 					}).
 					Obj(),
 			},
-			wantWorker1Jobs: []batchv1.Job{
-				*baseJobBuilder.Clone().
-					PrebuiltWorkloadLabel("wl1").
+			// The workload is nominated and dispatched again instead of being stuck with the
+			// check Pending forever.
+			wantManagersWorkloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
+					AdmissionCheck(kueue.AdmissionCheckState{
+						Name:    "ac1",
+						State:   kueue.CheckStatePending,
+						Message: `Reset to Pending after eviction. Previously: "Retry"`,
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job1", "uid1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q1").Obj(), now).
+					NominatedClusterNames("worker1").
+					Obj(),
+			},
+			wantManagersJobs: []batchv1.Job{
+				*baseJobManagedByKueueBuilder.Clone().Active(1).Obj(),
+			},
+			// The stale remote workload and job are gone, replaced by a fresh remote workload.
+			wantWorker1Workloads: []kueue.Workload{
+				*baseWorkloadBuilder.Clone().
 					Label(kueue.MultiKueueOriginLabel, defaultOrigin).
 					Obj(),
 			},
+			wantWorker1Jobs: nil,
 		},
 		"remote wl is finished, but the remote controller object must be owned before SyncJob": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},

--- a/test/integration/multikueue/jobs_test.go
+++ b/test/integration/multikueue/jobs_test.go
@@ -26,6 +26,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,6 +221,23 @@ var _ = ginkgo.Describe("MultiKueue", ginkgo.Label("area:multikueue", "feature:m
 					g.Expect(finished.Reason).NotTo(gomega.Equal(kueue.WorkloadFinishedReasonOutOfSync))
 				}
 			}, util.ConsistentDuration, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("the stale remote workload is dropped so the Job can be dispatched again", func() {
+			// An OutOfSync remote stays Finished forever. If it survived, every later
+			// reconcile would match it again and stop before the dispatch phase, so the Job
+			// could never be re-dispatched once the reset moved the check off Ready.
+			gomega.Eventually(func(g gomega.Gomega) {
+				remoteWl := &kueue.Workload{}
+				err := worker1TestCluster.client.Get(worker1TestCluster.ctx, wlLookupKey, remoteWl)
+				if apierrors.IsNotFound(err) {
+					return
+				}
+				g.Expect(err).To(gomega.Succeed())
+				// A remote that is present again is a freshly dispatched one, never the
+				// OutOfSync leftover.
+				g.Expect(apimeta.FindStatusCondition(remoteWl.Status.Conditions, kueue.WorkloadFinished)).To(gomega.BeNil())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 	})
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area multikueue

#### What this PR does / why we need it:

A remote workload that finishes with reason `OutOfSync` did not complete the user's Job: it no longer matches the Job it was created for, so it stays `Finished` forever and can never be admitted again.

`reconcileGroup` reset the admission check to `Retry` for that case but left the remote in place, and only did so while the check was still `Ready`. The `Retry` makes the core controller evict the workload, and eviction resets the check to `Pending`, so the check is never `Ready` again. From that point on the stale remote matched on every reconcile and returned early — ahead of the eviction, out-of-sync, admission and nomination steps. The workload kept its quota with the check stuck in `Pending`, and the manager Job was never dispatched to any worker nor finished.

The one path out was the "no quota reservation" cleanup, which only runs if a reconcile happens to observe the window between eviction and re-admission. That is missed whenever the worker is disconnected at that moment, the delete fails, or the events coalesce — so in practice the workload could stay wedged indefinitely.

This PR deletes the `OutOfSync` remotes before deciding what to do with the admission check, so the branch clears itself and the nomination step can dispatch the workload again. A follow-up commit from @YQ-Wang narrows the reset so it fires only when the `OutOfSync` remote is the admitting one, rather than on any remote match.

#### Which issue(s) this PR fixes:

None filed yet — see the note below.

#### Special notes for your reviewer:

- Commit 2 ("Reset the check only when the admitting remote is the OutOfSync one") is authored by @YQ-Wang, who will need to sign the CLA for this PR to go green.
- @tenzen-y asked for an issue describing what was observed in-cluster; that is still outstanding and will be filed separately, since it needs the cluster-side detail rather than just the code analysis above.
- Unit coverage is in `pkg/controller/admissionchecks/multikueue/workload_test.go`; `test/integration/multikueue/jobs_test.go` asserts the stale remote is dropped so the Job can be dispatched again.
- Verified with `go test ./pkg/controller/admissionchecks/multikueue/... -count=1`.
- AI disclosure: this change was prepared with AI assistance and reviewed by the author, per the Kubernetes AI tool usage policy.

#### Does this PR introduce a user-facing change?

```release-note
MultiKueue: Fixed a bug where a remote workload finishing with reason `OutOfSync` left the stale remote in place, wedging the admission check in `Pending`. The workload held its quota indefinitely and the manager Job was neither dispatched to a worker nor finished.
```
