### PR TITLE
TAS: reject prebuilt Workloads with mismatched topology requests

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1401,6 +1401,14 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 		if err != nil {
 			return nil
 		}
+		// FromAssignment injects this annotation for implicit TAS. Mirror it in
+		// the structured request used to compare against the running Job.
+		if psi.Annotations[kueue.PodSetUnconstrainedTopologyAnnotation] == "true" {
+			if ps.TopologyRequest == nil {
+				ps.TopologyRequest = &kueue.PodSetTopologyRequest{}
+			}
+			ps.TopologyRequest.Unconstrained = ptr.To(true)
+		}
 		if canBePartiallyAdmitted && ps.MinCount != nil {
 			// update the expected running count
 			ps.Count = psi.Count
@@ -1431,9 +1439,12 @@ func EquivalentToWorkload(ctx context.Context, c client.Client, job GenericJob, 
 	}
 	jobPodSets := clearMinCountsIfFeatureDisabled(getPodSets)
 
-	opts := make([]equality.ComparePodSetsOption, 0, 1)
+	opts := make([]equality.ComparePodSetsOption, 0, 2)
 	if workload.IsAdmitted(wl) {
 		opts = append(opts, equality.WithIgnoreTolerations())
+	}
+	if !features.Enabled(features.TopologyAwareScheduling) {
+		opts = append(opts, equality.WithIgnoreTopologyRequest())
 	}
 
 	if runningPodSets := expectedRunningPodSets(ctx, c, wl); runningPodSets != nil {

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -1407,7 +1407,7 @@ func expectedRunningPodSets(ctx context.Context, c client.Client, wl *kueue.Work
 			if ps.TopologyRequest == nil {
 				ps.TopologyRequest = &kueue.PodSetTopologyRequest{}
 			}
-			ps.TopologyRequest.Unconstrained = ptr.To(true)
+			ps.TopologyRequest.Unconstrained = new(true)
 		}
 		if canBePartiallyAdmitted && ps.MinCount != nil {
 			// update the expected running count

--- a/pkg/controller/jobframework/reconciler_internal_test.go
+++ b/pkg/controller/jobframework/reconciler_internal_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jobframework
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/featuregate"
+
+	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/features"
+	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
+	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
+)
+
+func TestExpectedRunningPodSetsKeepsImplicitTASRequestInSync(t *testing.T) {
+	features.SetFeatureGatesDuringTest(t, map[featuregate.Feature]bool{
+		features.TopologyAwareScheduling: true,
+	})
+
+	const podIndexLabel = "batch.kubernetes.io/job-completion-index"
+	assignment := utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+		Count(2).
+		TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+			Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 2).Obj()).
+			Obj()).
+		Obj()
+	wl := utiltestingapi.MakeWorkload("workload", "default").
+		PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+			PodIndexLabel(new(podIndexLabel)).
+			Obj()).
+		ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").PodSets(assignment).Obj(), time.Now()).
+		Obj()
+
+	got := expectedRunningPodSets(context.Background(), utiltesting.NewClientBuilder().Build(), wl)
+	if len(got) != 1 {
+		t.Fatalf("expected one running PodSet, got %d", len(got))
+	}
+	if got[0].TopologyRequest == nil || got[0].TopologyRequest.Unconstrained == nil || !*got[0].TopologyRequest.Unconstrained {
+		t.Fatalf("expected the injected unconstrained request, got %#v", got[0].TopologyRequest)
+	}
+	if got[0].TopologyRequest.PodIndexLabel == nil || *got[0].TopologyRequest.PodIndexLabel != podIndexLabel {
+		t.Errorf("expected pod index label %q to be retained, got %#v", podIndexLabel, got[0].TopologyRequest.PodIndexLabel)
+	}
+}

