### PR TITLE
MultiKueue: simplify AllAtOnce nomination set comparison

### DIFF
--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -907,18 +907,18 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
 		// group.remotes is a map, so iteration order is non-deterministic; sort for a
-		// stable persisted nomination instead of relying on a side effect of the
-		// set-equality check.
+		// stable persisted nomination.
 		slices.Sort(nominatedWorkers)
 
-		if !sets.New(group.local.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
-			if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
-				wl.Status.NominatedClusterNames = nominatedWorkers
-				return true, nil
-			}); err != nil {
-				log.V(2).Error(err, "Failed to patch nominated clusters", "workload", klog.KObj(group.local))
-				return reconcile.Result{}, err
+		if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
+			if sets.New(wl.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
+				return false, nil
 			}
+			wl.Status.NominatedClusterNames = nominatedWorkers
+			return true, nil
+		}); err != nil {
+			log.V(2).Error(err, "Failed to patch nominated clusters", "workload", klog.KObj(group.local))
+			return reconcile.Result{}, err
 		}
 	} else {
 		// Incremental dispatcher and External dispatcher path

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -906,14 +906,14 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		for workerName := range group.remotes {
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
-		// group.remotes is a map, so iteration order is non-deterministic; sort for a
-		// stable persisted nomination.
-		slices.Sort(nominatedWorkers)
 
 		if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 			if sets.New(wl.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
 				return false, nil
 			}
+			// group.remotes is a map, so iteration order is non-deterministic; sort only
+			// when we are about to persist, for a stable stored nomination.
+			slices.Sort(nominatedWorkers)
 			wl.Status.NominatedClusterNames = nominatedWorkers
 			return true, nil
 		}); err != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -839,7 +839,7 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 }
 
 // nominatedClusterSetsEqual reports whether stored and current contain the same set of cluster names,
-// independent of order. It does not mutate its arguments.
+// independent of order.
 func nominatedClusterSetsEqual(stored, current []string) bool {
 	if len(stored) != len(current) {
 		return false

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -907,13 +907,13 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
 
+		// group.remotes is a map, so iteration order is non-deterministic; sort only
+		// when we are about to persist, for a stable stored nomination.
+		slices.Sort(nominatedWorkers)
 		if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 			if sets.New(wl.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
 				return false, nil
 			}
-			// group.remotes is a map, so iteration order is non-deterministic; sort only
-			// when we are about to persist, for a stable stored nomination.
-			slices.Sort(nominatedWorkers)
 			wl.Status.NominatedClusterNames = nominatedWorkers
 			return true, nil
 		}); err != nil {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -839,12 +839,6 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 	return reconcile.Result{}, errors.Join(errs...)
 }
 
-// nominatedClusterSetsEqual reports whether stored and current contain the same set of cluster names,
-// independent of order.
-func nominatedClusterSetsEqual(stored, current []string) bool {
-	return sets.New(stored...).Equal(sets.New(current...))
-}
-
 func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group *wlGroup) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx).WithValues("op", "nominateAndSynchronizeWorkers")
 	log.V(3).Info("Nominate and Synchronize Worker Clusters")
@@ -917,7 +911,7 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		// set-equality check.
 		slices.Sort(nominatedWorkers)
 
-		if !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
+		if !sets.New(group.local.Status.NominatedClusterNames...).Equal(sets.New(nominatedWorkers...)) {
 			if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {
 				wl.Status.NominatedClusterNames = nominatedWorkers
 				return true, nil

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
@@ -841,14 +842,7 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 // nominatedClusterSetsEqual reports whether stored and current contain the same set of cluster names,
 // independent of order.
 func nominatedClusterSetsEqual(stored, current []string) bool {
-	if len(stored) != len(current) {
-		return false
-	}
-	s := slices.Clone(stored)
-	c := slices.Clone(current)
-	slices.Sort(s)
-	slices.Sort(c)
-	return slices.Equal(s, c)
+	return sets.New(stored...).Equal(sets.New(current...))
 }
 
 func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group *wlGroup) (reconcile.Result, error) {

--- a/pkg/controller/admissionchecks/multikueue/workload.go
+++ b/pkg/controller/admissionchecks/multikueue/workload.go
@@ -839,11 +839,16 @@ func (w *wlReconciler) syncToSingleCluster(ctx context.Context, log klog.Logger,
 }
 
 // nominatedClusterSetsEqual reports whether stored and current contain the same set of cluster names,
-// independent of order.
+// independent of order. It does not mutate its arguments.
 func nominatedClusterSetsEqual(stored, current []string) bool {
-	slices.Sort(stored)
-	slices.Sort(current)
-	return slices.Equal(stored, current)
+	if len(stored) != len(current) {
+		return false
+	}
+	s := slices.Clone(stored)
+	c := slices.Clone(current)
+	slices.Sort(s)
+	slices.Sort(c)
+	return slices.Equal(s, c)
 }
 
 func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group *wlGroup) (reconcile.Result, error) {
@@ -913,6 +918,10 @@ func (w *wlReconciler) nominateAndSynchronizeWorkers(ctx context.Context, group 
 		for workerName := range group.remotes {
 			nominatedWorkers = append(nominatedWorkers, workerName)
 		}
+		// group.remotes is a map, so iteration order is non-deterministic; sort for a
+		// stable persisted nomination instead of relying on a side effect of the
+		// set-equality check.
+		slices.Sort(nominatedWorkers)
 
 		if !nominatedClusterSetsEqual(group.local.Status.NominatedClusterNames, nominatedWorkers) {
 			if err := workloadpatching.PatchAdmissionStatus(ctx, w.client, group.local, w.clock, func(wl *kueue.Workload) (bool, error) {

--- a/pkg/controller/admissionchecks/multikueue/workload_test.go
+++ b/pkg/controller/admissionchecks/multikueue/workload_test.go
@@ -2555,7 +2555,7 @@ func TestNominateAndSynchronizeWorkers_MoreCases(t *testing.T) {
 			remotes:                   map[string]*kueue.Workload{remoteNames[0]: {}, remoteNames[1]: {}},
 			nominatedWorkers:          []string{remoteNames[1], remoteNames[0]}, // reversed (not sorted)
 			wantCreated:               nil,
-			wantNominatedClusterNames: []string{remoteNames[0], remoteNames[1]}, // sorted in-place even without a patch
+			wantNominatedClusterNames: []string{remoteNames[1], remoteNames[0]}, // unchanged: set is equal, so no patch
 		},
 		// Incremental dispatcher tests were moved to a separate file.
 		{


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/area multikueue

#### What this PR does / why we need it:

A no-op refactor of how the MultiKueue `AllAtOnce` dispatcher decides whether to patch
`Workload.Status.NominatedClusterNames`. Extracted from #14539 so that feature stays
focused; behavior is unchanged.

Landing this first keeps #14539 focused on the feature; #14539 will be rebased on top once this merges.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

AI tools were used to help prepare this change, per the
[Kubernetes AI tool usage policy](https://www.kubernetes.dev/docs/guide/pull-requests/#ai-guidance).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nominated worker cluster sets during synchronization.
  * Preserved existing ordering when no update is required.
  * Ensured all-at-once nominations are stored in a consistent, deterministic order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->