### PR TITLE
fix(flake): pull-kueue-test-e2e-certmanager-main

### DIFF
--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -242,10 +242,6 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 				}, util.VeryLongTimeout, util.LongInterval).Should(gomega.Succeed())
 			})
 
-			ginkgo.By("waiting for controller manager certificate reload", func() {
-				time.Sleep(3 * time.Second)
-			})
-
 			ginkgo.By("checking that the metrics are still available", func() {
 				expectedMetric := []string{
 					"kueue_quota_reserved_workloads_total",
@@ -262,8 +258,7 @@ func getKueueMetricsSecure(curlPodName, curlContainerName string) ([]byte, error
 		[]string{
 			"/bin/sh", "-c",
 			fmt.Sprintf(
-				"curl -s --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
-				certMountPath,
+				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
 				metricsServiceName,
 				kueueNS,
 			),
@@ -282,5 +277,5 @@ func expectMetricsToBeAvailableWithTimeout(curlPodName, curlContainerName string
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(string(metricsOutput)).Should(utiltesting.ContainMetrics(metrics))
-	}, timeout, 2*time.Second).Should(gomega.Succeed())
+	}, timeout, util.Interval).Should(gomega.Succeed())
 }

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -258,8 +258,7 @@ func getKueueMetricsSecure(curlPodName, curlContainerName string) ([]byte, error
 		[]string{
 			"/bin/sh", "-c",
 			fmt.Sprintf(
-				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
-				metricsServiceName,
+				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics", metricsServiceName,
 				kueueNS,
 			),
 		})

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -256,7 +256,8 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 func getKueueMetricsSecure(curlPodName, curlContainerName string) ([]byte, error) {
 	metricsOutput, _, err := util.KExecute(ctx, cfg, restClient, kueueNS, curlPodName, curlContainerName,
 		[]string{
-			"/bin/sh", "-c",
+			"/bin/sh",
+			"-c",
 			fmt.Sprintf(
 				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
 				certMountPath,

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -242,6 +242,10 @@ var _ = ginkgo.Describe("Metrics", ginkgo.Ordered, func() {
 				}, util.VeryLongTimeout, util.LongInterval).Should(gomega.Succeed())
 			})
 
+			ginkgo.By("waiting for controller manager certificate reload", func() {
+				time.Sleep(3 * time.Second)
+			})
+
 			ginkgo.By("checking that the metrics are still available", func() {
 				expectedMetric := []string{
 					"kueue_quota_reserved_workloads_total",
@@ -278,5 +282,5 @@ func expectMetricsToBeAvailableWithTimeout(curlPodName, curlContainerName string
 		g.Expect(err).NotTo(gomega.HaveOccurred())
 
 		g.Expect(string(metricsOutput)).Should(utiltesting.ContainMetrics(metrics))
-	}, timeout, util.Interval).Should(gomega.Succeed())
+	}, timeout, 2*time.Second).Should(gomega.Succeed())
 }

--- a/test/e2e/certmanager/metrics_test.go
+++ b/test/e2e/certmanager/metrics_test.go
@@ -258,7 +258,9 @@ func getKueueMetricsSecure(curlPodName, curlContainerName string) ([]byte, error
 		[]string{
 			"/bin/sh", "-c",
 			fmt.Sprintf(
-				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics", metricsServiceName,
+				"curl -s --connect-timeout 5 --max-time 15 --cacert %s/ca.crt -H \"Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\" https://%s.%s.svc.cluster.local:8443/metrics",
+				certMountPath,
+				metricsServiceName,
 				kueueNS,
 			),
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind flake
/area testing


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

Fixes #14471

#### Special notes for your reviewer:

 3-second sleep is now after the certificate verification block and before the metrics check.
 Polling interval changed from util.Interval to 2*time.Second in the metrics function.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved certificate metrics test reliability by enforcing connection and total execution timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->