### PR TITLE
TAS: account for domains a second pass reassignment moves onto

### DIFF
--- a/pkg/scheduler/flavorassigner/flavorassigner.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner.go
@@ -105,35 +105,70 @@ func (a *Assignment) SetRepresentativeMode(mode FlavorAssignmentMode) {
 // ComputeTASNetUsage computes the net TAS usage for the assignment
 func (a *Assignment) ComputeTASNetUsage(log logr.Logger, cq *schdcache.ClusterQueueSnapshot, wl *workload.Info, prevAdmission *kueue.Admission) workload.TASUsage {
 	result := make(workload.TASUsage)
-	for i, psa := range a.PodSets {
-		if psa.TopologyAssignment != nil {
-			if prevAdmission != nil && prevAdmission.PodSetAssignments[i].TopologyAssignment != nil {
+	for _, psa := range a.PodSets {
+		if psa.TopologyAssignment == nil {
+			continue
+		}
+		// Pods the current admission already places on a domain are accounted for
+		// in the snapshot through the cache, so only the additional pods count
+		// towards the net usage. Comparing per domain rather than skipping the
+		// whole PodSet matters when the assignment changed: a second pass
+		// replacing an unhealthy node moves pods onto a domain nothing has
+		// accounted for yet, and that claim has to be checked and recorded like
+		// any other.
+		accounted := admittedDomainCounts(prevAdmission, psa.Name)
+		podSet := podset.FindPodSetByName(wl.Obj.Spec.PodSets, psa.Name)
+		if podSet == nil {
+			log.Error(nil, "PodSet not found while computing TAS net usage", "podSet", psa.Name)
+			continue
+		}
+		tasFlavor, err := onlyTASFlavor(psa.Flavors, cq.TASFlavors)
+		if err != nil {
+			log.Error(err, "Failed to find TAS flavor while computing TAS net usage", "podSet", psa.Name)
+			continue
+		}
+		singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
+		for _, domain := range psa.TopologyAssignment.Domains {
+			count := domain.Count - accounted[tas.DomainID(domain.Values)]
+			if count <= 0 {
+				// Unchanged, or the domain now holds fewer pods than the
+				// admission already accounts for. Releasing the surplus is not
+				// expressible here, since a Usage value is applied with a single
+				// add or subtract, so the snapshot keeps counting it until the
+				// next one is built.
 				continue
 			}
-			podSet := podset.FindPodSetByName(wl.Obj.Spec.PodSets, psa.Name)
-			if podSet == nil {
-				log.Error(nil, "PodSet not found while computing TAS net usage", "podSet", psa.Name)
-				continue
-			}
-			tasFlavor, err := onlyTASFlavor(psa.Flavors, cq.TASFlavors)
-			if err != nil {
-				log.Error(err, "Failed to find TAS flavor while computing TAS net usage", "podSet", psa.Name)
-				continue
-			}
-			singlePodRequests := resources.NewRequestsFromPodSpec(&podSet.Template.Spec)
 			if _, ok := result[*tasFlavor]; !ok {
 				result[*tasFlavor] = make(workload.TASFlavorUsage, 0)
 			}
-			for _, domain := range psa.TopologyAssignment.Domains {
-				result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
-					Values:            domain.Values,
-					SinglePodRequests: singlePodRequests.Clone(),
-					Count:             domain.Count,
-				})
-			}
+			result[*tasFlavor] = append(result[*tasFlavor], workload.TopologyDomainRequests{
+				Values:            domain.Values,
+				SinglePodRequests: singlePodRequests.Clone(),
+				Count:             count,
+			})
 		}
 	}
 	return result
+}
+
+// admittedDomainCounts returns the number of pods per topology domain that the
+// workload's current admission already contributes to the snapshot, keyed by
+// domain. It returns nil when the PodSet has no admitted topology assignment.
+func admittedDomainCounts(prevAdmission *kueue.Admission, psName kueue.PodSetReference) map[tas.TopologyDomainID]int32 {
+	if prevAdmission == nil {
+		return nil
+	}
+	idx := slices.IndexFunc(prevAdmission.PodSetAssignments, func(psa kueue.PodSetAssignment) bool {
+		return psa.Name == psName
+	})
+	if idx == -1 || prevAdmission.PodSetAssignments[idx].TopologyAssignment == nil {
+		return nil
+	}
+	counts := make(map[tas.TopologyDomainID]int32)
+	for _, domain := range tas.InternalFrom(prevAdmission.PodSetAssignments[idx].TopologyAssignment).Domains {
+		counts[tas.DomainID(domain.Values)] += domain.Count
+	}
+	return counts
 }
 
 // Borrows returns the borrowing level of the assignment.

--- a/pkg/scheduler/flavorassigner/flavorassigner_test.go
+++ b/pkg/scheduler/flavorassigner/flavorassigner_test.go
@@ -4922,6 +4922,112 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 				}},
 			},
 		},
