### PR TITLE
Cherry pick 14020 to release 0.18

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -86,7 +87,8 @@ const (
 )
 
 var (
-	errWatchEstablishTimeout = errors.New("watch establishment timed out")
+	errWatchEstablishTimeout    = errors.New("watch establishment timed out")
+	errWatchEstablishInProgress = errors.New("watch establishment is already in progress")
 
 	establishBackoff = utilwait.NewBackoff(initialEstablishTimeout, maxEstablishTimeout, 2, 0)
 )
@@ -126,6 +128,8 @@ type remoteClient struct {
 	config       *clientConfig
 	origin       string
 	adapters     map[string]jobframework.MultiKueueAdapter
+
+	watchEstablishing atomic.Bool
 
 	connState connectionState
 
@@ -282,6 +286,13 @@ func (rc *remoteClient) increaseFailedConnAttempt() *time.Duration {
 	return &d
 }
 
+func (rc *remoteClient) deferConnAttempt(d time.Duration) *time.Duration {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.retryConnNextAttempt = metav1.NewTime(rc.clock.Now().Add(d))
+	return &d
+}
+
 // updateConfigAndRefreshWatchers - will try to recreate the k8s client and restart watching if the new config is different than
 // the one currently used, a reconnect was requested, or the client was marked as disconnected.
 // If the encountered error is not permanent the duration after which a retry should be done is returned.
@@ -328,6 +339,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 
 	startWatcher, err := rc.establishWatcher(watchCtx, kueue.GroupVersion.WithKind("Workload").GroupKind().String(), &workloadKueueWatcher{})
 	if err != nil {
+		if errors.Is(err, errWatchEstablishInProgress) {
+			return rc.deferConnAttempt(retryIncrement), err
+		}
 		rc.disconnect()
 		return rc.increaseFailedConnAttempt(), err
 	}
@@ -341,6 +355,9 @@ func (rc *remoteClient) updateConfigAndRefreshWatchers(watchCtx context.Context,
 		}
 		startWatcher, err := rc.establishWatcher(watchCtx, kind, watcher)
 		if err != nil {
+			if errors.Is(err, errWatchEstablishInProgress) {
+				return rc.deferConnAttempt(retryIncrement), err
+			}
 			// not being able to setup a watcher is not ideal but we can function with only the wl watcher.
 			ctrl.LoggerFrom(watchCtx).Error(err, "Unable to establish the watcher", "kind", kind)
 			// however let's not accept this for now.
@@ -382,7 +399,18 @@ func (cw *cancelOnStopWatcher) Stop() {
 // timeout. On timeout the in-flight Watch is canceled and
 // errWatchEstablishTimeout is returned so the caller falls back to the
 // standard failedConnAttempts / retryAfter backoff in updateConfigAndRefreshWatchers.
-func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectList, origin string, timeout time.Duration) (watch.Interface, error) {
+func establishWatch(
+	ctx context.Context,
+	c client.WithWatch,
+	obj client.ObjectList,
+	origin string,
+	timeout time.Duration,
+	establishing *atomic.Bool,
+	shouldWatchHonorsCancellation bool,
+) (watch.Interface, error) {
+	if !establishing.CompareAndSwap(false, true) {
+		return nil, errWatchEstablishInProgress
+	}
 	type result struct {
 		w   watch.Interface
 		err error
@@ -400,6 +428,7 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 
 	select {
 	case r := <-resultCh:
+		establishing.Store(false)
 		if r.err != nil {
 			cancel()
 			return nil, r.err
@@ -407,8 +436,16 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 		return &cancelOnStopWatcher{Interface: r.w, cancel: cancel}, nil
 	case <-time.After(timeout):
 		cancel()
-		if r := <-resultCh; r.w != nil {
-			r.w.Stop()
+		cleanup := func() {
+			defer establishing.Store(false)
+			if r := <-resultCh; r.w != nil {
+				r.w.Stop()
+			}
+		}
+		if shouldWatchHonorsCancellation {
+			go cleanup()
+		} else {
+			cleanup()
 		}
 		return nil, errWatchEstablishTimeout
 	}
@@ -416,7 +453,8 @@ func establishWatch(ctx context.Context, c client.WithWatch, obj client.ObjectLi
 
 func (rc *remoteClient) establishWatcher(ctx context.Context, kind string, w jobframework.MultiKueueWatcher) (func(), error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("watchKind", kind)
-	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishBackoff.WaitTime(int(rc.failedConnAttempts)+1))
+	shouldWatchHonorsCancellation := rc.config == nil || rc.config.RestConfig == nil || rc.config.RestConfig.ExecProvider == nil
+	newWatcher, err := establishWatch(ctx, rc.client, w.GetEmptyList(), rc.origin, establishBackoff.WaitTime(int(rc.failedConnAttempts)+1), &rc.watchEstablishing, shouldWatchHonorsCancellation)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
+++ b/pkg/controller/admissionchecks/multikueue/multikueuecluster_test.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -1277,9 +1278,10 @@ func TestEstablishWatch(t *testing.T) {
 	errBoom := errors.New("boom")
 
 	cases := map[string]struct {
-		interceptor interceptor.Funcs
-		wantErr     error
-		maxElapsed  time.Duration
+		interceptor  interceptor.Funcs
+		establishing *atomic.Bool
+		wantErr      error
+		maxElapsed   time.Duration
 	}{
 		"hung Watch times out": {
 			interceptor: interceptor.Funcs{
@@ -1299,6 +1301,14 @@ func TestEstablishWatch(t *testing.T) {
 			},
 			wantErr: errBoom,
 		},
+		"watch establishment in progress returns error": {
+			establishing: func() *atomic.Bool {
+				b := &atomic.Bool{}
+				b.Store(true)
+				return b
+			}(),
+			wantErr: errWatchEstablishInProgress,
+		},
 		"success returns without waiting": {
 			maxElapsed: testTimeout,
 		},
@@ -1308,8 +1318,13 @@ func TestEstablishWatch(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			c := getClientBuilder(ctx).WithInterceptorFuncs(tc.interceptor).Build()
 
+			establishing := tc.establishing
+			if establishing == nil {
+				establishing = &atomic.Bool{}
+			}
+
 			start := time.Now()
-			w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout)
+			w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout, establishing, true)
 			elapsed := time.Since(start)
 
 			if !errors.Is(err, tc.wantErr) {
@@ -1328,8 +1343,50 @@ func TestEstablishWatch(t *testing.T) {
 	}
 
 	// Watch races with the timeout: returns a non-nil watcher just after
-	// time.After fires. Must Stop() it to avoid leaking the stream.
+	// time.After fires. Must Stop() it to avoid leaking the stream, and
+	// establishWatch must return immediately without blocking on the late Watch call.
 	t.Run("racing watcher is stopped on timeout", func(t *testing.T) {
+		fw := watch.NewFake()
+		releaseWatch := make(chan struct{})
+		c := getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
+			Watch: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+				time.Sleep(2 * testTimeout)
+				<-releaseWatch
+				return fw, nil
+			},
+		}).Build()
+
+		var establishing atomic.Bool
+		start := time.Now()
+		w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout, &establishing, true)
+		elapsed := time.Since(start)
+		if !errors.Is(err, errWatchEstablishTimeout) {
+			t.Fatalf("want errWatchEstablishTimeout, got: %v", err)
+		}
+		if w != nil {
+			t.Fatalf("want nil watcher, got: %v", w)
+		}
+		if elapsed >= 2*testTimeout {
+			t.Fatalf("took %v, expected < %v; establishWatch blocked on the late watch call", elapsed, 2*testTimeout)
+		}
+		close(releaseWatch)
+		select {
+		case _, ok := <-fw.ResultChan():
+			if ok {
+				t.Fatal("unexpected event before watcher was stopped")
+			}
+		case <-time.After(5 * testTimeout):
+			t.Fatal("racing watcher was not Stop()ed; would leak")
+		}
+
+		if err := wait.PollUntilContextTimeout(ctx, 10*time.Millisecond, 5*testTimeout, true, func(context.Context) (bool, error) {
+			return !establishing.Load(), nil
+		}); err != nil {
+			t.Fatal("watch establishment guard was not released")
+		}
+	})
+
+	t.Run("watch establishment in progress blocks concurrent attempt until finished", func(t *testing.T) {
 		fw := watch.NewFake()
 		c := getClientBuilder(ctx).WithInterceptorFuncs(interceptor.Funcs{
 			Watch: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
@@ -1338,16 +1395,43 @@ func TestEstablishWatch(t *testing.T) {
 			},
 		}).Build()
 
-		w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout)
+		var establishing atomic.Bool
+		w, err := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout, &establishing, true)
 		if !errors.Is(err, errWatchEstablishTimeout) {
 			t.Fatalf("want errWatchEstablishTimeout, got: %v", err)
 		}
 		if w != nil {
 			t.Fatalf("want nil watcher, got: %v", w)
 		}
-		if !fw.IsStopped() {
+		// Subsequent attempt while background watch establishment is still running must fail with errWatchEstablishInProgress.
+		w2, err2 := establishWatch(ctx, c, &kueue.WorkloadList{}, "test-origin", testTimeout, &establishing, true)
+		if !errors.Is(err2, errWatchEstablishInProgress) {
+			t.Fatalf("want errWatchEstablishInProgress, got: %v", err2)
+		}
+		if w2 != nil {
+			t.Fatalf("want nil watcher, got: %v", w2)
+		}
+
+		// Wait for the background watch to complete and clean up.
+		select {
+		case _, ok := <-fw.ResultChan():
+			if ok {
+				t.Fatal("unexpected event before watcher was stopped")
+			}
+		case <-time.After(5 * testTimeout):
 			t.Fatal("racing watcher was not Stop()ed; would leak")
 		}
+
+		// Now that the late watch is cleaned up and establishing reset to false, another attempt should succeed.
+		cFast := getClientBuilder(ctx).Build()
+		w3, err3 := establishWatch(ctx, cFast, &kueue.WorkloadList{}, "test-origin", testTimeout, &establishing, true)
+		if err3 != nil {
+			t.Fatalf("unexpected error establishing watch after background finished: %v", err3)
+		}
+		if w3 == nil {
+			t.Fatal("expected non-nil watcher")
+		}
+		w3.Stop()
 	})
 }
 


### PR DESCRIPTION
Cherry pick of #14020 on release-0.18

```release-note
MultiKueue: Fixed a bug that caused the establishWatch timeout handler to block synchronously until the watch operation finished.
```