### PR TITLE
Automated cherry pick of #14203: Skip Kueue-side node health filtering under SchedulerLibraryIntegration

### DIFF
--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
@@ -41,32 +42,47 @@ type nodesCache struct {
 	// when a node is added or removed, or when its labels, taints, or allocatable
 	// resources change - not on every Node update event.
 	generation int64
+
+	// schedulableAndReadyNodes tracks node names that are both schedulable and ready
+	schedulableAndReadyNodes sets.Set[string]
 }
 
 func newNodesCache() *nodesCache {
 	return &nodesCache{
-		nodes: make(map[string]*corev1.Node),
+		nodes:                    make(map[string]*corev1.Node),
+		schedulableAndReadyNodes: sets.New[string](),
 	}
 }
 
 func (t *nodesCache) sync(node *corev1.Node) {
+	schedulableAndReady := !node.Spec.Unschedulable &&
+		utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	if !features.Enabled(features.SchedulerLibraryIntegration) {
-		schedulableAndReady := !node.Spec.Unschedulable &&
-			utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-		if !schedulableAndReady {
-			t.deleteWithoutLock(node.Name)
-			return
-		}
-	}
 
-	stripped := copyAndStripNode(node)
-	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
+	if !features.Enabled(features.SchedulerLibraryIntegration) && !schedulableAndReady {
+		t.deleteWithoutLock(node.Name)
 		return
 	}
 
-	t.nodes[node.Name] = stripped
+	availabilityChanged := t.schedulableAndReadyNodes.Has(node.Name) != schedulableAndReady
+	if schedulableAndReady {
+		t.schedulableAndReadyNodes.Insert(node.Name)
+	} else {
+		t.schedulableAndReadyNodes.Delete(node.Name)
+	}
+
+	stripped := copyAndStripNode(node)
+	existing, found := t.nodes[node.Name]
+	nodeChanged := !found || !strippedNodesEqual(existing, stripped)
+
+	if !nodeChanged && !availabilityChanged {
+		return
+	}
+
+	if nodeChanged {
+		t.nodes[node.Name] = stripped
+	}
 	t.generation++
 }
 
