### PR TITLE
Automated cherry pick of #13328: Inject the Link to the new published release

### DIFF
--- a/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
+++ b/.github/ISSUE_TEMPLATE/NEW_RELEASE.md
@@ -33,8 +33,8 @@ Please do not remove items from the checklist
   - [ ] Run `./hack/releasing/promote_pull.sh $VERSION` to submit the promotion PR
   - [ ] Wait for the PR to be merged <!-- K8S_IO_PULL --> <!-- example kubernetes/k8s.io#7899 -->
   - [ ] Use `/wait-for-prod-images` to verify that the promoted images are available.
-- [ ] Publish the draft release prepared at the [GitHub releases page](https://github.com/kubernetes-sigs/kueue/releases).
-      Link: <!-- example https://github.com/kubernetes-sigs/kueue/releases/tag/v0.1.0 -->
+- [ ] Use `/publish-release` to publish the release prepared at the [GitHub releases page](https://github.com/kubernetes-sigs/kueue/releases).
+      Link: <!-- RELEASE_LINK --> <!-- example https://github.com/kubernetes-sigs/kueue/releases/tag/v0.1.0 -->
 - [ ] Run the [openvex action](https://github.com/kubernetes-sigs/kueue/actions/workflows/openvex.yaml) to generate openvex data. The action will add the file to the release artifacts.
 - [ ] Run the [SBOM action](https://github.com/kubernetes-sigs/kueue/actions/workflows/sbom.yaml) to generate the SBOM and add it to the release.
 - [ ] Update the `main` branch :

--- a/.github/workflows/release-utils.yml
+++ b/.github/workflows/release-utils.yml
@@ -509,9 +509,21 @@ jobs:
             exit 1
           fi
 
-          if [ "$COMMAND" != "create-release-candidate" ]; then
-            gh issue comment "$ISSUE_NUMBER" --body "✅ Release \`$VERSION\` has been successfully published."
+          # Construct the release URL and inject it into the issue body.
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${VERSION}"
+          CURRENT_BODY=$(gh issue view "$ISSUE_NUMBER" --json body -q .body)
+          UPDATED_BODY=$(printf '%s' "$CURRENT_BODY" | sed "s|<!-- RELEASE_LINK -->|${RELEASE_URL}|")
+          if [ "$CURRENT_BODY" != "$UPDATED_BODY" ]; then
+            gh issue edit "$ISSUE_NUMBER" --body "$UPDATED_BODY"
           fi
+
+          BODY="$(cat <<EOF
+          ✅ Release \`$VERSION\` has been successfully published.
+          Link: ${RELEASE_URL}
+          EOF
+          )"
+          echo "$BODY"
+          gh issue comment "$ISSUE_NUMBER" --body "$BODY"
 
   prepare-pull:
     name: Prepare Pull


### PR DESCRIPTION
Cherry pick of #13328 on release-0.18.

#13328: Inject the Link to the new published release

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind feature


```release-note
NONE
```