### PR TITLE
fix(features): record PodIntegrationValidateGroupOwner as introduced in 0.19

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -933,7 +933,7 @@ var defaultVersionedFeatureGates = map[featuregate.Feature]featuregate.Versioned
 	},
 
 	PodIntegrationValidateGroupOwner: {
-		{Version: version.MustParse("0.20"), Default: true, PreRelease: featuregate.Beta},
+		{Version: version.MustParse("0.19"), Default: true, PreRelease: featuregate.Beta},
 	},
 }
 

--- a/site/data/featuregates/versioned_feature_list.yaml
+++ b/site/data/featuregates/versioned_feature_list.yaml
@@ -330,7 +330,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.19"
 - name: PriorityBoost
   versionedSpecs:
   - default: false

--- a/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
+++ b/test/compatibility_lifecycle/reference/versioned_feature_list.yaml
@@ -330,7 +330,7 @@
   - default: true
     lockToDefault: false
     preRelease: Beta
-    version: "0.20"
+    version: "0.19"
 - name: PriorityBoost
   versionedSpecs:
   - default: false


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind documentation
/area integrations

#### What this PR does / why we need it:

`PodIntegrationValidateGroupOwner` landed on this branch via #14599 (the release-0.19 cherry-pick of #13960) with an introduction version of `0.20`. It ships in `0.19`, so the generated feature-gate list on this branch advertises the wrong release. This records `0.19` and regenerates the list.

The whole diff is three one-line changes:

- `pkg/features/kube_features.go` — `version.MustParse("0.20")` → `version.MustParse("0.19")` for that gate's single versioned spec. `Default: true` and `PreRelease: featuregate.Beta` are unchanged.
- `site/data/featuregates/versioned_feature_list.yaml` — `version: "0.20"` → `"0.19"`
- `test/compatibility_lifecycle/reference/versioned_feature_list.yaml` — same

Both YAML files are generated; they were produced by `make generate-featuregates` rather than hand-edited, and the tree is clean afterwards.

#### Which issue(s) this PR fixes:

None.

#### Special notes for your reviewer:

**This is a documentation/metadata correction with no runtime behavior change.** The gate was already enabled by default on this branch even while recorded as `0.20`, and it stays enabled now.

Why the recorded version has no runtime effect today: `pkg/features/kube_features.go` registers Kueue's versioned gates on the shared `utilfeature.DefaultMutableFeatureGate` from `k8s.io/apiserver`, and Kueue never calls `SetEmulationVersion` on it. The emulation version therefore stays at the Kubernetes binary version (`1.36` with `k8s.io/component-base v0.36.2`), which is greater than every Kueue `0.x` version, so `featureSpecAtEmulationAndMinCompatVersion` always selects the newest spec and never falls through to the disabled `PreAlpha` default. I confirmed this empirically on this branch: `Enabled(PodIntegrationValidateGroupOwner)` is `true` with the spec recorded as either `0.19` or `0.20`.

So the only thing wrong was the advertised release, which the website's feature-gate table renders from `site/data/featuregates/versioned_feature_list.yaml`.

Verified locally on this branch: `go build ./pkg/...` succeeds, `go test ./pkg/features/...` passes, `gofmt -l pkg/features` is empty, and `git status` is clean after `make generate-featuregates`. The pod controller and integration suites were not re-run — this change does not touch that code.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```