### PR TITLE
Optimize classical preemption candidate pool collection

### DIFF
--- a/pkg/cache/scheduler/cohort_snapshot.go
+++ b/pkg/cache/scheduler/cohort_snapshot.go
@@ -90,3 +90,9 @@ func (c *CohortSnapshot) fairWeight() float64 {
 func (c *CohortSnapshot) BorrowingWith(fr resources.FlavorResource, val resources.Amount) bool {
 	return c.ResourceNode.SubtreeQuota[fr].Cmp(c.ResourceNode.Usage[fr].Add(val)) < 0
 }
+
+// Available returns the capacity of the Cohort available for its members to
+// borrow, accounting for usage and BorrowingLimits up the cohort hierarchy.
+func (c *CohortSnapshot) Available(fr resources.FlavorResource) resources.Amount {
+	return resources.MaxAmount(resources.NewAmount(0), available(c, fr))
+}

--- a/pkg/scheduler/preemption/classical/candidate_generator.go
+++ b/pkg/scheduler/preemption/classical/candidate_generator.go
@@ -88,12 +88,14 @@ const (
 // or above nominal for any flavor-resource needing preemption.
 //
 // The band is collapsed conjunctively: it is exceedsBorrowing only when EVERY
-// flavor-resource needing preemption exceeds its borrowing limit. Cross-queue
-// preemption frees cohort quota, which cannot raise the queue's own borrowing
-// cap, so only then are hierarchy/priority candidates provably useless for all
-// resources driving preemption. A single over-limit resource must not poison
-// the classification — another resource may still be freed by reclaiming from
-// other queues.
+// flavor-resource needing preemption exceeds its borrowing limit AND the cohort's
+// free quota already covers request - usage (the amount that must come from the
+// cohort once the queue reclaims its own usage). Cross-queue preemption can only
+// help by freeing cohort quota (a queue's own borrowing cap cannot be raised), so
+// it is provably useless only when both conditions hold for all resources driving
+// preemption. A single over-limit resource, or a cohort whose free quota is held
+// by borrowing siblings, must not poison the classification — preempting other
+// queues may still be required to make the workload fit.
 func classifyQuotaBand(
 	cq *schdcache.ClusterQueueSnapshot,
 	requests resources.FlavorResourceQuantities,
@@ -118,7 +120,15 @@ func classifyQuotaBand(
 			upper = upper.Add(*quota.BorrowingLimit)
 		}
 		switch {
-		case hasBorrowingLimit && after.Cmp(upper) > 0:
+		// needed = request - usage is the amount the cohort must supply from its
+		// free capacity: same-queue preemption returns only local quota, so the
+		// rest must come from the cohort. Using after - nominal instead understates
+		// this by the queue's unused nominal (nominal - usage) and over-prunes when
+		// a borrowing sibling holds that slack — cross-queue reclaim is then still
+		// required. Verified: with q nominal=4/limit=4 usage=1 request=8, same-queue
+		// preemption alone suffices only once cohort free >= 7 (= request - usage),
+		// not >= 5 (= after - nominal).
+		case hasBorrowingLimit && after.Cmp(upper) > 0 && cohortCanSupplyBorrowing(cq, fr, requests[fr].Sub(usage)):
 			band = min(band, exceedsBorrowing)
 		case after.Cmp(nominal) > 0:
 			band = min(band, withinBorrowing)
@@ -134,6 +144,21 @@ func classifyQuotaBand(
 		}
 	}
 	return band, usageAtOrAboveNominal
+}
+
+// cohortCanSupplyBorrowing reports whether the cohort's currently free quota
+// already covers needed. Callers pass needed = request - usage: reclaiming the
+// queue's own workloads returns only local quota (it cannot raise the queue's
+// borrowing cap), so request - usage is the amount that must instead come from
+// the cohort's free capacity. When the cohort already has that much free,
+// cross-queue preemption cannot help and is skipped; otherwise other queues may
+// still need to be preempted to release cohort quota, so they must be kept.
+func cohortCanSupplyBorrowing(cq *schdcache.ClusterQueueSnapshot, fr resources.FlavorResource, needed resources.Amount) bool {
+	if !cq.HasParent() {
+		// Without a cohort there are no cross-queue candidates to skip.
+		return true
+	}
+	return cq.Parent().Available(fr).Cmp(needed) >= 0
 }
 
 // NewCandidateIterator creates a new iterator that yields candidate workloads for preemption
@@ -181,12 +206,22 @@ func NewCandidateIterator(
 	var noCandidateFromOtherQueues bool
 	switch band {
 	// exceedsBorrowing: every resource needing preemption exceeds the borrowing
-	// limit, so preempting workloads in other queues would not free up any
-	// space usable by this queue — freed cohort quota cannot raise the queue's
-	// own borrowing cap. Only same-queue candidates are worth considering.
-	// The hierarchy/priority collection (the O(N) cohort scan) is skipped
-	// entirely — that is the short-circuit optimization, so
-	// collect_hierarchy_priority is not emitted.
+	// limit and the cohort can already supply all the borrowing the queue would
+	// need, so preempting workloads in other queues cannot free up anything
+	// usable by this queue. Only same-queue candidates are worth considering —
+	// we don't collect candidates from other ClusterQueues in the cohort, which
+	// avoids the O(N) cohort scan on this path.
+	//
+	// By design this path can only ever preempt within the queue:
+	// sameQueueCandidates is built by collectSameQueueCandidates, which scans
+	// exactly ctx.Cq's own workloads. The hierarchy/priority pools — the only
+	// source of other-queue candidates — are not collected here at all. That is
+	// safe because a case that genuinely needs a cross-queue victim implies the
+	// cohort cannot supply request-usage on its own, which makes
+	// cohortCanSupplyBorrowing return false and routes the band to
+	// withinBorrowing (where the cross-queue pools ARE collected) rather than
+	// here. So the two conditions are mutually exclusive: if we reach this
+	// branch, no other-queue preemption was ever required.
 	case exceedsBorrowing:
 		sortByOrdering(sameQueueCandidates)
 		allCandidates = sameQueueCandidates

--- a/pkg/scheduler/preemption/classical/candidate_generator.go
+++ b/pkg/scheduler/preemption/classical/candidate_generator.go
@@ -70,6 +70,53 @@ func splitEvicted(workloads []*candidateElem) ([]*candidateElem, []*candidateEle
 	return workloads[:firstFalse], workloads[firstFalse:]
 }
 
+// quotaBand classifies where the cluster queue's usage lands after admitting the
+// incoming workload, relative to its nominal quota and borrowing limit.
+type quotaBand int
+
+const (
+	// usage + request <= nominal: fits within the guaranteed (nominal) quota.
+	withinNominal quotaBand = iota
+	// nominal < usage + request <= borrowingLimit: needs to borrow within the cohort.
+	withinBorrowing
+	// usage + request > borrowingLimit: exceeds the borrowing limit.
+	exceedsBorrowing
+)
+
+// classifyQuotaBand computes the quotaBand for the preemptor cluster queue after
+// admitting the incoming workload, and reports whether the queue is already
+// borrowing (usage above nominal) for any of the requested resources.
+func classifyQuotaBand(cq *schdcache.ClusterQueueSnapshot, requests resources.FlavorResourceQuantities) (quotaBand, bool) {
+	var band quotaBand
+	var usageBorrowing bool
+	for fr, val := range requests {
+		usage := cq.ResourceNode.Usage[fr]
+		after := usage.Add(val)
+		quota := cq.QuotaFor(fr)
+		nominal := quota.Nominal
+
+		// A nil BorrowingLimit means borrowing is unlimited, so usage can never
+		// exceed the borrowing limit and only nominal is a meaningful boundary.
+		hasBorrowingLimit := quota.BorrowingLimit != nil
+		upper := nominal
+		if hasBorrowingLimit {
+			upper = upper.Add(*quota.BorrowingLimit)
+		}
+		switch {
+		case hasBorrowingLimit && after.Cmp(upper) > 0:
+			band = max(band, exceedsBorrowing)
+		case after.Cmp(nominal) > 0:
+			band = max(band, withinBorrowing)
+		default: // after <= nominal
+			band = max(band, withinNominal)
+		}
+		if !usageBorrowing && usage.Cmp(nominal) > 0 {
+			usageBorrowing = true
+		}
+	}
+	return band, usageBorrowing
+}
+
 // NewCandidateIterator creates a new iterator that yields candidate workloads for preemption
 // The iterator can be used to perform two independent runs over the list of candidates:
 // with and without borrowing. The runs are independent which means that the same candidates
@@ -83,34 +130,75 @@ func NewCandidateIterator(
 	clock clock.Clock,
 	ordering func(logr.Logger, bool, *workload.Info, *workload.Info, kueue.ClusterQueueReference, time.Time) int,
 ) *candidateIterator {
-	sameQueueCandidates := collectSameQueueCandidates(hierarchicalReclaimCtx)
-	hierarchyCandidates, priorityCandidates := collectCandidatesForHierarchicalReclaim(hierarchicalReclaimCtx)
-	slices.SortFunc(sameQueueCandidates, func(a, b *candidateElem) int {
-		return ordering(hierarchicalReclaimCtx.Log, enabledAfs, a.wl, b.wl, hierarchicalReclaimCtx.Cq.Name, clock.Now())
-	})
-	slices.SortFunc(priorityCandidates, func(a, b *candidateElem) int {
-		return ordering(hierarchicalReclaimCtx.Log, enabledAfs, a.wl, b.wl, hierarchicalReclaimCtx.Cq.Name, clock.Now())
-	})
-	slices.SortFunc(hierarchyCandidates, func(a, b *candidateElem) int {
-		return ordering(hierarchicalReclaimCtx.Log, enabledAfs, a.wl, b.wl, hierarchicalReclaimCtx.Cq.Name, clock.Now())
-	})
+	cq := hierarchicalReclaimCtx.Cq
+	band, usageBorrowing := classifyQuotaBand(cq, hierarchicalReclaimCtx.Requests)
 
-	evictedHierarchicalReclaimCandidates, nonEvictedHierarchicalReclaimCandidates := splitEvicted(hierarchyCandidates)
-	evictedSTCandidates, nonEvictedSTCandidates := splitEvicted(priorityCandidates)
-	evictedSameQueueCandidates, nonEvictedSameQueueCandidates := splitEvicted(sameQueueCandidates)
-	allCandidates := make([]*candidateElem, 0, len(hierarchyCandidates)+len(priorityCandidates)+len(sameQueueCandidates))
-	allCandidates = append(allCandidates, evictedHierarchicalReclaimCandidates...)
-	allCandidates = append(allCandidates, evictedSTCandidates...)
-	allCandidates = append(allCandidates, evictedSameQueueCandidates...)
-	allCandidates = append(allCandidates, nonEvictedHierarchicalReclaimCandidates...)
-	allCandidates = append(allCandidates, nonEvictedSTCandidates...)
-	allCandidates = append(allCandidates, nonEvictedSameQueueCandidates...)
+	sameQueueCandidates := collectSameQueueCandidates(hierarchicalReclaimCtx)
+	var hierarchyCandidates, priorityCandidates []*candidateElem
+
+	sortByOrdering := func(candidates []*candidateElem) {
+		slices.SortFunc(candidates, func(a, b *candidateElem) int {
+			return ordering(hierarchicalReclaimCtx.Log, enabledAfs, a.wl, b.wl, hierarchicalReclaimCtx.Cq.Name, clock.Now())
+		})
+	}
+	// buildOrderedCandidates concatenates the candidate lists so that already
+	// evicted workloads come first (they are the cheapest to preempt), keeping the
+	// hierarchical-reclaim -> priority -> same-queue precedence within each group.
+	buildOrderedCandidates := func(hierarchy, priority, sameQueue []*candidateElem) []*candidateElem {
+		evictedHierarchy, nonEvictedHierarchy := splitEvicted(hierarchy)
+		evictedPriority, nonEvictedPriority := splitEvicted(priority)
+		evictedSameQueue, nonEvictedSameQueue := splitEvicted(sameQueue)
+		out := make([]*candidateElem, 0, len(hierarchy)+len(priority)+len(sameQueue))
+		out = append(out, evictedHierarchy...)
+		out = append(out, evictedPriority...)
+		out = append(out, evictedSameQueue...)
+		out = append(out, nonEvictedHierarchy...)
+		out = append(out, nonEvictedPriority...)
+		out = append(out, nonEvictedSameQueue...)
+		return out
+	}
+
+	var allCandidates []*candidateElem
+	var noCandidateFromOtherQueues bool
+	switch band {
+	// exceedsBorrowing: usage already exceeds the borrowing limit, so preempting
+	// workloads in other queues would not free up any space for this queue.
+	// Only same-queue candidates are worth considering. The hierarchy/priority
+	// collection (the O(N) cohort scan) is skipped entirely — that is the
+	// short-circuit optimization, so collect_hierarchy_priority is not emitted.
+	case exceedsBorrowing:
+		sortByOrdering(sameQueueCandidates)
+		allCandidates = sameQueueCandidates
+		noCandidateFromOtherQueues = true
+	// withinBorrowing / withinNominal: both consider all candidate groups
+	// (hierarchy, priority, same-queue) with identical collection and sort logic.
+	// One shared special case: when hierarchy candidates are empty AND borrowing
+	// within the cohort is forbidden AND the queue is already borrowing,
+	// preempting other queues cannot free space usable by this workload, so
+	// priority (other-queue) candidates are dropped. In practice this only fires
+	// in the withinBorrowing band (withinNominal implies usage <= nominal), but
+	// the guard is expressed on usageBorrowing, not on the band.
+	case withinBorrowing, withinNominal:
+		hierarchyCandidates, priorityCandidates = collectCandidatesForHierarchicalReclaim(hierarchicalReclaimCtx)
+		if len(hierarchyCandidates) == 0 {
+			borrowWithinCohortForbidden, _ := IsBorrowingWithinCohortForbidden(cq)
+			if borrowWithinCohortForbidden && usageBorrowing {
+				priorityCandidates = nil
+			}
+		}
+		sortByOrdering(hierarchyCandidates)
+		sortByOrdering(priorityCandidates)
+		sortByOrdering(sameQueueCandidates)
+		allCandidates = buildOrderedCandidates(hierarchyCandidates, priorityCandidates, sameQueueCandidates)
+		noCandidateFromOtherQueues = len(hierarchyCandidates) == 0 && len(priorityCandidates) == 0
+	}
+
 	return &candidateIterator{
 		runIndex:                          0,
 		frsNeedPreemption:                 frsNeedPreemption,
 		snapshot:                          snapshot,
 		candidates:                        allCandidates,
-		NoCandidateFromOtherQueues:        len(hierarchyCandidates) == 0 && len(priorityCandidates) == 0,
+		NoCandidateFromOtherQueues:        noCandidateFromOtherQueues,
 		NoCandidateForHierarchicalReclaim: len(hierarchyCandidates) == 0,
 		hierarchicalReclaimCtx:            hierarchicalReclaimCtx,
 	}

--- a/pkg/scheduler/preemption/classical/candidate_generator.go
+++ b/pkg/scheduler/preemption/classical/candidate_generator.go
@@ -84,14 +84,29 @@ const (
 )
 
 // classifyQuotaBand computes the quotaBand for the preemptor cluster queue after
-// admitting the incoming workload, and reports whether the queue is already
-// borrowing (usage above nominal) for any of the requested resources.
-func classifyQuotaBand(cq *schdcache.ClusterQueueSnapshot, requests resources.FlavorResourceQuantities) (quotaBand, bool) {
-	var band quotaBand
-	var usageBorrowing bool
-	for fr, val := range requests {
+// admitting the incoming workload, and reports whether the queue's usage is at
+// or above nominal for any flavor-resource needing preemption.
+//
+// The band is collapsed conjunctively: it is exceedsBorrowing only when EVERY
+// flavor-resource needing preemption exceeds its borrowing limit. Cross-queue
+// preemption frees cohort quota, which cannot raise the queue's own borrowing
+// cap, so only then are hierarchy/priority candidates provably useless for all
+// resources driving preemption. A single over-limit resource must not poison
+// the classification — another resource may still be freed by reclaiming from
+// other queues.
+func classifyQuotaBand(
+	cq *schdcache.ClusterQueueSnapshot,
+	requests resources.FlavorResourceQuantities,
+	frsNeedPreemption sets.Set[resources.FlavorResource],
+) (quotaBand, bool) {
+	if len(frsNeedPreemption) == 0 {
+		return withinNominal, false
+	}
+	band := exceedsBorrowing
+	var usageAtOrAboveNominal bool
+	for fr := range frsNeedPreemption {
 		usage := cq.ResourceNode.Usage[fr]
-		after := usage.Add(val)
+		after := usage.Add(requests[fr])
 		quota := cq.QuotaFor(fr)
 		nominal := quota.Nominal
 
@@ -104,17 +119,21 @@ func classifyQuotaBand(cq *schdcache.ClusterQueueSnapshot, requests resources.Fl
 		}
 		switch {
 		case hasBorrowingLimit && after.Cmp(upper) > 0:
-			band = max(band, exceedsBorrowing)
+			band = min(band, exceedsBorrowing)
 		case after.Cmp(nominal) > 0:
-			band = max(band, withinBorrowing)
+			band = min(band, withinBorrowing)
 		default: // after <= nominal
-			band = max(band, withinNominal)
+			band = min(band, withinNominal)
 		}
-		if !usageBorrowing && usage.Cmp(nominal) > 0 {
-			usageBorrowing = true
+		// Mirror queueUnderNominalInResourcesNeedingPreemption: the consumer
+		// skips the no-borrowing run when usage >= nominal for a resource
+		// needing preemption, making ReclaimWithoutBorrowing priority
+		// candidates unusable.
+		if !usageAtOrAboveNominal && usage.Cmp(nominal) >= 0 {
+			usageAtOrAboveNominal = true
 		}
 	}
-	return band, usageBorrowing
+	return band, usageAtOrAboveNominal
 }
 
 // NewCandidateIterator creates a new iterator that yields candidate workloads for preemption
@@ -131,7 +150,7 @@ func NewCandidateIterator(
 	ordering func(logr.Logger, bool, *workload.Info, *workload.Info, kueue.ClusterQueueReference, time.Time) int,
 ) *candidateIterator {
 	cq := hierarchicalReclaimCtx.Cq
-	band, usageBorrowing := classifyQuotaBand(cq, hierarchicalReclaimCtx.Requests)
+	band, usageAtOrAboveNominal := classifyQuotaBand(cq, hierarchicalReclaimCtx.Requests, frsNeedPreemption)
 
 	sameQueueCandidates := collectSameQueueCandidates(hierarchicalReclaimCtx)
 	var hierarchyCandidates, priorityCandidates []*candidateElem
@@ -161,11 +180,13 @@ func NewCandidateIterator(
 	var allCandidates []*candidateElem
 	var noCandidateFromOtherQueues bool
 	switch band {
-	// exceedsBorrowing: usage already exceeds the borrowing limit, so preempting
-	// workloads in other queues would not free up any space for this queue.
-	// Only same-queue candidates are worth considering. The hierarchy/priority
-	// collection (the O(N) cohort scan) is skipped entirely — that is the
-	// short-circuit optimization, so collect_hierarchy_priority is not emitted.
+	// exceedsBorrowing: every resource needing preemption exceeds the borrowing
+	// limit, so preempting workloads in other queues would not free up any
+	// space usable by this queue — freed cohort quota cannot raise the queue's
+	// own borrowing cap. Only same-queue candidates are worth considering.
+	// The hierarchy/priority collection (the O(N) cohort scan) is skipped
+	// entirely — that is the short-circuit optimization, so
+	// collect_hierarchy_priority is not emitted.
 	case exceedsBorrowing:
 		sortByOrdering(sameQueueCandidates)
 		allCandidates = sameQueueCandidates
@@ -173,16 +194,17 @@ func NewCandidateIterator(
 	// withinBorrowing / withinNominal: both consider all candidate groups
 	// (hierarchy, priority, same-queue) with identical collection and sort logic.
 	// One shared special case: when hierarchy candidates are empty AND borrowing
-	// within the cohort is forbidden AND the queue is already borrowing,
-	// preempting other queues cannot free space usable by this workload, so
-	// priority (other-queue) candidates are dropped. In practice this only fires
-	// in the withinBorrowing band (withinNominal implies usage <= nominal), but
-	// the guard is expressed on usageBorrowing, not on the band.
+	// within the cohort is forbidden AND the queue is at or above nominal in a
+	// resource needing preemption, the consumer only runs the borrowing pass,
+	// in which ReclaimWithoutBorrowing priority candidates are invalid anyway,
+	// so they are dropped here. The guard mirrors
+	// queueUnderNominalInResourcesNeedingPreemption used by the consumer, so
+	// dropping the candidates cannot change the outcome.
 	case withinBorrowing, withinNominal:
 		hierarchyCandidates, priorityCandidates = collectCandidatesForHierarchicalReclaim(hierarchicalReclaimCtx)
 		if len(hierarchyCandidates) == 0 {
 			borrowWithinCohortForbidden, _ := IsBorrowingWithinCohortForbidden(cq)
-			if borrowWithinCohortForbidden && usageBorrowing {
+			if borrowWithinCohortForbidden && usageAtOrAboveNominal {
 				priorityCandidates = nil
 			}
 		}

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -1905,6 +1905,344 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Obj(),
 			},
 		},
+		//            R(0)
+		//        /          \
+		//     q(2,          donor(2)
+		//  borrowLimit 2)
+		// q usage 1, donor usage 3 (borrowing 1 of q's lent nominal),
+		// incoming(4) into q: usage(1)+4 = 5 > nominal(2)+borrowingLimit(2) = 4.
+		// Same-queue preemption alone is insufficient: after preempting q's own
+		// workload, q still needs to borrow 2 but the cohort has only 1 free,
+		// so donor's workload must be preempted to free cohort quota.
+		"exceeds borrowing limit with full cohort: cross-queue reclaim needed": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2", "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						BorrowWithinCohort: &kueue.BorrowWithinCohort{
+							Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+						},
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("donor").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("donor_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(10).
+				Request(corev1.ResourceCPU, "4").
+				Obj(),
+			targetCQ: "q",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 2,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("donor_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /r/q; preemptee path: /r/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclaimWhileBorrowing",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /r/q; preemptee path: /r/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(), *utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+		},
+		// cohort has slack but it is occupied by a borrowing sibling, so
+		// same-queue preemption alone cannot free it.
+		//              R(0)
+		//        /       |        \
+		//     q(4,     donor(2)   idle(6)
+		//  borrowLimit 4)
+		// q usage 1 (below nominal, not borrowing), donor usage 5 (borrowing 3),
+		// idle usage 0 -> cohort free = 12-6 = 6.
+		// incoming(8) into q: usage(1)+8 = 9 > nominal(4)+borrowingLimit(4) = 8.
+		// After preempting q's own workload, q can still only pull
+		// min(withMaxFromParent 8, parentAvailable 7) = 7 < 8, because donor's
+		// borrowed 5 keeps parentAvailable below q's borrowing cap. Only
+		// reclaiming donor frees the cohort quota q needs, so the cross-queue
+		// candidate must be kept. The pre-fix "needed = after - nominal = 5"
+		// wrongly judged cohort free (6) >= 5 and pruned the donor candidate,
+		// yielding 0 preemptions; "needed = request - usage = 7" > 6 keeps it.
+		"exceeds borrowing limit but cohort slack is held by a borrowing sibling: cross-queue reclaim needed": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "4", "4").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						BorrowWithinCohort: &kueue.BorrowWithinCohort{
+							Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+						},
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("donor").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("idle").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "6").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("donor_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "5").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(10).
+				Request(corev1.ResourceCPU, "8").
+				Obj(),
+			targetCQ: "q",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 2,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("donor_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "5").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "5").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /r/q; preemptee path: /r/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclaimWhileBorrowing",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /r/q; preemptee path: /r/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(), *utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "1").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "1").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+		},
+		//              R(0)
+		//        /      |       \
+		//     q(2,   q_other(2)  q_idle(10)
+		//  borrowLimit 2)
+		// q usage 4 (at cap), q_other usage 3 (over nominal -> a legal
+		// cross-queue candidate), q_idle usage 0 -> cohort has 7 free.
+		// incoming(1) into q: usage(4)+1 = 5 > nominal(2)+borrowingLimit(2) = 4,
+		// and needed = request(1) - usage(4) <= 0 <= cohort free 7 => band ==
+		// exceedsBorrowing, cross-queue collection is skipped. On the base
+		// revision the same outcome must hold: other_low may be transiently
+		// preempted first, but fillBackWorkloads adds it back because same-queue
+		// preemption alone suffices when the cohort supply is not the binding
+		// constraint.
+		"exceeds borrowing limit with idle cohort: same-queue preemption only, cross-queue candidate untouched": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2", "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						BorrowWithinCohort: &kueue.BorrowWithinCohort{
+							Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+						},
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("q_other").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("q_idle").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "10").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("other_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(10).
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			targetCQ: "q",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 1,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("other_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("q_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q; preemptee path: /r/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+		},
+		//
 		//
 		//            R(0)
 		//        /         \

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -1810,6 +1810,278 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Obj(),
 			},
 		},
+		//
+		//            R(0)
+		//        /          \
+		//   q_exceed(2,       q_other(4)
+		//     borrowLimit 2)
+		//
+		// q_exceed borrows the full extra 2 (usage 4 = nominal 2 + borrowingLimit 2),
+		// borrowed from q_other's idle nominal. incoming(1) into q_exceed:
+		// usage(4)+1 = 5 > nominal(2)+borrowingLimit(2) = 4 => band == exceedsBorrowing.
+		// Borrowing more from the cohort can never lift the per-queue borrowing limit,
+		// so q_other's workload is useless as a candidate; only reclaiming q_exceed's
+		// own usage frees space. We preempt the in-queue workload and, once its 4 units
+		// are freed, incoming(1) fits within nominal. q_other is left untouched.
+		"exceeds borrowing limit: reclaim within queue only": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q_exceed").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2", "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("q_other").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "4").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("in_queue_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_exceed").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("other_queue_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(0).
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			targetCQ: "q_exceed",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 1,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("in_queue_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "4").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_exceed").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "4").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q_exceed; preemptee path: /r/q_exceed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q_exceed; preemptee path: /r/q_exceed",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("other_queue_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+			},
+		},
+		//
+		//            R(0)
+		//        /         \
+		//   q_exceed(2,      q_other(2)
+		//     borrowLimit 2,
+		//     withinCQ Never)
+		//
+		// Same exceedsBorrowing topology, but q_exceed forbids in-queue preemption.
+		// sameQueueCandidates is empty and no other-queue candidate can help, so
+		// nothing is preempted.
+		"exceeds borrowing limit, within-CQ never: no candidate": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q_exceed").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2", "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyNever,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("q_other").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("in_queue_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_exceed").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("other_queue_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(0).
+				Request(corev1.ResourceCPU, "3").
+				Obj(),
+			targetCQ: "q_exceed",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 0,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("in_queue_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_exceed").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("other_queue_low", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_other").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+			},
+		},
+		//
+		//            R(0)
+		//        /         \
+		//   q_borrow(2)      q_donor(4)
+		//
+		// q_borrow already borrows (usage 3 > nominal 2), incoming(1) keeps it
+		// borrowing (band == withinBorrowing) with no hierarchical advantage.
+		// BorrowWithinCohort is nil (not configured) => the special case must treat
+		// borrowing-within-cohort as forbidden without a nil-pointer panic, and fall
+		// back to same-queue reclamation. Regression guard for that nil dereference.
+		//
+		// The cohort must be genuinely full so that Preempt is the honest mode:
+		// cohort total = q_borrow(2) + q_donor(4) = 6, borrower_low uses 3 in
+		// q_borrow (borrowing 1) and donor_mid uses 3 in q_donor (within its own
+		// nominal, so it is NOT a candidate). Together they fill the cohort (6/6),
+		// so q_borrow.Available == 0 and incoming(1) cannot fit without preemption.
+		// donor_mid stays within nominal => no other-queue candidate; only same-queue
+		// reclamation of borrower_low frees room.
+		"borrowing needed, BorrowWithinCohort nil: reclaim within queue": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("r").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q_borrow").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("q_donor").
+					Cohort("r").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "4").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("borrower_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_borrow").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("donor_mid", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(0).
+				Request(corev1.ResourceCPU, "1").
+				Obj(),
+			targetCQ: "q_borrow",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 1,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("borrower_low", "").
+					Priority(-5).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_borrow").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q_borrow; preemptee path: /r/q_borrow",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /r/q_borrow; preemptee path: /r/q_borrow",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("donor_mid", "").
+					Priority(-10).
+					Request(corev1.ResourceCPU, "3").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q_donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "3").Obj()).Obj(), now).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, useMergePatch := range []bool{false, true} {

--- a/pkg/scheduler/preemption/preemption_hierarchical_test.go
+++ b/pkg/scheduler/preemption/preemption_hierarchical_test.go
@@ -2082,6 +2082,246 @@ func TestHierarchicalPreemptions(t *testing.T) {
 					Obj(),
 			},
 		},
+		//
+		//             c(cpu=2, mem=2Gi)
+		//        /                    \
+		// q(cpu=2/lim0, mem=1Gi)   donor(cpu=0, mem=1Gi)
+		//
+		// same_queue_cpu fills q's cpu (2/2); donor_mem borrows q's unused
+		// memory nominal (using 2Gi of the cohort's 2Gi). The incoming workload
+		// needs 1 cpu + 1Gi memory: cpu exceeds q's borrowing limit
+		// (usage 2 + 1 > nominal 2 + limit 0), while memory only lacks cohort
+		// capacity. One resource exceeding the borrowing limit must not skip the
+		// hierarchy/priority pools, because cross-queue reclaim is still
+		// required for the other resource.
+		"mixed resources: only cpu exceeds borrowing limit, memory still reclaimed across queues": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("c").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q").
+					Cohort("c").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "2", "0").
+					Resource(corev1.ResourceMemory, "1Gi").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						BorrowWithinCohort: &kueue.BorrowWithinCohort{
+							Policy: kueue.BorrowWithinCohortPolicyLowerPriority,
+						},
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("donor").
+					Cohort("c").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "0").
+					Resource(corev1.ResourceMemory, "1Gi").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("same_queue_cpu", "").
+					Priority(0).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("donor_mem", "").
+					Priority(0).
+					Request(corev1.ResourceMemory, "2Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceMemory, "default", "2Gi").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(1).
+				Request(corev1.ResourceCPU, "1").
+				Request(corev1.ResourceMemory, "1Gi").
+				Obj(),
+			targetCQ: "q",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+				corev1.ResourceMemory: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 2,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("donor_mem", "").
+					Priority(0).
+					Request(corev1.ResourceMemory, "2Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("donor").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceMemory, "default", "2Gi").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /c/q; preemptee path: /c/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclaimWhileBorrowing",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort while borrowing; preemptor path: /c/q; preemptee path: /c/donor",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+				*utiltestingapi.MakeWorkload("same_queue_cpu", "").
+					Priority(0).
+					Request(corev1.ResourceCPU, "2").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "2").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /c/q; preemptee path: /c/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /c/q; preemptee path: /c/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+		},
+		//
+		//             c(cpu=10, mem=20Gi)
+		//        /                       \
+		// q(cpu=10, mem=10Gi)          b(cpu=0, mem=10Gi)
+		//
+		// q borrows cpu (xy_hog uses 11 of nominal 10), but cpu does NOT need
+		// preemption. b overuses memory (25Gi of the cohort's 20Gi), so q's
+		// Available(memory) is 0 and memory needs preemption even though q's
+		// own memory usage is far below nominal. Borrowing a resource that is
+		// not up for preemption must not cause the priority candidates to be
+		// dropped: the consumer still runs the no-borrowing pass, in which
+		// ReclaimWithoutBorrowing candidates like b_mem are valid.
+		"borrowing a resource not needing preemption: priority candidates kept": {
+			cohorts: []*kueue.Cohort{
+				utiltestingapi.MakeCohort("c").Obj(),
+			},
+			clusterQueues: []*kueue.ClusterQueue{
+				utiltestingapi.MakeClusterQueue("q").
+					Cohort("c").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "10").
+					Resource(corev1.ResourceMemory, "10Gi").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+						// BorrowWithinCohort is unset, so borrowing within the
+						// cohort is forbidden.
+					}).Obj(),
+				utiltestingapi.MakeClusterQueue("b").
+					Cohort("c").ResourceGroup(*utiltestingapi.MakeFlavorQuotas("default").
+					Resource(corev1.ResourceCPU, "0").
+					Resource(corev1.ResourceMemory, "10Gi").
+					Obj()).
+					Preemption(kueue.ClusterQueuePreemption{
+						WithinClusterQueue:  kueue.PreemptionPolicyLowerPriority,
+						ReclaimWithinCohort: kueue.PreemptionPolicyAny,
+					}).Obj(),
+			},
+			admitted: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("xy_hog", "").
+					Priority(0).
+					Request(corev1.ResourceCPU, "11").
+					Request(corev1.ResourceMemory, "1Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "11").
+							Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).Obj(), now).
+					Obj(),
+				*utiltestingapi.MakeWorkload("b_mem", "").
+					Priority(0).
+					Request(corev1.ResourceMemory, "25Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("b").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceMemory, "default", "25Gi").Obj()).Obj(), now).
+					Obj(),
+			},
+			incoming: baseIncomingWl.Clone().
+				Priority(1).
+				Request(corev1.ResourceCPU, "1").
+				Request(corev1.ResourceMemory, "1Gi").
+				Obj(),
+			targetCQ: "q",
+			assignment: singlePodSetAssignment(flavorassigner.ResourceAssignment{
+				corev1.ResourceCPU: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Fit,
+				},
+				corev1.ResourceMemory: &flavorassigner.FlavorAssignment{
+					Name: "default",
+					Mode: flavorassigner.Preempt,
+				},
+			}),
+			wantPreempted: 2,
+			wantWorkloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("b_mem", "").
+					Priority(0).
+					Request(corev1.ResourceMemory, "25Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("b").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceMemory, "default", "25Gi").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort; preemptor path: /c/q; preemptee path: /c/b",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InCohortReclamation",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to reclamation within the cohort; preemptor path: /c/q; preemptee path: /c/b",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(), *utiltestingapi.MakeWorkload("xy_hog", "").
+					Priority(0).
+					Request(corev1.ResourceCPU, "11").
+					Request(corev1.ResourceMemory, "1Gi").
+					ReserveQuotaAt(utiltestingapi.MakeAdmission("q").
+						PodSets(utiltestingapi.MakePodSetAssignment(kueue.DefaultPodSetName).
+							Assignment(corev1.ResourceCPU, "default", "11").
+							Assignment(corev1.ResourceMemory, "default", "1Gi").Obj()).Obj(), now).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadEvicted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "Preempted",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /c/q; preemptee path: /c/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					Condition(metav1.Condition{
+						Type:               kueue.WorkloadPreempted,
+						Status:             metav1.ConditionTrue,
+						Reason:             "InClusterQueue",
+						Message:            "Preempted to accommodate a workload (UID: wl-in, JobUID: job-in) due to prioritization in the ClusterQueue; preemptor path: /c/q; preemptee path: /c/q",
+						LastTransitionTime: metav1.NewTime(now),
+					}).
+					SchedulingStatsEviction(kueue.WorkloadSchedulingStatsEviction{Reason: "Preempted", Count: 1}).
+					Obj(),
+			},
+		},
 	}
 	for name, tc := range cases {
 		for _, useMergePatch := range []bool{false, true} {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Optimizes the classical preemption candidate pool collection. Previously
`NewCandidateIterator` always collected and sorted all three candidate pools
(same-queue, hierarchy, priority) before the caller decided — via a
short-circuit — that some of them could not help the incoming workload.

This PR classifies the preemptor cluster queue's post-admission quota position
and skips the O(N) cohort scan for hierarchy/priority candidates when they
provably cannot free usable space (the queue would exceed its borrowing limit,
or it is already borrowing with cohort borrowing forbidden and no hierarchical
candidate). The result is behavior-preserving — the skipped pools are exactly
the ones the caller's existing short-circuit would have discarded — while
avoiding wasted collection and sorting on the hot preemption path.

#### Which issue(s) this PR fixes:

Related to #14608

#### Special notes for your reviewer:

The change is intended to be behavior-preserving. Added
`TestHierarchicalPreemptions` cases cover the exceeds-borrowing-limit reclaim
path, the WithinClusterQueue=Never no-candidate case, and a regression guard
for a nil `BorrowWithinCohort` configuration.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workload preemption decisions when quota borrowing limits are reached.
  * Prioritizes reclaiming workloads within the affected queue when required.
  * Preserves hierarchical and priority-based preemption behavior across resource types.
  * Retains eligible priority candidates when borrowed resources do not require preemption.
  * Supports accurate cohort capacity calculations for borrowing across resource types.

* **Bug Fixes**
  * Prevents invalid preemption candidates when within-queue preemption is disabled.
  * Safely handles unspecified cohort borrowing settings.
  * Correctly enforces borrowing restrictions during candidate selection.
  * Handles cross-queue reclamation correctly when borrowing siblings consume available quota.
  * Prevents candidate selection when reclaiming eligible workloads cannot satisfy borrowing limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->