--- a/pkg/controller/jobframework/reconciler_internal_test.go
+++ b/pkg/controller/jobframework/reconciler_internal_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package jobframework
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -49,7 +48,7 @@ func TestExpectedRunningPodSetsKeepsImplicitTASRequestInSync(t *testing.T) {
 		ReserveQuotaAt(utiltestingapi.MakeAdmission("cluster-queue").PodSets(assignment).Obj(), time.Now()).
 		Obj()
 
-	got := expectedRunningPodSets(context.Background(), utiltesting.NewClientBuilder().Build(), wl)
+	got := expectedRunningPodSets(t.Context(), utiltesting.NewClientBuilder().Build(), wl)
 	if len(got) != 1 {
 		t.Fatalf("expected one running PodSet, got %d", len(got))
 	}

--- a/pkg/controller/jobframework/reconciler_internal_test.go
+++ b/pkg/controller/jobframework/reconciler_internal_test.go
@@ -20,10 +20,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/featuregate"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	"sigs.k8s.io/kueue/pkg/constants"
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltesting "sigs.k8s.io/kueue/pkg/util/testing"
 	utiltestingapi "sigs.k8s.io/kueue/pkg/util/testing/v1beta2"
@@ -49,13 +51,24 @@ func TestExpectedRunningPodSetsKeepsImplicitTASRequestInSync(t *testing.T) {
 		Obj()
 
 	got := expectedRunningPodSets(t.Context(), utiltesting.NewClientBuilder().Build(), wl)
-	if len(got) != 1 {
-		t.Fatalf("expected one running PodSet, got %d", len(got))
+	want := []kueue.PodSet{
+		*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 2).
+			Labels(map[string]string{
+				constants.ClusterQueueLabel: "cluster-queue",
+				constants.LocalQueueLabel:   "",
+				constants.PodSetLabel:       string(kueue.DefaultPodSetName),
+			}).
+			Annotations(map[string]string{
+				kueue.PodSetUnconstrainedTopologyAnnotation: "true",
+				kueue.WorkloadAnnotation:                    "workload",
+			}).
+			NodeSelector(map[string]string{}).
+			SchedulingGates(corev1.PodSchedulingGate{Name: kueue.TopologySchedulingGate}).
+			UnconstrainedTopologyRequest().
+			PodIndexLabel(new(podIndexLabel)).
+			Obj(),
 	}
-	if got[0].TopologyRequest == nil || got[0].TopologyRequest.Unconstrained == nil || !*got[0].TopologyRequest.Unconstrained {
-		t.Fatalf("expected the injected unconstrained request, got %#v", got[0].TopologyRequest)
-	}
-	if got[0].TopologyRequest.PodIndexLabel == nil || *got[0].TopologyRequest.PodIndexLabel != podIndexLabel {
-		t.Errorf("expected pod index label %q to be retained, got %#v", podIndexLabel, got[0].TopologyRequest.PodIndexLabel)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("running PodSets (-want,+got):\n%s", diff)
 	}
 }

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4260,6 +4260,73 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"prebuilt workload with a different topology request is out of sync": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling: true,
+
+				features.AssignQueueLabelsForPods: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				Suspend(false).
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, corev1.LabelHostname).
+				UID("test-uid").
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
+						Request(corev1.ResourceCPU, "1").
+						PriorityClass("test-pc").
+						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: corev1.LabelTopologyZone}).
+						RequiredTopologyRequest(corev1.LabelTopologyZone).
+						Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
+						Request(corev1.ResourceCPU, "1").
+						PriorityClass("test-pc").
+						Annotations(map[string]string{kueue.PodSetRequiredTopologyAnnotation: corev1.LabelTopologyZone}).
+						RequiredTopologyRequest(corev1.LabelTopologyZone).
+						Obj()).
+					Queue("test-queue").
+					WorkloadPriorityClassRef("test-wpc").
+					Priority(100).
+					Labels(map[string]string{
+						controllerconsts.JobUIDLabel: "test-uid",
+					}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
+					Condition(metav1.Condition{
+						Type:    kueue.WorkloadFinished,
+						Status:  metav1.ConditionTrue,
+						Reason:  "OutOfSync",
+						Message: "The prebuilt workload is out of sync with its user job",
+					}).
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Stopped",
+					Message:   "missing workload",
+				},
+			},
+			wantErr: jobframework.ErrPrebuiltWorkloadNotFound,
+		},
 		"when the prebuilt workload is owned by another object": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: false,

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4267,8 +4267,15 @@ func TestReconciler(t *testing.T) {
 			},
 			job: baseJobWrapper.
 				Clone().
+				Suspend(false).
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				UID("test-uid").
+				PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				PodAnnotation(kueue.WorkloadAnnotation, "prebuilt-workload").
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.LocalQueueLabel, localQueueName).
+				PodLabel(constants.ClusterQueueLabel, clusterQueueName).
+				SchedulingGate(kueue.TopologySchedulingGate).
 				Obj(),
 			wantJob: *baseJobWrapper.
 				Clone().