@@ -79,6 +95,7 @@ func (t *nodesCache) delete(nodeName string) {
 func (t *nodesCache) deleteWithoutLock(nodeName string) {
 	if _, found := t.nodes[nodeName]; found {
 		delete(t.nodes, nodeName)
+		t.schedulableAndReadyNodes.Delete(nodeName)
 		t.generation++
 	}
 }
@@ -90,7 +107,14 @@ func (t *nodesCache) find(nodeLabels map[string]string, levels []string) ([]*cor
 	t.lock.RLock()
 	defer t.lock.RUnlock()
 	filteredNodes := make([]*corev1.Node, 0, len(t.nodes))
+	shouldExcludeUnschedulableAndNotReadyNodes :=
+		features.Enabled(features.SchedulerLibraryIntegration) &&
+			(len(levels) == 0 || !utiltas.IsLowestLevelHostname(levels))
+
 	for _, node := range t.nodes {
+		if shouldExcludeUnschedulableAndNotReadyNodes && !t.schedulableAndReadyNodes.Has(node.Name) {
+			continue
+		}
 		if utiltas.NodeMatchesFlavor(node.Labels, nodeLabels, levels) {
 			filteredNodes = append(filteredNodes, node)
 		}

--- a/pkg/cache/scheduler/tas_nodes_cache.go
+++ b/pkg/cache/scheduler/tas_nodes_cache.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
 )
 
@@ -49,20 +50,22 @@ func newNodesCache() *nodesCache {
 }
 
 func (t *nodesCache) sync(node *corev1.Node) {
-	schedulableAndReady := !node.Spec.Unschedulable &&
-		utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
-
 	t.lock.Lock()
 	defer t.lock.Unlock()
-
-	if !schedulableAndReady {
-		t.deleteWithoutLock(node.Name)
-		return
+	if !features.Enabled(features.SchedulerLibraryIntegration) {
+		schedulableAndReady := !node.Spec.Unschedulable &&
+			utiltas.IsNodeStatusConditionTrue(node.Status.Conditions, corev1.NodeReady)
+		if !schedulableAndReady {
+			t.deleteWithoutLock(node.Name)
+			return
+		}
 	}
+
 	stripped := copyAndStripNode(node)
 	if existing, found := t.nodes[node.Name]; found && strippedNodesEqual(existing, stripped) {
 		return
 	}
+
 	t.nodes[node.Name] = stripped
 	t.generation++
 }
@@ -113,7 +116,8 @@ func copyAndStripNode(node *corev1.Node) *corev1.Node {
 			Labels: node.Labels,
 		},
 		Spec: corev1.NodeSpec{
-			Taints: node.Spec.Taints,
+			Unschedulable: node.Spec.Unschedulable,
+			Taints:        node.Spec.Taints,
 		},
 		Status: corev1.NodeStatus{
 			Allocatable: node.Status.Allocatable,
@@ -127,6 +131,7 @@ func copyAndStripNode(node *corev1.Node) *corev1.Node {
 // such as kubelet heartbeats.
 func strippedNodesEqual(a, b *corev1.Node) bool {
 	return maps.Equal(a.Labels, b.Labels) &&
+		a.Spec.Unschedulable == b.Spec.Unschedulable &&
 		equality.Semantic.DeepEqual(a.Spec.Taints, b.Spec.Taints) &&
 		equality.Semantic.DeepEqual(a.Status.Allocatable, b.Status.Allocatable)
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
@@ -153,20 +156,189 @@ func TestNodesCacheFind(t *testing.T) {
 	}
 }
 
-func TestNodesCacheWithSchedulerLibraryIntegration(t *testing.T) {
-	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
-
-	nc := newNodesCache()
-	unreadyNode := node.MakeNode("unready-node").DeepCopy()
-	unschedNode := node.MakeNode("unsched-node").Unschedulable().Obj()
-
-	nc.sync(unreadyNode)
-	nc.sync(unschedNode)
-
-	if _, found := nc.nodes["unready-node"]; !found {
-		t.Errorf("expected unready-node to be cached when SchedulerLibraryIntegration is enabled")
+func TestNodesCacheGeneration(t *testing.T) {
+	baseNode := func() *node.NodeWrapper {
+		return node.MakeNode("gen-test").
+			Label("cloud.provider.com/zone", "us-east-1a").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}).
+			Ready()
 	}
-	if _, found := nc.nodes["unsched-node"]; !found {
-		t.Errorf("expected unsched-node to be cached when SchedulerLibraryIntegration is enabled")
+
+	testCases := map[string]struct {
+		prime     []*corev1.Node
+		op        func(nc *nodesCache)
+		wantDelta int64
+	}{
+		"sync of a new ready node bumps": {
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 1,
+		},
+		"re-sync of an identical node does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 0,
+		},
+		"heartbeat-only update does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().
+					ResourceVersion("2").
+					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
+					Obj())
+			},
+			wantDelta: 0,
+		},
+		"equivalent allocatable expressed in different units does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4000m"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 0,
+		},
+		"label change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
+			},
+			wantDelta: 1,
+		},
+		"allocatable change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"taint change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Taints(corev1.Taint{
+					Key:    "example.com/gpu",
+					Effect: corev1.TaintEffectNoSchedule,
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"transition to unschedulable removes the node and bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Unschedulable().Obj())
+			},
+			wantDelta: 1,
+		},
+		"sync of an absent not-ready node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.sync(node.MakeNode("gen-test").Obj())
+			},
+			wantDelta: 0,
+		},
+		"delete of an existing node bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.delete("gen-test")
+			},
+			wantDelta: 1,
+		},
+		"delete of an absent node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.delete("other")
+			},
+			wantDelta: 0,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			nc := newNodesCache()
+			for _, n := range tc.prime {
+				nc.sync(n)
+			}
+			before := nc.currentGeneration()
+			tc.op(nc)
+			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
+				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
+			}
+		})
+	}
+}
+
+func TestNodesCacheSync(t *testing.T) {
+	nodeWrapper := node.MakeNode("test")
+
+	testCases := map[string]struct {
+		enableSchedulerLibraryIntegration bool
+		prime                             []corev1.Node
+		op                                func(nc *nodesCache)
+		wantNodes                         []corev1.Node
+		wantSchedulableAndReady           []string
+	}{
+		"FG disabled: sync not ready removes node": {
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.DeepCopy())
+			},
+		},
+		"FG disabled: sync ready adds node": {
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Obj())
+			},
+			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady: []string{"test"},
+		},
+		"FG enabled: sync not ready keeps node in cache but not in schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.DeepCopy())
+			},
+			wantNodes: []corev1.Node{*nodeWrapper.DeepCopy()},
+		},
+		"FG enabled: sync unschedulable keeps node in cache but not in schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Unschedulable().Obj())
+			},
+			wantNodes: []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
+		},
+		"FG enabled: sync ready adds node to cache and schedulableAndReady": {
+			enableSchedulerLibraryIntegration: true,
+			op: func(nc *nodesCache) {
+				nc.sync(nodeWrapper.Clone().Ready().Obj())
+			},
+			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady: []string{"test"},
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, tc.enableSchedulerLibraryIntegration)
+			nc := newNodesCache()
+			for i := range tc.prime {
+				nc.sync(&tc.prime[i])
+			}
+			tc.op(nc)
+
+			wantNodesMap := make(map[string]*corev1.Node, len(tc.wantNodes))
+			for i := range tc.wantNodes {
+				wantNodesMap[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
+			}
+			if diff := cmp.Diff(wantNodesMap, nc.nodes); diff != "" {
+				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
+			}
+			wantSet := sets.New(tc.wantSchedulableAndReady...)
+			if diff := cmp.Diff(wantSet, nc.schedulableAndReadyNodes); diff != "" {
+				t.Errorf("Unexpected schedulableAndReadyNodes (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
@@ -151,124 +149,6 @@ func TestNodesCacheFind(t *testing.T) {
 				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestNodesCacheGeneration(t *testing.T) {
-	baseNode := func() *node.NodeWrapper {
-		return node.MakeNode("gen-test").
-			Label("cloud.provider.com/zone", "us-east-1a").
-			StatusAllocatable(corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("4"),
-				corev1.ResourceMemory: resource.MustParse("16Gi"),
-			}).
-			Ready()
-	}
-
-	testCases := map[string]struct {
-		prime     []*corev1.Node
-		op        func(nc *nodesCache)
-		wantDelta int64
-	}{
-		"sync of a new ready node bumps": {
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Obj())
-			},
-			wantDelta: 1,
-		},
-		"re-sync of an identical node does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Obj())
-			},
-			wantDelta: 0,
-		},
-		"heartbeat-only update does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().
-					ResourceVersion("2").
-					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
-					Obj())
-			},
-			wantDelta: 0,
-		},
-		"equivalent allocatable expressed in different units does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4000m"),
-					corev1.ResourceMemory: resource.MustParse("16Gi"),
-				}).Obj())
-			},
-			wantDelta: 0,
-		},
-		"label change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
-			},
-			wantDelta: 1,
-		},
-		"allocatable change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("8"),
-					corev1.ResourceMemory: resource.MustParse("16Gi"),
-				}).Obj())
-			},
-			wantDelta: 1,
-		},
-		"taint change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Taints(corev1.Taint{
-					Key:    "example.com/gpu",
-					Effect: corev1.TaintEffectNoSchedule,
-				}).Obj())
-			},
-			wantDelta: 1,
-		},
-		"transition to unschedulable removes the node and bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Unschedulable().Obj())
-			},
-			wantDelta: 1,
-		},
-		"sync of an absent not-ready node does not bump": {
-			op: func(nc *nodesCache) {
-				nc.sync(node.MakeNode("gen-test").Obj())
-			},
-			wantDelta: 0,
-		},
-		"delete of an existing node bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.delete("gen-test")
-			},
-			wantDelta: 1,
-		},
-		"delete of an absent node does not bump": {
-			op: func(nc *nodesCache) {
-				nc.delete("other")
-			},
-			wantDelta: 0,
-		},
-	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			nc := newNodesCache()
-			for _, n := range tc.prime {
-				nc.sync(n)
-			}
-			before := nc.currentGeneration()
-			tc.op(nc)
-			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
-				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,9 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"sigs.k8s.io/kueue/pkg/features"
 	"sigs.k8s.io/kueue/pkg/util/testingjobs/node"
 )
 
