### PR TITLE
test: add integration tests verifying no eviction on capacity shrink

### DIFF
--- a/test/integration/singlecluster/scheduler/scheduler_test.go
+++ b/test/integration/singlecluster/scheduler/scheduler_test.go
@@ -1844,6 +1844,78 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 1)
 		})
 
+		ginkgo.It("Should not evict admitted workloads after reparenting child cohort to a smaller root", func() {
+			//    root-a (2 CPU)     root-b (1 CPU)
+			//        |
+			//      child (no quota)
+			//        |
+			//       cq (0 CPU)
+			rootA := utiltestingapi.MakeCohort("root-a").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2").Obj(),
+				).Obj()
+			rootB := utiltestingapi.MakeCohort("root-b").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "1").Obj(),
+				).Obj()
+			childCohort := utiltestingapi.MakeCohort("child").Parent("root-a").Obj()
+			util.MustCreate(ctx, k8sClient, rootA)
+			util.MustCreate(ctx, k8sClient, rootB)
+			util.MustCreate(ctx, k8sClient, childCohort)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, rootA, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, rootB, true)
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, childCohort, true)
+			})
+
+			cq = utiltestingapi.MakeClusterQueue("cq").
+				Cohort("child").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			util.MustCreate(ctx, k8sClient, queue)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+
+			ginkgo.By("submitting three workloads that fit under root-a's 2 CPU capacity")
+			wl1 := utiltestingapi.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl2 := utiltestingapi.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl3 := utiltestingapi.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.MustCreate(ctx, k8sClient, wl3)
+
+			ginkgo.By("verifying all three workloads are admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl1, wl2, wl3)
+
+			ginkgo.By("reparenting child cohort from root-a to root-b")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(childCohort), childCohort)).Should(gomega.Succeed())
+				childCohort.Spec.ParentName = "root-b"
+				g.Expect(k8sClient.Update(ctx, childCohort)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying admitted workloads are NOT evicted after capacity shrink")
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, wl := range []*kueue.Workload{wl1, wl2, wl3} {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeFalse())
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying new workload stays pending under reduced root-b capacity")
+			wlNew := utiltestingapi.MakeWorkload("wl-new", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wlNew)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlNew)
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
+		})
+
 		ginkgo.It("Should admit overflow workload after reparenting child cohort to a larger root", func() {
 			//    root-a (1 CPU)     root-b (2 CPU)
 			//        |
@@ -1913,6 +1985,80 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl1, wl2)
 			util.ExpectPendingWorkloadsMetric(cq, 0, 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(cq, "", 3)
+		})
+
+		ginkgo.It("Should not evict admitted workloads after reducing ancestor cohort quota below usage", func() {
+			//    root (2 CPU → 1 CPU)
+			//         |
+			//       child (no quota)
+			//         |
+			//        cq (0 CPU nominal)
+			//
+			// 3 × 500m workloads admitted (1.5 CPU borrowed from root).
+			// Reducing root to 1 CPU places quota below usage.
+			// Admitted workloads must not be evicted; new workload stays pending.
+			root := utiltestingapi.MakeCohort("").GeneratedName("root-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, root)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			})
+
+			childCohort := utiltestingapi.MakeCohort("").GeneratedName("child-").
+				Parent(kueue.CohortReference(root.GetName())).Obj()
+			util.MustCreate(ctx, k8sClient, childCohort)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, childCohort, true)
+			})
+
+			cq = utiltestingapi.MakeClusterQueue("cq").
+				Cohort(kueue.CohortReference(childCohort.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(cq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, cq)
+			util.MustCreate(ctx, k8sClient, queue)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, cq)
+
+			ginkgo.By("submitting three workloads that fit under root's 2 CPU capacity")
+			wl1 := utiltestingapi.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl2 := utiltestingapi.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl3 := utiltestingapi.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.MustCreate(ctx, k8sClient, wl3)
+
+			ginkgo.By("verifying all three workloads are admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, cq.Name, wl1, wl2, wl3)
+
+			ginkgo.By("reducing root cohort nominal quota to 1 CPU (below 1.5 CPU in use)")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(root), root)).Should(gomega.Succeed())
+				root.Spec.ResourceGroups[0].Flavors[0].Resources[0].NominalQuota = resource.MustParse("1")
+				g.Expect(k8sClient.Update(ctx, root)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying admitted workloads are NOT evicted after quota reduction")
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, wl := range []*kueue.Workload{wl1, wl2, wl3} {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeFalse())
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying new workload stays pending under reduced root capacity")
+			wlNew := utiltestingapi.MakeWorkload("wl-new", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wlNew)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlNew)
+			util.ExpectPendingWorkloadsMetric(cq, 0, 1)
 		})
 	})
 