@@ -4321,14 +4328,6 @@ func TestReconciler(t *testing.T) {
 					Labels(map[string]string{controllerconsts.JobUIDLabel: "test-uid"}).
 					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
 					Obj(),
-			},
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
-					EventType: "Normal",
-					Reason:    "Started",
-					Message:   "Admitted by clusterQueue cq",
-				},
 			},
 		},
 		"prebuilt workload with a different topology request is out of sync": {

--- a/pkg/controller/jobs/job/job_controller_test.go
+++ b/pkg/controller/jobs/job/job_controller_test.go
@@ -4260,6 +4260,77 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"admitted prebuilt workload with implicit TAS remains in sync": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:  true,
+				features.AssignQueueLabelsForPods: true,
+			},
+			job: baseJobWrapper.
+				Clone().
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				Obj(),
+			wantJob: *baseJobWrapper.
+				Clone().
+				Suspend(false).
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				UID("test-uid").
+				PodAnnotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				PodAnnotation(kueue.WorkloadAnnotation, "prebuilt-workload").
+				PodLabel(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+				PodLabel(constants.LocalQueueLabel, localQueueName).
+				PodLabel(constants.ClusterQueueLabel, clusterQueueName).
+				SchedulingGate(kueue.TopologySchedulingGate).
+				Obj(),
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
+						Request(corev1.ResourceCPU, "1").
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						Obj()).
+					Queue(localQueueName).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Count(10).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 10).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 10).
+						Request(corev1.ResourceCPU, "1").
+						PodIndexLabel(new(batchv1.JobCompletionIndexAnnotation)).
+						Obj()).
+					Queue(localQueueName).
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Count(10).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 10).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Labels(map[string]string{controllerconsts.JobUIDLabel: "test-uid"}).
+					ControllerReference(batchv1.SchemeGroupVersion.WithKind("Job"), "job", "test-uid").
+					Obj(),
+			},
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "job", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Started",
+					Message:   "Admitted by clusterQueue cq",
+				},
+			},
+		},
 		"prebuilt workload with a different topology request is out of sync": {
 			featureGates: map[featuregate.Feature]bool{
 				features.TopologyAwareScheduling: true,

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -453,7 +453,12 @@ func TestReconciler(t *testing.T) {
 				ManagedByKueueLabel().
 				PrebuiltWorkloadLabel("prebuilt-workload").
 				KueueFinalizer().
-				KueueSchedulingGate().
+				TopologySchedulingGate().
+				Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+				Label(constants.LocalQueueLabel, localUserQueueName).
+				Label(constants.ClusterQueueLabel, clusterQueueName).
+				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				Annotation(kueue.WorkloadAnnotation, "prebuilt-workload").
 				Obj()},
 			wantPods: []corev1.Pod{*basePodWrapper.
 				Clone().
@@ -508,14 +513,6 @@ func TestReconciler(t *testing.T) {
 					Obj(),
 			},
 			workloadCmpOpts: defaultWorkloadCmpOpts,
-			wantEvents: []utiltesting.EventRecord{
-				{
-					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
-					EventType: "Normal",
-					Reason:    "Started",
-					Message:   "Admitted by clusterQueue cq",
-				},
-			},
 		},
 		"non-matching admitted workload is deleted and pod is finalized": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},

--- a/pkg/controller/jobs/pod/pod_controller_test.go
+++ b/pkg/controller/jobs/pod/pod_controller_test.go
@@ -443,6 +443,80 @@ func TestReconciler(t *testing.T) {
 				},
 			},
 		},