@@ -154,120 +153,20 @@ func TestNodesCacheFind(t *testing.T) {
 	}
 }
 
-func TestNodesCacheGeneration(t *testing.T) {
-	baseNode := func() *node.NodeWrapper {
-		return node.MakeNode("gen-test").
-			Label("cloud.provider.com/zone", "us-east-1a").
-			StatusAllocatable(corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("4"),
-				corev1.ResourceMemory: resource.MustParse("16Gi"),
-			}).
-			Ready()
-	}
+func TestNodesCacheWithSchedulerLibraryIntegration(t *testing.T) {
+	features.SetFeatureGateDuringTest(t, features.SchedulerLibraryIntegration, true)
 
-	testCases := map[string]struct {
-		prime     []*corev1.Node
-		op        func(nc *nodesCache)
-		wantDelta int64
-	}{
-		"sync of a new ready node bumps": {
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Obj())
-			},
-			wantDelta: 1,
-		},
-		"re-sync of an identical node does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Obj())
-			},
-			wantDelta: 0,
-		},
-		"heartbeat-only update does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().
-					ResourceVersion("2").
-					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
-					Obj())
-			},
-			wantDelta: 0,
-		},
-		"equivalent allocatable expressed in different units does not bump": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("4000m"),
-					corev1.ResourceMemory: resource.MustParse("16Gi"),
-				}).Obj())
-			},
-			wantDelta: 0,
-		},
-		"label change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
-			},
-			wantDelta: 1,
-		},
-		"allocatable change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("8"),
-					corev1.ResourceMemory: resource.MustParse("16Gi"),
-				}).Obj())
-			},
-			wantDelta: 1,
-		},
-		"taint change bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Taints(corev1.Taint{
-					Key:    "example.com/gpu",
-					Effect: corev1.TaintEffectNoSchedule,
-				}).Obj())
-			},
-			wantDelta: 1,
-		},
-		"transition to unschedulable removes the node and bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.sync(baseNode().Unschedulable().Obj())
-			},
-			wantDelta: 1,
-		},
-		"sync of an absent not-ready node does not bump": {
-			op: func(nc *nodesCache) {
-				nc.sync(node.MakeNode("gen-test").Obj())
-			},
-			wantDelta: 0,
-		},
-		"delete of an existing node bumps": {
-			prime: []*corev1.Node{baseNode().Obj()},
-			op: func(nc *nodesCache) {
-				nc.delete("gen-test")
-			},
-			wantDelta: 1,
-		},
-		"delete of an absent node does not bump": {
-			op: func(nc *nodesCache) {
-				nc.delete("other")
-			},
-			wantDelta: 0,
-		},
+	nc := newNodesCache()
+	unreadyNode := node.MakeNode("unready-node").DeepCopy()
+	unschedNode := node.MakeNode("unsched-node").Unschedulable().Obj()
+
+	nc.sync(unreadyNode)
+	nc.sync(unschedNode)
+
+	if _, found := nc.nodes["unready-node"]; !found {
+		t.Errorf("expected unready-node to be cached when SchedulerLibraryIntegration is enabled")
 	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			nc := newNodesCache()
-			for _, n := range tc.prime {
-				nc.sync(n)
-			}
-			before := nc.currentGeneration()
-			tc.op(nc)
-			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
-				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
-			}
-		})
+	if _, found := nc.nodes["unsched-node"]; !found {
+		t.Errorf("expected unsched-node to be cached when SchedulerLibraryIntegration is enabled")
 	}
 }

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"sigs.k8s.io/kueue/pkg/features"
@@ -149,6 +151,124 @@ func TestNodesCacheFind(t *testing.T) {
 				return a.Name < b.Name
 			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestNodesCacheGeneration(t *testing.T) {
+	baseNode := func() *node.NodeWrapper {
+		return node.MakeNode("gen-test").
+			Label("cloud.provider.com/zone", "us-east-1a").
+			StatusAllocatable(corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("4"),
+				corev1.ResourceMemory: resource.MustParse("16Gi"),
+			}).
+			Ready()
+	}
+
+	testCases := map[string]struct {
+		prime     []*corev1.Node
+		op        func(nc *nodesCache)
+		wantDelta int64
+	}{
+		"sync of a new ready node bumps": {
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 1,
+		},
+		"re-sync of an identical node does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Obj())
+			},
+			wantDelta: 0,
+		},
+		"heartbeat-only update does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().
+					ResourceVersion("2").
+					ConditionHeartbeat(corev1.NodeReady, metav1.Now()).
+					Obj())
+			},
+			wantDelta: 0,
+		},
+		"equivalent allocatable expressed in different units does not bump": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4000m"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 0,
+		},
+		"label change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Label("cloud.provider.com/zone", "us-east-1b").Obj())
+			},
+			wantDelta: 1,
+		},
+		"allocatable change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().StatusAllocatable(corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("8"),
+					corev1.ResourceMemory: resource.MustParse("16Gi"),
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"taint change bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Taints(corev1.Taint{
+					Key:    "example.com/gpu",
+					Effect: corev1.TaintEffectNoSchedule,
+				}).Obj())
+			},
+			wantDelta: 1,
+		},
+		"transition to unschedulable removes the node and bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.sync(baseNode().Unschedulable().Obj())
+			},
+			wantDelta: 1,
+		},
+		"sync of an absent not-ready node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.sync(node.MakeNode("gen-test").Obj())
+			},
+			wantDelta: 0,
+		},
+		"delete of an existing node bumps": {
+			prime: []*corev1.Node{baseNode().Obj()},
+			op: func(nc *nodesCache) {
+				nc.delete("gen-test")
+			},
+			wantDelta: 1,
+		},
+		"delete of an absent node does not bump": {
+			op: func(nc *nodesCache) {
+				nc.delete("other")
+			},
+			wantDelta: 0,
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			nc := newNodesCache()
+			for _, n := range tc.prime {
+				nc.sync(n)
+			}
+			before := nc.currentGeneration()
+			tc.op(nc)
+			if delta := nc.currentGeneration() - before; delta != tc.wantDelta {
+				t.Errorf("unexpected generation delta: got %d, want %d", delta, tc.wantDelta)
 			}
 		})
 	}

