### PR TITLE
docs: keep importer flag list in alphabetical order

### DIFF
--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -80,17 +80,17 @@ Usage:
   importer import [flags]
 
 Flags:
-      --add-labels stringToString     additional label=value pairs to be added to the imported pods and created workloads (default [])
-      --exclude-resource-prefixes strings  resource name prefixes ignored by Kueue during workload quota accounting
-      --burst int                     client Burst, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit (default 50)
-  -c, --concurrent-workers uint       number of concurrent import workers (default 8)
-      --dry-run                       don't import, check the config only (default true)
-  -h, --help                          help for import
-  -n, --namespace strings             target namespaces (at least one should be provided)
-      --qps float32                   client QPS, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit (default 50)
-      --queuelabel string             label used to identify the target local queue
-      --queuemapping stringToString   mapping from "queuelabel" label values to local queue names (default [])
-      --queuemapping-file string      yaml file containing extra mappings from "queuelabel" label values to local queue names
+      --add-labels stringToString           additional label=value pairs to be added to the imported pods and created workloads (default [])
+      --burst int                           client Burst, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit (default 50)
+  -c, --concurrent-workers uint             number of concurrent import workers (default 8)
+      --dry-run                             don't import, check the config only (default true)
+      --exclude-resource-prefixes strings   resource name prefixes ignored by Kueue during workload quota accounting
+  -h, --help                                help for import
+  -n, --namespace strings                   target namespaces (at least one should be provided)
+      --qps float32                         client QPS, as described in https://kubernetes.io/docs/reference/config-api/apiserver-eventratelimit.v1alpha1/#eventratelimit-admission-k8s-io-v1alpha1-Limit (default 50)
+      --queuelabel string                   label used to identify the target local queue
+      --queuemapping stringToString         mapping from "queuelabel" label values to local queue names (default [])
+      --queuemapping-file string            yaml file containing extra mappings from "queuelabel" label values to local queue names
 
 Global Flags:
   -v, --verbose count   verbosity (specify multiple times to increase the log level)


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Update `cmd/importer/README.md` so that the documented `importer import` flags follow the alphabetical order emitted by the command help output.

The `--exclude-resource-prefixes` entry is moved from before `--burst` to its alphabetically correct position (after `--dry-run` and before `-h, --help`).

#### Which issue(s) this PR fixes:

Fixes #14587

#### Special notes for your reviewer:

AI assistance was used to generate this pull request.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the sample importer flag output formatting and ordering in the README.
  * Flag descriptions and available options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->