+		"single pod with admitted prebuilt workload and implicit TAS remains in sync": {
+			featureGates: map[featuregate.Feature]bool{
+				features.TopologyAwareScheduling:       true,
+				features.WorkloadIdentifierAnnotations: false,
+			},
+			pods: []corev1.Pod{*basePodWrapper.
+				Clone().
+				ManagedByKueueLabel().
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				KueueFinalizer().
+				KueueSchedulingGate().
+				Obj()},
+			wantPods: []corev1.Pod{*basePodWrapper.
+				Clone().
+				ManagedByKueueLabel().
+				PrebuiltWorkloadLabel("prebuilt-workload").
+				KueueFinalizer().
+				TopologySchedulingGate().
+				Label(constants.PodSetLabel, string(kueue.DefaultPodSetName)).
+				Label(constants.LocalQueueLabel, localUserQueueName).
+				Label(constants.ClusterQueueLabel, clusterQueueName).
+				Annotation(kueue.PodSetUnconstrainedTopologyAnnotation, "true").
+				Annotation(kueue.WorkloadAnnotation, "prebuilt-workload").
+				Obj()},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Queue(localUserQueueName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
+						Obj()).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 1).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("prebuilt-workload", "ns").
+					Finalizers(kueue.ResourceInUseFinalizerName).
+					Queue(localUserQueueName).
+					PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+						Request(corev1.ResourceCPU, "1").
+						SchedulingGates(corev1.PodSchedulingGate{Name: podconstants.SchedulingGateName}).
+						PodIndexLabel(new(kueue.PodGroupPodIndexLabel)).
+						Obj()).
+					ControllerReference(corev1.SchemeGroupVersion.WithKind("Pod"), "pod", "test-uid").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission(clusterQueueName).
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{corev1.LabelHostname}).
+								Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"node-a"}, 1).Obj()).
+								Obj()).
+							Obj()).
+						Obj(), now).
+					AdmittedAt(true, now).
+					Obj(),
+			},
+			workloadCmpOpts: defaultWorkloadCmpOpts,
+			wantEvents: []utiltesting.EventRecord{
+				{
+					Key:       types.NamespacedName{Name: "pod", Namespace: "ns"},
+					EventType: "Normal",
+					Reason:    "Started",
+					Message:   "Admitted by clusterQueue cq",
+				},
+			},
+		},
 		"non-matching admitted workload is deleted and pod is finalized": {
 			featureGates: map[featuregate.Feature]bool{features.WorkloadIdentifierAnnotations: false},
 			pods: []corev1.Pod{*basePodWrapper.

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -22,10 +22,12 @@ import (
 	"k8s.io/utils/ptr"
 
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
 type ComparePodSetsOptions struct {
-	ignoreTolerations bool
+	ignoreTolerations     bool
+	ignoreTopologyRequest bool
 }
 
 type ComparePodSetsOption func(*ComparePodSetsOptions)
@@ -36,13 +38,15 @@ func WithIgnoreTolerations() ComparePodSetsOption {
 	}
 }
 
+func WithIgnoreTopologyRequest() ComparePodSetsOption {
+	return func(options *ComparePodSetsOptions) {
+		options.ignoreTopologyRequest = true
+	}
+}
+
 // TODO: Revisit this, maybe we should extend the check to everything that could potentially impact
 // the workload scheduling (priority, nodeSelectors(when suspended), tolerations and maybe more)
-func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) bool {
-	opts := &ComparePodSetsOptions{}
-	for _, opt := range options {
-		opt(opts)
-	}
+func comparePodTemplate(a, b *corev1.PodSpec, opts *ComparePodSetsOptions) bool {
 	if !opts.ignoreTolerations && !equality.Semantic.DeepEqual(a.Tolerations, b.Tolerations) {
 		return false
 	}
@@ -52,30 +56,37 @@ func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) b
 	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
 }
 
-// hasTopologyConstraint excludes derived indexing fields, which can be present
-// for non-TAS Jobs and absent from older Workloads.
-func hasTopologyConstraint(r *kueue.PodSetTopologyRequest) bool {
-	return r != nil && (r.Required != nil ||
-		r.Preferred != nil ||
-		r.Unconstrained != nil ||
-		r.PodSetSliceRequiredTopology != nil ||
-		r.PodSetSliceSize != nil ||
-		len(r.PodsetSliceRequiredTopologyConstraints) != 0)
+func normalizedTopologyRequest(r *kueue.PodSetTopologyRequest) *kueue.PodSetTopologyRequest {
+	if r == nil {
+		return nil
+	}
+	result := r.DeepCopy()
+	if constraints := utiltas.PodSetSliceRequiredTopologyConstraints(result); len(constraints) > 0 {
+		result.PodsetSliceRequiredTopologyConstraints = constraints
+		result.PodSetSliceRequiredTopology = nil
+		result.PodSetSliceSize = nil
+	}
+	return result
 }
 
 func ComparePodSets(a, b *kueue.PodSet, options ...ComparePodSetsOption) bool {
+	opts := &ComparePodSetsOptions{}
+	for _, opt := range options {
+		opt(opts)
+	}
 	if a.Count != b.Count {
 		return false
 	}
 	if ptr.Deref(a.MinCount, -1) != ptr.Deref(b.MinCount, -1) {
 		return false
 	}
-	if (hasTopologyConstraint(a.TopologyRequest) || hasTopologyConstraint(b.TopologyRequest)) &&
-		!equality.Semantic.DeepEqual(a.TopologyRequest, b.TopologyRequest) {
+	if !opts.ignoreTopologyRequest &&
+		(utiltas.HasTopologyConstraint(a.TopologyRequest) || utiltas.HasTopologyConstraint(b.TopologyRequest)) &&
+		!equality.Semantic.DeepEqual(normalizedTopologyRequest(a.TopologyRequest), normalizedTopologyRequest(b.TopologyRequest)) {
 		return false
 	}
 
-	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec, options...)
+	return comparePodTemplate(&a.Template.Spec, &b.Template.Spec, opts)
 }
 
 func ComparePodSetSlices(a, b []kueue.PodSet, options ...ComparePodSetsOption) bool {

--- a/pkg/util/equality/podset.go
+++ b/pkg/util/equality/podset.go
@@ -52,11 +52,26 @@ func comparePodTemplate(a, b *corev1.PodSpec, options ...ComparePodSetsOption) b
 	return equality.Semantic.DeepEqual(a.Containers, b.Containers)
 }
 
+// hasTopologyConstraint excludes derived indexing fields, which can be present
+// for non-TAS Jobs and absent from older Workloads.
+func hasTopologyConstraint(r *kueue.PodSetTopologyRequest) bool {
+	return r != nil && (r.Required != nil ||
+		r.Preferred != nil ||
+		r.Unconstrained != nil ||
+		r.PodSetSliceRequiredTopology != nil ||
+		r.PodSetSliceSize != nil ||
+		len(r.PodsetSliceRequiredTopologyConstraints) != 0)
+}
+
 func ComparePodSets(a, b *kueue.PodSet, options ...ComparePodSetsOption) bool {
 	if a.Count != b.Count {
 		return false
 	}
 	if ptr.Deref(a.MinCount, -1) != ptr.Deref(b.MinCount, -1) {
+		return false
+	}
+	if (hasTopologyConstraint(a.TopologyRequest) || hasTopologyConstraint(b.TopologyRequest)) &&
+		!equality.Semantic.DeepEqual(a.TopologyRequest, b.TopologyRequest) {
 		return false
 	}
 

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -48,6 +48,42 @@ func TestComparePodSetSlices(t *testing.T) {
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).NodeSelector(map[string]string{"key": "val"}).Obj()},
 			wantEquivalent: true,
 		},
+		"same required topology": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			wantEquivalent: true,
+		},
+		"different required topology": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelTopologyZone).Obj()},
+			wantEquivalent: false,
+		},
+		"topology request present on one side": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).Obj()},
+			wantEquivalent: false,
+		},
+		"required and preferred topology": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).PreferredTopologyRequest(corev1.LabelHostname).Obj()},
+			wantEquivalent: false,
+		},
+		"derived pod index without topology constraint": {
+			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).PodIndexLabel(new("index")).Obj()},
+			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).Obj()},
+			wantEquivalent: true,
+		},
+		"different pod index under topology constraint": {
+			a: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).
+				RequiredTopologyRequest(corev1.LabelHostname).
+				PodIndexLabel(new("index-a")).
+				Obj()},
+			b: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).
+				RequiredTopologyRequest(corev1.LabelHostname).
+				PodIndexLabel(new("index-b")).
+				Obj()},
+			wantEquivalent: false,
+		},
 		"different requests": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "2").Obj()},