--- a/pkg/cache/scheduler/tas_nodes_cache_test.go
+++ b/pkg/cache/scheduler/tas_nodes_cache_test.go
@@ -280,43 +280,33 @@ func TestNodesCacheSync(t *testing.T) {
 	testCases := map[string]struct {
 		enableSchedulerLibraryIntegration bool
 		prime                             []corev1.Node
-		op                                func(nc *nodesCache)
+		node                              *corev1.Node
 		wantNodes                         []corev1.Node
 		wantSchedulableAndReady           []string
 	}{
 		"FG disabled: sync not ready removes node": {
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.DeepCopy())
-			},
+			node: nodeWrapper.DeepCopy(),
 		},
 		"FG disabled: sync ready adds node": {
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Obj())
-			},
+			node:                    nodeWrapper.Clone().Ready().Obj(),
 			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
 			wantSchedulableAndReady: []string{"test"},
 		},
 		"FG enabled: sync not ready keeps node in cache but not in schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.DeepCopy())
-			},
-			wantNodes: []corev1.Node{*nodeWrapper.DeepCopy()},
+			node:                              nodeWrapper.DeepCopy(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.DeepCopy()},
 		},
 		"FG enabled: sync unschedulable keeps node in cache but not in schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Unschedulable().Obj())
