### PR TITLE
Retry image builds on rate limits and lock errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ IMAGE_BUILD_RETRY = $(PROJECT_DIR)/hack/testing/retry.sh \
 	--delay 2 \
 	--exponential \
 	--stream \
-	--continue-if "grep -qiE '(context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized|connection reset by peer)' {output}" \
+	--continue-if "grep -qiE '(context deadline exceeded|unexpected status from HEAD request to .*: 401 Unauthorized|connection reset by peer|too ?many ?requests|ref .* locked for .*: unavailable)' {output}" \
 	-- env
 
 MAKE_TIMING ?= $(if $(filter 1 true TRUE yes YES on ON,$(CI)),1,0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind kep

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

/kind flake

#### What this PR does / why we need it:

`IMAGE_BUILD_RETRY` wraps every image build in `hack/testing/retry.sh` with seven attempts and exponential backoff. `retry.sh` retries only when the failure output matches the `--continue-if` allowlist. The run in the linked issue hit two errors that are not on that list, so the build failed on the first attempt with the retry budget untouched:

```
retry [1/7] failed
retry: aborting early as continue-if condition failed (fail-fast)
```

This PR adds a pattern for each to that allowlist.

The first error is registry rate limiting. Loading the Go builder image metadata from `public.ecr.aws` returned 429. The output spells it both as containerd's HTTP status text (`: 429 Too Many Requests`) and as the registry error code (`toomanyrequests: Rate exceeded`), so `too ?many ?requests` covers both, plus Docker Hub's `toomanyrequests: You have reached your pull rate limit`.

The second error is a buildkit content-store lock, on the `arm64` and `ppc64le` legs. `image-pushing-postsubmit` runs five `buildx` invocations against a single buildkit daemon, so they race to write the same `BASE_IMAGE` index. The losers get `ref ... locked for 119.894969ms (since ...): unavailable`, matched by `ref .* locked for .*: unavailable`. The lock is held for milliseconds, so the index is there by the time `retry.sh` retries.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #14544

#### Special notes for your reviewer:

Tested the `--continue-if` expression against the failure log from the linked issue and one fixture per error class.

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image builds now retry when the registry reports rate limiting or a temporarily locked, unavailable image reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->