### PR TITLE
Fix LocalQueue identity in fair-sharing preemption

### DIFF
--- a/pkg/scheduler/preemption/common/ordering.go
+++ b/pkg/scheduler/preemption/common/ordering.go
@@ -59,8 +59,8 @@ func CandidatesOrdering(log logr.Logger, afsEnabled bool, a, b *workload.Info, c
 				resourceUsagePreemptionEnabled(a, b) &&
 				a.LocalQueueFSUsage != b.LocalQueueFSUsage {
 				log.V(5).Info("Comparing workloads by LocalQueue fair sharing usage",
-					"workloadA", klog.KObj(a.Obj), "queueA", a.Obj.Spec.QueueName, "usageA", a.LocalQueueFSUsage,
-					"workloadB", klog.KObj(b.Obj), "queueB", b.Obj.Spec.QueueName, "usageB", b.LocalQueueFSUsage)
+					"workloadA", klog.KObj(a.Obj), "queueA", klog.KRef(a.Obj.Namespace, string(a.Obj.Spec.QueueName)), "usageA", a.LocalQueueFSUsage,
+					"workloadB", klog.KObj(b.Obj), "queueB", klog.KRef(b.Obj.Namespace, string(b.Obj.Spec.QueueName)), "usageB", b.LocalQueueFSUsage)
 				return cmp.Compare(*b.LocalQueueFSUsage, *a.LocalQueueFSUsage)
 			}
 			return 0

--- a/pkg/scheduler/preemption/common/ordering.go
+++ b/pkg/scheduler/preemption/common/ordering.go
@@ -28,6 +28,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	cmputil "sigs.k8s.io/kueue/pkg/util/cmp"
 	"sigs.k8s.io/kueue/pkg/util/priority"
+	utilqueue "sigs.k8s.io/kueue/pkg/util/queue"
 	"sigs.k8s.io/kueue/pkg/workload"
 	workloadevict "sigs.k8s.io/kueue/pkg/workload/evict"
 )
@@ -88,7 +89,7 @@ func resourceUsagePreemptionEnabled(a, b *workload.Info) bool {
 	// we can compare their LocalQueue usage.
 	// If the LocalQueueUsage is not nil for both Workloads, it means the feature gate has been enabled, and the
 	// AdmissionScope of the ClusterQueue is set to UsageBasedFairSharing. We inherit this information from the snapshot initialization.
-	return a.ClusterQueue == b.ClusterQueue && a.Obj.Spec.QueueName != b.Obj.Spec.QueueName && a.LocalQueueFSUsage != nil && b.LocalQueueFSUsage != nil
+	return a.ClusterQueue == b.ClusterQueue && utilqueue.KeyFromWorkload(a.Obj) != utilqueue.KeyFromWorkload(b.Obj) && a.LocalQueueFSUsage != nil && b.LocalQueueFSUsage != nil
 }
 
 func quotaReservationTime(wl *kueue.Workload, now time.Time) time.Time {

--- a/pkg/scheduler/preemption/preemption_test.go
+++ b/pkg/scheduler/preemption/preemption_test.go
@@ -4636,6 +4636,20 @@ func TestCandidatesOrdering(t *testing.T) {
 		Obj())
 	wlHighUsageLqDifCQ.LocalQueueFSUsage = new(1.0)
 
+	wlLowUsageSameNameLq := workload.NewInfo(utiltestingapi.MakeWorkload("low_same_name_lq_usage", "team-a").
+		Queue("default").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
+		Priority(-10).
+		Obj())
+	wlLowUsageSameNameLq.LocalQueueFSUsage = new(0.1)
+
+	wlHighUsageSameNameLq := workload.NewInfo(utiltestingapi.MakeWorkload("high_same_name_lq_usage", "team-b").
+		Queue("default").
+		ReserveQuotaAt(utiltestingapi.MakeAdmission(kueue.ClusterQueueReference(preemptorCq)).Obj(), now).
+		Priority(10).
+		Obj())
+	wlHighUsageSameNameLq.LocalQueueFSUsage = new(1.0)
+
 	cases := map[string]struct {
 		candidates     []workload.Info
 		wantCandidates []workload.Reference
@@ -4750,6 +4764,14 @@ func TestCandidatesOrdering(t *testing.T) {
 				*wlMidUsageLq,
 			},
 			wantCandidates: []workload.Reference{"mid_lq_usage", "low_lq_usage"},
+			featureGates:   map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
+		},
+		"workloads from same-named LQs in different namespaces are sorted by LQ usage": {
+			candidates: []workload.Info{
+				*wlLowUsageSameNameLq,
+				*wlHighUsageSameNameLq,
+			},
+			wantCandidates: []workload.Reference{"high_same_name_lq_usage", "low_same_name_lq_usage"},
 			featureGates:   map[featuregate.Feature]bool{features.AdmissionFairSharing: true},
 		},
 		"workloads from different CQ are sorted based on priority and timestamp": {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Admission fair-sharing preemption orders candidate Workloads from different LocalQueues in the same ClusterQueue by their LocalQueue usage. The existing identity check compared only `spec.queueName`, even though LocalQueue names are namespace-scoped.

As a result, Workloads from same-named LocalQueues in different namespaces were treated as belonging to the same LocalQueue. Their usage comparison was skipped, and lower-priority or more recently admitted Workloads could be selected for preemption even when their LocalQueue had lower usage.

This change compares the full namespace-qualified LocalQueue reference using `utilqueue.KeyFromWorkload`. It also adds a regression case with `team-a/default` and `team-b/default` that verifies the higher-usage LocalQueue remains first in the preemption candidate order.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

The regression test fails on `main`, ordering the lower-usage LocalQueue first, and passes with the namespace-qualified identity check.

Validation:
- `go test ./pkg/scheduler/preemption/... -count=1`
- `go vet ./pkg/scheduler/preemption/...`
- `go test ./pkg/scheduler/... -count=1`

AI assistance disclosure: Codex was used to help inspect the code, draft the change, and run tests. The author reviewed and validated the result.

#### Does this PR introduce a user-facing change?

```release-note
AdmissionFairSharing: Fixed preemption ordering for Workloads from same-named LocalQueues in different namespaces so that LocalQueue usage is considered.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload preemption ordering by correctly distinguishing local queues with the same name in different namespaces.
  * Ensured fairness ordering accurately accounts for local-queue resource usage.

* **Tests**
  * Added coverage for cross-namespace local queues and fairness-based candidate ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->