-			},
-			wantNodes: []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
+			node:                              nodeWrapper.Clone().Ready().Unschedulable().Obj(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.Clone().Ready().Unschedulable().Obj()},
 		},
 		"FG enabled: sync ready adds node to cache and schedulableAndReady": {
 			enableSchedulerLibraryIntegration: true,
-			op: func(nc *nodesCache) {
-				nc.sync(nodeWrapper.Clone().Ready().Obj())
-			},
-			wantNodes:               []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
-			wantSchedulableAndReady: []string{"test"},
+			node:                              nodeWrapper.Clone().Ready().Obj(),
+			wantNodes:                         []corev1.Node{*nodeWrapper.Clone().Ready().Obj()},
+			wantSchedulableAndReady:           []string{"test"},
 		},
 	}
 	for name, tc := range testCases {
@@ -326,17 +316,18 @@ func TestNodesCacheSync(t *testing.T) {
 			for i := range tc.prime {
 				nc.sync(&tc.prime[i])
 			}
-			tc.op(nc)
+			nc.sync(tc.node)
 
-			wantNodesMap := make(map[string]*corev1.Node, len(tc.wantNodes))
+			wantNodeNameNodes := make(map[string]*corev1.Node, len(tc.wantNodes))
 			for i := range tc.wantNodes {
-				wantNodesMap[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
+				wantNodeNameNodes[tc.wantNodes[i].Name] = copyAndStripNode(&tc.wantNodes[i])
 			}
-			if diff := cmp.Diff(wantNodesMap, nc.nodes); diff != "" {
+			if diff := cmp.Diff(wantNodeNameNodes, nc.nodes, cmpopts.SortMaps(func(a, b string) bool {
+				return a < b
+			})); diff != "" {
 				t.Errorf("Unexpected nodes (-want,+got):\n%s", diff)
 			}
-			wantSet := sets.New(tc.wantSchedulableAndReady...)
-			if diff := cmp.Diff(wantSet, nc.schedulableAndReadyNodes); diff != "" {
+			if diff := cmp.Diff(sets.New(tc.wantSchedulableAndReady...), nc.schedulableAndReadyNodes); diff != "" {
 				t.Errorf("Unexpected schedulableAndReadyNodes (-want,+got):\n%s", diff)
 			}
 		})

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -86,6 +86,12 @@ func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.Sc
 	return &wasSimulator{sim: sim}, nil
 }
 
+// NewWASSimulatorForTest creates a WAS simulator backed by a fake client,
+// suitable for unit tests that need the full filter plugin pipeline.
+func NewWASSimulatorForTest(ctx context.Context) (simulator.SchedulingSimulator, error) {
+	return NewWASSimulator(ctx, &rest.Config{})
+}
+
 func (s *wasSimulator) NewFeasibilityChecker(ctx context.Context, nodes []*corev1.Node) (simulator.NodeFeasibilityChecker, error) {
 	clusterSnap, err := s.sim.NewClusterSnapshot(ctx, nil, nodes)
 	if err != nil {

--- a/pkg/cache/scheduler/was/scheduling_simulator.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator.go
@@ -14,6 +14,7 @@ import (
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultbinder"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeaffinity"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeunschedulable"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/queuesort"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	schedLibSimulator "sigs.k8s.io/scheduler-library/pkg/simulator"
@@ -43,6 +44,7 @@ func NewWASSimulator(ctx context.Context, restConfig *rest.Config) (simulator.Sc
 					},
 					Filter: schedulerconfig.PluginSet{
 						Enabled: []schedulerconfig.Plugin{
+							{Name: nodeunschedulable.Name},
 							{Name: tainttoleration.Name},
 							{Name: nodeaffinity.Name},
 						},

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -40,7 +40,6 @@ func (c *testCandidate) GetID() utiltas.TopologyDomainID { return c.id }
 func (c *testCandidate) GetAffinityScore() int64         { return c.affinityScore }
 func (c *testCandidate) SetAffinityScore(score int64)    { c.affinityScore = score }
 
-
 func TestNodeUnschedulableFeasibility(t *testing.T) {
 	ctx := t.Context()
 

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -1,0 +1,248 @@
+//go:build !exclude_scheduler_library
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package was
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
+	utiltas "sigs.k8s.io/kueue/pkg/util/tas"
+)
+
+type testCandidate struct {
+	node          *corev1.Node
+	id            utiltas.TopologyDomainID
+	affinityScore int64
+}
+
+func (c *testCandidate) GetNode() *corev1.Node           { return c.node }
+func (c *testCandidate) GetID() utiltas.TopologyDomainID { return c.id }
+func (c *testCandidate) GetAffinityScore() int64         { return c.affinityScore }
+func (c *testCandidate) SetAffinityScore(score int64)    { c.affinityScore = score }
+
+func TestNodePortsFeasibility(t *testing.T) {
+	ctx := t.Context()
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{corev1.LabelHostname: "node1"}},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
+		Status: corev1.NodeStatus{
+			Allocatable: corev1.ResourceList{
+				corev1.ResourceCPU:  resource.MustParse("4"),
+				corev1.ResourcePods: resource.MustParse("10"),
+			},
+			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+		},
+	}
+	nodes := []*corev1.Node{node1, node2}
+
+	existingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "default", UID: "uid-1"},
+		Spec: corev1.PodSpec{
+			NodeName: "node1",
+			Containers: []corev1.Container{{
+				Name:  "c",
+				Image: "busybox",
+				Ports: []corev1.ContainerPort{{
+					ContainerPort: 8080,
+					HostPort:      8080,
+					Protocol:      corev1.ProtocolTCP,
+				}},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	tests := map[string]struct {
+		pods         []*corev1.Pod
+		candidatePod corev1.PodTemplateSpec
+		wantFeasible map[string]bool
+	}{
+		"hostPort conflict excludes node with occupied port": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+							HostPort:      8080,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node2": true},
+		},
+		"different hostPort has no conflict": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 9090,
+							HostPort:      9090,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+		"pod without hostPort passes through unaffected": {
+			pods: []*corev1.Pod{existingPod},
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+						},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+		"no existing pods means all nodes feasible": {
+			pods: nil,
+			candidatePod: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "c",
+						Image: "busybox",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+							HostPort:      8080,
+							Protocol:      corev1.ProtocolTCP,
+						}},
+					}},
+				},
+			},
+			wantFeasible: map[string]bool{"node1": true, "node2": true},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim, err := NewWASSimulatorForTest(ctx)
+			if err != nil {
+				t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+			}
+
+			candidates := func(yield func(simulator.Candidate) bool) {
+				for _, n := range nodes {
+					if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+						return
+					}
+				}
+			}
+
+			for _, pod := range tc.pods {
+				sim.TrackPod(pod)
+			}
+			snapshot, err := sim.Snapshot(ctx, nodes)
+			if err != nil {
+				t.Fatalf("CreateSnapshot failed: %v", err)
+			}
+
+			stats := &simulator.NodeExclusionStats{}
+			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+				PodTemplate: &tc.candidatePod,
+			}, stats)
+			if err != nil {
+				t.Fatalf("FindFeasibleNodes failed: %v", err)
+			}
+
+			gotNames := make(map[string]bool)
+			for _, r := range results {
+				gotNames[r.GetNode().Name] = true
+			}
+
+			if len(gotNames) != len(tc.wantFeasible) {
+				t.Errorf("got feasible nodes %v, want %v", gotNames, tc.wantFeasible)
+				return
+			}
+			for n := range tc.wantFeasible {
+				if !gotNames[n] {
+					t.Errorf("expected node %s to be feasible, got %v", n, gotNames)
+				}
+			}
+		})
+	}
+}
+
+func TestNodeUnschedulableFeasibility(t *testing.T) {
+	ctx := t.Context()
+
+	node1 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{corev1.LabelHostname: "node1"}},
+		Spec:       corev1.NodeSpec{Unschedulable: true},
+	}
+	node2 := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
+		Spec:       corev1.NodeSpec{Unschedulable: false},
+	}
+	nodes := []*corev1.Node{node1, node2}
+
+	sim, err := NewWASSimulatorForTest(ctx)
+	if err != nil {
+		t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+	}
+
+	candidates := func(yield func(simulator.Candidate) bool) {
+		for _, n := range nodes {
+			if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+				return
+			}
+		}
+	}
+
+	checker, err := sim.NewFeasibilityChecker(ctx, nodes)
+	if err != nil {
+		t.Fatalf("NewFeasibilityChecker failed: %v", err)
+	}
+
+	results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+		PodTemplate: &corev1.PodTemplateSpec{},
+	}, &simulator.NodeExclusionStats{})
+	if err != nil {
+		t.Fatalf("FindFeasibleNodes failed: %v", err)
+	}
+
+	if len(results) != 1 || results[0].GetNode().Name != "node2" {
+		t.Errorf("expected only node2 to be feasible, got %v", results)
+	}
+}

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"sigs.k8s.io/kueue/pkg/cache/scheduler/simulator"
@@ -41,169 +40,6 @@ func (c *testCandidate) GetID() utiltas.TopologyDomainID { return c.id }
 func (c *testCandidate) GetAffinityScore() int64         { return c.affinityScore }
 func (c *testCandidate) SetAffinityScore(score int64)    { c.affinityScore = score }
 