@@ -2027,6 +2173,161 @@ var _ = ginkgo.Describe("Scheduler", func() {
 			util.ExpectAdmittedWorkloadsTotalMetric(prodCQ, "", 2)
 			util.ExpectQuotaReservedWorkloadsTotalMetric(devCQ, "", 0)
 			util.ExpectAdmittedWorkloadsTotalMetric(devCQ, "", 0)
+		})
+	})
+
+	ginkgo.When("Admitted workloads are not evicted when effective cohort capacity shrinks", func() {
+		var borrowerCq *kueue.ClusterQueue
+
+		ginkgo.AfterEach(func() {
+			util.ExpectObjectToBeDeleted(ctx, k8sClient, borrowerCq, true)
+		})
+
+		ginkgo.It("Should not evict borrowed workloads when lender cohort tightens lendingLimit", func() {
+			//    root (0 CPU)
+			//    ├── lender (2 CPU, lendingLimit=2)
+			//    └── borrower (0 CPU)
+			//           └── borrower-cq (0 CPU nominal)
+			//
+			// 3 × 500m workloads admitted by borrowing from lender.
+			// Tightening lender's lendingLimit from 2 CPU → 0 must not evict
+			// already-admitted workloads; new workload stays pending.
+			root := utiltestingapi.MakeCohort("").GeneratedName("root-").Obj()
+			util.MustCreate(ctx, k8sClient, root)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			})
+
+			lender := utiltestingapi.MakeCohort("").GeneratedName("lender-").
+				Parent(kueue.CohortReference(root.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2", "", "2").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, lender)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, lender, true)
+			})
+
+			borrowerCohort := utiltestingapi.MakeCohort("").GeneratedName("borrower-").
+				Parent(kueue.CohortReference(root.GetName())).Obj()
+			util.MustCreate(ctx, k8sClient, borrowerCohort)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, borrowerCohort, true)
+			})
+
+			borrowerCq = utiltestingapi.MakeClusterQueue("borrower-cq").
+				Cohort(kueue.CohortReference(borrowerCohort.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, borrowerCq)
+
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(borrowerCq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, borrowerCq)
+
+			ginkgo.By("submitting three workloads that borrow from lender cohort")
+			wl1 := utiltestingapi.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl2 := utiltestingapi.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl3 := utiltestingapi.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.MustCreate(ctx, k8sClient, wl3)
+
+			ginkgo.By("verifying all three workloads are admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, borrowerCq.Name, wl1, wl2, wl3)
+
+			ginkgo.By("tightening lender cohort's lendingLimit from 2 CPU to 0")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(lender), lender)).Should(gomega.Succeed())
+				lender.Spec.ResourceGroups[0].Flavors[0].Resources[0].LendingLimit = new(resource.MustParse("0"))
+				g.Expect(k8sClient.Update(ctx, lender)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying admitted workloads are NOT evicted after lendingLimit tighten")
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, wl := range []*kueue.Workload{wl1, wl2, wl3} {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeFalse())
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying new workload stays pending after lendingLimit tighten")
+			wlNew := utiltestingapi.MakeWorkload("wl-new", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wlNew)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlNew)
+			util.ExpectPendingWorkloadsMetric(borrowerCq, 0, 1)
+		})
+
+		ginkgo.It("Should not evict borrowed workloads when borrower CQ sets borrowingLimit to zero", func() {
+			//    root (2 CPU)
+			//        |
+			//    borrower-cq (0 CPU nominal, no borrowingLimit → borrows freely)
+			//
+			// 3 × 500m workloads admitted via borrowing from root.
+			// Setting borrowingLimit=0 on borrower-cq must not evict already-admitted
+			// workloads; new workload stays pending.
+			root := utiltestingapi.MakeCohort("").GeneratedName("root-").
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "2").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, root)
+			ginkgo.DeferCleanup(func() {
+				util.ExpectObjectToBeDeleted(ctx, k8sClient, root, true)
+			})
+
+			borrowerCq = utiltestingapi.MakeClusterQueue("borrower-cq").
+				Cohort(kueue.CohortReference(root.GetName())).
+				ResourceGroup(
+					*utiltestingapi.MakeFlavorQuotas("on-demand").Resource(corev1.ResourceCPU, "0").Obj(),
+				).Obj()
+			util.MustCreate(ctx, k8sClient, borrowerCq)
+
+			queue := utiltestingapi.MakeLocalQueue("queue", ns.Name).ClusterQueue(borrowerCq.Name).Obj()
+			util.MustCreate(ctx, k8sClient, queue)
+			util.ExpectClusterQueuesToBeActive(ctx, k8sClient, borrowerCq)
+
+			ginkgo.By("submitting three workloads that borrow from root cohort")
+			wl1 := utiltestingapi.MakeWorkload("wl-1", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl2 := utiltestingapi.MakeWorkload("wl-2", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			wl3 := utiltestingapi.MakeWorkload("wl-3", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wl1)
+			util.MustCreate(ctx, k8sClient, wl2)
+			util.MustCreate(ctx, k8sClient, wl3)
+
+			ginkgo.By("verifying all three workloads are admitted")
+			util.ExpectWorkloadsToHaveQuotaReservation(ctx, k8sClient, borrowerCq.Name, wl1, wl2, wl3)
+
+			ginkgo.By("setting borrowingLimit to zero on borrower CQ")
+			gomega.Eventually(func(g gomega.Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(borrowerCq), borrowerCq)).Should(gomega.Succeed())
+				borrowerCq.Spec.ResourceGroups[0].Flavors[0].Resources[0].BorrowingLimit = new(resource.MustParse("0"))
+				g.Expect(k8sClient.Update(ctx, borrowerCq)).Should(gomega.Succeed())
+			}, util.Timeout, util.Interval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying admitted workloads are NOT evicted after borrowingLimit set to zero")
+			gomega.Consistently(func(g gomega.Gomega) {
+				for _, wl := range []*kueue.Workload{wl1, wl2, wl3} {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(wl), wl)).Should(gomega.Succeed())
+					g.Expect(wl.Status.Admission).ShouldNot(gomega.BeNil())
+					g.Expect(meta.IsStatusConditionTrue(wl.Status.Conditions, kueue.WorkloadEvicted)).To(gomega.BeFalse())
+				}
+			}, util.ConsistentDuration, util.ShortInterval).Should(gomega.Succeed())
+
+			ginkgo.By("verifying new workload stays pending after borrowingLimit set to zero")
+			wlNew := utiltestingapi.MakeWorkload("wl-new", ns.Name).Queue(kueue.LocalQueueName(queue.Name)).
+				Request(corev1.ResourceCPU, "500m").Obj()
+			util.MustCreate(ctx, k8sClient, wlNew)
+			util.ExpectWorkloadsToBePending(ctx, k8sClient, wlNew)
+			util.ExpectPendingWorkloadsMetric(borrowerCq, 0, 1)
 		})
 	})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/area testing

<!--
Add one of the following kinds:
/kind bug
/area testing

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

Please also consider setting the area:
/area tas
/area was
/area integrations
/area multikueue
/area dashboard
/area localization
/area testing
/area website
-->

#### What this PR does / why we need it:

 Adds scheduler integration tests verifying that already-admitted workloads
  are not evicted when effective cohort capacity shrinks. Four scenarios are
  covered, each triggering a different path to reduced schedulable capacity:

  - reparenting a child Cohort to a smaller root
  - reducing an ancestor Cohort's nominal quota below current usage
  - tightening lendingLimit on a lender Cohort while a sibling subtree holds borrowed workloads
  - setting borrowingLimit=0 on a ClusterQueue that is actively borrowing

  The tests live alongside the existing hierarchical cohort scheduling tests
  in `test/integration/singlecluster/scheduler/scheduler_test.go`. 
  They run as part of the existing integration CI target without configuration changes.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #13716 

#### Special notes for your reviewer:

-   All 4 new specs pass with `--procs=4` (matching CI config).
-   Stable across repeated runs (`--repeat=4`, 5 total runs × 4 specs = 20 spec executions, all passed).
-   No regressions in existing 114 specs in `scheduler_test.go` (118 total | 0 Failed in full scheduler suite).


#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