--- a/pkg/util/equality/podset_test.go
+++ b/pkg/util/equality/podset_test.go
@@ -28,10 +28,11 @@ import (
 
 func TestComparePodSetSlices(t *testing.T) {
 	cases := map[string]struct {
-		a                 []kueue.PodSet
-		b                 []kueue.PodSet
-		ignoreTolerations bool
-		wantEquivalent    bool
+		a                     []kueue.PodSet
+		b                     []kueue.PodSet
+		ignoreTolerations     bool
+		ignoreTopologyRequest bool
+		wantEquivalent        bool
 	}{
 		"different name": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Obj()},
@@ -58,6 +59,12 @@ func TestComparePodSetSlices(t *testing.T) {
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelTopologyZone).Obj()},
 			wantEquivalent: false,
 		},
+		"different required topology ignored": {
+			a:                     []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
+			b:                     []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelTopologyZone).Obj()},
+			ignoreTopologyRequest: true,
+			wantEquivalent:        true,
+		},
 		"topology request present on one side": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).RequiredTopologyRequest(corev1.LabelHostname).Obj()},
 			b:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).Obj()},
@@ -83,6 +90,19 @@ func TestComparePodSetSlices(t *testing.T) {
 				PodIndexLabel(new("index-b")).
 				Obj()},
 			wantEquivalent: false,