-func TestNodePortsFeasibility(t *testing.T) {
-	ctx := t.Context()
-
-	node1 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node1", Labels: map[string]string{corev1.LabelHostname: "node1"}},
-		Status: corev1.NodeStatus{
-			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU:  resource.MustParse("4"),
-				corev1.ResourcePods: resource.MustParse("10"),
-			},
-			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
-		},
-	}
-	node2 := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
-		Status: corev1.NodeStatus{
-			Allocatable: corev1.ResourceList{
-				corev1.ResourceCPU:  resource.MustParse("4"),
-				corev1.ResourcePods: resource.MustParse("10"),
-			},
-			Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
-		},
-	}
-	nodes := []*corev1.Node{node1, node2}
-
-	existingPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "existing-pod", Namespace: "default", UID: "uid-1"},
-		Spec: corev1.PodSpec{
-			NodeName: "node1",
-			Containers: []corev1.Container{{
-				Name:  "c",
-				Image: "busybox",
-				Ports: []corev1.ContainerPort{{
-					ContainerPort: 8080,
-					HostPort:      8080,
-					Protocol:      corev1.ProtocolTCP,
-				}},
-			}},
-		},
-		Status: corev1.PodStatus{Phase: corev1.PodRunning},
-	}
-
-	tests := map[string]struct {
-		pods         []*corev1.Pod
-		candidatePod corev1.PodTemplateSpec
-		wantFeasible map[string]bool
-	}{
-		"hostPort conflict excludes node with occupied port": {
-			pods: []*corev1.Pod{existingPod},
-			candidatePod: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "c",
-						Image: "busybox",
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: 8080,
-							HostPort:      8080,
-							Protocol:      corev1.ProtocolTCP,
-						}},
-					}},
-				},
-			},
-			wantFeasible: map[string]bool{"node2": true},
-		},
-		"different hostPort has no conflict": {
-			pods: []*corev1.Pod{existingPod},
-			candidatePod: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "c",
-						Image: "busybox",
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: 9090,
-							HostPort:      9090,
-							Protocol:      corev1.ProtocolTCP,
-						}},
-					}},
-				},
-			},
-			wantFeasible: map[string]bool{"node1": true, "node2": true},
-		},
-		"pod without hostPort passes through unaffected": {
-			pods: []*corev1.Pod{existingPod},
-			candidatePod: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "c",
-						Image: "busybox",
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
-						},
-					}},
-				},
-			},
-			wantFeasible: map[string]bool{"node1": true, "node2": true},
-		},
-		"no existing pods means all nodes feasible": {
-			pods: nil,
-			candidatePod: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{
-						Name:  "c",
-						Image: "busybox",
-						Ports: []corev1.ContainerPort{{
-							ContainerPort: 8080,
-							HostPort:      8080,
-							Protocol:      corev1.ProtocolTCP,
-						}},
-					}},
-				},
-			},
-			wantFeasible: map[string]bool{"node1": true, "node2": true},
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			sim, err := NewWASSimulatorForTest(ctx)
-			if err != nil {
-				t.Fatalf("NewWASSimulatorForTest failed: %v", err)
-			}
-
-			candidates := func(yield func(simulator.Candidate) bool) {
-				for _, n := range nodes {
-					if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
-						return
-					}
-				}
-			}
-
-			for _, pod := range tc.pods {
-				sim.TrackPod(pod)
-			}
-			snapshot, err := sim.Snapshot(ctx, nodes)
-			if err != nil {
-				t.Fatalf("CreateSnapshot failed: %v", err)
-			}
-
-			stats := &simulator.NodeExclusionStats{}
-			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
-				PodTemplate: &tc.candidatePod,
-			}, stats)
-			if err != nil {
-				t.Fatalf("FindFeasibleNodes failed: %v", err)
-			}
-
-			gotNames := make(map[string]bool)
-			for _, r := range results {
-				gotNames[r.GetNode().Name] = true
-			}
-
-			if len(gotNames) != len(tc.wantFeasible) {
-				t.Errorf("got feasible nodes %v, want %v", gotNames, tc.wantFeasible)
-				return
-			}
-			for n := range tc.wantFeasible {
-				if !gotNames[n] {
-					t.Errorf("expected node %s to be feasible, got %v", n, gotNames)
-				}
-			}
-		})
-	}
-}
 
 func TestNodeUnschedulableFeasibility(t *testing.T) {
 	ctx := t.Context()
@@ -249,12 +85,12 @@ func TestNodeUnschedulableFeasibility(t *testing.T) {
 				}
 			}
 
