### PR TITLE
KEP-14615: Elastic Jobs and ProvisioningRequest compatibility constraints

### DIFF
--- a/keps/14615-elastic-jobs-provisioning-request-scope/README.md
+++ b/keps/14615-elastic-jobs-provisioning-request-scope/README.md
@@ -1,0 +1,186 @@
+# KEP-14615: Elastic Jobs and ProvisioningRequest Compatibility Constraints
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Per-pod vs. per-template annotation lifetime](#per-pod-vs-per-template-annotation-lifetime)
+  - [<code>provisioningClassName</code> scope](#provisioningclassname-scope)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Test Plan](#test-plan)
+    - [Unit Tests](#unit-tests)
+    - [Integration Tests](#integration-tests)
+- [Alternatives](#alternatives)
+<!-- /toc -->
+
+## Summary
+
+This KEP documents the compatibility constraints between elastic Jobs
+(`ElasticJobsViaWorkloadSlices`) and Kueue's `ProvisioningRequest` admission-check
+integration. It formalizes two things raised during review of the elastic-job
+scale-up/scale-down support ([#14316](https://github.com/kubernetes-sigs/kueue/pull/14316)):
+
+1. Which `provisioningClassName`s have been exercised against the elastic-job code
+   path and are considered in scope, vs. which are explicitly out of scope today.
+2. The per-pod vs. per-template lifetime rule for `ProvisioningRequest` identity
+   annotations that makes elastic scale-up safe to combine with GKE's
+   nodeSelector-injection behavior for `queued-provisioning.gke.io`.
+
+## Motivation
+
+Elastic Jobs replace a running Workload's PodSet counts in place via
+`WorkloadSlice` replacement, re-admitting the same underlying Job/RayCluster
+template through multiple scale-up/scale-down cycles. `ProvisioningRequest`
+admission checks (in particular `queued-provisioning.gke.io` on GKE) rely on a
+per-request identity annotation (`autoscaling.x-k8s.io/consume-provisioning-request`)
+to let the cloud provider's admission webhook inject a nodeSelector that scopes a
+pod to the specific node(s) created for that request. If that identity annotation
+were allowed to persist on the long-lived, shared elastic job template, every
+future pod (from later, unrelated scale-ups) would inherit a stale value, and a
+reviewer correctly flagged that a missing/stale nodeSelector would let a pod
+schedule onto arbitrary capacity instead of the capacity actually reserved for it.
+
+This KEP exists to write that constraint down explicitly, rather than leave it as
+implicit knowledge in `podset.go`/`elastic_job_ungater.go`, and to scope which
+`provisioningClassName`s have actually been verified against it.
+
+### Goals
+- Document the per-pod vs. per-template lifetime rule for
+  `ProvisioningRequest` identity annotations (`consume-provisioning-request`,
+  `provisioning-class-name`) on elastic Jobs.
+- Enumerate which `provisioningClassName`s are verified-safe for elastic Jobs
+  today, and which are explicitly out of scope / unverified.
+- Give follow-up KEPs/issues a documented baseline instead of re-deriving this
+  from code each time a new `provisioningClassName` or elastic-job interaction
+  is proposed.
+
+### Non-Goals
+- Implementing support for any of the out-of-scope classes/scenarios listed
+  below (TPU multi-host queued provisioning, non-GKE queued/reservation
+  classes, elastic + MultiKueue, concurrent overlapping scale-ups).
+- Changing the `ProvisioningRequest` admission-check controller's class-agnostic
+  behavior — Kueue does not and should not branch on `provisioningClassName`.
+- Re-designing the elastic-job / `WorkloadSlice` replacement mechanism itself.
+
+## Proposal
+
+### Per-pod vs. per-template annotation lifetime
+
+Two `ProvisioningRequest` identity annotations are relevant:
+
+- `autoscaling.x-k8s.io/consume-provisioning-request` — identifies *one specific*
+  `ProvisioningRequest`. Changes every time a new PRQ is created, i.e. on every
+  scale-up of an elastic Job.
+- `autoscaling.x-k8s.io/provisioning-class-name` — stable for the life of the
+  Workload/AdmissionCheck.
+
+For a normal (non-elastic) Job, both annotations are written once onto the Job's
+Pod template at admission — there is no lifetime conflict, since the Job (and its
+template) is never re-admitted.
+
+For an **elastic** Job, the Job/RayCluster template is long-lived and shared by
+every pod the workload will ever have, but each scale-up mints a *new*
+`ProvisioningRequest` with a *new* `consume-provisioning-request` value. Writing
+that value onto the shared template would leak a stale PRQ identity onto every
+subsequently created pod — including pods from future, unrelated scale-ups —
+silently invalidating the nodeSelector-scoping guarantee.
+
+The rule this KEP formalizes:
+
+- **Template-level**: `consume-provisioning-request` must never persist on the
+  elastic job's shared template. It is stripped on every metadata refresh/merge.
+  `provisioning-class-name` may persist there, since it is stable across the
+  workload's lifetime.
+- **Per-pod**: each gated pod receives its correct, current
+  `consume-provisioning-request` value filled in exactly once, only while absent.
+  Once set on a pod, it is immutable — a pod is never ungated with a
+  mismatched/stale PRQ identity relative to the update it's being reconciled
+  against.
+
+Reference implementation (as of [#14316](https://github.com/kubernetes-sigs/kueue/pull/14316)):
+- `pkg/podset/podset.go`, `Merge()` — strips `consume-provisioning-request` from
+  the elastic job template before merge.
+- `pkg/controller/elasticjobs/elastic_job_ungater.go`,
+  `refreshPodAdmission()` / `podAdmissionCompatible()` — fills the annotation
+  per-pod only while absent, and refuses to overwrite a conflicting existing
+  value.
+
+### `provisioningClassName` scope
+
+Kueue's `ProvisioningRequest` admission-check controller
+(`pkg/controller/admissionchecks/provisioning`) is class-agnostic by design — it
+never branches on the `provisioningClassName` string. Scope here is about which
+classes have actually been exercised against the elastic-job code path (workload
+slicing, mid-flight PodSet metadata refresh, per-pod annotation gating) and
+reasoned about for the nodeSelector-safety property above.
+
+**In scope — verified:**
+
+| `provisioningClassName` | Mechanism | Verified how |
+|---|---|---|
+| `queued-provisioning.gke.io` | GKE flex-start w/ queued provisioning (DWS resize-request, atomic gang-provisioning) | Live end-to-end repro on GKE against real GPU capacity: confirmed `consume-provisioning-request` present per-pod, GKE's webhook injected the matching nodeSelector + `cloud.google.com/gke-queued` toleration honored. Elastic scale-up/scale-down exercised separately with `cpu-atomic-provisioning-check`. |
+| `best-effort-atomic-scale-up.autoscaling.x-k8s.io` | Community cluster-autoscaler best-effort atomic scale-up | No nodeSelector-injection step for this class (capacity-check only, no per-PRQ node pinning) — the risk this KEP documents doesn't apply. Covered by unit/integration tests. |
+| `check-capacity.autoscaling.x-k8s.io` | Community cluster-autoscaler capacity check (no provisioning side effect) | Same as above: check-only semantics, no node identity to leak. Covered by existing test suite. |
+
+**Out of scope — not exercised, tracked as follow-up:**
+
+| `provisioningClassName` / scenario | Why out of scope |
+|---|---|
+| TPU-flavored `queued-provisioning.gke.io` (multi-host slice gang scheduling) | The same annotation mechanism is expected to apply, but multi-host TPU slices add gang-scheduling-across-nodes semantics not yet run against an elastic PodSet. |
+| Non-GKE queued/reservation classes | Whether and how a cloud's admission webhook injects a nodeSelector is implementation-specific per cloud/autoscaler; not verified for any non-GKE class. |
+| Elastic Job + MultiKueue, combined with any `ProvisioningRequest` class | MultiKueue delays TAS/PRQ assignment to the worker cluster and follows a different flavor-assignment path; combining that with elastic re-slicing is untested. |
+| Concurrent/overlapping scale-ups on the same elastic Workload | The current implementation tracks one scale-up in flight at a time via a previous-PodSet-counts annotation; a second scale-up arriving before the first is fully admitted is an explicit known limitation, not a verified-safe path. |
+
+### Notes/Constraints/Caveats
+
+- This KEP documents existing behavior introduced in
+  [#14316](https://github.com/kubernetes-sigs/kueue/pull/14316); it does not
+  introduce new API surface.
+- The out-of-scope table above should be treated as a living list — closing one
+  of those gaps should update this KEP rather than only the implementation PR.
+
+### Risks and Mitigations
+
+- **R**: A future change to `podset.go`/`elastic_job_ungater.go` could
+  accidentally let `consume-provisioning-request` leak back onto the shared
+  template. **M**: covered by existing unit tests asserting the annotation is
+  stripped on merge; this KEP gives reviewers of future PRs the "why" to enforce
+  that invariant explicitly in review.
+- **R**: A new `provisioningClassName` (e.g. a different cloud's queued/reserved
+  provisioning) is adopted by a user running elastic Jobs without verifying the
+  nodeSelector-injection assumption holds. **M**: the out-of-scope table above
+  should be checked/extended before recommending elastic Jobs with a new class.
+
+## Design Details
+
+No new API surface. This KEP is documentation of existing, shipped behavior and
+its verified scope; see the `Proposal` section for the concrete code references.
+
+### Test Plan
+
+#### Unit Tests
+- `pkg/podset`: `Merge` strips `consume-provisioning-request` from the elastic
+  job template.
+- `pkg/controller/elasticjobs`: `refreshPodAdmission` / `podAdmissionCompatible`
+  fill the annotation per-pod once, and refuse to overwrite a conflicting value.
+
+#### Integration Tests
+- `test/integration/singlecluster/controller/admissionchecks/provisioning`:
+  elastic Job scale-up while a `ProvisioningRequest` admission check is enabled;
+  running Job's pod template stays immutable/stale-safe across a metadata
+  refresh attempt.
+
+## Alternatives
+
+- **Branch admission-check behavior on `provisioningClassName`**: rejected —
+  Kueue's provisioning admission-check controller is intentionally class-agnostic;
+  adding class-specific branching would couple Kueue core to cloud-specific
+  webhook behavior it doesn't control.
+- **Persist `consume-provisioning-request` on the template and rely on the
+  ungater to correct it before use**: rejected — this reintroduces a window
+  where a newly created pod could briefly carry a stale identity before
+  correction, which is exactly the risk this KEP documents avoiding.

--- a/keps/14615-elastic-jobs-provisioning-request-scope/kep.yaml
+++ b/keps/14615-elastic-jobs-provisioning-request-scope/kep.yaml
@@ -1,0 +1,38 @@
+title: Elastic Jobs and ProvisioningRequest Compatibility Constraints
+kep-number: 14615
+authors:
+  - "@neilb-dotcom"
+status: provisional
+creation-date: 2026-08-19
+reviewers:
+  - "@sohankunkerkar"
+  - "@yaroslava-serdiuk"
+approvers:
+  - TBD
+
+see-also:
+  - "/keps/1136-provisioning-request-support"
+  - "/keps/1788-pass-parameters-to-ProvReq"
+replaces:
+  -
+
+# The target maturity stage in the current dev cycle for this KEP.
+stage: beta
+
+# The most recent milestone for which work toward delivery of this KEP has been
+# done. This can be the current (upcoming) milestone, if it is being actively
+# worked on.
+latest-milestone: "v0.18"
+
+# The milestone at which this feature was, or is targeted to be, at each stage.
+milestone:
+  alpha: "v0.15"
+  beta: "v0.18"
+
+# The following PRR answers are required at alpha release
+# List the feature gate name and the components for which it must be enabled
+feature-gates:
+  - name: ElasticJobsViaWorkloadSlices
+    components:
+      - kueue-controller-manager
+disable-supported: true


### PR DESCRIPTION
Documents the design for combining elastic WorkloadSlices with ProvisioningRequest admission checks, including incremental capacity requests, per-pod provisioning identity, supported provisioning classes, recovery limitations, and graduation criteria.

Raised during review of #14316.

Fixes #14615

#### What type of PR is this?

/kind kep

#### What this PR does / why we need it:

Adds a KEP for running elastic workloads with ProvisioningRequest admission checks.

The proposal introduces the Alpha, default-off `ElasticJobsViaWorkloadSlicesForProvisioningRequests` feature gate, dependent on `ElasticJobsViaWorkloadSlices`.

The design covers:

1. Creating a chain of ProvisioningRequests corresponding to WorkloadSlice replacements.
2. Sizing each request as the delta between the current quota-reserved slice and the latest live admitted, non-evicted slice.
3. Retiring superseded pending requests so overlapping scale-ups request capacity from the last successfully admitted baseline.
4. Keeping request-specific identity and node selectors off shared elastic templates and applying them directly to gated pods before ungating.
5. Handling scale-down or already-covered capacity without creating an invalid empty ProvisioningRequest.
6. Documenting validation status for queued provisioning, best-effort atomic scale-up, and capacity-check classes.
7. Documenting known limitations around late replacement pods, Workload retention, TAS, MultiKueue, and provider-specific behavior.
8. Defining Alpha, Beta, and Stable graduation criteria.

No new Kubernetes API fields are introduced. Runtime behavior is implemented behind the new feature gate in #14316.

#### Which issue(s) this PR fixes:

Fixes #14615

#### Special notes for your reviewer:

The proposal was expanded and reorganized following review feedback on #14316 and this KEP:

- Summary and Proposal now focus on the high-level enhancement.
- Technical mechanics are under Design Details.
- Testing evidence is under Notes.
- The previous-count snapshot annotation was dropped for Alpha; delta sizing now uses the live WorkloadSlice chain.
- Baseline loss after Workload GC is documented as a safe over-provisioning risk, with finalizer-based retention left for Beta consideration.
- Late replacement-pod selector and ordering risks are documented explicitly.

The implementation was validated on `default-dev` with:

- queued and atomic `1 -> 2 pending -> 3` overlapping scale-up;
- queued and atomic sequential `1 -? 2 -> 3 -> 4 -> 5` scale-up;
- request retirement and delta sizing at every transition;
- request-specific per-pod selectors and identities;
- split-node VM failure where an unaffected pod retained its UID and the failed pod was replaced;
- focused unit/vet, provisioning integration, and full Job integration suites.