+		"accounts for a domain the recomputed assignment moved to, when the previous admission held a different domain": {
+			// A second pass replacing an unhealthy node moves the PodSet to a domain
+			// nothing has accounted for yet. That claim has to reach the net usage,
+			// otherwise the fits check never validates it and AddUsage never records it.
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU:    {Name: "tas"},
+						corev1.ResourceMemory: {Name: "tas"},
+					},
+					Count: 2,
+					TopologyAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Values: []string{"node-b"},
+							Count:  2,
+						}},
+					},
+				}},
+			},
+			wl: workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+							Request(corev1.ResourceCPU, "1").
+							Request(corev1.ResourceMemory, "1Gi").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			cq: &schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+					"tas": {},
+				},
+			},
+			prevAdmission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					TopologyAssignment: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 2).Obj()).
+						Obj(),
+				}},
+			},
+			want: workload.TASUsage{
+				"tas": []workload.TopologyDomainRequests{{
+					Values: []string{"node-b"},
+					SinglePodRequests: resources.NewRequestsFromResourceList(corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					}),
+					Count: 2,
+				}},
+			},
+		},
+		"counts only the additional pods when the recomputed assignment grew an already admitted domain": {
+			assignment: Assignment{
+				PodSets: []PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					Flavors: ResourceAssignment{
+						corev1.ResourceCPU: {Name: "tas"},
+					},
+					Count: 3,
+					TopologyAssignment: &tas.TopologyAssignment{
+						Levels: []string{corev1.LabelHostname},
+						Domains: []tas.TopologyDomainAssignment{{
+							Values: []string{"node-a"},
+							Count:  3,
+						}},
+					},
+				}},
+			},
+			wl: workload.NewInfo(&kueue.Workload{
+				Spec: kueue.WorkloadSpec{
+					PodSets: []kueue.PodSet{
+						*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 3).
+							Request(corev1.ResourceCPU, "1").
+							RequiredTopologyRequest(corev1.LabelHostname).
+							Obj(),
+					},
+				},
+			}),
+			cq: &schdcache.ClusterQueueSnapshot{
+				TASFlavors: map[kueue.ResourceFlavorReference]*schdcache.TASFlavorSnapshot{
+					"tas": {},
+				},
+			},
+			prevAdmission: &kueue.Admission{
+				PodSetAssignments: []kueue.PodSetAssignment{{
+					Name: kueue.DefaultPodSetName,
+					TopologyAssignment: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 1).Obj()).
+						Obj(),
+				}},
+			},
+			want: workload.TASUsage{
+				"tas": []workload.TopologyDomainRequests{{
+					Values: []string{"node-a"},
+					SinglePodRequests: resources.NewRequestsFromResourceList(corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					}),
+					Count: 2,
+				}},
+			},
+		},
 		"skips usage already present in previous admission": {
 			assignment: Assignment{
 				PodSets: []PodSetAssignment{{
@@ -4960,8 +5066,12 @@ func TestAssignment_ComputeTASNetUsage(t *testing.T) {
 			},
 			prevAdmission: &kueue.Admission{
 				PodSetAssignments: []kueue.PodSetAssignment{{
-					Name:               kueue.DefaultPodSetName,
-					TopologyAssignment: &kueue.TopologyAssignment{},
+					Name: kueue.DefaultPodSetName,
+					// Same domain and count as the new assignment, so the snapshot
+					// already accounts for all of it.
+					TopologyAssignment: utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+						Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 2).Obj()).
+						Obj(),
 				}},
 			},
 			want: workload.TASUsage{},

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -595,10 +595,13 @@ func TestScheduleForTAS(t *testing.T) {
 		},
 		"second pass replacement must not take a domain claimed by another workload in the same cycle": {
 			// "replaced" keeps its admission while its node is unhealthy, so the
-			// second pass looks for a replacement domain. "contender" is a pending
-			// workload admitted in the same cycle. The replacement must not land on
-			// the node contender just took, which would pin its pod to a full node
-			// for good.
+			// second pass looks for a replacement domain. It is processed ahead of
+			// the pending "contender", because the classical iterator sorts
+			// quota-reserved entries first so they can be considered for a second
+			// pass. The replacement takes x2, and contender then has to observe x2
+			// as claimed and land on x3 instead. Without recording the replacement's
+			// claim, contender is admitted onto the same node and its pod is pinned
+			// to a full node for good.
 			//
 			// Neither state of TASFailedNodeReplacementFailFast prevents this: the
 			// fail-fast eviction is guarded on mode != Fit, and a skipped fits check

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -593,6 +593,100 @@ func TestScheduleForTAS(t *testing.T) {
 				utiltesting.MakeEventRecord("default", "foo", "Admitted", corev1.EventTypeNormal).Obj(),
 			},
 		},
+		"second pass replacement must not take a domain claimed by another workload in the same cycle": {
+			// "replaced" keeps its admission while its node is unhealthy, so the
+			// second pass looks for a replacement domain. "contender" is a pending
+			// workload admitted in the same cycle. The replacement must not land on
+			// the node contender just took, which would pin its pod to a full node
+			// for good.
+			//
+			// Neither state of TASFailedNodeReplacementFailFast prevents this: the
+			// fail-fast eviction is guarded on mode != Fit, and a skipped fits check
+			// is what leaves the mode at Fit.
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x3").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x3").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("replaced", "default").
+					UnhealthyNodes("x1").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					ReserveQuotaAt(
+						utiltestingapi.MakeAdmission("tas-main").
+							PodSets(utiltestingapi.MakePodSetAssignment("one").
+								Assignment(corev1.ResourceCPU, "tas-default", "1").
+								TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+									Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+									Obj()).
+								Obj()).
+							Obj(), now,
+					).
+					AdmittedAt(true, now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("contender", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("one", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/replaced": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+				"default/contender": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("one").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x3"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "contender", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "contender", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+		},
 		"workload with unhealthyNode annotation; second pass; baseline scenario": {
 			nodes:           defaultNodes,
 			admissionChecks: []kueue.AdmissionCheck{defaultProvCheck},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Under TAS, two workloads could be admitted onto the same node in a single scheduling cycle when one of them was having a node replaced. A topology assignment becomes a hard `kubernetes.io/hostname` selector, so the workload that loses the node is not just deprioritized: its pod is pinned to a node that is already full, every other node is excluded by affinity, and it stays `Unschedulable` until the PodsReady timeout evicts it. For a gang workload that takes down the whole job.

`ComputeTASNetUsage` skips a PodSet whenever the workload already has an admission carrying a `TopologyAssignment`. That is correct while the assignment is unchanged, since the cache already contributes that usage to the snapshot, but the check never compares the admitted domains against the new ones. A second pass replacing an unhealthy node moves pods onto a different domain and the PodSet is still skipped, so the net TAS usage comes back empty.

Three things follow from the empty usage. `ClusterQueueSnapshot.Fits` iterates `usage.TAS`, so with nothing to iterate it returns `FitsCheckOk` and never checks whether the replacement domain has capacity. Because the result is not `FitsCheckNoTAS`, `updateAssignmentIfNeeded` does not recompute, which skips the mechanism built to resolve same-cycle domain conflicts. And `AddUsage` records nothing, so the claimed domain stays invisible to later entries in the same cycle.

This PR compares per domain and counts only the additional pods. An unchanged domain still contributes nothing, a domain the reassignment moved onto contributes in full, and a domain that grew contributes its increment.

#### Which issue(s) this PR fixes:

Fixes #14570

#### Special notes for your reviewer:

Reachable on default settings. `TASFailedNodeReplacementFailFast` defaults to false, which is what keeps the admission and the assignment in place during the second pass. Turning it on does not help either, because the fail-fast eviction is guarded on `mode != Fit` and the skipped fits check is what leaves the mode at `Fit`. The behaviour is the same on `release-0.18`, where this code is identical.

Releasing a domain the workload left behind is out of scope here. A `Usage` value is applied with a single add or subtract, so it cannot carry the subtraction, and the vacated domain stays counted until the next snapshot is built. That direction is conservative: a domain looks busier than it is, never emptier, so it cannot cause the double booking this fixes. The worst case is an avoidable requeue for another workload in the same cycle. Doing this properly means modelling a second pass as a release followed by a claim, which touches the three `AddUsage` call sites in `processEntry`, the removal set in `fits()`, and the behaviour when `admit()` fails after the release. Worth its own change rather than being folded in here.

Tests, all failing without the change and passing with it:

- `pkg/scheduler/scheduler_tas_test.go`, `second pass replacement must not take a domain claimed by another workload in the same cycle`. Three single-CPU nodes, one workload admitted on `x1` and carrying `UnhealthyNodes("x1")`, one pending workload in the same cycle. Without the fix both land on `x2` while `x3` sits free, in all five scenario variants, regardless of which is processed first.
- `pkg/scheduler/flavorassigner/flavorassigner_test.go`, two cases in `TestAssignment_ComputeTASNetUsage` covering a domain the reassignment moved onto and a domain that grew.

This PR was developed with AI assistance.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Fixed a bug where replacing an unhealthy node could assign a workload to a node already claimed by another workload in the same scheduling cycle, leaving its pod permanently Unschedulable until the PodsReady timeout evicted it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topology-aware scheduling when workloads are reassigned across domains.
  * Correctly accounts for only newly required capacity, including increased pod counts and changed domain placements.
  * Prevented node overcommitment and domain overlap during scheduling replacements.

* **Tests**
  * Added coverage for reassigned workloads, increased domain usage, and second-pass scheduling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->