-			snapshot, err := sim.Snapshot(ctx, tc.nodes)
+			checker, err := sim.NewFeasibilityChecker(ctx, tc.nodes)
 			if err != nil {
-				t.Fatalf("Snapshot failed: %v", err)
+				t.Fatalf("NewFeasibilityChecker failed: %v", err)
 			}
 
-			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+			results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
 				PodTemplate: &tc.candidatePod,
 			}, &simulator.NodeExclusionStats{})
 			if err != nil {

--- a/pkg/cache/scheduler/was/scheduling_simulator_test.go
+++ b/pkg/cache/scheduler/was/scheduling_simulator_test.go
@@ -21,6 +21,7 @@ package was
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -215,34 +216,59 @@ func TestNodeUnschedulableFeasibility(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "node2", Labels: map[string]string{corev1.LabelHostname: "node2"}},
 		Spec:       corev1.NodeSpec{Unschedulable: false},
 	}
-	nodes := []*corev1.Node{node1, node2}
 
-	sim, err := NewWASSimulatorForTest(ctx)
-	if err != nil {
-		t.Fatalf("NewWASSimulatorForTest failed: %v", err)
+	tests := map[string]struct {
+		nodes        []*corev1.Node
+		candidatePod corev1.PodTemplateSpec
+		wantFeasible map[string]bool
+	}{
+		"unschedulable node is excluded": {
+			nodes:        []*corev1.Node{node1, node2},
+			candidatePod: corev1.PodTemplateSpec{},
+			wantFeasible: map[string]bool{"node2": true},
+		},
+		"all schedulable nodes are feasible": {
+			nodes:        []*corev1.Node{node2},
+			candidatePod: corev1.PodTemplateSpec{},
+			wantFeasible: map[string]bool{"node2": true},
+		},
 	}
 
-	candidates := func(yield func(simulator.Candidate) bool) {
-		for _, n := range nodes {
-			if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
-				return
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sim, err := NewWASSimulatorForTest(ctx)
+			if err != nil {
+				t.Fatalf("NewWASSimulatorForTest failed: %v", err)
 			}
-		}
-	}
 
-	checker, err := sim.NewFeasibilityChecker(ctx, nodes)
-	if err != nil {
-		t.Fatalf("NewFeasibilityChecker failed: %v", err)
-	}
+			candidates := func(yield func(simulator.Candidate) bool) {
+				for _, n := range tc.nodes {
+					if !yield(&testCandidate{node: n, id: utiltas.TopologyDomainID(n.Name)}) {
+						return
+					}
+				}
+			}
 
-	results, err := checker.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
-		PodTemplate: &corev1.PodTemplateSpec{},
-	}, &simulator.NodeExclusionStats{})
-	if err != nil {
-		t.Fatalf("FindFeasibleNodes failed: %v", err)
-	}
+			snapshot, err := sim.Snapshot(ctx, tc.nodes)
+			if err != nil {
+				t.Fatalf("Snapshot failed: %v", err)
+			}
 
