### PR TITLE
DRA: Pair a requeued Workload with quota charges computed for its current generation

### DIFF
--- a/pkg/cache/queue/cluster_queue.go
+++ b/pkg/cache/queue/cluster_queue.go
@@ -386,8 +386,12 @@ func (c *ClusterQueue) PushOrUpdate(wInfo *workload.Info) {
 	defer c.rwm.Unlock()
 	key := workload.Key(wInfo.Obj)
 	// Skip if the scheduler is actively processing this workload.
-	// RequeueWorkload will handle placement with the latest version.
+	// RequeueWorkload will handle placement with the latest version, and consumes
+	// the captured Info so it can pair the object with charges computed for it.
 	if c.workloads.HasInflight(key) {
+		if features.Enabled(features.KueueDRAIntegration) {
+			c.workloads.CaptureInflightUpdate(wInfo)
+		}
 		return
 	}
 	if oldInfo := c.workloads.GetInadmissible(key); oldInfo != nil {

--- a/pkg/cache/queue/cluster_queue_test.go
+++ b/pkg/cache/queue/cluster_queue_test.go
@@ -249,6 +249,93 @@ func TestPushOrUpdateSkipsInflightWorkload(t *testing.T) {
 	}
 }
 
+// TestInflightUpdateCapture covers the lifecycle of the Info that PushOrUpdate
+// captures instead of dropping while a workload is inflight. For DRA-backed
+// workloads that Info is the only carrier of the preprocessed quota charges, so
+// it must survive until requeue consumes it — and never past that, or a later
+// cycle would be charged for a workload shape nobody asked for.
+func TestInflightUpdateCapture(t *testing.T) {
+	now := time.Now()
+	const wlName = "workload-1"
+
+	// afterPop runs once the workload is inflight and the update has been
+	// captured; wantCapturedGeneration is what a subsequent requeue should find.
+	cases := map[string]struct {
+		draEnabled             bool
+		afterPop               func(ctx context.Context, log logr.Logger, cq *ClusterQueue)
+		wantCapturedGeneration int64
+	}{
+		"update while inflight is captured": {
+			draEnabled:             true,
+			wantCapturedGeneration: 2,
+		},
+		"nothing is captured while the DRA integration is disabled": {
+			draEnabled: false,
+		},
+		"capture is dropped when the workload is deleted": {
+			draEnabled: true,
+			afterPop: func(_ context.Context, log logr.Logger, cq *ClusterQueue) {
+				cq.Delete(log, workload.Reference(defaultNamespace+"/"+wlName))
+			},
+		},
+		"capture is dropped when the workload is requeued": {
+			draEnabled: true,
+			afterPop: func(ctx context.Context, _ logr.Logger, cq *ClusterQueue) {
+				wl := utiltestingapi.MakeWorkload(wlName, defaultNamespace).Creation(now).Generation(2).Obj()
+				cq.RequeueIfNotPresent(ctx, workload.NewInfo(wl), RequeueReasonGeneric, "")
+			},
+		},
+		"capture is dropped when another workload is popped": {
+			draEnabled: true,
+			afterPop: func(_ context.Context, _ logr.Logger, cq *ClusterQueue) {
+				other := utiltestingapi.MakeWorkload("workload-2", defaultNamespace).Creation(now).Obj()
+				cq.PushOrUpdate(workload.NewInfo(other))
+				cq.Pop()
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, tc.draEnabled)
+			ctx, log := utiltesting.ContextWithLog(t)
+			cq := newClusterQueueImpl(ctx, nil, nil, defaultOrdering, testingclock.NewFakeClock(now))
+
+			wl := utiltestingapi.MakeWorkload(wlName, defaultNamespace).Creation(now).Generation(1).Obj()
+			cq.PushOrUpdate(workload.NewInfo(wl))
+			if head := cq.Pop(); head == nil {
+				t.Fatal("expected to pop workload")
+			}
+
+			// The workload controller re-pushes a newer generation while the
+			// scheduler still owns the workload.
+			updated := utiltestingapi.MakeWorkload(wlName, defaultNamespace).Creation(now).Generation(2).Obj()
+			cq.PushOrUpdate(workload.NewInfo(updated))
+
+			if tc.afterPop != nil {
+				tc.afterPop(ctx, log, cq)
+			}
+
+			captured := cq.workloads.ConsumeInflightUpdate(workload.Key(wl))
+			if tc.wantCapturedGeneration == 0 {
+				if captured != nil {
+					t.Fatalf("expected no captured update, got generation %d", captured.Obj.Generation)
+				}
+				return
+			}
+			if captured == nil {
+				t.Fatalf("expected a captured update of generation %d, got none", tc.wantCapturedGeneration)
+			}
+			if captured.Obj.Generation != tc.wantCapturedGeneration {
+				t.Errorf("captured generation = %d, want %d", captured.Obj.Generation, tc.wantCapturedGeneration)
+			}
+			if again := cq.workloads.ConsumeInflightUpdate(workload.Key(wl)); again != nil {
+				t.Error("captured update was returned twice; it must be cleared once consumed")
+			}
+		})
+	}
+}
+
 func TestPushOrUpdateGenerationChanged(t *testing.T) {
 	now := time.Now()
 

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -836,8 +836,22 @@ func (m *Manager) forgetInflight(cqName kueue.ClusterQueueReference, key workloa
 //   - an update that arrived while the workload was inflight was dropped by
 //     PushOrUpdate and captured instead; it carries both the newer object and
 //     the charges preprocessed for it, so it is preferred;
-//   - otherwise the charges this Info already holds are correct as long as the
-//     object has not moved on since the scheduler took it.
+//   - otherwise the charges this Info already holds are reused while the object
+//     has not moved on since the scheduler took it.
+//
+// The second bullet is weaker than it reads, and the returned bool inherits that
+// weakness. For DRA extended resources the charge is not a function of the object
+// alone: resolveQuotaKey derives the quota key from the DeviceClasses matching the
+// requested extended resource and from deviceClassMappings, so a DeviceClass
+// created or changed while the workload is inflight moves the charge with
+// metadata.generation untouched. The capture normally carries such a change, but
+// deviceClassHandler.reconcileWorkloads only pushes to the queue directly when
+// !NeedsDRAReconcile, which is false for a workload requesting a resource the
+// extended-resource cache already knows, so that workload reaches the controller
+// only through the delayed requeue. A requeue landing inside that window finds no
+// capture and a matching generation, and reports true here even though the charges
+// predate the DeviceClass. The effect is the same single cycle described above,
+// and the reconcile that follows re-pushes the workload with the current charges.
 func (m *Manager) draRequeueOption(log logr.Logger, info *workload.Info, w *kueue.Workload, cq *ClusterQueue) (workload.InfoOption, bool) {
 	if cq != nil {
 		if captured := cq.workloads.ConsumeInflightUpdate(workload.Key(w)); captured != nil && captured.Obj.Generation == w.Generation {

--- a/pkg/cache/queue/manager.go
+++ b/pkg/cache/queue/manager.go
@@ -784,15 +784,22 @@ func (m *Manager) RequeueWorkload(ctx context.Context, info *workload.Info, reas
 		return false
 	}
 	log := ctrl.LoggerFrom(ctx)
+	cq := m.hm.ClusterQueue(q.ClusterQueue)
 	workload.AdjustResources(ctx, m.client, &w)
 	if dra.NeedsDRAReconcile(&w, m.draBackedResources) {
-		info.Update(log, &w, workload.WithPreserveTotalRequests())
+		opt, paired := m.draRequeueOption(log, info, &w, cq)
+		info.Update(log, &w, opt)
+		if !paired {
+			// The scheduling hash would describe neither the charges nor the
+			// object alone, and an equivalence class bulk-moves other workloads,
+			// so opt this workload out of equivalence hashing for the cycle.
+			info.SchedulingHash = workload.SchedulingHashUnknown
+		}
 	} else {
 		info.Update(log, &w, m.workloadInfoOptions...)
 	}
 	m.addWorkload(info, q)
 
-	cq := m.hm.ClusterQueue(q.ClusterQueue)
 	if cq == nil {
 		return false
 	}
@@ -815,6 +822,34 @@ func (m *Manager) forgetInflight(cqName kueue.ClusterQueueReference, key workloa
 	}
 	cq.forgetInflight(key)
 	reportCQPendingWorkloads(m, cq)
+}
+
+// draRequeueOption decides where the TotalRequests of a requeued DRA-backed
+// workload come from, and reports whether they are known to describe w.
+//
+// DRA quota charges are resolved by the workload controller and cannot be
+// rebuilt here, because the spec carries resourceClaims rather than the quota
+// keys they translate to; rebuilding would requeue the workload asking for
+// almost nothing. So the charges are reused, but only from a computation made
+// for the same generation as the object being requeued:
+//
+//   - an update that arrived while the workload was inflight was dropped by
+//     PushOrUpdate and captured instead; it carries both the newer object and
+//     the charges preprocessed for it, so it is preferred;
+//   - otherwise the charges this Info already holds are correct as long as the
+//     object has not moved on since the scheduler took it.
+func (m *Manager) draRequeueOption(log logr.Logger, info *workload.Info, w *kueue.Workload, cq *ClusterQueue) (workload.InfoOption, bool) {
+	if cq != nil {
+		if captured := cq.workloads.ConsumeInflightUpdate(workload.Key(w)); captured != nil && captured.Obj.Generation == w.Generation {
+			return workload.WithTotalRequestsFrom(captured.TotalRequests), true
+		}
+	}
+	if info.Obj.Generation == w.Generation {
+		return workload.WithPreserveTotalRequests(), true
+	}
+	log.V(3).Info("Requeuing DRA workload with quota charges preprocessed for an older generation; the reconcile for the current generation will re-push it",
+		"workload", klog.KObj(w), "generation", w.Generation, "chargedGeneration", info.Obj.Generation)
+	return workload.WithPreserveTotalRequests(), false
 }
 
 // Delete the workload from queue or cluster queue.

--- a/pkg/cache/queue/manager_test.go
+++ b/pkg/cache/queue/manager_test.go
@@ -43,6 +43,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/metrics"
+	"sigs.k8s.io/kueue/pkg/resources"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
 	"sigs.k8s.io/kueue/pkg/util/queue"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
@@ -145,6 +146,143 @@ func TestAddLocalQueue_DRAReconcileChannelGuaranteedDelivery(t *testing.T) {
 	// The workload event must have been delivered (guaranteed, not dropped).
 	if got := len(ch); got != 1 {
 		t.Fatalf("unexpected draReconcileChannel length: got %d, want 1", got)
+	}
+}
+
+// TestRequeueWorkloadDRAPairsObjectWithCharges verifies that a requeued
+// DRA-backed workload never carries quota charges preprocessed for a different
+// generation of the object it is requeued with. DRA charges live only in the
+// Info — they cannot be rebuilt from the spec — so requeue has to source them
+// from a computation made for the object it is about to queue.
+func TestRequeueWorkloadDRAPairsObjectWithCharges(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.KueueDRAIntegration, true)
+	features.SetFeatureGateDuringTest(t, features.SchedulingEquivalenceHashing, true)
+
+	claimTmpl := "claim-tmpl"
+	// The pod spec carries a resourceClaim, so the workload is DRA-backed; the
+	// quota key it translates to ("gpu") only ever comes from preprocessing.
+	makeWorkload := func(generation int64) *kueue.Workload {
+		return utiltestingapi.MakeWorkload("wl", defaultNamespace).Queue("lq").Generation(generation).PodSets(
+			*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).PodSpec(corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{{Name: "rc", ResourceClaimTemplateName: &claimTmpl}},
+			}).Obj(),
+		).Obj()
+	}
+	draCharges := func(gpus int64) workload.InfoOption {
+		return workload.WithPreprocessedDRAResources(
+			map[kueue.PodSetReference]corev1.ResourceList{
+				kueue.DefaultPodSetName: {"gpu": *resource.NewQuantity(gpus, resource.DecimalSI)},
+			},
+			nil,
+		)
+	}
+
+	cases := map[string]struct {
+		// clientGeneration is the newest object, the one requeue fetches.
+		clientGeneration int64
+		// capturedGeneration, when non-zero, is re-pushed by the workload
+		// controller while the workload is inflight, carrying capturedGPUs.
+		capturedGeneration int64
+		capturedGPUs       int64
+		wantGPUs           int64
+		wantHashUnknown    bool
+	}{
+		"adopts charges preprocessed for the newest object": {
+			clientGeneration:   2,
+			capturedGeneration: 2,
+			capturedGPUs:       4,
+			wantGPUs:           4,
+		},
+		"preserves its own charges when the object did not change": {
+			clientGeneration: 1,
+			wantGPUs:         1,
+		},
+		"drops the scheduling hash when no charges describe the newest object": {
+			clientGeneration: 2,
+			wantGPUs:         1,
+			wantHashUnknown:  true,
+		},
+		"ignores a captured update that is itself out of date": {
+			clientGeneration:   3,
+			capturedGeneration: 2,
+			capturedGPUs:       4,
+			wantGPUs:           1,
+			wantHashUnknown:    true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, log := utiltesting.ContextWithLog(t)
+			lq := utiltestingapi.MakeLocalQueue("lq", defaultNamespace).ClusterQueue("cq").Obj()
+			// The client holds the newest object, which is what requeue fetches.
+			kClient := utiltesting.NewFakeClient(makeWorkload(tc.clientGeneration), lq)
+			manager := NewManagerForUnitTests(kClient, nil, WithPreemptionExpectations(preemptexpectations.New()))
+			// AddLocalQueue hands pre-existing DRA workloads to the workload
+			// controller instead of queueing them, and the send is blocking.
+			manager.SetDRAReconcileChannel(make(chan event.TypedGenericEvent[*kueue.Workload], 1))
+			if err := manager.AddClusterQueue(ctx, utiltestingapi.MakeClusterQueue("cq").Obj()); err != nil {
+				t.Fatalf("Failed adding ClusterQueue: %v", err)
+			}
+			if err := manager.AddLocalQueue(ctx, lq); err != nil {
+				t.Fatalf("Failed adding LocalQueue: %v", err)
+			}
+
+			// The workload controller preprocesses generation 1 and queues it.
+			if err := manager.AddOrUpdateWorkload(log, makeWorkload(1), draCharges(1)); err != nil {
+				t.Fatalf("Failed adding workload: %v", err)
+			}
+			cq := manager.hm.ClusterQueue("cq")
+			inflight := cq.Pop()
+			if inflight == nil {
+				t.Fatal("expected to pop workload")
+			}
+
+			if tc.capturedGeneration != 0 {
+				// A newer generation is preprocessed and queued while the
+				// scheduler still owns the workload.
+				if err := manager.AddOrUpdateWorkload(log, makeWorkload(tc.capturedGeneration), draCharges(tc.capturedGPUs)); err != nil {
+					t.Fatalf("Failed updating inflight workload: %v", err)
+				}
+			}
+
+			if !manager.RequeueWorkload(ctx, inflight, RequeueReasonGeneric, "") {
+				t.Fatal("expected the workload to be requeued")
+			}
+
+			requeued := cq.trackedInfo(workload.Key(inflight.Obj))
+			if requeued == nil {
+				t.Fatal("expected the requeued workload to be tracked by the ClusterQueue")
+			}
+			if got := requeued.Obj.Generation; got != tc.clientGeneration {
+				t.Errorf("requeued generation = %d, want the newest object %d", got, tc.clientGeneration)
+			}
+			wantRequests := []workload.PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": tc.wantGPUs}),
+				Count:    1,
+			}}
+			if diff := cmp.Diff(wantRequests, requeued.TotalRequests,
+				cmpopts.IgnoreFields(workload.PodSetResources{}, "Flavors"),
+				cmp.Comparer(resources.Equal)); diff != "" {
+				t.Errorf("requeued TotalRequests (-want,+got):\n%s", diff)
+			}
+
+			gotHashUnknown := requeued.SchedulingHash == workload.SchedulingHashUnknown
+			if gotHashUnknown != tc.wantHashUnknown {
+				t.Errorf("SchedulingHash unknown = %t, want %t (hash %q)", gotHashUnknown, tc.wantHashUnknown, requeued.SchedulingHash)
+			}
+			if !tc.wantHashUnknown {
+				// The hash must describe the pair that was actually queued, so
+				// it has to match a fresh Info built from that same pair.
+				want := workload.NewInfo(requeued.Obj, workload.WithTotalRequestsFrom(requeued.TotalRequests))
+				want.UpdateSchedulingHash(log)
+				if requeued.SchedulingHash != want.SchedulingHash {
+					t.Errorf("SchedulingHash = %q, want %q: the hash does not describe the requeued object and its charges",
+						requeued.SchedulingHash, want.SchedulingHash)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/cache/queue/pending_workloads.go
+++ b/pkg/cache/queue/pending_workloads.go
@@ -57,6 +57,15 @@ type PendingWorkloads struct {
 	// back into a queue.
 	inflight *workload.Info
 
+	// inflightUpdate holds the newest Info the workload controller produced for
+	// the inflight workload while the scheduler owned it. Such an Info cannot be
+	// placed without breaking the invariant above, and for DRA-backed workloads
+	// the Info is the sole carrier of the preprocessed quota charges: dropping it
+	// would leave requeue pairing the newest object with charges computed for an
+	// older generation. Only set while KueueDRAIntegration is enabled, and always
+	// set and cleared together with inflight.
+	inflightUpdate *workload.Info
+
 	// schedulingHashes tracks the scheduling equivalence hashes of pending
 	// workloads for the pending_scheduling_hashes metric.
 	schedulingHashes *schedulingHashCounts
@@ -108,8 +117,7 @@ func (p *PendingWorkloads) PopActive() *workload.Info {
 	defer p.Unlock()
 
 	if p.active.Len() == 0 {
-		p.inflight = nil
-		p.schedulingHashes.clearInflight()
+		p.clearInflight()
 		return nil
 	}
 
@@ -117,9 +125,53 @@ func (p *PendingWorkloads) PopActive() *workload.Info {
 	metrics.UntrackWorkload(p.customLabels, p.activeTracker, wl.Obj)
 	p.schedulingHashes.moveActiveToInflight(wl)
 	p.subtractPendingResources(wl)
-	p.inflight = wl
-	p.inflight.LastEvaluatedGeneration = p.inflight.Obj.Generation
+	p.setInflight(wl)
 	return p.inflight
+}
+
+// setInflight marks wl as the workload the scheduler is processing. Any update
+// captured for the previous inflight workload is dropped: it describes a
+// workload the scheduler no longer owns. Must be called with the lock held.
+func (p *PendingWorkloads) setInflight(wl *workload.Info) {
+	p.inflight = wl
+	p.inflightUpdate = nil
+	p.inflight.LastEvaluatedGeneration = p.inflight.Obj.Generation
+}
+
+// clearInflight must be called with the lock held.
+func (p *PendingWorkloads) clearInflight() {
+	p.inflight = nil
+	p.inflightUpdate = nil
+	p.schedulingHashes.clearInflight()
+}
+
+// CaptureInflightUpdate keeps wInfo as the newest Info produced for the inflight
+// workload, so requeue can pair the object with charges computed for it. It is a
+// no-op unless wInfo is the workload currently inflight, which is rechecked here
+// because callers test HasInflight under a separate acquisition of this lock.
+func (p *PendingWorkloads) CaptureInflightUpdate(wInfo *workload.Info) {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.inflight == nil || workloadKey(p.inflight) != workloadKey(wInfo) {
+		return
+	}
+	p.inflightUpdate = wInfo
+}
+
+// ConsumeInflightUpdate returns the Info captured for ref while it was inflight,
+// and clears it so it cannot be replayed into a later scheduling cycle. Returns
+// nil when no update arrived during the cycle.
+func (p *PendingWorkloads) ConsumeInflightUpdate(ref workload.Reference) *workload.Info {
+	p.Lock()
+	defer p.Unlock()
+
+	if p.inflightUpdate == nil || workloadKey(p.inflightUpdate) != ref {
+		return nil
+	}
+	captured := p.inflightUpdate
+	p.inflightUpdate = nil
+	return captured
 }
 
 func (p *PendingWorkloads) activeIterator() iter.Seq[*workload.Info] {
@@ -203,8 +255,7 @@ func (p *PendingWorkloads) ForgetInflightByKey(ref workload.Reference) {
 	defer p.Unlock()
 
 	if p.inflight != nil && workloadKey(p.inflight) == ref {
-		p.inflight = nil
-		p.schedulingHashes.clearInflight()
+		p.clearInflight()
 	}
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -135,6 +135,7 @@ type InfoOptions struct {
 	excludedResourcePrefixes []string
 	resourceTransformations  map[corev1.ResourceName]*config.ResourceTransformation
 	preserveTotalRequests    bool
+	adoptedTotalRequests     []PodSetResources
 	dra
 }
 
@@ -162,6 +163,19 @@ func WithResourceTransformations(transforms []config.ResourceTransformation) Inf
 func WithPreserveTotalRequests() InfoOption {
 	return func(o *InfoOptions) {
 		o.preserveTotalRequests = true
+	}
+}
+
+// WithTotalRequestsFrom makes Update adopt TotalRequests that were computed
+// elsewhere for the same Workload generation, instead of rebuilding them from
+// the object. Used when requeuing a DRA-backed workload whose preprocessing was
+// redone by the workload controller while the scheduler owned the workload:
+// DRA charges cannot be recomputed from the object, so the only way to keep the
+// object and its charges paired is to take both from that newer computation.
+// Takes precedence over WithPreserveTotalRequests.
+func WithTotalRequestsFrom(totalRequests []PodSetResources) InfoOption {
+	return func(o *InfoOptions) {
+		o.adoptedTotalRequests = totalRequests
 	}
 }
 
@@ -353,7 +367,8 @@ func (i *Info) UpdateSchedulingHash(log logr.Logger) {
 
 // Update refreshes the object reference, rebuilds TotalRequests, and
 // recomputes the scheduling hash. Pass WithPreserveTotalRequests to skip
-// the TotalRequests rebuild (e.g., to retain DRA preprocessing on requeue).
+// the TotalRequests rebuild (e.g., to retain DRA preprocessing on requeue),
+// or WithTotalRequestsFrom to adopt requests computed for the same generation.
 func (i *Info) Update(log logr.Logger, wl *kueue.Workload, opts ...InfoOption) {
 	i.Obj = wl
 	i.rebuildTotalRequests(opts...)
@@ -361,8 +376,8 @@ func (i *Info) Update(log logr.Logger, wl *kueue.Workload, opts ...InfoOption) {
 }
 
 // rebuildTotalRequests refreshes ClusterQueue and recomputes TotalRequests
-// from the current workload state. When WithPreserveTotalRequests is set,
-// only TotalRequests recomputation is skipped.
+// from the current workload state. When WithTotalRequestsFrom or
+// WithPreserveTotalRequests is set, only TotalRequests recomputation is skipped.
 func (i *Info) rebuildTotalRequests(opts ...InfoOption) {
 	options := defaultOptions
 	for _, opt := range opts {
@@ -374,13 +389,49 @@ func (i *Info) rebuildTotalRequests(opts ...InfoOption) {
 	} else {
 		i.ClusterQueue = ""
 	}
-	if !options.preserveTotalRequests {
-		if admitted {
-			i.TotalRequests = totalRequestsFromAdmission(i.Obj)
-		} else {
-			i.TotalRequests = totalRequestsFromPodSets(i.Obj, &options)
+	switch {
+	case options.adoptedTotalRequests != nil:
+		i.TotalRequests = clonePodSetResources(options.adoptedTotalRequests)
+	case options.preserveTotalRequests:
+		// Keep whatever this Info already carries.
+	case admitted:
+		i.TotalRequests = totalRequestsFromAdmission(i.Obj)
+	default:
+		i.TotalRequests = totalRequestsFromPodSets(i.Obj, &options)
+	}
+}
+
+// clonePodSetResources deep-copies the mutable parts of src. The source belongs
+// to a different Info that may still be referenced elsewhere, and requests are
+// mutated in place (Mul, Divide, FloorToZero), so sharing them would let one
+// Info silently change the other's charges.
+func clonePodSetResources(src []PodSetResources) []PodSetResources {
+	dst := make([]PodSetResources, len(src))
+	for i, ps := range src {
+		dst[i] = ps
+		if ps.Requests != nil {
+			dst[i].Requests = ps.Requests.Clone()
+		}
+		dst[i].Flavors = maps.Clone(ps.Flavors)
+		if ps.DelayedTopologyRequest != nil {
+			dst[i].DelayedTopologyRequest = new(*ps.DelayedTopologyRequest)
+		}
+		if ps.TopologyRequest != nil {
+			tr := *ps.TopologyRequest
+			tr.Levels = slices.Clone(ps.TopologyRequest.Levels)
+			tr.DomainRequests = make([]TopologyDomainRequests, len(ps.TopologyRequest.DomainRequests))
+			for j, dr := range ps.TopologyRequest.DomainRequests {
+				cloned := dr
+				cloned.Values = slices.Clone(dr.Values)
+				if dr.SinglePodRequests != nil {
+					cloned.SinglePodRequests = dr.SinglePodRequests.Clone()
+				}
+				tr.DomainRequests[j] = cloned
+			}
+			dst[i].TopologyRequest = &tr
 		}
 	}
+	return dst
 }
 
 // computeSchedulingHash returns a deterministic hash of the workload's

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -1131,6 +1131,63 @@ func TestUpdateWithRebuild(t *testing.T) {
 				Count:    1,
 			}},
 		},
+		"WithTotalRequestsFrom adopts DRA requests preprocessed for the newer object": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			initialOptions: []InfoOption{
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{
+						kueue.DefaultPodSetName: {"gpu": resource.MustParse("1")},
+					},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+						kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
+					},
+				),
+			},
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "2").Obj(),
+			updateOptions: []InfoOption{WithTotalRequestsFrom([]PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+				Count:    1,
+			}})},
+			// Neither the preserved charge (gpu: 1) nor a rebuild from the spec
+			// (example.com/gpu: 2, the untranslated request).
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+				Count:    1,
+			}},
+		},
+		"WithTotalRequestsFrom takes precedence over WithPreserveTotalRequests": {
+			initial: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "1").Obj(),
+			initialOptions: []InfoOption{
+				WithPreprocessedDRAResources(
+					map[kueue.PodSetReference]corev1.ResourceList{
+						kueue.DefaultPodSetName: {"gpu": resource.MustParse("1")},
+					},
+					map[kueue.PodSetReference]sets.Set[corev1.ResourceName]{
+						kueue.DefaultPodSetName: sets.New[corev1.ResourceName]("example.com/gpu"),
+					},
+				),
+			},
+			updated: utiltestingapi.MakeWorkload("wl", "ns").
+				Request("example.com/gpu", "2").Obj(),
+			updateOptions: []InfoOption{
+				WithPreserveTotalRequests(),
+				WithTotalRequestsFrom([]PodSetResources{{
+					Name:     kueue.DefaultPodSetName,
+					Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+					Count:    1,
+				}}),
+			},
+			wantRequests: []PodSetResources{{
+				Name:     kueue.DefaultPodSetName,
+				Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+				Count:    1,
+			}},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -1149,6 +1206,36 @@ func TestUpdateWithRebuild(t *testing.T) {
 				t.Errorf("TotalRequests after Update (-want,+got):\n%s", diff)
 			}
 		})
+	}
+}
+
+// TestUpdateWithTotalRequestsFromClones guards the aliasing hazard of adopting
+// another Info's requests: requests are mutated in place elsewhere (Mul,
+// Divide, FloorToZero), so a shallow adoption would let the source Info silently
+// change the charges of the Info that adopted them.
+func TestUpdateWithTotalRequestsFromClones(t *testing.T) {
+	source := []PodSetResources{{
+		Name:     kueue.DefaultPodSetName,
+		Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+		Count:    1,
+		Flavors:  map[corev1.ResourceName]kueue.ResourceFlavorReference{"gpu": "flavor"},
+	}}
+
+	info := NewInfo(utiltestingapi.MakeWorkload("wl", "ns").Request("example.com/gpu", "2").Obj())
+	info.Update(logr.Discard(), utiltestingapi.MakeWorkload("wl", "ns").Request("example.com/gpu", "2").Obj(),
+		WithTotalRequestsFrom(source))
+
+	source[0].Requests.Mul(4)
+	source[0].Flavors["gpu"] = "other-flavor"
+
+	want := []PodSetResources{{
+		Name:     kueue.DefaultPodSetName,
+		Requests: resources.NewRequestsFromMap(map[corev1.ResourceName]int64{"gpu": 2}),
+		Count:    1,
+		Flavors:  map[corev1.ResourceName]kueue.ResourceFlavorReference{"gpu": "flavor"},
+	}}
+	if diff := cmp.Diff(want, info.TotalRequests, cmp.Comparer(resources.Equal)); diff != "" {
+		t.Errorf("TotalRequests changed after mutating the source (-want,+got):\n%s", diff)
 	}
 }
 

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -1351,6 +1351,58 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.It("Should keep DRA-translated requests when a workload is requeued after failing admission", func() {
+			ginkgo.By("Creating DeviceClass")
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Admitting a workload that takes most of the quota")
+			wl1 := utiltestingapi.MakeWorkload("requeue-dra-wl1", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "6").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl1)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating a second workload that does not fit, so the scheduler requeues it")
+			wl2 := utiltestingapi.MakeWorkload("requeue-dra-wl2", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "6").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Freeing the quota")
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, wl1, true)
+
+			ginkgo.By("Verifying the requeued workload is admitted with its DRA-translated requests")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				// Requeue must not rebuild the requests from the spec: that would
+				// charge the raw extended resource, which the ClusterQueue does not
+				// even declare quota for.
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKeyWithValue(
+					corev1.ResourceName(logicalName), resource.MustParse("6")),
+					"requeued workload should still be charged under the DRA logical name %q", logicalName)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.It("Should requeue inadmissible workload when DeviceClass extendedResourceName is updated", func() {
 			const newExtendedResourceName = "example.com/tpu"
 

--- a/test/integration/singlecluster/controller/dra/dra_test.go
+++ b/test/integration/singlecluster/controller/dra/dra_test.go
@@ -1351,6 +1351,66 @@ var _ = ginkgo.Describe("DRA Integration", ginkgo.Ordered, ginkgo.ContinueOnFail
 			}, util.Timeout, util.Interval).Should(gomega.Succeed())
 		})
 
