### PR TITLE
Fix time-to-readiness metrics being reported after failure recovery

### DIFF
--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -567,7 +567,8 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 				log.Error(err, "Updating workload status")
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
-			// update the metrics only when PodsReady condition status is true
+			// update the metrics only when PodsReady condition status is true and the workload started for the first time.
+			// This avoids re-emitting the time-to-readiness metrics when the workload recovered readiness (`kueue.WorkloadRecovered`).
 			if condition.Status == metav1.ConditionTrue && condition.Reason == kueue.WorkloadStarted {
 				cqName := wl.Status.Admission.ClusterQueue
 				priorityClassName := workloadpatching.PriorityClassName(wl)

--- a/pkg/controller/jobframework/reconciler.go
+++ b/pkg/controller/jobframework/reconciler.go
@@ -568,7 +568,7 @@ func (r *JobReconciler) ReconcileGenericJob(ctx context.Context, req ctrl.Reques
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			// update the metrics only when PodsReady condition status is true
-			if condition.Status == metav1.ConditionTrue {
+			if condition.Status == metav1.ConditionTrue && condition.Reason == kueue.WorkloadStarted {
 				cqName := wl.Status.Admission.ClusterQueue
 				priorityClassName := workloadpatching.PriorityClassName(wl)
 				queuedUntilReadyWaitTime := workload.QueuedWaitTime(wl, r.clock)

--- a/test/e2e/sequential/baseline/waitforpodsready_test.go
+++ b/test/e2e/sequential/baseline/waitforpodsready_test.go
@@ -487,5 +487,13 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 				{"kueue_evicted_workloads_once_total", ns.Name},
 			})
 		})
+
+		ginkgo.By("verifying that the wait time metrics count remained 1", func() {
+			util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
+				{"kueue_ready_wait_time_seconds_count", cq.Name, "} 1"},
+				{"kueue_admitted_until_ready_wait_time_seconds_count", cq.Name, "} 1"},
+				{"kueue_local_queue_ready_wait_time_seconds_count", ns.Name, lq.Name, "} 1"},
+				{"kueue_local_queue_admitted_until_ready_wait_time_seconds_count", ns.Name, lq.Name, "} 1"}})
+		})
 	})
 })

--- a/test/e2e/sequential/baseline/waitforpodsready_test.go
+++ b/test/e2e/sequential/baseline/waitforpodsready_test.go
@@ -488,7 +488,7 @@ var _ = ginkgo.Describe("WaitForPodsReady with default Timeout and a long Recove
 			})
 		})
 
-		ginkgo.By("verifying that the wait time metrics count remained 1", func() {
+		ginkgo.By("verifying that the time-to-readiness metrics were not re-emitted after recovery", func() {
 			util.ExpectMetricsToBeAvailable(ctx, cfg, restClient, curlPod.Name, curlContainerName, [][]string{
 				{"kueue_ready_wait_time_seconds_count", cq.Name, "} 1"},
 				{"kueue_admitted_until_ready_wait_time_seconds_count", cq.Name, "} 1"},


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #14623

#### Special notes for your reviewer:
I'm not sure this should be gated, probably not. I doubt someone relies on the current behavior of metrics being exported after recovery.

We are missing some dedicated `kueue_workload_recovery_time_seconds` metric I think 🤔 

#### Does this PR introduce a user-facing change?
```release-note
Observability: Fixed a bug where the `kueue_ready_wait_time_seconds`, `kueue_admitted_until_ready_wait_time`, `kueue_local_queue_ready_wait_time_seconds` and `kueue_local_queue_admitted_until_ready_wait_time_seconds` metrics were emitted after failure recovery, skewing the metric towards longer wait times.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PodsReady metric reporting so recovered pods do not create duplicate readiness metrics.
  * Readiness metrics are now recorded only when workloads initially start.
  * Confirmed pod recovery does not emit eviction metrics or alter wait-time metric counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->