-	if len(results) != 1 || results[0].GetNode().Name != "node2" {
-		t.Errorf("expected only node2 to be feasible, got %v", results)
+			results, err := snapshot.FindFeasibleNodes(ctx, candidates, &simulator.PodRequirements{
+				PodTemplate: &tc.candidatePod,
+			}, &simulator.NodeExclusionStats{})
+			if err != nil {
+				t.Fatalf("FindFeasibleNodes failed: %v", err)
+			}
+
+			gotNames := make(map[string]bool)
+			for _, r := range results {
+				gotNames[r.GetNode().Name] = true
+			}
+
+			if diff := cmp.Diff(tc.wantFeasible, gotNames); diff != "" {
+				t.Errorf("Unexpected feasible nodes (-want,+got):\n%s", diff)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/scheduler_tas_test.go
+++ b/pkg/scheduler/scheduler_tas_test.go
@@ -41,6 +41,7 @@ import (
 	kueue "sigs.k8s.io/kueue/apis/kueue/v1beta2"
 	qcache "sigs.k8s.io/kueue/pkg/cache/queue"
 	schdcache "sigs.k8s.io/kueue/pkg/cache/scheduler"
+	"sigs.k8s.io/kueue/pkg/cache/scheduler/was"
 	tasindexer "sigs.k8s.io/kueue/pkg/controller/tas/indexer"
 	"sigs.k8s.io/kueue/pkg/features"
 	preemptexpectations "sigs.k8s.io/kueue/pkg/scheduler/preemption/expectations"
@@ -3505,6 +3506,159 @@ func TestScheduleForTAS(t *testing.T) {
 					Obj(),
 			},
 		},
+		"SchedulerLibraryIntegration enabled: generic TAS workload admitted on healthy node": {
+			nodes:           defaultSingleNode,
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
+		"SchedulerLibraryIntegration enabled: non-hostname lowest-level TAS excludes unschedulable node": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(tasRackLabel, "r1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(tasRackLabel, "r2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Unschedulable().
+					Ready().
+					Obj(),
+			},
+			topologies: []kueue.Topology{
+				*utiltestingapi.MakeTopology("tas-rack-only").
+					Levels(tasRackLabel).
+					Obj(),
+			},
+			resourceFlavors: []kueue.ResourceFlavor{
+				*utiltestingapi.MakeResourceFlavor("tas-rack-flavor").
+					NodeLabel("tas-node", "true").
+					TopologyName("tas-rack-only").
+					Obj(),
+			},
+			clusterQueues: []kueue.ClusterQueue{
+				*utiltestingapi.MakeClusterQueue("tas-main").
+					ResourceGroup(*utiltestingapi.MakeFlavorQuotas("tas-rack-flavor").
+						Resource(corev1.ResourceCPU, "50").Obj()).
+					Obj(),
+			},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-rack", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(tasRackLabel).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl-rack": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-rack-flavor", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment([]string{tasRackLabel}).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"r1"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-rack", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-rack", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
+		"SchedulerLibraryIntegration enabled: hostname lowest-level TAS filters unschedulable node via WAS": {
+			nodes: []corev1.Node{
+				*testingnode.MakeNode("x1").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x1").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Unschedulable().
+					Ready().
+					Obj(),
+				*testingnode.MakeNode("x2").
+					Label("tas-node", "true").
+					Label(corev1.LabelHostname, "x2").
+					StatusAllocatable(corev1.ResourceList{
+						corev1.ResourceCPU:  resource.MustParse("1"),
+						corev1.ResourcePods: resource.MustParse("10"),
+					}).
+					Ready().
+					Obj(),
+			},
+			topologies:      []kueue.Topology{defaultSingleLevelTopology},
+			resourceFlavors: []kueue.ResourceFlavor{defaultTASFlavor},
+			clusterQueues:   []kueue.ClusterQueue{defaultClusterQueue},
+			workloads: []kueue.Workload{
+				*utiltestingapi.MakeWorkload("wl-hostname", "default").
+					Queue("tas-main").
+					PodSets(*utiltestingapi.MakePodSet("main", 1).
+						RequiredTopologyRequest(corev1.LabelHostname).
+						Request(corev1.ResourceCPU, "1").
+						Obj()).
+					Obj(),
+			},
+			wantNewAssignments: map[workload.Reference]kueue.Admission{
+				"default/wl-hostname": *utiltestingapi.MakeAdmission("tas-main").
+					PodSets(utiltestingapi.MakePodSetAssignment("main").
+						Assignment(corev1.ResourceCPU, "tas-default", "1").
+						TopologyAssignment(utiltestingapi.MakeTopologyAssignment(utiltas.Levels(&defaultSingleLevelTopology)).
+							Domain(utiltestingapi.MakeTopologyDomainAssignment([]string{"x2"}, 1).Obj()).
+							Obj()).
+						Obj()).
+					Obj(),
+			},
+			eventCmpOpts: cmp.Options{eventIgnoreMessage},
+			wantEvents: []utiltesting.EventRecord{
+				utiltesting.MakeEventRecord("default", "wl-hostname", "QuotaReserved", corev1.EventTypeNormal).Obj(),
+				utiltesting.MakeEventRecord("default", "wl-hostname", "Admitted", corev1.EventTypeNormal).Obj(),
+			},
+			featureGates: map[featuregate.Feature]bool{
+				features.SchedulerLibraryIntegration: true,
+			},
+		},
 	}
 	scenarios := []map[featuregate.Feature]bool{
 		{
@@ -3583,7 +3737,15 @@ func TestScheduleForTAS(t *testing.T) {
 					_ = tasindexer.SetupIndexes(ctx, utiltesting.AsIndexer(clientBuilder))
 					cl := clientBuilder.Build()
 					recorder := &utiltesting.EventRecorder{}
-					cqCache := schdcache.New(cl, schdcache.WithResourceTransformations(tc.resourceTransformations))
+					cacheOptions := []schdcache.Option{schdcache.WithResourceTransformations(tc.resourceTransformations)}
+					if features.Enabled(features.SchedulerLibraryIntegration) {
+						sim, err := was.NewWASSimulatorForTest(ctx)
+						if err != nil {
+							t.Fatalf("Failed to initialize WAS scheduling simulator: %v", err)
+						}
+						cacheOptions = append(cacheOptions, schdcache.WithSchedulingSimulator(sim))
+					}
+					cqCache := schdcache.New(cl, cacheOptions...)
 					fakeClock := testingclock.NewFakeClock(now)
 					qManager := qcache.NewManagerForUnitTests(cl, cqCache,
 						qcache.WithClock(fakeClock), qcache.WithResourceTransformations(tc.resourceTransformations))


### PR DESCRIPTION
Cherry pick of #14203 on release-0.19.

#14203: Skip Kueue-side node health filtering under SchedulerLibraryIntegration

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

#### What type of PR is this?
/kind cleanup


```release-note
WorkloadAwareScheduler: Delegated TAS node readiness and `spec.unschedulable` checks to the `scheduler-library` instead of applying them when building the TAS node cache. Controlled by the `SchedulerLibraryIntegration` feature gate, which is Alpha and disabled by default.
```