### PR TITLE
Add workload annotation to pods when SchedulerLibraryIntegration FG enabled.

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1739,7 +1739,7 @@ func getPodSetsInfoFromStatus(ctx context.Context, c client.Client, w *kueue.Wor
 		if err != nil {
 			return nil, err
 		}
-		if features.Enabled(features.TopologyAwareScheduling) {
+		if features.Enabled(features.TopologyAwareScheduling) || features.Enabled(features.SchedulerLibraryIntegration) {
 			info.Annotations[kueue.WorkloadAnnotation] = w.Name
 		}
 		if workloadslicing.IsElasticWorkload(w) {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -436,6 +436,37 @@ func TestReconcileGenericJob(t *testing.T) {
 					Obj(),
 			},
 		},
+		"setup workload annotations for pods": {
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+			req:     baseReq,
+			job:     baseJob.Clone().Obj(),
+			podSets: basePodSets,
+			wantWorkloads: []kueue.Workload{
+				*baseWl.Clone().
+					Name("job-test-job-ce737").
+					Obj(),
+			},
+			wantPodSets: []podset.PodSetInfo{
+				{
+					Name:  "main",
+					Count: 1,
+					Annotations: map[string]string{
+						kueue.WorkloadAnnotation: "job-test-job-ce737",
+					},
+					Labels: map[string]string{
+						kueueconstants.ClusterQueueLabel: "default-cq",
+						kueueconstants.LocalQueueLabel:   "test-lq",
+						kueueconstants.PodSetLabel:       "main",
+					},
+					Affinity:        nil,
+					NodeSelector:    map[string]string{},
+					Tolerations:     nil,
+					SchedulingGates: nil,
+				},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -439,13 +439,49 @@ func TestReconcileGenericJob(t *testing.T) {
 		"setup workload annotations for pods": {
 			featureGates: map[featuregate.Feature]bool{
 				features.SchedulerLibraryIntegration: true,
+				features.TopologyAwareScheduling:     false,
 			},
 			req:     baseReq,
 			job:     baseJob.Clone().Obj(),
 			podSets: basePodSets,
+			objs: []client.Object{
+				baseWl.Clone().Name("job-test-job-1").
+					Conditions(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Admission(&kueue.Admission{
+						ClusterQueue: "default-cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  "main",
+								Count: ptr.To(int32(1)),
+							},
+						},
+					}).
+					Obj(),
+			},
 			wantWorkloads: []kueue.Workload{
-				*baseWl.Clone().
-					Name("job-test-job-ce737").
+				*baseWl.Clone().Name("job-test-job-1").
+					Conditions(metav1.Condition{
+						Type:   kueue.WorkloadQuotaReserved,
+						Status: metav1.ConditionTrue,
+					}, metav1.Condition{
+						Type:   kueue.WorkloadAdmitted,
+						Status: metav1.ConditionTrue,
+					}).
+					Admission(&kueue.Admission{
+						ClusterQueue: "default-cq",
+						PodSetAssignments: []kueue.PodSetAssignment{
+							{
+								Name:  "main",
+								Count: ptr.To(int32(1)),
+							},
+						},
+					}).
 					Obj(),
 			},
 			wantPodSets: []podset.PodSetInfo{
@@ -453,17 +489,14 @@ func TestReconcileGenericJob(t *testing.T) {
 					Name:  "main",
 					Count: 1,
 					Annotations: map[string]string{
-						kueue.WorkloadAnnotation: "job-test-job-ce737",
+						kueue.WorkloadAnnotation: "job-test-job-1",
 					},
 					Labels: map[string]string{
 						kueueconstants.ClusterQueueLabel: "default-cq",
 						kueueconstants.LocalQueueLabel:   "test-lq",
 						kueueconstants.PodSetLabel:       "main",
 					},
-					Affinity:        nil,
-					NodeSelector:    map[string]string{},
-					Tolerations:     nil,
-					SchedulingGates: nil,
+					NodeSelector: map[string]string{},
 				},
 			},
 		},

--- a/pkg/controller/jobframework/reconciler_test.go
+++ b/pkg/controller/jobframework/reconciler_test.go
@@ -458,7 +458,7 @@ func TestReconcileGenericJob(t *testing.T) {
 						PodSetAssignments: []kueue.PodSetAssignment{
 							{
 								Name:  "main",
-								Count: ptr.To(int32(1)),
+								Count: new(int32(1)),
 							},
 						},
 					}).
@@ -478,7 +478,7 @@ func TestReconcileGenericJob(t *testing.T) {
 						PodSetAssignments: []kueue.PodSetAssignment{
 							{
 								Name:  "main",
-								Count: ptr.To(int32(1)),
+								Count: new(int32(1)),
 							},
 						},
 					}).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:
Ensures all Pods created by kueue-managed jobs are annotated with the name of their corresponding workload.
This allows to streamline the workload-to-pod matching mechanism. The mechanism is needed to allow matching workload preemptions to pods we need to preempt in the cluster cache of the scheduler library. This is required to allow us to simulate preemptions with the scheduler-library in the future.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Contributes to #13702

#### Special notes for your reviewer:
AI used for test development.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
WorkloadAwareScheduler: Added the kueue.x-k8s.io/workload annotation to Pods created by Kueue-managed jobs when the SchedulerLibraryIntegration feature gate is enabled; previously only TopologyAwareScheduling added it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved workload-to-pod association using workload, prebuilt-workload, group, or slice annotations.
  - Workload names are now included in pod metadata when topology-aware scheduling or scheduler library integration is enabled.
  - Added fallback handling when workload slice names are not explicitly provided.

- **Bug Fixes**
  - Prevented pods from unrelated namespaces or workloads from being incorrectly matched.
  - Improved pod matching across supported workload types and scheduling configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->