+		ginkgo.It("Should admit a requeued workload with the DRA-translated requests of its updated spec", func() {
+			ginkgo.By("Creating DeviceClass")
+			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).
+				ExtendedResourceName(extendedResourceName).
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, deviceClass)).To(gomega.Succeed())
+			defer func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, deviceClass, true)
+			}()
+
+			ginkgo.By("Admitting a workload that takes most of the quota")
+			wl1 := utiltestingapi.MakeWorkload("updated-dra-wl1", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "6").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl1)).To(gomega.Succeed())
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl1), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Creating a second workload that does not fit, so the scheduler keeps requeuing it")
+			wl2 := utiltestingapi.MakeWorkload("updated-dra-wl2", ns.Name).
+				Queue("dc-tracking-lq").
+				Request(corev1.ResourceName(extendedResourceName), "6").
+				Obj()
+			gomega.Expect(k8sClient.Create(ctx, wl2)).To(gomega.Succeed())
+			gomega.Consistently(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeFalse())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("Shrinking its request so it fits, bumping the generation while it is being requeued")
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				updatedWl.Spec.PodSets[0].Template.Spec.Containers[0].Resources.Requests[corev1.ResourceName(extendedResourceName)] =
+					resource.MustParse("2")
+				g.Expect(k8sClient.Update(ctx, &updatedWl)).To(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("Verifying it is admitted with the updated charge, not the one it was requeued with")
+			// The workload only fits under the updated request, so pairing the new
+			// generation with the charge preprocessed for the old one would leave it
+			// pending forever. Whether the update lands while the scheduler holds the
+			// workload inflight (consumed from the capture at requeue) or while it is
+			// back in the queue, the admitted charge has to describe the current spec.
+			gomega.Eventually(func(g gomega.Gomega) {
+				var updatedWl kueue.Workload
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl2), &updatedWl)).To(gomega.Succeed())
+				g.Expect(workload.HasQuotaReservation(&updatedWl)).To(gomega.BeTrue())
+				assignment := updatedWl.Status.Admission.PodSetAssignments[0]
+				g.Expect(assignment.ResourceUsage).To(gomega.HaveKeyWithValue(
+					corev1.ResourceName(logicalName), resource.MustParse("2")),
+					"admitted charge should match the updated spec under the DRA logical name %q", logicalName)
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
 		ginkgo.It("Should keep DRA-translated requests when a workload is requeued after failing admission", func() {
 			ginkgo.By("Creating DeviceClass")
 			deviceClass := utiltesting.MakeDeviceClass(deviceClassName).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area dra

#### What this PR does / why we need it:

When a DRA-backed Workload is updated while inflight in the scheduler, it can be requeued with its newest object paired with quota charges preprocessed for an older generation.

`PushOrUpdate` drops updates for the workload the scheduler is processing, assuming requeue re-reads the object anyway. That holds for requests rebuilt from the object, but not for DRA: those charges are resolved by the workload controller and the `workload.Info` is the only place they exist, so the dropped Info is the only copy pairing the newer object with charges computed for it. `RequeueWorkload` then fetches the newest object but keeps the charges it already holds, and the scheduling-equivalence hash is derived from that mix — one cycle of over- or under-admission, plus a hash describing neither shape.

This PR sources the charges from a computation made for the generation being requeued:

1. `PushOrUpdate` **captures the Info it would have dropped** while a workload is inflight. It is set and cleared together with `inflight`, so no later cycle can be charged for a workload shape nobody asked for. The capture is only taken while `KueueDRAIntegration` is enabled; with the gate off, the path is unchanged.
2. `RequeueWorkload` **prefers that capture when its generation matches the object**; otherwise, it preserves its own charges while the object has not moved on.
3. If neither describes the newest object, the charges are kept but the hash is dropped to `SchedulingHashUnknown`, so the mismatch cannot bulk-move unrelated workloads.

Rebuilding from the object is deliberately not an option: the spec carries `resourceClaims`, not the quota keys they translate to, so a rebuild would requeue the workload asking for almost nothing. Checking the capture **before** falling back to preservation also covers footprint changes that don't bump the generation, such as a LimitRange default surfacing or a DeviceClass mutating while inflight.

#### Which issue(s) this PR fixes:

Fixes #14535 

**Open design question.** Case 3 is mitigated, not eliminated: the workload is requeued with one-generation-stale charges and no hash, and self-heals when the reconcile for the current generation re-pushes it. Closing the window fully would mean either firing `draReconcileChannel` from the requeue path (needs `RequeueWorkload` restructured to send outside `m.Lock()`, as `addLocalQueueLocked` already does) or requeuing to `inadmissibleWorkloads` under a new requeue reason. Both are left out to keep the diff reviewable — happy to follow up with either.

Re-running DRA preprocessing at requeue was rejected: it needs the client, ResourceSlice cache and DeviceClass mapper, and `RequeueWorkload` holds `m.Lock()`.

Distinct from #13930 and #14035, which are about the reconciler calling `AddOrUpdateWorkload`; builds on the preserve-path added in #11927.

**Testing.** Unit coverage for the new `WithTotalRequestsFrom` option (including that adopted requests are deep-copied), the capture lifecycle, and all three cases through the real `Manager.RequeueWorkload` — reverting the fix fails 3 of those 4 cases. The integration test covers the requeue branch but **not** the capture path: there is no hook to hold a workload inflight deterministically in envtest, and a timing-based spec would just become a flake. Commits are split so each builds and passes on its own.

#### Does this PR introduce a user-facing change?

```release-note
DRA: Fixed a bug where a Workload updated while the scheduler was processing it could be requeued with its newest spec paired with quota charges preprocessed for an older generation, causing one scheduling cycle of over- or under-admission and an incorrect scheduling-equivalence hash.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workload updates received while scheduling is in progress.
  * Ensured requeued workloads use quota information from the latest workload generation.
  * Fixed stale quota data handling to trigger accurate rescheduling.
  * Improved admission of workloads with translated resource requests after quota becomes available.
  * Preserved accurate resource and quota data when capacity changes during scheduling.

* **Improvements**
  * Added support for preserving and safely reusing precomputed workload resource requests.
  * Improved reliability when workload resource requests or quota details change during scheduling.
  * Improved handling of DRA-backed workloads during requeue and quota recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->