+		},
+		"legacy and unified slice topology constraints": {
+			a: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).
+				SliceRequiredTopologyRequest(corev1.LabelHostname).
+				SliceSizeTopologyRequest(2).
+				Obj()},
+			b: []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).
+				SliceRequiredTopologyConstraints(kueue.PodsetSliceRequiredTopologyConstraint{
+					Topology: corev1.LabelHostname,
+					Size:     2,
+				}).
+				Obj()},
+			wantEquivalent: true,
 		},
 		"different requests": {
 			a:              []kueue.PodSet{*utiltestingapi.MakePodSet("ps", 10).SetMinimumCount(5).Request("res", "1").Obj()},
@@ -178,6 +198,9 @@ func TestComparePodSetSlices(t *testing.T) {
 			options := make([]ComparePodSetsOption, 0, 1)
 			if tc.ignoreTolerations {
 				options = append(options, WithIgnoreTolerations())
+			}
+			if tc.ignoreTopologyRequest {
+				options = append(options, WithIgnoreTopologyRequest())
 			}
 			got := ComparePodSetSlices(tc.a, tc.b, options...)
 			if got != tc.wantEquivalent {

--- a/pkg/util/tas/tas.go
+++ b/pkg/util/tas/tas.go
@@ -81,6 +81,18 @@ func IsExplicitTAS(annots map[string]string) bool {
 	return false
 }
 
+// HasTopologyConstraint reports whether the request contains a field that
+// explicitly opts the PodSet into topology-aware scheduling. Derived indexing
+// fields alone don't constitute a topology constraint.
+func HasTopologyConstraint(tr *kueue.PodSetTopologyRequest) bool {
+	return tr != nil && (tr.Unconstrained != nil ||
+		tr.Required != nil ||
+		tr.Preferred != nil ||
+		tr.PodSetSliceRequiredTopology != nil ||
+		tr.PodSetSliceSize != nil ||
+		len(tr.PodsetSliceRequiredTopologyConstraints) > 0)
+}
+
 func NodeLabelsFromKeysAndValues(keys, values []string) map[string]string {
 	result := make(map[string]string, len(keys))
 	for i := range keys {

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -535,9 +535,7 @@ func (i *Info) IsUsingTAS() bool {
 func IsExplicitlyRequestingTAS(podSets ...kueue.PodSet) bool {
 	return slices.ContainsFunc(podSets,
 		func(ps kueue.PodSet) bool {
-			tr := ps.TopologyRequest
-			return tr != nil &&
-				(tr.Unconstrained != nil || tr.Required != nil || tr.Preferred != nil || tr.PodSetSliceRequiredTopology != nil || tr.PodSetSliceSize != nil || len(tr.PodsetSliceRequiredTopologyConstraints) > 0)
+			return tas.HasTopologyConstraint(ps.TopologyRequest)
 		})
 }
 

--- a/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
+++ b/test/integration/singlecluster/controller/jobs/job/job_controller_test.go
@@ -3817,6 +3817,54 @@ var _ = ginkgo.Describe("Job controller with TopologyAwareScheduling", ginkgo.Or
 		})
 	})
 
+	ginkgo.It("should finish a prebuilt workload whose topology request differs from the job as OutOfSync", func() {
+		container := corev1.Container{
+			Name:  "c",
+			Image: "pause",
+		}
+		testingjob.SetContainerDefaults(&container)
+		container.Resources = corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		}
+
+		job := testingjob.MakeJob("job", ns.Name).
+			Queue(kueue.LocalQueueName(localQueue.Name)).
+			PrebuiltWorkloadLabel("prebuilt-wl").
+			PodAnnotation(kueue.PodSetRequiredTopologyAnnotation, tasBlockLabel).
+			Containers(*container.DeepCopy()).
+			Obj()
+		ginkgo.By("creating a job which requires block and references a prebuilt workload", func() {
+			util.MustCreate(ctx, k8sClient, job)
+		})
+
+		wl := utiltestingapi.MakeWorkload("prebuilt-wl", ns.Name).
+			PodSets(*utiltestingapi.MakePodSet(kueue.DefaultPodSetName, 1).
+				Containers(*container.DeepCopy()).
+				PreferredTopologyRequest(tasBlockLabel).
+				Obj()).
+			Obj()
+		ginkgo.By("creating a matching prebuilt workload which only prefers block", func() {
+			util.MustCreate(ctx, k8sClient, wl)
+		})
+
+		ginkgo.By("verify the workload is finished as OutOfSync", func() {
+			gomega.Eventually(func(g gomega.Gomega) {
+				createdWl := kueue.Workload{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), &createdWl)).To(gomega.Succeed())
+				g.Expect(createdWl.Status.Conditions).To(
+					utiltesting.HaveConditionStatusTrueAndReason(kueue.WorkloadFinished, kueue.WorkloadFinishedReasonOutOfSync))
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+		})
+
+		ginkgo.By("verify the job stays suspended", func() {
+			gomega.Consistently(func(g gomega.Gomega) {
+				createdJob := batchv1.Job{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(job), &createdJob)).To(gomega.Succeed())
+				g.Expect(ptr.Deref(createdJob.Spec.Suspend, false)).To(gomega.BeTrue())
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+		})
+	})
+
 	ginkgo.It("should admit workload with topology unconstrained annotation which fits", func() {
 		job := testingjob.MakeJob("job", ns.Name).
 			Queue(kueue.LocalQueueName(localQueue.Name)).


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/area tas

#### What this PR does / why we need it:

Prebuilt Workload equivalence compared PodSet counts and selected PodSpec fields but ignored `PodSet.TopologyRequest`. A Job requiring all Pods in one hostname domain could therefore adopt a Workload requiring only one zone domain. In the unsuspended-Job path, stopping the Job could then restore the Workload's zone annotation over the Job's hostname annotation.

This PR compares the complete `TopologyRequest` whenever either PodSet contains an explicit TAS placement constraint. Requests containing only derived indexing fields remain compatible with `nil`, preserving existing non-TAS Workloads that predate those derived fields. Legacy and unified slice topology constraints are normalized before comparison.

For admitted implicit-TAS Workloads, Kueue injects the unconstrained-topology annotation into the running Job. The expected running PodSet now mirrors that derived state so the Job is not incorrectly marked out of sync. Topology requests are ignored when the TAS feature gate is disabled, matching how Job PodSets are constructed in that mode.

The Job reconciler regression verifies that a hostname Job does not adopt a zone Workload, keeps its original annotation, and finishes the incompatible Workload as `OutOfSync`. Additional unit coverage verifies implicit-TAS derived state and compatibility between legacy and unified slice constraints.

#### Which issue(s) this PR fixes:

Fixes #14583

#### Special notes for your reviewer:

An unconditional deep comparison was tested first, but it rejected existing non-TAS Workloads when a Job integration derived only `PodIndexLabel`. The explicit-constraint guard follows the same distinction as `workload.IsExplicitlyRequestingTAS`; once either side requests TAS placement, all request fields, including indexing and grouping information, are compared.

Validation:

```text
go test ./pkg/util/equality ./pkg/util/tas ./pkg/workload ./pkg/controller/jobframework ./pkg/controller/jobs/job ./pkg/controller/jobs/pod -count=1
go vet ./pkg/util/equality ./pkg/util/tas ./pkg/workload ./pkg/controller/jobframework ./pkg/controller/jobs/job ./pkg/controller/jobs/pod
git diff --check
```

This PR was developed with AI assistance. I reviewed the change and ran the tests above against current main.

#### Does this PR introduce a user-facing change?

```release-note
TAS: Prebuilt Workloads whose topology request differs from their Job or single Pod are now rejected as out of sync instead of being adopted. For TAS Indexed Jobs, the prebuilt Workload's `podIndexLabel` must also match the Job-derived value. Pod groups are unaffected.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prebuilt Jobs and Pods using implicit topology-aware scheduling now reconcile correctly.
  * Workload and Job state, labels, annotations, topology requests, and scheduling gates remain synchronized.
  * Topology comparisons now accurately handle implicit, required, preferred, legacy, and unified settings.
  * Mismatched topology requirements are detected and reported as out of sync.
  * Topology differences are ignored when topology-aware scheduling is disabled.

* **Tests**
  * Added coverage for admitted prebuilt workloads, topology assignments, topology mismatches, and pod-index behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
